### PR TITLE
feat(emoji): plain-language emoji search via CLDR keywords and alias sets

### DIFF
--- a/apps/backend/scripts/add-emoji-groups.ts
+++ b/apps/backend/scripts/add-emoji-groups.ts
@@ -88,7 +88,7 @@ function parseEmojiTest(text: string): Map<string, { group: string; order: numbe
 
 async function main() {
   // Read existing emoji data
-  const emojiDataPath = join(import.meta.dir, "../src/lib/emoji-data.json")
+  const emojiDataPath = join(import.meta.dir, "../src/features/emoji/emoji-data.json")
   const emojiData: EmojiData = JSON.parse(readFileSync(emojiDataPath, "utf-8"))
 
   console.log(`Found ${emojiData.emojis.length} emojis in emoji-data.json`)

--- a/apps/backend/scripts/build-emoji-aliases.ts
+++ b/apps/backend/scripts/build-emoji-aliases.ts
@@ -69,6 +69,24 @@ function fold(text: string): string {
   return text.toLowerCase().replace(/[\s_-]/g, "")
 }
 
+/**
+ * Reduce a CLDR annotation to characters a picker query can plausibly contain:
+ * diacritics folded to ASCII, everything outside [a-z0-9 _+-] turned into a
+ * separator. Punctuation left in place would match queries no one means —
+ * "a button (blood type)" made `:)` match 🅰️, so the classic smiley typo held
+ * the emoji popup open and swallowed the Enter that should have sent the
+ * message (tests/browser/emoji-shortcuts.spec.ts).
+ */
+function sanitizeKeyword(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9 _+-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
 function toList(value: string | string[] | undefined): string[] {
   if (value === undefined) return []
   return Array.isArray(value) ? value : [value]
@@ -139,7 +157,7 @@ async function main() {
     const covered = new Set(entry.shortcodes.map(fold))
     const keywords: string[] = []
     for (const raw of [...(source.tags ?? []), source.label]) {
-      const keyword = raw.toLowerCase().trim()
+      const keyword = sanitizeKeyword(raw)
       // A keyword identical to one of this emoji's own shortcodes is pure
       // payload — the shortcode already matches at a strictly better tier.
       if (!keyword || covered.has(fold(keyword))) continue
@@ -150,7 +168,12 @@ async function main() {
     keywordCount += keywords.length
   }
 
-  writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`)
+  // Format through prettier, not bare JSON.stringify: lint-staged reformats the
+  // file on commit, so unformatted output makes every regeneration a 14k-line
+  // whitespace diff instead of the handful of lines that actually changed.
+  const prettier = await import("prettier")
+  const config = await prettier.resolveConfig(dataPath)
+  writeFileSync(dataPath, await prettier.format(JSON.stringify(data), { ...config, filepath: dataPath }))
 
   console.log(`Added ${Object.values(added).reduce((sum, n) => sum + n, 0)} shortcodes`, added)
   console.log(`Wrote ${keywordCount} keywords`)

--- a/apps/backend/scripts/build-emoji-aliases.ts
+++ b/apps/backend/scripts/build-emoji-aliases.ts
@@ -1,0 +1,164 @@
+/**
+ * Rebuild the `shortcodes` aliases and `keywords` of emoji-data.json from
+ * emojibase-data (CLDR annotations + the GitHub/Slack/JoyPixels shortcode sets).
+ *
+ * Run: bun apps/backend/scripts/build-emoji-aliases.ts
+ *
+ * Two separate outputs, because they are not interchangeable:
+ *
+ * - `shortcodes` are resolvable: `:name:` round-trips through toEmoji/toShortcode
+ *   and gets persisted, so every one must map to exactly one emoji (enforced by
+ *   the collision test in emoji.test.ts). A name already claimed by another emoji
+ *   is dropped rather than duplicated.
+ * - `keywords` are search-only. They are the CLDR annotation tags ("sad",
+ *   "unhappy", "tear"), which are deliberately shared across emoji and would
+ *   make `:face:` ambiguous if they were shortcodes.
+ *
+ * shortcodes[0] is never touched — it is the canonical form already persisted in
+ * message content and reactions.
+ */
+
+import { readFileSync, writeFileSync } from "fs"
+import { join } from "path"
+
+const EMOJIBASE_VERSION = "17.0.0"
+const CDN = `https://cdn.jsdelivr.net/npm/emojibase-data@${EMOJIBASE_VERSION}/en`
+
+/** Ordered by how likely a user is to type the set's spelling first. */
+const SHORTCODE_SETS = ["github", "iamcal", "emojibase", "joypixels", "cldr"] as const
+
+/** Same body as SHORTCODE_REGEX in emoji.ts — a name that fails it cannot round-trip. */
+const SHORTCODE_BODY = /^[a-z0-9_+-]+$/
+
+interface EmojiEntry {
+  emoji: string
+  shortcodes: string[]
+  group?: string
+  order?: number
+  keywords?: string[]
+}
+
+interface EmojibaseEmoji {
+  emoji: string
+  text?: string
+  hexcode: string
+  label: string
+  tags?: string[]
+  skins?: EmojibaseEmoji[]
+}
+
+type ShortcodeSet = Record<string, string | string[]>
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const url = `${CDN}/${path}`
+  console.log(`Fetching ${url}`)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`)
+  }
+  return response.json() as Promise<T>
+}
+
+/** Variation selectors differ between sources; compare without them. */
+function normalizeEmoji(emoji: string): string {
+  return emoji.replace(/️/g, "")
+}
+
+/** Separator-insensitive form, so "thumbs up" and "thumbs_up" compare equal. */
+function fold(text: string): string {
+  return text.toLowerCase().replace(/[\s_-]/g, "")
+}
+
+function toList(value: string | string[] | undefined): string[] {
+  if (value === undefined) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function indexByEmoji(emojis: EmojibaseEmoji[]): Map<string, EmojibaseEmoji> {
+  const index = new Map<string, EmojibaseEmoji>()
+  const add = (entry: EmojibaseEmoji) => {
+    index.set(normalizeEmoji(entry.emoji), entry)
+    if (entry.text) index.set(normalizeEmoji(entry.text), entry)
+    for (const skin of entry.skins ?? []) add(skin)
+  }
+  for (const entry of emojis) add(entry)
+  return index
+}
+
+async function main() {
+  const dataPath = join(import.meta.dir, "../src/features/emoji/emoji-data.json")
+  const data: { emojis: EmojiEntry[] } = JSON.parse(readFileSync(dataPath, "utf-8"))
+  console.log(`Loaded ${data.emojis.length} emojis from emoji-data.json`)
+
+  const [emojibase, ...shortcodeSets] = await Promise.all([
+    fetchJson<EmojibaseEmoji[]>("data.json"),
+    ...SHORTCODE_SETS.map((name) => fetchJson<ShortcodeSet>(`shortcodes/${name}.json`)),
+  ])
+
+  const byEmoji = indexByEmoji(emojibase)
+
+  const unmatched = data.emojis.filter((entry) => !byEmoji.has(normalizeEmoji(entry.emoji)))
+  if (unmatched.length > 0) {
+    throw new Error(
+      `${unmatched.length} emoji in emoji-data.json are absent from emojibase ${EMOJIBASE_VERSION}: ` +
+        unmatched.map((entry) => `${entry.emoji} (${entry.shortcodes[0]})`).join(", ")
+    )
+  }
+
+  // Every existing shortcode keeps its owner. Set priority beats dataset order:
+  // walking one whole set before the next stops a low-priority alias of an early
+  // emoji from claiming a name the next set gives to its canonical owner.
+  const owner = new Map<string, string>()
+  for (const entry of data.emojis) {
+    for (const shortcode of entry.shortcodes) owner.set(shortcode, entry.emoji)
+  }
+
+  const added: Record<string, number> = {}
+  const contested: string[] = []
+  for (const [index, set] of shortcodeSets.entries()) {
+    const setName = SHORTCODE_SETS[index]
+    for (const entry of data.emojis) {
+      const source = byEmoji.get(normalizeEmoji(entry.emoji))!
+      for (const shortcode of toList(set[source.hexcode])) {
+        if (!SHORTCODE_BODY.test(shortcode)) continue
+        const existing = owner.get(shortcode)
+        if (existing === undefined) {
+          owner.set(shortcode, entry.emoji)
+          entry.shortcodes.push(shortcode)
+          added[setName] = (added[setName] ?? 0) + 1
+        } else if (existing !== entry.emoji) {
+          contested.push(`${shortcode}: kept by ${existing}, dropped from ${entry.emoji} (${setName})`)
+        }
+      }
+    }
+  }
+
+  let keywordCount = 0
+  for (const entry of data.emojis) {
+    const source = byEmoji.get(normalizeEmoji(entry.emoji))!
+    const covered = new Set(entry.shortcodes.map(fold))
+    const keywords: string[] = []
+    for (const raw of [...(source.tags ?? []), source.label]) {
+      const keyword = raw.toLowerCase().trim()
+      // A keyword identical to one of this emoji's own shortcodes is pure
+      // payload — the shortcode already matches at a strictly better tier.
+      if (!keyword || covered.has(fold(keyword))) continue
+      covered.add(fold(keyword))
+      keywords.push(keyword)
+    }
+    entry.keywords = keywords
+    keywordCount += keywords.length
+  }
+
+  writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`)
+
+  console.log(`Added ${Object.values(added).reduce((sum, n) => sum + n, 0)} shortcodes`, added)
+  console.log(`Wrote ${keywordCount} keywords`)
+  console.log(`${contested.length} shortcodes were already claimed and dropped:`)
+  for (const line of contested) console.log(`  ${line}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/backend/src/features/emoji/emoji-data.json
+++ b/apps/backend/src/features/emoji/emoji-data.json
@@ -2,8451 +2,11519 @@
   "emojis": [
     {
       "emoji": "😀",
-      "shortcodes": ["grinning", "happy"],
+      "shortcodes": ["grinning", "happy", "grinning_face"],
       "group": "smileys",
-      "order": 0
+      "order": 0,
+      "keywords": ["cheerful", "cheery", "face", "grin", "laugh", "nice", "smile", "smiling", "teeth"]
     },
     {
       "emoji": "😃",
-      "shortcodes": ["smiley"],
+      "shortcodes": ["smiley", "grinning_face_with_big_eyes"],
       "group": "smileys",
-      "order": 1
+      "order": 1,
+      "keywords": [
+        "awesome",
+        "big",
+        "eyes",
+        "face",
+        "grin",
+        "grinning",
+        "happy",
+        "mouth",
+        "open",
+        "smile",
+        "smiling",
+        "teeth",
+        "yay"
+      ]
     },
     {
       "emoji": "😄",
-      "shortcodes": ["smile"],
+      "shortcodes": ["smile", "grinning_face_with_closed_eyes", "grinning_face_with_smiling_eyes"],
       "group": "smileys",
-      "order": 2
+      "order": 2,
+      "keywords": ["eye", "eyes", "face", "grin", "grinning", "happy", "laugh", "lol", "mouth", "open", "smiling"]
     },
     {
       "emoji": "😁",
-      "shortcodes": ["grin", "happy_grin"],
+      "shortcodes": ["grin", "happy_grin", "beaming_face", "beaming_face_with_smiling_eyes"],
       "group": "smileys",
-      "order": 3
+      "order": 3,
+      "keywords": ["beaming", "eye", "eyes", "face", "grinning", "happy", "nice", "smile", "smiling", "teeth"]
     },
     {
       "emoji": "😆",
-      "shortcodes": ["laughing", "satisfied"],
+      "shortcodes": ["laughing", "satisfied", "squinting_face", "grinning_squinting_face"],
       "group": "smileys",
-      "order": 4
+      "order": 4,
+      "keywords": [
+        "closed",
+        "eyes",
+        "face",
+        "grinning",
+        "haha",
+        "hahaha",
+        "happy",
+        "laugh",
+        "lol",
+        "mouth",
+        "open",
+        "rofl",
+        "smile",
+        "smiling",
+        "squinting"
+      ]
     },
     {
       "emoji": "😅",
-      "shortcodes": ["sweat_smile"],
+      "shortcodes": ["sweat_smile", "grinning_face_with_sweat"],
       "group": "smileys",
-      "order": 5
+      "order": 5,
+      "keywords": [
+        "cold",
+        "dejected",
+        "excited",
+        "face",
+        "grinning",
+        "mouth",
+        "nervous",
+        "open",
+        "smile",
+        "smiling",
+        "stress",
+        "stressed",
+        "sweat"
+      ]
     },
     {
       "emoji": "🤣",
-      "shortcodes": ["rofl", "lol", "lmao"],
+      "shortcodes": ["rofl", "lol", "lmao", "rolling_on_the_floor_laughing"],
       "group": "smileys",
-      "order": 6
+      "order": 6,
+      "keywords": [
+        "crying",
+        "face",
+        "floor",
+        "funny",
+        "haha",
+        "happy",
+        "hehe",
+        "hilarious",
+        "joy",
+        "laugh",
+        "roflmao",
+        "rolling",
+        "tear"
+      ]
     },
     {
       "emoji": "😂",
-      "shortcodes": ["joy", "laughing_tears", "tears_of_joy"],
+      "shortcodes": ["joy", "laughing_tears", "tears_of_joy", "face_with_tears_of_joy"],
       "group": "smileys",
-      "order": 7
+      "order": 7,
+      "keywords": [
+        "crying",
+        "face",
+        "feels",
+        "funny",
+        "haha",
+        "happy",
+        "hehe",
+        "hilarious",
+        "laugh",
+        "lmao",
+        "lol",
+        "rofl",
+        "roflmao",
+        "tear"
+      ]
     },
     {
       "emoji": "🙂",
-      "shortcodes": ["slightly_smiling_face", "smile_face"],
+      "shortcodes": ["slightly_smiling_face", "smile_face", "slight_smile"],
       "group": "smileys",
-      "order": 8
+      "order": 8,
+      "keywords": ["face", "happy", "slightly", "smile", "smiling"]
     },
     {
       "emoji": "🙃",
-      "shortcodes": ["upside_down_face"],
+      "shortcodes": ["upside_down_face", "upside_down"],
       "group": "smileys",
-      "order": 9
+      "order": 9,
+      "keywords": ["face", "hehe", "smile"]
     },
     {
       "emoji": "😉",
-      "shortcodes": ["wink"],
+      "shortcodes": ["wink", "winking_face"],
       "group": "smileys",
-      "order": 11
+      "order": 11,
+      "keywords": ["face", "flirt", "heartbreaker", "sexy", "slide", "tease", "winking", "winks"]
     },
     {
       "emoji": "😊",
-      "shortcodes": ["blush", "smiling", "happy_blush"],
+      "shortcodes": [
+        "blush",
+        "smiling",
+        "happy_blush",
+        "smiling_face_with_closed_eyes",
+        "smiling_face_with_smiling_eyes"
+      ],
       "group": "smileys",
-      "order": 12
+      "order": 12,
+      "keywords": ["eye", "eyes", "face", "glad", "satisfied", "smile"]
     },
     {
       "emoji": "😇",
-      "shortcodes": ["innocent"],
+      "shortcodes": ["innocent", "halo", "smiling_face_with_halo"],
       "group": "smileys",
-      "order": 13
+      "order": 13,
+      "keywords": [
+        "angel",
+        "angelic",
+        "angels",
+        "blessed",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "happy",
+        "peaceful",
+        "smile",
+        "smiling",
+        "spirit",
+        "tale"
+      ]
     },
     {
       "emoji": "🥰",
-      "shortcodes": ["smiling_face_with_three_hearts"],
+      "shortcodes": ["smiling_face_with_three_hearts", "smiling_face_with_3_hearts", "smiling_face_with_hearts"],
       "group": "smileys",
-      "order": 14
+      "order": 14,
+      "keywords": [
+        "3",
+        "adore",
+        "crush",
+        "face",
+        "heart",
+        "hearts",
+        "ily",
+        "love",
+        "romance",
+        "smile",
+        "smiling",
+        "you"
+      ]
     },
     {
       "emoji": "😍",
-      "shortcodes": ["heart_eyes"],
+      "shortcodes": ["heart_eyes", "smiling_face_with_heart_eyes"],
       "group": "smileys",
-      "order": 15
+      "order": 15,
+      "keywords": [
+        "143",
+        "bae",
+        "eye",
+        "face",
+        "feels",
+        "hearts",
+        "ily",
+        "kisses",
+        "love",
+        "romance",
+        "romantic",
+        "smile",
+        "xoxo"
+      ]
     },
     {
       "emoji": "🤩",
-      "shortcodes": ["star_struck"],
+      "shortcodes": ["star_struck", "star-struck", "grinning_face_with_star_eyes"],
       "group": "smileys",
-      "order": 16
+      "order": 16,
+      "keywords": ["excited", "eyes", "face", "grinning", "smile", "star", "starry-eyed", "wow"]
     },
     {
       "emoji": "😘",
-      "shortcodes": ["kissing_heart"],
+      "shortcodes": ["kissing_heart", "blowing_a_kiss", "face_blowing_a_kiss"],
       "group": "smileys",
-      "order": 17
+      "order": 17,
+      "keywords": [
+        "adorbs",
+        "bae",
+        "blowing",
+        "face",
+        "flirt",
+        "heart",
+        "ily",
+        "kiss",
+        "love",
+        "lover",
+        "miss",
+        "muah",
+        "romantic",
+        "smooch",
+        "xoxo",
+        "you"
+      ]
     },
     {
       "emoji": "😗",
-      "shortcodes": ["kissing"],
+      "shortcodes": ["kissing", "kissing_face"],
       "group": "smileys",
-      "order": 18
+      "order": 18,
+      "keywords": ["143", "date", "dating", "face", "flirt", "ily", "kiss", "love", "smooch", "smooches", "xoxo", "you"]
     },
     {
       "emoji": "☺️",
-      "shortcodes": ["relaxed"],
+      "shortcodes": ["relaxed", "smiling_face"],
       "group": "smileys",
-      "order": 19
+      "order": 19,
+      "keywords": ["face", "happy", "outlined", "smile", "smiling"]
     },
     {
       "emoji": "😚",
-      "shortcodes": ["kissing_closed_eyes"],
+      "shortcodes": ["kissing_closed_eyes", "kissing_face_with_closed_eyes"],
       "group": "smileys",
-      "order": 21
+      "order": 21,
+      "keywords": [
+        "143",
+        "bae",
+        "blush",
+        "closed",
+        "date",
+        "dating",
+        "eye",
+        "eyes",
+        "face",
+        "flirt",
+        "ily",
+        "kisses",
+        "kissing",
+        "smooches",
+        "xoxo"
+      ]
     },
     {
       "emoji": "😙",
-      "shortcodes": ["kissing_smiling_eyes"],
+      "shortcodes": ["kissing_smiling_eyes", "kissing_face_with_smiling_eyes"],
       "group": "smileys",
-      "order": 22
+      "order": 22,
+      "keywords": [
+        "143",
+        "closed",
+        "date",
+        "dating",
+        "eye",
+        "eyes",
+        "face",
+        "flirt",
+        "ily",
+        "kiss",
+        "kisses",
+        "kissing",
+        "love",
+        "night",
+        "smile",
+        "smiling"
+      ]
     },
     {
       "emoji": "🥲",
       "shortcodes": ["smiling_face_with_tear", "smiling_tear"],
       "group": "smileys",
-      "order": 23
+      "order": 23,
+      "keywords": [
+        "face",
+        "glad",
+        "grateful",
+        "happy",
+        "joy",
+        "pain",
+        "proud",
+        "relieved",
+        "smile",
+        "smiley",
+        "smiling",
+        "tear",
+        "touched"
+      ]
     },
     {
       "emoji": "😋",
-      "shortcodes": ["yum"],
+      "shortcodes": ["yum", "savoring_food", "face_savoring_food"],
       "group": "smileys",
-      "order": 24
+      "order": 24,
+      "keywords": [
+        "delicious",
+        "eat",
+        "face",
+        "food",
+        "full",
+        "hungry",
+        "savor",
+        "smile",
+        "smiling",
+        "tasty",
+        "um",
+        "yummy"
+      ]
     },
     {
       "emoji": "😛",
-      "shortcodes": ["stuck_out_tongue"],
+      "shortcodes": ["stuck_out_tongue", "face_with_tongue"],
       "group": "smileys",
-      "order": 25
+      "order": 25,
+      "keywords": ["awesome", "cool", "face", "nice", "party", "stuck-out", "sweet", "tongue"]
     },
     {
       "emoji": "😜",
-      "shortcodes": ["stuck_out_tongue_winking_eye"],
+      "shortcodes": ["stuck_out_tongue_winking_eye", "winking_face_with_tongue"],
       "group": "smileys",
-      "order": 26
+      "order": 26,
+      "keywords": [
+        "crazy",
+        "epic",
+        "eye",
+        "face",
+        "funny",
+        "joke",
+        "loopy",
+        "nutty",
+        "party",
+        "stuck-out",
+        "tongue",
+        "wacky",
+        "weirdo",
+        "wink",
+        "winking",
+        "yolo"
+      ]
     },
     {
       "emoji": "🤪",
-      "shortcodes": ["zany_face"],
+      "shortcodes": ["zany_face", "grinning_face_with_one_large_and_one_small_eye", "zany"],
       "group": "smileys",
-      "order": 27
+      "order": 27,
+      "keywords": ["crazy", "eye", "eyes", "face", "goofy", "large", "small"]
     },
     {
       "emoji": "😝",
-      "shortcodes": ["stuck_out_tongue_closed_eyes"],
+      "shortcodes": ["stuck_out_tongue_closed_eyes", "squinting_face_with_tongue"],
       "group": "smileys",
-      "order": 28
+      "order": 28,
+      "keywords": [
+        "closed",
+        "eye",
+        "eyes",
+        "face",
+        "gross",
+        "horrible",
+        "omg",
+        "squinting",
+        "stuck-out",
+        "taste",
+        "tongue",
+        "whatever",
+        "yolo"
+      ]
     },
     {
       "emoji": "🤑",
-      "shortcodes": ["money_mouth_face"],
+      "shortcodes": ["money_mouth_face", "money_mouth"],
       "group": "smileys",
-      "order": 29
+      "order": 29,
+      "keywords": ["face", "money", "mouth", "paid"]
     },
     {
       "emoji": "🤗",
-      "shortcodes": ["hugs"],
+      "shortcodes": ["hugs", "hugging_face", "hug", "hugging", "smiling_face_with_open_hands"],
       "group": "smileys",
-      "order": 30
+      "order": 30,
+      "keywords": ["face", "hands", "open", "smiling"]
     },
     {
       "emoji": "🤭",
-      "shortcodes": ["hand_over_mouth"],
+      "shortcodes": [
+        "hand_over_mouth",
+        "face_with_hand_over_mouth",
+        "smiling_face_with_smiling_eyes_and_hand_covering_mouth"
+      ],
       "group": "smileys",
-      "order": 31
+      "order": 31,
+      "keywords": [
+        "face",
+        "giggle",
+        "giggling",
+        "hand",
+        "mouth",
+        "oops",
+        "realization",
+        "secret",
+        "shock",
+        "sudden",
+        "surprise",
+        "whoops"
+      ]
     },
     {
       "emoji": "🤫",
-      "shortcodes": ["shushing_face"],
+      "shortcodes": ["shushing_face", "face_with_finger_covering_closed_lips", "shush"],
       "group": "smileys",
-      "order": 34
+      "order": 34,
+      "keywords": ["face", "quiet", "shh", "shushing"]
     },
     {
       "emoji": "🤔",
-      "shortcodes": ["thinking", "hmm"],
+      "shortcodes": ["thinking", "hmm", "thinking_face", "wtf"],
       "group": "smileys",
-      "order": 35
+      "order": 35,
+      "keywords": ["chin", "consider", "face", "ponder", "pondering", "wondering"]
     },
     {
       "emoji": "🤐",
-      "shortcodes": ["zipper_mouth_face"],
+      "shortcodes": ["zipper_mouth_face", "zipper_mouth"],
       "group": "smileys",
-      "order": 37
+      "order": 37,
+      "keywords": ["face", "keep", "mouth", "quiet", "secret", "shut", "zip", "zipper"]
     },
     {
       "emoji": "🤨",
-      "shortcodes": ["raised_eyebrow"],
+      "shortcodes": ["raised_eyebrow", "face_with_raised_eyebrow", "face_with_one_eyebrow_raised"],
       "group": "smileys",
-      "order": 38
+      "order": 38,
+      "keywords": [
+        "disapproval",
+        "disbelief",
+        "distrust",
+        "emoji",
+        "eyebrow",
+        "face",
+        "hmm",
+        "mild",
+        "raised",
+        "skeptic",
+        "skeptical",
+        "skepticism",
+        "surprise",
+        "what"
+      ]
     },
     {
       "emoji": "😐",
-      "shortcodes": ["neutral_face"],
+      "shortcodes": ["neutral_face", "neutral"],
       "group": "smileys",
-      "order": 39
+      "order": 39,
+      "keywords": [
+        "awkward",
+        "blank",
+        "deadpan",
+        "expressionless",
+        "face",
+        "fine",
+        "jealous",
+        "meh",
+        "oh",
+        "shade",
+        "straight",
+        "unamused",
+        "unhappy",
+        "unimpressed",
+        "whatever"
+      ]
     },
     {
       "emoji": "😑",
-      "shortcodes": ["expressionless"],
+      "shortcodes": ["expressionless", "expressionless_face"],
       "group": "smileys",
-      "order": 40
+      "order": 40,
+      "keywords": [
+        "awkward",
+        "dead",
+        "face",
+        "fine",
+        "inexpressive",
+        "jealous",
+        "meh",
+        "not",
+        "oh",
+        "omg",
+        "straight",
+        "uh",
+        "unhappy",
+        "unimpressed",
+        "whatever"
+      ]
     },
     {
       "emoji": "😶",
-      "shortcodes": ["no_mouth"],
+      "shortcodes": ["no_mouth", "face_without_mouth"],
       "group": "smileys",
-      "order": 41
+      "order": 41,
+      "keywords": [
+        "awkward",
+        "blank",
+        "expressionless",
+        "face",
+        "mouth",
+        "mouthless",
+        "mute",
+        "quiet",
+        "secret",
+        "silence",
+        "silent",
+        "speechless"
+      ]
     },
     {
       "emoji": "😏",
-      "shortcodes": ["smirk"],
+      "shortcodes": ["smirk", "smirking", "smirking_face"],
       "group": "smileys",
-      "order": 45
+      "order": 45,
+      "keywords": [
+        "boss",
+        "dapper",
+        "face",
+        "flirt",
+        "homie",
+        "kidding",
+        "leer",
+        "shade",
+        "slick",
+        "sly",
+        "smug",
+        "snicker",
+        "suave",
+        "suspicious",
+        "swag"
+      ]
     },
     {
       "emoji": "😒",
-      "shortcodes": ["unamused"],
+      "shortcodes": ["unamused", "unamused_face"],
       "group": "smileys",
-      "order": 46
+      "order": 46,
+      "keywords": [
+        "...",
+        "bored",
+        "face",
+        "fine",
+        "jealous",
+        "jel",
+        "jelly",
+        "pissed",
+        "smh",
+        "ugh",
+        "uhh",
+        "unhappy",
+        "weird",
+        "whatever"
+      ]
     },
     {
       "emoji": "🙄",
-      "shortcodes": ["roll_eyes", "eye_roll"],
+      "shortcodes": ["roll_eyes", "eye_roll", "face_with_rolling_eyes", "rolling_eyes"],
       "group": "smileys",
-      "order": 47
+      "order": 47,
+      "keywords": ["eyes", "face", "rolling", "shade", "ugh", "whatever"]
     },
     {
       "emoji": "😬",
-      "shortcodes": ["grimacing"],
+      "shortcodes": ["grimacing", "grimacing_face"],
       "group": "smileys",
-      "order": 48
+      "order": 48,
+      "keywords": ["awk", "awkward", "dentist", "face", "grimace", "grinning", "smile", "smiling"]
     },
     {
       "emoji": "🤥",
-      "shortcodes": ["lying_face"],
+      "shortcodes": ["lying_face", "lying", "liar"],
       "group": "smileys",
-      "order": 50
+      "order": 50,
+      "keywords": ["face", "lie", "pinocchio"]
     },
     {
       "emoji": "😌",
-      "shortcodes": ["relieved"],
+      "shortcodes": ["relieved", "relieved_face"],
       "group": "smileys",
-      "order": 56
+      "order": 56,
+      "keywords": ["calm", "face", "peace", "relief", "zen"]
     },
     {
       "emoji": "😔",
-      "shortcodes": ["pensive"],
+      "shortcodes": ["pensive", "pensive_face"],
       "group": "smileys",
-      "order": 57
+      "order": 57,
+      "keywords": ["awful", "bored", "dejected", "died", "disappointed", "face", "losing", "lost", "sad", "sucks"]
     },
     {
       "emoji": "😪",
-      "shortcodes": ["sleepy"],
+      "shortcodes": ["sleepy", "sleepy_face"],
       "group": "smileys",
-      "order": 58
+      "order": 58,
+      "keywords": ["crying", "face", "good", "night", "sad", "sleep", "sleeping", "tired"]
     },
     {
       "emoji": "🤤",
-      "shortcodes": ["drooling_face"],
+      "shortcodes": ["drooling_face", "drooling", "drool"],
       "group": "smileys",
-      "order": 59
+      "order": 59,
+      "keywords": ["face"]
     },
     {
       "emoji": "😴",
       "shortcodes": ["sleeping", "sleeping_face", "snooze"],
       "group": "smileys",
-      "order": 60
+      "order": 60,
+      "keywords": [
+        "bed",
+        "bedtime",
+        "face",
+        "good",
+        "goodnight",
+        "nap",
+        "night",
+        "sleep",
+        "tired",
+        "whatever",
+        "yawn",
+        "zzz"
+      ]
     },
     {
       "emoji": "😷",
-      "shortcodes": ["mask"],
+      "shortcodes": ["mask", "medical_mask", "face_with_medical_mask"],
       "group": "smileys",
-      "order": 62
+      "order": 62,
+      "keywords": ["cold", "dentist", "dermatologist", "doctor", "dr", "face", "germs", "medical", "medicine", "sick"]
     },
     {
       "emoji": "🤒",
-      "shortcodes": ["face_with_thermometer"],
+      "shortcodes": ["face_with_thermometer", "thermometer_face"],
       "group": "smileys",
-      "order": 63
+      "order": 63,
+      "keywords": ["face", "ill", "sick", "thermometer"]
     },
     {
       "emoji": "🤕",
-      "shortcodes": ["face_with_head_bandage"],
+      "shortcodes": ["face_with_head_bandage", "head_bandage"],
       "group": "smileys",
-      "order": 64
+      "order": 64,
+      "keywords": ["bandage", "face", "hurt", "injury", "ouch"]
     },
     {
       "emoji": "🤢",
-      "shortcodes": ["nauseated_face"],
+      "shortcodes": ["nauseated_face", "nauseated", "sick"],
       "group": "smileys",
-      "order": 65
+      "order": 65,
+      "keywords": ["face", "gross", "nasty", "vomit"]
     },
     {
       "emoji": "🤮",
-      "shortcodes": ["vomiting_face"],
+      "shortcodes": ["vomiting_face", "face_vomiting", "face_with_open_mouth_vomiting", "vomiting"],
       "group": "smileys",
-      "order": 66
+      "order": 66,
+      "keywords": ["barf", "ew", "face", "gross", "puke", "sick", "spew", "throw", "up", "vomit"]
     },
     {
       "emoji": "🤧",
-      "shortcodes": ["sneezing_face"],
+      "shortcodes": ["sneezing_face", "sneezing", "sneeze"],
       "group": "smileys",
-      "order": 67
+      "order": 67,
+      "keywords": ["face", "fever", "flu", "gesundheit", "sick"]
     },
     {
       "emoji": "🥵",
       "shortcodes": ["hot_face"],
       "group": "smileys",
-      "order": 68
+      "order": 68,
+      "keywords": ["dying", "face", "feverish", "heat", "hot", "panting", "red-faced", "stroke", "sweating", "tongue"]
     },
     {
       "emoji": "🥶",
-      "shortcodes": ["cold_face"],
+      "shortcodes": ["cold_face", "cold"],
       "group": "smileys",
-      "order": 69
+      "order": 69,
+      "keywords": ["blue", "blue-faced", "face", "freezing", "frostbite", "icicles", "subzero", "teeth"]
     },
     {
       "emoji": "🥴",
-      "shortcodes": ["woozy_face"],
+      "shortcodes": ["woozy_face", "woozy"],
       "group": "smileys",
-      "order": 70
+      "order": 70,
+      "keywords": ["dizzy", "drunk", "eyes", "face", "intoxicated", "mouth", "tipsy", "uneven", "wavy"]
     },
     {
       "emoji": "😵",
-      "shortcodes": ["dizzy_face"],
+      "shortcodes": ["dizzy_face", "knocked_out", "face_with_crossed_out_eyes"],
       "group": "smileys",
-      "order": 71
+      "order": 71,
+      "keywords": ["crossed-out", "dead", "dizzy", "eyes", "face", "feels", "knocked", "out", "sick", "tired"]
     },
     {
       "emoji": "🤯",
-      "shortcodes": ["exploding_head"],
+      "shortcodes": ["exploding_head", "shocked_face_with_exploding_head"],
       "group": "smileys",
-      "order": 73
+      "order": 73,
+      "keywords": ["blown", "explode", "exploding", "head", "mind", "mindblown", "no", "shocked", "way"]
     },
     {
       "emoji": "🤠",
-      "shortcodes": ["cowboy_hat_face"],
+      "shortcodes": ["cowboy_hat_face", "face_with_cowboy_hat", "cowboy", "cowboy_face"],
       "group": "smileys",
-      "order": 74
+      "order": 74,
+      "keywords": ["cowgirl", "face", "hat"]
     },
     {
       "emoji": "🥳",
-      "shortcodes": ["partying_face"],
+      "shortcodes": ["partying_face", "hooray", "partying"],
       "group": "smileys",
-      "order": 75
+      "order": 75,
+      "keywords": ["bday", "birthday", "celebrate", "celebration", "excited", "face", "happy", "hat", "horn", "party"]
     },
     {
       "emoji": "🥸",
-      "shortcodes": ["disguised_face"],
+      "shortcodes": ["disguised_face", "disguised"],
       "group": "smileys",
-      "order": 76
+      "order": 76,
+      "keywords": [
+        "disguise",
+        "eyebrow",
+        "face",
+        "glasses",
+        "incognito",
+        "moustache",
+        "mustache",
+        "nose",
+        "person",
+        "spy",
+        "tache",
+        "tash"
+      ]
     },
     {
       "emoji": "😎",
-      "shortcodes": ["sunglasses"],
+      "shortcodes": ["sunglasses", "smiling_face_with_sunglasses", "sunglasses_cool", "too_cool"],
       "group": "smileys",
-      "order": 77
+      "order": 77,
+      "keywords": [
+        "awesome",
+        "beach",
+        "bright",
+        "bro",
+        "chilling",
+        "cool",
+        "face",
+        "rad",
+        "relaxed",
+        "shades",
+        "slay",
+        "smile",
+        "style",
+        "swag",
+        "win"
+      ]
     },
     {
       "emoji": "🤓",
-      "shortcodes": ["nerd_face"],
+      "shortcodes": ["nerd_face", "nerd"],
       "group": "smileys",
-      "order": 78
+      "order": 78,
+      "keywords": ["brainy", "clever", "expert", "face", "geek", "gifted", "glasses", "intelligent", "smart"]
     },
     {
       "emoji": "🧐",
-      "shortcodes": ["monocle_face"],
+      "shortcodes": ["monocle_face", "face_with_monocle"],
       "group": "smileys",
-      "order": 79
+      "order": 79,
+      "keywords": ["classy", "face", "fancy", "monocle", "rich", "stuffy", "wealthy"]
     },
     {
       "emoji": "😕",
-      "shortcodes": ["confused"],
+      "shortcodes": ["confused", "confused_face"],
       "group": "smileys",
-      "order": 80
+      "order": 80,
+      "keywords": ["befuddled", "confusing", "dunno", "face", "frown", "hm", "meh", "not", "sad", "sorry", "sure"]
     },
     {
       "emoji": "😟",
-      "shortcodes": ["worried"],
+      "shortcodes": ["worried", "worried_face"],
       "group": "smileys",
-      "order": 82
+      "order": 82,
+      "keywords": [
+        "anxious",
+        "butterflies",
+        "face",
+        "nerves",
+        "nervous",
+        "sad",
+        "stress",
+        "stressed",
+        "surprised",
+        "worry"
+      ]
     },
     {
       "emoji": "🙁",
-      "shortcodes": ["slightly_frowning_face"],
+      "shortcodes": ["slightly_frowning_face", "slight_frown"],
       "group": "smileys",
-      "order": 83
+      "order": 83,
+      "keywords": ["face", "frown", "frowning", "sad", "slightly"]
     },
     {
       "emoji": "☹️",
-      "shortcodes": ["frowning_face"],
+      "shortcodes": ["frowning_face", "white_frowning_face", "frowning2"],
       "group": "smileys",
-      "order": 84
+      "order": 84,
+      "keywords": ["face", "frown", "frowning", "sad"]
     },
     {
       "emoji": "😮",
-      "shortcodes": ["open_mouth"],
+      "shortcodes": ["open_mouth", "face_with_open_mouth"],
       "group": "smileys",
-      "order": 86
+      "order": 86,
+      "keywords": [
+        "believe",
+        "face",
+        "forgot",
+        "mouth",
+        "omg",
+        "open",
+        "shocked",
+        "surprised",
+        "sympathy",
+        "unbelievable",
+        "unreal",
+        "whoa",
+        "wow",
+        "you"
+      ]
     },
     {
       "emoji": "😯",
-      "shortcodes": ["hushed"],
+      "shortcodes": ["hushed", "hushed_face"],
       "group": "smileys",
-      "order": 87
+      "order": 87,
+      "keywords": ["epic", "face", "omg", "stunned", "surprised", "whoa", "woah"]
     },
     {
       "emoji": "😲",
-      "shortcodes": ["astonished"],
+      "shortcodes": ["astonished", "astonished_face"],
       "group": "smileys",
-      "order": 88
+      "order": 88,
+      "keywords": ["cost", "face", "no", "omg", "shocked", "totally", "way"]
     },
     {
       "emoji": "😳",
-      "shortcodes": ["flushed"],
+      "shortcodes": ["flushed", "flushed_face"],
       "group": "smileys",
-      "order": 89
+      "order": 89,
+      "keywords": [
+        "amazed",
+        "awkward",
+        "crazy",
+        "dazed",
+        "dead",
+        "disbelief",
+        "embarrassed",
+        "face",
+        "geez",
+        "heat",
+        "hot",
+        "impressed",
+        "jeez",
+        "what",
+        "wow"
+      ]
     },
     {
       "emoji": "🥺",
       "shortcodes": ["pleading_face", "pleading"],
       "group": "smileys",
-      "order": 90
+      "order": 90,
+      "keywords": ["begging", "big", "eyes", "face", "mercy", "not", "please", "pretty", "puppy", "sad", "why"]
     },
     {
       "emoji": "😦",
-      "shortcodes": ["frowning"],
+      "shortcodes": ["frowning", "frowning_face_with_open_mouth"],
       "group": "smileys",
-      "order": 92
+      "order": 92,
+      "keywords": ["caught", "face", "frown", "guard", "mouth", "open", "scared", "scary", "surprise", "what", "wow"]
     },
     {
       "emoji": "😧",
-      "shortcodes": ["anguished"],
+      "shortcodes": ["anguished", "anguished_face"],
       "group": "smileys",
-      "order": 93
+      "order": 93,
+      "keywords": ["face", "forgot", "scared", "scary", "stressed", "surprise", "unhappy", "what", "wow"]
     },
     {
       "emoji": "😨",
-      "shortcodes": ["fearful"],
+      "shortcodes": ["fearful", "fearful_face"],
       "group": "smileys",
-      "order": 94
+      "order": 94,
+      "keywords": ["afraid", "anxious", "blame", "face", "fear", "scared", "worried"]
     },
     {
       "emoji": "😰",
-      "shortcodes": ["cold_sweat"],
+      "shortcodes": ["cold_sweat", "anxious", "anxious_face", "anxious_face_with_sweat"],
       "group": "smileys",
-      "order": 95
+      "order": 95,
+      "keywords": ["blue", "cold", "eek", "face", "mouth", "nervous", "open", "rushed", "scared", "sweat", "yikes"]
     },
     {
       "emoji": "😥",
-      "shortcodes": ["disappointed_relieved"],
+      "shortcodes": ["disappointed_relieved", "sad_relieved_face", "sad_but_relieved_face"],
       "group": "smileys",
-      "order": 96
+      "order": 96,
+      "keywords": [
+        "anxious",
+        "call",
+        "close",
+        "complicated",
+        "disappointed",
+        "face",
+        "not",
+        "relieved",
+        "sad",
+        "sweat",
+        "time",
+        "whew"
+      ]
     },
     {
       "emoji": "😢",
-      "shortcodes": ["cry"],
+      "shortcodes": ["cry", "crying_face"],
       "group": "smileys",
-      "order": 97
+      "order": 97,
+      "keywords": ["awful", "crying", "face", "feels", "miss", "sad", "tear", "triste", "unhappy"]
     },
     {
       "emoji": "😭",
-      "shortcodes": ["sob", "crying", "sobbing"],
+      "shortcodes": ["sob", "crying", "sobbing", "loudly_crying_face"],
       "group": "smileys",
-      "order": 98
+      "order": 98,
+      "keywords": ["bawling", "cry", "face", "loudly", "sad", "tear", "tears", "unhappy"]
     },
     {
       "emoji": "😱",
-      "shortcodes": ["scream", "screaming", "shocked"],
+      "shortcodes": ["scream", "screaming", "shocked", "screaming_in_fear", "face_screaming_in_fear"],
       "group": "smileys",
-      "order": 99
+      "order": 99,
+      "keywords": ["epic", "face", "fear", "fearful", "munch", "scared", "screamer", "surprised", "woah"]
     },
     {
       "emoji": "😖",
-      "shortcodes": ["confounded"],
+      "shortcodes": ["confounded", "confounded_face"],
       "group": "smileys",
-      "order": 100
+      "order": 100,
+      "keywords": ["annoyed", "confused", "cringe", "distraught", "face", "feels", "frustrated", "mad", "sad"]
     },
     {
       "emoji": "😣",
-      "shortcodes": ["persevere"],
+      "shortcodes": ["persevere", "persevering_face"],
       "group": "smileys",
-      "order": 101
+      "order": 101,
+      "keywords": ["concentrate", "concentration", "face", "focus", "headache", "persevering"]
     },
     {
       "emoji": "😞",
-      "shortcodes": ["disappointed"],
+      "shortcodes": ["disappointed", "disappointed_face"],
       "group": "smileys",
-      "order": 102
+      "order": 102,
+      "keywords": ["awful", "blame", "dejected", "face", "fail", "losing", "sad", "unhappy"]
     },
     {
       "emoji": "😓",
-      "shortcodes": ["sweat"],
+      "shortcodes": ["sweat", "downcast_face", "downcast_face_with_sweat"],
       "group": "smileys",
-      "order": 103
+      "order": 103,
+      "keywords": ["close", "cold", "downcast", "face", "feels", "headache", "nervous", "sad", "scared", "yikes"]
     },
     {
       "emoji": "😩",
-      "shortcodes": ["weary"],
+      "shortcodes": ["weary", "weary_face"],
       "group": "smileys",
-      "order": 104
+      "order": 104,
+      "keywords": ["crying", "face", "fail", "feels", "hungry", "mad", "nooo", "sad", "sleepy", "tired", "unhappy"]
     },
     {
       "emoji": "😫",
-      "shortcodes": ["tired_face"],
+      "shortcodes": ["tired_face", "tired"],
       "group": "smileys",
-      "order": 105
+      "order": 105,
+      "keywords": ["cost", "face", "feels", "nap", "sad", "sneeze"]
     },
     {
       "emoji": "🥱",
-      "shortcodes": ["yawning_face"],
+      "shortcodes": ["yawning_face", "yawn", "yawning"],
       "group": "smileys",
-      "order": 106
+      "order": 106,
+      "keywords": [
+        "bedtime",
+        "bored",
+        "face",
+        "goodnight",
+        "nap",
+        "night",
+        "sleep",
+        "sleepy",
+        "tired",
+        "whatever",
+        "zzz"
+      ]
     },
     {
       "emoji": "😤",
-      "shortcodes": ["triumph"],
+      "shortcodes": ["triumph", "nose_steam", "face_with_steam_from_nose"],
       "group": "smileys",
-      "order": 107
+      "order": 107,
+      "keywords": [
+        "anger",
+        "angry",
+        "face",
+        "feels",
+        "fume",
+        "fuming",
+        "furious",
+        "fury",
+        "mad",
+        "nose",
+        "steam",
+        "unhappy",
+        "won"
+      ]
     },
     {
       "emoji": "😡",
-      "shortcodes": ["rage"],
+      "shortcodes": ["rage", "pout", "enraged_face"],
       "group": "smileys",
-      "order": 108
+      "order": 108,
+      "keywords": [
+        "anger",
+        "angry",
+        "enraged",
+        "face",
+        "feels",
+        "mad",
+        "maddening",
+        "pouting",
+        "red",
+        "shade",
+        "unhappy",
+        "upset"
+      ]
     },
     {
       "emoji": "😠",
-      "shortcodes": ["angry"],
+      "shortcodes": ["angry", "angry_face"],
       "group": "smileys",
-      "order": 109
+      "order": 109,
+      "keywords": [
+        "anger",
+        "blame",
+        "face",
+        "feels",
+        "frustrated",
+        "mad",
+        "maddening",
+        "rage",
+        "shade",
+        "unhappy",
+        "upset"
+      ]
     },
     {
       "emoji": "🤬",
-      "shortcodes": ["cursing_face"],
+      "shortcodes": [
+        "cursing_face",
+        "face_with_symbols_on_mouth",
+        "serious_face_with_symbols_covering_mouth",
+        "censored",
+        "face_with_symbols_over_mouth"
+      ],
       "group": "smileys",
-      "order": 110
+      "order": 110,
+      "keywords": ["censor", "cursing", "cussing", "face", "mad", "mouth", "pissed", "swearing", "symbols"]
     },
     {
       "emoji": "😈",
-      "shortcodes": ["smiling_imp"],
+      "shortcodes": ["smiling_imp", "smiling_face_with_horns"],
       "group": "smileys",
-      "order": 111
+      "order": 111,
+      "keywords": [
+        "demon",
+        "devil",
+        "evil",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "horns",
+        "purple",
+        "shade",
+        "smile",
+        "smiling",
+        "tale"
+      ]
     },
     {
       "emoji": "👿",
-      "shortcodes": ["imp"],
+      "shortcodes": ["imp", "angry_imp", "angry_face_with_horns"],
       "group": "smileys",
-      "order": 112
+      "order": 112,
+      "keywords": [
+        "angry",
+        "demon",
+        "devil",
+        "evil",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "horns",
+        "mischievous",
+        "purple",
+        "shade",
+        "tale"
+      ]
     },
     {
       "emoji": "💀",
-      "shortcodes": ["skull", "dead", "rip"],
+      "shortcodes": ["skull", "dead", "rip", "skeleton"],
       "group": "smileys",
-      "order": 113
+      "order": 113,
+      "keywords": ["body", "death", "face", "fairy", "fairytale", "i’m", "lmao", "monster", "tale", "yolo"]
     },
     {
       "emoji": "☠️",
-      "shortcodes": ["skull_and_crossbones"],
+      "shortcodes": ["skull_and_crossbones", "skull_crossbones"],
       "group": "smileys",
-      "order": 114
+      "order": 114,
+      "keywords": ["bone", "crossbones", "dead", "death", "face", "monster", "skull"]
     },
     {
       "emoji": "💩",
-      "shortcodes": ["hankey", "poop"],
+      "shortcodes": ["hankey", "poop", "shit", "poo", "pile_of_poo"],
       "group": "smileys",
-      "order": 116
+      "order": 116,
+      "keywords": [
+        "bs",
+        "comic",
+        "doo",
+        "dung",
+        "face",
+        "fml",
+        "monster",
+        "pile",
+        "smelly",
+        "smh",
+        "stink",
+        "stinks",
+        "stinky",
+        "turd"
+      ]
     },
     {
       "emoji": "🤡",
-      "shortcodes": ["clown_face"],
+      "shortcodes": ["clown_face", "clown"],
       "group": "smileys",
-      "order": 117
+      "order": 117,
+      "keywords": ["face"]
     },
     {
       "emoji": "👹",
-      "shortcodes": ["japanese_ogre"],
+      "shortcodes": ["japanese_ogre", "ogre"],
       "group": "smileys",
-      "order": 118
+      "order": 118,
+      "keywords": ["creature", "devil", "face", "fairy", "fairytale", "fantasy", "mask", "monster", "scary", "tale"]
     },
     {
       "emoji": "👺",
-      "shortcodes": ["japanese_goblin"],
+      "shortcodes": ["japanese_goblin", "goblin"],
       "group": "smileys",
-      "order": 119
+      "order": 119,
+      "keywords": ["angry", "creature", "face", "fairy", "fairytale", "fantasy", "mask", "mean", "monster", "tale"]
     },
     {
       "emoji": "👻",
       "shortcodes": ["ghost"],
       "group": "smileys",
-      "order": 120
+      "order": 120,
+      "keywords": [
+        "boo",
+        "creature",
+        "excited",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "halloween",
+        "haunting",
+        "monster",
+        "scary",
+        "silly",
+        "tale"
+      ]
     },
     {
       "emoji": "👽",
       "shortcodes": ["alien"],
       "group": "smileys",
-      "order": 121
+      "order": 121,
+      "keywords": [
+        "creature",
+        "extraterrestrial",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "monster",
+        "space",
+        "tale",
+        "ufo"
+      ]
     },
     {
       "emoji": "👾",
-      "shortcodes": ["space_invader"],
+      "shortcodes": ["space_invader", "alien_monster"],
       "group": "smileys",
-      "order": 122
+      "order": 122,
+      "keywords": [
+        "alien",
+        "creature",
+        "extraterrestrial",
+        "face",
+        "fairy",
+        "fairytale",
+        "fantasy",
+        "game",
+        "gamer",
+        "games",
+        "monster",
+        "pixelated",
+        "space",
+        "tale",
+        "ufo"
+      ]
     },
     {
       "emoji": "🤖",
-      "shortcodes": ["robot"],
+      "shortcodes": ["robot", "robot_face"],
       "group": "smileys",
-      "order": 123
+      "order": 123,
+      "keywords": ["face", "monster"]
     },
     {
       "emoji": "😺",
-      "shortcodes": ["smiley_cat"],
+      "shortcodes": ["smiley_cat", "grinning_cat"],
       "group": "smileys",
-      "order": 124
+      "order": 124,
+      "keywords": ["animal", "cat", "face", "grinning", "mouth", "open", "smile", "smiling"]
     },
     {
       "emoji": "😸",
-      "shortcodes": ["smile_cat"],
+      "shortcodes": ["smile_cat", "grinning_cat_with_closed_eyes", "grinning_cat_with_smiling_eyes"],
       "group": "smileys",
-      "order": 125
+      "order": 125,
+      "keywords": ["animal", "cat", "eye", "eyes", "face", "grin", "grinning", "smile", "smiling"]
     },
     {
       "emoji": "😹",
-      "shortcodes": ["joy_cat"],
+      "shortcodes": ["joy_cat", "tears_of_joy_cat", "cat_with_tears_of_joy"],
       "group": "smileys",
-      "order": 126
+      "order": 126,
+      "keywords": ["animal", "cat", "face", "joy", "laugh", "laughing", "lol", "tear", "tears"]
     },
     {
       "emoji": "😻",
-      "shortcodes": ["heart_eyes_cat"],
+      "shortcodes": ["heart_eyes_cat", "smiling_cat_with_heart_eyes"],
       "group": "smileys",
-      "order": 127
+      "order": 127,
+      "keywords": ["animal", "cat", "eye", "face", "heart", "heart-eyes", "love", "smile", "smiling"]
     },
     {
       "emoji": "😼",
-      "shortcodes": ["smirk_cat"],
+      "shortcodes": ["smirk_cat", "wry_smile_cat", "cat_with_wry_smile"],
       "group": "smileys",
-      "order": 128
+      "order": 128,
+      "keywords": ["animal", "cat", "face", "ironic", "smile", "wry"]
     },
     {
       "emoji": "😽",
       "shortcodes": ["kissing_cat"],
       "group": "smileys",
-      "order": 129
+      "order": 129,
+      "keywords": ["animal", "cat", "closed", "eye", "eyes", "face", "kiss", "kissing"]
     },
     {
       "emoji": "🙀",
-      "shortcodes": ["scream_cat"],
+      "shortcodes": ["scream_cat", "weary_cat"],
       "group": "smileys",
-      "order": 130
+      "order": 130,
+      "keywords": ["animal", "cat", "face", "oh", "surprised", "weary"]
     },
     {
       "emoji": "😿",
-      "shortcodes": ["crying_cat_face"],
+      "shortcodes": ["crying_cat_face", "crying_cat"],
       "group": "smileys",
-      "order": 131
+      "order": 131,
+      "keywords": ["animal", "cat", "cry", "crying", "face", "sad", "tear"]
     },
     {
       "emoji": "😾",
       "shortcodes": ["pouting_cat"],
       "group": "smileys",
-      "order": 132
+      "order": 132,
+      "keywords": ["animal", "cat", "face", "pouting"]
     },
     {
       "emoji": "🙈",
-      "shortcodes": ["see_no_evil"],
+      "shortcodes": ["see_no_evil", "see_no_evil_monkey"],
       "group": "smileys",
-      "order": 133
+      "order": 133,
+      "keywords": [
+        "embarrassed",
+        "evil",
+        "face",
+        "forbidden",
+        "forgot",
+        "gesture",
+        "hide",
+        "monkey",
+        "no",
+        "omg",
+        "prohibited",
+        "scared",
+        "secret",
+        "smh",
+        "watch"
+      ]
     },
     {
       "emoji": "🙉",
-      "shortcodes": ["hear_no_evil"],
+      "shortcodes": ["hear_no_evil", "hear_no_evil_monkey"],
       "group": "smileys",
-      "order": 134
+      "order": 134,
+      "keywords": [
+        "animal",
+        "ears",
+        "evil",
+        "face",
+        "forbidden",
+        "gesture",
+        "hear",
+        "listen",
+        "monkey",
+        "no",
+        "not",
+        "prohibited",
+        "secret",
+        "shh",
+        "tmi"
+      ]
     },
     {
       "emoji": "🙊",
-      "shortcodes": ["speak_no_evil"],
+      "shortcodes": ["speak_no_evil", "speak_no_evil_monkey"],
       "group": "smileys",
-      "order": 135
+      "order": 135,
+      "keywords": [
+        "animal",
+        "evil",
+        "face",
+        "forbidden",
+        "gesture",
+        "monkey",
+        "no",
+        "not",
+        "oops",
+        "prohibited",
+        "quiet",
+        "secret",
+        "speak",
+        "stealth"
+      ]
     },
     {
       "emoji": "💌",
       "shortcodes": ["love_letter"],
       "group": "smileys",
-      "order": 136
+      "order": 136,
+      "keywords": ["heart", "letter", "love", "mail", "romance", "valentine"]
     },
     {
       "emoji": "💘",
-      "shortcodes": ["cupid"],
+      "shortcodes": ["cupid", "heart_with_arrow"],
       "group": "smileys",
-      "order": 137
+      "order": 137,
+      "keywords": ["143", "adorbs", "arrow", "date", "emotion", "heart", "ily", "love", "romance", "valentine"]
     },
     {
       "emoji": "💝",
-      "shortcodes": ["gift_heart"],
+      "shortcodes": ["gift_heart", "heart_with_ribbon"],
       "group": "smileys",
-      "order": 138
+      "order": 138,
+      "keywords": ["143", "anniversary", "emotion", "heart", "ily", "kisses", "ribbon", "valentine", "xoxo"]
     },
     {
       "emoji": "💖",
       "shortcodes": ["sparkling_heart"],
       "group": "smileys",
-      "order": 139
+      "order": 139,
+      "keywords": [
+        "143",
+        "emotion",
+        "excited",
+        "good",
+        "heart",
+        "ily",
+        "kisses",
+        "morning",
+        "night",
+        "sparkle",
+        "sparkling",
+        "xoxo"
+      ]
     },
     {
       "emoji": "💗",
-      "shortcodes": ["heartpulse"],
+      "shortcodes": ["heartpulse", "growing_heart"],
       "group": "smileys",
-      "order": 140
+      "order": 140,
+      "keywords": ["143", "emotion", "excited", "growing", "heart", "ily", "kisses", "muah", "nervous", "pulse", "xoxo"]
     },
     {
       "emoji": "💓",
-      "shortcodes": ["heartbeat"],
+      "shortcodes": ["heartbeat", "beating_heart"],
       "group": "smileys",
-      "order": 141
+      "order": 141,
+      "keywords": ["143", "beating", "cardio", "emotion", "heart", "ily", "love", "pulsating", "pulse"]
     },
     {
       "emoji": "💞",
       "shortcodes": ["revolving_hearts"],
       "group": "smileys",
-      "order": 142
+      "order": 142,
+      "keywords": ["143", "adorbs", "anniversary", "emotion", "heart", "hearts", "revolving"]
     },
     {
       "emoji": "💕",
       "shortcodes": ["two_hearts"],
       "group": "smileys",
-      "order": 143
+      "order": 143,
+      "keywords": [
+        "143",
+        "anniversary",
+        "date",
+        "dating",
+        "emotion",
+        "heart",
+        "hearts",
+        "ily",
+        "kisses",
+        "love",
+        "loving",
+        "two",
+        "xoxo"
+      ]
     },
     {
       "emoji": "💟",
       "shortcodes": ["heart_decoration"],
       "group": "smileys",
-      "order": 144
+      "order": 144,
+      "keywords": ["143", "decoration", "emotion", "heart", "hearth", "purple", "white"]
     },
     {
       "emoji": "❣️",
-      "shortcodes": ["heavy_heart_exclamation"],
+      "shortcodes": ["heavy_heart_exclamation", "heavy_heart_exclamation_mark_ornament", "heart_exclamation"],
       "group": "smileys",
-      "order": 145
+      "order": 145,
+      "keywords": ["exclamation", "heart", "heavy", "mark", "punctuation"]
     },
     {
       "emoji": "💔",
       "shortcodes": ["broken_heart"],
       "group": "smileys",
-      "order": 147
+      "order": 147,
+      "keywords": ["break", "broken", "crushed", "emotion", "heart", "heartbroken", "lonely", "sad"]
     },
     {
       "emoji": "❤️",
       "shortcodes": ["heart", "red_heart"],
       "group": "smileys",
-      "order": 152
+      "order": 152,
+      "keywords": ["emotion", "love", "red"]
     },
     {
       "emoji": "🧡",
       "shortcodes": ["orange_heart"],
       "group": "smileys",
-      "order": 155
+      "order": 155,
+      "keywords": ["143", "heart", "orange"]
     },
     {
       "emoji": "💛",
       "shortcodes": ["yellow_heart"],
       "group": "smileys",
-      "order": 156
+      "order": 156,
+      "keywords": ["143", "cardiac", "emotion", "heart", "ily", "love", "yellow"]
     },
     {
       "emoji": "💚",
       "shortcodes": ["green_heart"],
       "group": "smileys",
-      "order": 157
+      "order": 157,
+      "keywords": ["143", "emotion", "green", "heart", "ily", "love", "romantic"]
     },
     {
       "emoji": "💙",
       "shortcodes": ["blue_heart"],
       "group": "smileys",
-      "order": 158
+      "order": 158,
+      "keywords": ["143", "blue", "emotion", "heart", "ily", "love", "romance"]
     },
     {
       "emoji": "💜",
       "shortcodes": ["purple_heart"],
       "group": "smileys",
-      "order": 160
+      "order": 160,
+      "keywords": ["143", "bestest", "emotion", "heart", "ily", "love", "purple"]
     },
     {
       "emoji": "🤎",
       "shortcodes": ["brown_heart"],
       "group": "smileys",
-      "order": 161
+      "order": 161,
+      "keywords": ["143", "brown", "heart"]
     },
     {
       "emoji": "🖤",
       "shortcodes": ["black_heart"],
       "group": "smileys",
-      "order": 162
+      "order": 162,
+      "keywords": ["black", "evil", "heart", "wicked"]
     },
     {
       "emoji": "🤍",
       "shortcodes": ["white_heart"],
       "group": "smileys",
-      "order": 164
+      "order": 164,
+      "keywords": ["143", "heart", "white"]
     },
     {
       "emoji": "💋",
-      "shortcodes": ["kiss"],
+      "shortcodes": ["kiss", "kiss_mark"],
       "group": "smileys",
-      "order": 165
+      "order": 165,
+      "keywords": ["dating", "emotion", "heart", "kissing", "lips", "mark", "romance", "sexy"]
     },
     {
       "emoji": "💯",
-      "shortcodes": ["100", "hundred", "perfect", "full_marks"],
+      "shortcodes": ["100", "hundred", "perfect", "full_marks", "hundred_points"],
       "group": "smileys",
-      "order": 166
+      "order": 166,
+      "keywords": [
+        "a+",
+        "agree",
+        "clearly",
+        "definitely",
+        "faithful",
+        "fleek",
+        "full",
+        "keep",
+        "point",
+        "score",
+        "true",
+        "truth",
+        "yup"
+      ]
     },
     {
       "emoji": "💢",
-      "shortcodes": ["anger"],
+      "shortcodes": ["anger", "anger_symbol"],
       "group": "smileys",
-      "order": 167
+      "order": 167,
+      "keywords": ["angry", "comic", "mad", "symbol", "upset"]
     },
     {
       "emoji": "💥",
       "shortcodes": ["boom", "collision"],
       "group": "smileys",
-      "order": 168
+      "order": 168,
+      "keywords": ["bomb", "collide", "comic", "explode"]
     },
     {
       "emoji": "💫",
       "shortcodes": ["dizzy"],
       "group": "smileys",
-      "order": 169
+      "order": 169,
+      "keywords": ["comic", "shining", "shooting", "star", "stars"]
     },
     {
       "emoji": "💦",
-      "shortcodes": ["sweat_drops"],
+      "shortcodes": ["sweat_drops", "sweat_droplets"],
       "group": "smileys",
-      "order": 170
+      "order": 170,
+      "keywords": [
+        "comic",
+        "drip",
+        "droplet",
+        "droplets",
+        "drops",
+        "splashing",
+        "squirt",
+        "sweat",
+        "water",
+        "wet",
+        "work",
+        "workout"
+      ]
     },
     {
       "emoji": "💨",
-      "shortcodes": ["dash"],
+      "shortcodes": ["dash", "dashing_away"],
       "group": "smileys",
-      "order": 171
+      "order": 171,
+      "keywords": ["away", "cloud", "comic", "dashing", "fart", "fast", "go", "gone", "gotta", "running", "smoke"]
     },
     {
       "emoji": "🕳️",
       "shortcodes": ["hole"],
       "group": "smileys",
-      "order": 172
+      "order": 172,
+      "keywords": []
     },
     {
       "emoji": "💬",
       "shortcodes": ["speech_balloon"],
       "group": "smileys",
-      "order": 174
+      "order": 174,
+      "keywords": ["balloon", "bubble", "comic", "dialog", "message", "sms", "speech", "talk", "text", "typing"]
     },
     {
       "emoji": "👁️‍🗨️",
-      "shortcodes": ["eye_speech_bubble"],
+      "shortcodes": ["eye_speech_bubble", "eye-in-speech-bubble", "eye_in_speech_bubble"],
       "group": "smileys",
-      "order": 175
+      "order": 175,
+      "keywords": ["balloon", "bubble", "eye", "speech", "witness"]
     },
     {
       "emoji": "🗨️",
-      "shortcodes": ["left_speech_bubble"],
+      "shortcodes": ["left_speech_bubble", "speech_left"],
       "group": "smileys",
-      "order": 179
+      "order": 179,
+      "keywords": ["balloon", "bubble", "dialog", "left", "speech"]
     },
     {
       "emoji": "🗯️",
-      "shortcodes": ["right_anger_bubble"],
+      "shortcodes": ["right_anger_bubble", "anger_right"],
       "group": "smileys",
-      "order": 181
+      "order": 181,
+      "keywords": ["anger", "angry", "balloon", "bubble", "mad", "right"]
     },
     {
       "emoji": "💭",
       "shortcodes": ["thought_balloon"],
       "group": "smileys",
-      "order": 183
+      "order": 183,
+      "keywords": [
+        "balloon",
+        "bubble",
+        "cartoon",
+        "cloud",
+        "comic",
+        "daydream",
+        "decisions",
+        "dream",
+        "idea",
+        "invent",
+        "invention",
+        "realize",
+        "think",
+        "thoughts",
+        "wonder"
+      ]
     },
     {
       "emoji": "💤",
       "shortcodes": ["zzz"],
       "group": "smileys",
-      "order": 184
+      "order": 184,
+      "keywords": ["comic", "good", "goodnight", "night", "sleep", "sleeping", "sleepy", "tired"]
     },
     {
       "emoji": "👋",
-      "shortcodes": ["wave", "hello", "hi", "bye"],
+      "shortcodes": ["wave", "hello", "hi", "bye", "waving_hand"],
       "group": "people",
-      "order": 0
+      "order": 0,
+      "keywords": ["cya", "g2g", "greetings", "gtg", "hand", "hey", "later", "outtie", "ttfn", "ttyl", "yo", "you"]
     },
     {
       "emoji": "🤚",
-      "shortcodes": ["raised_back_of_hand"],
+      "shortcodes": ["raised_back_of_hand", "back_of_hand"],
       "group": "people",
-      "order": 6
+      "order": 6,
+      "keywords": ["back", "backhand", "hand", "raised"]
     },
     {
       "emoji": "🖐️",
-      "shortcodes": ["raised_hand_with_fingers_splayed"],
+      "shortcodes": ["raised_hand_with_fingers_splayed", "hand_splayed", "hand_with_fingers_splayed"],
       "group": "people",
-      "order": 12
+      "order": 12,
+      "keywords": ["finger", "fingers", "hand", "raised", "splayed", "stop"]
     },
     {
       "emoji": "✋",
-      "shortcodes": ["hand", "raised_hand"],
+      "shortcodes": ["hand", "raised_hand", "high_five"],
       "group": "people",
-      "order": 19
+      "order": 19,
+      "keywords": ["5", "five", "high", "raised", "stop"]
     },
     {
       "emoji": "🖖",
-      "shortcodes": ["vulcan_salute"],
+      "shortcodes": ["vulcan_salute", "spock-hand", "vulcan", "raised_hand_with_part_between_middle_and_ring_fingers"],
       "group": "people",
-      "order": 25
+      "order": 25,
+      "keywords": ["finger", "hand", "hands", "salute"]
     },
     {
       "emoji": "👌",
       "shortcodes": ["ok_hand"],
       "group": "people",
-      "order": 67
+      "order": 67,
+      "keywords": [
+        "awesome",
+        "bet",
+        "dope",
+        "fleek",
+        "fosho",
+        "got",
+        "gotcha",
+        "hand",
+        "legit",
+        "ok",
+        "okay",
+        "pinch",
+        "rad",
+        "sure",
+        "sweet",
+        "three"
+      ]
     },
     {
       "emoji": "🤌",
-      "shortcodes": ["pinched_fingers"],
+      "shortcodes": ["pinched_fingers", "pinch"],
       "group": "people",
-      "order": 73
+      "order": 73,
+      "keywords": [
+        "fingers",
+        "gesture",
+        "hand",
+        "hold",
+        "huh",
+        "interrogation",
+        "patience",
+        "pinched",
+        "relax",
+        "sarcastic",
+        "ugh",
+        "what",
+        "zip"
+      ]
     },
     {
       "emoji": "🤏",
       "shortcodes": ["pinching_hand"],
       "group": "people",
-      "order": 79
+      "order": 79,
+      "keywords": ["amount", "bit", "fingers", "hand", "little", "pinching", "small", "sort"]
     },
     {
       "emoji": "✌️",
-      "shortcodes": ["v"],
+      "shortcodes": ["v", "victory", "victory_hand"],
       "group": "people",
-      "order": 85
+      "order": 85,
+      "keywords": ["hand", "peace"]
     },
     {
       "emoji": "🤞",
-      "shortcodes": ["crossed_fingers"],
+      "shortcodes": [
+        "crossed_fingers",
+        "hand_with_index_and_middle_fingers_crossed",
+        "fingers_crossed",
+        "hand_with_index_and_middle_finger_crossed"
+      ],
       "group": "people",
-      "order": 92
+      "order": 92,
+      "keywords": ["cross", "crossed", "finger", "fingers", "hand", "luck"]
     },
     {
       "emoji": "🤟",
-      "shortcodes": ["love_you_gesture"],
+      "shortcodes": ["love_you_gesture", "i_love_you_hand_sign"],
       "group": "people",
-      "order": 104
+      "order": 104,
+      "keywords": ["fingers", "gesture", "hand", "ily", "love", "love-you", "three", "you"]
     },
     {
       "emoji": "🤘",
-      "shortcodes": ["metal"],
+      "shortcodes": ["metal", "the_horns", "sign_of_the_horns"],
       "group": "people",
-      "order": 110
+      "order": 110,
+      "keywords": ["finger", "hand", "horns", "rock-on", "sign"]
     },
     {
       "emoji": "🤙",
-      "shortcodes": ["call_me_hand"],
+      "shortcodes": ["call_me_hand", "call_me"],
       "group": "people",
-      "order": 116
+      "order": 116,
+      "keywords": ["call", "hand", "hang", "loose", "me", "shaka"]
     },
     {
       "emoji": "👈",
-      "shortcodes": ["point_left"],
+      "shortcodes": ["point_left", "backhand_index_pointing_left"],
       "group": "people",
-      "order": 122
+      "order": 122,
+      "keywords": ["backhand", "finger", "hand", "index", "left", "point", "pointing"]
     },
     {
       "emoji": "👉",
-      "shortcodes": ["point_right"],
+      "shortcodes": ["point_right", "backhand_index_pointing_right"],
       "group": "people",
-      "order": 128
+      "order": 128,
+      "keywords": ["backhand", "finger", "hand", "index", "point", "pointing", "right"]
     },
     {
       "emoji": "👆",
-      "shortcodes": ["point_up_2"],
+      "shortcodes": ["point_up_2", "backhand_index_pointing_up"],
       "group": "people",
-      "order": 134
+      "order": 134,
+      "keywords": ["backhand", "finger", "hand", "index", "point", "pointing", "up"]
     },
     {
       "emoji": "🖕",
-      "shortcodes": ["middle_finger"],
+      "shortcodes": ["middle_finger", "fu", "reversed_hand_with_middle_finger_extended"],
       "group": "people",
-      "order": 140
+      "order": 140,
+      "keywords": ["finger", "hand", "middle"]
     },
     {
       "emoji": "👇",
-      "shortcodes": ["point_down"],
+      "shortcodes": ["point_down", "backhand_index_pointing_down"],
       "group": "people",
-      "order": 146
+      "order": 146,
+      "keywords": ["backhand", "down", "finger", "hand", "index", "point", "pointing"]
     },
     {
       "emoji": "☝️",
-      "shortcodes": ["point_up"],
+      "shortcodes": ["point_up", "index_pointing_up"],
       "group": "people",
-      "order": 152
+      "order": 152,
+      "keywords": ["finger", "hand", "index", "point", "pointing", "this", "up"]
     },
     {
       "emoji": "👍",
-      "shortcodes": ["+1", "thumbsup"],
+      "shortcodes": ["+1", "thumbsup", "thumbup", "thumbs_up"],
       "group": "people",
-      "order": 165
+      "order": 165,
+      "keywords": ["good", "hand", "like", "thumb", "up", "yes"]
     },
     {
       "emoji": "👎",
-      "shortcodes": ["-1", "thumbsdown"],
+      "shortcodes": ["-1", "thumbsdown", "thumbdown", "thumbs_down"],
       "group": "people",
-      "order": 171
+      "order": 171,
+      "keywords": ["bad", "dislike", "down", "good", "hand", "no", "nope", "thumb", "thumbs"]
     },
     {
       "emoji": "✊",
-      "shortcodes": ["fist_raised", "fist"],
+      "shortcodes": ["fist_raised", "fist", "raised_fist"],
       "group": "people",
-      "order": 177
+      "order": 177,
+      "keywords": ["clenched", "hand", "punch", "raised", "solidarity"]
     },
     {
       "emoji": "👊",
-      "shortcodes": ["fist_oncoming", "facepunch", "punch"],
+      "shortcodes": ["fist_oncoming", "facepunch", "punch", "oncoming_fist"],
       "group": "people",
-      "order": 183
+      "order": 183,
+      "keywords": [
+        "absolutely",
+        "agree",
+        "boom",
+        "bro",
+        "bruh",
+        "bump",
+        "clenched",
+        "correct",
+        "fist",
+        "hand",
+        "knuckle",
+        "oncoming",
+        "pound",
+        "rock",
+        "ttyl"
+      ]
     },
     {
       "emoji": "🤛",
-      "shortcodes": ["fist_left"],
+      "shortcodes": ["fist_left", "left-facing_fist", "left_facing_fist", "left_fist"],
       "group": "people",
-      "order": 189
+      "order": 189,
+      "keywords": ["fist", "left-facing", "leftwards"]
     },
     {
       "emoji": "🤜",
-      "shortcodes": ["fist_right"],
+      "shortcodes": ["fist_right", "right-facing_fist", "right_facing_fist", "right_fist"],
       "group": "people",
-      "order": 195
+      "order": 195,
+      "keywords": ["fist", "right-facing", "rightwards"]
     },
     {
       "emoji": "👏",
-      "shortcodes": ["clap", "clapping", "applause"],
+      "shortcodes": ["clap", "clapping", "applause", "clapping_hands"],
       "group": "people",
-      "order": 201
+      "order": 201,
+      "keywords": [
+        "approval",
+        "awesome",
+        "congrats",
+        "congratulations",
+        "excited",
+        "good",
+        "great",
+        "hand",
+        "homie",
+        "job",
+        "nice",
+        "prayed",
+        "well",
+        "yay"
+      ]
     },
     {
       "emoji": "🙌",
-      "shortcodes": ["raised_hands", "praise"],
+      "shortcodes": ["raised_hands", "praise", "raising_hands"],
       "group": "people",
-      "order": 207
+      "order": 207,
+      "keywords": ["celebration", "gesture", "hand", "hands", "hooray", "raised", "raising"]
     },
     {
       "emoji": "👐",
       "shortcodes": ["open_hands"],
       "group": "people",
-      "order": 219
+      "order": 219,
+      "keywords": ["hand", "hands", "hug", "jazz", "open", "swerve"]
     },
     {
       "emoji": "🤲",
       "shortcodes": ["palms_up_together"],
       "group": "people",
-      "order": 225
+      "order": 225,
+      "keywords": ["cupped", "dua", "hands", "palms", "pray", "prayer", "together", "up", "wish"]
     },
     {
       "emoji": "🤝",
-      "shortcodes": ["handshake", "handshake_deal", "agreement"],
+      "shortcodes": ["handshake", "handshake_deal", "agreement", "shaking_hands"],
       "group": "people",
-      "order": 231
+      "order": 231,
+      "keywords": ["deal", "hand", "meeting", "shake"]
     },
     {
       "emoji": "🙏",
-      "shortcodes": ["pray", "please", "thanks", "thank_you"],
+      "shortcodes": ["pray", "please", "thanks", "thank_you", "folded_hands"],
       "group": "people",
-      "order": 257
+      "order": 257,
+      "keywords": [
+        "appreciate",
+        "ask",
+        "beg",
+        "blessed",
+        "bow",
+        "cmon",
+        "five",
+        "folded",
+        "gesture",
+        "hand",
+        "high",
+        "thx"
+      ]
     },
     {
       "emoji": "✍️",
       "shortcodes": ["writing_hand"],
       "group": "people",
-      "order": 263
+      "order": 263,
+      "keywords": ["hand", "write", "writing"]
     },
     {
       "emoji": "💅",
-      "shortcodes": ["nail_care"],
+      "shortcodes": ["nail_care", "nail_polish"],
       "group": "people",
-      "order": 270
+      "order": 270,
+      "keywords": ["bored", "care", "cosmetics", "done", "makeup", "manicure", "nail", "polish", "whatever"]
     },
     {
       "emoji": "🤳",
       "shortcodes": ["selfie"],
       "group": "people",
-      "order": 276
+      "order": 276,
+      "keywords": ["camera", "phone"]
     },
     {
       "emoji": "💪",
-      "shortcodes": ["muscle", "strong", "flex"],
+      "shortcodes": ["muscle", "strong", "flex", "right_bicep", "flexed_biceps"],
       "group": "people",
-      "order": 282
+      "order": 282,
+      "keywords": [
+        "arm",
+        "beast",
+        "bench",
+        "biceps",
+        "bodybuilder",
+        "bro",
+        "curls",
+        "gains",
+        "gym",
+        "jacked",
+        "press",
+        "ripped",
+        "weightlift"
+      ]
     },
     {
       "emoji": "🦾",
       "shortcodes": ["mechanical_arm"],
       "group": "people",
-      "order": 288
+      "order": 288,
+      "keywords": ["accessibility", "arm", "mechanical", "prosthetic"]
     },
     {
       "emoji": "🦿",
       "shortcodes": ["mechanical_leg"],
       "group": "people",
-      "order": 289
+      "order": 289,
+      "keywords": ["accessibility", "leg", "mechanical", "prosthetic"]
     },
     {
       "emoji": "🦵",
       "shortcodes": ["leg"],
       "group": "people",
-      "order": 290
+      "order": 290,
+      "keywords": ["bent", "foot", "kick", "knee", "limb"]
     },
     {
       "emoji": "🦶",
       "shortcodes": ["foot"],
       "group": "people",
-      "order": 296
+      "order": 296,
+      "keywords": ["ankle", "feet", "kick", "stomp"]
     },
     {
       "emoji": "👂",
       "shortcodes": ["ear"],
       "group": "people",
-      "order": 302
+      "order": 302,
+      "keywords": ["body", "ears", "hear", "hearing", "listen", "listening", "sound"]
     },
     {
       "emoji": "🦻",
-      "shortcodes": ["ear_with_hearing_aid"],
+      "shortcodes": ["ear_with_hearing_aid", "hearing_aid"],
       "group": "people",
-      "order": 308
+      "order": 308,
+      "keywords": ["accessibility", "aid", "ear", "hard", "hearing"]
     },
     {
       "emoji": "👃",
       "shortcodes": ["nose"],
       "group": "people",
-      "order": 314
+      "order": 314,
+      "keywords": ["body", "noses", "nosey", "odor", "smell", "smells"]
     },
     {
       "emoji": "🧠",
       "shortcodes": ["brain"],
       "group": "people",
-      "order": 320
+      "order": 320,
+      "keywords": ["intelligent", "smart"]
     },
     {
       "emoji": "🫀",
       "shortcodes": ["anatomical_heart"],
       "group": "people",
-      "order": 321
+      "order": 321,
+      "keywords": ["anatomical", "beat", "cardiology", "heart", "heartbeat", "organ", "pulse", "real", "red"]
     },
     {
       "emoji": "🫁",
       "shortcodes": ["lungs"],
       "group": "people",
-      "order": 322
+      "order": 322,
+      "keywords": ["breath", "breathe", "exhalation", "inhalation", "lung", "organ", "respiration"]
     },
     {
       "emoji": "🦷",
       "shortcodes": ["tooth"],
       "group": "people",
-      "order": 323
+      "order": 323,
+      "keywords": ["dentist", "pearly", "teeth", "white"]
     },
     {
       "emoji": "🦴",
       "shortcodes": ["bone"],
       "group": "people",
-      "order": 324
+      "order": 324,
+      "keywords": ["bones", "dog", "skeleton", "wishbone"]
     },
     {
       "emoji": "👀",
       "shortcodes": ["eyes", "looking", "watching"],
       "group": "people",
-      "order": 325
+      "order": 325,
+      "keywords": ["body", "eye", "face", "googly", "look", "omg", "peep", "see", "seeing"]
     },
     {
       "emoji": "👁️",
       "shortcodes": ["eye"],
       "group": "people",
-      "order": 326
+      "order": 326,
+      "keywords": ["1", "body", "one"]
     },
     {
       "emoji": "👅",
       "shortcodes": ["tongue"],
       "group": "people",
-      "order": 328
+      "order": 328,
+      "keywords": ["body", "lick", "slurp"]
     },
     {
       "emoji": "👄",
-      "shortcodes": ["lips"],
+      "shortcodes": ["lips", "mouth"],
       "group": "people",
-      "order": 329
+      "order": 329,
+      "keywords": ["beauty", "body", "kiss", "kissing", "lipstick"]
     },
     {
       "emoji": "👶",
       "shortcodes": ["baby"],
       "group": "people",
-      "order": 331
+      "order": 331,
+      "keywords": ["babies", "children", "goo", "infant", "newborn", "pregnant", "young"]
     },
     {
       "emoji": "👦",
       "shortcodes": ["boy"],
       "group": "people",
-      "order": 343
+      "order": 343,
+      "keywords": ["bright-eyed", "child", "grandson", "kid", "son", "young", "younger"]
     },
     {
       "emoji": "👧",
       "shortcodes": ["girl"],
       "group": "people",
-      "order": 349
+      "order": 349,
+      "keywords": ["bright-eyed", "child", "daughter", "granddaughter", "kid", "virgo", "young", "younger", "zodiac"]
     },
     {
       "emoji": "🧑",
-      "shortcodes": ["adult"],
+      "shortcodes": ["adult", "person"],
       "group": "people",
-      "order": 355
+      "order": 355,
+      "keywords": []
     },
     {
       "emoji": "👱",
-      "shortcodes": ["person_blond_hair"],
+      "shortcodes": ["person_blond_hair", "blond_haired_person", "person_with_blond_hair", "blond_haired"],
       "group": "people",
-      "order": 361
+      "order": 361,
+      "keywords": ["blond", "human", "person", "person: blond hair"]
     },
     {
       "emoji": "👨",
       "shortcodes": ["man"],
       "group": "people",
-      "order": 367
+      "order": 367,
+      "keywords": ["adult", "bro"]
     },
     {
       "emoji": "🧔",
-      "shortcodes": ["bearded_person"],
+      "shortcodes": ["bearded_person", "person_bearded", "person_beard"],
       "group": "people",
-      "order": 373
+      "order": 373,
+      "keywords": ["beard", "bearded", "person", "whiskers", "person: beard"]
     },
     {
       "emoji": "👩",
       "shortcodes": ["woman"],
       "group": "people",
-      "order": 427
+      "order": 427,
+      "keywords": ["adult", "lady"]
     },
     {
       "emoji": "🧓",
-      "shortcodes": ["older_adult"],
+      "shortcodes": ["older_adult", "older_person"],
       "group": "people",
-      "order": 505
+      "order": 505,
+      "keywords": ["adult", "elderly", "grandparent", "old", "person", "wise"]
     },
     {
       "emoji": "👴",
-      "shortcodes": ["older_man"],
+      "shortcodes": ["older_man", "old_man"],
       "group": "people",
-      "order": 511
+      "order": 511,
+      "keywords": ["adult", "bald", "elderly", "gramps", "grandfather", "grandpa", "man", "old", "wise"]
     },
     {
       "emoji": "👵",
-      "shortcodes": ["older_woman"],
+      "shortcodes": ["older_woman", "grandma", "old_woman"],
       "group": "people",
-      "order": 517
+      "order": 517,
+      "keywords": ["adult", "elderly", "grandmother", "granny", "lady", "old", "wise", "woman"]
     },
     {
       "emoji": "🙍",
-      "shortcodes": ["person_frowning"],
+      "shortcodes": ["person_frowning", "frowning_person"],
       "group": "people",
-      "order": 523
+      "order": 523,
+      "keywords": [
+        "annoyed",
+        "disappointed",
+        "disgruntled",
+        "disturbed",
+        "frown",
+        "frowning",
+        "frustrated",
+        "gesture",
+        "irritated",
+        "person",
+        "upset"
+      ]
     },
     {
       "emoji": "🙎",
-      "shortcodes": ["person_pouting"],
+      "shortcodes": ["person_pouting", "pouting_face", "person_with_pouting_face", "pouting"],
       "group": "people",
-      "order": 553
+      "order": 553,
+      "keywords": ["disappointed", "downtrodden", "frown", "grimace", "person", "scowl", "sulk", "upset", "whine"]
     },
     {
       "emoji": "🙅",
-      "shortcodes": ["no_good"],
+      "shortcodes": ["no_good", "person_gesturing_no"],
       "group": "people",
-      "order": 583
+      "order": 583,
+      "keywords": ["forbidden", "gesture", "hand", "no", "not", "person", "prohibit"]
     },
     {
       "emoji": "🙆",
-      "shortcodes": ["ok_woman"],
+      "shortcodes": ["ok_woman", "ok_person", "all_good", "person_gesturing_ok"],
       "group": "people",
-      "order": 613
+      "order": 613,
+      "keywords": ["exercise", "gesture", "gesturing", "hand", "ok", "omg", "person"]
     },
     {
       "emoji": "💁",
-      "shortcodes": ["information_desk_person", "tipping_hand_person"],
+      "shortcodes": ["information_desk_person", "tipping_hand_person", "person_tipping_hand"],
       "group": "people",
-      "order": 643
+      "order": 643,
+      "keywords": [
+        "fetch",
+        "flick",
+        "flip",
+        "gossip",
+        "hand",
+        "person",
+        "sarcasm",
+        "sarcastic",
+        "sassy",
+        "seriously",
+        "tipping",
+        "whatever"
+      ]
     },
     {
       "emoji": "🙋",
-      "shortcodes": ["raising_hand"],
+      "shortcodes": ["raising_hand", "person_raising_hand"],
       "group": "people",
-      "order": 673
+      "order": 673,
+      "keywords": ["gesture", "hand", "here", "know", "me", "person", "pick", "question", "raise", "raising"]
     },
     {
       "emoji": "🧏",
       "shortcodes": ["deaf_person"],
       "group": "people",
-      "order": 703
+      "order": 703,
+      "keywords": ["accessibility", "deaf", "ear", "gesture", "hear", "person"]
     },
     {
       "emoji": "🙇",
-      "shortcodes": ["bow"],
+      "shortcodes": ["bow", "person_bowing"],
       "group": "people",
-      "order": 733
+      "order": 733,
+      "keywords": [
+        "apology",
+        "ask",
+        "beg",
+        "bowing",
+        "favor",
+        "forgive",
+        "gesture",
+        "meditate",
+        "meditation",
+        "person",
+        "pity",
+        "regret",
+        "sorry"
+      ]
     },
     {
       "emoji": "🤦",
-      "shortcodes": ["facepalm"],
+      "shortcodes": ["facepalm", "face_palm", "person_facepalming"],
       "group": "people",
-      "order": 763
+      "order": 763,
+      "keywords": ["again", "bewilder", "disbelief", "exasperation", "no", "not", "oh", "omg", "person", "shock", "smh"]
     },
     {
       "emoji": "🤷",
-      "shortcodes": ["shrug", "shrug_person"],
+      "shortcodes": ["shrug", "shrug_person", "person_shrugging"],
       "group": "people",
-      "order": 793
+      "order": 793,
+      "keywords": [
+        "doubt",
+        "dunno",
+        "guess",
+        "idk",
+        "ignorance",
+        "indifference",
+        "knows",
+        "maybe",
+        "person",
+        "shrugging",
+        "whatever",
+        "who"
+      ]
     },
     {
       "emoji": "👮",
-      "shortcodes": ["cop"],
+      "shortcodes": ["cop", "police_officer"],
       "group": "people",
-      "order": 1165
+      "order": 1165,
+      "keywords": ["apprehend", "arrest", "citation", "law", "officer", "over", "police", "pulled", "undercover"]
     },
     {
       "emoji": "🕵️",
-      "shortcodes": ["detective"],
+      "shortcodes": ["detective", "sleuth_or_spy", "spy"],
       "group": "people",
-      "order": 1195
+      "order": 1195,
+      "keywords": ["sleuth"]
     },
     {
       "emoji": "💂",
-      "shortcodes": ["guardsman"],
+      "shortcodes": ["guardsman", "guard"],
       "group": "people",
-      "order": 1230
+      "order": 1230,
+      "keywords": ["buckingham", "helmet", "london", "palace"]
     },
     {
       "emoji": "🥷",
       "shortcodes": ["ninja"],
       "group": "people",
-      "order": 1260
+      "order": 1260,
+      "keywords": [
+        "assassin",
+        "fight",
+        "fighter",
+        "hidden",
+        "person",
+        "secret",
+        "skills",
+        "sly",
+        "soldier",
+        "stealth",
+        "war"
+      ]
     },
     {
       "emoji": "👷",
       "shortcodes": ["construction_worker"],
       "group": "people",
-      "order": 1266
+      "order": 1266,
+      "keywords": [
+        "build",
+        "construction",
+        "fix",
+        "hardhat",
+        "hat",
+        "man",
+        "person",
+        "rebuild",
+        "remodel",
+        "repair",
+        "work",
+        "worker"
+      ]
     },
     {
       "emoji": "🤴",
       "shortcodes": ["prince"],
       "group": "people",
-      "order": 1302
+      "order": 1302,
+      "keywords": ["crown", "fairy", "fairytale", "fantasy", "king", "royal", "royalty", "tale"]
     },
     {
       "emoji": "👸",
       "shortcodes": ["princess"],
       "group": "people",
-      "order": 1308
+      "order": 1308,
+      "keywords": ["crown", "fairy", "fairytale", "fantasy", "queen", "royal", "royalty", "tale"]
     },
     {
       "emoji": "👳",
-      "shortcodes": ["person_with_turban"],
+      "shortcodes": ["person_with_turban", "man_with_turban", "person_wearing_turban"],
       "group": "people",
-      "order": 1314
+      "order": 1314,
+      "keywords": ["person", "turban", "wearing"]
     },
     {
       "emoji": "👲",
-      "shortcodes": ["man_with_gua_pi_mao"],
+      "shortcodes": ["man_with_gua_pi_mao", "person_with_skullcap", "man_with_chinese_cap"],
       "group": "people",
-      "order": 1344
+      "order": 1344,
+      "keywords": ["cap", "chinese", "gua", "guapi", "hat", "mao", "person", "pi", "skullcap"]
     },
     {
       "emoji": "🧕",
-      "shortcodes": ["woman_with_headscarf"],
+      "shortcodes": ["woman_with_headscarf", "person_with_headscarf"],
       "group": "people",
-      "order": 1350
+      "order": 1350,
+      "keywords": ["bandana", "head", "headscarf", "hijab", "kerchief", "mantilla", "tichel", "woman"]
     },
     {
       "emoji": "🤵",
       "shortcodes": ["person_in_tuxedo"],
       "group": "people",
-      "order": 1356
+      "order": 1356,
+      "keywords": ["formal", "person", "tuxedo", "wedding"]
     },
     {
       "emoji": "👰",
-      "shortcodes": ["bride_with_veil"],
+      "shortcodes": ["bride_with_veil", "person_with_veil"],
       "group": "people",
-      "order": 1386
+      "order": 1386,
+      "keywords": ["person", "veil", "wedding"]
     },
     {
       "emoji": "🤰",
-      "shortcodes": ["pregnant_woman"],
+      "shortcodes": ["pregnant_woman", "expecting_woman"],
       "group": "people",
-      "order": 1416
+      "order": 1416,
+      "keywords": ["pregnant", "woman"]
     },
     {
       "emoji": "🤱",
-      "shortcodes": ["breast_feeding"],
+      "shortcodes": ["breast_feeding", "breast-feeding"],
       "group": "people",
-      "order": 1434
+      "order": 1434,
+      "keywords": ["baby", "breast", "feeding", "mom", "mother", "nursing", "woman"]
     },
     {
       "emoji": "👼",
-      "shortcodes": ["angel"],
+      "shortcodes": ["angel", "baby_angel"],
       "group": "people",
-      "order": 1458
+      "order": 1458,
+      "keywords": ["baby", "church", "face", "fairy", "fairytale", "fantasy", "tale"]
     },
     {
       "emoji": "🎅",
-      "shortcodes": ["santa"],
+      "shortcodes": ["santa", "santa_claus"],
       "group": "people",
-      "order": 1464
+      "order": 1464,
+      "keywords": [
+        "celebration",
+        "christmas",
+        "claus",
+        "fairy",
+        "fantasy",
+        "father",
+        "holiday",
+        "merry",
+        "tale",
+        "xmas"
+      ]
     },
     {
       "emoji": "🤶",
-      "shortcodes": ["mrs_claus"],
+      "shortcodes": ["mrs_claus", "mother_christmas"],
       "group": "people",
-      "order": 1470
+      "order": 1470,
+      "keywords": [
+        "celebration",
+        "christmas",
+        "claus",
+        "fairy",
+        "fantasy",
+        "holiday",
+        "merry",
+        "mother",
+        "mrs",
+        "santa",
+        "tale",
+        "xmas",
+        "mrs. claus"
+      ]
     },
     {
       "emoji": "🦸",
       "shortcodes": ["superhero"],
       "group": "people",
-      "order": 1482
+      "order": 1482,
+      "keywords": ["good", "hero", "superpower"]
     },
     {
       "emoji": "🦹",
       "shortcodes": ["supervillain"],
       "group": "people",
-      "order": 1512
+      "order": 1512,
+      "keywords": ["bad", "criminal", "evil", "superpower", "villain"]
     },
     {
       "emoji": "🧙",
       "shortcodes": ["mage"],
       "group": "people",
-      "order": 1542
+      "order": 1542,
+      "keywords": ["fantasy", "magic", "play", "sorcerer", "sorceress", "sorcery", "spell", "summon", "witch", "wizard"]
     },
     {
       "emoji": "🧚",
       "shortcodes": ["fairy"],
       "group": "people",
-      "order": 1572
+      "order": 1572,
+      "keywords": ["fairytale", "fantasy", "myth", "person", "pixie", "tale", "wings"]
     },
     {
       "emoji": "🧛",
       "shortcodes": ["vampire"],
       "group": "people",
-      "order": 1602
+      "order": 1602,
+      "keywords": ["blood", "dracula", "fangs", "halloween", "scary", "supernatural", "teeth", "undead"]
     },
     {
       "emoji": "🧜",
       "shortcodes": ["merperson"],
       "group": "people",
-      "order": 1632
+      "order": 1632,
+      "keywords": ["creature", "fairytale", "folklore", "ocean", "sea", "siren", "trident"]
     },
     {
       "emoji": "🧝",
       "shortcodes": ["elf"],
       "group": "people",
-      "order": 1662
+      "order": 1662,
+      "keywords": ["elves", "enchantment", "fantasy", "folklore", "magic", "magical", "myth"]
     },
     {
       "emoji": "🧞",
       "shortcodes": ["genie"],
       "group": "people",
-      "order": 1692
+      "order": 1692,
+      "keywords": ["djinn", "fantasy", "jinn", "lamp", "myth", "rub", "wishes"]
     },
     {
       "emoji": "🧟",
       "shortcodes": ["zombie"],
       "group": "people",
-      "order": 1697
+      "order": 1697,
+      "keywords": ["apocalypse", "dead", "halloween", "horror", "scary", "undead", "walking"]
     },
     {
       "emoji": "💆",
-      "shortcodes": ["massage"],
+      "shortcodes": ["massage", "person_getting_massage"],
       "group": "people",
-      "order": 1703
+      "order": 1703,
+      "keywords": [
+        "face",
+        "getting",
+        "headache",
+        "person",
+        "relax",
+        "relaxing",
+        "salon",
+        "soothe",
+        "spa",
+        "tension",
+        "therapy",
+        "treatment"
+      ]
     },
     {
       "emoji": "💇",
-      "shortcodes": ["haircut"],
+      "shortcodes": ["haircut", "person_getting_haircut"],
       "group": "people",
-      "order": 1733
+      "order": 1733,
+      "keywords": [
+        "barber",
+        "beauty",
+        "chop",
+        "cosmetology",
+        "cut",
+        "groom",
+        "hair",
+        "parlor",
+        "person",
+        "shears",
+        "style"
+      ]
     },
     {
       "emoji": "🚶",
-      "shortcodes": ["walking"],
+      "shortcodes": ["walking", "person_walking"],
       "group": "people",
-      "order": 1763
+      "order": 1763,
+      "keywords": ["amble", "gait", "hike", "man", "pace", "pedestrian", "person", "stride", "stroll", "walk"]
     },
     {
       "emoji": "🧍",
-      "shortcodes": ["standing_person"],
+      "shortcodes": ["standing_person", "person_standing", "standing"],
       "group": "people",
-      "order": 1853
+      "order": 1853,
+      "keywords": ["person", "stand"]
     },
     {
       "emoji": "🧎",
-      "shortcodes": ["kneeling_person"],
+      "shortcodes": ["kneeling_person", "kneeling", "person_kneeling"],
       "group": "people",
-      "order": 1883
+      "order": 1883,
+      "keywords": ["kneel", "knees", "person"]
     },
     {
       "emoji": "🧑‍🦯",
-      "shortcodes": ["person_with_probing_cane"],
+      "shortcodes": ["person_with_probing_cane", "person_with_white_cane"],
       "group": "people",
-      "order": 1973
+      "order": 1973,
+      "keywords": ["accessibility", "blind", "cane", "person", "probing", "white"]
     },
     {
       "emoji": "🧑‍🦼",
       "shortcodes": ["person_in_motorized_wheelchair"],
       "group": "people",
-      "order": 2027
+      "order": 2027,
+      "keywords": ["accessibility", "motorized", "person", "wheelchair"]
     },
     {
       "emoji": "🧑‍🦽",
       "shortcodes": ["person_in_manual_wheelchair"],
       "group": "people",
-      "order": 2081
+      "order": 2081,
+      "keywords": ["accessibility", "manual", "person", "wheelchair"]
     },
     {
       "emoji": "🏃",
-      "shortcodes": ["runner", "running"],
+      "shortcodes": ["runner", "running", "person_running"],
       "group": "people",
-      "order": 2135
+      "order": 2135,
+      "keywords": ["fast", "hurry", "marathon", "move", "person", "quick", "race", "racing", "run", "rush", "speed"]
     },
     {
       "emoji": "💃",
-      "shortcodes": ["dancer"],
+      "shortcodes": ["dancer", "woman_dancing"],
       "group": "people",
-      "order": 2225
+      "order": 2225,
+      "keywords": [
+        "dance",
+        "dancing",
+        "elegant",
+        "festive",
+        "flair",
+        "flamenco",
+        "groove",
+        "let’s",
+        "salsa",
+        "tango",
+        "woman"
+      ]
     },
     {
       "emoji": "🕺",
-      "shortcodes": ["man_dancing"],
+      "shortcodes": ["man_dancing", "male_dancer"],
       "group": "people",
-      "order": 2231
+      "order": 2231,
+      "keywords": [
+        "dance",
+        "dancer",
+        "dancing",
+        "elegant",
+        "festive",
+        "flair",
+        "flamenco",
+        "groove",
+        "let’s",
+        "man",
+        "salsa",
+        "tango"
+      ]
     },
     {
       "emoji": "🕴️",
-      "shortcodes": ["person_in_suit_levitating"],
+      "shortcodes": [
+        "person_in_suit_levitating",
+        "business_suit_levitating",
+        "man_in_business_suit_levitating",
+        "levitate",
+        "levitating"
+      ],
       "group": "people",
-      "order": 2237
+      "order": 2237,
+      "keywords": ["business", "person", "suit"]
     },
     {
       "emoji": "👯",
-      "shortcodes": ["dancers"],
+      "shortcodes": ["dancers", "people_with_bunny_ears_partying", "people_with_bunny_ears"],
       "group": "people",
-      "order": 2244
+      "order": 2244,
+      "keywords": [
+        "bestie",
+        "bff",
+        "bunny",
+        "counterpart",
+        "dancer",
+        "double",
+        "ear",
+        "identical",
+        "pair",
+        "party",
+        "partying",
+        "people",
+        "soulmate",
+        "twin",
+        "twinsies"
+      ]
     },
     {
       "emoji": "🧖",
-      "shortcodes": ["sauna_person"],
+      "shortcodes": ["sauna_person", "person_in_steamy_room"],
       "group": "people",
-      "order": 2249
+      "order": 2249,
+      "keywords": [
+        "day",
+        "luxurious",
+        "pamper",
+        "person",
+        "relax",
+        "room",
+        "sauna",
+        "spa",
+        "steam",
+        "steambath",
+        "unwind"
+      ]
     },
     {
       "emoji": "🧗",
-      "shortcodes": ["climbing"],
+      "shortcodes": ["climbing", "person_climbing"],
       "group": "people",
-      "order": 2279
+      "order": 2279,
+      "keywords": ["climb", "climber", "mountain", "person", "rock", "scale", "up"]
     },
     {
       "emoji": "🤺",
-      "shortcodes": ["person_fencing"],
+      "shortcodes": ["person_fencing", "fencer", "fencing"],
       "group": "people",
-      "order": 2309
+      "order": 2309,
+      "keywords": ["person", "sword"]
     },
     {
       "emoji": "🏇",
       "shortcodes": ["horse_racing"],
       "group": "people",
-      "order": 2310
+      "order": 2310,
+      "keywords": ["horse", "jockey", "racehorse", "racing", "riding", "sport"]
     },
     {
       "emoji": "⛷️",
-      "shortcodes": ["skier"],
+      "shortcodes": ["skier", "person_skiing", "skiing"],
       "group": "people",
-      "order": 2316
+      "order": 2316,
+      "keywords": ["ski", "snow"]
     },
     {
       "emoji": "🏂",
-      "shortcodes": ["snowboarder"],
+      "shortcodes": ["snowboarder", "person_snowboarding", "snowboarding"],
       "group": "people",
-      "order": 2318
+      "order": 2318,
+      "keywords": ["ski", "snow", "snowboard", "sport"]
     },
     {
       "emoji": "🏌️",
-      "shortcodes": ["golfing"],
+      "shortcodes": ["golfing", "golfer", "person_golfing"],
       "group": "people",
-      "order": 2324
+      "order": 2324,
+      "keywords": ["ball", "birdie", "caddy", "driving", "golf", "green", "person", "pga", "putt", "range", "tee"]
     },
     {
       "emoji": "🏄",
-      "shortcodes": ["surfer"],
+      "shortcodes": ["surfer", "person_surfing", "surfing"],
       "group": "people",
-      "order": 2359
+      "order": 2359,
+      "keywords": ["beach", "ocean", "person", "sport", "surf", "swell", "waves"]
     },
     {
       "emoji": "🚣",
-      "shortcodes": ["rowboat"],
+      "shortcodes": ["rowboat", "person_rowing_boat"],
       "group": "people",
-      "order": 2389
+      "order": 2389,
+      "keywords": [
+        "boat",
+        "canoe",
+        "cruise",
+        "fishing",
+        "lake",
+        "oar",
+        "paddle",
+        "person",
+        "raft",
+        "river",
+        "row",
+        "rowing"
+      ]
     },
     {
       "emoji": "🏊",
-      "shortcodes": ["swimmer"],
+      "shortcodes": ["swimmer", "person_swimming", "swimming"],
       "group": "people",
-      "order": 2419
+      "order": 2419,
+      "keywords": ["freestyle", "person", "sport", "swim", "triathlon"]
     },
     {
       "emoji": "⛹️",
-      "shortcodes": ["bouncing_ball_person"],
+      "shortcodes": ["bouncing_ball_person", "person_with_ball", "person_bouncing_ball", "basketball_player"],
       "group": "people",
-      "order": 2449
+      "order": 2449,
+      "keywords": [
+        "athletic",
+        "ball",
+        "basketball",
+        "bouncing",
+        "championship",
+        "dribble",
+        "net",
+        "person",
+        "player",
+        "throw"
+      ]
     },
     {
       "emoji": "🏋️",
-      "shortcodes": ["weight_lifting"],
+      "shortcodes": ["weight_lifting", "weight_lifter", "person_lifting_weights", "lifter"],
       "group": "people",
-      "order": 2484
+      "order": 2484,
+      "keywords": [
+        "barbell",
+        "bodybuilder",
+        "deadlift",
+        "lifting",
+        "person",
+        "powerlifting",
+        "weight",
+        "weights",
+        "workout"
+      ]
     },
     {
       "emoji": "🚴",
-      "shortcodes": ["bicyclist"],
+      "shortcodes": ["bicyclist", "biking", "person_biking"],
       "group": "people",
-      "order": 2519
+      "order": 2519,
+      "keywords": ["bicycle", "bike", "cycle", "cyclist", "person", "riding", "sport"]
     },
     {
       "emoji": "🚵",
-      "shortcodes": ["mountain_bicyclist"],
+      "shortcodes": ["mountain_bicyclist", "mountain_biking", "person_mountain_biking"],
       "group": "people",
-      "order": 2549
+      "order": 2549,
+      "keywords": [
+        "bicycle",
+        "bicyclist",
+        "bike",
+        "biking",
+        "cycle",
+        "cyclist",
+        "mountain",
+        "person",
+        "riding",
+        "sport"
+      ]
     },
     {
       "emoji": "🤸",
-      "shortcodes": ["cartwheeling"],
+      "shortcodes": ["cartwheeling", "person_doing_cartwheel", "person_cartwheel", "cartwheel", "person_cartwheeling"],
       "group": "people",
-      "order": 2579
+      "order": 2579,
+      "keywords": ["active", "excited", "flip", "gymnastics", "happy", "person", "somersault"]
     },
     {
       "emoji": "🤼",
-      "shortcodes": ["wrestling"],
+      "shortcodes": ["wrestling", "wrestlers", "people_wrestling"],
       "group": "people",
-      "order": 2609
+      "order": 2609,
+      "keywords": ["combat", "duel", "grapple", "people", "ring", "tournament", "wrestle"]
     },
     {
       "emoji": "🤽",
-      "shortcodes": ["water_polo"],
+      "shortcodes": ["water_polo", "person_playing_water_polo"],
       "group": "people",
-      "order": 2614
+      "order": 2614,
+      "keywords": ["person", "playing", "polo", "sport", "swimming", "water"]
     },
     {
       "emoji": "🤾",
-      "shortcodes": ["handball_person"],
+      "shortcodes": ["handball_person", "handball", "person_playing_handball"],
       "group": "people",
-      "order": 2644
+      "order": 2644,
+      "keywords": [
+        "athletics",
+        "ball",
+        "catch",
+        "chuck",
+        "hurl",
+        "lob",
+        "person",
+        "pitch",
+        "playing",
+        "sport",
+        "throw",
+        "toss"
+      ]
     },
     {
       "emoji": "🤹",
-      "shortcodes": ["juggling_person"],
+      "shortcodes": ["juggling_person", "juggling", "juggler", "person_juggling"],
       "group": "people",
-      "order": 2674
+      "order": 2674,
+      "keywords": ["act", "balance", "balancing", "handle", "juggle", "manage", "multitask", "person", "skill"]
     },
     {
       "emoji": "🧘",
-      "shortcodes": ["lotus_position"],
+      "shortcodes": ["lotus_position", "person_in_lotus_position"],
       "group": "people",
-      "order": 2704
+      "order": 2704,
+      "keywords": [
+        "cross",
+        "legged",
+        "legs",
+        "lotus",
+        "meditation",
+        "peace",
+        "person",
+        "position",
+        "relax",
+        "serenity",
+        "yoga",
+        "yogi",
+        "zen"
+      ]
     },
     {
       "emoji": "🛀",
-      "shortcodes": ["bath"],
+      "shortcodes": ["bath", "person_taking_bath"],
       "group": "people",
-      "order": 2734
+      "order": 2734,
+      "keywords": ["bathtub", "person", "taking", "tub"]
     },
     {
       "emoji": "🛌",
-      "shortcodes": ["sleeping_bed"],
+      "shortcodes": ["sleeping_bed", "sleeping_accommodation", "person_in_bed"],
       "group": "people",
-      "order": 2740
+      "order": 2740,
+      "keywords": ["bed", "bedtime", "good", "goodnight", "hotel", "nap", "night", "person", "sleep", "tired", "zzz"]
     },
     {
       "emoji": "🧑‍🤝‍🧑",
       "shortcodes": ["people_holding_hands"],
       "group": "people",
-      "order": 2746
+      "order": 2746,
+      "keywords": ["bae", "bestie", "bff", "couple", "dating", "flirt", "friends", "hand", "hold", "people", "twins"]
     },
     {
       "emoji": "👭",
-      "shortcodes": ["two_women_holding_hands"],
+      "shortcodes": ["two_women_holding_hands", "women_holding_hands"],
       "group": "people",
-      "order": 2772
+      "order": 2772,
+      "keywords": [
+        "bae",
+        "bestie",
+        "bff",
+        "couple",
+        "dating",
+        "flirt",
+        "friends",
+        "girls",
+        "hand",
+        "hold",
+        "sisters",
+        "twins",
+        "women"
+      ]
     },
     {
       "emoji": "👫",
-      "shortcodes": ["couple"],
+      "shortcodes": ["couple", "man_and_woman_holding_hands", "woman_and_man_holding_hands"],
       "group": "people",
-      "order": 2798
+      "order": 2798,
+      "keywords": ["bae", "bestie", "bff", "dating", "flirt", "friends", "hand", "hold", "man", "twins", "woman"]
     },
     {
       "emoji": "👬",
-      "shortcodes": ["two_men_holding_hands"],
+      "shortcodes": ["two_men_holding_hands", "men_holding_hands"],
       "group": "people",
-      "order": 2824
+      "order": 2824,
+      "keywords": [
+        "bae",
+        "bestie",
+        "bff",
+        "boys",
+        "brothers",
+        "couple",
+        "dating",
+        "flirt",
+        "friends",
+        "hand",
+        "hold",
+        "men",
+        "twins"
+      ]
     },
     {
       "emoji": "💏",
-      "shortcodes": ["couplekiss"],
+      "shortcodes": ["couplekiss", "couple_kiss"],
       "group": "people",
-      "order": 2850
+      "order": 2850,
+      "keywords": [
+        "anniversary",
+        "babe",
+        "bae",
+        "couple",
+        "date",
+        "dating",
+        "heart",
+        "love",
+        "mwah",
+        "person",
+        "romance",
+        "together",
+        "xoxo",
+        "kiss"
+      ]
     },
     {
       "emoji": "💑",
       "shortcodes": ["couple_with_heart"],
       "group": "people",
-      "order": 3052
+      "order": 3052,
+      "keywords": [
+        "anniversary",
+        "babe",
+        "bae",
+        "couple",
+        "dating",
+        "heart",
+        "kiss",
+        "love",
+        "person",
+        "relationship",
+        "romance",
+        "together",
+        "you"
+      ]
     },
     {
       "emoji": "🗣️",
-      "shortcodes": ["speaking_head"],
+      "shortcodes": ["speaking_head", "speaking_head_in_silhouette"],
       "group": "people",
-      "order": 3279
+      "order": 3279,
+      "keywords": ["face", "head", "silhouette", "speak", "speaking"]
     },
     {
       "emoji": "👤",
       "shortcodes": ["bust_in_silhouette"],
       "group": "people",
-      "order": 3281
+      "order": 3281,
+      "keywords": ["bust", "mysterious", "shadow", "silhouette"]
     },
     {
       "emoji": "👥",
       "shortcodes": ["busts_in_silhouette"],
       "group": "people",
-      "order": 3282
+      "order": 3282,
+      "keywords": ["bff", "bust", "busts", "everyone", "friend", "friends", "people", "silhouette"]
     },
     {
       "emoji": "🫂",
       "shortcodes": ["people_hugging"],
       "group": "people",
-      "order": 3283
+      "order": 3283,
+      "keywords": [
+        "comfort",
+        "embrace",
+        "farewell",
+        "friendship",
+        "goodbye",
+        "hello",
+        "hug",
+        "hugging",
+        "love",
+        "people",
+        "thanks"
+      ]
     },
     {
       "emoji": "👪",
       "shortcodes": ["family"],
       "group": "people",
-      "order": 3284
+      "order": 3284,
+      "keywords": ["child"]
     },
     {
       "emoji": "👣",
       "shortcodes": ["footprints"],
       "group": "people",
-      "order": 3289
+      "order": 3289,
+      "keywords": ["barefoot", "clothing", "footprint", "omw", "print", "walk"]
     },
     {
       "emoji": "🐵",
       "shortcodes": ["monkey_face"],
       "group": "animals",
-      "order": 0
+      "order": 0,
+      "keywords": ["animal", "banana", "face", "monkey"]
     },
     {
       "emoji": "🐒",
       "shortcodes": ["monkey"],
       "group": "animals",
-      "order": 1
+      "order": 1,
+      "keywords": ["animal", "banana"]
     },
     {
       "emoji": "🦍",
       "shortcodes": ["gorilla"],
       "group": "animals",
-      "order": 2
+      "order": 2,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🦧",
       "shortcodes": ["orangutan"],
       "group": "animals",
-      "order": 3
+      "order": 3,
+      "keywords": ["animal", "ape", "monkey"]
     },
     {
       "emoji": "🐶",
-      "shortcodes": ["dog"],
+      "shortcodes": ["dog", "dog_face"],
       "group": "animals",
-      "order": 4
+      "order": 4,
+      "keywords": ["adorbs", "animal", "face", "pet", "puppies", "puppy"]
     },
     {
       "emoji": "🐕",
       "shortcodes": ["dog2"],
       "group": "animals",
-      "order": 5
+      "order": 5,
+      "keywords": ["animal", "animals", "dogs", "pet", "dog"]
     },
     {
       "emoji": "🦮",
       "shortcodes": ["guide_dog"],
       "group": "animals",
-      "order": 6
+      "order": 6,
+      "keywords": ["accessibility", "animal", "blind", "dog", "guide"]
     },
     {
       "emoji": "🐕‍🦺",
       "shortcodes": ["service_dog"],
       "group": "animals",
-      "order": 7
+      "order": 7,
+      "keywords": ["accessibility", "animal", "assistance", "dog", "service"]
     },
     {
       "emoji": "🐩",
       "shortcodes": ["poodle"],
       "group": "animals",
-      "order": 8
+      "order": 8,
+      "keywords": ["animal", "dog", "fluffy"]
     },
     {
       "emoji": "🐺",
-      "shortcodes": ["wolf"],
+      "shortcodes": ["wolf", "wolf_face"],
       "group": "animals",
-      "order": 9
+      "order": 9,
+      "keywords": ["animal", "face"]
     },
     {
       "emoji": "🦊",
-      "shortcodes": ["fox_face"],
+      "shortcodes": ["fox_face", "fox"],
       "group": "animals",
-      "order": 10
+      "order": 10,
+      "keywords": ["animal", "face"]
     },
     {
       "emoji": "🦝",
       "shortcodes": ["raccoon"],
       "group": "animals",
-      "order": 11
+      "order": 11,
+      "keywords": ["animal", "curious", "sly"]
     },
     {
       "emoji": "🐱",
-      "shortcodes": ["cat"],
+      "shortcodes": ["cat", "cat_face"],
       "group": "animals",
-      "order": 12
+      "order": 12,
+      "keywords": ["animal", "face", "kitten", "kitty", "pet"]
     },
     {
       "emoji": "🐈",
       "shortcodes": ["cat2"],
       "group": "animals",
-      "order": 13
+      "order": 13,
+      "keywords": ["animal", "animals", "cats", "kitten", "pet", "cat"]
     },
     {
       "emoji": "🐈‍⬛",
       "shortcodes": ["black_cat"],
       "group": "animals",
-      "order": 14
+      "order": 14,
+      "keywords": ["animal", "black", "cat", "feline", "halloween", "meow", "unlucky"]
     },
     {
       "emoji": "🦁",
-      "shortcodes": ["lion"],
+      "shortcodes": ["lion", "lion_face"],
       "group": "animals",
-      "order": 15
+      "order": 15,
+      "keywords": ["alpha", "animal", "face", "leo", "mane", "order", "rawr", "roar", "safari", "strong", "zodiac"]
     },
     {
       "emoji": "🐯",
-      "shortcodes": ["tiger"],
+      "shortcodes": ["tiger", "tiger_face"],
       "group": "animals",
-      "order": 16
+      "order": 16,
+      "keywords": ["animal", "big", "cat", "face", "predator"]
     },
     {
       "emoji": "🐅",
       "shortcodes": ["tiger2"],
       "group": "animals",
-      "order": 17
+      "order": 17,
+      "keywords": ["animal", "big", "cat", "predator", "zoo", "tiger"]
     },
     {
       "emoji": "🐆",
       "shortcodes": ["leopard"],
       "group": "animals",
-      "order": 18
+      "order": 18,
+      "keywords": ["animal", "big", "cat", "predator", "zoo"]
     },
     {
       "emoji": "🐴",
-      "shortcodes": ["horse"],
+      "shortcodes": ["horse", "horse_face"],
       "group": "animals",
-      "order": 19
+      "order": 19,
+      "keywords": ["animal", "dressage", "equine", "face", "farm", "horses"]
     },
     {
       "emoji": "🐎",
       "shortcodes": ["racehorse"],
       "group": "animals",
-      "order": 22
+      "order": 22,
+      "keywords": ["animal", "equestrian", "farm", "racing", "horse"]
     },
     {
       "emoji": "🦄",
-      "shortcodes": ["unicorn"],
+      "shortcodes": ["unicorn", "unicorn_face"],
       "group": "animals",
-      "order": 23
+      "order": 23,
+      "keywords": ["face"]
     },
     {
       "emoji": "🦓",
-      "shortcodes": ["zebra"],
+      "shortcodes": ["zebra", "zebra_face"],
       "group": "animals",
-      "order": 24
+      "order": 24,
+      "keywords": ["animal", "stripe"]
     },
     {
       "emoji": "🦌",
       "shortcodes": ["deer"],
       "group": "animals",
-      "order": 25
+      "order": 25,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🦬",
       "shortcodes": ["bison"],
       "group": "animals",
-      "order": 26
+      "order": 26,
+      "keywords": ["animal", "buffalo", "herd", "wisent"]
     },
     {
       "emoji": "🐮",
-      "shortcodes": ["cow"],
+      "shortcodes": ["cow", "cow_face"],
       "group": "animals",
-      "order": 27
+      "order": 27,
+      "keywords": ["animal", "face", "farm", "milk", "moo"]
     },
     {
       "emoji": "🐂",
       "shortcodes": ["ox"],
       "group": "animals",
-      "order": 28
+      "order": 28,
+      "keywords": ["animal", "animals", "bull", "farm", "taurus", "zodiac"]
     },
     {
       "emoji": "🐃",
       "shortcodes": ["water_buffalo"],
       "group": "animals",
-      "order": 29
+      "order": 29,
+      "keywords": ["animal", "buffalo", "water", "zoo"]
     },
     {
       "emoji": "🐄",
       "shortcodes": ["cow2"],
       "group": "animals",
-      "order": 30
+      "order": 30,
+      "keywords": ["animal", "animals", "farm", "milk", "moo", "cow"]
     },
     {
       "emoji": "🐷",
-      "shortcodes": ["pig"],
+      "shortcodes": ["pig", "pig_face"],
       "group": "animals",
-      "order": 31
+      "order": 31,
+      "keywords": ["animal", "bacon", "face", "farm", "pork"]
     },
     {
       "emoji": "🐖",
       "shortcodes": ["pig2"],
       "group": "animals",
-      "order": 32
+      "order": 32,
+      "keywords": ["animal", "bacon", "farm", "pork", "sow", "pig"]
     },
     {
       "emoji": "🐗",
       "shortcodes": ["boar"],
       "group": "animals",
-      "order": 33
+      "order": 33,
+      "keywords": ["animal", "pig"]
     },
     {
       "emoji": "🐽",
       "shortcodes": ["pig_nose"],
       "group": "animals",
-      "order": 34
+      "order": 34,
+      "keywords": ["animal", "face", "farm", "nose", "pig", "smell", "snout"]
     },
     {
       "emoji": "🐏",
       "shortcodes": ["ram"],
       "group": "animals",
-      "order": 35
+      "order": 35,
+      "keywords": ["animal", "aries", "horns", "male", "sheep", "zodiac", "zoo"]
     },
     {
       "emoji": "🐑",
-      "shortcodes": ["sheep"],
+      "shortcodes": ["sheep", "ewe"],
       "group": "animals",
-      "order": 36
+      "order": 36,
+      "keywords": ["animal", "baa", "farm", "female", "fluffy", "lamb", "wool"]
     },
     {
       "emoji": "🐐",
       "shortcodes": ["goat"],
       "group": "animals",
-      "order": 37
+      "order": 37,
+      "keywords": ["animal", "capricorn", "farm", "milk", "zodiac"]
     },
     {
       "emoji": "🐪",
       "shortcodes": ["dromedary_camel"],
       "group": "animals",
-      "order": 38
+      "order": 38,
+      "keywords": ["animal", "desert", "dromedary", "hump", "one", "camel"]
     },
     {
       "emoji": "🐫",
-      "shortcodes": ["camel"],
+      "shortcodes": ["camel", "two_hump_camel"],
       "group": "animals",
-      "order": 39
+      "order": 39,
+      "keywords": ["animal", "bactrian", "desert", "hump", "two", "two-hump"]
     },
     {
       "emoji": "🦙",
       "shortcodes": ["llama"],
       "group": "animals",
-      "order": 40
+      "order": 40,
+      "keywords": ["alpaca", "animal", "guanaco", "vicuña", "wool"]
     },
     {
       "emoji": "🦒",
-      "shortcodes": ["giraffe"],
+      "shortcodes": ["giraffe", "giraffe_face"],
       "group": "animals",
-      "order": 41
+      "order": 41,
+      "keywords": ["animal", "spots"]
     },
     {
       "emoji": "🐘",
       "shortcodes": ["elephant"],
       "group": "animals",
-      "order": 42
+      "order": 42,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🦣",
       "shortcodes": ["mammoth"],
       "group": "animals",
-      "order": 43
+      "order": 43,
+      "keywords": ["animal", "extinction", "large", "tusk", "wooly"]
     },
     {
       "emoji": "🦏",
-      "shortcodes": ["rhinoceros"],
+      "shortcodes": ["rhinoceros", "rhino"],
       "group": "animals",
-      "order": 44
+      "order": 44,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🦛",
-      "shortcodes": ["hippopotamus"],
+      "shortcodes": ["hippopotamus", "hippo"],
       "group": "animals",
-      "order": 45
+      "order": 45,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🐭",
-      "shortcodes": ["mouse"],
+      "shortcodes": ["mouse", "mouse_face"],
       "group": "animals",
-      "order": 46
+      "order": 46,
+      "keywords": ["animal", "face"]
     },
     {
       "emoji": "🐁",
       "shortcodes": ["mouse2"],
       "group": "animals",
-      "order": 47
+      "order": 47,
+      "keywords": ["animal", "animals", "mouse"]
     },
     {
       "emoji": "🐀",
       "shortcodes": ["rat"],
       "group": "animals",
-      "order": 48
+      "order": 48,
+      "keywords": ["animal"]
     },
     {
       "emoji": "🐹",
-      "shortcodes": ["hamster"],
+      "shortcodes": ["hamster", "hamster_face"],
       "group": "animals",
-      "order": 49
+      "order": 49,
+      "keywords": ["animal", "face", "pet"]
     },
     {
       "emoji": "🐰",
-      "shortcodes": ["rabbit"],
+      "shortcodes": ["rabbit", "rabbit_face"],
       "group": "animals",
-      "order": 50
+      "order": 50,
+      "keywords": ["animal", "bunny", "face", "pet"]
     },
     {
       "emoji": "🐇",
       "shortcodes": ["rabbit2"],
       "group": "animals",
-      "order": 51
+      "order": 51,
+      "keywords": ["animal", "bunny", "pet", "rabbit"]
     },
     {
       "emoji": "🐿️",
       "shortcodes": ["chipmunk"],
       "group": "animals",
-      "order": 52
+      "order": 52,
+      "keywords": ["animal", "squirrel"]
     },
     {
       "emoji": "🦫",
       "shortcodes": ["beaver"],
       "group": "animals",
-      "order": 54
+      "order": 54,
+      "keywords": ["animal", "dam", "teeth"]
     },
     {
       "emoji": "🦔",
       "shortcodes": ["hedgehog"],
       "group": "animals",
-      "order": 55
+      "order": 55,
+      "keywords": ["animal", "spiny"]
     },
     {
       "emoji": "🦇",
       "shortcodes": ["bat"],
       "group": "animals",
-      "order": 56
+      "order": 56,
+      "keywords": ["animal", "vampire"]
     },
     {
       "emoji": "🐻",
-      "shortcodes": ["bear"],
+      "shortcodes": ["bear", "bear_face"],
       "group": "animals",
-      "order": 57
+      "order": 57,
+      "keywords": ["animal", "face", "grizzly", "growl", "honey"]
     },
     {
       "emoji": "🐻‍❄️",
-      "shortcodes": ["polar_bear"],
+      "shortcodes": ["polar_bear", "polar_bear_face"],
       "group": "animals",
-      "order": 58
+      "order": 58,
+      "keywords": ["animal", "arctic", "bear", "polar", "white"]
     },
     {
       "emoji": "🐨",
-      "shortcodes": ["koala"],
+      "shortcodes": ["koala", "koala_face"],
       "group": "animals",
-      "order": 60
+      "order": 60,
+      "keywords": ["animal", "australia", "bear", "down", "face", "marsupial", "under"]
     },
     {
       "emoji": "🐼",
-      "shortcodes": ["panda_face"],
+      "shortcodes": ["panda_face", "panda"],
       "group": "animals",
-      "order": 61
+      "order": 61,
+      "keywords": ["animal", "bamboo", "face"]
     },
     {
       "emoji": "🦥",
       "shortcodes": ["sloth"],
       "group": "animals",
-      "order": 62
+      "order": 62,
+      "keywords": ["lazy", "slow"]
     },
     {
       "emoji": "🦦",
       "shortcodes": ["otter"],
       "group": "animals",
-      "order": 63
+      "order": 63,
+      "keywords": ["animal", "fishing", "playful"]
     },
     {
       "emoji": "🦨",
       "shortcodes": ["skunk"],
       "group": "animals",
-      "order": 64
+      "order": 64,
+      "keywords": ["animal", "stink"]
     },
     {
       "emoji": "🦘",
       "shortcodes": ["kangaroo"],
       "group": "animals",
-      "order": 65
+      "order": 65,
+      "keywords": ["animal", "joey", "jump", "marsupial"]
     },
     {
       "emoji": "🦡",
       "shortcodes": ["badger"],
       "group": "animals",
-      "order": 66
+      "order": 66,
+      "keywords": ["animal", "honey", "pester"]
     },
     {
       "emoji": "🐾",
       "shortcodes": ["feet", "paw_prints"],
       "group": "animals",
-      "order": 67
+      "order": 67,
+      "keywords": ["paw", "paws", "print", "prints"]
     },
     {
       "emoji": "🦃",
       "shortcodes": ["turkey"],
       "group": "animals",
-      "order": 68
+      "order": 68,
+      "keywords": ["bird", "gobble", "thanksgiving"]
     },
     {
       "emoji": "🐔",
-      "shortcodes": ["chicken"],
+      "shortcodes": ["chicken", "chicken_face"],
       "group": "animals",
-      "order": 69
+      "order": 69,
+      "keywords": ["animal", "bird", "ornithology"]
     },
     {
       "emoji": "🐓",
       "shortcodes": ["rooster"],
       "group": "animals",
-      "order": 70
+      "order": 70,
+      "keywords": ["animal", "bird", "ornithology"]
     },
     {
       "emoji": "🐣",
       "shortcodes": ["hatching_chick"],
       "group": "animals",
-      "order": 71
+      "order": 71,
+      "keywords": ["animal", "baby", "bird", "chick", "egg", "hatching"]
     },
     {
       "emoji": "🐤",
       "shortcodes": ["baby_chick"],
       "group": "animals",
-      "order": 72
+      "order": 72,
+      "keywords": ["animal", "baby", "bird", "chick", "ornithology"]
     },
     {
       "emoji": "🐥",
-      "shortcodes": ["hatched_chick"],
+      "shortcodes": ["hatched_chick", "front_facing_baby_chick"],
       "group": "animals",
-      "order": 73
+      "order": 73,
+      "keywords": ["animal", "baby", "bird", "chick", "front-facing", "newborn", "ornithology"]
     },
     {
       "emoji": "🐦",
-      "shortcodes": ["bird"],
+      "shortcodes": ["bird", "bird_face"],
       "group": "animals",
-      "order": 74
+      "order": 74,
+      "keywords": ["animal", "ornithology"]
     },
     {
       "emoji": "🐧",
-      "shortcodes": ["penguin"],
+      "shortcodes": ["penguin", "penguin_face"],
       "group": "animals",
-      "order": 75
+      "order": 75,
+      "keywords": ["animal", "antarctica", "bird", "ornithology"]
     },
     {
       "emoji": "🕊️",
-      "shortcodes": ["dove"],
+      "shortcodes": ["dove", "dove_of_peace"],
       "group": "animals",
-      "order": 76
+      "order": 76,
+      "keywords": ["bird", "fly", "ornithology", "peace"]
     },
     {
       "emoji": "🦅",
       "shortcodes": ["eagle"],
       "group": "animals",
-      "order": 78
+      "order": 78,
+      "keywords": ["animal", "bird", "ornithology"]
     },
     {
       "emoji": "🦆",
       "shortcodes": ["duck"],
       "group": "animals",
-      "order": 79
+      "order": 79,
+      "keywords": ["animal", "bird", "ornithology"]
     },
     {
       "emoji": "🦢",
       "shortcodes": ["swan"],
       "group": "animals",
-      "order": 80
+      "order": 80,
+      "keywords": ["animal", "bird", "cygnet", "duckling", "ornithology", "ugly"]
     },
     {
       "emoji": "🦉",
       "shortcodes": ["owl"],
       "group": "animals",
-      "order": 81
+      "order": 81,
+      "keywords": ["animal", "bird", "ornithology", "wise"]
     },
     {
       "emoji": "🦤",
       "shortcodes": ["dodo"],
       "group": "animals",
-      "order": 82
+      "order": 82,
+      "keywords": ["animal", "bird", "extinction", "large", "ornithology"]
     },
     {
       "emoji": "🪶",
       "shortcodes": ["feather"],
       "group": "animals",
-      "order": 83
+      "order": 83,
+      "keywords": ["bird", "flight", "light", "plumage"]
     },
     {
       "emoji": "🦩",
       "shortcodes": ["flamingo"],
       "group": "animals",
-      "order": 84
+      "order": 84,
+      "keywords": ["animal", "bird", "flamboyant", "ornithology", "tropical"]
     },
     {
       "emoji": "🦚",
       "shortcodes": ["peacock"],
       "group": "animals",
-      "order": 85
+      "order": 85,
+      "keywords": ["animal", "bird", "colorful", "ornithology", "ostentatious", "peahen", "pretty", "proud"]
     },
     {
       "emoji": "🦜",
       "shortcodes": ["parrot"],
       "group": "animals",
-      "order": 86
+      "order": 86,
+      "keywords": ["animal", "bird", "ornithology", "pirate", "talk"]
     },
     {
       "emoji": "🐸",
-      "shortcodes": ["frog"],
+      "shortcodes": ["frog", "frog_face"],
       "group": "animals",
-      "order": 91
+      "order": 91,
+      "keywords": ["animal", "face"]
     },
     {
       "emoji": "🐊",
       "shortcodes": ["crocodile"],
       "group": "animals",
-      "order": 92
+      "order": 92,
+      "keywords": ["animal", "zoo"]
     },
     {
       "emoji": "🐢",
       "shortcodes": ["turtle"],
       "group": "animals",
-      "order": 93
+      "order": 93,
+      "keywords": ["animal", "terrapin", "tortoise"]
     },
     {
       "emoji": "🦎",
       "shortcodes": ["lizard"],
       "group": "animals",
-      "order": 94
+      "order": 94,
+      "keywords": ["animal", "reptile"]
     },
     {
       "emoji": "🐍",
       "shortcodes": ["snake"],
       "group": "animals",
-      "order": 95
+      "order": 95,
+      "keywords": ["animal", "bearer", "ophiuchus", "serpent", "zodiac"]
     },
     {
       "emoji": "🐲",
       "shortcodes": ["dragon_face"],
       "group": "animals",
-      "order": 96
+      "order": 96,
+      "keywords": ["animal", "dragon", "face", "fairy", "fairytale", "tale"]
     },
     {
       "emoji": "🐉",
       "shortcodes": ["dragon"],
       "group": "animals",
-      "order": 97
+      "order": 97,
+      "keywords": ["animal", "fairy", "fairytale", "knights", "tale"]
     },
     {
       "emoji": "🦕",
       "shortcodes": ["sauropod"],
       "group": "animals",
-      "order": 98
+      "order": 98,
+      "keywords": ["brachiosaurus", "brontosaurus", "dinosaur", "diplodocus"]
     },
     {
       "emoji": "🦖",
-      "shortcodes": ["t-rex"],
+      "shortcodes": ["t-rex", "trex", "t_rex"],
       "group": "animals",
-      "order": 99
+      "order": 99,
+      "keywords": ["dinosaur", "rex", "t", "tyrannosaurus"]
     },
     {
       "emoji": "🐳",
-      "shortcodes": ["whale"],
+      "shortcodes": ["whale", "spouting_whale"],
       "group": "animals",
-      "order": 100
+      "order": 100,
+      "keywords": ["animal", "beach", "face", "ocean", "spouting"]
     },
     {
       "emoji": "🐋",
       "shortcodes": ["whale2"],
       "group": "animals",
-      "order": 101
+      "order": 101,
+      "keywords": ["animal", "beach", "ocean", "whale"]
     },
     {
       "emoji": "🐬",
       "shortcodes": ["dolphin", "flipper"],
       "group": "animals",
-      "order": 102
+      "order": 102,
+      "keywords": ["animal", "beach", "ocean"]
     },
     {
       "emoji": "🦭",
       "shortcodes": ["seal"],
       "group": "animals",
-      "order": 103
+      "order": 103,
+      "keywords": ["animal", "lion", "ocean", "sea"]
     },
     {
       "emoji": "🐟",
       "shortcodes": ["fish"],
       "group": "animals",
-      "order": 104
+      "order": 104,
+      "keywords": ["animal", "dinner", "fishes", "fishing", "pisces", "zodiac"]
     },
     {
       "emoji": "🐠",
       "shortcodes": ["tropical_fish"],
       "group": "animals",
-      "order": 105
+      "order": 105,
+      "keywords": ["animal", "fish", "fishes", "tropical"]
     },
     {
       "emoji": "🐡",
       "shortcodes": ["blowfish"],
       "group": "animals",
-      "order": 106
+      "order": 106,
+      "keywords": ["animal", "fish"]
     },
     {
       "emoji": "🦈",
       "shortcodes": ["shark"],
       "group": "animals",
-      "order": 107
+      "order": 107,
+      "keywords": ["animal", "fish"]
     },
     {
       "emoji": "🐙",
       "shortcodes": ["octopus"],
       "group": "animals",
-      "order": 108
+      "order": 108,
+      "keywords": ["animal", "creature", "ocean"]
     },
     {
       "emoji": "🐚",
-      "shortcodes": ["shell"],
+      "shortcodes": ["shell", "spiral_shell"],
       "group": "animals",
-      "order": 109
+      "order": 109,
+      "keywords": ["animal", "beach", "conch", "sea", "spiral"]
     },
     {
       "emoji": "🦀",
       "shortcodes": ["crab"],
       "group": "animals",
-      "order": 112
+      "order": 112,
+      "keywords": ["cancer", "zodiac"]
     },
     {
       "emoji": "🦞",
       "shortcodes": ["lobster"],
       "group": "animals",
-      "order": 113
+      "order": 113,
+      "keywords": ["animal", "bisque", "claws", "seafood"]
     },
     {
       "emoji": "🦐",
       "shortcodes": ["shrimp"],
       "group": "animals",
-      "order": 114
+      "order": 114,
+      "keywords": ["food", "shellfish", "small"]
     },
     {
       "emoji": "🦑",
       "shortcodes": ["squid"],
       "group": "animals",
-      "order": 115
+      "order": 115,
+      "keywords": ["animal", "food", "mollusk"]
     },
     {
       "emoji": "🦪",
       "shortcodes": ["oyster"],
       "group": "animals",
-      "order": 116
+      "order": 116,
+      "keywords": ["diving", "pearl"]
     },
     {
       "emoji": "🐌",
       "shortcodes": ["snail"],
       "group": "animals",
-      "order": 117
+      "order": 117,
+      "keywords": ["animal", "escargot", "garden", "nature", "slug"]
     },
     {
       "emoji": "🦋",
       "shortcodes": ["butterfly"],
       "group": "animals",
-      "order": 118
+      "order": 118,
+      "keywords": ["insect", "pretty"]
     },
     {
       "emoji": "🐛",
       "shortcodes": ["bug", "bug_fix"],
       "group": "animals",
-      "order": 119
+      "order": 119,
+      "keywords": ["animal", "garden", "insect"]
     },
     {
       "emoji": "🐜",
       "shortcodes": ["ant"],
       "group": "animals",
-      "order": 120
+      "order": 120,
+      "keywords": ["animal", "garden", "insect"]
     },
     {
       "emoji": "🐝",
       "shortcodes": ["bee", "honeybee"],
       "group": "animals",
-      "order": 121
+      "order": 121,
+      "keywords": ["animal", "bumblebee", "honey", "insect", "nature", "spring"]
     },
     {
       "emoji": "🪲",
       "shortcodes": ["beetle"],
       "group": "animals",
-      "order": 122
+      "order": 122,
+      "keywords": ["animal", "bug", "insect"]
     },
     {
       "emoji": "🐞",
-      "shortcodes": ["lady_beetle"],
+      "shortcodes": ["lady_beetle", "ladybug"],
       "group": "animals",
-      "order": 123
+      "order": 123,
+      "keywords": ["animal", "beetle", "garden", "insect", "lady", "ladybird", "nature"]
     },
     {
       "emoji": "🦗",
       "shortcodes": ["cricket"],
       "group": "animals",
-      "order": 124
+      "order": 124,
+      "keywords": ["animal", "bug", "grasshopper", "insect", "orthoptera"]
     },
     {
       "emoji": "🪳",
       "shortcodes": ["cockroach"],
       "group": "animals",
-      "order": 125
+      "order": 125,
+      "keywords": ["animal", "insect", "pest", "roach"]
     },
     {
       "emoji": "🕷️",
       "shortcodes": ["spider"],
       "group": "animals",
-      "order": 126
+      "order": 126,
+      "keywords": ["animal", "insect"]
     },
     {
       "emoji": "🕸️",
       "shortcodes": ["spider_web"],
       "group": "animals",
-      "order": 128
+      "order": 128,
+      "keywords": ["spider", "web"]
     },
     {
       "emoji": "🦂",
       "shortcodes": ["scorpion"],
       "group": "animals",
-      "order": 130
+      "order": 130,
+      "keywords": ["scorpio", "scorpius", "zodiac"]
     },
     {
       "emoji": "🦟",
       "shortcodes": ["mosquito"],
       "group": "animals",
-      "order": 131
+      "order": 131,
+      "keywords": ["bite", "disease", "fever", "insect", "malaria", "pest", "virus"]
     },
     {
       "emoji": "🪰",
       "shortcodes": ["fly"],
       "group": "animals",
-      "order": 132
+      "order": 132,
+      "keywords": ["animal", "disease", "insect", "maggot", "pest", "rotting"]
     },
     {
       "emoji": "🪱",
       "shortcodes": ["worm"],
       "group": "animals",
-      "order": 133
+      "order": 133,
+      "keywords": ["animal", "annelid", "earthworm", "parasite"]
     },
     {
       "emoji": "🦠",
       "shortcodes": ["microbe"],
       "group": "animals",
-      "order": 134
+      "order": 134,
+      "keywords": ["amoeba", "bacteria", "science", "virus"]
     },
     {
       "emoji": "💐",
       "shortcodes": ["bouquet"],
       "group": "animals",
-      "order": 135
+      "order": 135,
+      "keywords": ["anniversary", "birthday", "date", "flower", "love", "plant", "romance"]
     },
     {
       "emoji": "🌸",
       "shortcodes": ["cherry_blossom"],
       "group": "animals",
-      "order": 136
+      "order": 136,
+      "keywords": ["blossom", "cherry", "flower", "plant", "spring", "springtime"]
     },
     {
       "emoji": "💮",
       "shortcodes": ["white_flower"],
       "group": "animals",
-      "order": 137
+      "order": 137,
+      "keywords": ["flower", "white"]
     },
     {
       "emoji": "🏵️",
       "shortcodes": ["rosette"],
       "group": "animals",
-      "order": 139
+      "order": 139,
+      "keywords": ["plant"]
     },
     {
       "emoji": "🌹",
       "shortcodes": ["rose"],
       "group": "animals",
-      "order": 141
+      "order": 141,
+      "keywords": ["beauty", "elegant", "flower", "love", "plant", "red", "valentine"]
     },
     {
       "emoji": "🥀",
-      "shortcodes": ["wilted_flower"],
+      "shortcodes": ["wilted_flower", "wilted_rose"],
       "group": "animals",
-      "order": 142
+      "order": 142,
+      "keywords": ["dying", "flower", "wilted"]
     },
     {
       "emoji": "🌺",
       "shortcodes": ["hibiscus"],
       "group": "animals",
-      "order": 143
+      "order": 143,
+      "keywords": ["flower", "plant"]
     },
     {
       "emoji": "🌻",
       "shortcodes": ["sunflower"],
       "group": "animals",
-      "order": 144
+      "order": 144,
+      "keywords": ["flower", "outdoors", "plant", "sun"]
     },
     {
       "emoji": "🌼",
       "shortcodes": ["blossom"],
       "group": "animals",
-      "order": 145
+      "order": 145,
+      "keywords": ["buttercup", "dandelion", "flower", "plant"]
     },
     {
       "emoji": "🌷",
       "shortcodes": ["tulip"],
       "group": "animals",
-      "order": 146
+      "order": 146,
+      "keywords": ["blossom", "flower", "growth", "plant"]
     },
     {
       "emoji": "🌱",
       "shortcodes": ["seedling"],
       "group": "animals",
-      "order": 148
+      "order": 148,
+      "keywords": ["plant", "sapling", "sprout", "young"]
     },
     {
       "emoji": "🪴",
       "shortcodes": ["potted_plant"],
       "group": "animals",
-      "order": 149
+      "order": 149,
+      "keywords": ["decor", "grow", "house", "nurturing", "plant", "pot", "potted"]
     },
     {
       "emoji": "🌲",
       "shortcodes": ["evergreen_tree"],
       "group": "animals",
-      "order": 150
+      "order": 150,
+      "keywords": ["christmas", "evergreen", "forest", "pine", "tree"]
     },
     {
       "emoji": "🌳",
       "shortcodes": ["deciduous_tree"],
       "group": "animals",
-      "order": 151
+      "order": 151,
+      "keywords": ["deciduous", "forest", "green", "habitat", "shedding", "tree"]
     },
     {
       "emoji": "🌴",
       "shortcodes": ["palm_tree"],
       "group": "animals",
-      "order": 152
+      "order": 152,
+      "keywords": ["beach", "palm", "plant", "tree", "tropical"]
     },
     {
       "emoji": "🌵",
       "shortcodes": ["cactus"],
       "group": "animals",
-      "order": 153
+      "order": 153,
+      "keywords": ["desert", "drought", "nature", "plant"]
     },
     {
       "emoji": "🌾",
-      "shortcodes": ["ear_of_rice"],
+      "shortcodes": ["ear_of_rice", "sheaf_of_rice"],
       "group": "animals",
-      "order": 154
+      "order": 154,
+      "keywords": ["ear", "grain", "grains", "plant", "rice", "sheaf"]
     },
     {
       "emoji": "🌿",
       "shortcodes": ["herb"],
       "group": "animals",
-      "order": 155
+      "order": 155,
+      "keywords": ["leaf", "plant"]
     },
     {
       "emoji": "☘️",
       "shortcodes": ["shamrock"],
       "group": "animals",
-      "order": 156
+      "order": 156,
+      "keywords": ["irish", "plant"]
     },
     {
       "emoji": "🍀",
       "shortcodes": ["four_leaf_clover"],
       "group": "animals",
-      "order": 158
+      "order": 158,
+      "keywords": ["4", "clover", "four", "four-leaf", "irish", "leaf", "lucky", "plant"]
     },
     {
       "emoji": "🍁",
       "shortcodes": ["maple_leaf"],
       "group": "animals",
-      "order": 159
+      "order": 159,
+      "keywords": ["falling", "leaf", "maple"]
     },
     {
       "emoji": "🍂",
       "shortcodes": ["fallen_leaf"],
       "group": "animals",
-      "order": 160
+      "order": 160,
+      "keywords": ["autumn", "fall", "fallen", "falling", "leaf"]
     },
     {
       "emoji": "🍃",
-      "shortcodes": ["leaves"],
+      "shortcodes": ["leaves", "leaf_fluttering_in_wind"],
       "group": "animals",
-      "order": 161
+      "order": 161,
+      "keywords": ["blow", "flutter", "fluttering", "leaf", "wind"]
     },
     {
       "emoji": "🍄",
       "shortcodes": ["mushroom"],
       "group": "animals",
-      "order": 164
+      "order": 164,
+      "keywords": ["fungus", "toadstool"]
     },
     {
       "emoji": "🍇",
       "shortcodes": ["grapes"],
       "group": "food",
-      "order": 0
+      "order": 0,
+      "keywords": ["dionysus", "fruit", "grape"]
     },
     {
       "emoji": "🍈",
       "shortcodes": ["melon"],
       "group": "food",
-      "order": 1
+      "order": 1,
+      "keywords": ["cantaloupe", "fruit"]
     },
     {
       "emoji": "🍉",
       "shortcodes": ["watermelon"],
       "group": "food",
-      "order": 2
+      "order": 2,
+      "keywords": ["fruit"]
     },
     {
       "emoji": "🍊",
       "shortcodes": ["tangerine", "orange", "mandarin"],
       "group": "food",
-      "order": 3
+      "order": 3,
+      "keywords": ["c", "citrus", "fruit", "nectarine", "vitamin"]
     },
     {
       "emoji": "🍋",
       "shortcodes": ["lemon"],
       "group": "food",
-      "order": 4
+      "order": 4,
+      "keywords": ["citrus", "fruit", "sour"]
     },
     {
       "emoji": "🍌",
       "shortcodes": ["banana"],
       "group": "food",
-      "order": 6
+      "order": 6,
+      "keywords": ["fruit", "potassium"]
     },
     {
       "emoji": "🍍",
       "shortcodes": ["pineapple"],
       "group": "food",
-      "order": 7
+      "order": 7,
+      "keywords": ["colada", "fruit", "pina", "tropical"]
     },
     {
       "emoji": "🥭",
       "shortcodes": ["mango"],
       "group": "food",
-      "order": 8
+      "order": 8,
+      "keywords": ["food", "fruit", "tropical"]
     },
     {
       "emoji": "🍎",
-      "shortcodes": ["apple"],
+      "shortcodes": ["apple", "red_apple"],
       "group": "food",
-      "order": 9
+      "order": 9,
+      "keywords": ["diet", "food", "fruit", "health", "red", "ripe"]
     },
     {
       "emoji": "🍏",
       "shortcodes": ["green_apple"],
       "group": "food",
-      "order": 10
+      "order": 10,
+      "keywords": ["apple", "fruit", "green"]
     },
     {
       "emoji": "🍐",
       "shortcodes": ["pear"],
       "group": "food",
-      "order": 11
+      "order": 11,
+      "keywords": ["fruit"]
     },
     {
       "emoji": "🍑",
       "shortcodes": ["peach"],
       "group": "food",
-      "order": 12
+      "order": 12,
+      "keywords": ["fruit"]
     },
     {
       "emoji": "🍒",
       "shortcodes": ["cherries"],
       "group": "food",
-      "order": 13
+      "order": 13,
+      "keywords": ["berries", "cherry", "fruit", "red"]
     },
     {
       "emoji": "🍓",
       "shortcodes": ["strawberry"],
       "group": "food",
-      "order": 14
+      "order": 14,
+      "keywords": ["berry", "fruit"]
     },
     {
       "emoji": "🫐",
       "shortcodes": ["blueberries"],
       "group": "food",
-      "order": 15
+      "order": 15,
+      "keywords": ["berries", "berry", "bilberry", "blue", "blueberry", "food", "fruit"]
     },
     {
       "emoji": "🥝",
-      "shortcodes": ["kiwi_fruit"],
+      "shortcodes": ["kiwi_fruit", "kiwifruit", "kiwi"],
       "group": "food",
-      "order": 16
+      "order": 16,
+      "keywords": ["food", "fruit"]
     },
     {
       "emoji": "🍅",
       "shortcodes": ["tomato"],
       "group": "food",
-      "order": 17
+      "order": 17,
+      "keywords": ["food", "fruit", "vegetable"]
     },
     {
       "emoji": "🫒",
       "shortcodes": ["olive"],
       "group": "food",
-      "order": 18
+      "order": 18,
+      "keywords": ["food"]
     },
     {
       "emoji": "🥥",
       "shortcodes": ["coconut"],
       "group": "food",
-      "order": 19
+      "order": 19,
+      "keywords": ["colada", "palm", "piña"]
     },
     {
       "emoji": "🥑",
       "shortcodes": ["avocado"],
       "group": "food",
-      "order": 20
+      "order": 20,
+      "keywords": ["food", "fruit"]
     },
     {
       "emoji": "🍆",
       "shortcodes": ["eggplant"],
       "group": "food",
-      "order": 21
+      "order": 21,
+      "keywords": ["aubergine", "vegetable"]
     },
     {
       "emoji": "🥔",
       "shortcodes": ["potato"],
       "group": "food",
-      "order": 22
+      "order": 22,
+      "keywords": ["food", "vegetable"]
     },
     {
       "emoji": "🥕",
       "shortcodes": ["carrot"],
       "group": "food",
-      "order": 23
+      "order": 23,
+      "keywords": ["food", "vegetable"]
     },
     {
       "emoji": "🌽",
-      "shortcodes": ["corn"],
+      "shortcodes": ["corn", "ear_of_corn"],
       "group": "food",
-      "order": 24
+      "order": 24,
+      "keywords": ["crops", "ear", "farm", "maize", "maze"]
     },
     {
       "emoji": "🌶️",
       "shortcodes": ["hot_pepper"],
       "group": "food",
-      "order": 25
+      "order": 25,
+      "keywords": ["hot", "pepper"]
     },
     {
       "emoji": "🫑",
       "shortcodes": ["bell_pepper"],
       "group": "food",
-      "order": 27
+      "order": 27,
+      "keywords": ["bell", "capsicum", "food", "pepper", "vegetable"]
     },
     {
       "emoji": "🥒",
       "shortcodes": ["cucumber"],
       "group": "food",
-      "order": 28
+      "order": 28,
+      "keywords": ["food", "pickle", "vegetable"]
     },
     {
       "emoji": "🥬",
       "shortcodes": ["leafy_green"],
       "group": "food",
-      "order": 29
+      "order": 29,
+      "keywords": ["bok", "burgers", "cabbage", "choy", "green", "kale", "leafy", "lettuce", "salad"]
     },
     {
       "emoji": "🥦",
       "shortcodes": ["broccoli"],
       "group": "food",
-      "order": 30
+      "order": 30,
+      "keywords": ["cabbage", "wild"]
     },
     {
       "emoji": "🧄",
       "shortcodes": ["garlic"],
       "group": "food",
-      "order": 31
+      "order": 31,
+      "keywords": ["flavoring"]
     },
     {
       "emoji": "🧅",
       "shortcodes": ["onion"],
       "group": "food",
-      "order": 32
+      "order": 32,
+      "keywords": ["flavoring"]
     },
     {
       "emoji": "🥜",
-      "shortcodes": ["peanuts"],
+      "shortcodes": ["peanuts", "shelled_peanut"],
       "group": "food",
-      "order": 33
+      "order": 33,
+      "keywords": ["food", "nut", "peanut", "vegetable"]
     },
     {
       "emoji": "🌰",
       "shortcodes": ["chestnut"],
       "group": "food",
-      "order": 35
+      "order": 35,
+      "keywords": ["almond", "plant"]
     },
     {
       "emoji": "🍞",
       "shortcodes": ["bread"],
       "group": "food",
-      "order": 40
+      "order": 40,
+      "keywords": ["carbs", "food", "grain", "loaf", "restaurant", "toast", "wheat"]
     },
     {
       "emoji": "🥐",
       "shortcodes": ["croissant"],
       "group": "food",
-      "order": 41
+      "order": 41,
+      "keywords": ["bread", "breakfast", "crescent", "food", "french", "roll"]
     },
     {
       "emoji": "🥖",
-      "shortcodes": ["baguette_bread"],
+      "shortcodes": ["baguette_bread", "french_bread"],
       "group": "food",
-      "order": 42
+      "order": 42,
+      "keywords": ["baguette", "bread", "food", "french"]
     },
     {
       "emoji": "🫓",
       "shortcodes": ["flatbread"],
       "group": "food",
-      "order": 43
+      "order": 43,
+      "keywords": ["arepa", "bread", "food", "gordita", "lavash", "naan", "pita"]
     },
     {
       "emoji": "🥨",
       "shortcodes": ["pretzel"],
       "group": "food",
-      "order": 44
+      "order": 44,
+      "keywords": ["convoluted", "twisted"]
     },
     {
       "emoji": "🥯",
       "shortcodes": ["bagel"],
       "group": "food",
-      "order": 45
+      "order": 45,
+      "keywords": ["bakery", "bread", "breakfast", "schmear"]
     },
     {
       "emoji": "🥞",
       "shortcodes": ["pancakes"],
       "group": "food",
-      "order": 46
+      "order": 46,
+      "keywords": ["breakfast", "crêpe", "food", "hotcake", "pancake"]
     },
     {
       "emoji": "🧇",
       "shortcodes": ["waffle"],
       "group": "food",
-      "order": 47
+      "order": 47,
+      "keywords": ["breakfast", "indecisive", "iron"]
     },
     {
       "emoji": "🧀",
-      "shortcodes": ["cheese"],
+      "shortcodes": ["cheese", "cheese_wedge"],
       "group": "food",
-      "order": 48
+      "order": 48,
+      "keywords": ["wedge"]
     },
     {
       "emoji": "🍖",
       "shortcodes": ["meat_on_bone"],
       "group": "food",
-      "order": 49
+      "order": 49,
+      "keywords": ["bone", "meat"]
     },
     {
       "emoji": "🍗",
       "shortcodes": ["poultry_leg"],
       "group": "food",
-      "order": 50
+      "order": 50,
+      "keywords": ["bone", "chicken", "drumstick", "hungry", "leg", "poultry", "turkey"]
     },
     {
       "emoji": "🥩",
       "shortcodes": ["cut_of_meat"],
       "group": "food",
-      "order": 51
+      "order": 51,
+      "keywords": ["chop", "cut", "lambchop", "meat", "porkchop", "red", "steak"]
     },
     {
       "emoji": "🥓",
       "shortcodes": ["bacon"],
       "group": "food",
-      "order": 52
+      "order": 52,
+      "keywords": ["breakfast", "food", "meat"]
     },
     {
       "emoji": "🍔",
       "shortcodes": ["hamburger"],
       "group": "food",
-      "order": 53
+      "order": 53,
+      "keywords": ["burger", "eat", "fast", "food", "hungry"]
     },
     {
       "emoji": "🍟",
-      "shortcodes": ["fries"],
+      "shortcodes": ["fries", "french_fries"],
       "group": "food",
-      "order": 54
+      "order": 54,
+      "keywords": ["fast", "food", "french"]
     },
     {
       "emoji": "🍕",
       "shortcodes": ["pizza"],
       "group": "food",
-      "order": 55
+      "order": 55,
+      "keywords": ["cheese", "food", "hungry", "pepperoni", "slice"]
     },
     {
       "emoji": "🌭",
-      "shortcodes": ["hotdog"],
+      "shortcodes": ["hotdog", "hot_dog"],
       "group": "food",
-      "order": 56
+      "order": 56,
+      "keywords": ["dog", "frankfurter", "hot", "sausage"]
     },
     {
       "emoji": "🥪",
       "shortcodes": ["sandwich"],
       "group": "food",
-      "order": 57
+      "order": 57,
+      "keywords": ["bread"]
     },
     {
       "emoji": "🌮",
       "shortcodes": ["taco"],
       "group": "food",
-      "order": 58
+      "order": 58,
+      "keywords": ["mexican"]
     },
     {
       "emoji": "🌯",
       "shortcodes": ["burrito"],
       "group": "food",
-      "order": 59
+      "order": 59,
+      "keywords": ["mexican", "wrap"]
     },
     {
       "emoji": "🫔",
       "shortcodes": ["tamale"],
       "group": "food",
-      "order": 60
+      "order": 60,
+      "keywords": ["food", "mexican", "pamonha", "wrapped"]
     },
     {
       "emoji": "🥙",
-      "shortcodes": ["stuffed_flatbread"],
+      "shortcodes": ["stuffed_flatbread", "stuffed_pita"],
       "group": "food",
-      "order": 61
+      "order": 61,
+      "keywords": ["falafel", "flatbread", "food", "gyro", "kebab", "stuffed"]
     },
     {
       "emoji": "🧆",
       "shortcodes": ["falafel"],
       "group": "food",
-      "order": 62
+      "order": 62,
+      "keywords": ["chickpea", "meatball"]
     },
     {
       "emoji": "🥚",
       "shortcodes": ["egg"],
       "group": "food",
-      "order": 63
+      "order": 63,
+      "keywords": ["breakfast", "food"]
     },
     {
       "emoji": "🍳",
-      "shortcodes": ["fried_egg"],
+      "shortcodes": ["fried_egg", "cooking"],
       "group": "food",
-      "order": 64
+      "order": 64,
+      "keywords": ["breakfast", "easy", "egg", "fry", "frying", "over", "pan", "restaurant", "side", "sunny", "up"]
     },
     {
       "emoji": "🥘",
-      "shortcodes": ["shallow_pan_of_food"],
+      "shortcodes": ["shallow_pan_of_food", "paella"],
       "group": "food",
-      "order": 65
+      "order": 65,
+      "keywords": ["casserole", "food", "pan", "shallow"]
     },
     {
       "emoji": "🍲",
-      "shortcodes": ["stew"],
+      "shortcodes": ["stew", "pot_of_food"],
       "group": "food",
-      "order": 66
+      "order": 66,
+      "keywords": ["food", "pot", "soup"]
     },
     {
       "emoji": "🫕",
       "shortcodes": ["fondue"],
       "group": "food",
-      "order": 67
+      "order": 67,
+      "keywords": ["cheese", "chocolate", "food", "melted", "pot", "ski"]
     },
     {
       "emoji": "🥣",
       "shortcodes": ["bowl_with_spoon"],
       "group": "food",
-      "order": 68
+      "order": 68,
+      "keywords": ["bowl", "breakfast", "cereal", "congee", "oatmeal", "porridge", "spoon"]
     },
     {
       "emoji": "🥗",
-      "shortcodes": ["green_salad"],
+      "shortcodes": ["green_salad", "salad"],
       "group": "food",
-      "order": 69
+      "order": 69,
+      "keywords": ["food", "green"]
     },
     {
       "emoji": "🍿",
       "shortcodes": ["popcorn"],
       "group": "food",
-      "order": 70
+      "order": 70,
+      "keywords": ["corn", "movie", "pop"]
     },
     {
       "emoji": "🧈",
       "shortcodes": ["butter"],
       "group": "food",
-      "order": 71
+      "order": 71,
+      "keywords": ["dairy"]
     },
     {
       "emoji": "🧂",
       "shortcodes": ["salt"],
       "group": "food",
-      "order": 72
+      "order": 72,
+      "keywords": ["condiment", "flavor", "mad", "salty", "shaker", "taste", "upset"]
     },
     {
       "emoji": "🥫",
       "shortcodes": ["canned_food"],
       "group": "food",
-      "order": 73
+      "order": 73,
+      "keywords": ["can", "canned", "food"]
     },
     {
       "emoji": "🍱",
-      "shortcodes": ["bento"],
+      "shortcodes": ["bento", "bento_box"],
       "group": "food",
-      "order": 74
+      "order": 74,
+      "keywords": ["box", "food"]
     },
     {
       "emoji": "🍘",
       "shortcodes": ["rice_cracker"],
       "group": "food",
-      "order": 75
+      "order": 75,
+      "keywords": ["cracker", "food", "rice"]
     },
     {
       "emoji": "🍙",
       "shortcodes": ["rice_ball"],
       "group": "food",
-      "order": 76
+      "order": 76,
+      "keywords": ["ball", "food", "japanese", "rice"]
     },
     {
       "emoji": "🍚",
-      "shortcodes": ["rice"],
+      "shortcodes": ["rice", "cooked_rice"],
       "group": "food",
-      "order": 77
+      "order": 77,
+      "keywords": ["cooked", "food"]
     },
     {
       "emoji": "🍛",
-      "shortcodes": ["curry"],
+      "shortcodes": ["curry", "curry_rice"],
       "group": "food",
-      "order": 78
+      "order": 78,
+      "keywords": ["food", "rice"]
     },
     {
       "emoji": "🍜",
-      "shortcodes": ["ramen"],
+      "shortcodes": ["ramen", "steaming_bowl"],
       "group": "food",
-      "order": 79
+      "order": 79,
+      "keywords": ["bowl", "chopsticks", "food", "noodle", "pho", "soup", "steaming"]
     },
     {
       "emoji": "🍝",
       "shortcodes": ["spaghetti"],
       "group": "food",
-      "order": 80
+      "order": 80,
+      "keywords": ["food", "meatballs", "pasta", "restaurant"]
     },
     {
       "emoji": "🍠",
-      "shortcodes": ["sweet_potato"],
+      "shortcodes": ["sweet_potato", "roasted_sweet_potato"],
       "group": "food",
-      "order": 81
+      "order": 81,
+      "keywords": ["food", "potato", "roasted", "sweet"]
     },
     {
       "emoji": "🍢",
       "shortcodes": ["oden"],
       "group": "food",
-      "order": 82
+      "order": 82,
+      "keywords": ["food", "kebab", "restaurant", "seafood", "skewer", "stick"]
     },
     {
       "emoji": "🍣",
       "shortcodes": ["sushi"],
       "group": "food",
-      "order": 83
+      "order": 83,
+      "keywords": ["food"]
     },
     {
       "emoji": "🍤",
       "shortcodes": ["fried_shrimp"],
       "group": "food",
-      "order": 84
+      "order": 84,
+      "keywords": ["fried", "prawn", "shrimp", "tempura"]
     },
     {
       "emoji": "🍥",
-      "shortcodes": ["fish_cake"],
+      "shortcodes": ["fish_cake", "fish_cake_with_swirl"],
       "group": "food",
-      "order": 85
+      "order": 85,
+      "keywords": ["cake", "fish", "food", "pastry", "restaurant", "swirl"]
     },
     {
       "emoji": "🥮",
       "shortcodes": ["moon_cake"],
       "group": "food",
-      "order": 86
+      "order": 86,
+      "keywords": ["autumn", "cake", "festival", "moon", "yuèbǐng"]
     },
     {
       "emoji": "🍡",
       "shortcodes": ["dango"],
       "group": "food",
-      "order": 87
+      "order": 87,
+      "keywords": ["dessert", "japanese", "skewer", "stick", "sweet"]
     },
     {
       "emoji": "🥟",
       "shortcodes": ["dumpling"],
       "group": "food",
-      "order": 88
+      "order": 88,
+      "keywords": ["empanada", "gyōza", "jiaozi", "pierogi", "potsticker"]
     },
     {
       "emoji": "🥠",
       "shortcodes": ["fortune_cookie"],
       "group": "food",
-      "order": 89
+      "order": 89,
+      "keywords": ["cookie", "fortune", "prophecy"]
     },
     {
       "emoji": "🥡",
       "shortcodes": ["takeout_box"],
       "group": "food",
-      "order": 90
+      "order": 90,
+      "keywords": ["box", "chopsticks", "delivery", "food", "oyster", "pail", "takeout"]
     },
     {
       "emoji": "🍦",
-      "shortcodes": ["icecream"],
+      "shortcodes": ["icecream", "soft_serve", "soft_ice_cream"],
       "group": "food",
-      "order": 91
+      "order": 91,
+      "keywords": ["cream", "dessert", "food", "ice", "restaurant", "serve", "soft", "sweet"]
     },
     {
       "emoji": "🍧",
       "shortcodes": ["shaved_ice"],
       "group": "food",
-      "order": 92
+      "order": 92,
+      "keywords": ["dessert", "ice", "restaurant", "shaved", "sweet"]
     },
     {
       "emoji": "🍨",
       "shortcodes": ["ice_cream"],
       "group": "food",
-      "order": 93
+      "order": 93,
+      "keywords": ["cream", "dessert", "food", "ice", "restaurant", "sweet"]
     },
     {
       "emoji": "🍩",
       "shortcodes": ["doughnut"],
       "group": "food",
-      "order": 94
+      "order": 94,
+      "keywords": ["breakfast", "dessert", "donut", "food", "sweet"]
     },
     {
       "emoji": "🍪",
       "shortcodes": ["cookie"],
       "group": "food",
-      "order": 95
+      "order": 95,
+      "keywords": ["chip", "chocolate", "dessert", "sweet"]
     },
     {
       "emoji": "🎂",
-      "shortcodes": ["birthday"],
+      "shortcodes": ["birthday", "birthday_cake"],
       "group": "food",
-      "order": 96
+      "order": 96,
+      "keywords": ["bday", "cake", "celebration", "dessert", "happy", "pastry", "sweet"]
     },
     {
       "emoji": "🍰",
-      "shortcodes": ["cake"],
+      "shortcodes": ["cake", "shortcake"],
       "group": "food",
-      "order": 97
+      "order": 97,
+      "keywords": ["dessert", "pastry", "slice", "sweet"]
     },
     {
       "emoji": "🧁",
       "shortcodes": ["cupcake"],
       "group": "food",
-      "order": 98
+      "order": 98,
+      "keywords": ["bakery", "dessert", "sprinkles", "sugar", "sweet", "treat"]
     },
     {
       "emoji": "🥧",
       "shortcodes": ["pie"],
       "group": "food",
-      "order": 99
+      "order": 99,
+      "keywords": ["apple", "filling", "fruit", "meat", "pastry", "pumpkin", "slice"]
     },
     {
       "emoji": "🍫",
       "shortcodes": ["chocolate_bar"],
       "group": "food",
-      "order": 100
+      "order": 100,
+      "keywords": ["bar", "candy", "chocolate", "dessert", "halloween", "sweet", "tooth"]
     },
     {
       "emoji": "🍬",
       "shortcodes": ["candy"],
       "group": "food",
-      "order": 101
+      "order": 101,
+      "keywords": ["cavities", "dessert", "halloween", "restaurant", "sweet", "tooth", "wrapper"]
     },
     {
       "emoji": "🍭",
       "shortcodes": ["lollipop"],
       "group": "food",
-      "order": 102
+      "order": 102,
+      "keywords": ["candy", "dessert", "food", "restaurant", "sweet"]
     },
     {
       "emoji": "🍮",
-      "shortcodes": ["custard"],
+      "shortcodes": ["custard", "pudding", "flan"],
       "group": "food",
-      "order": 103
+      "order": 103,
+      "keywords": ["dessert", "sweet"]
     },
     {
       "emoji": "🍯",
       "shortcodes": ["honey_pot"],
       "group": "food",
-      "order": 104
+      "order": 104,
+      "keywords": ["barrel", "bear", "food", "honey", "jar", "pot", "sweet"]
     },
     {
       "emoji": "🍼",
       "shortcodes": ["baby_bottle"],
       "group": "food",
-      "order": 105
+      "order": 105,
+      "keywords": ["babies", "baby", "birth", "born", "bottle", "drink", "infant", "milk", "newborn"]
     },
     {
       "emoji": "🥛",
-      "shortcodes": ["milk_glass"],
+      "shortcodes": ["milk_glass", "glass_of_milk", "milk"],
       "group": "food",
-      "order": 106
+      "order": 106,
+      "keywords": ["drink", "glass"]
     },
     {
       "emoji": "☕",
-      "shortcodes": ["coffee"],
+      "shortcodes": ["coffee", "hot_beverage"],
       "group": "food",
-      "order": 107
+      "order": 107,
+      "keywords": ["beverage", "cafe", "caffeine", "chai", "drink", "hot", "morning", "steaming", "tea"]
     },
     {
       "emoji": "🫖",
       "shortcodes": ["teapot"],
       "group": "food",
-      "order": 108
+      "order": 108,
+      "keywords": ["brew", "drink", "food", "pot", "tea"]
     },
     {
       "emoji": "🍵",
-      "shortcodes": ["tea"],
+      "shortcodes": ["tea", "teacup_without_handle"],
       "group": "food",
-      "order": 109
+      "order": 109,
+      "keywords": ["beverage", "cup", "drink", "handle", "oolong", "teacup"]
     },
     {
       "emoji": "🍶",
       "shortcodes": ["sake"],
       "group": "food",
-      "order": 110
+      "order": 110,
+      "keywords": ["bar", "beverage", "bottle", "cup", "drink", "restaurant"]
     },
     {
       "emoji": "🍾",
-      "shortcodes": ["champagne"],
+      "shortcodes": ["champagne", "bottle_with_popping_cork"],
       "group": "food",
-      "order": 111
+      "order": 111,
+      "keywords": ["bar", "bottle", "cork", "drink", "popping"]
     },
     {
       "emoji": "🍷",
       "shortcodes": ["wine_glass"],
       "group": "food",
-      "order": 112
+      "order": 112,
+      "keywords": [
+        "alcohol",
+        "bar",
+        "beverage",
+        "booze",
+        "club",
+        "drink",
+        "drinking",
+        "drinks",
+        "glass",
+        "restaurant",
+        "wine"
+      ]
     },
     {
       "emoji": "🍸",
-      "shortcodes": ["cocktail"],
+      "shortcodes": ["cocktail", "cocktail_glass"],
       "group": "food",
-      "order": 113
+      "order": 113,
+      "keywords": ["alcohol", "bar", "booze", "club", "drink", "drinking", "drinks", "glass", "mad", "martini", "men"]
     },
     {
       "emoji": "🍹",
       "shortcodes": ["tropical_drink"],
       "group": "food",
-      "order": 114
+      "order": 114,
+      "keywords": [
+        "alcohol",
+        "bar",
+        "booze",
+        "club",
+        "cocktail",
+        "drink",
+        "drinking",
+        "drinks",
+        "drunk",
+        "mai",
+        "party",
+        "tai",
+        "tropical",
+        "tropics"
+      ]
     },
     {
       "emoji": "🍺",
-      "shortcodes": ["beer"],
+      "shortcodes": ["beer", "beer_mug"],
       "group": "food",
-      "order": 115
+      "order": 115,
+      "keywords": [
+        "alcohol",
+        "ale",
+        "bar",
+        "booze",
+        "drink",
+        "drinking",
+        "drinks",
+        "mug",
+        "octoberfest",
+        "oktoberfest",
+        "pint",
+        "stein",
+        "summer"
+      ]
     },
     {
       "emoji": "🍻",
-      "shortcodes": ["beers"],
+      "shortcodes": ["beers", "clinking_beer_mugs"],
       "group": "food",
-      "order": 116
+      "order": 116,
+      "keywords": [
+        "alcohol",
+        "bar",
+        "beer",
+        "booze",
+        "bottoms",
+        "cheers",
+        "clink",
+        "clinking",
+        "drinking",
+        "drinks",
+        "mugs"
+      ]
     },
     {
       "emoji": "🥂",
-      "shortcodes": ["clinking_glasses"],
+      "shortcodes": ["clinking_glasses", "champagne_glass", "clinking_glass"],
       "group": "food",
-      "order": 117
+      "order": 117,
+      "keywords": ["celebrate", "clink", "clinking", "drink", "glass", "glasses"]
     },
     {
       "emoji": "🥃",
-      "shortcodes": ["tumbler_glass"],
+      "shortcodes": ["tumbler_glass", "whisky"],
       "group": "food",
-      "order": 118
+      "order": 118,
+      "keywords": ["glass", "liquor", "scotch", "shot", "tumbler", "whiskey"]
     },
     {
       "emoji": "🥤",
       "shortcodes": ["cup_with_straw"],
       "group": "food",
-      "order": 120
+      "order": 120,
+      "keywords": ["cup", "drink", "juice", "malt", "soda", "soft", "straw", "water"]
     },
     {
       "emoji": "🧋",
-      "shortcodes": ["bubble_tea"],
+      "shortcodes": ["bubble_tea", "boba_drink"],
       "group": "food",
-      "order": 121
+      "order": 121,
+      "keywords": ["boba", "bubble", "food", "milk", "pearl", "tea"]
     },
     {
       "emoji": "🧃",
-      "shortcodes": ["beverage_box"],
+      "shortcodes": ["beverage_box", "juice_box"],
       "group": "food",
-      "order": 122
+      "order": 122,
+      "keywords": ["beverage", "box", "juice", "straw", "sweet"]
     },
     {
       "emoji": "🧉",
-      "shortcodes": ["mate"],
+      "shortcodes": ["mate", "mate_drink"],
       "group": "food",
-      "order": 123
+      "order": 123,
+      "keywords": ["drink"]
     },
     {
       "emoji": "🧊",
-      "shortcodes": ["ice_cube"],
+      "shortcodes": ["ice_cube", "ice"],
       "group": "food",
-      "order": 124
+      "order": 124,
+      "keywords": ["cold", "cube", "iceberg"]
     },
     {
       "emoji": "🥢",
       "shortcodes": ["chopsticks"],
       "group": "food",
-      "order": 125
+      "order": 125,
+      "keywords": ["hashi", "jeotgarak", "kuaizi"]
     },
     {
       "emoji": "🍽️",
-      "shortcodes": ["plate_with_cutlery"],
+      "shortcodes": ["plate_with_cutlery", "knife_fork_plate", "fork_knife_plate", "fork_and_knife_with_plate"],
       "group": "food",
-      "order": 126
+      "order": 126,
+      "keywords": ["cooking", "dinner", "eat", "fork", "knife", "plate"]
     },
     {
       "emoji": "🍴",
       "shortcodes": ["fork_and_knife"],
       "group": "food",
-      "order": 128
+      "order": 128,
+      "keywords": [
+        "breakfast",
+        "breaky",
+        "cooking",
+        "cutlery",
+        "delicious",
+        "dinner",
+        "eat",
+        "feed",
+        "food",
+        "fork",
+        "hungry",
+        "knife",
+        "lunch",
+        "restaurant",
+        "yum",
+        "yummy"
+      ]
     },
     {
       "emoji": "🥄",
       "shortcodes": ["spoon"],
       "group": "food",
-      "order": 129
+      "order": 129,
+      "keywords": ["eat", "tableware"]
     },
     {
       "emoji": "🔪",
-      "shortcodes": ["hocho", "knife"],
+      "shortcodes": ["hocho", "knife", "kitchen_knife"],
       "group": "food",
-      "order": 130
+      "order": 130,
+      "keywords": ["chef", "cooking", "kitchen", "tool", "weapon"]
     },
     {
       "emoji": "🏺",
       "shortcodes": ["amphora"],
       "group": "food",
-      "order": 132
+      "order": 132,
+      "keywords": ["aquarius", "cooking", "drink", "jug", "tool", "weapon", "zodiac"]
     },
     {
       "emoji": "🌍",
-      "shortcodes": ["earth_africa"],
+      "shortcodes": ["earth_africa", "earth_europe", "globe_showing_europe_africa"],
       "group": "travel",
-      "order": 0
+      "order": 0,
+      "keywords": ["africa", "earth", "europe", "europe-africa", "globe", "showing", "world"]
     },
     {
       "emoji": "🌎",
-      "shortcodes": ["earth_americas"],
+      "shortcodes": ["earth_americas", "globe_showing_americas"],
       "group": "travel",
-      "order": 1
+      "order": 1,
+      "keywords": ["americas", "earth", "globe", "showing", "world"]
     },
     {
       "emoji": "🌏",
-      "shortcodes": ["earth_asia"],
+      "shortcodes": ["earth_asia", "globe_showing_asia_australia"],
       "group": "travel",
-      "order": 2
+      "order": 2,
+      "keywords": ["asia", "asia-australia", "australia", "earth", "globe", "showing", "world"]
     },
     {
       "emoji": "🌐",
       "shortcodes": ["globe_with_meridians"],
       "group": "travel",
-      "order": 3
+      "order": 3,
+      "keywords": ["earth", "globe", "internet", "meridians", "web", "world", "worldwide"]
     },
     {
       "emoji": "🗺️",
-      "shortcodes": ["world_map"],
+      "shortcodes": ["world_map", "map"],
       "group": "travel",
-      "order": 4
+      "order": 4,
+      "keywords": ["world"]
     },
     {
       "emoji": "🗾",
-      "shortcodes": ["japan"],
+      "shortcodes": ["japan", "japan_map", "map_of_japan"],
       "group": "travel",
-      "order": 6
+      "order": 6,
+      "keywords": ["map"]
     },
     {
       "emoji": "🧭",
       "shortcodes": ["compass"],
       "group": "travel",
-      "order": 7
+      "order": 7,
+      "keywords": ["direction", "magnetic", "navigation", "orienteering"]
     },
     {
       "emoji": "🏔️",
-      "shortcodes": ["mountain_snow"],
+      "shortcodes": ["mountain_snow", "snow_capped_mountain"],
       "group": "travel",
-      "order": 8
+      "order": 8,
+      "keywords": ["cold", "mountain", "snow", "snow-capped"]
     },
     {
       "emoji": "⛰️",
       "shortcodes": ["mountain"],
       "group": "travel",
-      "order": 10
+      "order": 10,
+      "keywords": []
     },
     {
       "emoji": "🌋",
       "shortcodes": ["volcano"],
       "group": "travel",
-      "order": 12
+      "order": 12,
+      "keywords": ["eruption", "mountain", "nature"]
     },
     {
       "emoji": "🗻",
       "shortcodes": ["mount_fuji"],
       "group": "travel",
-      "order": 13
+      "order": 13,
+      "keywords": ["fuji", "mount", "mountain", "nature"]
     },
     {
       "emoji": "🏕️",
       "shortcodes": ["camping"],
       "group": "travel",
-      "order": 14
+      "order": 14,
+      "keywords": []
     },
     {
       "emoji": "🏖️",
-      "shortcodes": ["beach_umbrella"],
+      "shortcodes": ["beach_umbrella", "beach_with_umbrella", "beach"],
       "group": "travel",
-      "order": 16
+      "order": 16,
+      "keywords": ["umbrella"]
     },
     {
       "emoji": "🏜️",
       "shortcodes": ["desert"],
       "group": "travel",
-      "order": 18
+      "order": 18,
+      "keywords": []
     },
     {
       "emoji": "🏝️",
-      "shortcodes": ["desert_island"],
+      "shortcodes": ["desert_island", "island"],
       "group": "travel",
-      "order": 20
+      "order": 20,
+      "keywords": ["desert"]
     },
     {
       "emoji": "🏞️",
-      "shortcodes": ["national_park"],
+      "shortcodes": ["national_park", "park"],
       "group": "travel",
-      "order": 22
+      "order": 22,
+      "keywords": ["national"]
     },
     {
       "emoji": "🏟️",
       "shortcodes": ["stadium"],
       "group": "travel",
-      "order": 24
+      "order": 24,
+      "keywords": []
     },
     {
       "emoji": "🏛️",
       "shortcodes": ["classical_building"],
       "group": "travel",
-      "order": 26
+      "order": 26,
+      "keywords": ["building", "classical"]
     },
     {
       "emoji": "🏗️",
-      "shortcodes": ["building_construction"],
+      "shortcodes": ["building_construction", "construction_site"],
       "group": "travel",
-      "order": 28
+      "order": 28,
+      "keywords": ["building", "construction", "crane"]
     },
     {
       "emoji": "🧱",
-      "shortcodes": ["bricks"],
+      "shortcodes": ["bricks", "brick"],
       "group": "travel",
-      "order": 30
+      "order": 30,
+      "keywords": ["clay", "mortar", "wall"]
     },
     {
       "emoji": "🪨",
       "shortcodes": ["rock"],
       "group": "travel",
-      "order": 31
+      "order": 31,
+      "keywords": ["boulder", "heavy", "solid", "stone", "tough"]
     },
     {
       "emoji": "🪵",
       "shortcodes": ["wood"],
       "group": "travel",
-      "order": 32
+      "order": 32,
+      "keywords": ["log", "lumber", "timber"]
     },
     {
       "emoji": "🛖",
       "shortcodes": ["hut"],
       "group": "travel",
-      "order": 33
+      "order": 33,
+      "keywords": ["home", "house", "roundhouse", "shelter", "yurt"]
     },
     {
       "emoji": "🏘️",
-      "shortcodes": ["houses"],
+      "shortcodes": ["houses", "house_buildings", "homes"],
       "group": "travel",
-      "order": 34
+      "order": 34,
+      "keywords": ["house"]
     },
     {
       "emoji": "🏚️",
-      "shortcodes": ["derelict_house"],
+      "shortcodes": ["derelict_house", "derelict_house_building", "house_abandoned"],
       "group": "travel",
-      "order": 36
+      "order": 36,
+      "keywords": ["derelict", "home", "house"]
     },
     {
       "emoji": "🏠",
       "shortcodes": ["house"],
       "group": "travel",
-      "order": 38
+      "order": 38,
+      "keywords": ["building", "country", "heart", "home", "ranch", "settle", "simple", "suburban", "suburbia", "where"]
     },
     {
       "emoji": "🏡",
       "shortcodes": ["house_with_garden"],
       "group": "travel",
-      "order": 39
+      "order": 39,
+      "keywords": [
+        "building",
+        "country",
+        "garden",
+        "heart",
+        "home",
+        "house",
+        "ranch",
+        "settle",
+        "simple",
+        "suburban",
+        "suburbia",
+        "where"
+      ]
     },
     {
       "emoji": "🏢",
-      "shortcodes": ["office"],
+      "shortcodes": ["office", "office_building"],
       "group": "travel",
-      "order": 40
+      "order": 40,
+      "keywords": ["building", "city", "cubical", "job"]
     },
     {
       "emoji": "🏣",
-      "shortcodes": ["post_office"],
+      "shortcodes": ["post_office", "japanese_post_office"],
       "group": "travel",
-      "order": 41
+      "order": 41,
+      "keywords": ["building", "japanese", "office", "post"]
     },
     {
       "emoji": "🏤",
       "shortcodes": ["european_post_office"],
       "group": "travel",
-      "order": 42
+      "order": 42,
+      "keywords": ["building", "european", "office", "post", "post office"]
     },
     {
       "emoji": "🏥",
       "shortcodes": ["hospital"],
       "group": "travel",
-      "order": 43
+      "order": 43,
+      "keywords": ["building", "doctor", "medicine"]
     },
     {
       "emoji": "🏦",
       "shortcodes": ["bank"],
       "group": "travel",
-      "order": 44
+      "order": 44,
+      "keywords": ["building"]
     },
     {
       "emoji": "🏨",
       "shortcodes": ["hotel"],
       "group": "travel",
-      "order": 45
+      "order": 45,
+      "keywords": ["building"]
     },
     {
       "emoji": "🏩",
       "shortcodes": ["love_hotel"],
       "group": "travel",
-      "order": 46
+      "order": 46,
+      "keywords": ["building", "hotel", "love"]
     },
     {
       "emoji": "🏪",
       "shortcodes": ["convenience_store"],
       "group": "travel",
-      "order": 47
+      "order": 47,
+      "keywords": ["24", "building", "convenience", "hours", "store"]
     },
     {
       "emoji": "🏫",
       "shortcodes": ["school"],
       "group": "travel",
-      "order": 48
+      "order": 48,
+      "keywords": ["building"]
     },
     {
       "emoji": "🏬",
       "shortcodes": ["department_store"],
       "group": "travel",
-      "order": 49
+      "order": 49,
+      "keywords": ["building", "department", "store"]
     },
     {
       "emoji": "🏭",
       "shortcodes": ["factory"],
       "group": "travel",
-      "order": 50
+      "order": 50,
+      "keywords": ["building"]
     },
     {
       "emoji": "🏯",
       "shortcodes": ["japanese_castle"],
       "group": "travel",
-      "order": 51
+      "order": 51,
+      "keywords": ["building", "castle", "japanese"]
     },
     {
       "emoji": "🏰",
-      "shortcodes": ["european_castle"],
+      "shortcodes": ["european_castle", "castle"],
       "group": "travel",
-      "order": 52
+      "order": 52,
+      "keywords": ["building", "european"]
     },
     {
       "emoji": "💒",
       "shortcodes": ["child", "wedding"],
       "group": "travel",
-      "order": 53
+      "order": 53,
+      "keywords": ["chapel", "hitched", "nuptials", "romance"]
     },
     {
       "emoji": "🗼",
       "shortcodes": ["tokyo_tower"],
       "group": "travel",
-      "order": 54
+      "order": 54,
+      "keywords": ["tokyo", "tower"]
     },
     {
       "emoji": "🗽",
       "shortcodes": ["statue_of_liberty"],
       "group": "travel",
-      "order": 55
+      "order": 55,
+      "keywords": ["liberty", "new", "ny", "nyc", "statue", "york"]
     },
     {
       "emoji": "⛪",
       "shortcodes": ["church"],
       "group": "travel",
-      "order": 56
+      "order": 56,
+      "keywords": ["bless", "chapel", "christian", "cross", "religion"]
     },
     {
       "emoji": "🕌",
       "shortcodes": ["mosque"],
       "group": "travel",
-      "order": 57
+      "order": 57,
+      "keywords": ["islam", "masjid", "muslim", "religion"]
     },
     {
       "emoji": "🛕",
       "shortcodes": ["hindu_temple"],
       "group": "travel",
-      "order": 58
+      "order": 58,
+      "keywords": ["hindu", "temple"]
     },
     {
       "emoji": "🕍",
       "shortcodes": ["synagogue"],
       "group": "travel",
-      "order": 59
+      "order": 59,
+      "keywords": ["jew", "jewish", "judaism", "religion", "temple"]
     },
     {
       "emoji": "⛩️",
       "shortcodes": ["shinto_shrine"],
       "group": "travel",
-      "order": 60
+      "order": 60,
+      "keywords": ["religion", "shinto", "shrine"]
     },
     {
       "emoji": "🕋",
       "shortcodes": ["kaaba"],
       "group": "travel",
-      "order": 62
+      "order": 62,
+      "keywords": ["hajj", "islam", "muslim", "religion", "umrah"]
     },
     {
       "emoji": "⛲",
       "shortcodes": ["fountain"],
       "group": "travel",
-      "order": 63
+      "order": 63,
+      "keywords": []
     },
     {
       "emoji": "⛺",
       "shortcodes": ["tent"],
       "group": "travel",
-      "order": 64
+      "order": 64,
+      "keywords": ["camping"]
     },
     {
       "emoji": "🌁",
       "shortcodes": ["foggy"],
       "group": "travel",
-      "order": 65
+      "order": 65,
+      "keywords": ["fog"]
     },
     {
       "emoji": "🌃",
       "shortcodes": ["night_with_stars"],
       "group": "travel",
-      "order": 66
+      "order": 66,
+      "keywords": ["night", "star", "stars"]
     },
     {
       "emoji": "🏙️",
       "shortcodes": ["cityscape"],
       "group": "travel",
-      "order": 67
+      "order": 67,
+      "keywords": ["city"]
     },
     {
       "emoji": "🌄",
       "shortcodes": ["sunrise_over_mountains"],
       "group": "travel",
-      "order": 69
+      "order": 69,
+      "keywords": ["morning", "mountains", "over", "sun", "sunrise"]
     },
     {
       "emoji": "🌅",
       "shortcodes": ["sunrise"],
       "group": "travel",
-      "order": 70
+      "order": 70,
+      "keywords": ["morning", "nature", "sun"]
     },
     {
       "emoji": "🌆",
-      "shortcodes": ["city_sunset"],
+      "shortcodes": ["city_sunset", "city_dusk", "cityscape_at_dusk"],
       "group": "travel",
-      "order": 71
+      "order": 71,
+      "keywords": ["at", "building", "city", "cityscape", "dusk", "evening", "landscape", "sun", "sunset"]
     },
     {
       "emoji": "🌇",
-      "shortcodes": ["city_sunrise"],
+      "shortcodes": ["city_sunrise", "sunset"],
       "group": "travel",
-      "order": 72
+      "order": 72,
+      "keywords": ["building", "dusk", "sun"]
     },
     {
       "emoji": "🌉",
       "shortcodes": ["bridge_at_night"],
       "group": "travel",
-      "order": 73
+      "order": 73,
+      "keywords": ["at", "bridge", "night"]
     },
     {
       "emoji": "♨️",
-      "shortcodes": ["hotsprings"],
+      "shortcodes": ["hotsprings", "hot_springs"],
       "group": "travel",
-      "order": 74
+      "order": 74,
+      "keywords": ["hot", "springs", "steaming"]
     },
     {
       "emoji": "🎠",
       "shortcodes": ["carousel_horse"],
       "group": "travel",
-      "order": 76
+      "order": 76,
+      "keywords": ["carousel", "entertainment", "horse"]
     },
     {
       "emoji": "🎡",
       "shortcodes": ["ferris_wheel"],
       "group": "travel",
-      "order": 78
+      "order": 78,
+      "keywords": ["amusement", "ferris", "park", "theme", "wheel"]
     },
     {
       "emoji": "🎢",
       "shortcodes": ["roller_coaster"],
       "group": "travel",
-      "order": 79
+      "order": 79,
+      "keywords": ["amusement", "coaster", "park", "roller", "theme"]
     },
     {
       "emoji": "💈",
-      "shortcodes": ["barber"],
+      "shortcodes": ["barber", "barber_pole"],
       "group": "travel",
-      "order": 80
+      "order": 80,
+      "keywords": ["cut", "fresh", "haircut", "pole", "shave"]
     },
     {
       "emoji": "🎪",
       "shortcodes": ["circus_tent"],
       "group": "travel",
-      "order": 81
+      "order": 81,
+      "keywords": ["circus", "tent"]
     },
     {
       "emoji": "🚂",
-      "shortcodes": ["steam_locomotive"],
+      "shortcodes": ["steam_locomotive", "locomotive"],
       "group": "travel",
-      "order": 82
+      "order": 82,
+      "keywords": ["caboose", "engine", "railway", "steam", "train", "trains", "travel"]
     },
     {
       "emoji": "🚃",
       "shortcodes": ["railway_car"],
       "group": "travel",
-      "order": 83
+      "order": 83,
+      "keywords": ["car", "electric", "railway", "train", "tram", "travel", "trolleybus"]
     },
     {
       "emoji": "🚄",
-      "shortcodes": ["bullettrain_side"],
+      "shortcodes": ["bullettrain_side", "high_speed_train"],
       "group": "travel",
-      "order": 84
+      "order": 84,
+      "keywords": ["high-speed", "railway", "shinkansen", "speed", "train"]
     },
     {
       "emoji": "🚅",
-      "shortcodes": ["bullettrain_front"],
+      "shortcodes": ["bullettrain_front", "bullet_train"],
       "group": "travel",
-      "order": 85
+      "order": 85,
+      "keywords": ["bullet", "high-speed", "nose", "railway", "shinkansen", "speed", "train", "travel"]
     },
     {
       "emoji": "🚆",
       "shortcodes": ["train2"],
       "group": "travel",
-      "order": 86
+      "order": 86,
+      "keywords": ["arrived", "choo", "railway", "train"]
     },
     {
       "emoji": "🚇",
       "shortcodes": ["metro"],
       "group": "travel",
-      "order": 87
+      "order": 87,
+      "keywords": ["subway", "travel"]
     },
     {
       "emoji": "🚈",
       "shortcodes": ["light_rail"],
       "group": "travel",
-      "order": 88
+      "order": 88,
+      "keywords": ["arrived", "light", "monorail", "rail", "railway"]
     },
     {
       "emoji": "🚉",
       "shortcodes": ["station"],
       "group": "travel",
-      "order": 89
+      "order": 89,
+      "keywords": ["railway", "train"]
     },
     {
       "emoji": "🚊",
       "shortcodes": ["tram"],
       "group": "travel",
-      "order": 90
+      "order": 90,
+      "keywords": ["trolleybus"]
     },
     {
       "emoji": "🚝",
       "shortcodes": ["monorail"],
       "group": "travel",
-      "order": 91
+      "order": 91,
+      "keywords": ["vehicle"]
     },
     {
       "emoji": "🚞",
       "shortcodes": ["mountain_railway"],
       "group": "travel",
-      "order": 92
+      "order": 92,
+      "keywords": ["car", "mountain", "railway", "trip"]
     },
     {
       "emoji": "🚋",
-      "shortcodes": ["train"],
+      "shortcodes": ["train", "tram_car"],
       "group": "travel",
-      "order": 93
+      "order": 93,
+      "keywords": ["bus", "car", "tram", "trolley", "trolleybus"]
     },
     {
       "emoji": "🚌",
       "shortcodes": ["bus"],
       "group": "travel",
-      "order": 94
+      "order": 94,
+      "keywords": ["school", "vehicle"]
     },
     {
       "emoji": "🚍",
       "shortcodes": ["oncoming_bus"],
       "group": "travel",
-      "order": 95
+      "order": 95,
+      "keywords": ["bus", "cars", "oncoming"]
     },
     {
       "emoji": "🚎",
       "shortcodes": ["trolleybus"],
       "group": "travel",
-      "order": 96
+      "order": 96,
+      "keywords": ["bus", "tram", "trolley"]
     },
     {
       "emoji": "🚐",
       "shortcodes": ["minibus"],
       "group": "travel",
-      "order": 97
+      "order": 97,
+      "keywords": ["bus", "drive", "van", "vehicle"]
     },
     {
       "emoji": "🚑",
       "shortcodes": ["ambulance"],
       "group": "travel",
-      "order": 98
+      "order": 98,
+      "keywords": ["emergency", "vehicle"]
     },
     {
       "emoji": "🚒",
       "shortcodes": ["fire_engine"],
       "group": "travel",
-      "order": 99
+      "order": 99,
+      "keywords": ["engine", "fire", "truck"]
     },
     {
       "emoji": "🚓",
       "shortcodes": ["police_car"],
       "group": "travel",
-      "order": 100
+      "order": 100,
+      "keywords": ["5–0", "car", "cops", "patrol", "police"]
     },
     {
       "emoji": "🚔",
       "shortcodes": ["oncoming_police_car"],
       "group": "travel",
-      "order": 101
+      "order": 101,
+      "keywords": ["car", "oncoming", "police"]
     },
     {
       "emoji": "🚕",
       "shortcodes": ["taxi"],
       "group": "travel",
-      "order": 102
+      "order": 102,
+      "keywords": ["cab", "cabbie", "car", "drive", "vehicle", "yellow"]
     },
     {
       "emoji": "🚖",
       "shortcodes": ["oncoming_taxi"],
       "group": "travel",
-      "order": 103
+      "order": 103,
+      "keywords": ["cab", "cabbie", "cars", "drove", "hail", "oncoming", "taxi", "yellow"]
     },
     {
       "emoji": "🚗",
-      "shortcodes": ["car", "red_car"],
+      "shortcodes": ["car", "red_car", "automobile"],
       "group": "travel",
-      "order": 104
+      "order": 104,
+      "keywords": ["driving", "vehicle"]
     },
     {
       "emoji": "🚘",
       "shortcodes": ["oncoming_automobile"],
       "group": "travel",
-      "order": 105
+      "order": 105,
+      "keywords": ["automobile", "car", "cars", "drove", "oncoming", "vehicle"]
     },
     {
       "emoji": "🚙",
-      "shortcodes": ["blue_car"],
+      "shortcodes": ["blue_car", "suv", "sport_utility_vehicle"],
       "group": "travel",
-      "order": 106
+      "order": 106,
+      "keywords": ["car", "drive", "recreational", "sport", "sportutility", "utility", "vehicle"]
     },
     {
       "emoji": "🛻",
       "shortcodes": ["pickup_truck"],
       "group": "travel",
-      "order": 107
+      "order": 107,
+      "keywords": ["automobile", "car", "flatbed", "pick-up", "transportation", "truck"]
     },
     {
       "emoji": "🚚",
-      "shortcodes": ["truck"],
+      "shortcodes": ["truck", "delivery_truck"],
       "group": "travel",
-      "order": 108
+      "order": 108,
+      "keywords": ["car", "delivery", "drive", "vehicle"]
     },
     {
       "emoji": "🚛",
       "shortcodes": ["articulated_lorry"],
       "group": "travel",
-      "order": 109
+      "order": 109,
+      "keywords": ["articulated", "car", "drive", "lorry", "move", "semi", "truck", "vehicle"]
     },
     {
       "emoji": "🚜",
       "shortcodes": ["tractor"],
       "group": "travel",
-      "order": 110
+      "order": 110,
+      "keywords": ["vehicle"]
     },
     {
       "emoji": "🏎️",
-      "shortcodes": ["racing_car"],
+      "shortcodes": ["racing_car", "race_car"],
       "group": "travel",
-      "order": 111
+      "order": 111,
+      "keywords": ["car", "racing", "zoom"]
     },
     {
       "emoji": "🏍️",
-      "shortcodes": ["motorcycle"],
+      "shortcodes": ["motorcycle", "racing_motorcycle"],
       "group": "travel",
-      "order": 113
+      "order": 113,
+      "keywords": ["racing"]
     },
     {
       "emoji": "🛵",
-      "shortcodes": ["motor_scooter"],
+      "shortcodes": ["motor_scooter", "motorbike"],
       "group": "travel",
-      "order": 115
+      "order": 115,
+      "keywords": ["motor", "scooter"]
     },
     {
       "emoji": "🦽",
       "shortcodes": ["manual_wheelchair"],
       "group": "travel",
-      "order": 116
+      "order": 116,
+      "keywords": ["accessibility", "manual", "wheelchair"]
     },
     {
       "emoji": "🦼",
       "shortcodes": ["motorized_wheelchair"],
       "group": "travel",
-      "order": 117
+      "order": 117,
+      "keywords": ["accessibility", "motorized", "wheelchair"]
     },
     {
       "emoji": "🛺",
       "shortcodes": ["auto_rickshaw"],
       "group": "travel",
-      "order": 118
+      "order": 118,
+      "keywords": ["auto", "rickshaw", "tuk"]
     },
     {
       "emoji": "🚲",
-      "shortcodes": ["bike"],
+      "shortcodes": ["bike", "bicycle"],
       "group": "travel",
-      "order": 119
+      "order": 119,
+      "keywords": ["class", "cycle", "cycling", "cyclist", "gang", "ride", "spin", "spinning"]
     },
     {
       "emoji": "🛴",
-      "shortcodes": ["kick_scooter"],
+      "shortcodes": ["kick_scooter", "scooter"],
       "group": "travel",
-      "order": 120
+      "order": 120,
+      "keywords": ["kick"]
     },
     {
       "emoji": "🛹",
       "shortcodes": ["skateboard"],
       "group": "travel",
-      "order": 121
+      "order": 121,
+      "keywords": ["board", "skate", "skater", "wheels"]
     },
     {
       "emoji": "🛼",
       "shortcodes": ["roller_skate"],
       "group": "travel",
-      "order": 122
+      "order": 122,
+      "keywords": ["blades", "roller", "skate", "skates", "sport"]
     },
     {
       "emoji": "🚏",
-      "shortcodes": ["busstop"],
+      "shortcodes": ["busstop", "bus_stop"],
       "group": "travel",
-      "order": 123
+      "order": 123,
+      "keywords": ["bus", "stop"]
     },
     {
       "emoji": "🛣️",
       "shortcodes": ["motorway"],
       "group": "travel",
-      "order": 124
+      "order": 124,
+      "keywords": ["highway", "road"]
     },
     {
       "emoji": "🛤️",
-      "shortcodes": ["railway_track"],
+      "shortcodes": ["railway_track", "railroad_track"],
       "group": "travel",
-      "order": 126
+      "order": 126,
+      "keywords": ["railway", "track", "train"]
     },
     {
       "emoji": "🛢️",
-      "shortcodes": ["oil_drum"],
+      "shortcodes": ["oil_drum", "oil"],
       "group": "travel",
-      "order": 128
+      "order": 128,
+      "keywords": ["drum"]
     },
     {
       "emoji": "⛽",
-      "shortcodes": ["fuelpump"],
+      "shortcodes": ["fuelpump", "fuel_pump"],
       "group": "travel",
-      "order": 130
+      "order": 130,
+      "keywords": ["diesel", "fuel", "gas", "gasoline", "pump", "station"]
     },
     {
       "emoji": "🚨",
-      "shortcodes": ["rotating_light"],
+      "shortcodes": ["rotating_light", "police_car_light"],
       "group": "travel",
-      "order": 132
+      "order": 132,
+      "keywords": ["alarm", "alert", "beacon", "car", "emergency", "light", "police", "revolving", "siren"]
     },
     {
       "emoji": "🚥",
-      "shortcodes": ["traffic_light"],
+      "shortcodes": ["traffic_light", "horizontal_traffic_light"],
       "group": "travel",
-      "order": 133
+      "order": 133,
+      "keywords": ["horizontal", "intersection", "light", "signal", "stop", "stoplight", "traffic"]
     },
     {
       "emoji": "🚦",
       "shortcodes": ["vertical_traffic_light"],
       "group": "travel",
-      "order": 134
+      "order": 134,
+      "keywords": ["drove", "intersection", "light", "signal", "stop", "stoplight", "traffic", "vertical"]
     },
     {
       "emoji": "🛑",
-      "shortcodes": ["stop_sign"],
+      "shortcodes": ["stop_sign", "octagonal_sign"],
       "group": "travel",
-      "order": 135
+      "order": 135,
+      "keywords": ["octagonal", "sign", "stop"]
     },
     {
       "emoji": "🚧",
       "shortcodes": ["construction"],
       "group": "travel",
-      "order": 136
+      "order": 136,
+      "keywords": ["barrier"]
     },
     {
       "emoji": "⚓",
       "shortcodes": ["anchor"],
       "group": "travel",
-      "order": 137
+      "order": 137,
+      "keywords": ["ship", "tool"]
     },
     {
       "emoji": "⛵",
       "shortcodes": ["boat", "sailboat"],
       "group": "travel",
-      "order": 139
+      "order": 139,
+      "keywords": ["resort", "sailing", "sea", "yacht"]
     },
     {
       "emoji": "🛶",
-      "shortcodes": ["canoe"],
+      "shortcodes": ["canoe", "kayak"],
       "group": "travel",
-      "order": 140
+      "order": 140,
+      "keywords": ["boat"]
     },
     {
       "emoji": "🚤",
       "shortcodes": ["speedboat"],
       "group": "travel",
-      "order": 141
+      "order": 141,
+      "keywords": ["billionaire", "boat", "lake", "luxury", "millionaire", "summer", "travel"]
     },
     {
       "emoji": "🛳️",
-      "shortcodes": ["passenger_ship"],
+      "shortcodes": ["passenger_ship", "cruise_ship"],
       "group": "travel",
-      "order": 142
+      "order": 142,
+      "keywords": ["passenger", "ship"]
     },
     {
       "emoji": "⛴️",
       "shortcodes": ["ferry"],
       "group": "travel",
-      "order": 144
+      "order": 144,
+      "keywords": ["boat", "passenger"]
     },
     {
       "emoji": "🛥️",
-      "shortcodes": ["motor_boat"],
+      "shortcodes": ["motor_boat", "motorboat"],
       "group": "travel",
-      "order": 146
+      "order": 146,
+      "keywords": ["boat", "motor"]
     },
     {
       "emoji": "🚢",
       "shortcodes": ["ship"],
       "group": "travel",
-      "order": 148
+      "order": 148,
+      "keywords": ["boat", "passenger", "travel"]
     },
     {
       "emoji": "✈️",
       "shortcodes": ["airplane"],
       "group": "travel",
-      "order": 149
+      "order": 149,
+      "keywords": ["aeroplane", "fly", "flying", "jet", "plane", "travel"]
     },
     {
       "emoji": "🛩️",
-      "shortcodes": ["small_airplane"],
+      "shortcodes": ["small_airplane", "airplane_small"],
       "group": "travel",
-      "order": 151
+      "order": 151,
+      "keywords": ["aeroplane", "airplane", "plane", "small"]
     },
     {
       "emoji": "🛫",
-      "shortcodes": ["flight_departure"],
+      "shortcodes": ["flight_departure", "airplane_departure"],
       "group": "travel",
-      "order": 153
+      "order": 153,
+      "keywords": ["aeroplane", "airplane", "check-in", "departure", "departures", "plane"]
     },
     {
       "emoji": "🛬",
-      "shortcodes": ["flight_arrival"],
+      "shortcodes": ["flight_arrival", "airplane_arriving", "airplane_arrival"],
       "group": "travel",
-      "order": 154
+      "order": 154,
+      "keywords": ["aeroplane", "airplane", "arrival", "arrivals", "arriving", "landing", "plane"]
     },
     {
       "emoji": "🪂",
       "shortcodes": ["parachute"],
       "group": "travel",
-      "order": 155
+      "order": 155,
+      "keywords": ["hang-glide", "parasail", "skydive"]
     },
     {
       "emoji": "💺",
       "shortcodes": ["seat"],
       "group": "travel",
-      "order": 156
+      "order": 156,
+      "keywords": ["chair"]
     },
     {
       "emoji": "🚁",
       "shortcodes": ["helicopter"],
       "group": "travel",
-      "order": 157
+      "order": 157,
+      "keywords": ["copter", "roflcopter", "travel", "vehicle"]
     },
     {
       "emoji": "🚟",
       "shortcodes": ["suspension_railway"],
       "group": "travel",
-      "order": 158
+      "order": 158,
+      "keywords": ["railway", "suspension"]
     },
     {
       "emoji": "🚠",
       "shortcodes": ["mountain_cableway"],
       "group": "travel",
-      "order": 159
+      "order": 159,
+      "keywords": ["cable", "cableway", "gondola", "lift", "mountain", "ski"]
     },
     {
       "emoji": "🚡",
       "shortcodes": ["aerial_tramway"],
       "group": "travel",
-      "order": 160
+      "order": 160,
+      "keywords": ["aerial", "cable", "car", "gondola", "ropeway", "tramway"]
     },
     {
       "emoji": "🛰️",
-      "shortcodes": ["artificial_satellite"],
+      "shortcodes": ["artificial_satellite", "satellite_orbital"],
       "group": "travel",
-      "order": 161
+      "order": 161,
+      "keywords": ["space", "satellite"]
     },
     {
       "emoji": "🚀",
       "shortcodes": ["rocket", "launch", "blast_off"],
       "group": "travel",
-      "order": 163
+      "order": 163,
+      "keywords": ["rockets", "space", "travel"]
     },
     {
       "emoji": "🛸",
       "shortcodes": ["flying_saucer"],
       "group": "travel",
-      "order": 164
+      "order": 164,
+      "keywords": ["aliens", "extra", "flying", "saucer", "terrestrial", "ufo"]
     },
     {
       "emoji": "🛎️",
-      "shortcodes": ["bellhop_bell"],
+      "shortcodes": ["bellhop_bell", "bellhop"],
       "group": "travel",
-      "order": 165
+      "order": 165,
+      "keywords": ["bell", "hotel"]
     },
     {
       "emoji": "🧳",
       "shortcodes": ["luggage"],
       "group": "travel",
-      "order": 167
+      "order": 167,
+      "keywords": ["bag", "packing", "roller", "suitcase", "travel"]
     },
     {
       "emoji": "⌛",
-      "shortcodes": ["hourglass"],
+      "shortcodes": ["hourglass", "hourglass_done"],
       "group": "travel",
-      "order": 168
+      "order": 168,
+      "keywords": ["done", "sand", "time", "timer"]
     },
     {
       "emoji": "⏳",
-      "shortcodes": ["hourglass_flowing_sand"],
+      "shortcodes": ["hourglass_flowing_sand", "hourglass_not_done"],
       "group": "travel",
-      "order": 169
+      "order": 169,
+      "keywords": ["done", "flowing", "hourglass", "hours", "not", "sand", "timer", "waiting", "yolo"]
     },
     {
       "emoji": "⌚",
       "shortcodes": ["watch"],
       "group": "travel",
-      "order": 170
+      "order": 170,
+      "keywords": ["clock", "time"]
     },
     {
       "emoji": "⏰",
       "shortcodes": ["alarm_clock"],
       "group": "travel",
-      "order": 171
+      "order": 171,
+      "keywords": ["alarm", "clock", "hours", "hrs", "late", "time", "waiting"]
     },
     {
       "emoji": "⏱️",
       "shortcodes": ["stopwatch"],
       "group": "travel",
-      "order": 172
+      "order": 172,
+      "keywords": ["clock", "time"]
     },
     {
       "emoji": "⏲️",
-      "shortcodes": ["timer_clock"],
+      "shortcodes": ["timer_clock", "timer"],
       "group": "travel",
-      "order": 174
+      "order": 174,
+      "keywords": ["clock"]
     },
     {
       "emoji": "🕰️",
-      "shortcodes": ["mantelpiece_clock"],
+      "shortcodes": ["mantelpiece_clock", "clock", "mantlepiece_clock"],
       "group": "travel",
-      "order": 176
+      "order": 176,
+      "keywords": ["mantelpiece", "time"]
     },
     {
       "emoji": "🕛",
-      "shortcodes": ["clock12"],
+      "shortcodes": ["clock12", "twelve_oclock"],
       "group": "travel",
-      "order": 178
+      "order": 178,
+      "keywords": ["12", "12:00", "clock", "o’clock", "time", "twelve", "twelve o’clock"]
     },
     {
       "emoji": "🕧",
-      "shortcodes": ["clock1230"],
+      "shortcodes": ["clock1230", "twelve_thirty"],
       "group": "travel",
-      "order": 179
+      "order": 179,
+      "keywords": ["12", "12:30", "30", "clock", "thirty", "time", "twelve"]
     },
     {
       "emoji": "🕐",
-      "shortcodes": ["clock1"],
+      "shortcodes": ["clock1", "one_oclock"],
       "group": "travel",
-      "order": 180
+      "order": 180,
+      "keywords": ["1", "1:00", "clock", "one", "o’clock", "time", "one o’clock"]
     },
     {
       "emoji": "🕜",
-      "shortcodes": ["clock130"],
+      "shortcodes": ["clock130", "one_thirty"],
       "group": "travel",
-      "order": 181
+      "order": 181,
+      "keywords": ["1", "1:30", "30", "clock", "one", "thirty", "time"]
     },
     {
       "emoji": "🕑",
-      "shortcodes": ["clock2"],
+      "shortcodes": ["clock2", "two_oclock"],
       "group": "travel",
-      "order": 182
+      "order": 182,
+      "keywords": ["2", "2:00", "clock", "o’clock", "time", "two", "two o’clock"]
     },
     {
       "emoji": "🕝",
-      "shortcodes": ["clock230"],
+      "shortcodes": ["clock230", "two_thirty"],
       "group": "travel",
-      "order": 183
+      "order": 183,
+      "keywords": ["2", "2:30", "30", "clock", "thirty", "time", "two"]
     },
     {
       "emoji": "🕒",
-      "shortcodes": ["clock3"],
+      "shortcodes": ["clock3", "three_oclock"],
       "group": "travel",
-      "order": 184
+      "order": 184,
+      "keywords": ["3", "3:00", "clock", "o’clock", "three", "time", "three o’clock"]
     },
     {
       "emoji": "🕞",
-      "shortcodes": ["clock330"],
+      "shortcodes": ["clock330", "three_thirty"],
       "group": "travel",
-      "order": 185
+      "order": 185,
+      "keywords": ["3", "30", "3:30", "clock", "thirty", "three", "time"]
     },
     {
       "emoji": "🕓",
-      "shortcodes": ["clock4"],
+      "shortcodes": ["clock4", "four_oclock"],
       "group": "travel",
-      "order": 186
+      "order": 186,
+      "keywords": ["4", "4:00", "clock", "four", "o’clock", "time", "four o’clock"]
     },
     {
       "emoji": "🕟",
-      "shortcodes": ["clock430"],
+      "shortcodes": ["clock430", "four_thirty"],
       "group": "travel",
-      "order": 187
+      "order": 187,
+      "keywords": ["30", "4", "4:30", "clock", "four", "thirty", "time"]
     },
     {
       "emoji": "🕔",
-      "shortcodes": ["clock5"],
+      "shortcodes": ["clock5", "five_oclock"],
       "group": "travel",
-      "order": 188
+      "order": 188,
+      "keywords": ["5", "5:00", "clock", "five", "o’clock", "time", "five o’clock"]
     },
     {
       "emoji": "🕠",
-      "shortcodes": ["clock530"],
+      "shortcodes": ["clock530", "five_thirty"],
       "group": "travel",
-      "order": 189
+      "order": 189,
+      "keywords": ["30", "5", "5:30", "clock", "five", "thirty", "time"]
     },
     {
       "emoji": "🕕",
-      "shortcodes": ["clock6"],
+      "shortcodes": ["clock6", "six_oclock"],
       "group": "travel",
-      "order": 190
+      "order": 190,
+      "keywords": ["6", "6:00", "clock", "o’clock", "six", "time", "six o’clock"]
     },
     {
       "emoji": "🕡",
-      "shortcodes": ["clock630"],
+      "shortcodes": ["clock630", "six_thirty"],
       "group": "travel",
-      "order": 191
+      "order": 191,
+      "keywords": ["30", "6", "6:30", "clock", "six", "thirty"]
     },
     {
       "emoji": "🕖",
-      "shortcodes": ["clock7"],
+      "shortcodes": ["clock7", "seven_oclock"],
       "group": "travel",
-      "order": 192
+      "order": 192,
+      "keywords": ["0", "7", "7:00", "clock", "o’clock", "seven", "seven o’clock"]
     },
     {
       "emoji": "🕢",
-      "shortcodes": ["clock730"],
+      "shortcodes": ["clock730", "seven_thirty"],
       "group": "travel",
-      "order": 193
+      "order": 193,
+      "keywords": ["30", "7", "7:30", "clock", "seven", "thirty"]
     },
     {
       "emoji": "🕗",
-      "shortcodes": ["clock8"],
+      "shortcodes": ["clock8", "eight_oclock"],
       "group": "travel",
-      "order": 194
+      "order": 194,
+      "keywords": ["8", "8:00", "clock", "eight", "o’clock", "time", "eight o’clock"]
     },
     {
       "emoji": "🕣",
-      "shortcodes": ["clock830"],
+      "shortcodes": ["clock830", "eight_thirty"],
       "group": "travel",
-      "order": 195
+      "order": 195,
+      "keywords": ["30", "8", "8:30", "clock", "eight", "thirty", "time"]
     },
     {
       "emoji": "🕘",
-      "shortcodes": ["clock9"],
+      "shortcodes": ["clock9", "nine_oclock"],
       "group": "travel",
-      "order": 196
+      "order": 196,
+      "keywords": ["9", "9:00", "clock", "nine", "o’clock", "time", "nine o’clock"]
     },
     {
       "emoji": "🕤",
-      "shortcodes": ["clock930"],
+      "shortcodes": ["clock930", "nine_thirty"],
       "group": "travel",
-      "order": 197
+      "order": 197,
+      "keywords": ["30", "9", "9:30", "clock", "nine", "thirty", "time"]
     },
     {
       "emoji": "🕙",
-      "shortcodes": ["clock10"],
+      "shortcodes": ["clock10", "ten_oclock"],
       "group": "travel",
-      "order": 198
+      "order": 198,
+      "keywords": ["0", "10", "10:00", "clock", "o’clock", "ten", "ten o’clock"]
     },
     {
       "emoji": "🕥",
-      "shortcodes": ["clock1030"],
+      "shortcodes": ["clock1030", "ten_thirty"],
       "group": "travel",
-      "order": 199
+      "order": 199,
+      "keywords": ["10", "10:30", "30", "clock", "ten", "thirty", "time"]
     },
     {
       "emoji": "🕚",
-      "shortcodes": ["clock11"],
+      "shortcodes": ["clock11", "eleven_oclock"],
       "group": "travel",
-      "order": 200
+      "order": 200,
+      "keywords": ["11", "11:00", "clock", "eleven", "o’clock", "time", "eleven o’clock"]
     },
     {
       "emoji": "🕦",
-      "shortcodes": ["clock1130"],
+      "shortcodes": ["clock1130", "eleven_thirty"],
       "group": "travel",
-      "order": 201
+      "order": 201,
+      "keywords": ["11", "11:30", "30", "clock", "eleven", "thirty", "time"]
     },
     {
       "emoji": "🌑",
       "shortcodes": ["new_moon"],
       "group": "travel",
-      "order": 202
+      "order": 202,
+      "keywords": ["dark", "moon", "new", "space"]
     },
     {
       "emoji": "🌒",
       "shortcodes": ["waxing_crescent_moon"],
       "group": "travel",
-      "order": 203
+      "order": 203,
+      "keywords": ["crescent", "dreams", "moon", "space", "waxing"]
     },
     {
       "emoji": "🌓",
       "shortcodes": ["first_quarter_moon"],
       "group": "travel",
-      "order": 204
+      "order": 204,
+      "keywords": ["first", "moon", "quarter", "space"]
     },
     {
       "emoji": "🌔",
       "shortcodes": ["moon", "waxing_gibbous_moon"],
       "group": "travel",
-      "order": 205
+      "order": 205,
+      "keywords": ["gibbous", "space", "waxing"]
     },
     {
       "emoji": "🌕",
       "shortcodes": ["full_moon"],
       "group": "travel",
-      "order": 206
+      "order": 206,
+      "keywords": ["full", "moon", "space"]
     },
     {
       "emoji": "🌖",
       "shortcodes": ["waning_gibbous_moon"],
       "group": "travel",
-      "order": 207
+      "order": 207,
+      "keywords": ["gibbous", "moon", "space", "waning"]
     },
     {
       "emoji": "🌗",
       "shortcodes": ["last_quarter_moon"],
       "group": "travel",
-      "order": 208
+      "order": 208,
+      "keywords": ["last", "moon", "quarter", "space"]
     },
     {
       "emoji": "🌘",
       "shortcodes": ["waning_crescent_moon"],
       "group": "travel",
-      "order": 209
+      "order": 209,
+      "keywords": ["crescent", "moon", "space", "waning"]
     },
     {
       "emoji": "🌙",
       "shortcodes": ["crescent_moon"],
       "group": "travel",
-      "order": 210
+      "order": 210,
+      "keywords": ["crescent", "moon", "ramadan", "space"]
     },
     {
       "emoji": "🌚",
-      "shortcodes": ["new_moon_with_face"],
+      "shortcodes": ["new_moon_with_face", "new_moon_face"],
       "group": "travel",
-      "order": 211
+      "order": 211,
+      "keywords": ["face", "moon", "new", "space"]
     },
     {
       "emoji": "🌛",
-      "shortcodes": ["first_quarter_moon_with_face"],
+      "shortcodes": ["first_quarter_moon_with_face", "first_quarter_moon_face"],
       "group": "travel",
-      "order": 212
+      "order": 212,
+      "keywords": ["face", "first", "moon", "quarter", "space"]
     },
     {
       "emoji": "🌜",
-      "shortcodes": ["last_quarter_moon_with_face"],
+      "shortcodes": ["last_quarter_moon_with_face", "last_quarter_moon_face"],
       "group": "travel",
-      "order": 213
+      "order": 213,
+      "keywords": ["dreams", "face", "last", "moon", "quarter"]
     },
     {
       "emoji": "🌡️",
       "shortcodes": ["thermometer"],
       "group": "travel",
-      "order": 214
+      "order": 214,
+      "keywords": ["weather"]
     },
     {
       "emoji": "☀️",
-      "shortcodes": ["sunny"],
+      "shortcodes": ["sunny", "sun"],
       "group": "travel",
-      "order": 216
+      "order": 216,
+      "keywords": ["bright", "rays", "space", "weather"]
     },
     {
       "emoji": "🌝",
-      "shortcodes": ["full_moon_with_face"],
+      "shortcodes": ["full_moon_with_face", "full_moon_face"],
       "group": "travel",
-      "order": 218
+      "order": 218,
+      "keywords": ["bright", "face", "full", "moon"]
     },
     {
       "emoji": "🌞",
       "shortcodes": ["sun_with_face"],
       "group": "travel",
-      "order": 219
+      "order": 219,
+      "keywords": ["beach", "bright", "day", "face", "heat", "shine", "sun", "sunny", "sunshine", "weather"]
     },
     {
       "emoji": "🪐",
-      "shortcodes": ["ringed_planet"],
+      "shortcodes": ["ringed_planet", "saturn"],
       "group": "travel",
-      "order": 220
+      "order": 220,
+      "keywords": ["planet", "ringed", "saturnine"]
     },
     {
       "emoji": "⭐",
       "shortcodes": ["star"],
       "group": "travel",
-      "order": 221
+      "order": 221,
+      "keywords": ["astronomy", "medium", "stars", "white"]
     },
     {
       "emoji": "🌟",
-      "shortcodes": ["star2"],
+      "shortcodes": ["star2", "glowing_star"],
       "group": "travel",
-      "order": 222
+      "order": 222,
+      "keywords": ["glittery", "glow", "glowing", "night", "shining", "sparkle", "star", "win"]
     },
     {
       "emoji": "🌠",
-      "shortcodes": ["stars"],
+      "shortcodes": ["stars", "shooting_star"],
       "group": "travel",
-      "order": 223
+      "order": 223,
+      "keywords": ["falling", "night", "shooting", "space", "star"]
     },
     {
       "emoji": "🌌",
       "shortcodes": ["milky_way"],
       "group": "travel",
-      "order": 224
+      "order": 224,
+      "keywords": ["milky", "space", "way"]
     },
     {
       "emoji": "☁️",
       "shortcodes": ["cloud"],
       "group": "travel",
-      "order": 225
+      "order": 225,
+      "keywords": ["weather"]
     },
     {
       "emoji": "⛅",
       "shortcodes": ["partly_sunny"],
       "group": "travel",
-      "order": 227
+      "order": 227,
+      "keywords": ["behind", "cloud", "cloudy", "sun", "weather", "sun behind cloud"]
     },
     {
       "emoji": "⛈️",
-      "shortcodes": ["cloud_with_lightning_and_rain"],
+      "shortcodes": ["cloud_with_lightning_and_rain", "thunder_cloud_and_rain", "stormy", "thunder_cloud_rain"],
       "group": "travel",
-      "order": 228
+      "order": 228,
+      "keywords": ["cloud", "lightning", "rain", "thunder", "thunderstorm"]
     },
     {
       "emoji": "🌤️",
-      "shortcodes": ["sun_behind_small_cloud"],
+      "shortcodes": [
+        "sun_behind_small_cloud",
+        "mostly_sunny",
+        "sun_small_cloud",
+        "white_sun_small_cloud",
+        "white_sun_with_small_cloud"
+      ],
       "group": "travel",
-      "order": 230
+      "order": 230,
+      "keywords": ["behind", "cloud", "sun", "weather"]
     },
     {
       "emoji": "🌥️",
-      "shortcodes": ["sun_behind_large_cloud"],
+      "shortcodes": [
+        "sun_behind_large_cloud",
+        "barely_sunny",
+        "sun_behind_cloud",
+        "cloudy",
+        "white_sun_cloud",
+        "white_sun_behind_cloud"
+      ],
       "group": "travel",
-      "order": 232
+      "order": 232,
+      "keywords": ["behind", "cloud", "sun", "weather"]
     },
     {
       "emoji": "🌦️",
-      "shortcodes": ["sun_behind_rain_cloud"],
+      "shortcodes": [
+        "sun_behind_rain_cloud",
+        "partly_sunny_rain",
+        "sun_and_rain",
+        "white_sun_rain_cloud",
+        "white_sun_behind_cloud_with_rain"
+      ],
       "group": "travel",
-      "order": 234
+      "order": 234,
+      "keywords": ["behind", "cloud", "rain", "sun", "weather"]
     },
     {
       "emoji": "🌧️",
-      "shortcodes": ["cloud_with_rain"],
+      "shortcodes": ["cloud_with_rain", "rain_cloud", "rainy", "cloud_rain"],
       "group": "travel",
-      "order": 236
+      "order": 236,
+      "keywords": ["cloud", "rain", "weather"]
     },
     {
       "emoji": "🌨️",
-      "shortcodes": ["cloud_with_snow"],
+      "shortcodes": ["cloud_with_snow", "snow_cloud", "snowy", "cloud_snow"],
       "group": "travel",
-      "order": 238
+      "order": 238,
+      "keywords": ["cloud", "cold", "snow", "weather"]
     },
     {
       "emoji": "🌩️",
-      "shortcodes": ["cloud_with_lightning"],
+      "shortcodes": ["cloud_with_lightning", "lightning", "lightning_cloud", "cloud_lightning"],
       "group": "travel",
-      "order": 240
+      "order": 240,
+      "keywords": ["cloud", "weather"]
     },
     {
       "emoji": "🌪️",
-      "shortcodes": ["tornado"],
+      "shortcodes": ["tornado", "tornado_cloud", "cloud_tornado", "cloud_with_tornado"],
       "group": "travel",
-      "order": 242
+      "order": 242,
+      "keywords": ["cloud", "weather", "whirlwind"]
     },
     {
       "emoji": "🌫️",
       "shortcodes": ["fog"],
       "group": "travel",
-      "order": 244
+      "order": 244,
+      "keywords": ["cloud", "weather"]
     },
     {
       "emoji": "🌬️",
-      "shortcodes": ["wind_face"],
+      "shortcodes": ["wind_face", "wind_blowing_face"],
       "group": "travel",
-      "order": 246
+      "order": 246,
+      "keywords": ["blow", "cloud", "face", "wind"]
     },
     {
       "emoji": "🌀",
       "shortcodes": ["cyclone"],
       "group": "travel",
-      "order": 248
+      "order": 248,
+      "keywords": ["dizzy", "hurricane", "twister", "typhoon", "weather"]
     },
     {
       "emoji": "🌈",
       "shortcodes": ["rainbow"],
       "group": "travel",
-      "order": 249
+      "order": 249,
+      "keywords": [
+        "gay",
+        "genderqueer",
+        "glbt",
+        "glbtq",
+        "lesbian",
+        "lgbt",
+        "lgbtq",
+        "lgbtqia",
+        "nature",
+        "pride",
+        "queer",
+        "rain",
+        "trans",
+        "transgender",
+        "weather"
+      ]
     },
     {
       "emoji": "🌂",
       "shortcodes": ["closed_umbrella"],
       "group": "travel",
-      "order": 250
+      "order": 250,
+      "keywords": ["closed", "clothing", "rain", "umbrella"]
     },
     {
       "emoji": "☂️",
-      "shortcodes": ["open_umbrella"],
+      "shortcodes": ["open_umbrella", "umbrella2"],
       "group": "travel",
-      "order": 251
+      "order": 251,
+      "keywords": ["clothing", "rain", "umbrella"]
     },
     {
       "emoji": "☔",
-      "shortcodes": ["umbrella"],
+      "shortcodes": ["umbrella", "umbrella_with_rain_drops", "umbrella_with_rain"],
       "group": "travel",
-      "order": 253
+      "order": 253,
+      "keywords": ["clothing", "drop", "drops", "rain", "weather"]
     },
     {
       "emoji": "⛱️",
-      "shortcodes": ["parasol_on_ground"],
+      "shortcodes": ["parasol_on_ground", "umbrella_on_ground"],
       "group": "travel",
-      "order": 254
+      "order": 254,
+      "keywords": ["ground", "rain", "sun", "umbrella"]
     },
     {
       "emoji": "⚡",
-      "shortcodes": ["zap"],
+      "shortcodes": ["zap", "high_voltage"],
       "group": "travel",
-      "order": 256
+      "order": 256,
+      "keywords": [
+        "danger",
+        "electric",
+        "electricity",
+        "high",
+        "lightning",
+        "nature",
+        "thunder",
+        "thunderbolt",
+        "voltage"
+      ]
     },
     {
       "emoji": "❄️",
       "shortcodes": ["snowflake"],
       "group": "travel",
-      "order": 257
+      "order": 257,
+      "keywords": ["cold", "snow", "weather"]
     },
     {
       "emoji": "☃️",
-      "shortcodes": ["snowman_with_snow"],
+      "shortcodes": ["snowman_with_snow", "snowman2"],
       "group": "travel",
-      "order": 259
+      "order": 259,
+      "keywords": ["cold", "man", "snow", "snowman"]
     },
     {
       "emoji": "⛄",
-      "shortcodes": ["snowman"],
+      "shortcodes": ["snowman", "snowman_without_snow"],
       "group": "travel",
-      "order": 261
+      "order": 261,
+      "keywords": ["cold", "man", "snow"]
     },
     {
       "emoji": "☄️",
       "shortcodes": ["comet"],
       "group": "travel",
-      "order": 262
+      "order": 262,
+      "keywords": ["space"]
     },
     {
       "emoji": "🔥",
-      "shortcodes": ["fire", "lit", "hot"],
+      "shortcodes": ["fire", "lit", "hot", "flame"],
       "group": "travel",
-      "order": 264
+      "order": 264,
+      "keywords": ["af", "burn", "litaf", "tool"]
     },
     {
       "emoji": "💧",
       "shortcodes": ["droplet"],
       "group": "travel",
-      "order": 265
+      "order": 265,
+      "keywords": ["cold", "comic", "drop", "nature", "sad", "sweat", "tear", "water", "weather"]
     },
     {
       "emoji": "🌊",
-      "shortcodes": ["ocean"],
+      "shortcodes": ["ocean", "water_wave"],
       "group": "travel",
-      "order": 266
+      "order": 266,
+      "keywords": ["nature", "surf", "surfer", "surfing", "water", "wave"]
     },
     {
       "emoji": "🎃",
       "shortcodes": ["jack_o_lantern"],
       "group": "activities",
-      "order": 0
+      "order": 0,
+      "keywords": ["celebration", "halloween", "jack", "lantern", "pumpkin"]
     },
     {
       "emoji": "🎄",
       "shortcodes": ["christmas_tree"],
       "group": "activities",
-      "order": 1
+      "order": 1,
+      "keywords": ["celebration", "christmas", "tree"]
     },
     {
       "emoji": "🎆",
       "shortcodes": ["fireworks"],
       "group": "activities",
-      "order": 2
+      "order": 2,
+      "keywords": ["boom", "celebration", "entertainment", "yolo"]
     },
     {
       "emoji": "🎇",
       "shortcodes": ["sparkler"],
       "group": "activities",
-      "order": 3
+      "order": 3,
+      "keywords": ["boom", "celebration", "fireworks", "sparkle"]
     },
     {
       "emoji": "🧨",
       "shortcodes": ["firecracker"],
       "group": "activities",
-      "order": 4
+      "order": 4,
+      "keywords": ["dynamite", "explosive", "fire", "fireworks", "light", "pop", "popping", "spark"]
     },
     {
       "emoji": "✨",
       "shortcodes": ["sparkles"],
       "group": "activities",
-      "order": 5
+      "order": 5,
+      "keywords": ["*", "magic", "sparkle", "star"]
     },
     {
       "emoji": "🎈",
       "shortcodes": ["balloon"],
       "group": "activities",
-      "order": 6
+      "order": 6,
+      "keywords": ["birthday", "celebrate", "celebration"]
     },
     {
       "emoji": "🎉",
-      "shortcodes": ["tada", "celebration", "party", "celebrate"],
+      "shortcodes": ["tada", "celebration", "party", "celebrate", "party_popper"],
       "group": "activities",
-      "order": 7
+      "order": 7,
+      "keywords": ["awesome", "birthday", "excited", "hooray", "popper", "woohoo"]
     },
     {
       "emoji": "🎊",
       "shortcodes": ["confetti_ball", "party_popper2"],
       "group": "activities",
-      "order": 8
+      "order": 8,
+      "keywords": ["ball", "celebrate", "celebration", "confetti", "party", "woohoo"]
     },
     {
       "emoji": "🎋",
       "shortcodes": ["tanabata_tree"],
       "group": "activities",
-      "order": 9
+      "order": 9,
+      "keywords": ["banner", "celebration", "japanese", "tanabata", "tree"]
     },
     {
       "emoji": "🎍",
-      "shortcodes": ["bamboo"],
+      "shortcodes": ["bamboo", "pine_decoration"],
       "group": "activities",
-      "order": 10
+      "order": 10,
+      "keywords": ["celebration", "decoration", "japanese", "pine", "plant"]
     },
     {
       "emoji": "🎎",
-      "shortcodes": ["dolls"],
+      "shortcodes": ["dolls", "japanese_dolls"],
       "group": "activities",
-      "order": 11
+      "order": 11,
+      "keywords": ["celebration", "doll", "festival", "japanese"]
     },
     {
       "emoji": "🎏",
-      "shortcodes": ["flags"],
+      "shortcodes": ["flags", "carp_streamer"],
       "group": "activities",
-      "order": 12
+      "order": 12,
+      "keywords": ["carp", "celebration", "streamer"]
     },
     {
       "emoji": "🎐",
       "shortcodes": ["wind_chime"],
       "group": "activities",
-      "order": 13
+      "order": 13,
+      "keywords": ["bell", "celebration", "chime", "wind"]
     },
     {
       "emoji": "🎑",
-      "shortcodes": ["rice_scene"],
+      "shortcodes": ["rice_scene", "moon_ceremony", "moon_viewing_ceremony"],
       "group": "activities",
-      "order": 14
+      "order": 14,
+      "keywords": ["celebration", "ceremony", "moon", "viewing"]
     },
     {
       "emoji": "🧧",
       "shortcodes": ["red_envelope"],
       "group": "activities",
-      "order": 15
+      "order": 15,
+      "keywords": ["envelope", "gift", "good", "hóngbāo", "lai", "luck", "money", "red", "see"]
     },
     {
       "emoji": "🎀",
       "shortcodes": ["ribbon"],
       "group": "activities",
-      "order": 16
+      "order": 16,
+      "keywords": ["celebration"]
     },
     {
       "emoji": "🎁",
-      "shortcodes": ["gift"],
+      "shortcodes": ["gift", "wrapped_gift"],
       "group": "activities",
-      "order": 17
+      "order": 17,
+      "keywords": ["birthday", "bow", "box", "celebration", "christmas", "present", "surprise", "wrapped"]
     },
     {
       "emoji": "🎗️",
       "shortcodes": ["reminder_ribbon"],
       "group": "activities",
-      "order": 18
+      "order": 18,
+      "keywords": ["celebration", "reminder", "ribbon"]
     },
     {
       "emoji": "🎟️",
-      "shortcodes": ["tickets"],
+      "shortcodes": ["tickets", "admission_tickets"],
       "group": "activities",
-      "order": 20
+      "order": 20,
+      "keywords": ["admission", "ticket"]
     },
     {
       "emoji": "🎫",
       "shortcodes": ["ticket"],
       "group": "activities",
-      "order": 22
+      "order": 22,
+      "keywords": ["admission", "stub"]
     },
     {
       "emoji": "🎖️",
-      "shortcodes": ["medal_military"],
+      "shortcodes": ["medal_military", "medal", "military_medal"],
       "group": "activities",
-      "order": 23
+      "order": 23,
+      "keywords": ["award", "celebration", "military"]
     },
     {
       "emoji": "🏆",
       "shortcodes": ["trophy"],
       "group": "activities",
-      "order": 25
+      "order": 25,
+      "keywords": ["champion", "champs", "prize", "slay", "sport", "victory", "win", "winning"]
     },
     {
       "emoji": "🏅",
-      "shortcodes": ["medal_sports"],
+      "shortcodes": ["medal_sports", "sports_medal"],
       "group": "activities",
-      "order": 26
+      "order": 26,
+      "keywords": ["award", "gold", "medal", "sports", "winner"]
     },
     {
       "emoji": "🥇",
-      "shortcodes": ["1st_place_medal"],
+      "shortcodes": ["1st_place_medal", "first_place_medal", "1st", "first_place"],
       "group": "activities",
-      "order": 27
+      "order": 27,
+      "keywords": ["first", "gold", "medal", "place"]
     },
     {
       "emoji": "🥈",
-      "shortcodes": ["2nd_place_medal"],
+      "shortcodes": ["2nd_place_medal", "second_place_medal", "2nd", "second_place"],
       "group": "activities",
-      "order": 28
+      "order": 28,
+      "keywords": ["medal", "place", "second", "silver"]
     },
     {
       "emoji": "🥉",
-      "shortcodes": ["3rd_place_medal"],
+      "shortcodes": ["3rd_place_medal", "third_place_medal", "3rd", "third_place"],
       "group": "activities",
-      "order": 29
+      "order": 29,
+      "keywords": ["bronze", "medal", "place", "third"]
     },
     {
       "emoji": "⚽",
-      "shortcodes": ["soccer"],
+      "shortcodes": ["soccer", "soccer_ball"],
       "group": "activities",
-      "order": 30
+      "order": 30,
+      "keywords": ["ball", "football", "futbol", "sport"]
     },
     {
       "emoji": "⚾",
       "shortcodes": ["baseball"],
       "group": "activities",
-      "order": 31
+      "order": 31,
+      "keywords": ["ball", "sport"]
     },
     {
       "emoji": "🥎",
       "shortcodes": ["softball"],
       "group": "activities",
-      "order": 32
+      "order": 32,
+      "keywords": ["ball", "glove", "sports", "underarm"]
     },
     {
       "emoji": "🏀",
       "shortcodes": ["basketball"],
       "group": "activities",
-      "order": 33
+      "order": 33,
+      "keywords": ["ball", "hoop", "sport"]
     },
     {
       "emoji": "🏐",
       "shortcodes": ["volleyball"],
       "group": "activities",
-      "order": 34
+      "order": 34,
+      "keywords": ["ball", "game"]
     },
     {
       "emoji": "🏈",
-      "shortcodes": ["football"],
+      "shortcodes": ["football", "american_football"],
       "group": "activities",
-      "order": 35
+      "order": 35,
+      "keywords": ["american", "ball", "bowl", "sport", "super"]
     },
     {
       "emoji": "🏉",
       "shortcodes": ["rugby_football"],
       "group": "activities",
-      "order": 36
+      "order": 36,
+      "keywords": ["ball", "football", "rugby", "sport"]
     },
     {
       "emoji": "🎾",
       "shortcodes": ["tennis"],
       "group": "activities",
-      "order": 37
+      "order": 37,
+      "keywords": ["ball", "racquet", "sport"]
     },
     {
       "emoji": "🥏",
       "shortcodes": ["flying_disc"],
       "group": "activities",
-      "order": 38
+      "order": 38,
+      "keywords": ["disc", "flying", "ultimate"]
     },
     {
       "emoji": "🎳",
       "shortcodes": ["bowling"],
       "group": "activities",
-      "order": 39
+      "order": 39,
+      "keywords": ["ball", "game", "sport", "strike"]
     },
     {
       "emoji": "🏏",
-      "shortcodes": ["cricket_game"],
+      "shortcodes": ["cricket_game", "cricket_bat_and_ball", "cricket_bat_ball"],
       "group": "activities",
-      "order": 40
+      "order": 40,
+      "keywords": ["ball", "bat", "cricket", "game"]
     },
     {
       "emoji": "🏑",
-      "shortcodes": ["field_hockey"],
+      "shortcodes": ["field_hockey", "field_hockey_stick_and_ball"],
       "group": "activities",
-      "order": 41
+      "order": 41,
+      "keywords": ["ball", "field", "game", "hockey", "stick"]
     },
     {
       "emoji": "🏒",
-      "shortcodes": ["ice_hockey"],
+      "shortcodes": ["ice_hockey", "ice_hockey_stick_and_puck", "hockey"],
       "group": "activities",
-      "order": 42
+      "order": 42,
+      "keywords": ["game", "ice", "puck", "stick"]
     },
     {
       "emoji": "🥍",
       "shortcodes": ["lacrosse"],
       "group": "activities",
-      "order": 43
+      "order": 43,
+      "keywords": ["ball", "goal", "sports", "stick"]
     },
     {
       "emoji": "🏓",
-      "shortcodes": ["ping_pong"],
+      "shortcodes": ["ping_pong", "table_tennis_paddle_and_ball", "table_tennis"],
       "group": "activities",
-      "order": 44
+      "order": 44,
+      "keywords": ["ball", "bat", "game", "paddle", "ping", "pong", "table", "tennis"]
     },
     {
       "emoji": "🏸",
-      "shortcodes": ["badminton"],
+      "shortcodes": ["badminton", "badminton_racquet_and_shuttlecock"],
       "group": "activities",
-      "order": 45
+      "order": 45,
+      "keywords": ["birdie", "game", "racquet", "shuttlecock"]
     },
     {
       "emoji": "🥊",
-      "shortcodes": ["boxing_glove"],
+      "shortcodes": ["boxing_glove", "boxing_gloves"],
       "group": "activities",
-      "order": 46
+      "order": 46,
+      "keywords": ["boxing", "glove"]
     },
     {
       "emoji": "🥋",
-      "shortcodes": ["martial_arts_uniform"],
+      "shortcodes": ["martial_arts_uniform", "karate_uniform"],
       "group": "activities",
-      "order": 47
+      "order": 47,
+      "keywords": ["arts", "judo", "karate", "martial", "taekwondo", "uniform"]
     },
     {
       "emoji": "🥅",
-      "shortcodes": ["goal_net"],
+      "shortcodes": ["goal_net", "goal"],
       "group": "activities",
-      "order": 48
+      "order": 48,
+      "keywords": ["net"]
     },
     {
       "emoji": "⛳",
-      "shortcodes": ["golf"],
+      "shortcodes": ["golf", "flag_in_hole"],
       "group": "activities",
-      "order": 49
+      "order": 49,
+      "keywords": ["flag", "hole", "sport"]
     },
     {
       "emoji": "⛸️",
       "shortcodes": ["ice_skate"],
       "group": "activities",
-      "order": 50
+      "order": 50,
+      "keywords": ["ice", "skate", "skating"]
     },
     {
       "emoji": "🎣",
-      "shortcodes": ["fishing_pole_and_fish"],
+      "shortcodes": ["fishing_pole_and_fish", "fishing_pole"],
       "group": "activities",
-      "order": 52
+      "order": 52,
+      "keywords": ["entertainment", "fish", "fishing", "pole", "sport"]
     },
     {
       "emoji": "🤿",
       "shortcodes": ["diving_mask"],
       "group": "activities",
-      "order": 53
+      "order": 53,
+      "keywords": ["diving", "mask", "scuba", "snorkeling"]
     },
     {
       "emoji": "🎽",
-      "shortcodes": ["running_shirt_with_sash"],
+      "shortcodes": ["running_shirt_with_sash", "running_shirt"],
       "group": "activities",
-      "order": 54
+      "order": 54,
+      "keywords": ["athletics", "running", "sash", "shirt"]
     },
     {
       "emoji": "🎿",
-      "shortcodes": ["ski"],
+      "shortcodes": ["ski", "skis"],
       "group": "activities",
-      "order": 55
+      "order": 55,
+      "keywords": ["snow", "sport"]
     },
     {
       "emoji": "🛷",
       "shortcodes": ["sled"],
       "group": "activities",
-      "order": 56
+      "order": 56,
+      "keywords": ["luge", "sledge", "sleigh", "snow", "toboggan"]
     },
     {
       "emoji": "🥌",
       "shortcodes": ["curling_stone"],
       "group": "activities",
-      "order": 57
+      "order": 57,
+      "keywords": ["curling", "game", "rock", "stone"]
     },
     {
       "emoji": "🎯",
-      "shortcodes": ["dart", "bullseye", "on_target"],
+      "shortcodes": ["dart", "bullseye", "on_target", "direct_hit"],
       "group": "activities",
-      "order": 58
+      "order": 58,
+      "keywords": ["bull", "direct", "entertainment", "game", "hit", "target"]
     },
     {
       "emoji": "🪀",
-      "shortcodes": ["yo_yo"],
+      "shortcodes": ["yo_yo", "yo-yo"],
       "group": "activities",
-      "order": 59
+      "order": 59,
+      "keywords": ["fluctuate", "toy"]
     },
     {
       "emoji": "🪁",
       "shortcodes": ["kite"],
       "group": "activities",
-      "order": 60
+      "order": 60,
+      "keywords": ["fly", "soar"]
     },
     {
       "emoji": "🔫",
-      "shortcodes": ["gun"],
+      "shortcodes": ["gun", "pistol", "water_pistol"],
       "group": "activities",
-      "order": 61
+      "order": 61,
+      "keywords": ["handgun", "revolver", "tool", "water", "weapon"]
     },
     {
       "emoji": "🎱",
-      "shortcodes": ["8ball"],
+      "shortcodes": ["8ball", "billiards", "pool_8_ball"],
       "group": "activities",
-      "order": 62
+      "order": 62,
+      "keywords": ["8", "ball", "billiard", "eight", "game", "pool"]
     },
     {
       "emoji": "🔮",
       "shortcodes": ["crystal_ball"],
       "group": "activities",
-      "order": 63
+      "order": 63,
+      "keywords": ["ball", "crystal", "fairy", "fairytale", "fantasy", "fortune", "future", "magic", "tale", "tool"]
     },
     {
       "emoji": "🪄",
       "shortcodes": ["magic_wand"],
       "group": "activities",
-      "order": 64
+      "order": 64,
+      "keywords": ["magic", "magician", "wand", "witch", "wizard"]
     },
     {
       "emoji": "🎮",
-      "shortcodes": ["video_game"],
+      "shortcodes": ["video_game", "controller"],
       "group": "activities",
-      "order": 65
+      "order": 65,
+      "keywords": ["entertainment", "game", "video"]
     },
     {
       "emoji": "🕹️",
       "shortcodes": ["joystick"],
       "group": "activities",
-      "order": 66
+      "order": 66,
+      "keywords": ["game", "video", "videogame"]
     },
     {
       "emoji": "🎰",
       "shortcodes": ["slot_machine"],
       "group": "activities",
-      "order": 68
+      "order": 68,
+      "keywords": ["casino", "gamble", "gambling", "game", "machine", "slot", "slots"]
     },
     {
       "emoji": "🎲",
       "shortcodes": ["game_die"],
       "group": "activities",
-      "order": 69
+      "order": 69,
+      "keywords": ["dice", "die", "entertainment", "game"]
     },
     {
       "emoji": "🧩",
-      "shortcodes": ["jigsaw"],
+      "shortcodes": ["jigsaw", "puzzle_piece"],
       "group": "activities",
-      "order": 70
+      "order": 70,
+      "keywords": ["clue", "interlocking", "piece", "puzzle"]
     },
     {
       "emoji": "🧸",
       "shortcodes": ["teddy_bear"],
       "group": "activities",
-      "order": 71
+      "order": 71,
+      "keywords": ["bear", "plaything", "plush", "stuffed", "teddy", "toy"]
     },
     {
       "emoji": "🪅",
       "shortcodes": ["pinata"],
       "group": "activities",
-      "order": 72
+      "order": 72,
+      "keywords": ["candy", "celebrate", "celebration", "cinco", "de", "festive", "mayo", "party", "pinada", "piñata"]
     },
     {
       "emoji": "🪆",
       "shortcodes": ["nesting_dolls"],
       "group": "activities",
-      "order": 74
+      "order": 74,
+      "keywords": ["babooshka", "baboushka", "babushka", "doll", "dolls", "matryoshka", "nesting", "russia"]
     },
     {
       "emoji": "♠️",
-      "shortcodes": ["spades"],
+      "shortcodes": ["spades", "spade_suit"],
       "group": "activities",
-      "order": 75
+      "order": 75,
+      "keywords": ["card", "game", "spade", "suit"]
     },
     {
       "emoji": "♥️",
-      "shortcodes": ["hearts"],
+      "shortcodes": ["hearts", "heart_suit"],
       "group": "activities",
-      "order": 77
+      "order": 77,
+      "keywords": ["card", "emotion", "game", "heart", "suit"]
     },
     {
       "emoji": "♦️",
-      "shortcodes": ["diamonds"],
+      "shortcodes": ["diamonds", "diamond_suit"],
       "group": "activities",
-      "order": 79
+      "order": 79,
+      "keywords": ["card", "diamond", "game", "suit"]
     },
     {
       "emoji": "♣️",
-      "shortcodes": ["clubs"],
+      "shortcodes": ["clubs", "club_suit"],
       "group": "activities",
-      "order": 81
+      "order": 81,
+      "keywords": ["card", "club", "game", "suit"]
     },
     {
       "emoji": "♟️",
       "shortcodes": ["chess_pawn"],
       "group": "activities",
-      "order": 83
+      "order": 83,
+      "keywords": ["chess", "dupe", "expendable", "pawn"]
     },
     {
       "emoji": "🃏",
-      "shortcodes": ["black_joker"],
+      "shortcodes": ["black_joker", "joker"],
       "group": "activities",
-      "order": 85
+      "order": 85,
+      "keywords": ["card", "game", "wildcard"]
     },
     {
       "emoji": "🀄",
-      "shortcodes": ["mahjong"],
+      "shortcodes": ["mahjong", "mahjong_red_dragon"],
       "group": "activities",
-      "order": 86
+      "order": 86,
+      "keywords": ["dragon", "game", "red"]
     },
     {
       "emoji": "🎴",
       "shortcodes": ["flower_playing_cards"],
       "group": "activities",
-      "order": 87
+      "order": 87,
+      "keywords": ["card", "cards", "flower", "game", "japanese", "playing"]
     },
     {
       "emoji": "🎭",
       "shortcodes": ["performing_arts"],
       "group": "activities",
-      "order": 88
+      "order": 88,
+      "keywords": [
+        "actor",
+        "actress",
+        "art",
+        "arts",
+        "entertainment",
+        "mask",
+        "performing",
+        "theater",
+        "theatre",
+        "thespian"
+      ]
     },
     {
       "emoji": "🖼️",
-      "shortcodes": ["framed_picture"],
+      "shortcodes": ["framed_picture", "frame_with_picture", "frame_photo"],
       "group": "activities",
-      "order": 89
+      "order": 89,
+      "keywords": ["art", "frame", "framed", "museum", "painting", "picture"]
     },
     {
       "emoji": "🎨",
-      "shortcodes": ["art"],
+      "shortcodes": ["art", "palette", "artist_palette"],
       "group": "activities",
-      "order": 91
+      "order": 91,
+      "keywords": ["artist", "artsy", "arty", "colorful", "creative", "entertainment", "museum", "painter", "painting"]
     },
     {
       "emoji": "🧵",
       "shortcodes": ["thread"],
       "group": "activities",
-      "order": 92
+      "order": 92,
+      "keywords": ["needle", "sewing", "spool", "string"]
     },
     {
       "emoji": "🪡",
       "shortcodes": ["sewing_needle"],
       "group": "activities",
-      "order": 93
+      "order": 93,
+      "keywords": ["embroidery", "needle", "sew", "sewing", "stitches", "sutures", "tailoring", "thread"]
     },
     {
       "emoji": "🧶",
       "shortcodes": ["yarn"],
       "group": "activities",
-      "order": 94
+      "order": 94,
+      "keywords": ["ball", "crochet", "knit"]
     },
     {
       "emoji": "🪢",
       "shortcodes": ["knot"],
       "group": "activities",
-      "order": 95
+      "order": 95,
+      "keywords": ["cord", "rope", "tangled", "tie", "twine", "twist"]
     },
     {
       "emoji": "👓",
-      "shortcodes": ["eyeglasses"],
+      "shortcodes": ["eyeglasses", "glasses"],
       "group": "objects",
-      "order": 0
+      "order": 0,
+      "keywords": ["clothing", "eye", "eyewear"]
     },
     {
       "emoji": "🕶️",
       "shortcodes": ["dark_sunglasses"],
       "group": "objects",
-      "order": 1
+      "order": 1,
+      "keywords": ["dark", "eye", "eyewear", "glasses", "sunglasses"]
     },
     {
       "emoji": "🥽",
       "shortcodes": ["goggles"],
       "group": "objects",
-      "order": 3
+      "order": 3,
+      "keywords": ["dive", "eye", "protection", "scuba", "swimming", "welding"]
     },
     {
       "emoji": "🥼",
       "shortcodes": ["lab_coat"],
       "group": "objects",
-      "order": 4
+      "order": 4,
+      "keywords": ["clothes", "coat", "doctor", "dr", "experiment", "jacket", "lab", "scientist", "white"]
     },
     {
       "emoji": "🦺",
       "shortcodes": ["safety_vest"],
       "group": "objects",
-      "order": 5
+      "order": 5,
+      "keywords": ["emergency", "safety", "vest"]
     },
     {
       "emoji": "👔",
       "shortcodes": ["necktie"],
       "group": "objects",
-      "order": 6
+      "order": 6,
+      "keywords": ["clothing", "employed", "serious", "shirt", "tie"]
     },
     {
       "emoji": "👕",
-      "shortcodes": ["shirt", "tshirt"],
+      "shortcodes": ["shirt", "tshirt", "t_shirt"],
       "group": "objects",
-      "order": 7
+      "order": 7,
+      "keywords": ["blue", "casual", "clothes", "clothing", "collar", "dressed", "shopping", "weekend"]
     },
     {
       "emoji": "👖",
       "shortcodes": ["jeans"],
       "group": "objects",
-      "order": 8
+      "order": 8,
+      "keywords": [
+        "blue",
+        "casual",
+        "clothes",
+        "clothing",
+        "denim",
+        "dressed",
+        "pants",
+        "shopping",
+        "trousers",
+        "weekend"
+      ]
     },
     {
       "emoji": "🧣",
       "shortcodes": ["scarf"],
       "group": "objects",
-      "order": 9
+      "order": 9,
+      "keywords": ["bundle", "cold", "neck", "up"]
     },
     {
       "emoji": "🧤",
       "shortcodes": ["gloves"],
       "group": "objects",
-      "order": 10
+      "order": 10,
+      "keywords": ["hand"]
     },
     {
       "emoji": "🧥",
       "shortcodes": ["coat"],
       "group": "objects",
-      "order": 11
+      "order": 11,
+      "keywords": ["brr", "bundle", "cold", "jacket", "up"]
     },
     {
       "emoji": "🧦",
       "shortcodes": ["socks"],
       "group": "objects",
-      "order": 12
+      "order": 12,
+      "keywords": ["stocking"]
     },
     {
       "emoji": "👗",
       "shortcodes": ["dress"],
       "group": "objects",
-      "order": 13
+      "order": 13,
+      "keywords": ["clothes", "clothing", "dressed", "fancy", "shopping"]
     },
     {
       "emoji": "👘",
       "shortcodes": ["kimono"],
       "group": "objects",
-      "order": 14
+      "order": 14,
+      "keywords": ["clothing", "comfortable"]
     },
     {
       "emoji": "🥻",
       "shortcodes": ["sari"],
       "group": "objects",
-      "order": 15
+      "order": 15,
+      "keywords": ["clothing", "dress"]
     },
     {
       "emoji": "🩱",
-      "shortcodes": ["one_piece_swimsuit"],
+      "shortcodes": ["one_piece_swimsuit", "one-piece_swimsuit"],
       "group": "objects",
-      "order": 16
+      "order": 16,
+      "keywords": ["bathing", "one-piece", "suit", "swimsuit"]
     },
     {
       "emoji": "🩲",
-      "shortcodes": ["swim_brief"],
+      "shortcodes": ["swim_brief", "briefs"],
       "group": "objects",
-      "order": 17
+      "order": 17,
+      "keywords": ["bathing", "one-piece", "suit", "swimsuit", "underwear"]
     },
     {
       "emoji": "🩳",
       "shortcodes": ["shorts"],
       "group": "objects",
-      "order": 18
+      "order": 18,
+      "keywords": ["bathing", "pants", "suit", "swimsuit", "underwear"]
     },
     {
       "emoji": "👙",
       "shortcodes": ["bikini"],
       "group": "objects",
-      "order": 19
+      "order": 19,
+      "keywords": ["bathing", "beach", "clothing", "pool", "suit", "swim"]
     },
     {
       "emoji": "👚",
       "shortcodes": ["womans_clothes"],
       "group": "objects",
-      "order": 20
+      "order": 20,
+      "keywords": [
+        "blouse",
+        "clothes",
+        "clothing",
+        "collar",
+        "dress",
+        "dressed",
+        "lady",
+        "shirt",
+        "shopping",
+        "woman",
+        "woman’s",
+        "woman’s clothes"
+      ]
     },
     {
       "emoji": "👛",
       "shortcodes": ["purse"],
       "group": "objects",
-      "order": 22
+      "order": 22,
+      "keywords": ["clothes", "clothing", "coin", "dress", "fancy", "handbag", "shopping"]
     },
     {
       "emoji": "👜",
       "shortcodes": ["handbag"],
       "group": "objects",
-      "order": 23
+      "order": 23,
+      "keywords": ["bag", "clothes", "clothing", "dress", "lady", "purse", "shopping"]
     },
     {
       "emoji": "👝",
-      "shortcodes": ["pouch"],
+      "shortcodes": ["pouch", "clutch_bag"],
       "group": "objects",
-      "order": 24
+      "order": 24,
+      "keywords": ["bag", "clothes", "clothing", "clutch", "dress", "handbag", "purse"]
     },
     {
       "emoji": "🛍️",
-      "shortcodes": ["shopping"],
+      "shortcodes": ["shopping", "shopping_bags"],
       "group": "objects",
-      "order": 25
+      "order": 25,
+      "keywords": ["bag", "bags", "hotel"]
     },
     {
       "emoji": "🎒",
-      "shortcodes": ["school_satchel"],
+      "shortcodes": ["school_satchel", "backpack"],
       "group": "objects",
-      "order": 27
+      "order": 27,
+      "keywords": ["backpacking", "bag", "bookbag", "education", "rucksack", "satchel", "school"]
     },
     {
       "emoji": "🩴",
       "shortcodes": ["thong_sandal"],
       "group": "objects",
-      "order": 28
+      "order": 28,
+      "keywords": ["beach", "flip", "flop", "sandal", "sandals", "shoe", "thong", "thongs", "zōri"]
     },
     {
       "emoji": "👞",
       "shortcodes": ["mans_shoe", "shoe"],
       "group": "objects",
-      "order": 29
+      "order": 29,
+      "keywords": [
+        "brown",
+        "clothes",
+        "clothing",
+        "feet",
+        "foot",
+        "kick",
+        "man",
+        "man’s",
+        "shoes",
+        "shopping",
+        "man’s shoe"
+      ]
     },
     {
       "emoji": "👟",
-      "shortcodes": ["athletic_shoe"],
+      "shortcodes": ["athletic_shoe", "sneaker", "running_shoe"],
       "group": "objects",
-      "order": 30
+      "order": 30,
+      "keywords": ["athletic", "clothes", "clothing", "fast", "kick", "running", "shoe", "shoes", "shopping", "tennis"]
     },
     {
       "emoji": "🥾",
       "shortcodes": ["hiking_boot"],
       "group": "objects",
-      "order": 31
+      "order": 31,
+      "keywords": ["backpacking", "boot", "brown", "camping", "hiking", "outdoors", "shoe"]
     },
     {
       "emoji": "🥿",
-      "shortcodes": ["flat_shoe"],
+      "shortcodes": ["flat_shoe", "womans_flat_shoe"],
       "group": "objects",
-      "order": 32
+      "order": 32,
+      "keywords": ["ballet", "comfy", "flat", "flats", "shoe", "slip-on", "slipper"]
     },
     {
       "emoji": "👠",
-      "shortcodes": ["high_heel"],
+      "shortcodes": ["high_heel", "high_heeled_shoe"],
       "group": "objects",
-      "order": 33
+      "order": 33,
+      "keywords": [
+        "clothes",
+        "clothing",
+        "dress",
+        "fashion",
+        "heel",
+        "heels",
+        "high-heeled",
+        "shoe",
+        "shoes",
+        "shopping",
+        "stiletto",
+        "woman"
+      ]
     },
     {
       "emoji": "👡",
-      "shortcodes": ["sandal"],
+      "shortcodes": ["sandal", "womans_sandal"],
       "group": "objects",
-      "order": 34
+      "order": 34,
+      "keywords": ["clothing", "shoe", "woman", "woman’s", "woman’s sandal"]
     },
     {
       "emoji": "🩰",
       "shortcodes": ["ballet_shoes"],
       "group": "objects",
-      "order": 35
+      "order": 35,
+      "keywords": ["ballet", "dance", "shoes"]
     },
     {
       "emoji": "👢",
-      "shortcodes": ["boot"],
+      "shortcodes": ["boot", "womans_boot"],
       "group": "objects",
-      "order": 36
+      "order": 36,
+      "keywords": ["clothes", "clothing", "dress", "shoe", "shoes", "shopping", "woman", "woman’s", "woman’s boot"]
     },
     {
       "emoji": "👑",
       "shortcodes": ["crown"],
       "group": "objects",
-      "order": 38
+      "order": 38,
+      "keywords": ["clothing", "family", "king", "medieval", "queen", "royal", "royalty", "win"]
     },
     {
       "emoji": "👒",
       "shortcodes": ["womans_hat"],
       "group": "objects",
-      "order": 39
+      "order": 39,
+      "keywords": ["clothes", "clothing", "garden", "hat", "hats", "party", "woman", "woman’s", "woman’s hat"]
     },
     {
       "emoji": "🎩",
-      "shortcodes": ["tophat"],
+      "shortcodes": ["tophat", "top_hat"],
       "group": "objects",
-      "order": 40
+      "order": 40,
+      "keywords": ["clothes", "clothing", "fancy", "formal", "hat", "magic", "top"]
     },
     {
       "emoji": "🎓",
-      "shortcodes": ["mortar_board"],
+      "shortcodes": ["mortar_board", "graduation_cap"],
       "group": "objects",
-      "order": 41
+      "order": 41,
+      "keywords": ["cap", "celebration", "clothing", "education", "graduation", "hat", "scholar"]
     },
     {
       "emoji": "🧢",
       "shortcodes": ["billed_cap"],
       "group": "objects",
-      "order": 42
+      "order": 42,
+      "keywords": ["baseball", "bent", "billed", "cap", "dad", "hat"]
     },
     {
       "emoji": "🪖",
       "shortcodes": ["military_helmet"],
       "group": "objects",
-      "order": 43
+      "order": 43,
+      "keywords": ["army", "helmet", "military", "soldier", "war", "warrior"]
     },
     {
       "emoji": "⛑️",
-      "shortcodes": ["rescue_worker_helmet"],
+      "shortcodes": ["rescue_worker_helmet", "helmet_with_white_cross", "helmet_with_cross", "rescue_workers_helmet"],
       "group": "objects",
-      "order": 44
+      "order": 44,
+      "keywords": ["aid", "cross", "face", "hat", "helmet", "rescue", "worker’s", "rescue worker’s helmet"]
     },
     {
       "emoji": "📿",
       "shortcodes": ["prayer_beads"],
       "group": "objects",
-      "order": 46
+      "order": 46,
+      "keywords": ["beads", "clothing", "necklace", "prayer", "religion"]
     },
     {
       "emoji": "💄",
       "shortcodes": ["lipstick"],
       "group": "objects",
-      "order": 47
+      "order": 47,
+      "keywords": ["cosmetics", "date", "makeup"]
     },
     {
       "emoji": "💍",
       "shortcodes": ["ring"],
       "group": "objects",
-      "order": 48
+      "order": 48,
+      "keywords": ["diamond", "engaged", "engagement", "married", "romance", "shiny", "sparkling", "wedding"]
     },
     {
       "emoji": "💎",
-      "shortcodes": ["gem"],
+      "shortcodes": ["gem", "gem_stone"],
       "group": "objects",
-      "order": 49
+      "order": 49,
+      "keywords": ["diamond", "engagement", "jewel", "money", "romance", "stone", "wedding"]
     },
     {
       "emoji": "🔇",
-      "shortcodes": ["mute"],
+      "shortcodes": ["mute", "no_sound", "muted_speaker"],
       "group": "objects",
-      "order": 50
+      "order": 50,
+      "keywords": ["muted", "quiet", "silent", "sound", "speaker"]
     },
     {
       "emoji": "🔈",
-      "shortcodes": ["speaker"],
+      "shortcodes": ["speaker", "low_volume", "quiet_sound", "speaker_low_volume"],
       "group": "objects",
-      "order": 51
+      "order": 51,
+      "keywords": ["low", "soft", "sound", "volume"]
     },
     {
       "emoji": "🔉",
-      "shortcodes": ["sound"],
+      "shortcodes": ["sound", "medium_volumne", "speaker_medium_volume"],
       "group": "objects",
-      "order": 52
+      "order": 52,
+      "keywords": ["medium", "speaker", "volume"]
     },
     {
       "emoji": "🔊",
-      "shortcodes": ["loud_sound"],
+      "shortcodes": ["loud_sound", "high_volume", "speaker_high_volume"],
       "group": "objects",
-      "order": 53
+      "order": 53,
+      "keywords": ["high", "loud", "music", "sound", "speaker", "volume"]
     },
     {
       "emoji": "📢",
       "shortcodes": ["loudspeaker"],
       "group": "objects",
-      "order": 54
+      "order": 54,
+      "keywords": ["address", "communication", "loud", "public", "sound"]
     },
     {
       "emoji": "📣",
-      "shortcodes": ["mega"],
+      "shortcodes": ["mega", "megaphone"],
       "group": "objects",
-      "order": 55
+      "order": 55,
+      "keywords": ["cheering", "sound"]
     },
     {
       "emoji": "📯",
       "shortcodes": ["postal_horn"],
       "group": "objects",
-      "order": 56
+      "order": 56,
+      "keywords": ["horn", "post", "postal"]
     },
     {
       "emoji": "🔔",
       "shortcodes": ["bell"],
       "group": "objects",
-      "order": 57
+      "order": 57,
+      "keywords": ["break", "church", "sound"]
     },
     {
       "emoji": "🔕",
-      "shortcodes": ["no_bell"],
+      "shortcodes": ["no_bell", "bell_with_slash"],
       "group": "objects",
-      "order": 58
+      "order": 58,
+      "keywords": ["bell", "forbidden", "mute", "no", "not", "prohibited", "quiet", "silent", "slash", "sound"]
     },
     {
       "emoji": "🎼",
       "shortcodes": ["musical_score"],
       "group": "objects",
-      "order": 59
+      "order": 59,
+      "keywords": ["music", "musical", "note", "score"]
     },
     {
       "emoji": "🎵",
       "shortcodes": ["musical_note"],
       "group": "objects",
-      "order": 60
+      "order": 60,
+      "keywords": ["music", "musical", "note", "sound"]
     },
     {
       "emoji": "🎶",
-      "shortcodes": ["notes"],
+      "shortcodes": ["notes", "musical_notes"],
       "group": "objects",
-      "order": 61
+      "order": 61,
+      "keywords": ["music", "musical", "note", "sound"]
     },
     {
       "emoji": "🎙️",
-      "shortcodes": ["studio_microphone"],
+      "shortcodes": ["studio_microphone", "microphone2"],
       "group": "objects",
-      "order": 62
+      "order": 62,
+      "keywords": ["mic", "microphone", "music", "studio"]
     },
     {
       "emoji": "🎚️",
       "shortcodes": ["level_slider"],
       "group": "objects",
-      "order": 64
+      "order": 64,
+      "keywords": ["level", "music", "slider"]
     },
     {
       "emoji": "🎛️",
       "shortcodes": ["control_knobs"],
       "group": "objects",
-      "order": 66
+      "order": 66,
+      "keywords": ["control", "knobs", "music"]
     },
     {
       "emoji": "🎤",
       "shortcodes": ["microphone"],
       "group": "objects",
-      "order": 68
+      "order": 68,
+      "keywords": ["karaoke", "mic", "music", "sing", "sound"]
     },
     {
       "emoji": "🎧",
-      "shortcodes": ["headphones"],
+      "shortcodes": ["headphones", "headphone"],
       "group": "objects",
-      "order": 69
+      "order": 69,
+      "keywords": ["earbud", "sound"]
     },
     {
       "emoji": "📻",
       "shortcodes": ["radio"],
       "group": "objects",
-      "order": 70
+      "order": 70,
+      "keywords": ["entertainment", "tbt", "video"]
     },
     {
       "emoji": "🎷",
       "shortcodes": ["saxophone"],
       "group": "objects",
-      "order": 71
+      "order": 71,
+      "keywords": ["instrument", "music", "sax"]
     },
     {
       "emoji": "🪗",
       "shortcodes": ["accordion"],
       "group": "objects",
-      "order": 72
+      "order": 72,
+      "keywords": ["box", "concertina", "instrument", "music", "squeeze", "squeezebox"]
     },
     {
       "emoji": "🎸",
       "shortcodes": ["guitar"],
       "group": "objects",
-      "order": 73
+      "order": 73,
+      "keywords": ["instrument", "music", "strat"]
     },
     {
       "emoji": "🎹",
       "shortcodes": ["musical_keyboard"],
       "group": "objects",
-      "order": 74
+      "order": 74,
+      "keywords": ["instrument", "keyboard", "music", "musical", "piano"]
     },
     {
       "emoji": "🎺",
       "shortcodes": ["trumpet"],
       "group": "objects",
-      "order": 75
+      "order": 75,
+      "keywords": ["instrument", "music"]
     },
     {
       "emoji": "🎻",
       "shortcodes": ["violin"],
       "group": "objects",
-      "order": 76
+      "order": 76,
+      "keywords": ["instrument", "music"]
     },
     {
       "emoji": "🪕",
       "shortcodes": ["banjo"],
       "group": "objects",
-      "order": 77
+      "order": 77,
+      "keywords": ["music", "stringed"]
     },
     {
       "emoji": "🥁",
-      "shortcodes": ["drum"],
+      "shortcodes": ["drum", "drum_with_drumsticks"],
       "group": "objects",
-      "order": 78
+      "order": 78,
+      "keywords": ["drumsticks", "music"]
     },
     {
       "emoji": "🪘",
       "shortcodes": ["long_drum"],
       "group": "objects",
-      "order": 79
+      "order": 79,
+      "keywords": ["beat", "conga", "drum", "instrument", "long", "rhythm"]
     },
     {
       "emoji": "📱",
-      "shortcodes": ["iphone"],
+      "shortcodes": ["iphone", "android", "mobile_phone"],
       "group": "objects",
-      "order": 83
+      "order": 83,
+      "keywords": ["cell", "communication", "mobile", "phone", "telephone"]
     },
     {
       "emoji": "📲",
-      "shortcodes": ["calling"],
+      "shortcodes": ["calling", "mobile_phone_arrow", "mobile_phone_with_arrow"],
       "group": "objects",
-      "order": 84
+      "order": 84,
+      "keywords": ["arrow", "build", "call", "cell", "communication", "mobile", "phone", "receive", "telephone"]
     },
     {
       "emoji": "☎️",
       "shortcodes": ["phone", "telephone"],
       "group": "objects",
-      "order": 85
+      "order": 85,
+      "keywords": []
     },
     {
       "emoji": "📞",
       "shortcodes": ["telephone_receiver"],
       "group": "objects",
-      "order": 87
+      "order": 87,
+      "keywords": ["communication", "phone", "receiver", "telephone", "voip"]
     },
     {
       "emoji": "📟",
       "shortcodes": ["pager"],
       "group": "objects",
-      "order": 88
+      "order": 88,
+      "keywords": ["communication"]
     },
     {
       "emoji": "📠",
-      "shortcodes": ["fax"],
+      "shortcodes": ["fax", "fax_machine"],
       "group": "objects",
-      "order": 89
+      "order": 89,
+      "keywords": ["communication", "machine"]
     },
     {
       "emoji": "🔋",
       "shortcodes": ["battery"],
       "group": "objects",
-      "order": 90
+      "order": 90,
+      "keywords": []
     },
     {
       "emoji": "🔌",
       "shortcodes": ["electric_plug"],
       "group": "objects",
-      "order": 92
+      "order": 92,
+      "keywords": ["electric", "electricity", "plug"]
     },
     {
       "emoji": "💻",
-      "shortcodes": ["computer"],
+      "shortcodes": ["computer", "laptop"],
       "group": "objects",
-      "order": 93
+      "order": 93,
+      "keywords": ["office", "pc", "personal"]
     },
     {
       "emoji": "🖥️",
-      "shortcodes": ["desktop_computer"],
+      "shortcodes": ["desktop_computer", "desktop"],
       "group": "objects",
-      "order": 94
+      "order": 94,
+      "keywords": ["computer", "monitor"]
     },
     {
       "emoji": "🖨️",
       "shortcodes": ["printer"],
       "group": "objects",
-      "order": 96
+      "order": 96,
+      "keywords": ["computer"]
     },
     {
       "emoji": "⌨️",
       "shortcodes": ["keyboard"],
       "group": "objects",
-      "order": 98
+      "order": 98,
+      "keywords": ["computer"]
     },
     {
       "emoji": "🖱️",
-      "shortcodes": ["computer_mouse"],
+      "shortcodes": ["computer_mouse", "three_button_mouse", "mouse_three_button"],
       "group": "objects",
-      "order": 100
+      "order": 100,
+      "keywords": ["computer", "mouse"]
     },
     {
       "emoji": "🖲️",
       "shortcodes": ["trackball"],
       "group": "objects",
-      "order": 102
+      "order": 102,
+      "keywords": ["computer"]
     },
     {
       "emoji": "💽",
-      "shortcodes": ["minidisc"],
+      "shortcodes": ["minidisc", "computer_disk"],
       "group": "objects",
-      "order": 104
+      "order": 104,
+      "keywords": ["computer", "disk", "minidisk", "optical"]
     },
     {
       "emoji": "💾",
       "shortcodes": ["floppy_disk"],
       "group": "objects",
-      "order": 105
+      "order": 105,
+      "keywords": ["computer", "disk", "floppy"]
     },
     {
       "emoji": "💿",
-      "shortcodes": ["cd"],
+      "shortcodes": ["cd", "optical_disk"],
       "group": "objects",
-      "order": 106
+      "order": 106,
+      "keywords": ["blu-ray", "computer", "disk", "dvd", "optical"]
     },
     {
       "emoji": "📀",
       "shortcodes": ["dvd"],
       "group": "objects",
-      "order": 107
+      "order": 107,
+      "keywords": ["blu-ray", "cd", "computer", "disk", "optical"]
     },
     {
       "emoji": "🧮",
       "shortcodes": ["abacus"],
       "group": "objects",
-      "order": 108
+      "order": 108,
+      "keywords": ["calculation", "calculator"]
     },
     {
       "emoji": "🎥",
       "shortcodes": ["movie_camera"],
       "group": "objects",
-      "order": 109
+      "order": 109,
+      "keywords": ["bollywood", "camera", "cinema", "film", "hollywood", "movie", "record"]
     },
     {
       "emoji": "🎞️",
-      "shortcodes": ["film_strip"],
+      "shortcodes": ["film_strip", "film_frames"],
       "group": "objects",
-      "order": 110
+      "order": 110,
+      "keywords": ["cinema", "film", "frames", "movie"]
     },
     {
       "emoji": "📽️",
-      "shortcodes": ["film_projector"],
+      "shortcodes": ["film_projector", "projector"],
       "group": "objects",
-      "order": 112
+      "order": 112,
+      "keywords": ["cinema", "film", "movie", "video"]
     },
     {
       "emoji": "🎬",
-      "shortcodes": ["clapper"],
+      "shortcodes": ["clapper", "clapper_board"],
       "group": "objects",
-      "order": 114
+      "order": 114,
+      "keywords": ["action", "board", "movie"]
     },
     {
       "emoji": "📺",
-      "shortcodes": ["tv"],
+      "shortcodes": ["tv", "television"],
       "group": "objects",
-      "order": 115
+      "order": 115,
+      "keywords": ["video"]
     },
     {
       "emoji": "📷",
       "shortcodes": ["camera"],
       "group": "objects",
-      "order": 116
+      "order": 116,
+      "keywords": ["photo", "selfie", "snap", "tbt", "trip", "video"]
     },
     {
       "emoji": "📸",
-      "shortcodes": ["camera_flash"],
+      "shortcodes": ["camera_flash", "camera_with_flash"],
       "group": "objects",
-      "order": 117
+      "order": 117,
+      "keywords": ["camera", "flash", "video"]
     },
     {
       "emoji": "📹",
       "shortcodes": ["video_camera"],
       "group": "objects",
-      "order": 118
+      "order": 118,
+      "keywords": ["camcorder", "camera", "tbt", "video"]
     },
     {
       "emoji": "📼",
-      "shortcodes": ["vhs"],
+      "shortcodes": ["vhs", "videocassette"],
       "group": "objects",
-      "order": 119
+      "order": 119,
+      "keywords": ["old", "school", "tape", "vcr", "video"]
     },
     {
       "emoji": "🔍",
-      "shortcodes": ["mag"],
+      "shortcodes": ["mag", "magnifying_glass_tilted_left"],
       "group": "objects",
-      "order": 120
+      "order": 120,
+      "keywords": ["glass", "lab", "left", "left-pointing", "magnifying", "science", "search", "tilted", "tool"]
     },
     {
       "emoji": "🔎",
-      "shortcodes": ["mag_right"],
+      "shortcodes": ["mag_right", "magnifying_glass_tilted_right"],
       "group": "objects",
-      "order": 121
+      "order": 121,
+      "keywords": [
+        "contact",
+        "glass",
+        "lab",
+        "magnifying",
+        "right",
+        "right-pointing",
+        "science",
+        "search",
+        "tilted",
+        "tool"
+      ]
     },
     {
       "emoji": "🕯️",
       "shortcodes": ["candle"],
       "group": "objects",
-      "order": 122
+      "order": 122,
+      "keywords": ["light"]
     },
     {
       "emoji": "💡",
-      "shortcodes": ["bulb", "idea", "lightbulb_idea"],
+      "shortcodes": ["bulb", "idea", "lightbulb_idea", "light_bulb"],
       "group": "objects",
-      "order": 124
+      "order": 124,
+      "keywords": ["comic", "electric", "light"]
     },
     {
       "emoji": "🔦",
       "shortcodes": ["flashlight"],
       "group": "objects",
-      "order": 125
+      "order": 125,
+      "keywords": ["electric", "light", "tool", "torch"]
     },
     {
       "emoji": "🏮",
-      "shortcodes": ["izakaya_lantern", "lantern"],
+      "shortcodes": ["izakaya_lantern", "lantern", "red_paper_lantern"],
       "group": "objects",
-      "order": 126
+      "order": 126,
+      "keywords": ["bar", "light", "paper", "red", "restaurant"]
     },
     {
       "emoji": "🪔",
       "shortcodes": ["diya_lamp"],
       "group": "objects",
-      "order": 127
+      "order": 127,
+      "keywords": ["diya", "lamp", "light", "oil"]
     },
     {
       "emoji": "📔",
       "shortcodes": ["notebook_with_decorative_cover"],
       "group": "objects",
-      "order": 128
+      "order": 128,
+      "keywords": ["book", "cover", "decorated", "decorative", "education", "notebook", "school", "writing"]
     },
     {
       "emoji": "📕",
       "shortcodes": ["closed_book"],
       "group": "objects",
-      "order": 129
+      "order": 129,
+      "keywords": ["book", "closed", "education"]
     },
     {
       "emoji": "📖",
       "shortcodes": ["book", "open_book"],
       "group": "objects",
-      "order": 130
+      "order": 130,
+      "keywords": ["education", "fantasy", "knowledge", "library", "novels", "open", "reading"]
     },
     {
       "emoji": "📗",
       "shortcodes": ["green_book"],
       "group": "objects",
-      "order": 131
+      "order": 131,
+      "keywords": ["book", "education", "fantasy", "green", "library", "reading"]
     },
     {
       "emoji": "📘",
       "shortcodes": ["blue_book"],
       "group": "objects",
-      "order": 132
+      "order": 132,
+      "keywords": ["blue", "book", "education", "fantasy", "library", "reading"]
     },
     {
       "emoji": "📙",
       "shortcodes": ["orange_book"],
       "group": "objects",
-      "order": 133
+      "order": 133,
+      "keywords": ["book", "education", "fantasy", "library", "orange", "reading"]
     },
     {
       "emoji": "📚",
       "shortcodes": ["books"],
       "group": "objects",
-      "order": 134
+      "order": 134,
+      "keywords": ["book", "education", "fantasy", "knowledge", "library", "novels", "reading", "school", "study"]
     },
     {
       "emoji": "📓",
       "shortcodes": ["notebook"],
       "group": "objects",
-      "order": 135
+      "order": 135,
+      "keywords": []
     },
     {
       "emoji": "📒",
       "shortcodes": ["ledger"],
       "group": "objects",
-      "order": 136
+      "order": 136,
+      "keywords": ["notebook"]
     },
     {
       "emoji": "📃",
       "shortcodes": ["page_with_curl"],
       "group": "objects",
-      "order": 137
+      "order": 137,
+      "keywords": ["curl", "document", "page", "paper"]
     },
     {
       "emoji": "📜",
       "shortcodes": ["scroll"],
       "group": "objects",
-      "order": 138
+      "order": 138,
+      "keywords": ["paper"]
     },
     {
       "emoji": "📄",
       "shortcodes": ["page_facing_up"],
       "group": "objects",
-      "order": 139
+      "order": 139,
+      "keywords": ["document", "facing", "page", "paper", "up"]
     },
     {
       "emoji": "📰",
       "shortcodes": ["newspaper"],
       "group": "objects",
-      "order": 140
+      "order": 140,
+      "keywords": ["communication", "news", "paper"]
     },
     {
       "emoji": "🗞️",
-      "shortcodes": ["newspaper_roll"],
+      "shortcodes": ["newspaper_roll", "rolled_up_newspaper", "newspaper2"],
       "group": "objects",
-      "order": 141
+      "order": 141,
+      "keywords": ["news", "newspaper", "paper", "rolled", "rolled-up"]
     },
     {
       "emoji": "📑",
       "shortcodes": ["bookmark_tabs"],
       "group": "objects",
-      "order": 143
+      "order": 143,
+      "keywords": ["bookmark", "mark", "marker", "tabs"]
     },
     {
       "emoji": "🔖",
       "shortcodes": ["bookmark"],
       "group": "objects",
-      "order": 144
+      "order": 144,
+      "keywords": ["mark"]
     },
     {
       "emoji": "🏷️",
       "shortcodes": ["label"],
       "group": "objects",
-      "order": 145
+      "order": 145,
+      "keywords": ["tag"]
     },
     {
       "emoji": "💰",
-      "shortcodes": ["moneybag"],
+      "shortcodes": ["moneybag", "money_bag"],
       "group": "objects",
-      "order": 147
+      "order": 147,
+      "keywords": [
+        "bag",
+        "bank",
+        "bet",
+        "billion",
+        "cash",
+        "cost",
+        "dollar",
+        "gold",
+        "million",
+        "money",
+        "paid",
+        "paying",
+        "pot",
+        "rich",
+        "win"
+      ]
     },
     {
       "emoji": "🪙",
       "shortcodes": ["coin"],
       "group": "objects",
-      "order": 148
+      "order": 148,
+      "keywords": ["dollar", "euro", "gold", "metal", "money", "rich", "silver", "treasure"]
     },
     {
       "emoji": "💴",
-      "shortcodes": ["yen"],
+      "shortcodes": ["yen", "yen_banknote"],
       "group": "objects",
-      "order": 149
+      "order": 149,
+      "keywords": ["bank", "banknote", "bill", "currency", "money", "note"]
     },
     {
       "emoji": "💵",
-      "shortcodes": ["dollar"],
+      "shortcodes": ["dollar", "dollar_banknote"],
       "group": "objects",
-      "order": 150
+      "order": 150,
+      "keywords": ["bank", "banknote", "bill", "currency", "money", "note"]
     },
     {
       "emoji": "💶",
-      "shortcodes": ["euro"],
+      "shortcodes": ["euro", "euro_banknote"],
       "group": "objects",
-      "order": 151
+      "order": 151,
+      "keywords": ["100", "bank", "banknote", "bill", "currency", "money", "note", "rich"]
     },
     {
       "emoji": "💷",
-      "shortcodes": ["pound"],
+      "shortcodes": ["pound", "pound_banknote"],
       "group": "objects",
-      "order": 152
+      "order": 152,
+      "keywords": ["bank", "banknote", "bill", "billion", "cash", "currency", "money", "note", "pounds"]
     },
     {
       "emoji": "💸",
       "shortcodes": ["money_with_wings"],
       "group": "objects",
-      "order": 153
+      "order": 153,
+      "keywords": [
+        "bank",
+        "banknote",
+        "bill",
+        "billion",
+        "cash",
+        "dollar",
+        "fly",
+        "million",
+        "money",
+        "note",
+        "pay",
+        "wings"
+      ]
     },
     {
       "emoji": "💳",
       "shortcodes": ["credit_card"],
       "group": "objects",
-      "order": 154
+      "order": 154,
+      "keywords": ["bank", "card", "cash", "charge", "credit", "money", "pay"]
     },
     {
       "emoji": "🧾",
       "shortcodes": ["receipt"],
       "group": "objects",
-      "order": 155
+      "order": 155,
+      "keywords": ["accounting", "bookkeeping", "evidence", "invoice", "proof"]
     },
     {
       "emoji": "💹",
-      "shortcodes": ["chart"],
+      "shortcodes": ["chart", "chart_increasing_with_yen"],
       "group": "objects",
-      "order": 156
+      "order": 156,
+      "keywords": [
+        "bank",
+        "currency",
+        "graph",
+        "growth",
+        "increasing",
+        "market",
+        "money",
+        "rise",
+        "trend",
+        "upward",
+        "yen"
+      ]
     },
     {
       "emoji": "✉️",
       "shortcodes": ["email", "envelope"],
       "group": "objects",
-      "order": 157
+      "order": 157,
+      "keywords": ["letter"]
     },
     {
       "emoji": "📧",
-      "shortcodes": ["e-mail"],
+      "shortcodes": ["e-mail", "e_mail"],
       "group": "objects",
-      "order": 159
+      "order": 159,
+      "keywords": ["letter", "mail"]
     },
     {
       "emoji": "📨",
       "shortcodes": ["incoming_envelope"],
       "group": "objects",
-      "order": 160
+      "order": 160,
+      "keywords": ["delivering", "e-mail", "envelope", "incoming", "letter", "mail", "receive", "sent"]
     },
     {
       "emoji": "📩",
       "shortcodes": ["envelope_with_arrow"],
       "group": "objects",
-      "order": 161
+      "order": 161,
+      "keywords": ["arrow", "communication", "down", "e-mail", "envelope", "letter", "mail", "outgoing", "send", "sent"]
     },
     {
       "emoji": "📤",
       "shortcodes": ["outbox_tray"],
       "group": "objects",
-      "order": 162
+      "order": 162,
+      "keywords": ["box", "email", "letter", "mail", "outbox", "sent", "tray"]
     },
     {
       "emoji": "📥",
       "shortcodes": ["inbox_tray"],
       "group": "objects",
-      "order": 163
+      "order": 163,
+      "keywords": ["box", "email", "inbox", "letter", "mail", "receive", "tray", "zero"]
     },
     {
       "emoji": "📦",
       "shortcodes": ["package"],
       "group": "objects",
-      "order": 164
+      "order": 164,
+      "keywords": ["box", "communication", "delivery", "parcel", "shipping"]
     },
     {
       "emoji": "📫",
-      "shortcodes": ["mailbox"],
+      "shortcodes": ["mailbox", "closed_mailbox_with_raised_flag"],
       "group": "objects",
-      "order": 165
+      "order": 165,
+      "keywords": ["closed", "communication", "flag", "mail", "postbox", "raised"]
     },
     {
       "emoji": "📪",
-      "shortcodes": ["mailbox_closed"],
+      "shortcodes": ["mailbox_closed", "closed_mailbox_with_lowered_flag"],
       "group": "objects",
-      "order": 166
+      "order": 166,
+      "keywords": ["closed", "flag", "lowered", "mail", "mailbox", "postbox"]
     },
     {
       "emoji": "📬",
-      "shortcodes": ["mailbox_with_mail"],
+      "shortcodes": ["mailbox_with_mail", "open_mailbox_with_raised_flag"],
       "group": "objects",
-      "order": 167
+      "order": 167,
+      "keywords": ["flag", "mail", "mailbox", "open", "postbox", "raised"]
     },
     {
       "emoji": "📭",
-      "shortcodes": ["mailbox_with_no_mail"],
+      "shortcodes": ["mailbox_with_no_mail", "open_mailbox_with_lowered_flag"],
       "group": "objects",
-      "order": 168
+      "order": 168,
+      "keywords": ["flag", "lowered", "mail", "mailbox", "open", "postbox"]
     },
     {
       "emoji": "📮",
       "shortcodes": ["postbox"],
       "group": "objects",
-      "order": 169
+      "order": 169,
+      "keywords": ["mail", "mailbox"]
     },
     {
       "emoji": "🗳️",
-      "shortcodes": ["ballot_box"],
+      "shortcodes": ["ballot_box", "ballot_box_with_ballot"],
       "group": "objects",
-      "order": 170
+      "order": 170,
+      "keywords": ["ballot", "box"]
     },
     {
       "emoji": "✏️",
       "shortcodes": ["pencil2"],
       "group": "objects",
-      "order": 172
+      "order": 172,
+      "keywords": ["pencil"]
     },
     {
       "emoji": "✒️",
       "shortcodes": ["black_nib"],
       "group": "objects",
-      "order": 174
+      "order": 174,
+      "keywords": ["black", "nib", "pen"]
     },
     {
       "emoji": "🖋️",
-      "shortcodes": ["fountain_pen"],
+      "shortcodes": ["fountain_pen", "lower_left_fountain_pen", "pen_fountain"],
       "group": "objects",
-      "order": 176
+      "order": 176,
+      "keywords": ["fountain", "pen"]
     },
     {
       "emoji": "🖊️",
-      "shortcodes": ["pen"],
+      "shortcodes": ["pen", "lower_left_ballpoint_pen", "pen_ballpoint"],
       "group": "objects",
-      "order": 178
+      "order": 178,
+      "keywords": ["ballpoint"]
     },
     {
       "emoji": "🖌️",
-      "shortcodes": ["paintbrush"],
+      "shortcodes": ["paintbrush", "lower_left_paintbrush"],
       "group": "objects",
-      "order": 180
+      "order": 180,
+      "keywords": ["painting"]
     },
     {
       "emoji": "🖍️",
-      "shortcodes": ["crayon"],
+      "shortcodes": ["crayon", "lower_left_crayon"],
       "group": "objects",
-      "order": 182
+      "order": 182,
+      "keywords": []
     },
     {
       "emoji": "📝",
       "shortcodes": ["memo", "pencil"],
       "group": "objects",
-      "order": 184
+      "order": 184,
+      "keywords": ["communication", "media", "notes"]
     },
     {
       "emoji": "💼",
       "shortcodes": ["briefcase"],
       "group": "objects",
-      "order": 185
+      "order": 185,
+      "keywords": ["office"]
     },
     {
       "emoji": "📁",
       "shortcodes": ["file_folder"],
       "group": "objects",
-      "order": 186
+      "order": 186,
+      "keywords": ["file", "folder"]
     },
     {
       "emoji": "📂",
       "shortcodes": ["open_file_folder"],
       "group": "objects",
-      "order": 187
+      "order": 187,
+      "keywords": ["file", "folder", "open"]
     },
     {
       "emoji": "🗂️",
-      "shortcodes": ["card_index_dividers"],
+      "shortcodes": ["card_index_dividers", "dividers"],
       "group": "objects",
-      "order": 188
+      "order": 188,
+      "keywords": ["card", "index"]
     },
     {
       "emoji": "📅",
       "shortcodes": ["date"],
       "group": "objects",
-      "order": 190
+      "order": 190,
+      "keywords": ["calendar"]
     },
     {
       "emoji": "📆",
-      "shortcodes": ["calendar"],
+      "shortcodes": ["calendar", "tear_off_calendar"],
       "group": "objects",
-      "order": 191
+      "order": 191,
+      "keywords": ["tear-off"]
     },
     {
       "emoji": "🗒️",
-      "shortcodes": ["spiral_notepad"],
+      "shortcodes": ["spiral_notepad", "spiral_note_pad", "notepad_spiral"],
       "group": "objects",
-      "order": 192
+      "order": 192,
+      "keywords": ["note", "notepad", "pad", "spiral"]
     },
     {
       "emoji": "🗓️",
-      "shortcodes": ["spiral_calendar"],
+      "shortcodes": ["spiral_calendar", "spiral_calendar_pad", "calendar_spiral"],
       "group": "objects",
-      "order": 194
+      "order": 194,
+      "keywords": ["calendar", "pad", "spiral"]
     },
     {
       "emoji": "📇",
       "shortcodes": ["card_index"],
       "group": "objects",
-      "order": 196
+      "order": 196,
+      "keywords": ["card", "index", "old", "rolodex", "school"]
     },
     {
       "emoji": "📈",
-      "shortcodes": ["chart_with_upwards_trend"],
+      "shortcodes": ["chart_with_upwards_trend", "chart_increasing"],
       "group": "objects",
-      "order": 197
+      "order": 197,
+      "keywords": ["chart", "data", "graph", "growth", "increasing", "right", "trend", "up", "upward"]
     },
     {
       "emoji": "📉",
-      "shortcodes": ["chart_with_downwards_trend"],
+      "shortcodes": ["chart_with_downwards_trend", "chart_decreasing"],
       "group": "objects",
-      "order": 198
+      "order": 198,
+      "keywords": ["chart", "data", "decreasing", "down", "downward", "graph", "negative", "trend"]
     },
     {
       "emoji": "📊",
       "shortcodes": ["bar_chart"],
       "group": "objects",
-      "order": 199
+      "order": 199,
+      "keywords": ["bar", "chart", "data", "graph"]
     },
     {
       "emoji": "📋",
       "shortcodes": ["clipboard"],
       "group": "objects",
-      "order": 200
+      "order": 200,
+      "keywords": ["do", "list", "notes"]
     },
     {
       "emoji": "📌",
       "shortcodes": ["pushpin", "pin"],
       "group": "objects",
-      "order": 201
+      "order": 201,
+      "keywords": ["collage"]
     },
     {
       "emoji": "📍",
       "shortcodes": ["round_pushpin"],
       "group": "objects",
-      "order": 202
+      "order": 202,
+      "keywords": ["location", "map", "pin", "pushpin", "round"]
     },
     {
       "emoji": "📎",
       "shortcodes": ["paperclip"],
       "group": "objects",
-      "order": 203
+      "order": 203,
+      "keywords": []
     },
     {
       "emoji": "🖇️",
-      "shortcodes": ["paperclips"],
+      "shortcodes": ["paperclips", "linked_paperclips"],
       "group": "objects",
-      "order": 204
+      "order": 204,
+      "keywords": ["link", "linked", "paperclip"]
     },
     {
       "emoji": "📏",
       "shortcodes": ["straight_ruler"],
       "group": "objects",
-      "order": 206
+      "order": 206,
+      "keywords": ["angle", "edge", "math", "ruler", "straight", "straightedge"]
     },
     {
       "emoji": "📐",
       "shortcodes": ["triangular_ruler"],
       "group": "objects",
-      "order": 207
+      "order": 207,
+      "keywords": ["angle", "math", "rule", "ruler", "set", "slide", "triangle", "triangular"]
     },
     {
       "emoji": "✂️",
       "shortcodes": ["scissors"],
       "group": "objects",
-      "order": 208
+      "order": 208,
+      "keywords": ["cut", "cutting", "paper", "tool"]
     },
     {
       "emoji": "🗃️",
-      "shortcodes": ["card_file_box"],
+      "shortcodes": ["card_file_box", "card_box"],
       "group": "objects",
-      "order": 210
+      "order": 210,
+      "keywords": ["box", "card", "file"]
     },
     {
       "emoji": "🗄️",
       "shortcodes": ["file_cabinet"],
       "group": "objects",
-      "order": 212
+      "order": 212,
+      "keywords": ["cabinet", "file", "filing", "paper"]
     },
     {
       "emoji": "🗑️",
-      "shortcodes": ["wastebasket"],
+      "shortcodes": ["wastebasket", "trashcan"],
       "group": "objects",
-      "order": 214
+      "order": 214,
+      "keywords": ["can", "garbage", "trash", "waste"]
     },
     {
       "emoji": "🔒",
-      "shortcodes": ["lock"],
+      "shortcodes": ["lock", "locked"],
       "group": "objects",
-      "order": 216
+      "order": 216,
+      "keywords": ["closed", "private"]
     },
     {
       "emoji": "🔓",
-      "shortcodes": ["unlock"],
+      "shortcodes": ["unlock", "unlocked"],
       "group": "objects",
-      "order": 217
+      "order": 217,
+      "keywords": ["cracked", "lock", "open"]
     },
     {
       "emoji": "🔏",
-      "shortcodes": ["lock_with_ink_pen"],
+      "shortcodes": ["lock_with_ink_pen", "locked_with_pen"],
       "group": "objects",
-      "order": 218
+      "order": 218,
+      "keywords": ["ink", "lock", "locked", "nib", "pen", "privacy"]
     },
     {
       "emoji": "🔐",
-      "shortcodes": ["closed_lock_with_key"],
+      "shortcodes": ["closed_lock_with_key", "locked_with_key"],
       "group": "objects",
-      "order": 219
+      "order": 219,
+      "keywords": ["bike", "closed", "key", "lock", "locked", "secure"]
     },
     {
       "emoji": "🔑",
       "shortcodes": ["key"],
       "group": "objects",
-      "order": 220
+      "order": 220,
+      "keywords": ["keys", "lock", "major", "password", "unlock"]
     },
     {
       "emoji": "🗝️",
-      "shortcodes": ["old_key"],
+      "shortcodes": ["old_key", "key2"],
       "group": "objects",
-      "order": 221
+      "order": 221,
+      "keywords": ["clue", "key", "lock", "old"]
     },
     {
       "emoji": "🔨",
       "shortcodes": ["hammer"],
       "group": "objects",
-      "order": 223
+      "order": 223,
+      "keywords": ["home", "improvement", "repairs", "tool"]
     },
     {
       "emoji": "🪓",
       "shortcodes": ["axe"],
       "group": "objects",
-      "order": 224
+      "order": 224,
+      "keywords": ["ax", "chop", "hatchet", "split", "wood"]
     },
     {
       "emoji": "⛏️",
       "shortcodes": ["pick"],
       "group": "objects",
-      "order": 225
+      "order": 225,
+      "keywords": ["hammer", "mining", "tool"]
     },
     {
       "emoji": "⚒️",
-      "shortcodes": ["hammer_and_pick"],
+      "shortcodes": ["hammer_and_pick", "hammer_pick"],
       "group": "objects",
-      "order": 227
+      "order": 227,
+      "keywords": ["hammer", "pick", "tool"]
     },
     {
       "emoji": "🛠️",
-      "shortcodes": ["hammer_and_wrench"],
+      "shortcodes": ["hammer_and_wrench", "tools"],
       "group": "objects",
-      "order": 229
+      "order": 229,
+      "keywords": ["hammer", "spanner", "tool", "wrench"]
     },
     {
       "emoji": "🗡️",
-      "shortcodes": ["dagger"],
+      "shortcodes": ["dagger", "dagger_knife"],
       "group": "objects",
-      "order": 231
+      "order": 231,
+      "keywords": ["knife", "weapon"]
     },
     {
       "emoji": "⚔️",
       "shortcodes": ["crossed_swords"],
       "group": "objects",
-      "order": 233
+      "order": 233,
+      "keywords": ["crossed", "swords", "weapon"]
     },
     {
       "emoji": "💣",
       "shortcodes": ["bomb"],
       "group": "objects",
-      "order": 235
+      "order": 235,
+      "keywords": ["boom", "comic", "dangerous", "explosion", "hot"]
     },
     {
       "emoji": "🪃",
       "shortcodes": ["boomerang"],
       "group": "objects",
-      "order": 236
+      "order": 236,
+      "keywords": ["rebound", "repercussion", "weapon"]
     },
     {
       "emoji": "🏹",
-      "shortcodes": ["bow_and_arrow"],
+      "shortcodes": ["bow_and_arrow", "archery"],
       "group": "objects",
-      "order": 237
+      "order": 237,
+      "keywords": ["archer", "arrow", "bow", "sagittarius", "tool", "weapon", "zodiac"]
     },
     {
       "emoji": "🛡️",
       "shortcodes": ["shield"],
       "group": "objects",
-      "order": 238
+      "order": 238,
+      "keywords": ["weapon"]
     },
     {
       "emoji": "🪚",
       "shortcodes": ["carpentry_saw"],
       "group": "objects",
-      "order": 240
+      "order": 240,
+      "keywords": ["carpenter", "carpentry", "cut", "lumber", "saw", "tool", "trim"]
     },
     {
       "emoji": "🔧",
       "shortcodes": ["wrench"],
       "group": "objects",
-      "order": 241
+      "order": 241,
+      "keywords": ["home", "improvement", "spanner", "tool"]
     },
     {
       "emoji": "🪛",
       "shortcodes": ["screwdriver"],
       "group": "objects",
-      "order": 242
+      "order": 242,
+      "keywords": ["flathead", "handy", "screw", "tool"]
     },
     {
       "emoji": "🔩",
       "shortcodes": ["nut_and_bolt"],
       "group": "objects",
-      "order": 243
+      "order": 243,
+      "keywords": ["bolt", "home", "improvement", "nut", "tool"]
     },
     {
       "emoji": "⚙️",
       "shortcodes": ["gear"],
       "group": "objects",
-      "order": 244
+      "order": 244,
+      "keywords": ["cog", "cogwheel", "tool"]
     },
     {
       "emoji": "🗜️",
-      "shortcodes": ["clamp"],
+      "shortcodes": ["clamp", "compression"],
       "group": "objects",
-      "order": 246
+      "order": 246,
+      "keywords": ["compress", "tool", "vice"]
     },
     {
       "emoji": "⚖️",
-      "shortcodes": ["balance_scale"],
+      "shortcodes": ["balance_scale", "scales"],
       "group": "objects",
-      "order": 248
+      "order": 248,
+      "keywords": ["balance", "justice", "libra", "scale", "tool", "weight", "zodiac"]
     },
     {
       "emoji": "🦯",
-      "shortcodes": ["probing_cane"],
+      "shortcodes": ["probing_cane", "white_cane"],
       "group": "objects",
-      "order": 250
+      "order": 250,
+      "keywords": ["accessibility", "blind", "cane", "probing", "white"]
     },
     {
       "emoji": "🔗",
       "shortcodes": ["link"],
       "group": "objects",
-      "order": 251
+      "order": 251,
+      "keywords": ["links"]
     },
     {
       "emoji": "⛓️",
       "shortcodes": ["chains"],
       "group": "objects",
-      "order": 254
+      "order": 254,
+      "keywords": ["chain"]
     },
     {
       "emoji": "🪝",
       "shortcodes": ["hook"],
       "group": "objects",
-      "order": 256
+      "order": 256,
+      "keywords": ["catch", "crook", "curve", "ensnare", "point", "selling"]
     },
     {
       "emoji": "🧰",
       "shortcodes": ["toolbox"],
       "group": "objects",
-      "order": 257
+      "order": 257,
+      "keywords": ["box", "chest", "mechanic", "red", "tool"]
     },
     {
       "emoji": "🧲",
       "shortcodes": ["magnet"],
       "group": "objects",
-      "order": 258
+      "order": 258,
+      "keywords": ["attraction", "horseshoe", "magnetic", "negative", "positive", "shape", "u"]
     },
     {
       "emoji": "🪜",
       "shortcodes": ["ladder"],
       "group": "objects",
-      "order": 259
+      "order": 259,
+      "keywords": ["climb", "rung", "step"]
     },
     {
       "emoji": "⚗️",
       "shortcodes": ["alembic"],
       "group": "objects",
-      "order": 261
+      "order": 261,
+      "keywords": ["chemistry", "tool"]
     },
     {
       "emoji": "🧪",
       "shortcodes": ["test_tube"],
       "group": "objects",
-      "order": 263
+      "order": 263,
+      "keywords": ["chemist", "chemistry", "experiment", "lab", "science", "test", "tube"]
     },
     {
       "emoji": "🧫",
       "shortcodes": ["petri_dish"],
       "group": "objects",
-      "order": 264
+      "order": 264,
+      "keywords": ["bacteria", "biologist", "biology", "culture", "dish", "lab", "petri"]
     },
     {
       "emoji": "🧬",
-      "shortcodes": ["dna"],
+      "shortcodes": ["dna", "double_helix"],
       "group": "objects",
-      "order": 265
+      "order": 265,
+      "keywords": ["biologist", "evolution", "gene", "genetics", "life"]
     },
     {
       "emoji": "🔬",
       "shortcodes": ["microscope"],
       "group": "objects",
-      "order": 266
+      "order": 266,
+      "keywords": ["experiment", "lab", "science", "tool"]
     },
     {
       "emoji": "🔭",
       "shortcodes": ["telescope"],
       "group": "objects",
-      "order": 267
+      "order": 267,
+      "keywords": ["contact", "extraterrestrial", "science", "tool"]
     },
     {
       "emoji": "📡",
-      "shortcodes": ["satellite"],
+      "shortcodes": ["satellite", "satellite_antenna"],
       "group": "objects",
-      "order": 268
+      "order": 268,
+      "keywords": ["aliens", "antenna", "contact", "dish", "science"]
     },
     {
       "emoji": "💉",
       "shortcodes": ["syringe"],
       "group": "objects",
-      "order": 269
+      "order": 269,
+      "keywords": ["doctor", "flu", "medicine", "needle", "shot", "sick", "tool", "vaccination"]
     },
     {
       "emoji": "🩸",
       "shortcodes": ["drop_of_blood"],
       "group": "objects",
-      "order": 270
+      "order": 270,
+      "keywords": ["bleed", "blood", "donation", "drop", "injury", "medicine", "menstruation"]
     },
     {
       "emoji": "💊",
       "shortcodes": ["pill"],
       "group": "objects",
-      "order": 271
+      "order": 271,
+      "keywords": ["doctor", "drugs", "medicated", "medicine", "pills", "sick", "vitamin"]
     },
     {
       "emoji": "🩹",
-      "shortcodes": ["adhesive_bandage"],
+      "shortcodes": ["adhesive_bandage", "bandaid"],
       "group": "objects",
-      "order": 272
+      "order": 272,
+      "keywords": ["adhesive", "bandage"]
     },
     {
       "emoji": "🩺",
       "shortcodes": ["stethoscope"],
       "group": "objects",
-      "order": 274
+      "order": 274,
+      "keywords": ["doctor", "heart", "medicine"]
     },
     {
       "emoji": "🚪",
       "shortcodes": ["door"],
       "group": "objects",
-      "order": 276
+      "order": 276,
+      "keywords": ["back", "closet", "front"]
     },
     {
       "emoji": "🛗",
       "shortcodes": ["elevator"],
       "group": "objects",
-      "order": 277
+      "order": 277,
+      "keywords": ["accessibility", "hoist", "lift"]
     },
     {
       "emoji": "🪞",
       "shortcodes": ["mirror"],
       "group": "objects",
-      "order": 278
+      "order": 278,
+      "keywords": ["makeup", "reflection", "reflector", "speculum"]
     },
     {
       "emoji": "🪟",
       "shortcodes": ["window"],
       "group": "objects",
-      "order": 279
+      "order": 279,
+      "keywords": ["air", "frame", "fresh", "opening", "transparent", "view"]
     },
     {
       "emoji": "🛏️",
       "shortcodes": ["bed"],
       "group": "objects",
-      "order": 280
+      "order": 280,
+      "keywords": ["hotel", "sleep"]
     },
     {
       "emoji": "🛋️",
-      "shortcodes": ["couch_and_lamp"],
+      "shortcodes": ["couch_and_lamp", "couch"],
       "group": "objects",
-      "order": 282
+      "order": 282,
+      "keywords": ["hotel", "lamp"]
     },
     {
       "emoji": "🪑",
       "shortcodes": ["chair"],
       "group": "objects",
-      "order": 284
+      "order": 284,
+      "keywords": ["seat", "sit"]
     },
     {
       "emoji": "🚽",
       "shortcodes": ["toilet"],
       "group": "objects",
-      "order": 285
+      "order": 285,
+      "keywords": ["bathroom"]
     },
     {
       "emoji": "🪠",
       "shortcodes": ["plunger"],
       "group": "objects",
-      "order": 286
+      "order": 286,
+      "keywords": ["cup", "force", "plumber", "poop", "suction", "toilet"]
     },
     {
       "emoji": "🚿",
       "shortcodes": ["shower"],
       "group": "objects",
-      "order": 287
+      "order": 287,
+      "keywords": ["water"]
     },
     {
       "emoji": "🛁",
       "shortcodes": ["bathtub"],
       "group": "objects",
-      "order": 288
+      "order": 288,
+      "keywords": ["bath"]
     },
     {
       "emoji": "🪤",
       "shortcodes": ["mouse_trap"],
       "group": "objects",
-      "order": 289
+      "order": 289,
+      "keywords": ["bait", "cheese", "lure", "mouse", "snare", "trap"]
     },
     {
       "emoji": "🪒",
       "shortcodes": ["razor"],
       "group": "objects",
-      "order": 290
+      "order": 290,
+      "keywords": ["sharp", "shave"]
     },
     {
       "emoji": "🧴",
-      "shortcodes": ["lotion_bottle"],
+      "shortcodes": ["lotion_bottle", "squeeze_bottle"],
       "group": "objects",
-      "order": 291
+      "order": 291,
+      "keywords": ["bottle", "lotion", "moisturizer", "shampoo", "sunscreen"]
     },
     {
       "emoji": "🧷",
       "shortcodes": ["safety_pin"],
       "group": "objects",
-      "order": 292
+      "order": 292,
+      "keywords": ["diaper", "pin", "punk", "rock", "safety"]
     },
     {
       "emoji": "🧹",
       "shortcodes": ["broom"],
       "group": "objects",
-      "order": 293
+      "order": 293,
+      "keywords": ["cleaning", "sweeping", "witch"]
     },
     {
       "emoji": "🧺",
       "shortcodes": ["basket"],
       "group": "objects",
-      "order": 294
+      "order": 294,
+      "keywords": ["farming", "laundry", "picnic"]
     },
     {
       "emoji": "🧻",
-      "shortcodes": ["roll_of_paper"],
+      "shortcodes": ["roll_of_paper", "toilet_paper"],
       "group": "objects",
-      "order": 295
+      "order": 295,
+      "keywords": ["paper", "roll", "toilet", "towels"]
     },
     {
       "emoji": "🪣",
       "shortcodes": ["bucket"],
       "group": "objects",
-      "order": 296
+      "order": 296,
+      "keywords": ["cask", "pail", "vat"]
     },
     {
       "emoji": "🧼",
       "shortcodes": ["soap"],
       "group": "objects",
-      "order": 297
+      "order": 297,
+      "keywords": ["bar", "bathing", "clean", "cleaning", "lather", "soapdish"]
     },
     {
       "emoji": "🪥",
       "shortcodes": ["toothbrush"],
       "group": "objects",
-      "order": 299
+      "order": 299,
+      "keywords": ["bathroom", "brush", "clean", "dental", "hygiene", "teeth", "toiletry"]
     },
     {
       "emoji": "🧽",
       "shortcodes": ["sponge"],
       "group": "objects",
-      "order": 300
+      "order": 300,
+      "keywords": ["absorbing", "cleaning", "porous", "soak"]
     },
     {
       "emoji": "🧯",
       "shortcodes": ["fire_extinguisher"],
       "group": "objects",
-      "order": 301
+      "order": 301,
+      "keywords": ["extinguish", "extinguisher", "fire", "quench"]
     },
     {
       "emoji": "🛒",
-      "shortcodes": ["shopping_cart"],
+      "shortcodes": ["shopping_cart", "shopping_trolley"],
       "group": "objects",
-      "order": 302
+      "order": 302,
+      "keywords": ["cart", "shopping", "trolley"]
     },
     {
       "emoji": "🚬",
-      "shortcodes": ["smoking"],
+      "shortcodes": ["smoking", "cigarette"],
       "group": "objects",
-      "order": 303
+      "order": 303,
+      "keywords": []
     },
     {
       "emoji": "⚰️",
       "shortcodes": ["coffin"],
       "group": "objects",
-      "order": 304
+      "order": 304,
+      "keywords": ["dead", "death", "vampire"]
     },
     {
       "emoji": "🪦",
       "shortcodes": ["headstone"],
       "group": "objects",
-      "order": 306
+      "order": 306,
+      "keywords": ["cemetery", "dead", "grave", "graveyard", "memorial", "rip", "tomb", "tombstone"]
     },
     {
       "emoji": "⚱️",
-      "shortcodes": ["funeral_urn"],
+      "shortcodes": ["funeral_urn", "urn"],
       "group": "objects",
-      "order": 307
+      "order": 307,
+      "keywords": ["ashes", "death", "funeral"]
     },
     {
       "emoji": "🧿",
       "shortcodes": ["nazar_amulet"],
       "group": "objects",
-      "order": 309
+      "order": 309,
+      "keywords": ["amulet", "bead", "blue", "charm", "evil-eye", "nazar", "talisman"]
     },
     {
       "emoji": "🗿",
-      "shortcodes": ["moyai"],
+      "shortcodes": ["moyai", "moai"],
       "group": "objects",
-      "order": 311
+      "order": 311,
+      "keywords": ["face", "statue", "stoneface", "travel"]
     },
     {
       "emoji": "🪧",
       "shortcodes": ["placard"],
       "group": "objects",
-      "order": 312
+      "order": 312,
+      "keywords": ["card", "demonstration", "notice", "picket", "plaque", "protest", "sign"]
     },
     {
       "emoji": "🏧",
-      "shortcodes": ["atm"],
+      "shortcodes": ["atm", "atm_sign"],
       "group": "symbols",
-      "order": 0
+      "order": 0,
+      "keywords": ["automated", "bank", "cash", "money", "sign", "teller"]
     },
     {
       "emoji": "🚮",
-      "shortcodes": ["put_litter_in_its_place"],
+      "shortcodes": ["put_litter_in_its_place", "litter_bin", "litter_in_bin_sign"],
       "group": "symbols",
-      "order": 1
+      "order": 1,
+      "keywords": ["bin", "litter", "sign"]
     },
     {
       "emoji": "🚰",
       "shortcodes": ["potable_water"],
       "group": "symbols",
-      "order": 2
+      "order": 2,
+      "keywords": ["drinking", "potable", "water"]
     },
     {
       "emoji": "♿",
-      "shortcodes": ["wheelchair"],
+      "shortcodes": ["wheelchair", "handicapped", "wheelchair_symbol"],
       "group": "symbols",
-      "order": 3
+      "order": 3,
+      "keywords": ["access", "handicap", "symbol"]
     },
     {
       "emoji": "🚹",
-      "shortcodes": ["mens"],
+      "shortcodes": ["mens", "mens_room"],
       "group": "symbols",
-      "order": 4
+      "order": 4,
+      "keywords": ["bathroom", "lavatory", "man", "men’s", "restroom", "room", "toilet", "wc", "men’s room"]
     },
     {
       "emoji": "🚺",
-      "shortcodes": ["womens"],
+      "shortcodes": ["womens", "womens_room"],
       "group": "symbols",
-      "order": 5
+      "order": 5,
+      "keywords": ["bathroom", "lavatory", "restroom", "room", "toilet", "wc", "woman", "women’s", "women’s room"]
     },
     {
       "emoji": "🚻",
-      "shortcodes": ["restroom"],
+      "shortcodes": ["restroom", "bathroom"],
       "group": "symbols",
-      "order": 6
+      "order": 6,
+      "keywords": ["lavatory", "toilet", "wc"]
     },
     {
       "emoji": "🚼",
       "shortcodes": ["baby_symbol"],
       "group": "symbols",
-      "order": 7
+      "order": 7,
+      "keywords": ["baby", "changing", "symbol"]
     },
     {
       "emoji": "🚾",
-      "shortcodes": ["wc"],
+      "shortcodes": ["wc", "water_closet"],
       "group": "symbols",
-      "order": 8
+      "order": 8,
+      "keywords": ["bathroom", "closet", "lavatory", "restroom", "toilet", "water"]
     },
     {
       "emoji": "🛂",
       "shortcodes": ["passport_control"],
       "group": "symbols",
-      "order": 9
+      "order": 9,
+      "keywords": ["control", "passport"]
     },
     {
       "emoji": "🛃",
       "shortcodes": ["customs"],
       "group": "symbols",
-      "order": 10
+      "order": 10,
+      "keywords": ["packing"]
     },
     {
       "emoji": "🛄",
       "shortcodes": ["baggage_claim"],
       "group": "symbols",
-      "order": 11
+      "order": 11,
+      "keywords": [
+        "arrived",
+        "baggage",
+        "bags",
+        "case",
+        "checked",
+        "claim",
+        "journey",
+        "packing",
+        "plane",
+        "ready",
+        "travel",
+        "trip"
+      ]
     },
     {
       "emoji": "🛅",
       "shortcodes": ["left_luggage"],
       "group": "symbols",
-      "order": 12
+      "order": 12,
+      "keywords": ["baggage", "case", "left", "locker", "luggage"]
     },
     {
       "emoji": "⚠️",
       "shortcodes": ["warning", "warning_sign", "caution"],
       "group": "symbols",
-      "order": 13
+      "order": 13,
+      "keywords": []
     },
     {
       "emoji": "🚸",
       "shortcodes": ["children_crossing"],
       "group": "symbols",
-      "order": 15
+      "order": 15,
+      "keywords": ["child", "children", "crossing", "pedestrian", "traffic"]
     },
     {
       "emoji": "⛔",
       "shortcodes": ["no_entry"],
       "group": "symbols",
-      "order": 16
+      "order": 16,
+      "keywords": ["do", "entry", "fail", "forbidden", "no", "not", "pass", "prohibited", "traffic"]
     },
     {
       "emoji": "🚫",
-      "shortcodes": ["no_entry_sign"],
+      "shortcodes": ["no_entry_sign", "prohibited"],
       "group": "symbols",
-      "order": 17
+      "order": 17,
+      "keywords": ["entry", "forbidden", "no", "not", "smoke"]
     },
     {
       "emoji": "🚳",
       "shortcodes": ["no_bicycles"],
       "group": "symbols",
-      "order": 18
+      "order": 18,
+      "keywords": ["bicycle", "bicycles", "bike", "forbidden", "no", "not", "prohibited"]
     },
     {
       "emoji": "🚭",
       "shortcodes": ["no_smoking"],
       "group": "symbols",
-      "order": 19
+      "order": 19,
+      "keywords": ["forbidden", "no", "not", "prohibited", "smoke", "smoking"]
     },
     {
       "emoji": "🚯",
-      "shortcodes": ["do_not_litter"],
+      "shortcodes": ["do_not_litter", "no_littering"],
       "group": "symbols",
-      "order": 20
+      "order": 20,
+      "keywords": ["forbidden", "litter", "littering", "no", "not", "prohibited"]
     },
     {
       "emoji": "🚱",
-      "shortcodes": ["non-potable_water"],
+      "shortcodes": ["non-potable_water", "non_potable_water"],
       "group": "symbols",
-      "order": 21
+      "order": 21,
+      "keywords": ["dry", "non-drinking", "non-potable", "prohibited", "water"]
     },
     {
       "emoji": "🚷",
       "shortcodes": ["no_pedestrians"],
       "group": "symbols",
-      "order": 22
+      "order": 22,
+      "keywords": ["forbidden", "no", "not", "pedestrian", "pedestrians", "prohibited"]
     },
     {
       "emoji": "📵",
       "shortcodes": ["no_mobile_phones"],
       "group": "symbols",
-      "order": 23
+      "order": 23,
+      "keywords": ["cell", "forbidden", "mobile", "no", "not", "phone", "phones", "prohibited", "telephone"]
     },
     {
       "emoji": "🔞",
-      "shortcodes": ["underage"],
+      "shortcodes": ["underage", "no_one_under_18", "no_one_under_eighteen"],
       "group": "symbols",
-      "order": 24
+      "order": 24,
+      "keywords": ["18", "age", "eighteen", "forbidden", "no", "not", "one", "prohibited", "restriction"]
     },
     {
       "emoji": "☢️",
-      "shortcodes": ["radioactive"],
+      "shortcodes": ["radioactive", "radioactive_sign"],
       "group": "symbols",
-      "order": 25
+      "order": 25,
+      "keywords": ["sign"]
     },
     {
       "emoji": "☣️",
-      "shortcodes": ["biohazard"],
+      "shortcodes": ["biohazard", "biohazard_sign"],
       "group": "symbols",
-      "order": 27
+      "order": 27,
+      "keywords": ["sign"]
     },
     {
       "emoji": "⬆️",
-      "shortcodes": ["arrow_up"],
+      "shortcodes": ["arrow_up", "up_arrow"],
       "group": "symbols",
-      "order": 29
+      "order": 29,
+      "keywords": ["arrow", "cardinal", "direction", "north", "up"]
     },
     {
       "emoji": "↗️",
-      "shortcodes": ["arrow_upper_right"],
+      "shortcodes": ["arrow_upper_right", "up_right_arrow"],
       "group": "symbols",
-      "order": 31
+      "order": 31,
+      "keywords": ["arrow", "direction", "intercardinal", "northeast", "up-right"]
     },
     {
       "emoji": "➡️",
-      "shortcodes": ["arrow_right"],
+      "shortcodes": ["arrow_right", "right_arrow"],
       "group": "symbols",
-      "order": 33
+      "order": 33,
+      "keywords": ["arrow", "cardinal", "direction", "east", "right"]
     },
     {
       "emoji": "↘️",
-      "shortcodes": ["arrow_lower_right"],
+      "shortcodes": ["arrow_lower_right", "down_right_arrow"],
       "group": "symbols",
-      "order": 35
+      "order": 35,
+      "keywords": ["arrow", "direction", "down-right", "intercardinal", "southeast"]
     },
     {
       "emoji": "⬇️",
-      "shortcodes": ["arrow_down"],
+      "shortcodes": ["arrow_down", "down_arrow"],
       "group": "symbols",
-      "order": 37
+      "order": 37,
+      "keywords": ["arrow", "cardinal", "direction", "down", "south"]
     },
     {
       "emoji": "↙️",
-      "shortcodes": ["arrow_lower_left"],
+      "shortcodes": ["arrow_lower_left", "down_left_arrow"],
       "group": "symbols",
-      "order": 39
+      "order": 39,
+      "keywords": ["arrow", "direction", "down-left", "intercardinal", "southwest"]
     },
     {
       "emoji": "⬅️",
-      "shortcodes": ["arrow_left"],
+      "shortcodes": ["arrow_left", "left_arrow"],
       "group": "symbols",
-      "order": 41
+      "order": 41,
+      "keywords": ["arrow", "cardinal", "direction", "left", "west"]
     },
     {
       "emoji": "↖️",
-      "shortcodes": ["arrow_upper_left"],
+      "shortcodes": ["arrow_upper_left", "up_left_arrow"],
       "group": "symbols",
-      "order": 43
+      "order": 43,
+      "keywords": ["arrow", "direction", "intercardinal", "northwest", "up-left"]
     },
     {
       "emoji": "↕️",
-      "shortcodes": ["arrow_up_down"],
+      "shortcodes": ["arrow_up_down", "up_down_arrow"],
       "group": "symbols",
-      "order": 45
+      "order": 45,
+      "keywords": ["arrow", "up-down"]
     },
     {
       "emoji": "↔️",
       "shortcodes": ["left_right_arrow"],
       "group": "symbols",
-      "order": 47
+      "order": 47,
+      "keywords": ["arrow", "left-right"]
     },
     {
       "emoji": "↩️",
-      "shortcodes": ["leftwards_arrow_with_hook"],
+      "shortcodes": ["leftwards_arrow_with_hook", "arrow_left_hook", "right_arrow_curving_left"],
       "group": "symbols",
-      "order": 49
+      "order": 49,
+      "keywords": ["arrow", "curving", "left", "right"]
     },
     {
       "emoji": "↪️",
-      "shortcodes": ["arrow_right_hook"],
+      "shortcodes": ["arrow_right_hook", "rightwards_arrow_with_hook", "left_arrow_curving_right"],
       "group": "symbols",
-      "order": 51
+      "order": 51,
+      "keywords": ["arrow", "curving", "left", "right"]
     },
     {
       "emoji": "⤴️",
-      "shortcodes": ["arrow_heading_up"],
+      "shortcodes": ["arrow_heading_up", "right_arrow_curving_up"],
       "group": "symbols",
-      "order": 53
+      "order": 53,
+      "keywords": ["arrow", "curving", "right", "up"]
     },
     {
       "emoji": "⤵️",
-      "shortcodes": ["arrow_heading_down"],
+      "shortcodes": ["arrow_heading_down", "right_arrow_curving_down"],
       "group": "symbols",
-      "order": 55
+      "order": 55,
+      "keywords": ["arrow", "curving", "down", "right"]
     },
     {
       "emoji": "🔃",
-      "shortcodes": ["arrows_clockwise"],
+      "shortcodes": ["arrows_clockwise", "clockwise", "clockwise_vertical_arrows"],
       "group": "symbols",
-      "order": 57
+      "order": 57,
+      "keywords": ["arrow", "arrows", "refresh", "reload", "vertical"]
     },
     {
       "emoji": "🔄",
-      "shortcodes": ["arrows_counterclockwise"],
+      "shortcodes": ["arrows_counterclockwise", "counterclockwise", "counterclockwise_arrows_button"],
       "group": "symbols",
-      "order": 58
+      "order": 58,
+      "keywords": ["again", "anticlockwise", "arrow", "arrows", "button", "deja", "refresh", "rewindershins", "vu"]
     },
     {
       "emoji": "🔙",
-      "shortcodes": ["back"],
+      "shortcodes": ["back", "back_arrow"],
       "group": "symbols",
-      "order": 59
+      "order": 59,
+      "keywords": ["arrow"]
     },
     {
       "emoji": "🔚",
-      "shortcodes": ["end"],
+      "shortcodes": ["end", "end_arrow"],
       "group": "symbols",
-      "order": 60
+      "order": 60,
+      "keywords": ["arrow"]
     },
     {
       "emoji": "🔛",
-      "shortcodes": ["on"],
+      "shortcodes": ["on", "on_arrow"],
       "group": "symbols",
-      "order": 61
+      "order": 61,
+      "keywords": ["arrow", "mark", "on!", "on! arrow"]
     },
     {
       "emoji": "🔜",
-      "shortcodes": ["soon"],
+      "shortcodes": ["soon", "soon_arrow"],
       "group": "symbols",
-      "order": 62
+      "order": 62,
+      "keywords": ["arrow", "brb", "omw"]
     },
     {
       "emoji": "🔝",
-      "shortcodes": ["top"],
+      "shortcodes": ["top", "top_arrow"],
       "group": "symbols",
-      "order": 63
+      "order": 63,
+      "keywords": ["arrow", "homie", "up"]
     },
     {
       "emoji": "🛐",
-      "shortcodes": ["place_of_worship"],
+      "shortcodes": ["place_of_worship", "worship_symbol"],
       "group": "symbols",
-      "order": 64
+      "order": 64,
+      "keywords": ["place", "pray", "religion", "worship"]
     },
     {
       "emoji": "⚛️",
-      "shortcodes": ["atom_symbol"],
+      "shortcodes": ["atom_symbol", "atom"],
       "group": "symbols",
-      "order": 65
+      "order": 65,
+      "keywords": ["atheist", "symbol"]
     },
     {
       "emoji": "🕉️",
-      "shortcodes": ["om"],
+      "shortcodes": ["om", "om_symbol"],
       "group": "symbols",
-      "order": 67
+      "order": 67,
+      "keywords": ["hindu", "religion"]
     },
     {
       "emoji": "✡️",
       "shortcodes": ["star_of_david"],
       "group": "symbols",
-      "order": 69
+      "order": 69,
+      "keywords": ["david", "jew", "jewish", "judaism", "religion", "star"]
     },
     {
       "emoji": "☸️",
       "shortcodes": ["wheel_of_dharma"],
       "group": "symbols",
-      "order": 71
+      "order": 71,
+      "keywords": ["buddhist", "dharma", "religion", "wheel"]
     },
     {
       "emoji": "☯️",
       "shortcodes": ["yin_yang"],
       "group": "symbols",
-      "order": 73
+      "order": 73,
+      "keywords": ["difficult", "lives", "religion", "tao", "taoist", "total", "yang", "yin"]
     },
     {
       "emoji": "✝️",
-      "shortcodes": ["latin_cross"],
+      "shortcodes": ["latin_cross", "cross"],
       "group": "symbols",
-      "order": 75
+      "order": 75,
+      "keywords": ["christ", "christian", "latin", "religion"]
     },
     {
       "emoji": "☦️",
       "shortcodes": ["orthodox_cross"],
       "group": "symbols",
-      "order": 77
+      "order": 77,
+      "keywords": ["christian", "cross", "orthodox", "religion"]
     },
     {
       "emoji": "☪️",
       "shortcodes": ["star_and_crescent"],
       "group": "symbols",
-      "order": 79
+      "order": 79,
+      "keywords": ["crescent", "islam", "muslim", "ramadan", "religion", "star"]
     },
     {
       "emoji": "☮️",
-      "shortcodes": ["peace_symbol"],
+      "shortcodes": ["peace_symbol", "peace"],
       "group": "symbols",
-      "order": 81
+      "order": 81,
+      "keywords": ["healing", "peaceful", "symbol"]
     },
     {
       "emoji": "🕎",
-      "shortcodes": ["menorah"],
+      "shortcodes": ["menorah", "menorah_with_nine_branches"],
       "group": "symbols",
-      "order": 83
+      "order": 83,
+      "keywords": ["candelabrum", "candlestick", "hanukkah", "jewish", "judaism", "religion"]
     },
     {
       "emoji": "🔯",
-      "shortcodes": ["six_pointed_star"],
+      "shortcodes": ["six_pointed_star", "dotted_six_pointed_star"],
       "group": "symbols",
-      "order": 84
+      "order": 84,
+      "keywords": ["dotted", "fortune", "jewish", "judaism", "six-pointed", "star"]
     },
     {
       "emoji": "♈",
       "shortcodes": ["aries"],
       "group": "symbols",
-      "order": 86
+      "order": 86,
+      "keywords": ["horoscope", "ram", "zodiac"]
     },
     {
       "emoji": "♉",
       "shortcodes": ["taurus"],
       "group": "symbols",
-      "order": 87
+      "order": 87,
+      "keywords": ["bull", "horoscope", "ox", "zodiac"]
     },
     {
       "emoji": "♊",
       "shortcodes": ["gemini"],
       "group": "symbols",
-      "order": 88
+      "order": 88,
+      "keywords": ["horoscope", "twins", "zodiac"]
     },
     {
       "emoji": "♋",
       "shortcodes": ["cancer"],
       "group": "symbols",
-      "order": 89
+      "order": 89,
+      "keywords": ["crab", "horoscope", "zodiac"]
     },
     {
       "emoji": "♌",
       "shortcodes": ["leo"],
       "group": "symbols",
-      "order": 90
+      "order": 90,
+      "keywords": ["horoscope", "lion", "zodiac"]
     },
     {
       "emoji": "♍",
       "shortcodes": ["virgo"],
       "group": "symbols",
-      "order": 91
+      "order": 91,
+      "keywords": ["horoscope", "zodiac"]
     },
     {
       "emoji": "♎",
       "shortcodes": ["libra"],
       "group": "symbols",
-      "order": 92
+      "order": 92,
+      "keywords": ["balance", "horoscope", "justice", "scales", "zodiac"]
     },
     {
       "emoji": "♏",
-      "shortcodes": ["scorpius"],
+      "shortcodes": ["scorpius", "scorpio"],
       "group": "symbols",
-      "order": 93
+      "order": 93,
+      "keywords": ["horoscope", "scorpion", "zodiac"]
     },
     {
       "emoji": "♐",
       "shortcodes": ["sagittarius"],
       "group": "symbols",
-      "order": 94
+      "order": 94,
+      "keywords": ["archer", "horoscope", "zodiac"]
     },
     {
       "emoji": "♑",
       "shortcodes": ["capricorn"],
       "group": "symbols",
-      "order": 95
+      "order": 95,
+      "keywords": ["goat", "horoscope", "zodiac"]
     },
     {
       "emoji": "♒",
       "shortcodes": ["aquarius"],
       "group": "symbols",
-      "order": 96
+      "order": 96,
+      "keywords": ["bearer", "horoscope", "water", "zodiac"]
     },
     {
       "emoji": "♓",
       "shortcodes": ["pisces"],
       "group": "symbols",
-      "order": 97
+      "order": 97,
+      "keywords": ["fish", "horoscope", "zodiac"]
     },
     {
       "emoji": "⛎",
       "shortcodes": ["ophiuchus"],
       "group": "symbols",
-      "order": 98
+      "order": 98,
+      "keywords": ["bearer", "serpent", "snake", "zodiac"]
     },
     {
       "emoji": "🔀",
-      "shortcodes": ["twisted_rightwards_arrows"],
+      "shortcodes": ["twisted_rightwards_arrows", "shuffle", "shuffle_tracks_button"],
       "group": "symbols",
-      "order": 99
+      "order": 99,
+      "keywords": ["arrow", "button", "crossed", "tracks"]
     },
     {
       "emoji": "🔁",
-      "shortcodes": ["repeat"],
+      "shortcodes": ["repeat", "repeat_button"],
       "group": "symbols",
-      "order": 100
+      "order": 100,
+      "keywords": ["arrow", "button", "clockwise"]
     },
     {
       "emoji": "🔂",
-      "shortcodes": ["repeat_one"],
+      "shortcodes": ["repeat_one", "repeat_single_button"],
       "group": "symbols",
-      "order": 101
+      "order": 101,
+      "keywords": ["arrow", "button", "clockwise", "once", "repeat", "single"]
     },
     {
       "emoji": "▶️",
-      "shortcodes": ["arrow_forward"],
+      "shortcodes": ["arrow_forward", "play", "play_button"],
       "group": "symbols",
-      "order": 102
+      "order": 102,
+      "keywords": ["arrow", "button", "right", "triangle"]
     },
     {
       "emoji": "⏩",
-      "shortcodes": ["fast_forward"],
+      "shortcodes": ["fast_forward", "fast_forward_button"],
       "group": "symbols",
-      "order": 104
+      "order": 104,
+      "keywords": ["arrow", "button", "double", "fast", "forward"]
     },
     {
       "emoji": "⏭️",
-      "shortcodes": ["next_track_button"],
+      "shortcodes": [
+        "next_track_button",
+        "black_right_pointing_double_triangle_with_vertical_bar",
+        "next_track",
+        "track_next"
+      ],
       "group": "symbols",
-      "order": 105
+      "order": 105,
+      "keywords": ["arrow", "button", "next", "scene", "track", "triangle"]
     },
     {
       "emoji": "⏯️",
-      "shortcodes": ["play_or_pause_button"],
+      "shortcodes": ["play_or_pause_button", "black_right_pointing_triangle_with_double_vertical_bar", "play_pause"],
       "group": "symbols",
-      "order": 107
+      "order": 107,
+      "keywords": ["arrow", "button", "pause", "play", "right", "triangle"]
     },
     {
       "emoji": "◀️",
-      "shortcodes": ["arrow_backward"],
+      "shortcodes": ["arrow_backward", "reverse", "reverse_button"],
       "group": "symbols",
-      "order": 109
+      "order": 109,
+      "keywords": ["arrow", "button", "left", "triangle"]
     },
     {
       "emoji": "⏪",
-      "shortcodes": ["rewind"],
+      "shortcodes": ["rewind", "fast_reverse", "fast_reverse_button"],
       "group": "symbols",
-      "order": 111
+      "order": 111,
+      "keywords": ["arrow", "button", "double", "fast", "reverse"]
     },
     {
       "emoji": "⏮️",
-      "shortcodes": ["previous_track_button"],
+      "shortcodes": [
+        "previous_track_button",
+        "black_left_pointing_double_triangle_with_vertical_bar",
+        "previous_track",
+        "track_previous",
+        "last_track_button"
+      ],
       "group": "symbols",
-      "order": 112
+      "order": 112,
+      "keywords": ["arrow", "button", "last", "previous", "scene", "track", "triangle"]
     },
     {
       "emoji": "🔼",
-      "shortcodes": ["arrow_up_small"],
+      "shortcodes": ["arrow_up_small", "upwards_button"],
       "group": "symbols",
-      "order": 114
+      "order": 114,
+      "keywords": ["arrow", "button", "red", "up", "upwards"]
     },
     {
       "emoji": "⏫",
-      "shortcodes": ["arrow_double_up"],
+      "shortcodes": ["arrow_double_up", "fast_up", "fast_up_button"],
       "group": "symbols",
-      "order": 115
+      "order": 115,
+      "keywords": ["arrow", "button", "double", "fast", "up"]
     },
     {
       "emoji": "🔽",
-      "shortcodes": ["arrow_down_small"],
+      "shortcodes": ["arrow_down_small", "down", "downwards_button"],
       "group": "symbols",
-      "order": 116
+      "order": 116,
+      "keywords": ["arrow", "button", "downwards", "red"]
     },
     {
       "emoji": "⏬",
-      "shortcodes": ["arrow_double_down"],
+      "shortcodes": ["arrow_double_down", "fast_down", "fast_down_button"],
       "group": "symbols",
-      "order": 117
+      "order": 117,
+      "keywords": ["arrow", "button", "double", "down", "fast"]
     },
     {
       "emoji": "⏸️",
-      "shortcodes": ["pause_button"],
+      "shortcodes": ["pause_button", "double_vertical_bar", "pause"],
       "group": "symbols",
-      "order": 118
+      "order": 118,
+      "keywords": ["bar", "button", "double", "vertical"]
     },
     {
       "emoji": "⏹️",
-      "shortcodes": ["stop_button"],
+      "shortcodes": ["stop_button", "black_square_for_stop", "stop"],
       "group": "symbols",
-      "order": 120
+      "order": 120,
+      "keywords": ["button", "square"]
     },
     {
       "emoji": "⏺️",
-      "shortcodes": ["record_button"],
+      "shortcodes": ["record_button", "black_circle_for_record", "record"],
       "group": "symbols",
-      "order": 122
+      "order": 122,
+      "keywords": ["button", "circle"]
     },
     {
       "emoji": "⏏️",
-      "shortcodes": ["eject_button"],
+      "shortcodes": ["eject_button", "eject", "eject_symbol"],
       "group": "symbols",
-      "order": 124
+      "order": 124,
+      "keywords": ["button"]
     },
     {
       "emoji": "🎦",
       "shortcodes": ["cinema"],
       "group": "symbols",
-      "order": 126
+      "order": 126,
+      "keywords": ["camera", "film", "movie"]
     },
     {
       "emoji": "🔅",
-      "shortcodes": ["low_brightness"],
+      "shortcodes": ["low_brightness", "dim_button"],
       "group": "symbols",
-      "order": 127
+      "order": 127,
+      "keywords": ["brightness", "button", "dim", "low"]
     },
     {
       "emoji": "🔆",
-      "shortcodes": ["high_brightness"],
+      "shortcodes": ["high_brightness", "bright_button"],
       "group": "symbols",
-      "order": 128
+      "order": 128,
+      "keywords": ["bright", "brightness", "button", "light"]
     },
     {
       "emoji": "📶",
-      "shortcodes": ["signal_strength"],
+      "shortcodes": ["signal_strength", "antenna_bars"],
       "group": "symbols",
-      "order": 129
+      "order": 129,
+      "keywords": ["antenna", "bar", "bars", "cell", "communication", "mobile", "phone", "signal", "telephone"]
     },
     {
       "emoji": "📳",
       "shortcodes": ["vibration_mode"],
       "group": "symbols",
-      "order": 131
+      "order": 131,
+      "keywords": ["cell", "communication", "mobile", "mode", "phone", "telephone", "vibration"]
     },
     {
       "emoji": "📴",
       "shortcodes": ["mobile_phone_off"],
       "group": "symbols",
-      "order": 132
+      "order": 132,
+      "keywords": ["cell", "mobile", "off", "phone", "telephone"]
     },
     {
       "emoji": "♀️",
-      "shortcodes": ["female_sign"],
+      "shortcodes": ["female_sign", "female"],
       "group": "symbols",
-      "order": 133
+      "order": 133,
+      "keywords": ["sign", "woman"]
     },
     {
       "emoji": "♂️",
-      "shortcodes": ["male_sign"],
+      "shortcodes": ["male_sign", "male"],
       "group": "symbols",
-      "order": 135
+      "order": 135,
+      "keywords": ["man", "sign"]
     },
     {
       "emoji": "⚧️",
       "shortcodes": ["transgender_symbol"],
       "group": "symbols",
-      "order": 137
+      "order": 137,
+      "keywords": ["symbol", "transgender"]
     },
     {
       "emoji": "✖️",
-      "shortcodes": ["heavy_multiplication_x"],
+      "shortcodes": ["heavy_multiplication_x", "multiplication", "multiply"],
       "group": "symbols",
-      "order": 139
+      "order": 139,
+      "keywords": ["cancel", "sign", "x", "×"]
     },
     {
       "emoji": "➕",
-      "shortcodes": ["heavy_plus_sign"],
+      "shortcodes": ["heavy_plus_sign", "plus"],
       "group": "symbols",
-      "order": 141
+      "order": 141,
+      "keywords": ["+"]
     },
     {
       "emoji": "➖",
-      "shortcodes": ["heavy_minus_sign"],
+      "shortcodes": ["heavy_minus_sign", "minus"],
       "group": "symbols",
-      "order": 142
+      "order": 142,
+      "keywords": ["-", "heavy", "math", "sign", "−"]
     },
     {
       "emoji": "➗",
-      "shortcodes": ["heavy_division_sign"],
+      "shortcodes": ["heavy_division_sign", "divide", "division"],
       "group": "symbols",
-      "order": 143
+      "order": 143,
+      "keywords": ["heavy", "math", "sign", "÷"]
     },
     {
       "emoji": "♾️",
       "shortcodes": ["infinity"],
       "group": "symbols",
-      "order": 145
+      "order": 145,
+      "keywords": ["forever", "unbounded", "universal"]
     },
     {
       "emoji": "‼️",
-      "shortcodes": ["bangbang"],
+      "shortcodes": ["bangbang", "double_exclamation", "double_exclamation_mark"],
       "group": "symbols",
-      "order": 147
+      "order": 147,
+      "keywords": ["!", "!!", "double", "exclamation", "mark", "punctuation"]
     },
     {
       "emoji": "⁉️",
-      "shortcodes": ["interrobang"],
+      "shortcodes": ["interrobang", "exclamation_question", "exclamation_question_mark"],
       "group": "symbols",
-      "order": 149
+      "order": 149,
+      "keywords": ["!", "!?", "?", "exclamation", "mark", "punctuation", "question"]
     },
     {
       "emoji": "❓",
-      "shortcodes": ["question", "question_mark", "huh"],
+      "shortcodes": ["question", "question_mark", "huh", "red_question_mark"],
       "group": "symbols",
-      "order": 151
+      "order": 151,
+      "keywords": ["?", "mark", "punctuation", "red"]
     },
     {
       "emoji": "❔",
-      "shortcodes": ["grey_question"],
+      "shortcodes": ["grey_question", "white_question", "white_question_mark"],
       "group": "symbols",
-      "order": 152
+      "order": 152,
+      "keywords": ["?", "mark", "outlined", "punctuation", "question", "white"]
     },
     {
       "emoji": "❕",
-      "shortcodes": ["grey_exclamation"],
+      "shortcodes": ["grey_exclamation", "white_exclamation", "white_exclamation_mark"],
       "group": "symbols",
-      "order": 153
+      "order": 153,
+      "keywords": ["!", "exclamation", "mark", "outlined", "punctuation", "white"]
     },
     {
       "emoji": "❗",
-      "shortcodes": ["exclamation", "heavy_exclamation_mark"],
+      "shortcodes": ["exclamation", "heavy_exclamation_mark", "red_exclamation_mark"],
       "group": "symbols",
-      "order": 154
+      "order": 154,
+      "keywords": ["!", "mark", "punctuation", "red"]
     },
     {
       "emoji": "〰️",
       "shortcodes": ["wavy_dash"],
       "group": "symbols",
-      "order": 155
+      "order": 155,
+      "keywords": ["dash", "punctuation", "wavy"]
     },
     {
       "emoji": "💱",
       "shortcodes": ["currency_exchange"],
       "group": "symbols",
-      "order": 157
+      "order": 157,
+      "keywords": ["bank", "currency", "exchange", "money"]
     },
     {
       "emoji": "💲",
       "shortcodes": ["heavy_dollar_sign"],
       "group": "symbols",
-      "order": 158
+      "order": 158,
+      "keywords": ["billion", "cash", "charge", "currency", "dollar", "heavy", "million", "money", "pay", "sign"]
     },
     {
       "emoji": "⚕️",
-      "shortcodes": ["medical_symbol"],
+      "shortcodes": ["medical_symbol", "staff_of_aesculapius", "medical"],
       "group": "symbols",
-      "order": 159
+      "order": 159,
+      "keywords": ["aesculapius", "medicine", "staff", "symbol"]
     },
     {
       "emoji": "♻️",
-      "shortcodes": ["recycle"],
+      "shortcodes": ["recycle", "recycling_symbol"],
       "group": "symbols",
-      "order": 161
+      "order": 161,
+      "keywords": ["recycling", "symbol"]
     },
     {
       "emoji": "⚜️",
-      "shortcodes": ["fleur_de_lis"],
+      "shortcodes": ["fleur_de_lis", "fleur-de-lis"],
       "group": "symbols",
-      "order": 163
+      "order": 163,
+      "keywords": ["knights"]
     },
     {
       "emoji": "🔱",
-      "shortcodes": ["trident"],
+      "shortcodes": ["trident", "trident_emblem"],
       "group": "symbols",
-      "order": 165
+      "order": 165,
+      "keywords": ["anchor", "emblem", "poseidon", "ship", "tool"]
     },
     {
       "emoji": "📛",
       "shortcodes": ["name_badge"],
       "group": "symbols",
-      "order": 166
+      "order": 166,
+      "keywords": ["badge", "name"]
     },
     {
       "emoji": "🔰",
-      "shortcodes": ["beginner"],
+      "shortcodes": ["beginner", "japanese_symbol_for_beginner"],
       "group": "symbols",
-      "order": 167
+      "order": 167,
+      "keywords": ["chevron", "green", "japanese", "leaf", "symbol", "tool", "yellow"]
     },
     {
       "emoji": "⭕",
-      "shortcodes": ["o"],
+      "shortcodes": ["o", "hollow_red_circle", "red_o"],
       "group": "symbols",
-      "order": 168
+      "order": 168,
+      "keywords": ["circle", "heavy", "hollow", "large", "red"]
     },
     {
       "emoji": "✅",
-      "shortcodes": ["white_check_mark", "done", "yes", "checkmark", "check_done"],
+      "shortcodes": ["white_check_mark", "done", "yes", "checkmark", "check_done", "check_mark_button"],
       "group": "symbols",
-      "order": 169
+      "order": 169,
+      "keywords": ["button", "check", "checked", "complete", "completed", "fixed", "mark", "tick", "✓"]
     },
     {
       "emoji": "☑️",
-      "shortcodes": ["ballot_box_with_check"],
+      "shortcodes": ["ballot_box_with_check", "check_box_with_check"],
       "group": "symbols",
-      "order": 170
+      "order": 170,
+      "keywords": ["ballot", "box", "check", "checked", "done", "off", "tick", "✓"]
     },
     {
       "emoji": "✔️",
-      "shortcodes": ["heavy_check_mark"],
+      "shortcodes": ["heavy_check_mark", "check_mark"],
       "group": "symbols",
-      "order": 172
+      "order": 172,
+      "keywords": ["check", "checked", "done", "heavy", "mark", "tick", "✓"]
     },
     {
       "emoji": "❌",
       "shortcodes": ["x", "no", "wrong", "cross_mark"],
       "group": "symbols",
-      "order": 174
+      "order": 174,
+      "keywords": ["cancel", "cross", "mark", "multiplication", "multiply", "×"]
     },
     {
       "emoji": "❎",
-      "shortcodes": ["negative_squared_cross_mark"],
+      "shortcodes": ["negative_squared_cross_mark", "cross_mark_button"],
       "group": "symbols",
-      "order": 175
+      "order": 175,
+      "keywords": ["button", "cross", "mark", "multiplication", "multiply", "square", "x", "×"]
     },
     {
       "emoji": "➰",
       "shortcodes": ["curly_loop"],
       "group": "symbols",
-      "order": 176
+      "order": 176,
+      "keywords": ["curl", "curly", "loop"]
     },
     {
       "emoji": "➿",
-      "shortcodes": ["loop"],
+      "shortcodes": ["loop", "double_curly_loop"],
       "group": "symbols",
-      "order": 177
+      "order": 177,
+      "keywords": ["curl", "curly", "double"]
     },
     {
       "emoji": "〽️",
       "shortcodes": ["part_alternation_mark"],
       "group": "symbols",
-      "order": 178
+      "order": 178,
+      "keywords": ["alternation", "mark", "part"]
     },
     {
       "emoji": "✳️",
       "shortcodes": ["eight_spoked_asterisk"],
       "group": "symbols",
-      "order": 180
+      "order": 180,
+      "keywords": ["*", "asterisk", "eight-spoked"]
     },
     {
       "emoji": "✴️",
-      "shortcodes": ["eight_pointed_black_star"],
+      "shortcodes": ["eight_pointed_black_star", "eight_pointed_star"],
       "group": "symbols",
-      "order": 182
+      "order": 182,
+      "keywords": ["*", "eight-pointed", "star"]
     },
     {
       "emoji": "❇️",
       "shortcodes": ["sparkle"],
       "group": "symbols",
-      "order": 184
+      "order": 184,
+      "keywords": ["*"]
     },
     {
       "emoji": "©️",
       "shortcodes": ["copyright"],
       "group": "symbols",
-      "order": 186
+      "order": 186,
+      "keywords": ["c"]
     },
     {
       "emoji": "®️",
       "shortcodes": ["registered"],
       "group": "symbols",
-      "order": 188
+      "order": 188,
+      "keywords": ["r"]
     },
     {
       "emoji": "™️",
-      "shortcodes": ["tm"],
+      "shortcodes": ["tm", "trade_mark"],
       "group": "symbols",
-      "order": 190
+      "order": 190,
+      "keywords": ["mark", "trade"]
     },
     {
       "emoji": "#️⃣",
-      "shortcodes": ["hash"],
+      "shortcodes": ["hash", "number_sign", "keycap_number_sign"],
       "group": "symbols",
-      "order": 193
+      "order": 193,
+      "keywords": ["keycap", "keycap: #"]
     },
     {
       "emoji": "*️⃣",
-      "shortcodes": ["asterisk"],
+      "shortcodes": ["asterisk", "keycap_star", "keycap_asterisk"],
       "group": "symbols",
-      "order": 195
+      "order": 195,
+      "keywords": ["keycap", "keycap: *"]
     },
     {
       "emoji": "0️⃣",
-      "shortcodes": ["zero"],
+      "shortcodes": ["zero", "keycap_0"],
       "group": "symbols",
-      "order": 197
+      "order": 197,
+      "keywords": ["0", "keycap", "keycap: 0"]
     },
     {
       "emoji": "1️⃣",
-      "shortcodes": ["one"],
+      "shortcodes": ["one", "keycap_1"],
       "group": "symbols",
-      "order": 199
+      "order": 199,
+      "keywords": ["1", "keycap", "keycap: 1"]
     },
     {
       "emoji": "2️⃣",
-      "shortcodes": ["two"],
+      "shortcodes": ["two", "keycap_2"],
       "group": "symbols",
-      "order": 201
+      "order": 201,
+      "keywords": ["2", "keycap", "keycap: 2"]
     },
     {
       "emoji": "3️⃣",
-      "shortcodes": ["three"],
+      "shortcodes": ["three", "keycap_3"],
       "group": "symbols",
-      "order": 203
+      "order": 203,
+      "keywords": ["3", "keycap", "keycap: 3"]
     },
     {
       "emoji": "4️⃣",
-      "shortcodes": ["four"],
+      "shortcodes": ["four", "keycap_4"],
       "group": "symbols",
-      "order": 205
+      "order": 205,
+      "keywords": ["4", "keycap", "keycap: 4"]
     },
     {
       "emoji": "5️⃣",
-      "shortcodes": ["five"],
+      "shortcodes": ["five", "keycap_5"],
       "group": "symbols",
-      "order": 207
+      "order": 207,
+      "keywords": ["5", "keycap", "keycap: 5"]
     },
     {
       "emoji": "6️⃣",
-      "shortcodes": ["six"],
+      "shortcodes": ["six", "keycap_6"],
       "group": "symbols",
-      "order": 209
+      "order": 209,
+      "keywords": ["6", "keycap", "keycap: 6"]
     },
     {
       "emoji": "7️⃣",
-      "shortcodes": ["seven"],
+      "shortcodes": ["seven", "keycap_7"],
       "group": "symbols",
-      "order": 211
+      "order": 211,
+      "keywords": ["7", "keycap", "keycap: 7"]
     },
     {
       "emoji": "8️⃣",
-      "shortcodes": ["eight"],
+      "shortcodes": ["eight", "keycap_8"],
       "group": "symbols",
-      "order": 213
+      "order": 213,
+      "keywords": ["8", "keycap", "keycap: 8"]
     },
     {
       "emoji": "9️⃣",
-      "shortcodes": ["nine"],
+      "shortcodes": ["nine", "keycap_9"],
       "group": "symbols",
-      "order": 215
+      "order": 215,
+      "keywords": ["9", "keycap", "keycap: 9"]
     },
     {
       "emoji": "🔟",
-      "shortcodes": ["keycap_ten"],
+      "shortcodes": ["keycap_ten", "ten", "keycap_10"],
       "group": "symbols",
-      "order": 217
+      "order": 217,
+      "keywords": ["keycap", "keycap: 10"]
     },
     {
       "emoji": "🔠",
-      "shortcodes": ["capital_abcd"],
+      "shortcodes": ["capital_abcd", "input_latin_uppercase"],
       "group": "symbols",
-      "order": 218
+      "order": 218,
+      "keywords": ["abcd", "input", "latin", "letters", "uppercase"]
     },
     {
       "emoji": "🔡",
-      "shortcodes": ["abcd"],
+      "shortcodes": ["abcd", "input_latin_lowercase"],
       "group": "symbols",
-      "order": 219
+      "order": 219,
+      "keywords": ["input", "latin", "letters", "lowercase"]
     },
     {
       "emoji": "🔢",
-      "shortcodes": ["1234"],
+      "shortcodes": ["1234", "input_numbers"],
       "group": "symbols",
-      "order": 220
+      "order": 220,
+      "keywords": ["input", "numbers"]
     },
     {
       "emoji": "🔣",
-      "shortcodes": ["symbols"],
+      "shortcodes": ["symbols", "input_symbols"],
       "group": "symbols",
-      "order": 221
+      "order": 221,
+      "keywords": ["%", "&", "input", "♪", "〒"]
     },
     {
       "emoji": "🔤",
-      "shortcodes": ["abc"],
+      "shortcodes": ["abc", "input_latin_letters"],
       "group": "symbols",
-      "order": 222
+      "order": 222,
+      "keywords": ["alphabet", "input", "latin", "letters"]
     },
     {
       "emoji": "🅰️",
-      "shortcodes": ["a"],
+      "shortcodes": ["a", "a_blood", "a_button_blood_type"],
       "group": "symbols",
-      "order": 223
+      "order": 223,
+      "keywords": ["blood", "button", "type", "a button (blood type)"]
     },
     {
       "emoji": "🆎",
-      "shortcodes": ["ab"],
+      "shortcodes": ["ab", "ab_blood", "ab_button_blood_type"],
       "group": "symbols",
-      "order": 225
+      "order": 225,
+      "keywords": ["blood", "button", "type", "ab button (blood type)"]
     },
     {
       "emoji": "🅱️",
-      "shortcodes": ["b"],
+      "shortcodes": ["b", "b_blood", "b_button_blood_type"],
       "group": "symbols",
-      "order": 226
+      "order": 226,
+      "keywords": ["blood", "button", "type", "b button (blood type)"]
     },
     {
       "emoji": "🆑",
-      "shortcodes": ["cl"],
+      "shortcodes": ["cl", "cl_button"],
       "group": "symbols",
-      "order": 228
+      "order": 228,
+      "keywords": ["button"]
     },
     {
       "emoji": "🆒",
-      "shortcodes": ["cool"],
+      "shortcodes": ["cool", "cool_button"],
       "group": "symbols",
-      "order": 229
+      "order": 229,
+      "keywords": ["button"]
     },
     {
       "emoji": "🆓",
-      "shortcodes": ["free"],
+      "shortcodes": ["free", "free_button"],
       "group": "symbols",
-      "order": 230
+      "order": 230,
+      "keywords": ["button"]
     },
     {
       "emoji": "ℹ️",
-      "shortcodes": ["information_source"],
+      "shortcodes": ["information_source", "info", "information"],
       "group": "symbols",
-      "order": 231
+      "order": 231,
+      "keywords": ["i"]
     },
     {
       "emoji": "🆔",
-      "shortcodes": ["id"],
+      "shortcodes": ["id", "id_button"],
       "group": "symbols",
-      "order": 233
+      "order": 233,
+      "keywords": ["button", "identity"]
     },
     {
       "emoji": "Ⓜ️",
-      "shortcodes": ["m"],
+      "shortcodes": ["m", "circled_m"],
       "group": "symbols",
-      "order": 234
+      "order": 234,
+      "keywords": ["circle", "circled"]
     },
     {
       "emoji": "🆕",
-      "shortcodes": ["new"],
+      "shortcodes": ["new", "new_button"],
       "group": "symbols",
-      "order": 236
+      "order": 236,
+      "keywords": ["button"]
     },
     {
       "emoji": "🆖",
-      "shortcodes": ["ng"],
+      "shortcodes": ["ng", "ng_button"],
       "group": "symbols",
-      "order": 237
+      "order": 237,
+      "keywords": ["button"]
     },
     {
       "emoji": "🅾️",
-      "shortcodes": ["o2"],
+      "shortcodes": ["o2", "o_blood", "o_button_blood_type"],
       "group": "symbols",
-      "order": 238
+      "order": 238,
+      "keywords": ["blood", "button", "o", "type", "o button (blood type)"]
     },
     {
       "emoji": "🆗",
-      "shortcodes": ["ok"],
+      "shortcodes": ["ok", "ok_button"],
       "group": "symbols",
-      "order": 240
+      "order": 240,
+      "keywords": ["button", "okay"]
     },
     {
       "emoji": "🅿️",
-      "shortcodes": ["parking"],
+      "shortcodes": ["parking", "p_button"],
       "group": "symbols",
-      "order": 241
+      "order": 241,
+      "keywords": ["button", "p"]
     },
     {
       "emoji": "🆘",
-      "shortcodes": ["sos"],
+      "shortcodes": ["sos", "sos_button"],
       "group": "symbols",
-      "order": 243
+      "order": 243,
+      "keywords": ["button", "help"]
     },
     {
       "emoji": "🆙",
-      "shortcodes": ["up"],
+      "shortcodes": ["up", "up2", "up_button"],
       "group": "symbols",
-      "order": 244
+      "order": 244,
+      "keywords": ["button", "mark", "up!", "up! button"]
     },
     {
       "emoji": "🆚",
-      "shortcodes": ["vs"],
+      "shortcodes": ["vs", "vs_button"],
       "group": "symbols",
-      "order": 245
+      "order": 245,
+      "keywords": ["button", "versus"]
     },
     {
       "emoji": "🈁",
-      "shortcodes": ["koko"],
+      "shortcodes": ["koko", "ja_here", "japanese_here_button"],
       "group": "symbols",
-      "order": 246
+      "order": 246,
+      "keywords": ["button", "here", "japanese", "katakana", "japanese “here” button"]
     },
     {
       "emoji": "🈂️",
-      "shortcodes": ["sa"],
+      "shortcodes": ["sa", "ja_service_charge", "japanese_service_charge_button"],
       "group": "symbols",
-      "order": 247
+      "order": 247,
+      "keywords": ["button", "charge", "japanese", "katakana", "service", "japanese “service charge” button"]
     },
     {
       "emoji": "🈷️",
-      "shortcodes": ["u6708"],
+      "shortcodes": ["u6708", "ja_monthly_amount", "japanese_monthly_amount_button"],
       "group": "symbols",
-      "order": 249
+      "order": 249,
+      "keywords": ["amount", "button", "ideograph", "japanese", "monthly", "japanese “monthly amount” button"]
     },
     {
       "emoji": "🈶",
-      "shortcodes": ["u6709"],
+      "shortcodes": ["u6709", "ja_not_free_of_carge", "japanese_not_free_of_charge_button"],
       "group": "symbols",
-      "order": 251
+      "order": 251,
+      "keywords": ["button", "charge", "free", "ideograph", "japanese", "not", "japanese “not free of charge” button"]
     },
     {
       "emoji": "🈯",
-      "shortcodes": ["u6307"],
+      "shortcodes": ["u6307", "ja_reserved", "japanese_reserved_button"],
       "group": "symbols",
-      "order": 252
+      "order": 252,
+      "keywords": ["button", "ideograph", "japanese", "reserved", "japanese “reserved” button"]
     },
     {
       "emoji": "🉐",
-      "shortcodes": ["ideograph_advantage"],
+      "shortcodes": ["ideograph_advantage", "ja_bargain", "japanese_bargain_button"],
       "group": "symbols",
-      "order": 253
+      "order": 253,
+      "keywords": ["bargain", "button", "ideograph", "japanese", "japanese “bargain” button"]
     },
     {
       "emoji": "🈹",
-      "shortcodes": ["u5272"],
+      "shortcodes": ["u5272", "ja_discount", "japanese_discount_button"],
       "group": "symbols",
-      "order": 254
+      "order": 254,
+      "keywords": ["button", "discount", "ideograph", "japanese", "japanese “discount” button"]
     },
     {
       "emoji": "🈚",
-      "shortcodes": ["u7121"],
+      "shortcodes": ["u7121", "ja_free_of_charge", "japanese_free_of_charge_button"],
       "group": "symbols",
-      "order": 255
+      "order": 255,
+      "keywords": ["button", "charge", "free", "ideograph", "japanese", "japanese “free of charge” button"]
     },
     {
       "emoji": "🈲",
-      "shortcodes": ["u7981"],
+      "shortcodes": ["u7981", "ja_prohibited", "japanese_prohibited_button"],
       "group": "symbols",
-      "order": 256
+      "order": 256,
+      "keywords": ["button", "ideograph", "japanese", "prohibited", "japanese “prohibited” button"]
     },
     {
       "emoji": "🉑",
-      "shortcodes": ["accept"],
+      "shortcodes": ["accept", "ja_acceptable", "japanese_acceptable_button"],
       "group": "symbols",
-      "order": 257
+      "order": 257,
+      "keywords": ["acceptable", "button", "ideograph", "japanese", "japanese “acceptable” button"]
     },
     {
       "emoji": "🈸",
-      "shortcodes": ["u7533"],
+      "shortcodes": ["u7533", "ja_application", "japanese_application_button"],
       "group": "symbols",
-      "order": 258
+      "order": 258,
+      "keywords": ["application", "button", "ideograph", "japanese", "japanese “application” button"]
     },
     {
       "emoji": "🈴",
-      "shortcodes": ["u5408"],
+      "shortcodes": ["u5408", "ja_passing_grade", "japanese_passing_grade_button"],
       "group": "symbols",
-      "order": 259
+      "order": 259,
+      "keywords": ["button", "grade", "ideograph", "japanese", "passing", "japanese “passing grade” button"]
     },
     {
       "emoji": "🈳",
-      "shortcodes": ["u7a7a"],
+      "shortcodes": ["u7a7a", "ja_vacancy", "japanese_vacancy_button"],
       "group": "symbols",
-      "order": 260
+      "order": 260,
+      "keywords": ["button", "ideograph", "japanese", "vacancy", "japanese “vacancy” button"]
     },
     {
       "emoji": "㊗️",
-      "shortcodes": ["congratulations"],
+      "shortcodes": ["congratulations", "ja_congratulations", "japanese_congratulations_button"],
       "group": "symbols",
-      "order": 261
+      "order": 261,
+      "keywords": ["button", "ideograph", "japanese", "japanese “congratulations” button"]
     },
     {
       "emoji": "㊙️",
-      "shortcodes": ["secret"],
+      "shortcodes": ["secret", "ja_secret", "japanese_secret_button"],
       "group": "symbols",
-      "order": 263
+      "order": 263,
+      "keywords": ["button", "ideograph", "japanese", "japanese “secret” button"]
     },
     {
       "emoji": "🈺",
-      "shortcodes": ["u55b6"],
+      "shortcodes": ["u55b6", "ja_open_for_business", "japanese_open_for_business_button"],
       "group": "symbols",
-      "order": 265
+      "order": 265,
+      "keywords": ["business", "button", "ideograph", "japanese", "open", "japanese “open for business” button"]
     },
     {
       "emoji": "🈵",
-      "shortcodes": ["u6e80"],
+      "shortcodes": ["u6e80", "ja_no_vacancy", "japanese_no_vacancy_button"],
       "group": "symbols",
-      "order": 266
+      "order": 266,
+      "keywords": ["button", "ideograph", "japanese", "no", "vacancy", "japanese “no vacancy” button"]
     },
     {
       "emoji": "🔴",
       "shortcodes": ["red_circle"],
       "group": "symbols",
-      "order": 267
+      "order": 267,
+      "keywords": ["circle", "geometric", "red"]
     },
     {
       "emoji": "🟠",
-      "shortcodes": ["orange_circle"],
+      "shortcodes": ["orange_circle", "large_orange_circle"],
       "group": "symbols",
-      "order": 268
+      "order": 268,
+      "keywords": ["circle", "orange"]
     },
     {
       "emoji": "🟡",
-      "shortcodes": ["yellow_circle"],
+      "shortcodes": ["yellow_circle", "large_yellow_circle"],
       "group": "symbols",
-      "order": 269
+      "order": 269,
+      "keywords": ["circle", "yellow"]
     },
     {
       "emoji": "🟢",
-      "shortcodes": ["green_circle"],
+      "shortcodes": ["green_circle", "large_green_circle"],
       "group": "symbols",
-      "order": 270
+      "order": 270,
+      "keywords": ["circle", "green"]
     },
     {
       "emoji": "🔵",
-      "shortcodes": ["large_blue_circle"],
+      "shortcodes": ["large_blue_circle", "blue_circle"],
       "group": "symbols",
-      "order": 271
+      "order": 271,
+      "keywords": ["blue", "circle", "geometric"]
     },
     {
       "emoji": "🟣",
-      "shortcodes": ["purple_circle"],
+      "shortcodes": ["purple_circle", "large_purple_circle"],
       "group": "symbols",
-      "order": 272
+      "order": 272,
+      "keywords": ["circle", "purple"]
     },
     {
       "emoji": "🟤",
-      "shortcodes": ["brown_circle"],
+      "shortcodes": ["brown_circle", "large_brown_circle"],
       "group": "symbols",
-      "order": 273
+      "order": 273,
+      "keywords": ["brown", "circle"]
     },
     {
       "emoji": "⚫",
       "shortcodes": ["black_circle"],
       "group": "symbols",
-      "order": 274
+      "order": 274,
+      "keywords": ["black", "circle", "geometric"]
     },
     {
       "emoji": "⚪",
       "shortcodes": ["white_circle"],
       "group": "symbols",
-      "order": 275
+      "order": 275,
+      "keywords": ["circle", "geometric", "white"]
     },
     {
       "emoji": "🟥",
-      "shortcodes": ["red_square"],
+      "shortcodes": ["red_square", "large_red_square"],
       "group": "symbols",
-      "order": 276
+      "order": 276,
+      "keywords": ["card", "penalty", "red", "square"]
     },
     {
       "emoji": "🟧",
-      "shortcodes": ["orange_square"],
+      "shortcodes": ["orange_square", "large_orange_square"],
       "group": "symbols",
-      "order": 277
+      "order": 277,
+      "keywords": ["orange", "square"]
     },
     {
       "emoji": "🟨",
-      "shortcodes": ["yellow_square"],
+      "shortcodes": ["yellow_square", "large_yellow_square"],
       "group": "symbols",
-      "order": 278
+      "order": 278,
+      "keywords": ["card", "penalty", "square", "yellow"]
     },
     {
       "emoji": "🟩",
-      "shortcodes": ["green_square"],
+      "shortcodes": ["green_square", "large_green_square"],
       "group": "symbols",
-      "order": 279
+      "order": 279,
+      "keywords": ["green", "square"]
     },
     {
       "emoji": "🟦",
-      "shortcodes": ["blue_square"],
+      "shortcodes": ["blue_square", "large_blue_square"],
       "group": "symbols",
-      "order": 280
+      "order": 280,
+      "keywords": ["blue", "square"]
     },
     {
       "emoji": "🟪",
-      "shortcodes": ["purple_square"],
+      "shortcodes": ["purple_square", "large_purple_square"],
       "group": "symbols",
-      "order": 281
+      "order": 281,
+      "keywords": ["purple", "square"]
     },
     {
       "emoji": "🟫",
-      "shortcodes": ["brown_square"],
+      "shortcodes": ["brown_square", "large_brown_square"],
       "group": "symbols",
-      "order": 282
+      "order": 282,
+      "keywords": ["brown", "square"]
     },
     {
       "emoji": "⬛",
       "shortcodes": ["black_large_square"],
       "group": "symbols",
-      "order": 283
+      "order": 283,
+      "keywords": ["black", "geometric", "large", "square"]
     },
     {
       "emoji": "⬜",
       "shortcodes": ["white_large_square"],
       "group": "symbols",
-      "order": 284
+      "order": 284,
+      "keywords": ["geometric", "large", "square", "white"]
     },
     {
       "emoji": "◼️",
       "shortcodes": ["black_medium_square"],
       "group": "symbols",
-      "order": 285
+      "order": 285,
+      "keywords": ["black", "geometric", "medium", "square"]
     },
     {
       "emoji": "◻️",
       "shortcodes": ["white_medium_square"],
       "group": "symbols",
-      "order": 287
+      "order": 287,
+      "keywords": ["geometric", "medium", "square", "white"]
     },
     {
       "emoji": "◾",
       "shortcodes": ["black_medium_small_square"],
       "group": "symbols",
-      "order": 289
+      "order": 289,
+      "keywords": ["black", "geometric", "medium-small", "square"]
     },
     {
       "emoji": "◽",
       "shortcodes": ["white_medium_small_square"],
       "group": "symbols",
-      "order": 290
+      "order": 290,
+      "keywords": ["geometric", "medium-small", "square", "white"]
     },
     {
       "emoji": "▪️",
       "shortcodes": ["black_small_square"],
       "group": "symbols",
-      "order": 291
+      "order": 291,
+      "keywords": ["black", "geometric", "small", "square"]
     },
     {
       "emoji": "▫️",
       "shortcodes": ["white_small_square"],
       "group": "symbols",
-      "order": 293
+      "order": 293,
+      "keywords": ["geometric", "small", "square", "white"]
     },
     {
       "emoji": "🔶",
       "shortcodes": ["large_orange_diamond"],
       "group": "symbols",
-      "order": 295
+      "order": 295,
+      "keywords": ["diamond", "geometric", "large", "orange"]
     },
     {
       "emoji": "🔷",
       "shortcodes": ["large_blue_diamond"],
       "group": "symbols",
-      "order": 296
+      "order": 296,
+      "keywords": ["blue", "diamond", "geometric", "large"]
     },
     {
       "emoji": "🔸",
       "shortcodes": ["small_orange_diamond"],
       "group": "symbols",
-      "order": 297
+      "order": 297,
+      "keywords": ["diamond", "geometric", "orange", "small"]
     },
     {
       "emoji": "🔹",
       "shortcodes": ["small_blue_diamond"],
       "group": "symbols",
-      "order": 298
+      "order": 298,
+      "keywords": ["blue", "diamond", "geometric", "small"]
     },
     {
       "emoji": "🔺",
-      "shortcodes": ["small_red_triangle"],
+      "shortcodes": ["small_red_triangle", "red_triangle_pointed_up"],
       "group": "symbols",
-      "order": 299
+      "order": 299,
+      "keywords": ["geometric", "pointed", "red", "triangle", "up"]
     },
     {
       "emoji": "🔻",
-      "shortcodes": ["small_red_triangle_down"],
+      "shortcodes": ["small_red_triangle_down", "red_triangle_pointed_down"],
       "group": "symbols",
-      "order": 300
+      "order": 300,
+      "keywords": ["down", "geometric", "pointed", "red", "triangle"]
     },
     {
       "emoji": "💠",
-      "shortcodes": ["diamond_shape_with_a_dot_inside"],
+      "shortcodes": ["diamond_shape_with_a_dot_inside", "diamond_with_a_dot"],
       "group": "symbols",
-      "order": 301
+      "order": 301,
+      "keywords": ["comic", "diamond", "dot", "geometric"]
     },
     {
       "emoji": "🔘",
       "shortcodes": ["radio_button"],
       "group": "symbols",
-      "order": 302
+      "order": 302,
+      "keywords": ["button", "geometric", "radio"]
     },
     {
       "emoji": "🔳",
       "shortcodes": ["white_square_button"],
       "group": "symbols",
-      "order": 303
+      "order": 303,
+      "keywords": ["button", "geometric", "outlined", "square", "white"]
     },
     {
       "emoji": "🔲",
       "shortcodes": ["black_square_button"],
       "group": "symbols",
-      "order": 304
+      "order": 304,
+      "keywords": ["black", "button", "geometric", "square"]
     },
     {
       "emoji": "🏁",
-      "shortcodes": ["checkered_flag"],
+      "shortcodes": ["checkered_flag", "chequered_flag"],
       "group": "flags",
-      "order": 0
+      "order": 0,
+      "keywords": ["checkered", "chequered", "finish", "flag", "flags", "game", "race", "racing", "sport", "win"]
     },
     {
       "emoji": "🚩",
-      "shortcodes": ["triangular_flag_on_post"],
+      "shortcodes": ["triangular_flag_on_post", "triangular_flag"],
       "group": "flags",
-      "order": 1
+      "order": 1,
+      "keywords": ["construction", "flag", "golf", "post", "triangular"]
     },
     {
       "emoji": "🎌",
       "shortcodes": ["crossed_flags"],
       "group": "flags",
-      "order": 2
+      "order": 2,
+      "keywords": ["celebration", "cross", "crossed", "flags", "japanese"]
     },
     {
       "emoji": "🏴",
-      "shortcodes": ["black_flag"],
+      "shortcodes": ["black_flag", "waving_black_flag", "flag_black"],
       "group": "flags",
-      "order": 3
+      "order": 3,
+      "keywords": ["black", "flag", "waving"]
     },
     {
       "emoji": "🏳️",
-      "shortcodes": ["white_flag"],
+      "shortcodes": ["white_flag", "waving_white_flag", "flag_white"],
       "group": "flags",
-      "order": 4
+      "order": 4,
+      "keywords": ["flag", "waving", "white"]
     },
     {
       "emoji": "🏳️‍🌈",
-      "shortcodes": ["rainbow_flag"],
+      "shortcodes": ["rainbow_flag", "rainbow-flag", "gay_pride_flag"],
       "group": "flags",
-      "order": 6
+      "order": 6,
+      "keywords": [
+        "bisexual",
+        "flag",
+        "gay",
+        "genderqueer",
+        "glbt",
+        "glbtq",
+        "lesbian",
+        "lgbt",
+        "lgbtq",
+        "lgbtqia",
+        "pride",
+        "queer",
+        "rainbow",
+        "trans",
+        "transgender"
+      ]
     },
     {
       "emoji": "🏳️‍⚧️",
       "shortcodes": ["transgender_flag"],
       "group": "flags",
-      "order": 8
+      "order": 8,
+      "keywords": ["blue", "flag", "light", "pink", "transgender", "white"]
     },
     {
       "emoji": "🏴‍☠️",
-      "shortcodes": ["pirate_flag"],
+      "shortcodes": ["pirate_flag", "jolly_roger"],
       "group": "flags",
-      "order": 12
+      "order": 12,
+      "keywords": ["flag", "jolly", "pirate", "plunder", "roger", "treasure"]
     },
     {
       "emoji": "🥹",
-      "shortcodes": ["face_holding_back_tears", "holding_back_tears"],
+      "shortcodes": ["face_holding_back_tears", "holding_back_tears", "watery_eyes"],
       "group": "smileys",
-      "order": 185
+      "order": 185,
+      "keywords": [
+        "admiration",
+        "aww",
+        "back",
+        "cry",
+        "embarrassed",
+        "face",
+        "feelings",
+        "grateful",
+        "gratitude",
+        "holding",
+        "joy",
+        "please",
+        "proud",
+        "resist",
+        "sad",
+        "tears"
+      ]
     },
     {
       "emoji": "🫠",
-      "shortcodes": ["melting_face", "melting"],
+      "shortcodes": ["melting_face", "melting", "melt"],
       "group": "smileys",
-      "order": 186
+      "order": 186,
+      "keywords": [
+        "disappear",
+        "dissolve",
+        "embarrassed",
+        "face",
+        "haha",
+        "heat",
+        "hot",
+        "liquid",
+        "lol",
+        "sarcasm",
+        "sarcastic"
+      ]
     },
     {
       "emoji": "🫡",
       "shortcodes": ["saluting_face", "salute", "saluting"],
       "group": "smileys",
-      "order": 187
+      "order": 187,
+      "keywords": ["face", "good", "luck", "ma’am", "ok", "respect", "sir", "troops", "yes"]
     },
     {
       "emoji": "🫢",
-      "shortcodes": ["face_with_open_eyes_and_hand_over_mouth", "shocked_gasp", "gasp_face"],
+      "shortcodes": [
+        "face_with_open_eyes_and_hand_over_mouth",
+        "shocked_gasp",
+        "gasp_face",
+        "face_with_open_eyes_hand_over_mouth",
+        "gasp"
+      ],
       "group": "smileys",
-      "order": 188
+      "order": 188,
+      "keywords": [
+        "amazement",
+        "awe",
+        "disbelief",
+        "embarrass",
+        "eyes",
+        "face",
+        "hand",
+        "mouth",
+        "omg",
+        "open",
+        "over",
+        "quiet",
+        "scared",
+        "shock",
+        "surprise"
+      ]
     },
     {
       "emoji": "🫣",
       "shortcodes": ["face_with_peeking_eye", "peeking", "peek"],
       "group": "smileys",
-      "order": 189
+      "order": 189,
+      "keywords": ["captivated", "embarrass", "eye", "face", "hide", "hiding", "peep", "scared", "shy", "stare"]
     },
     {
       "emoji": "🫤",
       "shortcodes": ["face_with_diagonal_mouth", "meh", "diagonal_mouth"],
       "group": "smileys",
-      "order": 190
+      "order": 190,
+      "keywords": [
+        "confused",
+        "confusion",
+        "diagonal",
+        "disappointed",
+        "doubt",
+        "doubtful",
+        "face",
+        "frustrated",
+        "frustration",
+        "mouth",
+        "skeptical",
+        "unsure",
+        "whatever",
+        "wtv"
+      ]
     },
     {
       "emoji": "🫥",
       "shortcodes": ["dotted_line_face", "invisible", "dotted_face"],
       "group": "smileys",
-      "order": 191
+      "order": 191,
+      "keywords": [
+        "depressed",
+        "disappear",
+        "dotted",
+        "face",
+        "hidden",
+        "hide",
+        "introvert",
+        "line",
+        "meh",
+        "whatever",
+        "wtv"
+      ]
     },
     {
       "emoji": "🫰",
       "shortcodes": ["hand_with_index_finger_and_thumb_crossed", "finger_heart", "money_fingers"],
       "group": "people",
-      "order": 3290
+      "order": 3290,
+      "keywords": ["<3", "crossed", "expensive", "finger", "hand", "heart", "index", "love", "money", "snap", "thumb"]
     },
     {
       "emoji": "🫱",
       "shortcodes": ["rightwards_hand", "open_hand_right", "palm_right", "hand_right"],
       "group": "people",
-      "order": 3291
+      "order": 3291,
+      "keywords": ["hand", "handshake", "hold", "reach", "right", "rightward", "rightwards", "shake"]
     },
     {
       "emoji": "🫲",
       "shortcodes": ["leftwards_hand", "open_hand_left", "palm_left", "hand_left"],
       "group": "people",
-      "order": 3292
+      "order": 3292,
+      "keywords": ["hand", "handshake", "hold", "left", "leftward", "leftwards", "reach", "shake"]
     },
     {
       "emoji": "🫳",
-      "shortcodes": ["palm_down_hand", "hand_palm_down"],
+      "shortcodes": ["palm_down_hand", "hand_palm_down", "palm_down"],
       "group": "people",
-      "order": 3293
+      "order": 3293,
+      "keywords": ["dismiss", "down", "drop", "dropped", "hand", "palm", "pick", "shoo", "up"]
     },
     {
       "emoji": "🫴",
-      "shortcodes": ["palm_up_hand", "hand_palm_up", "offer", "give"],
+      "shortcodes": ["palm_up_hand", "hand_palm_up", "offer", "give", "palm_up"],
       "group": "people",
-      "order": 3294
+      "order": 3294,
+      "keywords": ["beckon", "catch", "come", "hand", "hold", "know", "lift", "me", "palm", "tell"]
     },
     {
       "emoji": "🫵",
-      "shortcodes": ["index_pointing_at_viewer", "you", "pointing_at_you"],
+      "shortcodes": [
+        "index_pointing_at_viewer",
+        "you",
+        "pointing_at_you",
+        "index_pointing_at_the_viewer",
+        "point_forward"
+      ],
       "group": "people",
-      "order": 3295
+      "order": 3295,
+      "keywords": ["at", "finger", "hand", "index", "pointing", "poke", "viewer"]
     },
     {
       "emoji": "🫶",
       "shortcodes": ["heart_hands", "hand_heart", "love_hands"],
       "group": "people",
-      "order": 3296
+      "order": 3296,
+      "keywords": ["<3", "hands", "heart", "love", "you"]
     },
     {
       "emoji": "🫅",
       "shortcodes": ["person_with_crown", "royalty", "monarch"],
       "group": "people",
-      "order": 3297
+      "order": 3297,
+      "keywords": ["crown", "noble", "person", "regal", "royal"]
     },
     {
       "emoji": "🫃",
       "shortcodes": ["pregnant_man"],
       "group": "people",
-      "order": 3298
+      "order": 3298,
+      "keywords": ["belly", "bloated", "full", "man", "overeat", "pregnant"]
     },
     {
       "emoji": "🫄",
       "shortcodes": ["pregnant_person"],
       "group": "people",
-      "order": 3299
+      "order": 3299,
+      "keywords": ["belly", "bloated", "full", "overeat", "person", "pregnant", "stuffed"]
     },
     {
       "emoji": "🪺",
       "shortcodes": ["nest_with_eggs", "nest_eggs"],
       "group": "animals",
-      "order": 165
+      "order": 165,
+      "keywords": ["bird", "branch", "egg", "eggs", "nest", "nesting"]
     },
     {
       "emoji": "🪹",
-      "shortcodes": ["empty_nest", "nest_empty"],
+      "shortcodes": ["empty_nest", "nest_empty", "nest"],
       "group": "animals",
-      "order": 166
+      "order": 166,
+      "keywords": ["branch", "empty", "home", "nesting"]
     },
     {
       "emoji": "🫘",
       "shortcodes": ["beans"],
       "group": "food",
-      "order": 133
+      "order": 133,
+      "keywords": ["food", "kidney", "legume", "small"]
     },
     {
       "emoji": "🫗",
       "shortcodes": ["pouring_liquid", "pour"],
       "group": "food",
-      "order": 134
+      "order": 134,
+      "keywords": ["accident", "drink", "empty", "glass", "liquid", "oops", "pouring", "spill", "water"]
     },
     {
       "emoji": "🫙",
       "shortcodes": ["jar"],
       "group": "food",
-      "order": 135
+      "order": 135,
+      "keywords": ["condiment", "container", "empty", "nothing", "sauce", "store"]
     },
     {
       "emoji": "🛞",
       "shortcodes": ["wheel", "wheel_general"],
       "group": "travel",
-      "order": 267
+      "order": 267,
+      "keywords": ["car", "circle", "tire", "turn", "vehicle"]
     },
     {
       "emoji": "🩼",
       "shortcodes": ["crutch"],
       "group": "objects",
-      "order": 313
+      "order": 313,
+      "keywords": ["aid", "cane", "disability", "help", "hurt", "injured", "mobility", "stick"]
     },
     {
       "emoji": "🩻",
-      "shortcodes": ["x_ray", "xray"],
+      "shortcodes": ["x_ray", "xray", "x-ray"],
       "group": "objects",
-      "order": 314
+      "order": 314,
+      "keywords": ["bones", "doctor", "medical", "skeleton", "skull"]
     },
     {
       "emoji": "🪪",
-      "shortcodes": ["id_card", "identification", "passport_card"],
+      "shortcodes": ["id_card", "identification", "passport_card", "identification_card"],
       "group": "objects",
-      "order": 315
+      "order": 315,
+      "keywords": ["card", "credentials", "document", "id", "license", "security"]
     },
     {
       "emoji": "🪫",
       "shortcodes": ["low_battery", "battery_low"],
       "group": "objects",
-      "order": 316
+      "order": 316,
+      "keywords": ["battery", "drained", "electronic", "energy", "low", "power"]
     },
     {
       "emoji": "🪩",
       "shortcodes": ["mirror_ball", "disco_ball", "disco"],
       "group": "activities",
-      "order": 96
+      "order": 96,
+      "keywords": ["ball", "dance", "glitter", "mirror", "party"]
     },
     {
       "emoji": "🛟",
       "shortcodes": ["ring_buoy", "lifebuoy", "life_ring"],
       "group": "travel",
-      "order": 268
+      "order": 268,
+      "keywords": [
+        "buoy",
+        "float",
+        "life",
+        "lifesaver",
+        "preserver",
+        "rescue",
+        "ring",
+        "safety",
+        "save",
+        "saver",
+        "swim"
+      ]
     },
     {
       "emoji": "🪬",
       "shortcodes": ["hamsa", "hand_of_fatima"],
       "group": "objects",
-      "order": 317
+      "order": 317,
+      "keywords": ["amulet", "fatima", "fortune", "guide", "hand", "mary", "miriam", "palm", "protect", "protection"]
     },
     {
       "emoji": "🫧",
       "shortcodes": ["bubbles"],
       "group": "smileys",
-      "order": 192
+      "order": 192,
+      "keywords": ["bubble", "burp", "clean", "floating", "pearl", "soap", "underwater"]
     },
     {
       "emoji": "🟰",
       "shortcodes": ["heavy_equals_sign", "equals"],
       "group": "symbols",
-      "order": 305
+      "order": 305,
+      "keywords": ["answer", "equal", "equality", "heavy", "math", "sign"]
     },
     {
       "emoji": "🫨",
       "shortcodes": ["shaking_face", "shaking", "vibrating_face"],
       "group": "smileys",
-      "order": 193
+      "order": 193,
+      "keywords": ["crazy", "daze", "earthquake", "face", "omg", "panic", "shock", "surprise", "vibrate", "whoa", "wow"]
     },
     {
       "emoji": "🫷",
       "shortcodes": ["leftwards_pushing_hand", "push_left", "stop_left"],
       "group": "people",
-      "order": 3300
+      "order": 3300,
+      "keywords": [
+        "block",
+        "five",
+        "halt",
+        "hand",
+        "high",
+        "hold",
+        "leftward",
+        "leftwards",
+        "pause",
+        "push",
+        "pushing",
+        "refuse",
+        "slap",
+        "stop",
+        "wait"
+      ]
     },
     {
       "emoji": "🫸",
       "shortcodes": ["rightwards_pushing_hand", "push_right", "stop_right", "high_five_left"],
       "group": "people",
-      "order": 3301
+      "order": 3301,
+      "keywords": [
+        "block",
+        "five",
+        "halt",
+        "hand",
+        "high",
+        "hold",
+        "pause",
+        "push",
+        "pushing",
+        "refuse",
+        "rightward",
+        "rightwards",
+        "slap",
+        "stop",
+        "wait"
+      ]
     },
     {
       "emoji": "🪿",
       "shortcodes": ["goose"],
       "group": "animals",
-      "order": 167
+      "order": 167,
+      "keywords": [
+        "animal",
+        "bird",
+        "duck",
+        "flock",
+        "fowl",
+        "gaggle",
+        "gander",
+        "geese",
+        "honk",
+        "ornithology",
+        "silly"
+      ]
     },
     {
       "emoji": "🪼",
       "shortcodes": ["jellyfish"],
       "group": "animals",
-      "order": 168
+      "order": 168,
+      "keywords": [
+        "animal",
+        "aquarium",
+        "burn",
+        "invertebrate",
+        "jelly",
+        "life",
+        "marine",
+        "ocean",
+        "ouch",
+        "plankton",
+        "sea",
+        "sting",
+        "stinger",
+        "tentacles"
+      ]
     },
     {
       "emoji": "🐦‍⬛",
       "shortcodes": ["black_bird", "blackbird"],
       "group": "animals",
-      "order": 169
+      "order": 169,
+      "keywords": ["animal", "beak", "bird", "black", "caw", "corvid", "crow", "ornithology", "raven", "rook"]
     },
     {
       "emoji": "🪽",
       "shortcodes": ["wing"],
       "group": "animals",
-      "order": 170
+      "order": 170,
+      "keywords": ["angelic", "ascend", "aviation", "bird", "fly", "flying", "heavenly", "mythology", "soar"]
     },
     {
       "emoji": "🪻",
       "shortcodes": ["hyacinth", "lavender_flower"],
       "group": "animals",
-      "order": 171
+      "order": 171,
+      "keywords": [
+        "bloom",
+        "bluebonnet",
+        "flower",
+        "indigo",
+        "lavender",
+        "lilac",
+        "lupine",
+        "plant",
+        "purple",
+        "shrub",
+        "snapdragon",
+        "spring",
+        "violet"
+      ]
     },
     {
       "emoji": "🫚",
       "shortcodes": ["ginger_root", "ginger"],
       "group": "food",
-      "order": 136
+      "order": 136,
+      "keywords": ["beer", "health", "herb", "natural", "root", "spice"]
     },
     {
       "emoji": "🫛",
-      "shortcodes": ["pea_pod", "peas", "pod"],
+      "shortcodes": ["pea_pod", "peas", "pod", "pea"],
       "group": "food",
-      "order": 137
+      "order": 137,
+      "keywords": ["beans", "beanstalk", "edamame", "legume", "soybean", "vegetable", "veggie"]
     },
     {
       "emoji": "🪈",
       "shortcodes": ["flute"],
       "group": "activities",
-      "order": 97
+      "order": 97,
+      "keywords": [
+        "band",
+        "fife",
+        "flautist",
+        "instrument",
+        "marching",
+        "music",
+        "orchestra",
+        "piccolo",
+        "pipe",
+        "recorder",
+        "woodwind"
+      ]
     },
     {
       "emoji": "🪇",
       "shortcodes": ["maraca", "maracas"],
       "group": "activities",
-      "order": 98
+      "order": 98,
+      "keywords": ["cha", "dance", "instrument", "music", "party", "percussion", "rattle", "shake", "shaker"]
     },
     {
       "emoji": "🪯",
       "shortcodes": ["khanda"],
       "group": "symbols",
-      "order": 306
+      "order": 306,
+      "keywords": ["deg", "fateh", "khalsa", "religion", "sikh", "sikhism", "tegh"]
     },
     {
       "emoji": "🪭",
       "shortcodes": ["folding_hand_fan", "hand_fan", "folding_fan"],
       "group": "objects",
-      "order": 318
+      "order": 318,
+      "keywords": [
+        "clack",
+        "clap",
+        "cool",
+        "cooling",
+        "dance",
+        "fan",
+        "flirt",
+        "flutter",
+        "folding",
+        "hand",
+        "hot",
+        "shy"
+      ]
     },
     {
       "emoji": "🪮",
       "shortcodes": ["hair_pick", "afro_pick"],
       "group": "objects",
-      "order": 319
+      "order": 319,
+      "keywords": ["afro", "comb", "groom", "hair", "pick"]
     },
     {
       "emoji": "🛜",
       "shortcodes": ["wireless", "wifi"],
       "group": "symbols",
-      "order": 307
+      "order": 307,
+      "keywords": [
+        "broadband",
+        "computer",
+        "connectivity",
+        "hotspot",
+        "internet",
+        "network",
+        "router",
+        "smartphone",
+        "wlan"
+      ]
     },
     {
       "emoji": "🩷",
       "shortcodes": ["pink_heart", "heart_pink"],
       "group": "smileys",
-      "order": 195
+      "order": 195,
+      "keywords": ["143", "adorable", "cute", "emotion", "heart", "ily", "like", "love", "pink", "special", "sweet"]
     },
     {
       "emoji": "🩵",
       "shortcodes": ["light_blue_heart", "heart_light_blue"],
       "group": "smileys",
-      "order": 196
+      "order": 196,
+      "keywords": [
+        "143",
+        "blue",
+        "cute",
+        "cyan",
+        "emotion",
+        "heart",
+        "ily",
+        "light",
+        "like",
+        "love",
+        "sky",
+        "special",
+        "teal"
+      ]
     },
     {
       "emoji": "🩶",
       "shortcodes": ["grey_heart", "heart_grey", "gray_heart", "heart_gray"],
       "group": "smileys",
-      "order": 197
+      "order": 197,
+      "keywords": ["143", "emotion", "gray", "grey", "heart", "ily", "love", "silver", "slate", "special"]
     },
     {
       "emoji": "🐦‍🔥",
       "shortcodes": ["phoenix", "bird_on_fire"],
       "group": "animals",
-      "order": 172
+      "order": 172,
+      "keywords": [
+        "ascend",
+        "ascension",
+        "emerge",
+        "fantasy",
+        "firebird",
+        "glory",
+        "immortal",
+        "rebirth",
+        "reincarnation",
+        "reinvent",
+        "renewal",
+        "revival",
+        "revive",
+        "rise",
+        "transform"
+      ]
     },
     {
       "emoji": "🍋‍🟩",
       "shortcodes": ["lime", "green_lemon"],
       "group": "food",
-      "order": 138
+      "order": 138,
+      "keywords": [
+        "acidity",
+        "citrus",
+        "cocktail",
+        "fruit",
+        "garnish",
+        "key",
+        "margarita",
+        "mojito",
+        "refreshing",
+        "salsa",
+        "sour",
+        "tangy",
+        "tequila",
+        "tropical",
+        "zest"
+      ]
     },
     {
       "emoji": "🍄‍🟫",
       "shortcodes": ["brown_mushroom", "mushroom_brown"],
       "group": "food",
-      "order": 139
+      "order": 139,
+      "keywords": [
+        "food",
+        "fungi",
+        "fungus",
+        "mushroom",
+        "nature",
+        "pizza",
+        "portobello",
+        "shiitake",
+        "shroom",
+        "spore",
+        "sprout",
+        "toppings",
+        "truffle",
+        "vegetable",
+        "vegetarian",
+        "veggie"
+      ]
     },
     {
       "emoji": "⛓️‍💥",
       "shortcodes": ["broken_chain", "chain_break", "chains_broken"],
       "group": "objects",
-      "order": 320
+      "order": 320,
+      "keywords": ["break", "breaking", "broken", "chain", "cuffs", "freedom"]
     },
     {
       "emoji": "🫩",
-      "shortcodes": ["face_with_bags_under_eyes", "tired_eyes", "bags_under_eyes"],
+      "shortcodes": ["face_with_bags_under_eyes", "tired_eyes", "bags_under_eyes", "face_with_eye_bags"],
       "group": "smileys",
-      "order": 194
+      "order": 194,
+      "keywords": ["bags", "bored", "exhausted", "eyes", "face", "fatigued", "late", "sleepy", "tired", "weary"]
     },
     {
       "emoji": "🫆",
       "shortcodes": ["fingerprint", "print"],
       "group": "objects",
-      "order": 321
+      "order": 321,
+      "keywords": ["clue", "crime", "detective", "forensics", "identity", "mystery", "safety", "trace"]
     },
     {
       "emoji": "🪾",
       "shortcodes": ["leafless_tree", "bare_tree", "winter_tree"],
       "group": "animals",
-      "order": 173
+      "order": 173,
+      "keywords": ["bare", "barren", "branches", "dead", "drought", "leafless", "tree", "trunk", "winter", "wood"]
     },
     {
       "emoji": "🫜",
       "shortcodes": ["root_vegetable", "radish", "turnip"],
       "group": "food",
-      "order": 140
+      "order": 140,
+      "keywords": ["beet", "food", "garden", "root", "salad", "vegetable", "vegetarian"]
     },
     {
       "emoji": "🪉",
       "shortcodes": ["harp"],
       "group": "activities",
-      "order": 99
+      "order": 99,
+      "keywords": ["cupid", "instrument", "love", "music", "orchestra"]
     },
     {
       "emoji": "🪏",
       "shortcodes": ["shovel", "spade_tool"],
       "group": "objects",
-      "order": 322
+      "order": 322,
+      "keywords": ["bury", "dig", "garden", "hole", "plant", "scoop", "snow", "spade"]
     },
     {
       "emoji": "🫟",
       "shortcodes": ["splatter", "paint_splatter", "splat"],
       "group": "objects",
-      "order": 323
+      "order": 323,
+      "keywords": ["drip", "holi", "ink", "liquid", "mess", "paint", "spill", "stain"]
     },
     {
       "emoji": "🪷",
       "shortcodes": ["lotus", "lotus_flower"],
       "group": "animals",
-      "order": 174
+      "order": 174,
+      "keywords": ["beauty", "buddhism", "calm", "flower", "hinduism", "peace", "purity", "serenity"]
     },
     {
       "emoji": "🪸",
       "shortcodes": ["coral"],
       "group": "animals",
-      "order": 175
+      "order": 175,
+      "keywords": ["change", "climate", "ocean", "reef", "sea"]
     },
     {
       "emoji": "🫎",
       "shortcodes": ["moose"],
       "group": "animals",
-      "order": 176
+      "order": 176,
+      "keywords": ["alces", "animal", "antlers", "elk", "mammal"]
     },
     {
       "emoji": "🫏",
       "shortcodes": ["donkey"],
       "group": "animals",
-      "order": 177
+      "order": 177,
+      "keywords": ["animal", "ass", "burro", "hinny", "mammal", "mule", "stubborn"]
     }
   ]
 }

--- a/apps/backend/src/features/emoji/emoji-data.json
+++ b/apps/backend/src/features/emoji/emoji-data.json
@@ -594,7 +594,6 @@
       "group": "smileys",
       "order": 46,
       "keywords": [
-        "...",
         "bored",
         "face",
         "fine",
@@ -1182,7 +1181,7 @@
       "shortcodes": ["skull", "dead", "rip", "skeleton"],
       "group": "smileys",
       "order": 113,
-      "keywords": ["body", "death", "face", "fairy", "fairytale", "i’m", "lmao", "monster", "tale", "yolo"]
+      "keywords": ["body", "death", "face", "fairy", "fairytale", "i m", "lmao", "monster", "tale", "yolo"]
     },
     {
       "emoji": "☠️",
@@ -1213,13 +1212,7 @@
         "turd"
       ]
     },
-    {
-      "emoji": "🤡",
-      "shortcodes": ["clown_face", "clown"],
-      "group": "smileys",
-      "order": 117,
-      "keywords": ["face"]
-    },
+    { "emoji": "🤡", "shortcodes": ["clown_face", "clown"], "group": "smileys", "order": 117, "keywords": ["face"] },
     {
       "emoji": "👹",
       "shortcodes": ["japanese_ogre", "ogre"],
@@ -1677,13 +1670,7 @@
       "order": 171,
       "keywords": ["away", "cloud", "comic", "dashing", "fart", "fast", "go", "gone", "gotta", "running", "smoke"]
     },
-    {
-      "emoji": "🕳️",
-      "shortcodes": ["hole"],
-      "group": "smileys",
-      "order": 172,
-      "keywords": []
-    },
+    { "emoji": "🕳️", "shortcodes": ["hole"], "group": "smileys", "order": 172, "keywords": [] },
     {
       "emoji": "💬",
       "shortcodes": ["speech_balloon"],
@@ -2053,13 +2040,7 @@
       "order": 270,
       "keywords": ["bored", "care", "cosmetics", "done", "makeup", "manicure", "nail", "polish", "whatever"]
     },
-    {
-      "emoji": "🤳",
-      "shortcodes": ["selfie"],
-      "group": "people",
-      "order": 276,
-      "keywords": ["camera", "phone"]
-    },
+    { "emoji": "🤳", "shortcodes": ["selfie"], "group": "people", "order": 276, "keywords": ["camera", "phone"] },
     {
       "emoji": "💪",
       "shortcodes": ["muscle", "strong", "flex", "right_bicep", "flexed_biceps"],
@@ -2130,13 +2111,7 @@
       "order": 314,
       "keywords": ["body", "noses", "nosey", "odor", "smell", "smells"]
     },
-    {
-      "emoji": "🧠",
-      "shortcodes": ["brain"],
-      "group": "people",
-      "order": 320,
-      "keywords": ["intelligent", "smart"]
-    },
+    { "emoji": "🧠", "shortcodes": ["brain"], "group": "people", "order": 320, "keywords": ["intelligent", "smart"] },
     {
       "emoji": "🫀",
       "shortcodes": ["anatomical_heart"],
@@ -2172,20 +2147,8 @@
       "order": 325,
       "keywords": ["body", "eye", "face", "googly", "look", "omg", "peep", "see", "seeing"]
     },
-    {
-      "emoji": "👁️",
-      "shortcodes": ["eye"],
-      "group": "people",
-      "order": 326,
-      "keywords": ["1", "body", "one"]
-    },
-    {
-      "emoji": "👅",
-      "shortcodes": ["tongue"],
-      "group": "people",
-      "order": 328,
-      "keywords": ["body", "lick", "slurp"]
-    },
+    { "emoji": "👁️", "shortcodes": ["eye"], "group": "people", "order": 326, "keywords": ["1", "body", "one"] },
+    { "emoji": "👅", "shortcodes": ["tongue"], "group": "people", "order": 328, "keywords": ["body", "lick", "slurp"] },
     {
       "emoji": "👄",
       "shortcodes": ["lips", "mouth"],
@@ -2214,41 +2177,23 @@
       "order": 349,
       "keywords": ["bright-eyed", "child", "daughter", "granddaughter", "kid", "virgo", "young", "younger", "zodiac"]
     },
-    {
-      "emoji": "🧑",
-      "shortcodes": ["adult", "person"],
-      "group": "people",
-      "order": 355,
-      "keywords": []
-    },
+    { "emoji": "🧑", "shortcodes": ["adult", "person"], "group": "people", "order": 355, "keywords": [] },
     {
       "emoji": "👱",
       "shortcodes": ["person_blond_hair", "blond_haired_person", "person_with_blond_hair", "blond_haired"],
       "group": "people",
       "order": 361,
-      "keywords": ["blond", "human", "person", "person: blond hair"]
+      "keywords": ["blond", "human", "person"]
     },
-    {
-      "emoji": "👨",
-      "shortcodes": ["man"],
-      "group": "people",
-      "order": 367,
-      "keywords": ["adult", "bro"]
-    },
+    { "emoji": "👨", "shortcodes": ["man"], "group": "people", "order": 367, "keywords": ["adult", "bro"] },
     {
       "emoji": "🧔",
       "shortcodes": ["bearded_person", "person_bearded", "person_beard"],
       "group": "people",
       "order": 373,
-      "keywords": ["beard", "bearded", "person", "whiskers", "person: beard"]
+      "keywords": ["beard", "bearded", "person", "whiskers"]
     },
-    {
-      "emoji": "👩",
-      "shortcodes": ["woman"],
-      "group": "people",
-      "order": 427,
-      "keywords": ["adult", "lady"]
-    },
+    { "emoji": "👩", "shortcodes": ["woman"], "group": "people", "order": 427, "keywords": ["adult", "lady"] },
     {
       "emoji": "🧓",
       "shortcodes": ["older_adult", "older_person"],
@@ -2557,8 +2502,7 @@
         "mrs",
         "santa",
         "tale",
-        "xmas",
-        "mrs. claus"
+        "xmas"
       ]
     },
     {
@@ -2725,7 +2669,7 @@
         "flair",
         "flamenco",
         "groove",
-        "let’s",
+        "let s",
         "salsa",
         "tango",
         "woman"
@@ -2745,7 +2689,7 @@
         "flair",
         "flamenco",
         "groove",
-        "let’s",
+        "let s",
         "man",
         "salsa",
         "tango"
@@ -3164,13 +3108,7 @@
         "thanks"
       ]
     },
-    {
-      "emoji": "👪",
-      "shortcodes": ["family"],
-      "group": "people",
-      "order": 3284,
-      "keywords": ["child"]
-    },
+    { "emoji": "👪", "shortcodes": ["family"], "group": "people", "order": 3284, "keywords": ["child"] },
     {
       "emoji": "👣",
       "shortcodes": ["footprints"],
@@ -3185,20 +3123,8 @@
       "order": 0,
       "keywords": ["animal", "banana", "face", "monkey"]
     },
-    {
-      "emoji": "🐒",
-      "shortcodes": ["monkey"],
-      "group": "animals",
-      "order": 1,
-      "keywords": ["animal", "banana"]
-    },
-    {
-      "emoji": "🦍",
-      "shortcodes": ["gorilla"],
-      "group": "animals",
-      "order": 2,
-      "keywords": ["animal"]
-    },
+    { "emoji": "🐒", "shortcodes": ["monkey"], "group": "animals", "order": 1, "keywords": ["animal", "banana"] },
+    { "emoji": "🦍", "shortcodes": ["gorilla"], "group": "animals", "order": 2, "keywords": ["animal"] },
     {
       "emoji": "🦧",
       "shortcodes": ["orangutan"],
@@ -3325,13 +3251,7 @@
       "order": 22,
       "keywords": ["animal", "equestrian", "farm", "racing", "horse"]
     },
-    {
-      "emoji": "🦄",
-      "shortcodes": ["unicorn", "unicorn_face"],
-      "group": "animals",
-      "order": 23,
-      "keywords": ["face"]
-    },
+    { "emoji": "🦄", "shortcodes": ["unicorn", "unicorn_face"], "group": "animals", "order": 23, "keywords": ["face"] },
     {
       "emoji": "🦓",
       "shortcodes": ["zebra", "zebra_face"],
@@ -3339,13 +3259,7 @@
       "order": 24,
       "keywords": ["animal", "stripe"]
     },
-    {
-      "emoji": "🦌",
-      "shortcodes": ["deer"],
-      "group": "animals",
-      "order": 25,
-      "keywords": ["animal"]
-    },
+    { "emoji": "🦌", "shortcodes": ["deer"], "group": "animals", "order": 25, "keywords": ["animal"] },
     {
       "emoji": "🦬",
       "shortcodes": ["bison"],
@@ -3395,13 +3309,7 @@
       "order": 32,
       "keywords": ["animal", "bacon", "farm", "pork", "sow", "pig"]
     },
-    {
-      "emoji": "🐗",
-      "shortcodes": ["boar"],
-      "group": "animals",
-      "order": 33,
-      "keywords": ["animal", "pig"]
-    },
+    { "emoji": "🐗", "shortcodes": ["boar"], "group": "animals", "order": 33, "keywords": ["animal", "pig"] },
     {
       "emoji": "🐽",
       "shortcodes": ["pig_nose"],
@@ -3449,7 +3357,7 @@
       "shortcodes": ["llama"],
       "group": "animals",
       "order": 40,
-      "keywords": ["alpaca", "animal", "guanaco", "vicuña", "wool"]
+      "keywords": ["alpaca", "animal", "guanaco", "vicuna", "wool"]
     },
     {
       "emoji": "🦒",
@@ -3458,13 +3366,7 @@
       "order": 41,
       "keywords": ["animal", "spots"]
     },
-    {
-      "emoji": "🐘",
-      "shortcodes": ["elephant"],
-      "group": "animals",
-      "order": 42,
-      "keywords": ["animal"]
-    },
+    { "emoji": "🐘", "shortcodes": ["elephant"], "group": "animals", "order": 42, "keywords": ["animal"] },
     {
       "emoji": "🦣",
       "shortcodes": ["mammoth"],
@@ -3472,20 +3374,8 @@
       "order": 43,
       "keywords": ["animal", "extinction", "large", "tusk", "wooly"]
     },
-    {
-      "emoji": "🦏",
-      "shortcodes": ["rhinoceros", "rhino"],
-      "group": "animals",
-      "order": 44,
-      "keywords": ["animal"]
-    },
-    {
-      "emoji": "🦛",
-      "shortcodes": ["hippopotamus", "hippo"],
-      "group": "animals",
-      "order": 45,
-      "keywords": ["animal"]
-    },
+    { "emoji": "🦏", "shortcodes": ["rhinoceros", "rhino"], "group": "animals", "order": 44, "keywords": ["animal"] },
+    { "emoji": "🦛", "shortcodes": ["hippopotamus", "hippo"], "group": "animals", "order": 45, "keywords": ["animal"] },
     {
       "emoji": "🐭",
       "shortcodes": ["mouse", "mouse_face"],
@@ -3500,13 +3390,7 @@
       "order": 47,
       "keywords": ["animal", "animals", "mouse"]
     },
-    {
-      "emoji": "🐀",
-      "shortcodes": ["rat"],
-      "group": "animals",
-      "order": 48,
-      "keywords": ["animal"]
-    },
+    { "emoji": "🐀", "shortcodes": ["rat"], "group": "animals", "order": 48, "keywords": ["animal"] },
     {
       "emoji": "🐹",
       "shortcodes": ["hamster", "hamster_face"],
@@ -3528,13 +3412,7 @@
       "order": 51,
       "keywords": ["animal", "bunny", "pet", "rabbit"]
     },
-    {
-      "emoji": "🐿️",
-      "shortcodes": ["chipmunk"],
-      "group": "animals",
-      "order": 52,
-      "keywords": ["animal", "squirrel"]
-    },
+    { "emoji": "🐿️", "shortcodes": ["chipmunk"], "group": "animals", "order": 52, "keywords": ["animal", "squirrel"] },
     {
       "emoji": "🦫",
       "shortcodes": ["beaver"],
@@ -3542,20 +3420,8 @@
       "order": 54,
       "keywords": ["animal", "dam", "teeth"]
     },
-    {
-      "emoji": "🦔",
-      "shortcodes": ["hedgehog"],
-      "group": "animals",
-      "order": 55,
-      "keywords": ["animal", "spiny"]
-    },
-    {
-      "emoji": "🦇",
-      "shortcodes": ["bat"],
-      "group": "animals",
-      "order": 56,
-      "keywords": ["animal", "vampire"]
-    },
+    { "emoji": "🦔", "shortcodes": ["hedgehog"], "group": "animals", "order": 55, "keywords": ["animal", "spiny"] },
+    { "emoji": "🦇", "shortcodes": ["bat"], "group": "animals", "order": 56, "keywords": ["animal", "vampire"] },
     {
       "emoji": "🐻",
       "shortcodes": ["bear", "bear_face"],
@@ -3584,13 +3450,7 @@
       "order": 61,
       "keywords": ["animal", "bamboo", "face"]
     },
-    {
-      "emoji": "🦥",
-      "shortcodes": ["sloth"],
-      "group": "animals",
-      "order": 62,
-      "keywords": ["lazy", "slow"]
-    },
+    { "emoji": "🦥", "shortcodes": ["sloth"], "group": "animals", "order": 62, "keywords": ["lazy", "slow"] },
     {
       "emoji": "🦦",
       "shortcodes": ["otter"],
@@ -3598,13 +3458,7 @@
       "order": 63,
       "keywords": ["animal", "fishing", "playful"]
     },
-    {
-      "emoji": "🦨",
-      "shortcodes": ["skunk"],
-      "group": "animals",
-      "order": 64,
-      "keywords": ["animal", "stink"]
-    },
+    { "emoji": "🦨", "shortcodes": ["skunk"], "group": "animals", "order": 64, "keywords": ["animal", "stink"] },
     {
       "emoji": "🦘",
       "shortcodes": ["kangaroo"],
@@ -3759,13 +3613,7 @@
       "order": 91,
       "keywords": ["animal", "face"]
     },
-    {
-      "emoji": "🐊",
-      "shortcodes": ["crocodile"],
-      "group": "animals",
-      "order": 92,
-      "keywords": ["animal", "zoo"]
-    },
+    { "emoji": "🐊", "shortcodes": ["crocodile"], "group": "animals", "order": 92, "keywords": ["animal", "zoo"] },
     {
       "emoji": "🐢",
       "shortcodes": ["turtle"],
@@ -3773,13 +3621,7 @@
       "order": 93,
       "keywords": ["animal", "terrapin", "tortoise"]
     },
-    {
-      "emoji": "🦎",
-      "shortcodes": ["lizard"],
-      "group": "animals",
-      "order": 94,
-      "keywords": ["animal", "reptile"]
-    },
+    { "emoji": "🦎", "shortcodes": ["lizard"], "group": "animals", "order": 94, "keywords": ["animal", "reptile"] },
     {
       "emoji": "🐍",
       "shortcodes": ["snake"],
@@ -3857,20 +3699,8 @@
       "order": 105,
       "keywords": ["animal", "fish", "fishes", "tropical"]
     },
-    {
-      "emoji": "🐡",
-      "shortcodes": ["blowfish"],
-      "group": "animals",
-      "order": 106,
-      "keywords": ["animal", "fish"]
-    },
-    {
-      "emoji": "🦈",
-      "shortcodes": ["shark"],
-      "group": "animals",
-      "order": 107,
-      "keywords": ["animal", "fish"]
-    },
+    { "emoji": "🐡", "shortcodes": ["blowfish"], "group": "animals", "order": 106, "keywords": ["animal", "fish"] },
+    { "emoji": "🦈", "shortcodes": ["shark"], "group": "animals", "order": 107, "keywords": ["animal", "fish"] },
     {
       "emoji": "🐙",
       "shortcodes": ["octopus"],
@@ -3885,13 +3715,7 @@
       "order": 109,
       "keywords": ["animal", "beach", "conch", "sea", "spiral"]
     },
-    {
-      "emoji": "🦀",
-      "shortcodes": ["crab"],
-      "group": "animals",
-      "order": 112,
-      "keywords": ["cancer", "zodiac"]
-    },
+    { "emoji": "🦀", "shortcodes": ["crab"], "group": "animals", "order": 112, "keywords": ["cancer", "zodiac"] },
     {
       "emoji": "🦞",
       "shortcodes": ["lobster"],
@@ -3913,13 +3737,7 @@
       "order": 115,
       "keywords": ["animal", "food", "mollusk"]
     },
-    {
-      "emoji": "🦪",
-      "shortcodes": ["oyster"],
-      "group": "animals",
-      "order": 116,
-      "keywords": ["diving", "pearl"]
-    },
+    { "emoji": "🦪", "shortcodes": ["oyster"], "group": "animals", "order": 116, "keywords": ["diving", "pearl"] },
     {
       "emoji": "🐌",
       "shortcodes": ["snail"],
@@ -3927,13 +3745,7 @@
       "order": 117,
       "keywords": ["animal", "escargot", "garden", "nature", "slug"]
     },
-    {
-      "emoji": "🦋",
-      "shortcodes": ["butterfly"],
-      "group": "animals",
-      "order": 118,
-      "keywords": ["insect", "pretty"]
-    },
+    { "emoji": "🦋", "shortcodes": ["butterfly"], "group": "animals", "order": 118, "keywords": ["insect", "pretty"] },
     {
       "emoji": "🐛",
       "shortcodes": ["bug", "bug_fix"],
@@ -3983,20 +3795,8 @@
       "order": 125,
       "keywords": ["animal", "insect", "pest", "roach"]
     },
-    {
-      "emoji": "🕷️",
-      "shortcodes": ["spider"],
-      "group": "animals",
-      "order": 126,
-      "keywords": ["animal", "insect"]
-    },
-    {
-      "emoji": "🕸️",
-      "shortcodes": ["spider_web"],
-      "group": "animals",
-      "order": 128,
-      "keywords": ["spider", "web"]
-    },
+    { "emoji": "🕷️", "shortcodes": ["spider"], "group": "animals", "order": 126, "keywords": ["animal", "insect"] },
+    { "emoji": "🕸️", "shortcodes": ["spider_web"], "group": "animals", "order": 128, "keywords": ["spider", "web"] },
     {
       "emoji": "🦂",
       "shortcodes": ["scorpion"],
@@ -4053,13 +3853,7 @@
       "order": 137,
       "keywords": ["flower", "white"]
     },
-    {
-      "emoji": "🏵️",
-      "shortcodes": ["rosette"],
-      "group": "animals",
-      "order": 139,
-      "keywords": ["plant"]
-    },
+    { "emoji": "🏵️", "shortcodes": ["rosette"], "group": "animals", "order": 139, "keywords": ["plant"] },
     {
       "emoji": "🌹",
       "shortcodes": ["rose"],
@@ -4074,13 +3868,7 @@
       "order": 142,
       "keywords": ["dying", "flower", "wilted"]
     },
-    {
-      "emoji": "🌺",
-      "shortcodes": ["hibiscus"],
-      "group": "animals",
-      "order": 143,
-      "keywords": ["flower", "plant"]
-    },
+    { "emoji": "🌺", "shortcodes": ["hibiscus"], "group": "animals", "order": 143, "keywords": ["flower", "plant"] },
     {
       "emoji": "🌻",
       "shortcodes": ["sunflower"],
@@ -4151,20 +3939,8 @@
       "order": 154,
       "keywords": ["ear", "grain", "grains", "plant", "rice", "sheaf"]
     },
-    {
-      "emoji": "🌿",
-      "shortcodes": ["herb"],
-      "group": "animals",
-      "order": 155,
-      "keywords": ["leaf", "plant"]
-    },
-    {
-      "emoji": "☘️",
-      "shortcodes": ["shamrock"],
-      "group": "animals",
-      "order": 156,
-      "keywords": ["irish", "plant"]
-    },
+    { "emoji": "🌿", "shortcodes": ["herb"], "group": "animals", "order": 155, "keywords": ["leaf", "plant"] },
+    { "emoji": "☘️", "shortcodes": ["shamrock"], "group": "animals", "order": 156, "keywords": ["irish", "plant"] },
     {
       "emoji": "🍀",
       "shortcodes": ["four_leaf_clover"],
@@ -4207,20 +3983,8 @@
       "order": 0,
       "keywords": ["dionysus", "fruit", "grape"]
     },
-    {
-      "emoji": "🍈",
-      "shortcodes": ["melon"],
-      "group": "food",
-      "order": 1,
-      "keywords": ["cantaloupe", "fruit"]
-    },
-    {
-      "emoji": "🍉",
-      "shortcodes": ["watermelon"],
-      "group": "food",
-      "order": 2,
-      "keywords": ["fruit"]
-    },
+    { "emoji": "🍈", "shortcodes": ["melon"], "group": "food", "order": 1, "keywords": ["cantaloupe", "fruit"] },
+    { "emoji": "🍉", "shortcodes": ["watermelon"], "group": "food", "order": 2, "keywords": ["fruit"] },
     {
       "emoji": "🍊",
       "shortcodes": ["tangerine", "orange", "mandarin"],
@@ -4228,20 +3992,8 @@
       "order": 3,
       "keywords": ["c", "citrus", "fruit", "nectarine", "vitamin"]
     },
-    {
-      "emoji": "🍋",
-      "shortcodes": ["lemon"],
-      "group": "food",
-      "order": 4,
-      "keywords": ["citrus", "fruit", "sour"]
-    },
-    {
-      "emoji": "🍌",
-      "shortcodes": ["banana"],
-      "group": "food",
-      "order": 6,
-      "keywords": ["fruit", "potassium"]
-    },
+    { "emoji": "🍋", "shortcodes": ["lemon"], "group": "food", "order": 4, "keywords": ["citrus", "fruit", "sour"] },
+    { "emoji": "🍌", "shortcodes": ["banana"], "group": "food", "order": 6, "keywords": ["fruit", "potassium"] },
     {
       "emoji": "🍍",
       "shortcodes": ["pineapple"],
@@ -4249,13 +4001,7 @@
       "order": 7,
       "keywords": ["colada", "fruit", "pina", "tropical"]
     },
-    {
-      "emoji": "🥭",
-      "shortcodes": ["mango"],
-      "group": "food",
-      "order": 8,
-      "keywords": ["food", "fruit", "tropical"]
-    },
+    { "emoji": "🥭", "shortcodes": ["mango"], "group": "food", "order": 8, "keywords": ["food", "fruit", "tropical"] },
     {
       "emoji": "🍎",
       "shortcodes": ["apple", "red_apple"],
@@ -4270,20 +4016,8 @@
       "order": 10,
       "keywords": ["apple", "fruit", "green"]
     },
-    {
-      "emoji": "🍐",
-      "shortcodes": ["pear"],
-      "group": "food",
-      "order": 11,
-      "keywords": ["fruit"]
-    },
-    {
-      "emoji": "🍑",
-      "shortcodes": ["peach"],
-      "group": "food",
-      "order": 12,
-      "keywords": ["fruit"]
-    },
+    { "emoji": "🍐", "shortcodes": ["pear"], "group": "food", "order": 11, "keywords": ["fruit"] },
+    { "emoji": "🍑", "shortcodes": ["peach"], "group": "food", "order": 12, "keywords": ["fruit"] },
     {
       "emoji": "🍒",
       "shortcodes": ["cherries"],
@@ -4291,13 +4025,7 @@
       "order": 13,
       "keywords": ["berries", "cherry", "fruit", "red"]
     },
-    {
-      "emoji": "🍓",
-      "shortcodes": ["strawberry"],
-      "group": "food",
-      "order": 14,
-      "keywords": ["berry", "fruit"]
-    },
+    { "emoji": "🍓", "shortcodes": ["strawberry"], "group": "food", "order": 14, "keywords": ["berry", "fruit"] },
     {
       "emoji": "🫐",
       "shortcodes": ["blueberries"],
@@ -4319,48 +4047,12 @@
       "order": 17,
       "keywords": ["food", "fruit", "vegetable"]
     },
-    {
-      "emoji": "🫒",
-      "shortcodes": ["olive"],
-      "group": "food",
-      "order": 18,
-      "keywords": ["food"]
-    },
-    {
-      "emoji": "🥥",
-      "shortcodes": ["coconut"],
-      "group": "food",
-      "order": 19,
-      "keywords": ["colada", "palm", "piña"]
-    },
-    {
-      "emoji": "🥑",
-      "shortcodes": ["avocado"],
-      "group": "food",
-      "order": 20,
-      "keywords": ["food", "fruit"]
-    },
-    {
-      "emoji": "🍆",
-      "shortcodes": ["eggplant"],
-      "group": "food",
-      "order": 21,
-      "keywords": ["aubergine", "vegetable"]
-    },
-    {
-      "emoji": "🥔",
-      "shortcodes": ["potato"],
-      "group": "food",
-      "order": 22,
-      "keywords": ["food", "vegetable"]
-    },
-    {
-      "emoji": "🥕",
-      "shortcodes": ["carrot"],
-      "group": "food",
-      "order": 23,
-      "keywords": ["food", "vegetable"]
-    },
+    { "emoji": "🫒", "shortcodes": ["olive"], "group": "food", "order": 18, "keywords": ["food"] },
+    { "emoji": "🥥", "shortcodes": ["coconut"], "group": "food", "order": 19, "keywords": ["colada", "palm", "pina"] },
+    { "emoji": "🥑", "shortcodes": ["avocado"], "group": "food", "order": 20, "keywords": ["food", "fruit"] },
+    { "emoji": "🍆", "shortcodes": ["eggplant"], "group": "food", "order": 21, "keywords": ["aubergine", "vegetable"] },
+    { "emoji": "🥔", "shortcodes": ["potato"], "group": "food", "order": 22, "keywords": ["food", "vegetable"] },
+    { "emoji": "🥕", "shortcodes": ["carrot"], "group": "food", "order": 23, "keywords": ["food", "vegetable"] },
     {
       "emoji": "🌽",
       "shortcodes": ["corn", "ear_of_corn"],
@@ -4368,13 +4060,7 @@
       "order": 24,
       "keywords": ["crops", "ear", "farm", "maize", "maze"]
     },
-    {
-      "emoji": "🌶️",
-      "shortcodes": ["hot_pepper"],
-      "group": "food",
-      "order": 25,
-      "keywords": ["hot", "pepper"]
-    },
+    { "emoji": "🌶️", "shortcodes": ["hot_pepper"], "group": "food", "order": 25, "keywords": ["hot", "pepper"] },
     {
       "emoji": "🫑",
       "shortcodes": ["bell_pepper"],
@@ -4396,27 +4082,9 @@
       "order": 29,
       "keywords": ["bok", "burgers", "cabbage", "choy", "green", "kale", "leafy", "lettuce", "salad"]
     },
-    {
-      "emoji": "🥦",
-      "shortcodes": ["broccoli"],
-      "group": "food",
-      "order": 30,
-      "keywords": ["cabbage", "wild"]
-    },
-    {
-      "emoji": "🧄",
-      "shortcodes": ["garlic"],
-      "group": "food",
-      "order": 31,
-      "keywords": ["flavoring"]
-    },
-    {
-      "emoji": "🧅",
-      "shortcodes": ["onion"],
-      "group": "food",
-      "order": 32,
-      "keywords": ["flavoring"]
-    },
+    { "emoji": "🥦", "shortcodes": ["broccoli"], "group": "food", "order": 30, "keywords": ["cabbage", "wild"] },
+    { "emoji": "🧄", "shortcodes": ["garlic"], "group": "food", "order": 31, "keywords": ["flavoring"] },
+    { "emoji": "🧅", "shortcodes": ["onion"], "group": "food", "order": 32, "keywords": ["flavoring"] },
     {
       "emoji": "🥜",
       "shortcodes": ["peanuts", "shelled_peanut"],
@@ -4424,13 +4092,7 @@
       "order": 33,
       "keywords": ["food", "nut", "peanut", "vegetable"]
     },
-    {
-      "emoji": "🌰",
-      "shortcodes": ["chestnut"],
-      "group": "food",
-      "order": 35,
-      "keywords": ["almond", "plant"]
-    },
+    { "emoji": "🌰", "shortcodes": ["chestnut"], "group": "food", "order": 35, "keywords": ["almond", "plant"] },
     {
       "emoji": "🍞",
       "shortcodes": ["bread"],
@@ -4459,13 +4121,7 @@
       "order": 43,
       "keywords": ["arepa", "bread", "food", "gordita", "lavash", "naan", "pita"]
     },
-    {
-      "emoji": "🥨",
-      "shortcodes": ["pretzel"],
-      "group": "food",
-      "order": 44,
-      "keywords": ["convoluted", "twisted"]
-    },
+    { "emoji": "🥨", "shortcodes": ["pretzel"], "group": "food", "order": 44, "keywords": ["convoluted", "twisted"] },
     {
       "emoji": "🥯",
       "shortcodes": ["bagel"],
@@ -4478,7 +4134,7 @@
       "shortcodes": ["pancakes"],
       "group": "food",
       "order": 46,
-      "keywords": ["breakfast", "crêpe", "food", "hotcake", "pancake"]
+      "keywords": ["breakfast", "crepe", "food", "hotcake", "pancake"]
     },
     {
       "emoji": "🧇",
@@ -4487,20 +4143,8 @@
       "order": 47,
       "keywords": ["breakfast", "indecisive", "iron"]
     },
-    {
-      "emoji": "🧀",
-      "shortcodes": ["cheese", "cheese_wedge"],
-      "group": "food",
-      "order": 48,
-      "keywords": ["wedge"]
-    },
-    {
-      "emoji": "🍖",
-      "shortcodes": ["meat_on_bone"],
-      "group": "food",
-      "order": 49,
-      "keywords": ["bone", "meat"]
-    },
+    { "emoji": "🧀", "shortcodes": ["cheese", "cheese_wedge"], "group": "food", "order": 48, "keywords": ["wedge"] },
+    { "emoji": "🍖", "shortcodes": ["meat_on_bone"], "group": "food", "order": 49, "keywords": ["bone", "meat"] },
     {
       "emoji": "🍗",
       "shortcodes": ["poultry_leg"],
@@ -4515,13 +4159,7 @@
       "order": 51,
       "keywords": ["chop", "cut", "lambchop", "meat", "porkchop", "red", "steak"]
     },
-    {
-      "emoji": "🥓",
-      "shortcodes": ["bacon"],
-      "group": "food",
-      "order": 52,
-      "keywords": ["breakfast", "food", "meat"]
-    },
+    { "emoji": "🥓", "shortcodes": ["bacon"], "group": "food", "order": 52, "keywords": ["breakfast", "food", "meat"] },
     {
       "emoji": "🍔",
       "shortcodes": ["hamburger"],
@@ -4550,27 +4188,9 @@
       "order": 56,
       "keywords": ["dog", "frankfurter", "hot", "sausage"]
     },
-    {
-      "emoji": "🥪",
-      "shortcodes": ["sandwich"],
-      "group": "food",
-      "order": 57,
-      "keywords": ["bread"]
-    },
-    {
-      "emoji": "🌮",
-      "shortcodes": ["taco"],
-      "group": "food",
-      "order": 58,
-      "keywords": ["mexican"]
-    },
-    {
-      "emoji": "🌯",
-      "shortcodes": ["burrito"],
-      "group": "food",
-      "order": 59,
-      "keywords": ["mexican", "wrap"]
-    },
+    { "emoji": "🥪", "shortcodes": ["sandwich"], "group": "food", "order": 57, "keywords": ["bread"] },
+    { "emoji": "🌮", "shortcodes": ["taco"], "group": "food", "order": 58, "keywords": ["mexican"] },
+    { "emoji": "🌯", "shortcodes": ["burrito"], "group": "food", "order": 59, "keywords": ["mexican", "wrap"] },
     {
       "emoji": "🫔",
       "shortcodes": ["tamale"],
@@ -4585,20 +4205,8 @@
       "order": 61,
       "keywords": ["falafel", "flatbread", "food", "gyro", "kebab", "stuffed"]
     },
-    {
-      "emoji": "🧆",
-      "shortcodes": ["falafel"],
-      "group": "food",
-      "order": 62,
-      "keywords": ["chickpea", "meatball"]
-    },
-    {
-      "emoji": "🥚",
-      "shortcodes": ["egg"],
-      "group": "food",
-      "order": 63,
-      "keywords": ["breakfast", "food"]
-    },
+    { "emoji": "🧆", "shortcodes": ["falafel"], "group": "food", "order": 62, "keywords": ["chickpea", "meatball"] },
+    { "emoji": "🥚", "shortcodes": ["egg"], "group": "food", "order": 63, "keywords": ["breakfast", "food"] },
     {
       "emoji": "🍳",
       "shortcodes": ["fried_egg", "cooking"],
@@ -4641,20 +4249,8 @@
       "order": 69,
       "keywords": ["food", "green"]
     },
-    {
-      "emoji": "🍿",
-      "shortcodes": ["popcorn"],
-      "group": "food",
-      "order": 70,
-      "keywords": ["corn", "movie", "pop"]
-    },
-    {
-      "emoji": "🧈",
-      "shortcodes": ["butter"],
-      "group": "food",
-      "order": 71,
-      "keywords": ["dairy"]
-    },
+    { "emoji": "🍿", "shortcodes": ["popcorn"], "group": "food", "order": 70, "keywords": ["corn", "movie", "pop"] },
+    { "emoji": "🧈", "shortcodes": ["butter"], "group": "food", "order": 71, "keywords": ["dairy"] },
     {
       "emoji": "🧂",
       "shortcodes": ["salt"],
@@ -4669,13 +4265,7 @@
       "order": 73,
       "keywords": ["can", "canned", "food"]
     },
-    {
-      "emoji": "🍱",
-      "shortcodes": ["bento", "bento_box"],
-      "group": "food",
-      "order": 74,
-      "keywords": ["box", "food"]
-    },
+    { "emoji": "🍱", "shortcodes": ["bento", "bento_box"], "group": "food", "order": 74, "keywords": ["box", "food"] },
     {
       "emoji": "🍘",
       "shortcodes": ["rice_cracker"],
@@ -4732,13 +4322,7 @@
       "order": 82,
       "keywords": ["food", "kebab", "restaurant", "seafood", "skewer", "stick"]
     },
-    {
-      "emoji": "🍣",
-      "shortcodes": ["sushi"],
-      "group": "food",
-      "order": 83,
-      "keywords": ["food"]
-    },
+    { "emoji": "🍣", "shortcodes": ["sushi"], "group": "food", "order": 83, "keywords": ["food"] },
     {
       "emoji": "🍤",
       "shortcodes": ["fried_shrimp"],
@@ -4758,7 +4342,7 @@
       "shortcodes": ["moon_cake"],
       "group": "food",
       "order": 86,
-      "keywords": ["autumn", "cake", "festival", "moon", "yuèbǐng"]
+      "keywords": ["autumn", "cake", "festival", "moon", "yuebing"]
     },
     {
       "emoji": "🍡",
@@ -4772,7 +4356,7 @@
       "shortcodes": ["dumpling"],
       "group": "food",
       "order": 88,
-      "keywords": ["empanada", "gyōza", "jiaozi", "pierogi", "potsticker"]
+      "keywords": ["empanada", "gyoza", "jiaozi", "pierogi", "potsticker"]
     },
     {
       "emoji": "🥠",
@@ -5058,13 +4642,7 @@
       "order": 122,
       "keywords": ["beverage", "box", "juice", "straw", "sweet"]
     },
-    {
-      "emoji": "🧉",
-      "shortcodes": ["mate", "mate_drink"],
-      "group": "food",
-      "order": 123,
-      "keywords": ["drink"]
-    },
+    { "emoji": "🧉", "shortcodes": ["mate", "mate_drink"], "group": "food", "order": 123, "keywords": ["drink"] },
     {
       "emoji": "🧊",
       "shortcodes": ["ice_cube", "ice"],
@@ -5110,13 +4688,7 @@
         "yummy"
       ]
     },
-    {
-      "emoji": "🥄",
-      "shortcodes": ["spoon"],
-      "group": "food",
-      "order": 129,
-      "keywords": ["eat", "tableware"]
-    },
+    { "emoji": "🥄", "shortcodes": ["spoon"], "group": "food", "order": 129, "keywords": ["eat", "tableware"] },
     {
       "emoji": "🔪",
       "shortcodes": ["hocho", "knife", "kitchen_knife"],
@@ -5159,13 +4731,7 @@
       "order": 3,
       "keywords": ["earth", "globe", "internet", "meridians", "web", "world", "worldwide"]
     },
-    {
-      "emoji": "🗺️",
-      "shortcodes": ["world_map", "map"],
-      "group": "travel",
-      "order": 4,
-      "keywords": ["world"]
-    },
+    { "emoji": "🗺️", "shortcodes": ["world_map", "map"], "group": "travel", "order": 4, "keywords": ["world"] },
     {
       "emoji": "🗾",
       "shortcodes": ["japan", "japan_map", "map_of_japan"],
@@ -5187,13 +4753,7 @@
       "order": 8,
       "keywords": ["cold", "mountain", "snow", "snow-capped"]
     },
-    {
-      "emoji": "⛰️",
-      "shortcodes": ["mountain"],
-      "group": "travel",
-      "order": 10,
-      "keywords": []
-    },
+    { "emoji": "⛰️", "shortcodes": ["mountain"], "group": "travel", "order": 10, "keywords": [] },
     {
       "emoji": "🌋",
       "shortcodes": ["volcano"],
@@ -5208,13 +4768,7 @@
       "order": 13,
       "keywords": ["fuji", "mount", "mountain", "nature"]
     },
-    {
-      "emoji": "🏕️",
-      "shortcodes": ["camping"],
-      "group": "travel",
-      "order": 14,
-      "keywords": []
-    },
+    { "emoji": "🏕️", "shortcodes": ["camping"], "group": "travel", "order": 14, "keywords": [] },
     {
       "emoji": "🏖️",
       "shortcodes": ["beach_umbrella", "beach_with_umbrella", "beach"],
@@ -5222,13 +4776,7 @@
       "order": 16,
       "keywords": ["umbrella"]
     },
-    {
-      "emoji": "🏜️",
-      "shortcodes": ["desert"],
-      "group": "travel",
-      "order": 18,
-      "keywords": []
-    },
+    { "emoji": "🏜️", "shortcodes": ["desert"], "group": "travel", "order": 18, "keywords": [] },
     {
       "emoji": "🏝️",
       "shortcodes": ["desert_island", "island"],
@@ -5243,13 +4791,7 @@
       "order": 22,
       "keywords": ["national"]
     },
-    {
-      "emoji": "🏟️",
-      "shortcodes": ["stadium"],
-      "group": "travel",
-      "order": 24,
-      "keywords": []
-    },
+    { "emoji": "🏟️", "shortcodes": ["stadium"], "group": "travel", "order": 24, "keywords": [] },
     {
       "emoji": "🏛️",
       "shortcodes": ["classical_building"],
@@ -5278,13 +4820,7 @@
       "order": 31,
       "keywords": ["boulder", "heavy", "solid", "stone", "tough"]
     },
-    {
-      "emoji": "🪵",
-      "shortcodes": ["wood"],
-      "group": "travel",
-      "order": 32,
-      "keywords": ["log", "lumber", "timber"]
-    },
+    { "emoji": "🪵", "shortcodes": ["wood"], "group": "travel", "order": 32, "keywords": ["log", "lumber", "timber"] },
     {
       "emoji": "🛖",
       "shortcodes": ["hut"],
@@ -5361,20 +4897,8 @@
       "order": 43,
       "keywords": ["building", "doctor", "medicine"]
     },
-    {
-      "emoji": "🏦",
-      "shortcodes": ["bank"],
-      "group": "travel",
-      "order": 44,
-      "keywords": ["building"]
-    },
-    {
-      "emoji": "🏨",
-      "shortcodes": ["hotel"],
-      "group": "travel",
-      "order": 45,
-      "keywords": ["building"]
-    },
+    { "emoji": "🏦", "shortcodes": ["bank"], "group": "travel", "order": 44, "keywords": ["building"] },
+    { "emoji": "🏨", "shortcodes": ["hotel"], "group": "travel", "order": 45, "keywords": ["building"] },
     {
       "emoji": "🏩",
       "shortcodes": ["love_hotel"],
@@ -5389,13 +4913,7 @@
       "order": 47,
       "keywords": ["24", "building", "convenience", "hours", "store"]
     },
-    {
-      "emoji": "🏫",
-      "shortcodes": ["school"],
-      "group": "travel",
-      "order": 48,
-      "keywords": ["building"]
-    },
+    { "emoji": "🏫", "shortcodes": ["school"], "group": "travel", "order": 48, "keywords": ["building"] },
     {
       "emoji": "🏬",
       "shortcodes": ["department_store"],
@@ -5403,13 +4921,7 @@
       "order": 49,
       "keywords": ["building", "department", "store"]
     },
-    {
-      "emoji": "🏭",
-      "shortcodes": ["factory"],
-      "group": "travel",
-      "order": 50,
-      "keywords": ["building"]
-    },
+    { "emoji": "🏭", "shortcodes": ["factory"], "group": "travel", "order": 50, "keywords": ["building"] },
     {
       "emoji": "🏯",
       "shortcodes": ["japanese_castle"],
@@ -5431,13 +4943,7 @@
       "order": 53,
       "keywords": ["chapel", "hitched", "nuptials", "romance"]
     },
-    {
-      "emoji": "🗼",
-      "shortcodes": ["tokyo_tower"],
-      "group": "travel",
-      "order": 54,
-      "keywords": ["tokyo", "tower"]
-    },
+    { "emoji": "🗼", "shortcodes": ["tokyo_tower"], "group": "travel", "order": 54, "keywords": ["tokyo", "tower"] },
     {
       "emoji": "🗽",
       "shortcodes": ["statue_of_liberty"],
@@ -5459,13 +4965,7 @@
       "order": 57,
       "keywords": ["islam", "masjid", "muslim", "religion"]
     },
-    {
-      "emoji": "🛕",
-      "shortcodes": ["hindu_temple"],
-      "group": "travel",
-      "order": 58,
-      "keywords": ["hindu", "temple"]
-    },
+    { "emoji": "🛕", "shortcodes": ["hindu_temple"], "group": "travel", "order": 58, "keywords": ["hindu", "temple"] },
     {
       "emoji": "🕍",
       "shortcodes": ["synagogue"],
@@ -5487,27 +4987,9 @@
       "order": 62,
       "keywords": ["hajj", "islam", "muslim", "religion", "umrah"]
     },
-    {
-      "emoji": "⛲",
-      "shortcodes": ["fountain"],
-      "group": "travel",
-      "order": 63,
-      "keywords": []
-    },
-    {
-      "emoji": "⛺",
-      "shortcodes": ["tent"],
-      "group": "travel",
-      "order": 64,
-      "keywords": ["camping"]
-    },
-    {
-      "emoji": "🌁",
-      "shortcodes": ["foggy"],
-      "group": "travel",
-      "order": 65,
-      "keywords": ["fog"]
-    },
+    { "emoji": "⛲", "shortcodes": ["fountain"], "group": "travel", "order": 63, "keywords": [] },
+    { "emoji": "⛺", "shortcodes": ["tent"], "group": "travel", "order": 64, "keywords": ["camping"] },
+    { "emoji": "🌁", "shortcodes": ["foggy"], "group": "travel", "order": 65, "keywords": ["fog"] },
     {
       "emoji": "🌃",
       "shortcodes": ["night_with_stars"],
@@ -5515,13 +4997,7 @@
       "order": 66,
       "keywords": ["night", "star", "stars"]
     },
-    {
-      "emoji": "🏙️",
-      "shortcodes": ["cityscape"],
-      "group": "travel",
-      "order": 67,
-      "keywords": ["city"]
-    },
+    { "emoji": "🏙️", "shortcodes": ["cityscape"], "group": "travel", "order": 67, "keywords": ["city"] },
     {
       "emoji": "🌄",
       "shortcodes": ["sunrise_over_mountains"],
@@ -5592,13 +5068,7 @@
       "order": 80,
       "keywords": ["cut", "fresh", "haircut", "pole", "shave"]
     },
-    {
-      "emoji": "🎪",
-      "shortcodes": ["circus_tent"],
-      "group": "travel",
-      "order": 81,
-      "keywords": ["circus", "tent"]
-    },
+    { "emoji": "🎪", "shortcodes": ["circus_tent"], "group": "travel", "order": 81, "keywords": ["circus", "tent"] },
     {
       "emoji": "🚂",
       "shortcodes": ["steam_locomotive", "locomotive"],
@@ -5634,13 +5104,7 @@
       "order": 86,
       "keywords": ["arrived", "choo", "railway", "train"]
     },
-    {
-      "emoji": "🚇",
-      "shortcodes": ["metro"],
-      "group": "travel",
-      "order": 87,
-      "keywords": ["subway", "travel"]
-    },
+    { "emoji": "🚇", "shortcodes": ["metro"], "group": "travel", "order": 87, "keywords": ["subway", "travel"] },
     {
       "emoji": "🚈",
       "shortcodes": ["light_rail"],
@@ -5648,27 +5112,9 @@
       "order": 88,
       "keywords": ["arrived", "light", "monorail", "rail", "railway"]
     },
-    {
-      "emoji": "🚉",
-      "shortcodes": ["station"],
-      "group": "travel",
-      "order": 89,
-      "keywords": ["railway", "train"]
-    },
-    {
-      "emoji": "🚊",
-      "shortcodes": ["tram"],
-      "group": "travel",
-      "order": 90,
-      "keywords": ["trolleybus"]
-    },
-    {
-      "emoji": "🚝",
-      "shortcodes": ["monorail"],
-      "group": "travel",
-      "order": 91,
-      "keywords": ["vehicle"]
-    },
+    { "emoji": "🚉", "shortcodes": ["station"], "group": "travel", "order": 89, "keywords": ["railway", "train"] },
+    { "emoji": "🚊", "shortcodes": ["tram"], "group": "travel", "order": 90, "keywords": ["trolleybus"] },
+    { "emoji": "🚝", "shortcodes": ["monorail"], "group": "travel", "order": 91, "keywords": ["vehicle"] },
     {
       "emoji": "🚞",
       "shortcodes": ["mountain_railway"],
@@ -5683,13 +5129,7 @@
       "order": 93,
       "keywords": ["bus", "car", "tram", "trolley", "trolleybus"]
     },
-    {
-      "emoji": "🚌",
-      "shortcodes": ["bus"],
-      "group": "travel",
-      "order": 94,
-      "keywords": ["school", "vehicle"]
-    },
+    { "emoji": "🚌", "shortcodes": ["bus"], "group": "travel", "order": 94, "keywords": ["school", "vehicle"] },
     {
       "emoji": "🚍",
       "shortcodes": ["oncoming_bus"],
@@ -5730,7 +5170,7 @@
       "shortcodes": ["police_car"],
       "group": "travel",
       "order": 100,
-      "keywords": ["5–0", "car", "cops", "patrol", "police"]
+      "keywords": ["5 0", "car", "cops", "patrol", "police"]
     },
     {
       "emoji": "🚔",
@@ -5795,13 +5235,7 @@
       "order": 109,
       "keywords": ["articulated", "car", "drive", "lorry", "move", "semi", "truck", "vehicle"]
     },
-    {
-      "emoji": "🚜",
-      "shortcodes": ["tractor"],
-      "group": "travel",
-      "order": 110,
-      "keywords": ["vehicle"]
-    },
+    { "emoji": "🚜", "shortcodes": ["tractor"], "group": "travel", "order": 110, "keywords": ["vehicle"] },
     {
       "emoji": "🏎️",
       "shortcodes": ["racing_car", "race_car"],
@@ -5851,13 +5285,7 @@
       "order": 119,
       "keywords": ["class", "cycle", "cycling", "cyclist", "gang", "ride", "spin", "spinning"]
     },
-    {
-      "emoji": "🛴",
-      "shortcodes": ["kick_scooter", "scooter"],
-      "group": "travel",
-      "order": 120,
-      "keywords": ["kick"]
-    },
+    { "emoji": "🛴", "shortcodes": ["kick_scooter", "scooter"], "group": "travel", "order": 120, "keywords": ["kick"] },
     {
       "emoji": "🛹",
       "shortcodes": ["skateboard"],
@@ -5879,13 +5307,7 @@
       "order": 123,
       "keywords": ["bus", "stop"]
     },
-    {
-      "emoji": "🛣️",
-      "shortcodes": ["motorway"],
-      "group": "travel",
-      "order": 124,
-      "keywords": ["highway", "road"]
-    },
+    { "emoji": "🛣️", "shortcodes": ["motorway"], "group": "travel", "order": 124, "keywords": ["highway", "road"] },
     {
       "emoji": "🛤️",
       "shortcodes": ["railway_track", "railroad_track"],
@@ -5893,13 +5315,7 @@
       "order": 126,
       "keywords": ["railway", "track", "train"]
     },
-    {
-      "emoji": "🛢️",
-      "shortcodes": ["oil_drum", "oil"],
-      "group": "travel",
-      "order": 128,
-      "keywords": ["drum"]
-    },
+    { "emoji": "🛢️", "shortcodes": ["oil_drum", "oil"], "group": "travel", "order": 128, "keywords": ["drum"] },
     {
       "emoji": "⛽",
       "shortcodes": ["fuelpump", "fuel_pump"],
@@ -5935,20 +5351,8 @@
       "order": 135,
       "keywords": ["octagonal", "sign", "stop"]
     },
-    {
-      "emoji": "🚧",
-      "shortcodes": ["construction"],
-      "group": "travel",
-      "order": 136,
-      "keywords": ["barrier"]
-    },
-    {
-      "emoji": "⚓",
-      "shortcodes": ["anchor"],
-      "group": "travel",
-      "order": 137,
-      "keywords": ["ship", "tool"]
-    },
+    { "emoji": "🚧", "shortcodes": ["construction"], "group": "travel", "order": 136, "keywords": ["barrier"] },
+    { "emoji": "⚓", "shortcodes": ["anchor"], "group": "travel", "order": 137, "keywords": ["ship", "tool"] },
     {
       "emoji": "⛵",
       "shortcodes": ["boat", "sailboat"],
@@ -5956,13 +5360,7 @@
       "order": 139,
       "keywords": ["resort", "sailing", "sea", "yacht"]
     },
-    {
-      "emoji": "🛶",
-      "shortcodes": ["canoe", "kayak"],
-      "group": "travel",
-      "order": 140,
-      "keywords": ["boat"]
-    },
+    { "emoji": "🛶", "shortcodes": ["canoe", "kayak"], "group": "travel", "order": 140, "keywords": ["boat"] },
     {
       "emoji": "🚤",
       "shortcodes": ["speedboat"],
@@ -5977,13 +5375,7 @@
       "order": 142,
       "keywords": ["passenger", "ship"]
     },
-    {
-      "emoji": "⛴️",
-      "shortcodes": ["ferry"],
-      "group": "travel",
-      "order": 144,
-      "keywords": ["boat", "passenger"]
-    },
+    { "emoji": "⛴️", "shortcodes": ["ferry"], "group": "travel", "order": 144, "keywords": ["boat", "passenger"] },
     {
       "emoji": "🛥️",
       "shortcodes": ["motor_boat", "motorboat"],
@@ -6033,13 +5425,7 @@
       "order": 155,
       "keywords": ["hang-glide", "parasail", "skydive"]
     },
-    {
-      "emoji": "💺",
-      "shortcodes": ["seat"],
-      "group": "travel",
-      "order": 156,
-      "keywords": ["chair"]
-    },
+    { "emoji": "💺", "shortcodes": ["seat"], "group": "travel", "order": 156, "keywords": ["chair"] },
     {
       "emoji": "🚁",
       "shortcodes": ["helicopter"],
@@ -6117,13 +5503,7 @@
       "order": 169,
       "keywords": ["done", "flowing", "hourglass", "hours", "not", "sand", "timer", "waiting", "yolo"]
     },
-    {
-      "emoji": "⌚",
-      "shortcodes": ["watch"],
-      "group": "travel",
-      "order": 170,
-      "keywords": ["clock", "time"]
-    },
+    { "emoji": "⌚", "shortcodes": ["watch"], "group": "travel", "order": 170, "keywords": ["clock", "time"] },
     {
       "emoji": "⏰",
       "shortcodes": ["alarm_clock"],
@@ -6131,20 +5511,8 @@
       "order": 171,
       "keywords": ["alarm", "clock", "hours", "hrs", "late", "time", "waiting"]
     },
-    {
-      "emoji": "⏱️",
-      "shortcodes": ["stopwatch"],
-      "group": "travel",
-      "order": 172,
-      "keywords": ["clock", "time"]
-    },
-    {
-      "emoji": "⏲️",
-      "shortcodes": ["timer_clock", "timer"],
-      "group": "travel",
-      "order": 174,
-      "keywords": ["clock"]
-    },
+    { "emoji": "⏱️", "shortcodes": ["stopwatch"], "group": "travel", "order": 172, "keywords": ["clock", "time"] },
+    { "emoji": "⏲️", "shortcodes": ["timer_clock", "timer"], "group": "travel", "order": 174, "keywords": ["clock"] },
     {
       "emoji": "🕰️",
       "shortcodes": ["mantelpiece_clock", "clock", "mantlepiece_clock"],
@@ -6157,168 +5525,168 @@
       "shortcodes": ["clock12", "twelve_oclock"],
       "group": "travel",
       "order": 178,
-      "keywords": ["12", "12:00", "clock", "o’clock", "time", "twelve", "twelve o’clock"]
+      "keywords": ["12", "12 00", "clock", "o clock", "time", "twelve"]
     },
     {
       "emoji": "🕧",
       "shortcodes": ["clock1230", "twelve_thirty"],
       "group": "travel",
       "order": 179,
-      "keywords": ["12", "12:30", "30", "clock", "thirty", "time", "twelve"]
+      "keywords": ["12", "12 30", "30", "clock", "thirty", "time", "twelve"]
     },
     {
       "emoji": "🕐",
       "shortcodes": ["clock1", "one_oclock"],
       "group": "travel",
       "order": 180,
-      "keywords": ["1", "1:00", "clock", "one", "o’clock", "time", "one o’clock"]
+      "keywords": ["1", "1 00", "clock", "one", "o clock", "time"]
     },
     {
       "emoji": "🕜",
       "shortcodes": ["clock130", "one_thirty"],
       "group": "travel",
       "order": 181,
-      "keywords": ["1", "1:30", "30", "clock", "one", "thirty", "time"]
+      "keywords": ["1", "1 30", "30", "clock", "one", "thirty", "time"]
     },
     {
       "emoji": "🕑",
       "shortcodes": ["clock2", "two_oclock"],
       "group": "travel",
       "order": 182,
-      "keywords": ["2", "2:00", "clock", "o’clock", "time", "two", "two o’clock"]
+      "keywords": ["2", "2 00", "clock", "o clock", "time", "two"]
     },
     {
       "emoji": "🕝",
       "shortcodes": ["clock230", "two_thirty"],
       "group": "travel",
       "order": 183,
-      "keywords": ["2", "2:30", "30", "clock", "thirty", "time", "two"]
+      "keywords": ["2", "2 30", "30", "clock", "thirty", "time", "two"]
     },
     {
       "emoji": "🕒",
       "shortcodes": ["clock3", "three_oclock"],
       "group": "travel",
       "order": 184,
-      "keywords": ["3", "3:00", "clock", "o’clock", "three", "time", "three o’clock"]
+      "keywords": ["3", "3 00", "clock", "o clock", "three", "time"]
     },
     {
       "emoji": "🕞",
       "shortcodes": ["clock330", "three_thirty"],
       "group": "travel",
       "order": 185,
-      "keywords": ["3", "30", "3:30", "clock", "thirty", "three", "time"]
+      "keywords": ["3", "30", "3 30", "clock", "thirty", "three", "time"]
     },
     {
       "emoji": "🕓",
       "shortcodes": ["clock4", "four_oclock"],
       "group": "travel",
       "order": 186,
-      "keywords": ["4", "4:00", "clock", "four", "o’clock", "time", "four o’clock"]
+      "keywords": ["4", "4 00", "clock", "four", "o clock", "time"]
     },
     {
       "emoji": "🕟",
       "shortcodes": ["clock430", "four_thirty"],
       "group": "travel",
       "order": 187,
-      "keywords": ["30", "4", "4:30", "clock", "four", "thirty", "time"]
+      "keywords": ["30", "4", "4 30", "clock", "four", "thirty", "time"]
     },
     {
       "emoji": "🕔",
       "shortcodes": ["clock5", "five_oclock"],
       "group": "travel",
       "order": 188,
-      "keywords": ["5", "5:00", "clock", "five", "o’clock", "time", "five o’clock"]
+      "keywords": ["5", "5 00", "clock", "five", "o clock", "time"]
     },
     {
       "emoji": "🕠",
       "shortcodes": ["clock530", "five_thirty"],
       "group": "travel",
       "order": 189,
-      "keywords": ["30", "5", "5:30", "clock", "five", "thirty", "time"]
+      "keywords": ["30", "5", "5 30", "clock", "five", "thirty", "time"]
     },
     {
       "emoji": "🕕",
       "shortcodes": ["clock6", "six_oclock"],
       "group": "travel",
       "order": 190,
-      "keywords": ["6", "6:00", "clock", "o’clock", "six", "time", "six o’clock"]
+      "keywords": ["6", "6 00", "clock", "o clock", "six", "time"]
     },
     {
       "emoji": "🕡",
       "shortcodes": ["clock630", "six_thirty"],
       "group": "travel",
       "order": 191,
-      "keywords": ["30", "6", "6:30", "clock", "six", "thirty"]
+      "keywords": ["30", "6", "6 30", "clock", "six", "thirty"]
     },
     {
       "emoji": "🕖",
       "shortcodes": ["clock7", "seven_oclock"],
       "group": "travel",
       "order": 192,
-      "keywords": ["0", "7", "7:00", "clock", "o’clock", "seven", "seven o’clock"]
+      "keywords": ["0", "7", "7 00", "clock", "o clock", "seven"]
     },
     {
       "emoji": "🕢",
       "shortcodes": ["clock730", "seven_thirty"],
       "group": "travel",
       "order": 193,
-      "keywords": ["30", "7", "7:30", "clock", "seven", "thirty"]
+      "keywords": ["30", "7", "7 30", "clock", "seven", "thirty"]
     },
     {
       "emoji": "🕗",
       "shortcodes": ["clock8", "eight_oclock"],
       "group": "travel",
       "order": 194,
-      "keywords": ["8", "8:00", "clock", "eight", "o’clock", "time", "eight o’clock"]
+      "keywords": ["8", "8 00", "clock", "eight", "o clock", "time"]
     },
     {
       "emoji": "🕣",
       "shortcodes": ["clock830", "eight_thirty"],
       "group": "travel",
       "order": 195,
-      "keywords": ["30", "8", "8:30", "clock", "eight", "thirty", "time"]
+      "keywords": ["30", "8", "8 30", "clock", "eight", "thirty", "time"]
     },
     {
       "emoji": "🕘",
       "shortcodes": ["clock9", "nine_oclock"],
       "group": "travel",
       "order": 196,
-      "keywords": ["9", "9:00", "clock", "nine", "o’clock", "time", "nine o’clock"]
+      "keywords": ["9", "9 00", "clock", "nine", "o clock", "time"]
     },
     {
       "emoji": "🕤",
       "shortcodes": ["clock930", "nine_thirty"],
       "group": "travel",
       "order": 197,
-      "keywords": ["30", "9", "9:30", "clock", "nine", "thirty", "time"]
+      "keywords": ["30", "9", "9 30", "clock", "nine", "thirty", "time"]
     },
     {
       "emoji": "🕙",
       "shortcodes": ["clock10", "ten_oclock"],
       "group": "travel",
       "order": 198,
-      "keywords": ["0", "10", "10:00", "clock", "o’clock", "ten", "ten o’clock"]
+      "keywords": ["0", "10", "10 00", "clock", "o clock", "ten"]
     },
     {
       "emoji": "🕥",
       "shortcodes": ["clock1030", "ten_thirty"],
       "group": "travel",
       "order": 199,
-      "keywords": ["10", "10:30", "30", "clock", "ten", "thirty", "time"]
+      "keywords": ["10", "10 30", "30", "clock", "ten", "thirty", "time"]
     },
     {
       "emoji": "🕚",
       "shortcodes": ["clock11", "eleven_oclock"],
       "group": "travel",
       "order": 200,
-      "keywords": ["11", "11:00", "clock", "eleven", "o’clock", "time", "eleven o’clock"]
+      "keywords": ["11", "11 00", "clock", "eleven", "o clock", "time"]
     },
     {
       "emoji": "🕦",
       "shortcodes": ["clock1130", "eleven_thirty"],
       "group": "travel",
       "order": 201,
-      "keywords": ["11", "11:30", "30", "clock", "eleven", "thirty", "time"]
+      "keywords": ["11", "11 30", "30", "clock", "eleven", "thirty", "time"]
     },
     {
       "emoji": "🌑",
@@ -6404,13 +5772,7 @@
       "order": 213,
       "keywords": ["dreams", "face", "last", "moon", "quarter"]
     },
-    {
-      "emoji": "🌡️",
-      "shortcodes": ["thermometer"],
-      "group": "travel",
-      "order": 214,
-      "keywords": ["weather"]
-    },
+    { "emoji": "🌡️", "shortcodes": ["thermometer"], "group": "travel", "order": 214, "keywords": ["weather"] },
     {
       "emoji": "☀️",
       "shortcodes": ["sunny", "sun"],
@@ -6467,13 +5829,7 @@
       "order": 224,
       "keywords": ["milky", "space", "way"]
     },
-    {
-      "emoji": "☁️",
-      "shortcodes": ["cloud"],
-      "group": "travel",
-      "order": 225,
-      "keywords": ["weather"]
-    },
+    { "emoji": "☁️", "shortcodes": ["cloud"], "group": "travel", "order": 225, "keywords": ["weather"] },
     {
       "emoji": "⛅",
       "shortcodes": ["partly_sunny"],
@@ -6556,13 +5912,7 @@
       "order": 242,
       "keywords": ["cloud", "weather", "whirlwind"]
     },
-    {
-      "emoji": "🌫️",
-      "shortcodes": ["fog"],
-      "group": "travel",
-      "order": 244,
-      "keywords": ["cloud", "weather"]
-    },
+    { "emoji": "🌫️", "shortcodes": ["fog"], "group": "travel", "order": 244, "keywords": ["cloud", "weather"] },
     {
       "emoji": "🌬️",
       "shortcodes": ["wind_face", "wind_blowing_face"],
@@ -6666,13 +6016,7 @@
       "order": 261,
       "keywords": ["cold", "man", "snow"]
     },
-    {
-      "emoji": "☄️",
-      "shortcodes": ["comet"],
-      "group": "travel",
-      "order": 262,
-      "keywords": ["space"]
-    },
+    { "emoji": "☄️", "shortcodes": ["comet"], "group": "travel", "order": 262, "keywords": ["space"] },
     {
       "emoji": "🔥",
       "shortcodes": ["fire", "lit", "hot", "flame"],
@@ -6734,7 +6078,7 @@
       "shortcodes": ["sparkles"],
       "group": "activities",
       "order": 5,
-      "keywords": ["*", "magic", "sparkle", "star"]
+      "keywords": ["magic", "sparkle", "star"]
     },
     {
       "emoji": "🎈",
@@ -6804,15 +6148,9 @@
       "shortcodes": ["red_envelope"],
       "group": "activities",
       "order": 15,
-      "keywords": ["envelope", "gift", "good", "hóngbāo", "lai", "luck", "money", "red", "see"]
+      "keywords": ["envelope", "gift", "good", "hongbao", "lai", "luck", "money", "red", "see"]
     },
-    {
-      "emoji": "🎀",
-      "shortcodes": ["ribbon"],
-      "group": "activities",
-      "order": 16,
-      "keywords": ["celebration"]
-    },
+    { "emoji": "🎀", "shortcodes": ["ribbon"], "group": "activities", "order": 16, "keywords": ["celebration"] },
     {
       "emoji": "🎁",
       "shortcodes": ["gift", "wrapped_gift"],
@@ -6834,13 +6172,7 @@
       "order": 20,
       "keywords": ["admission", "ticket"]
     },
-    {
-      "emoji": "🎫",
-      "shortcodes": ["ticket"],
-      "group": "activities",
-      "order": 22,
-      "keywords": ["admission", "stub"]
-    },
+    { "emoji": "🎫", "shortcodes": ["ticket"], "group": "activities", "order": 22, "keywords": ["admission", "stub"] },
     {
       "emoji": "🎖️",
       "shortcodes": ["medal_military", "medal", "military_medal"],
@@ -6890,13 +6222,7 @@
       "order": 30,
       "keywords": ["ball", "football", "futbol", "sport"]
     },
-    {
-      "emoji": "⚾",
-      "shortcodes": ["baseball"],
-      "group": "activities",
-      "order": 31,
-      "keywords": ["ball", "sport"]
-    },
+    { "emoji": "⚾", "shortcodes": ["baseball"], "group": "activities", "order": 31, "keywords": ["ball", "sport"] },
     {
       "emoji": "🥎",
       "shortcodes": ["softball"],
@@ -6911,13 +6237,7 @@
       "order": 33,
       "keywords": ["ball", "hoop", "sport"]
     },
-    {
-      "emoji": "🏐",
-      "shortcodes": ["volleyball"],
-      "group": "activities",
-      "order": 34,
-      "keywords": ["ball", "game"]
-    },
+    { "emoji": "🏐", "shortcodes": ["volleyball"], "group": "activities", "order": 34, "keywords": ["ball", "game"] },
     {
       "emoji": "🏈",
       "shortcodes": ["football", "american_football"],
@@ -7009,13 +6329,7 @@
       "order": 47,
       "keywords": ["arts", "judo", "karate", "martial", "taekwondo", "uniform"]
     },
-    {
-      "emoji": "🥅",
-      "shortcodes": ["goal_net", "goal"],
-      "group": "activities",
-      "order": 48,
-      "keywords": ["net"]
-    },
+    { "emoji": "🥅", "shortcodes": ["goal_net", "goal"], "group": "activities", "order": 48, "keywords": ["net"] },
     {
       "emoji": "⛳",
       "shortcodes": ["golf", "flag_in_hole"],
@@ -7051,13 +6365,7 @@
       "order": 54,
       "keywords": ["athletics", "running", "sash", "shirt"]
     },
-    {
-      "emoji": "🎿",
-      "shortcodes": ["ski", "skis"],
-      "group": "activities",
-      "order": 55,
-      "keywords": ["snow", "sport"]
-    },
+    { "emoji": "🎿", "shortcodes": ["ski", "skis"], "group": "activities", "order": 55, "keywords": ["snow", "sport"] },
     {
       "emoji": "🛷",
       "shortcodes": ["sled"],
@@ -7086,13 +6394,7 @@
       "order": 59,
       "keywords": ["fluctuate", "toy"]
     },
-    {
-      "emoji": "🪁",
-      "shortcodes": ["kite"],
-      "group": "activities",
-      "order": 60,
-      "keywords": ["fly", "soar"]
-    },
+    { "emoji": "🪁", "shortcodes": ["kite"], "group": "activities", "order": 60, "keywords": ["fly", "soar"] },
     {
       "emoji": "🔫",
       "shortcodes": ["gun", "pistol", "water_pistol"],
@@ -7168,7 +6470,7 @@
       "shortcodes": ["pinata"],
       "group": "activities",
       "order": 72,
-      "keywords": ["candy", "celebrate", "celebration", "cinco", "de", "festive", "mayo", "party", "pinada", "piñata"]
+      "keywords": ["candy", "celebrate", "celebration", "cinco", "de", "festive", "mayo", "party", "pinada"]
     },
     {
       "emoji": "🪆",
@@ -7367,13 +6669,7 @@
       "order": 9,
       "keywords": ["bundle", "cold", "neck", "up"]
     },
-    {
-      "emoji": "🧤",
-      "shortcodes": ["gloves"],
-      "group": "objects",
-      "order": 10,
-      "keywords": ["hand"]
-    },
+    { "emoji": "🧤", "shortcodes": ["gloves"], "group": "objects", "order": 10, "keywords": ["hand"] },
     {
       "emoji": "🧥",
       "shortcodes": ["coat"],
@@ -7381,13 +6677,7 @@
       "order": 11,
       "keywords": ["brr", "bundle", "cold", "jacket", "up"]
     },
-    {
-      "emoji": "🧦",
-      "shortcodes": ["socks"],
-      "group": "objects",
-      "order": 12,
-      "keywords": ["stocking"]
-    },
+    { "emoji": "🧦", "shortcodes": ["socks"], "group": "objects", "order": 12, "keywords": ["stocking"] },
     {
       "emoji": "👗",
       "shortcodes": ["dress"],
@@ -7402,13 +6692,7 @@
       "order": 14,
       "keywords": ["clothing", "comfortable"]
     },
-    {
-      "emoji": "🥻",
-      "shortcodes": ["sari"],
-      "group": "objects",
-      "order": 15,
-      "keywords": ["clothing", "dress"]
-    },
+    { "emoji": "🥻", "shortcodes": ["sari"], "group": "objects", "order": 15, "keywords": ["clothing", "dress"] },
     {
       "emoji": "🩱",
       "shortcodes": ["one_piece_swimsuit", "one-piece_swimsuit"],
@@ -7453,8 +6737,7 @@
         "shirt",
         "shopping",
         "woman",
-        "woman’s",
-        "woman’s clothes"
+        "woman s"
       ]
     },
     {
@@ -7497,26 +6780,14 @@
       "shortcodes": ["thong_sandal"],
       "group": "objects",
       "order": 28,
-      "keywords": ["beach", "flip", "flop", "sandal", "sandals", "shoe", "thong", "thongs", "zōri"]
+      "keywords": ["beach", "flip", "flop", "sandal", "sandals", "shoe", "thong", "thongs", "zori"]
     },
     {
       "emoji": "👞",
       "shortcodes": ["mans_shoe", "shoe"],
       "group": "objects",
       "order": 29,
-      "keywords": [
-        "brown",
-        "clothes",
-        "clothing",
-        "feet",
-        "foot",
-        "kick",
-        "man",
-        "man’s",
-        "shoes",
-        "shopping",
-        "man’s shoe"
-      ]
+      "keywords": ["brown", "clothes", "clothing", "feet", "foot", "kick", "man", "man s", "shoes", "shopping"]
     },
     {
       "emoji": "👟",
@@ -7564,7 +6835,7 @@
       "shortcodes": ["sandal", "womans_sandal"],
       "group": "objects",
       "order": 34,
-      "keywords": ["clothing", "shoe", "woman", "woman’s", "woman’s sandal"]
+      "keywords": ["clothing", "shoe", "woman", "woman s"]
     },
     {
       "emoji": "🩰",
@@ -7578,7 +6849,7 @@
       "shortcodes": ["boot", "womans_boot"],
       "group": "objects",
       "order": 36,
-      "keywords": ["clothes", "clothing", "dress", "shoe", "shoes", "shopping", "woman", "woman’s", "woman’s boot"]
+      "keywords": ["clothes", "clothing", "dress", "shoe", "shoes", "shopping", "woman", "woman s"]
     },
     {
       "emoji": "👑",
@@ -7592,7 +6863,7 @@
       "shortcodes": ["womans_hat"],
       "group": "objects",
       "order": 39,
-      "keywords": ["clothes", "clothing", "garden", "hat", "hats", "party", "woman", "woman’s", "woman’s hat"]
+      "keywords": ["clothes", "clothing", "garden", "hat", "hats", "party", "woman", "woman s"]
     },
     {
       "emoji": "🎩",
@@ -7627,7 +6898,7 @@
       "shortcodes": ["rescue_worker_helmet", "helmet_with_white_cross", "helmet_with_cross", "rescue_workers_helmet"],
       "group": "objects",
       "order": 44,
-      "keywords": ["aid", "cross", "face", "hat", "helmet", "rescue", "worker’s", "rescue worker’s helmet"]
+      "keywords": ["aid", "cross", "face", "hat", "helmet", "rescue", "worker s"]
     },
     {
       "emoji": "📿",
@@ -7811,27 +7082,9 @@
       "order": 74,
       "keywords": ["instrument", "keyboard", "music", "musical", "piano"]
     },
-    {
-      "emoji": "🎺",
-      "shortcodes": ["trumpet"],
-      "group": "objects",
-      "order": 75,
-      "keywords": ["instrument", "music"]
-    },
-    {
-      "emoji": "🎻",
-      "shortcodes": ["violin"],
-      "group": "objects",
-      "order": 76,
-      "keywords": ["instrument", "music"]
-    },
-    {
-      "emoji": "🪕",
-      "shortcodes": ["banjo"],
-      "group": "objects",
-      "order": 77,
-      "keywords": ["music", "stringed"]
-    },
+    { "emoji": "🎺", "shortcodes": ["trumpet"], "group": "objects", "order": 75, "keywords": ["instrument", "music"] },
+    { "emoji": "🎻", "shortcodes": ["violin"], "group": "objects", "order": 76, "keywords": ["instrument", "music"] },
+    { "emoji": "🪕", "shortcodes": ["banjo"], "group": "objects", "order": 77, "keywords": ["music", "stringed"] },
     {
       "emoji": "🥁",
       "shortcodes": ["drum", "drum_with_drumsticks"],
@@ -7860,13 +7113,7 @@
       "order": 84,
       "keywords": ["arrow", "build", "call", "cell", "communication", "mobile", "phone", "receive", "telephone"]
     },
-    {
-      "emoji": "☎️",
-      "shortcodes": ["phone", "telephone"],
-      "group": "objects",
-      "order": 85,
-      "keywords": []
-    },
+    { "emoji": "☎️", "shortcodes": ["phone", "telephone"], "group": "objects", "order": 85, "keywords": [] },
     {
       "emoji": "📞",
       "shortcodes": ["telephone_receiver"],
@@ -7874,13 +7121,7 @@
       "order": 87,
       "keywords": ["communication", "phone", "receiver", "telephone", "voip"]
     },
-    {
-      "emoji": "📟",
-      "shortcodes": ["pager"],
-      "group": "objects",
-      "order": 88,
-      "keywords": ["communication"]
-    },
+    { "emoji": "📟", "shortcodes": ["pager"], "group": "objects", "order": 88, "keywords": ["communication"] },
     {
       "emoji": "📠",
       "shortcodes": ["fax", "fax_machine"],
@@ -7888,13 +7129,7 @@
       "order": 89,
       "keywords": ["communication", "machine"]
     },
-    {
-      "emoji": "🔋",
-      "shortcodes": ["battery"],
-      "group": "objects",
-      "order": 90,
-      "keywords": []
-    },
+    { "emoji": "🔋", "shortcodes": ["battery"], "group": "objects", "order": 90, "keywords": [] },
     {
       "emoji": "🔌",
       "shortcodes": ["electric_plug"],
@@ -7916,20 +7151,8 @@
       "order": 94,
       "keywords": ["computer", "monitor"]
     },
-    {
-      "emoji": "🖨️",
-      "shortcodes": ["printer"],
-      "group": "objects",
-      "order": 96,
-      "keywords": ["computer"]
-    },
-    {
-      "emoji": "⌨️",
-      "shortcodes": ["keyboard"],
-      "group": "objects",
-      "order": 98,
-      "keywords": ["computer"]
-    },
+    { "emoji": "🖨️", "shortcodes": ["printer"], "group": "objects", "order": 96, "keywords": ["computer"] },
+    { "emoji": "⌨️", "shortcodes": ["keyboard"], "group": "objects", "order": 98, "keywords": ["computer"] },
     {
       "emoji": "🖱️",
       "shortcodes": ["computer_mouse", "three_button_mouse", "mouse_three_button"],
@@ -7937,13 +7160,7 @@
       "order": 100,
       "keywords": ["computer", "mouse"]
     },
-    {
-      "emoji": "🖲️",
-      "shortcodes": ["trackball"],
-      "group": "objects",
-      "order": 102,
-      "keywords": ["computer"]
-    },
+    { "emoji": "🖲️", "shortcodes": ["trackball"], "group": "objects", "order": 102, "keywords": ["computer"] },
     {
       "emoji": "💽",
       "shortcodes": ["minidisc", "computer_disk"],
@@ -8007,13 +7224,7 @@
       "order": 114,
       "keywords": ["action", "board", "movie"]
     },
-    {
-      "emoji": "📺",
-      "shortcodes": ["tv", "television"],
-      "group": "objects",
-      "order": 115,
-      "keywords": ["video"]
-    },
+    { "emoji": "📺", "shortcodes": ["tv", "television"], "group": "objects", "order": 115, "keywords": ["video"] },
     {
       "emoji": "📷",
       "shortcodes": ["camera"],
@@ -8067,13 +7278,7 @@
         "tool"
       ]
     },
-    {
-      "emoji": "🕯️",
-      "shortcodes": ["candle"],
-      "group": "objects",
-      "order": 122,
-      "keywords": ["light"]
-    },
+    { "emoji": "🕯️", "shortcodes": ["candle"], "group": "objects", "order": 122, "keywords": ["light"] },
     {
       "emoji": "💡",
       "shortcodes": ["bulb", "idea", "lightbulb_idea", "light_bulb"],
@@ -8151,20 +7356,8 @@
       "order": 134,
       "keywords": ["book", "education", "fantasy", "knowledge", "library", "novels", "reading", "school", "study"]
     },
-    {
-      "emoji": "📓",
-      "shortcodes": ["notebook"],
-      "group": "objects",
-      "order": 135,
-      "keywords": []
-    },
-    {
-      "emoji": "📒",
-      "shortcodes": ["ledger"],
-      "group": "objects",
-      "order": 136,
-      "keywords": ["notebook"]
-    },
+    { "emoji": "📓", "shortcodes": ["notebook"], "group": "objects", "order": 135, "keywords": [] },
+    { "emoji": "📒", "shortcodes": ["ledger"], "group": "objects", "order": 136, "keywords": ["notebook"] },
     {
       "emoji": "📃",
       "shortcodes": ["page_with_curl"],
@@ -8172,13 +7365,7 @@
       "order": 137,
       "keywords": ["curl", "document", "page", "paper"]
     },
-    {
-      "emoji": "📜",
-      "shortcodes": ["scroll"],
-      "group": "objects",
-      "order": 138,
-      "keywords": ["paper"]
-    },
+    { "emoji": "📜", "shortcodes": ["scroll"], "group": "objects", "order": 138, "keywords": ["paper"] },
     {
       "emoji": "📄",
       "shortcodes": ["page_facing_up"],
@@ -8207,20 +7394,8 @@
       "order": 143,
       "keywords": ["bookmark", "mark", "marker", "tabs"]
     },
-    {
-      "emoji": "🔖",
-      "shortcodes": ["bookmark"],
-      "group": "objects",
-      "order": 144,
-      "keywords": ["mark"]
-    },
-    {
-      "emoji": "🏷️",
-      "shortcodes": ["label"],
-      "group": "objects",
-      "order": 145,
-      "keywords": ["tag"]
-    },
+    { "emoji": "🔖", "shortcodes": ["bookmark"], "group": "objects", "order": 144, "keywords": ["mark"] },
+    { "emoji": "🏷️", "shortcodes": ["label"], "group": "objects", "order": 145, "keywords": ["tag"] },
     {
       "emoji": "💰",
       "shortcodes": ["moneybag", "money_bag"],
@@ -8332,13 +7507,7 @@
         "yen"
       ]
     },
-    {
-      "emoji": "✉️",
-      "shortcodes": ["email", "envelope"],
-      "group": "objects",
-      "order": 157,
-      "keywords": ["letter"]
-    },
+    { "emoji": "✉️", "shortcodes": ["email", "envelope"], "group": "objects", "order": 157, "keywords": ["letter"] },
     {
       "emoji": "📧",
       "shortcodes": ["e-mail", "e_mail"],
@@ -8409,13 +7578,7 @@
       "order": 168,
       "keywords": ["flag", "lowered", "mail", "mailbox", "open", "postbox"]
     },
-    {
-      "emoji": "📮",
-      "shortcodes": ["postbox"],
-      "group": "objects",
-      "order": 169,
-      "keywords": ["mail", "mailbox"]
-    },
+    { "emoji": "📮", "shortcodes": ["postbox"], "group": "objects", "order": 169, "keywords": ["mail", "mailbox"] },
     {
       "emoji": "🗳️",
       "shortcodes": ["ballot_box", "ballot_box_with_ballot"],
@@ -8423,13 +7586,7 @@
       "order": 170,
       "keywords": ["ballot", "box"]
     },
-    {
-      "emoji": "✏️",
-      "shortcodes": ["pencil2"],
-      "group": "objects",
-      "order": 172,
-      "keywords": ["pencil"]
-    },
+    { "emoji": "✏️", "shortcodes": ["pencil2"], "group": "objects", "order": 172, "keywords": ["pencil"] },
     {
       "emoji": "✒️",
       "shortcodes": ["black_nib"],
@@ -8458,13 +7615,7 @@
       "order": 180,
       "keywords": ["painting"]
     },
-    {
-      "emoji": "🖍️",
-      "shortcodes": ["crayon", "lower_left_crayon"],
-      "group": "objects",
-      "order": 182,
-      "keywords": []
-    },
+    { "emoji": "🖍️", "shortcodes": ["crayon", "lower_left_crayon"], "group": "objects", "order": 182, "keywords": [] },
     {
       "emoji": "📝",
       "shortcodes": ["memo", "pencil"],
@@ -8472,20 +7623,8 @@
       "order": 184,
       "keywords": ["communication", "media", "notes"]
     },
-    {
-      "emoji": "💼",
-      "shortcodes": ["briefcase"],
-      "group": "objects",
-      "order": 185,
-      "keywords": ["office"]
-    },
-    {
-      "emoji": "📁",
-      "shortcodes": ["file_folder"],
-      "group": "objects",
-      "order": 186,
-      "keywords": ["file", "folder"]
-    },
+    { "emoji": "💼", "shortcodes": ["briefcase"], "group": "objects", "order": 185, "keywords": ["office"] },
+    { "emoji": "📁", "shortcodes": ["file_folder"], "group": "objects", "order": 186, "keywords": ["file", "folder"] },
     {
       "emoji": "📂",
       "shortcodes": ["open_file_folder"],
@@ -8500,13 +7639,7 @@
       "order": 188,
       "keywords": ["card", "index"]
     },
-    {
-      "emoji": "📅",
-      "shortcodes": ["date"],
-      "group": "objects",
-      "order": 190,
-      "keywords": ["calendar"]
-    },
+    { "emoji": "📅", "shortcodes": ["date"], "group": "objects", "order": 190, "keywords": ["calendar"] },
     {
       "emoji": "📆",
       "shortcodes": ["calendar", "tear_off_calendar"],
@@ -8563,13 +7696,7 @@
       "order": 200,
       "keywords": ["do", "list", "notes"]
     },
-    {
-      "emoji": "📌",
-      "shortcodes": ["pushpin", "pin"],
-      "group": "objects",
-      "order": 201,
-      "keywords": ["collage"]
-    },
+    { "emoji": "📌", "shortcodes": ["pushpin", "pin"], "group": "objects", "order": 201, "keywords": ["collage"] },
     {
       "emoji": "📍",
       "shortcodes": ["round_pushpin"],
@@ -8577,13 +7704,7 @@
       "order": 202,
       "keywords": ["location", "map", "pin", "pushpin", "round"]
     },
-    {
-      "emoji": "📎",
-      "shortcodes": ["paperclip"],
-      "group": "objects",
-      "order": 203,
-      "keywords": []
-    },
+    { "emoji": "📎", "shortcodes": ["paperclip"], "group": "objects", "order": 203, "keywords": [] },
     {
       "emoji": "🖇️",
       "shortcodes": ["paperclips", "linked_paperclips"],
@@ -8745,13 +7866,7 @@
       "order": 237,
       "keywords": ["archer", "arrow", "bow", "sagittarius", "tool", "weapon", "zodiac"]
     },
-    {
-      "emoji": "🛡️",
-      "shortcodes": ["shield"],
-      "group": "objects",
-      "order": 238,
-      "keywords": ["weapon"]
-    },
+    { "emoji": "🛡️", "shortcodes": ["shield"], "group": "objects", "order": 238, "keywords": ["weapon"] },
     {
       "emoji": "🪚",
       "shortcodes": ["carpentry_saw"],
@@ -8808,20 +7923,8 @@
       "order": 250,
       "keywords": ["accessibility", "blind", "cane", "probing", "white"]
     },
-    {
-      "emoji": "🔗",
-      "shortcodes": ["link"],
-      "group": "objects",
-      "order": 251,
-      "keywords": ["links"]
-    },
-    {
-      "emoji": "⛓️",
-      "shortcodes": ["chains"],
-      "group": "objects",
-      "order": 254,
-      "keywords": ["chain"]
-    },
+    { "emoji": "🔗", "shortcodes": ["link"], "group": "objects", "order": 251, "keywords": ["links"] },
+    { "emoji": "⛓️", "shortcodes": ["chains"], "group": "objects", "order": 254, "keywords": ["chain"] },
     {
       "emoji": "🪝",
       "shortcodes": ["hook"],
@@ -8850,13 +7953,7 @@
       "order": 259,
       "keywords": ["climb", "rung", "step"]
     },
-    {
-      "emoji": "⚗️",
-      "shortcodes": ["alembic"],
-      "group": "objects",
-      "order": 261,
-      "keywords": ["chemistry", "tool"]
-    },
+    { "emoji": "⚗️", "shortcodes": ["alembic"], "group": "objects", "order": 261, "keywords": ["chemistry", "tool"] },
     {
       "emoji": "🧪",
       "shortcodes": ["test_tube"],
@@ -8962,13 +8059,7 @@
       "order": 279,
       "keywords": ["air", "frame", "fresh", "opening", "transparent", "view"]
     },
-    {
-      "emoji": "🛏️",
-      "shortcodes": ["bed"],
-      "group": "objects",
-      "order": 280,
-      "keywords": ["hotel", "sleep"]
-    },
+    { "emoji": "🛏️", "shortcodes": ["bed"], "group": "objects", "order": 280, "keywords": ["hotel", "sleep"] },
     {
       "emoji": "🛋️",
       "shortcodes": ["couch_and_lamp", "couch"],
@@ -8976,20 +8067,8 @@
       "order": 282,
       "keywords": ["hotel", "lamp"]
     },
-    {
-      "emoji": "🪑",
-      "shortcodes": ["chair"],
-      "group": "objects",
-      "order": 284,
-      "keywords": ["seat", "sit"]
-    },
-    {
-      "emoji": "🚽",
-      "shortcodes": ["toilet"],
-      "group": "objects",
-      "order": 285,
-      "keywords": ["bathroom"]
-    },
+    { "emoji": "🪑", "shortcodes": ["chair"], "group": "objects", "order": 284, "keywords": ["seat", "sit"] },
+    { "emoji": "🚽", "shortcodes": ["toilet"], "group": "objects", "order": 285, "keywords": ["bathroom"] },
     {
       "emoji": "🪠",
       "shortcodes": ["plunger"],
@@ -8997,20 +8076,8 @@
       "order": 286,
       "keywords": ["cup", "force", "plumber", "poop", "suction", "toilet"]
     },
-    {
-      "emoji": "🚿",
-      "shortcodes": ["shower"],
-      "group": "objects",
-      "order": 287,
-      "keywords": ["water"]
-    },
-    {
-      "emoji": "🛁",
-      "shortcodes": ["bathtub"],
-      "group": "objects",
-      "order": 288,
-      "keywords": ["bath"]
-    },
+    { "emoji": "🚿", "shortcodes": ["shower"], "group": "objects", "order": 287, "keywords": ["water"] },
+    { "emoji": "🛁", "shortcodes": ["bathtub"], "group": "objects", "order": 288, "keywords": ["bath"] },
     {
       "emoji": "🪤",
       "shortcodes": ["mouse_trap"],
@@ -9018,13 +8085,7 @@
       "order": 289,
       "keywords": ["bait", "cheese", "lure", "mouse", "snare", "trap"]
     },
-    {
-      "emoji": "🪒",
-      "shortcodes": ["razor"],
-      "group": "objects",
-      "order": 290,
-      "keywords": ["sharp", "shave"]
-    },
+    { "emoji": "🪒", "shortcodes": ["razor"], "group": "objects", "order": 290, "keywords": ["sharp", "shave"] },
     {
       "emoji": "🧴",
       "shortcodes": ["lotion_bottle", "squeeze_bottle"],
@@ -9060,13 +8121,7 @@
       "order": 295,
       "keywords": ["paper", "roll", "toilet", "towels"]
     },
-    {
-      "emoji": "🪣",
-      "shortcodes": ["bucket"],
-      "group": "objects",
-      "order": 296,
-      "keywords": ["cask", "pail", "vat"]
-    },
+    { "emoji": "🪣", "shortcodes": ["bucket"], "group": "objects", "order": 296, "keywords": ["cask", "pail", "vat"] },
     {
       "emoji": "🧼",
       "shortcodes": ["soap"],
@@ -9102,13 +8157,7 @@
       "order": 302,
       "keywords": ["cart", "shopping", "trolley"]
     },
-    {
-      "emoji": "🚬",
-      "shortcodes": ["smoking", "cigarette"],
-      "group": "objects",
-      "order": 303,
-      "keywords": []
-    },
+    { "emoji": "🚬", "shortcodes": ["smoking", "cigarette"], "group": "objects", "order": 303, "keywords": [] },
     {
       "emoji": "⚰️",
       "shortcodes": ["coffin"],
@@ -9184,14 +8233,14 @@
       "shortcodes": ["mens", "mens_room"],
       "group": "symbols",
       "order": 4,
-      "keywords": ["bathroom", "lavatory", "man", "men’s", "restroom", "room", "toilet", "wc", "men’s room"]
+      "keywords": ["bathroom", "lavatory", "man", "restroom", "room", "toilet", "wc"]
     },
     {
       "emoji": "🚺",
       "shortcodes": ["womens", "womens_room"],
       "group": "symbols",
       "order": 5,
-      "keywords": ["bathroom", "lavatory", "restroom", "room", "toilet", "wc", "woman", "women’s", "women’s room"]
+      "keywords": ["bathroom", "lavatory", "restroom", "room", "toilet", "wc", "woman"]
     },
     {
       "emoji": "🚻",
@@ -9221,13 +8270,7 @@
       "order": 9,
       "keywords": ["control", "passport"]
     },
-    {
-      "emoji": "🛃",
-      "shortcodes": ["customs"],
-      "group": "symbols",
-      "order": 10,
-      "keywords": ["packing"]
-    },
+    { "emoji": "🛃", "shortcodes": ["customs"], "group": "symbols", "order": 10, "keywords": ["packing"] },
     {
       "emoji": "🛄",
       "shortcodes": ["baggage_claim"],
@@ -9458,27 +8501,9 @@
       "order": 58,
       "keywords": ["again", "anticlockwise", "arrow", "arrows", "button", "deja", "refresh", "rewindershins", "vu"]
     },
-    {
-      "emoji": "🔙",
-      "shortcodes": ["back", "back_arrow"],
-      "group": "symbols",
-      "order": 59,
-      "keywords": ["arrow"]
-    },
-    {
-      "emoji": "🔚",
-      "shortcodes": ["end", "end_arrow"],
-      "group": "symbols",
-      "order": 60,
-      "keywords": ["arrow"]
-    },
-    {
-      "emoji": "🔛",
-      "shortcodes": ["on", "on_arrow"],
-      "group": "symbols",
-      "order": 61,
-      "keywords": ["arrow", "mark", "on!", "on! arrow"]
-    },
+    { "emoji": "🔙", "shortcodes": ["back", "back_arrow"], "group": "symbols", "order": 59, "keywords": ["arrow"] },
+    { "emoji": "🔚", "shortcodes": ["end", "end_arrow"], "group": "symbols", "order": 60, "keywords": ["arrow"] },
+    { "emoji": "🔛", "shortcodes": ["on", "on_arrow"], "group": "symbols", "order": 61, "keywords": ["arrow", "mark"] },
     {
       "emoji": "🔜",
       "shortcodes": ["soon", "soon_arrow"],
@@ -9612,13 +8637,7 @@
       "order": 90,
       "keywords": ["horoscope", "lion", "zodiac"]
     },
-    {
-      "emoji": "♍",
-      "shortcodes": ["virgo"],
-      "group": "symbols",
-      "order": 91,
-      "keywords": ["horoscope", "zodiac"]
-    },
+    { "emoji": "♍", "shortcodes": ["virgo"], "group": "symbols", "order": 91, "keywords": ["horoscope", "zodiac"] },
     {
       "emoji": "♎",
       "shortcodes": ["libra"],
@@ -9873,28 +8892,22 @@
       "shortcodes": ["heavy_multiplication_x", "multiplication", "multiply"],
       "group": "symbols",
       "order": 139,
-      "keywords": ["cancel", "sign", "x", "×"]
+      "keywords": ["cancel", "sign", "x"]
     },
-    {
-      "emoji": "➕",
-      "shortcodes": ["heavy_plus_sign", "plus"],
-      "group": "symbols",
-      "order": 141,
-      "keywords": ["+"]
-    },
+    { "emoji": "➕", "shortcodes": ["heavy_plus_sign", "plus"], "group": "symbols", "order": 141, "keywords": ["+"] },
     {
       "emoji": "➖",
       "shortcodes": ["heavy_minus_sign", "minus"],
       "group": "symbols",
       "order": 142,
-      "keywords": ["-", "heavy", "math", "sign", "−"]
+      "keywords": ["-", "heavy", "math", "sign"]
     },
     {
       "emoji": "➗",
       "shortcodes": ["heavy_division_sign", "divide", "division"],
       "group": "symbols",
       "order": 143,
-      "keywords": ["heavy", "math", "sign", "÷"]
+      "keywords": ["heavy", "math", "sign"]
     },
     {
       "emoji": "♾️",
@@ -9908,42 +8921,42 @@
       "shortcodes": ["bangbang", "double_exclamation", "double_exclamation_mark"],
       "group": "symbols",
       "order": 147,
-      "keywords": ["!", "!!", "double", "exclamation", "mark", "punctuation"]
+      "keywords": ["double", "exclamation", "mark", "punctuation"]
     },
     {
       "emoji": "⁉️",
       "shortcodes": ["interrobang", "exclamation_question", "exclamation_question_mark"],
       "group": "symbols",
       "order": 149,
-      "keywords": ["!", "!?", "?", "exclamation", "mark", "punctuation", "question"]
+      "keywords": ["exclamation", "mark", "punctuation", "question"]
     },
     {
       "emoji": "❓",
       "shortcodes": ["question", "question_mark", "huh", "red_question_mark"],
       "group": "symbols",
       "order": 151,
-      "keywords": ["?", "mark", "punctuation", "red"]
+      "keywords": ["mark", "punctuation", "red"]
     },
     {
       "emoji": "❔",
       "shortcodes": ["grey_question", "white_question", "white_question_mark"],
       "group": "symbols",
       "order": 152,
-      "keywords": ["?", "mark", "outlined", "punctuation", "question", "white"]
+      "keywords": ["mark", "outlined", "punctuation", "question", "white"]
     },
     {
       "emoji": "❕",
       "shortcodes": ["grey_exclamation", "white_exclamation", "white_exclamation_mark"],
       "group": "symbols",
       "order": 153,
-      "keywords": ["!", "exclamation", "mark", "outlined", "punctuation", "white"]
+      "keywords": ["exclamation", "mark", "outlined", "punctuation", "white"]
     },
     {
       "emoji": "❗",
       "shortcodes": ["exclamation", "heavy_exclamation_mark", "red_exclamation_mark"],
       "group": "symbols",
       "order": 154,
-      "keywords": ["!", "mark", "punctuation", "red"]
+      "keywords": ["mark", "punctuation", "red"]
     },
     {
       "emoji": "〰️",
@@ -9994,13 +9007,7 @@
       "order": 165,
       "keywords": ["anchor", "emblem", "poseidon", "ship", "tool"]
     },
-    {
-      "emoji": "📛",
-      "shortcodes": ["name_badge"],
-      "group": "symbols",
-      "order": 166,
-      "keywords": ["badge", "name"]
-    },
+    { "emoji": "📛", "shortcodes": ["name_badge"], "group": "symbols", "order": 166, "keywords": ["badge", "name"] },
     {
       "emoji": "🔰",
       "shortcodes": ["beginner", "japanese_symbol_for_beginner"],
@@ -10020,35 +9027,35 @@
       "shortcodes": ["white_check_mark", "done", "yes", "checkmark", "check_done", "check_mark_button"],
       "group": "symbols",
       "order": 169,
-      "keywords": ["button", "check", "checked", "complete", "completed", "fixed", "mark", "tick", "✓"]
+      "keywords": ["button", "check", "checked", "complete", "completed", "fixed", "mark", "tick"]
     },
     {
       "emoji": "☑️",
       "shortcodes": ["ballot_box_with_check", "check_box_with_check"],
       "group": "symbols",
       "order": 170,
-      "keywords": ["ballot", "box", "check", "checked", "done", "off", "tick", "✓"]
+      "keywords": ["ballot", "box", "check", "checked", "done", "off", "tick"]
     },
     {
       "emoji": "✔️",
       "shortcodes": ["heavy_check_mark", "check_mark"],
       "group": "symbols",
       "order": 172,
-      "keywords": ["check", "checked", "done", "heavy", "mark", "tick", "✓"]
+      "keywords": ["check", "checked", "done", "heavy", "mark", "tick"]
     },
     {
       "emoji": "❌",
       "shortcodes": ["x", "no", "wrong", "cross_mark"],
       "group": "symbols",
       "order": 174,
-      "keywords": ["cancel", "cross", "mark", "multiplication", "multiply", "×"]
+      "keywords": ["cancel", "cross", "mark", "multiplication", "multiply"]
     },
     {
       "emoji": "❎",
       "shortcodes": ["negative_squared_cross_mark", "cross_mark_button"],
       "group": "symbols",
       "order": 175,
-      "keywords": ["button", "cross", "mark", "multiplication", "multiply", "square", "x", "×"]
+      "keywords": ["button", "cross", "mark", "multiplication", "multiply", "square", "x"]
     },
     {
       "emoji": "➰",
@@ -10076,36 +9083,18 @@
       "shortcodes": ["eight_spoked_asterisk"],
       "group": "symbols",
       "order": 180,
-      "keywords": ["*", "asterisk", "eight-spoked"]
+      "keywords": ["asterisk", "eight-spoked"]
     },
     {
       "emoji": "✴️",
       "shortcodes": ["eight_pointed_black_star", "eight_pointed_star"],
       "group": "symbols",
       "order": 182,
-      "keywords": ["*", "eight-pointed", "star"]
+      "keywords": ["eight-pointed", "star"]
     },
-    {
-      "emoji": "❇️",
-      "shortcodes": ["sparkle"],
-      "group": "symbols",
-      "order": 184,
-      "keywords": ["*"]
-    },
-    {
-      "emoji": "©️",
-      "shortcodes": ["copyright"],
-      "group": "symbols",
-      "order": 186,
-      "keywords": ["c"]
-    },
-    {
-      "emoji": "®️",
-      "shortcodes": ["registered"],
-      "group": "symbols",
-      "order": 188,
-      "keywords": ["r"]
-    },
+    { "emoji": "❇️", "shortcodes": ["sparkle"], "group": "symbols", "order": 184, "keywords": [] },
+    { "emoji": "©️", "shortcodes": ["copyright"], "group": "symbols", "order": 186, "keywords": ["c"] },
+    { "emoji": "®️", "shortcodes": ["registered"], "group": "symbols", "order": 188, "keywords": ["r"] },
     {
       "emoji": "™️",
       "shortcodes": ["tm", "trade_mark"],
@@ -10118,91 +9107,73 @@
       "shortcodes": ["hash", "number_sign", "keycap_number_sign"],
       "group": "symbols",
       "order": 193,
-      "keywords": ["keycap", "keycap: #"]
+      "keywords": ["keycap"]
     },
     {
       "emoji": "*️⃣",
       "shortcodes": ["asterisk", "keycap_star", "keycap_asterisk"],
       "group": "symbols",
       "order": 195,
-      "keywords": ["keycap", "keycap: *"]
+      "keywords": ["keycap"]
     },
     {
       "emoji": "0️⃣",
       "shortcodes": ["zero", "keycap_0"],
       "group": "symbols",
       "order": 197,
-      "keywords": ["0", "keycap", "keycap: 0"]
+      "keywords": ["0", "keycap"]
     },
-    {
-      "emoji": "1️⃣",
-      "shortcodes": ["one", "keycap_1"],
-      "group": "symbols",
-      "order": 199,
-      "keywords": ["1", "keycap", "keycap: 1"]
-    },
-    {
-      "emoji": "2️⃣",
-      "shortcodes": ["two", "keycap_2"],
-      "group": "symbols",
-      "order": 201,
-      "keywords": ["2", "keycap", "keycap: 2"]
-    },
+    { "emoji": "1️⃣", "shortcodes": ["one", "keycap_1"], "group": "symbols", "order": 199, "keywords": ["1", "keycap"] },
+    { "emoji": "2️⃣", "shortcodes": ["two", "keycap_2"], "group": "symbols", "order": 201, "keywords": ["2", "keycap"] },
     {
       "emoji": "3️⃣",
       "shortcodes": ["three", "keycap_3"],
       "group": "symbols",
       "order": 203,
-      "keywords": ["3", "keycap", "keycap: 3"]
+      "keywords": ["3", "keycap"]
     },
     {
       "emoji": "4️⃣",
       "shortcodes": ["four", "keycap_4"],
       "group": "symbols",
       "order": 205,
-      "keywords": ["4", "keycap", "keycap: 4"]
+      "keywords": ["4", "keycap"]
     },
     {
       "emoji": "5️⃣",
       "shortcodes": ["five", "keycap_5"],
       "group": "symbols",
       "order": 207,
-      "keywords": ["5", "keycap", "keycap: 5"]
+      "keywords": ["5", "keycap"]
     },
-    {
-      "emoji": "6️⃣",
-      "shortcodes": ["six", "keycap_6"],
-      "group": "symbols",
-      "order": 209,
-      "keywords": ["6", "keycap", "keycap: 6"]
-    },
+    { "emoji": "6️⃣", "shortcodes": ["six", "keycap_6"], "group": "symbols", "order": 209, "keywords": ["6", "keycap"] },
     {
       "emoji": "7️⃣",
       "shortcodes": ["seven", "keycap_7"],
       "group": "symbols",
       "order": 211,
-      "keywords": ["7", "keycap", "keycap: 7"]
+      "keywords": ["7", "keycap"]
     },
     {
       "emoji": "8️⃣",
       "shortcodes": ["eight", "keycap_8"],
       "group": "symbols",
       "order": 213,
-      "keywords": ["8", "keycap", "keycap: 8"]
+      "keywords": ["8", "keycap"]
     },
     {
       "emoji": "9️⃣",
       "shortcodes": ["nine", "keycap_9"],
       "group": "symbols",
       "order": 215,
-      "keywords": ["9", "keycap", "keycap: 9"]
+      "keywords": ["9", "keycap"]
     },
     {
       "emoji": "🔟",
       "shortcodes": ["keycap_ten", "ten", "keycap_10"],
       "group": "symbols",
       "order": 217,
-      "keywords": ["keycap", "keycap: 10"]
+      "keywords": ["keycap"]
     },
     {
       "emoji": "🔠",
@@ -10230,7 +9201,7 @@
       "shortcodes": ["symbols", "input_symbols"],
       "group": "symbols",
       "order": 221,
-      "keywords": ["%", "&", "input", "♪", "〒"]
+      "keywords": ["input"]
     },
     {
       "emoji": "🔤",
@@ -10244,43 +9215,25 @@
       "shortcodes": ["a", "a_blood", "a_button_blood_type"],
       "group": "symbols",
       "order": 223,
-      "keywords": ["blood", "button", "type", "a button (blood type)"]
+      "keywords": ["blood", "button", "type"]
     },
     {
       "emoji": "🆎",
       "shortcodes": ["ab", "ab_blood", "ab_button_blood_type"],
       "group": "symbols",
       "order": 225,
-      "keywords": ["blood", "button", "type", "ab button (blood type)"]
+      "keywords": ["blood", "button", "type"]
     },
     {
       "emoji": "🅱️",
       "shortcodes": ["b", "b_blood", "b_button_blood_type"],
       "group": "symbols",
       "order": 226,
-      "keywords": ["blood", "button", "type", "b button (blood type)"]
+      "keywords": ["blood", "button", "type"]
     },
-    {
-      "emoji": "🆑",
-      "shortcodes": ["cl", "cl_button"],
-      "group": "symbols",
-      "order": 228,
-      "keywords": ["button"]
-    },
-    {
-      "emoji": "🆒",
-      "shortcodes": ["cool", "cool_button"],
-      "group": "symbols",
-      "order": 229,
-      "keywords": ["button"]
-    },
-    {
-      "emoji": "🆓",
-      "shortcodes": ["free", "free_button"],
-      "group": "symbols",
-      "order": 230,
-      "keywords": ["button"]
-    },
+    { "emoji": "🆑", "shortcodes": ["cl", "cl_button"], "group": "symbols", "order": 228, "keywords": ["button"] },
+    { "emoji": "🆒", "shortcodes": ["cool", "cool_button"], "group": "symbols", "order": 229, "keywords": ["button"] },
+    { "emoji": "🆓", "shortcodes": ["free", "free_button"], "group": "symbols", "order": 230, "keywords": ["button"] },
     {
       "emoji": "ℹ️",
       "shortcodes": ["information_source", "info", "information"],
@@ -10302,26 +9255,14 @@
       "order": 234,
       "keywords": ["circle", "circled"]
     },
-    {
-      "emoji": "🆕",
-      "shortcodes": ["new", "new_button"],
-      "group": "symbols",
-      "order": 236,
-      "keywords": ["button"]
-    },
-    {
-      "emoji": "🆖",
-      "shortcodes": ["ng", "ng_button"],
-      "group": "symbols",
-      "order": 237,
-      "keywords": ["button"]
-    },
+    { "emoji": "🆕", "shortcodes": ["new", "new_button"], "group": "symbols", "order": 236, "keywords": ["button"] },
+    { "emoji": "🆖", "shortcodes": ["ng", "ng_button"], "group": "symbols", "order": 237, "keywords": ["button"] },
     {
       "emoji": "🅾️",
       "shortcodes": ["o2", "o_blood", "o_button_blood_type"],
       "group": "symbols",
       "order": 238,
-      "keywords": ["blood", "button", "o", "type", "o button (blood type)"]
+      "keywords": ["blood", "button", "o", "type"]
     },
     {
       "emoji": "🆗",
@@ -10349,7 +9290,7 @@
       "shortcodes": ["up", "up2", "up_button"],
       "group": "symbols",
       "order": 244,
-      "keywords": ["button", "mark", "up!", "up! button"]
+      "keywords": ["button", "mark"]
     },
     {
       "emoji": "🆚",
@@ -10363,119 +9304,119 @@
       "shortcodes": ["koko", "ja_here", "japanese_here_button"],
       "group": "symbols",
       "order": 246,
-      "keywords": ["button", "here", "japanese", "katakana", "japanese “here” button"]
+      "keywords": ["button", "here", "japanese", "katakana"]
     },
     {
       "emoji": "🈂️",
       "shortcodes": ["sa", "ja_service_charge", "japanese_service_charge_button"],
       "group": "symbols",
       "order": 247,
-      "keywords": ["button", "charge", "japanese", "katakana", "service", "japanese “service charge” button"]
+      "keywords": ["button", "charge", "japanese", "katakana", "service"]
     },
     {
       "emoji": "🈷️",
       "shortcodes": ["u6708", "ja_monthly_amount", "japanese_monthly_amount_button"],
       "group": "symbols",
       "order": 249,
-      "keywords": ["amount", "button", "ideograph", "japanese", "monthly", "japanese “monthly amount” button"]
+      "keywords": ["amount", "button", "ideograph", "japanese", "monthly"]
     },
     {
       "emoji": "🈶",
       "shortcodes": ["u6709", "ja_not_free_of_carge", "japanese_not_free_of_charge_button"],
       "group": "symbols",
       "order": 251,
-      "keywords": ["button", "charge", "free", "ideograph", "japanese", "not", "japanese “not free of charge” button"]
+      "keywords": ["button", "charge", "free", "ideograph", "japanese", "not"]
     },
     {
       "emoji": "🈯",
       "shortcodes": ["u6307", "ja_reserved", "japanese_reserved_button"],
       "group": "symbols",
       "order": 252,
-      "keywords": ["button", "ideograph", "japanese", "reserved", "japanese “reserved” button"]
+      "keywords": ["button", "ideograph", "japanese", "reserved"]
     },
     {
       "emoji": "🉐",
       "shortcodes": ["ideograph_advantage", "ja_bargain", "japanese_bargain_button"],
       "group": "symbols",
       "order": 253,
-      "keywords": ["bargain", "button", "ideograph", "japanese", "japanese “bargain” button"]
+      "keywords": ["bargain", "button", "ideograph", "japanese"]
     },
     {
       "emoji": "🈹",
       "shortcodes": ["u5272", "ja_discount", "japanese_discount_button"],
       "group": "symbols",
       "order": 254,
-      "keywords": ["button", "discount", "ideograph", "japanese", "japanese “discount” button"]
+      "keywords": ["button", "discount", "ideograph", "japanese"]
     },
     {
       "emoji": "🈚",
       "shortcodes": ["u7121", "ja_free_of_charge", "japanese_free_of_charge_button"],
       "group": "symbols",
       "order": 255,
-      "keywords": ["button", "charge", "free", "ideograph", "japanese", "japanese “free of charge” button"]
+      "keywords": ["button", "charge", "free", "ideograph", "japanese"]
     },
     {
       "emoji": "🈲",
       "shortcodes": ["u7981", "ja_prohibited", "japanese_prohibited_button"],
       "group": "symbols",
       "order": 256,
-      "keywords": ["button", "ideograph", "japanese", "prohibited", "japanese “prohibited” button"]
+      "keywords": ["button", "ideograph", "japanese", "prohibited"]
     },
     {
       "emoji": "🉑",
       "shortcodes": ["accept", "ja_acceptable", "japanese_acceptable_button"],
       "group": "symbols",
       "order": 257,
-      "keywords": ["acceptable", "button", "ideograph", "japanese", "japanese “acceptable” button"]
+      "keywords": ["acceptable", "button", "ideograph", "japanese"]
     },
     {
       "emoji": "🈸",
       "shortcodes": ["u7533", "ja_application", "japanese_application_button"],
       "group": "symbols",
       "order": 258,
-      "keywords": ["application", "button", "ideograph", "japanese", "japanese “application” button"]
+      "keywords": ["application", "button", "ideograph", "japanese"]
     },
     {
       "emoji": "🈴",
       "shortcodes": ["u5408", "ja_passing_grade", "japanese_passing_grade_button"],
       "group": "symbols",
       "order": 259,
-      "keywords": ["button", "grade", "ideograph", "japanese", "passing", "japanese “passing grade” button"]
+      "keywords": ["button", "grade", "ideograph", "japanese", "passing"]
     },
     {
       "emoji": "🈳",
       "shortcodes": ["u7a7a", "ja_vacancy", "japanese_vacancy_button"],
       "group": "symbols",
       "order": 260,
-      "keywords": ["button", "ideograph", "japanese", "vacancy", "japanese “vacancy” button"]
+      "keywords": ["button", "ideograph", "japanese", "vacancy"]
     },
     {
       "emoji": "㊗️",
       "shortcodes": ["congratulations", "ja_congratulations", "japanese_congratulations_button"],
       "group": "symbols",
       "order": 261,
-      "keywords": ["button", "ideograph", "japanese", "japanese “congratulations” button"]
+      "keywords": ["button", "ideograph", "japanese"]
     },
     {
       "emoji": "㊙️",
       "shortcodes": ["secret", "ja_secret", "japanese_secret_button"],
       "group": "symbols",
       "order": 263,
-      "keywords": ["button", "ideograph", "japanese", "japanese “secret” button"]
+      "keywords": ["button", "ideograph", "japanese"]
     },
     {
       "emoji": "🈺",
       "shortcodes": ["u55b6", "ja_open_for_business", "japanese_open_for_business_button"],
       "group": "symbols",
       "order": 265,
-      "keywords": ["business", "button", "ideograph", "japanese", "open", "japanese “open for business” button"]
+      "keywords": ["business", "button", "ideograph", "japanese", "open"]
     },
     {
       "emoji": "🈵",
       "shortcodes": ["u6e80", "ja_no_vacancy", "japanese_no_vacancy_button"],
       "group": "symbols",
       "order": 266,
-      "keywords": ["button", "ideograph", "japanese", "no", "vacancy", "japanese “no vacancy” button"]
+      "keywords": ["button", "ideograph", "japanese", "no", "vacancy"]
     },
     {
       "emoji": "🔴",
@@ -10835,7 +9776,7 @@
       "shortcodes": ["saluting_face", "salute", "saluting"],
       "group": "smileys",
       "order": 187,
-      "keywords": ["face", "good", "luck", "ma’am", "ok", "respect", "sir", "troops", "yes"]
+      "keywords": ["face", "good", "luck", "ma am", "ok", "respect", "sir", "troops", "yes"]
     },
     {
       "emoji": "🫢",
@@ -10919,7 +9860,7 @@
       "shortcodes": ["hand_with_index_finger_and_thumb_crossed", "finger_heart", "money_fingers"],
       "group": "people",
       "order": 3290,
-      "keywords": ["<3", "crossed", "expensive", "finger", "hand", "heart", "index", "love", "money", "snap", "thumb"]
+      "keywords": ["3", "crossed", "expensive", "finger", "hand", "heart", "index", "love", "money", "snap", "thumb"]
     },
     {
       "emoji": "🫱",
@@ -10967,7 +9908,7 @@
       "shortcodes": ["heart_hands", "hand_heart", "love_hands"],
       "group": "people",
       "order": 3296,
-      "keywords": ["<3", "hands", "heart", "love", "you"]
+      "keywords": ["3", "hands", "heart", "love", "you"]
     },
     {
       "emoji": "🫅",

--- a/apps/backend/src/features/emoji/emoji.test.ts
+++ b/apps/backend/src/features/emoji/emoji.test.ts
@@ -157,6 +157,34 @@ describe("Emoji Library", () => {
       expect(empty).toEqual([])
     })
 
+    test("no keyword duplicates a shortcode of the same emoji", () => {
+      // Keywords are the lower-ranked search band; one that repeats a shortcode
+      // this emoji already owns is payload that can never change a result.
+      const fold = (text: string) => text.toLowerCase().replace(/[\s_-]/g, "")
+      const redundant: string[] = []
+      for (const { emoji, shortcodes, keywords } of emojiData.emojis) {
+        const owned = new Set(shortcodes.map(fold))
+        for (const keyword of keywords) {
+          if (owned.has(fold(keyword))) redundant.push(`${emoji} -> "${keyword}"`)
+        }
+      }
+      expect(redundant).toEqual([])
+    })
+
+    test("keywords are lowercase and free of the colon wrapper", () => {
+      // Keywords never cross the wire as `:name:`; the only formatting contract
+      // is that search compares them lowercased and unwrapped.
+      const invalid: string[] = []
+      for (const { emoji, keywords } of emojiData.emojis) {
+        for (const keyword of keywords) {
+          if (keyword !== keyword.toLowerCase().trim() || /^:.*:$/.test(keyword)) {
+            invalid.push(`${emoji} -> "${keyword}"`)
+          }
+        }
+      }
+      expect(invalid).toEqual([])
+    })
+
     test("primary shortcode is canonical for toShortcode()", () => {
       // shortcodes[0] is the wire-format primary that toShortcode() returns
       // and is what gets persisted, displayed in tooltips, and rendered into
@@ -172,6 +200,41 @@ describe("Emoji Library", () => {
         .map(({ emoji, expected, actual }) => `${emoji}: expected ${expected}, got ${actual}`)
       expect(mismatches).toEqual([])
     })
+  })
+
+  describe("plain-language search coverage", () => {
+    // The dataset used to carry 1.13 shortcodes per emoji and nothing else, so
+    // searching the word a person actually thinks of ("sad", "cheers") returned
+    // nothing at all. These are the words, not the shortcode spellings — each
+    // must be an exact match on some emoji's shortcode or keyword, and the
+    // obvious emoji must be among the matches.
+    const expectations: Array<{ query: string; expected: string[] }> = [
+      { query: "sad", expected: ["😢", "😭", "😔", "☹️"] },
+      { query: "cheers", expected: ["🍻"] },
+      { query: "celebrate", expected: ["🎉", "🥳"] },
+      { query: "thanks", expected: ["🙏"] },
+      { query: "angry", expected: ["😠", "😡"] },
+      { query: "confused", expected: ["😕", "🫤"] },
+      { query: "tired", expected: ["😴", "🥱"] },
+      { query: "hug", expected: ["🤗", "🫂"] },
+      { query: "oops", expected: ["🤭"] },
+      { query: "excited", expected: ["🤩", "🥳"] },
+      { query: "disappointed", expected: ["😔", "😞"] },
+      { query: "money", expected: ["💰", "🤑"] },
+      { query: "idea", expected: ["💡"] },
+      { query: "bug", expected: ["🐛"] },
+    ]
+
+    for (const { query, expected } of expectations) {
+      test(`"${query}" matches ${expected.join("")}`, () => {
+        const matched = new Set(
+          emojiData.emojis
+            .filter((entry) => entry.shortcodes.includes(query) || entry.keywords.includes(query))
+            .map((entry) => entry.emoji)
+        )
+        expect(expected.filter((emoji) => !matched.has(emoji))).toEqual([])
+      })
+    }
   })
 
   describe("Unicode version coverage", () => {

--- a/apps/backend/src/features/emoji/emoji.test.ts
+++ b/apps/backend/src/features/emoji/emoji.test.ts
@@ -171,18 +171,34 @@ describe("Emoji Library", () => {
       expect(redundant).toEqual([])
     })
 
-    test("keywords are lowercase and free of the colon wrapper", () => {
-      // Keywords never cross the wire as `:name:`; the only formatting contract
-      // is that search compares them lowercased and unwrapped.
+    test("keywords contain only characters a picker query can carry", () => {
+      // Punctuation in a keyword matches queries nobody means. The CLDR label
+      // "A button (blood type)" made `:)` match 🅰️, so the classic smiley typo
+      // held the composer's emoji popup open and swallowed the Enter that
+      // should have sent the message.
+      const QUERY_SAFE = /^[a-z0-9 _+-]+$/
       const invalid: string[] = []
       for (const { emoji, keywords } of emojiData.emojis) {
         for (const keyword of keywords) {
-          if (keyword !== keyword.toLowerCase().trim() || /^:.*:$/.test(keyword)) {
-            invalid.push(`${emoji} -> "${keyword}"`)
-          }
+          if (!QUERY_SAFE.test(keyword)) invalid.push(`${emoji} -> "${keyword}"`)
         }
       }
       expect(invalid).toEqual([])
+    })
+
+    test("no emoji matches a bare punctuation query", () => {
+      // The `:)` regression above, stated as the behaviour rather than the
+      // format rule — a shortcode or keyword must never make an emoticon typo
+      // look like a search with results.
+      const matched: string[] = []
+      for (const query of [")", "(", ":", "!", "?", "*", "'", "."]) {
+        for (const { emoji, shortcodes, keywords } of emojiData.emojis) {
+          if ([...shortcodes, ...keywords].some((text) => text.includes(query))) {
+            matched.push(`"${query}" -> ${emoji}`)
+          }
+        }
+      }
+      expect(matched).toEqual([])
     })
 
     test("primary shortcode is canonical for toShortcode()", () => {

--- a/apps/backend/src/features/emoji/emoji.ts
+++ b/apps/backend/src/features/emoji/emoji.ts
@@ -106,16 +106,20 @@ export interface EmojiEntry {
   group: string
   order: number
   aliases: string[]
+  keywords: string[]
 }
 
-/** All emojis in API response format, each with its primary shortcode and aliases. */
+const emojiList: EmojiEntry[] = emojiData.emojis.map(({ emoji, shortcodes, group, order, keywords }) => ({
+  shortcode: shortcodes[0],
+  emoji,
+  type: "native" as const,
+  group: group ?? "symbols",
+  order: order ?? 9999,
+  aliases: shortcodes,
+  keywords: keywords ?? [],
+}))
+
+/** All emojis in API response format, each with its primary shortcode, aliases and search keywords. */
 export function getEmojiList(): EmojiEntry[] {
-  return emojiData.emojis.map(({ emoji, shortcodes, group, order }) => ({
-    shortcode: shortcodes[0],
-    emoji,
-    type: "native" as const,
-    group: group ?? "symbols",
-    order: order ?? 9999,
-    aliases: shortcodes,
-  }))
+  return emojiList
 }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -902,7 +902,16 @@ export interface CachedE2eDeviceKey {
 export interface CachedWorkspaceMetadata {
   id: string // workspaceId
   workspaceId: string
-  emojis: Array<{ shortcode: string; emoji: string; type: string; group: string; order: number; aliases: string[] }>
+  emojis: Array<{
+    shortcode: string
+    emoji: string
+    type: string
+    group: string
+    order: number
+    aliases: string[]
+    /** Absent on rows cached before search keywords shipped. */
+    keywords?: string[]
+  }>
   emojiWeights: Record<string, number>
   /**
    * Agent tool categories the workspace has tooling configured for (`web` +

--- a/apps/frontend/src/hooks/use-workspace-emoji.test.ts
+++ b/apps/frontend/src/hooks/use-workspace-emoji.test.ts
@@ -85,6 +85,27 @@ describe("useWorkspaceEmoji", () => {
       expect(entry?.aliases).toEqual(["love"])
     })
 
+    it("should resolve an alias, not just the primary shortcode", () => {
+      // The backend accepts every alias in `:shortcode:` markdown, so the
+      // composer input rule and renderer must resolve them too.
+      mockMetadata = {
+        id: workspaceId,
+        workspaceId,
+        emojis: [
+          { shortcode: "heart", emoji: "❤️", type: "native", group: "people", order: 0, aliases: ["heart", "love"] },
+        ],
+        emojiWeights: {},
+        commands: [],
+        _cachedAt: Date.now(),
+      }
+
+      const { result } = renderHook(() => useWorkspaceEmoji(workspaceId), {
+        wrapper: createTestWrapper(queryClient),
+      })
+      expect(result.current.toEmoji(":love:")).toBe("❤️")
+      expect(result.current.getEmoji("love")?.shortcode).toBe("heart")
+    })
+
     it("should strip colons from shortcode when looking up", () => {
       mockMetadata = {
         id: workspaceId,

--- a/apps/frontend/src/hooks/use-workspace-emoji.ts
+++ b/apps/frontend/src/hooks/use-workspace-emoji.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react"
 import { useWorkspaceMetadata } from "@/stores/workspace-store"
 import type { EmojiEntry } from "@threa/types"
+import { buildShortcodeIndex, stripShortcodeColons } from "@/lib/emoji-picker"
 
 interface WorkspaceEmojiData {
   /** All available emojis in the workspace */
@@ -25,19 +26,10 @@ export function useWorkspaceEmoji(workspaceId: string): WorkspaceEmojiData {
   const emojis = useMemo(() => (metadata?.emojis ?? []) as EmojiEntry[], [metadata])
   const emojiWeights = useMemo(() => metadata?.emojiWeights ?? {}, [metadata])
 
-  const emojiMap = useMemo(() => {
-    const map = new Map<string, EmojiEntry>()
-    for (const entry of emojis) {
-      map.set(entry.shortcode, entry)
-    }
-    return map
-  }, [emojis])
+  const emojiMap = useMemo(() => buildShortcodeIndex(emojis), [emojis])
 
   const getEmoji = useCallback(
-    (shortcode: string): EmojiEntry | undefined => {
-      const normalized = shortcode.startsWith(":") && shortcode.endsWith(":") ? shortcode.slice(1, -1) : shortcode
-      return emojiMap.get(normalized)
-    },
+    (shortcode: string): EmojiEntry | undefined => emojiMap.get(stripShortcodeColons(shortcode)),
     [emojiMap]
   )
 

--- a/apps/frontend/src/lib/emoji-picker.test.ts
+++ b/apps/frontend/src/lib/emoji-picker.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest"
 import type { EmojiEntry } from "@threa/types"
 import {
   buildQuickEmojis,
+  buildShortcodeIndex,
   filterBySearch,
+  stripShortcodeColons,
   indexToCoord,
   moveSelection,
   pickRecentlyUsed,
@@ -10,7 +12,7 @@ import {
   totalCount,
 } from "./emoji-picker"
 
-function make(shortcode: string, group: string, order: number, aliases?: string[]): EmojiEntry {
+function make(shortcode: string, group: string, order: number, aliases?: string[], keywords?: string[]): EmojiEntry {
   return {
     shortcode,
     emoji: shortcode,
@@ -18,6 +20,7 @@ function make(shortcode: string, group: string, order: number, aliases?: string[
     group,
     order,
     aliases: aliases ?? [shortcode],
+    keywords: keywords ?? [],
   }
 }
 
@@ -98,6 +101,47 @@ describe("filterBySearch", () => {
     const happy = make("happy_face", "people", 1, ["happy_face", "smile_alt"])
     const matches = filterBySearch([happy, smile], "smile")
     expect(matches.map((e) => e.shortcode)).toEqual(["smile", "happy_face"])
+  })
+
+  it("matches search keywords, which no shortcode spells", () => {
+    const cry = make("cry", "smileys", 1, ["cry"], ["sad", "unhappy", "tear"])
+    expect(filterBySearch([smile, cry], "unhappy").map((e) => e.shortcode)).toEqual(["cry"])
+  })
+
+  it("ranks a shortcode match above a keyword match", () => {
+    const sadFace = make("sad_face", "smileys", 9, ["sad_face"])
+    const cry = make("cry", "smileys", 1, ["cry"], ["sad"])
+    expect(filterBySearch([cry, sadFace], "sad").map((e) => e.shortcode)).toEqual(["sad_face", "cry"])
+  })
+
+  it("tolerates entries with no keywords field (emoji list cached before keywords shipped)", () => {
+    const legacy = { ...smile, keywords: undefined } as unknown as EmojiEntry
+    expect(filterBySearch([legacy], "smile").map((e) => e.shortcode)).toEqual(["smile"])
+  })
+})
+
+describe("buildShortcodeIndex", () => {
+  it("resolves aliases as well as primary shortcodes", () => {
+    const poop = make("poop", "people", 10, ["poop", "hankey", "shit"])
+    const index = buildShortcodeIndex([poop])
+    expect(index.get("hankey")).toBe(poop)
+    expect(index.get("poop")).toBe(poop)
+    expect(index.get("nope")).toBeUndefined()
+  })
+
+  it("never lets another emoji's alias shadow a primary shortcode", () => {
+    // A stale cached list can carry an alias that has since been reassigned;
+    // the primary must still win, whatever the input order.
+    const stale = make("old", "objects", 1, ["old", "smile"])
+    expect(buildShortcodeIndex([smile, stale]).get("smile")).toBe(smile)
+    expect(buildShortcodeIndex([stale, smile]).get("smile")).toBe(smile)
+  })
+})
+
+describe("stripShortcodeColons", () => {
+  it("unwraps :name: and leaves a bare name alone", () => {
+    expect(stripShortcodeColons(":smile:")).toBe("smile")
+    expect(stripShortcodeColons("smile")).toBe("smile")
   })
 })
 

--- a/apps/frontend/src/lib/emoji-picker.ts
+++ b/apps/frontend/src/lib/emoji-picker.ts
@@ -116,9 +116,10 @@ export function buildQuickEmojis(
 
 /**
  * Filter and rank emojis for a search query. The canonical shortcode is the
- * primary match target; other aliases score a tier below, so `:smile:` ranks
- * above an emoji that merely lists "smile" as a hidden alias. Ties keep input
- * order (default order for the grid, weight order for recents).
+ * primary match target; other aliases and the search keywords score a tier
+ * below, so `:smile:` ranks above an emoji that merely lists "smile" as a
+ * hidden synonym. Ties keep input order (default order for the grid, weight
+ * order for recents).
  *
  * `aliases` includes the primary shortcode (see EmojiEntry), so it is
  * excluded from the keyword band to keep the tier intent explicit.
@@ -126,8 +127,30 @@ export function buildQuickEmojis(
 export function filterBySearch(emojis: EmojiEntry[], query: string): EmojiEntry[] {
   return rankMatches(emojis, query, (e) => ({
     labels: [e.shortcode],
-    keywords: e.aliases.filter((alias) => alias !== e.shortcode),
+    keywords: [...e.aliases.filter((alias) => alias !== e.shortcode), ...(e.keywords ?? [])],
   }))
+}
+
+/**
+ * Index every emoji by its primary shortcode *and* its aliases, because the
+ * backend accepts any alias in `:shortcode:` markdown — a primary-only index
+ * leaves `:smiley_cat:` rendering as literal text.
+ *
+ * Aliases are globally unique (guarded by emoji.test.ts), but primaries are
+ * written last so a stale cached list can never shadow one.
+ */
+export function buildShortcodeIndex(emojis: EmojiEntry[]): Map<string, EmojiEntry> {
+  const index = new Map<string, EmojiEntry>()
+  for (const entry of emojis) {
+    for (const alias of entry.aliases) index.set(alias, entry)
+  }
+  for (const entry of emojis) index.set(entry.shortcode, entry)
+  return index
+}
+
+/** Strip the wrapping colons from `:name:`, leaving a bare name unchanged. */
+export function stripShortcodeColons(shortcode: string): string {
+  return shortcode.startsWith(":") && shortcode.endsWith(":") ? shortcode.slice(1, -1) : shortcode
 }
 
 export type Section = "recent" | "all"

--- a/apps/frontend/src/lib/markdown/emoji-context.tsx
+++ b/apps/frontend/src/lib/markdown/emoji-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react"
 import type { EmojiEntry } from "@threa/types"
+import { buildShortcodeIndex, stripShortcodeColons } from "@/lib/emoji-picker"
 
 type ToEmoji = (shortcode: string) => string | null
 
@@ -20,16 +21,9 @@ interface EmojiProviderProps {
  */
 export function EmojiProvider({ emojis, children }: EmojiProviderProps) {
   const value = useMemo<EmojiContextValue>(() => {
-    const shortcodeToEmoji = new Map<string, string>()
-    for (const entry of emojis) {
-      shortcodeToEmoji.set(entry.shortcode, entry.emoji)
-    }
-
+    const index = buildShortcodeIndex(emojis)
     return {
-      toEmoji: (shortcode: string) => {
-        const normalized = shortcode.startsWith(":") && shortcode.endsWith(":") ? shortcode.slice(1, -1) : shortcode
-        return shortcodeToEmoji.get(normalized) ?? null
-      },
+      toEmoji: (shortcode: string) => index.get(stripShortcodeColons(shortcode))?.emoji ?? null,
     }
   }, [emojis])
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1529,6 +1529,13 @@ export interface EmojiEntry {
   order: number
   /** All shortcodes including aliases (for search matching) */
   aliases: string[]
+  /**
+   * Search-only synonyms (CLDR annotation tags — "sad", "unhappy", "tear").
+   * Unlike aliases these are shared across emoji, so they never resolve a
+   * `:shortcode:`. Optional on the wire: a client reading a cached emoji list
+   * written before keywords shipped sees entries without it.
+   */
+  keywords?: string[]
 }
 
 export const CommandKinds = {


### PR DESCRIPTION
## Problem

`apps/backend/src/features/emoji/emoji-data.json` is hand-curated and carries **1.13 shortcodes per emoji** — 1585 names across 1408 emoji, with no other search text. `filterBySearch` (`apps/frontend/src/lib/emoji-picker.ts`) matches only against `shortcode` + `aliases`, so a person typing the word they actually think of finds nothing: `sad` returned **0 results**, `cheers` 0, `celebrate` 1, `thanks` 1. The picker looks broken even though the emoji is right there.

## Solution

Regenerate the dataset's search surface from `emojibase-data@17.0.0` (CLDR annotations + the GitHub/Slack/emojibase/JoyPixels/CLDR shortcode sets), split across two fields because they are not interchangeable.

- **`shortcodes` +932** (1585 → 2517). Resolvable: `:name:` round-trips through `toEmoji`/`toShortcode` and gets persisted, so every one must own exactly one emoji. First-claim-wins with **set priority over dataset order** — walking one whole set before the next stops a low-priority alias of an early emoji from taking a name the next set gives its canonical owner. 61 contested names were dropped and logged (`email` stays ✉️, `lol` stays 🤣, `yes` stays ✅). The existing collision test in `emoji.test.ts` still passes unchanged.
- **`keywords` +7433**, a new search-only field of CLDR annotation tags ("sad", "unhappy", "tear"). Kept **out** of `shortcodes` deliberately: `face` is a tag on ~300 emoji, so folding tags in would make `:face:` resolve to whichever entry happened to be last and would break the collision guard. Search-only means no wire-format contract — the format test only pins lowercase and no colon wrapper.
- **`shortcodes[0]` is never touched.** It is the canonical form already persisted in message content and reactions; `add-emoji-groups.ts`'s existing "primary shortcode is canonical" test pins it.
- **Alias resolution on the frontend.** `useWorkspaceEmoji` and `EmojiProvider` each indexed *primary* shortcodes only, so an alias the backend accepts (`:hankey:`) rendered as literal text and never auto-converted in the composer input rule. Pre-existing, but 932 new aliases make it reachable everywhere — both now share `buildShortcodeIndex`, which writes aliases first and primaries last so a stale cached list can never shadow a primary.
- **`keywords` is optional on the wire** (`EmojiEntry` in `packages/types`, `CachedWorkspaceMetadata` in `db/database.ts`). A client reading an emoji list cached before this shipped sees entries without it; `filterBySearch` reads `e.keywords ?? []`.
- **Keywords are sanitized to `[a-z0-9 _+-]`** — diacritics folded to ASCII, everything else reduced to a separator. CLDR labels carry punctuation, and `A button (blood type)` stored verbatim made the query `)` match 4 emoji, so typing `hello :)` held the composer emoji popup open and swallowed the Enter that sends the message. Caught by `tests/browser/emoji-shortcuts.spec.ts:189` on CI (note the shard job reported *success* — only `evaluate-results` went red). Two dataset guards now pin it: the character class, and "no emoji matches a bare punctuation query". Side benefit: `piña colada` folds to `pina colada` and becomes matchable.
- **The generator formats through prettier.** lint-staged rewrites its output on commit, so bare `JSON.stringify` made every regeneration a 14k-line whitespace diff; now re-running is a no-op.

Result: `sad` → 😢😭😔☹️😞 (63 hits), `cheers` → 🍻, `celebrate` → 🎉🥳🎊, `tired` → 😴🥱💤, `oops` → 🤭, `hug` → 🤗🫂.

Cost: the emoji bootstrap payload goes 166 KB → 257 KB raw, **+30 KB gzipped** (`compression()` is on in `app.ts`). `getEmojiList()` now builds its array once at module load instead of per request.

**Not in scope, found while here:** short queries whose letters fall inside an unrelated shortcode still rank badly — `yes` leads with 😍 because `heart_eyes` *contains* "yes" at label-contains (tier 4), which outranks ✅'s exact alias hit in the keyword band (tier 6). Pre-existing and unchanged by this PR; fixing it means interleaving `match-score.ts`'s tiers so an exact keyword beats an inexact label, which affects the command palette, mentions, channels and stream sort too. Separate PR.

**Also not in scope:** emojibase has 541 entries the dataset lacks — 262 country flags (we ship 8), ~230 gendered/role ZWJ variants (🤷‍♀️, 🧑‍⚕️), 8 Emoji 17.0 additions (🫪🫯🧑‍🩰…), and common sequences (😮‍💨 ❤️‍🔥 😵‍💫 🫦 🧒). Next PR.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/scripts/build-emoji-aliases.ts` | **new** — regenerates `shortcodes` + `keywords` from emojibase-data, pinned to 17.0.0 |
| `apps/backend/src/features/emoji/emoji-data.json` | +932 shortcodes, +7433 keywords |
| `apps/backend/src/features/emoji/emoji.ts` | `EmojiEntry.keywords`; list built once at module load |
| `apps/backend/src/features/emoji/emoji.test.ts` | keyword-redundancy, query-safe-character and bare-punctuation guards; 14 plain-language coverage cases |
| `apps/backend/scripts/add-emoji-groups.ts` | fix dead path — `src/lib/` → `src/features/emoji/` |
| `packages/types/src/api.ts` | `EmojiEntry.keywords?: string[]` |
| `apps/frontend/src/lib/emoji-picker.ts` | keywords in the search band; new `buildShortcodeIndex` / `stripShortcodeColons` |
| `apps/frontend/src/hooks/use-workspace-emoji.ts` | resolve via `buildShortcodeIndex` |
| `apps/frontend/src/lib/markdown/emoji-context.tsx` | same, replacing its own primary-only map |
| `apps/frontend/src/db/database.ts` | cached emoji rows carry optional `keywords` |

## Test plan

- [x] `bun run test` — 3849 backend unit + 371 e2e pass
- [x] `apps/frontend` vitest — 5458 pass across 489 files
- [x] `bun run typecheck`, `bun run lint` — clean
- [x] Each new test verified to fail when its guard is neutralised (keyword band removed, alias indexing removed, alias/primary write order swapped)
- [x] `bunx playwright test tests/browser/emoji-shortcuts.spec.ts` — 13 pass locally against the real app
- [ ] Ranking not live-verified in a running app — checked by driving the real `filterBySearch` over the real dataset in a throwaway probe

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098044&installation_model_id=20758&pr_number=1689&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1689&signature=bab45fbd03d731ab4d318006c4668012d441307dd6efd216ee9e8f0f1665a889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
