### PR TITLE
fix(composer): trigger popups survive keyboard word-correction

### DIFF
--- a/apps/frontend/src/components/editor/triggers/create-trigger-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/create-trigger-extension.ts
@@ -3,7 +3,7 @@ import Suggestion from "@tiptap/suggestion"
 import { PluginKey } from "@tiptap/pm/state"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
 import { currentWordContainsBacktick } from "../markdown-guards"
-import { withKeyboardCorrectionTolerance, type SuggestionActiveProbe } from "./keyboard-correction-match"
+import { withKeyboardCorrectionTolerance } from "./keyboard-correction-match"
 
 /**
  * Configuration for a single attribute on a trigger node.
@@ -144,11 +144,7 @@ export function createTriggerExtension<TItem, TAttrs extends object>(config: Tri
           char,
           allowSpaces: false,
           startOfLine,
-          // Called during state application, when this.editor.state still holds the
-          // pre-transaction state — so getState reads the *previous* active flag.
-          findSuggestionMatch: withKeyboardCorrectionTolerance(
-            () => (pluginKey.getState(this.editor.state) as SuggestionActiveProbe | undefined)?.active === true
-          ),
+          findSuggestionMatch: withKeyboardCorrectionTolerance(pluginKey, this.editor),
           // Disable suggestions in code contexts (code blocks and inline code)
           allow: ({ state, range }) => {
             const $from = state.doc.resolve(range.from)

--- a/apps/frontend/src/components/editor/triggers/create-trigger-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/create-trigger-extension.ts
@@ -3,6 +3,7 @@ import Suggestion from "@tiptap/suggestion"
 import { PluginKey } from "@tiptap/pm/state"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
 import { currentWordContainsBacktick } from "../markdown-guards"
+import { withKeyboardCorrectionTolerance, type SuggestionActiveProbe } from "./keyboard-correction-match"
 
 /**
  * Configuration for a single attribute on a trigger node.
@@ -143,6 +144,11 @@ export function createTriggerExtension<TItem, TAttrs extends object>(config: Tri
           char,
           allowSpaces: false,
           startOfLine,
+          // Called during state application, when this.editor.state still holds the
+          // pre-transaction state — so getState reads the *previous* active flag.
+          findSuggestionMatch: withKeyboardCorrectionTolerance(
+            () => (pluginKey.getState(this.editor.state) as SuggestionActiveProbe | undefined)?.active === true
+          ),
           // Disable suggestions in code contexts (code blocks and inline code)
           allow: ({ state, range }) => {
             const $from = state.doc.resolve(range.from)

--- a/apps/frontend/src/components/editor/triggers/emoji-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/emoji-extension.ts
@@ -5,6 +5,7 @@ import { PluginKey } from "@tiptap/pm/state"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
 import type { EmojiEntry } from "@threa/types"
 import { currentWordContainsBacktick, isInBacktickWord } from "../markdown-guards"
+import { withKeyboardCorrectionTolerance, type SuggestionActiveProbe } from "./keyboard-correction-match"
 
 export const EmojiPluginKey = new PluginKey("emoji")
 
@@ -142,6 +143,11 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
         char: ":",
         allowSpaces: false,
         startOfLine: false,
+        // Called during state application, when this.editor.state still holds the
+        // pre-transaction state — so getState reads the *previous* active flag.
+        findSuggestionMatch: withKeyboardCorrectionTolerance(
+          () => (EmojiPluginKey.getState(this.editor.state) as SuggestionActiveProbe | undefined)?.active === true
+        ),
         allow: ({ state, range }) => {
           const $from = state.doc.resolve(range.from)
 

--- a/apps/frontend/src/components/editor/triggers/emoji-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/emoji-extension.ts
@@ -5,7 +5,7 @@ import { PluginKey } from "@tiptap/pm/state"
 import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion"
 import type { EmojiEntry } from "@threa/types"
 import { currentWordContainsBacktick, isInBacktickWord } from "../markdown-guards"
-import { withKeyboardCorrectionTolerance, type SuggestionActiveProbe } from "./keyboard-correction-match"
+import { withKeyboardCorrectionTolerance } from "./keyboard-correction-match"
 
 export const EmojiPluginKey = new PluginKey("emoji")
 
@@ -143,11 +143,7 @@ export const EmojiExtension = Node.create<EmojiExtensionOptions>({
         char: ":",
         allowSpaces: false,
         startOfLine: false,
-        // Called during state application, when this.editor.state still holds the
-        // pre-transaction state — so getState reads the *previous* active flag.
-        findSuggestionMatch: withKeyboardCorrectionTolerance(
-          () => (EmojiPluginKey.getState(this.editor.state) as SuggestionActiveProbe | undefined)?.active === true
-        ),
+        findSuggestionMatch: withKeyboardCorrectionTolerance(EmojiPluginKey, this.editor),
         allow: ({ state, range }) => {
           const $from = state.doc.resolve(range.from)
 

--- a/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
+++ b/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
@@ -1,0 +1,50 @@
+import { escapeForRegEx } from "@tiptap/core"
+import { findSuggestionMatch, type SuggestionMatch, type Trigger } from "@tiptap/suggestion"
+
+/**
+ * Mobile keyboards insert a picked word suggestion with a leading space when the
+ * preceding character is punctuation: `:srig` becomes `: shrug` in a single
+ * transaction. The default matcher (allowSpaces: false) then returns null and the
+ * popup dies, even though the user is mid-pick.
+ *
+ * This wrapper falls back to matching `<char> <word>` at the caret, but only when
+ * the suggestion was already active before this transaction. A manually typed
+ * space deactivates the suggestion on its own transaction, so ordinary text like
+ * "ratio : 5" can never reopen the popup — only a multi-character insert landing
+ * while the popup is open (the keyboard word-correction) reaches the fallback.
+ */
+export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeof findSuggestionMatch {
+  return (config: Trigger): SuggestionMatch => {
+    const match = findSuggestionMatch(config)
+    if (match) return match
+    if (!wasActive()) return null
+
+    const { char, allowSpaces, allowToIncludeChar, allowedPrefixes, startOfLine, $position } = config
+    if (allowSpaces || allowToIncludeChar) return null
+
+    const text = $position.nodeBefore?.isText && $position.nodeBefore.text
+    if (!text) return null
+
+    const escapedChar = escapeForRegEx(char)
+    const prefix = startOfLine ? "^" : ""
+    const corrected = text.match(new RegExp(`${prefix}${escapedChar} [^\\s${escapedChar}]+$`))
+    if (!corrected || corrected.index === undefined) return null
+
+    const matchPrefix = text.slice(Math.max(0, corrected.index - 1), corrected.index)
+    if (allowedPrefixes !== null && !new RegExp(`^[${allowedPrefixes.join("")}\0]?$`).test(matchPrefix)) {
+      return null
+    }
+
+    const from = $position.pos - text.length + corrected.index
+    return {
+      range: { from, to: $position.pos },
+      query: corrected[0].slice(char.length + 1),
+      text: corrected[0],
+    }
+  }
+}
+
+/** Reads the previous active state of a suggestion plugin during state application. */
+export interface SuggestionActiveProbe {
+  active?: boolean
+}

--- a/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
+++ b/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
@@ -12,6 +12,11 @@ import { findSuggestionMatch, type SuggestionMatch, type Trigger } from "@tiptap
  * space deactivates the suggestion on its own transaction, so ordinary text like
  * "ratio : 5" can never reopen the popup — only a multi-character insert landing
  * while the popup is open (the keyboard word-correction) reaches the fallback.
+ *
+ * Keyboards also append a trailing space (`: shrug `), often as a follow-up
+ * transaction, so the pattern tolerates one. Only in the leading-space form: a
+ * plain `:fir ` still dismisses, and a second space after a correction dismisses
+ * too — the corrected state is the one place a single space can't.
  */
 export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeof findSuggestionMatch {
   return (config: Trigger): SuggestionMatch => {
@@ -27,7 +32,7 @@ export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeo
 
     const escapedChar = escapeForRegEx(char)
     const prefix = startOfLine ? "^" : ""
-    const corrected = text.match(new RegExp(`${prefix}${escapedChar} [^\\s${escapedChar}]+$`))
+    const corrected = text.match(new RegExp(`${prefix}${escapedChar} [^\\s${escapedChar}]+ ?$`))
     if (!corrected || corrected.index === undefined) return null
 
     const matchPrefix = text.slice(Math.max(0, corrected.index - 1), corrected.index)
@@ -38,7 +43,7 @@ export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeo
     const from = $position.pos - text.length + corrected.index
     return {
       range: { from, to: $position.pos },
-      query: corrected[0].slice(char.length + 1),
+      query: corrected[0].slice(char.length + 1).trimEnd(),
       text: corrected[0],
     }
   }

--- a/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
+++ b/apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts
@@ -1,4 +1,5 @@
-import { escapeForRegEx } from "@tiptap/core"
+import { escapeForRegEx, type Editor } from "@tiptap/core"
+import type { PluginKey } from "@tiptap/pm/state"
 import { findSuggestionMatch, type SuggestionMatch, type Trigger } from "@tiptap/suggestion"
 
 /**
@@ -18,7 +19,11 @@ import { findSuggestionMatch, type SuggestionMatch, type Trigger } from "@tiptap
  * plain `:fir ` still dismisses, and a second space after a correction dismisses
  * too — the corrected state is the one place a single space can't.
  */
-export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeof findSuggestionMatch {
+export function withKeyboardCorrectionTolerance(pluginKey: PluginKey, editor: Editor): typeof findSuggestionMatch {
+  // Runs during state application, when editor.state still holds the
+  // pre-transaction state — so this reads the *previous* active flag.
+  const wasActive = () => (pluginKey.getState(editor.state) as { active?: boolean } | undefined)?.active === true
+
   return (config: Trigger): SuggestionMatch => {
     const match = findSuggestionMatch(config)
     if (match) return match
@@ -47,9 +52,4 @@ export function withKeyboardCorrectionTolerance(wasActive: () => boolean): typeo
       text: corrected[0],
     }
   }
-}
-
-/** Reads the previous active state of a suggestion plugin during state application. */
-export interface SuggestionActiveProbe {
-  active?: boolean
 }

--- a/tests/browser/keyboard-correction-suggestion.spec.ts
+++ b/tests/browser/keyboard-correction-suggestion.spec.ts
@@ -76,6 +76,35 @@ test.describe("Keyboard word-correction in trigger popups", () => {
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
   })
 
+  test("emoji picker survives the keyboard's trailing space and still picks", async ({ page }) => {
+    const { editor } = await setupWorkspaceWithEditor(page, "kbtrail")
+
+    await page.keyboard.type(":fir")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+    // Keyboards deliver `: fire ` — the leading-space replacement, then a
+    // trailing space, usually as a follow-up transaction.
+    await simulateKeyboardWordCorrection(page, ":fir", ": fire")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible()
+    await simulateKeyboardWordCorrection(page, ": fire", ": fire ")
+
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible()
+    await expect(page.locator("[data-emoji-grid] button[aria-label=':fire:']").first()).toBeVisible()
+
+    // Picking replaces the whole `: fire ` range, both spaces included.
+    await page.keyboard.press("Enter")
+    await expect(editor).toContainText(EMOJI_RE)
+    await expect(editor).not.toContainText(":")
+    await expect(editor).not.toContainText("fire")
+
+    // A second space after a trailing-space correction still dismisses.
+    await page.keyboard.type(":fir")
+    await simulateKeyboardWordCorrection(page, ":fir", ": fire ")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible()
+    await page.keyboard.type(" ")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+  })
+
   test("manually typed space after the trigger still dismisses the picker for good", async ({ page }) => {
     await setupWorkspaceWithEditor(page, "kbspace")
 

--- a/tests/browser/keyboard-correction-suggestion.spec.ts
+++ b/tests/browser/keyboard-correction-suggestion.spec.ts
@@ -91,6 +91,26 @@ test.describe("Keyboard word-correction in trigger popups", () => {
     await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
   })
 
+  test("Escape-dismissed picker stays closed through a keyboard word-correction", async ({ page }) => {
+    const { editor } = await setupWorkspaceWithEditor(page, "kbescape")
+
+    await page.keyboard.type(":fir")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+    // Escape deactivates on its own transaction, so the correction lands with
+    // the popup inactive and must not reach the tolerant fallback.
+    await page.keyboard.press("Escape")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+
+    await simulateKeyboardWordCorrection(page, ":fir", ": fire")
+    await expect(editor).toContainText(": fire")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+
+    // Enter still sends the message rather than picking an emoji.
+    await page.keyboard.press("Enter")
+    await expect(page.getByRole("main").getByText(": fire")).toBeVisible({ timeout: 5000 })
+  })
+
   test("mention popup survives a word-correction with leading space and picks the mention", async ({ page }) => {
     const { editor, name } = await setupWorkspaceWithEditor(page, "kbmention")
     const [firstName] = name.split(" ")

--- a/tests/browser/keyboard-correction-suggestion.spec.ts
+++ b/tests/browser/keyboard-correction-suggestion.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace } from "./helpers"
+
+const EMOJI_RE = /\p{Extended_Pictographic}/u
+
+/**
+ * Mobile keyboard word-correction vs. trigger popups.
+ *
+ * When the user taps a keyboard suggestion mid-query (`:fir` → tap "fire"),
+ * mobile keyboards replace the word with a leading space because the trigger
+ * char is punctuation: the composer ends up with `: fire`. The suggestion
+ * popup must survive that single-transaction correction (query "fire"), while
+ * a manually typed space must still dismiss it for good.
+ */
+
+// Replays what a mobile keyboard does on suggestion tap: mutate the
+// contenteditable text node directly, in one DOM change, and move the caret —
+// ProseMirror's DOMObserver turns it into a single replacement transaction.
+// page.keyboard would produce per-character transactions, which is a different
+// (and already working) code path.
+async function simulateKeyboardWordCorrection(page: Page, find: string, replace: string) {
+  await page.evaluate(
+    ([find, replace]) => {
+      const editor = document.querySelector("[contenteditable='true']")
+      if (!editor) throw new Error("no contenteditable editor found")
+      const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+      let node: Text | null = null
+      while (walker.nextNode()) {
+        const candidate = walker.currentNode as Text
+        if (candidate.data.includes(find)) node = candidate
+      }
+      if (!node) throw new Error(`no text node containing ${JSON.stringify(find)}`)
+      const index = node.data.lastIndexOf(find)
+      node.replaceData(index, find.length, replace)
+      const selection = window.getSelection()
+      if (!selection) throw new Error("no selection")
+      const range = document.createRange()
+      range.setStart(node, index + replace.length)
+      range.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(range)
+    },
+    [find, replace] as const
+  )
+}
+
+async function setupWorkspaceWithEditor(page: Page, prefix: string) {
+  const context = await loginAndCreateWorkspace(page, prefix)
+  await page.getByRole("button", { name: "+ New Scratchpad" }).click()
+  await expect(page.getByText(/Type a message|No messages yet/)).toBeVisible({ timeout: 5000 })
+  const editor = page.locator("[contenteditable='true']")
+  await editor.click()
+  return { editor, ...context }
+}
+
+test.describe("Keyboard word-correction in trigger popups", () => {
+  test("emoji picker survives a word-correction with leading space and picks the emoji", async ({ page }) => {
+    const { editor } = await setupWorkspaceWithEditor(page, "kbemoji")
+
+    await page.keyboard.type(":fir")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+    // Keyboard replaces the fat-fingered "fir" with " fire" in one transaction.
+    await simulateKeyboardWordCorrection(page, ":fir", ": fire")
+    await expect(editor).toContainText(": fire")
+
+    // Picker stays open, filtered by the corrected word.
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible()
+    await expect(page.locator("[data-emoji-grid] button[aria-label=':fire:']").first()).toBeVisible()
+
+    // Picking replaces the whole `: fire` range, space included.
+    await page.keyboard.press("Enter")
+    await expect(editor).toContainText(EMOJI_RE)
+    await expect(editor).not.toContainText(":")
+    await expect(editor).not.toContainText("fire")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+  })
+
+  test("manually typed space after the trigger still dismisses the picker for good", async ({ page }) => {
+    await setupWorkspaceWithEditor(page, "kbspace")
+
+    await page.keyboard.type(":")
+    await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+    // A typed space closes the picker on its own transaction...
+    await page.keyboard.type(" ")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+
+    // ...so continuing to type a word after `: ` must NOT reopen it.
+    await page.keyboard.type("fire")
+    await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+  })
+
+  test("mention popup survives a word-correction with leading space and picks the mention", async ({ page }) => {
+    const { editor, name } = await setupWorkspaceWithEditor(page, "kbmention")
+    const [firstName] = name.split(" ")
+
+    const partial = firstName.slice(0, firstName.length - 2)
+    await page.keyboard.type(`@${partial}`)
+    await expect(page.getByRole("listbox")).toBeVisible({ timeout: 2000 })
+
+    await simulateKeyboardWordCorrection(page, `@${partial}`, `@ ${firstName}`)
+    await expect(editor).toContainText(`@ ${firstName}`)
+
+    await expect(page.getByRole("listbox")).toBeVisible()
+    await expect(page.getByRole("option").first()).toContainText(firstName)
+
+    await page.keyboard.press("Enter")
+    await expect(editor.locator("[data-type='mention']")).toBeVisible()
+    await expect(editor).not.toContainText(`@ ${firstName}`)
+    await expect(page.getByRole("listbox")).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Problem

Tapping a device-keyboard word suggestion mid-trigger-query kills the composer popup. Mobile keyboards insert the picked word with a leading space when the preceding character is punctuation: typing `:srig` and tapping "shrug" leaves `: shrug` in the composer. Every trigger runs tiptap `Suggestion` with `allowSpaces: false`, so the default `findSuggestionMatch` returns null on that transaction and the emoji/mention/command popup exits — the user has to go back, delete the space, and retype.

## Solution

A custom `findSuggestionMatch` (`keyboard-correction-match.ts`) that falls back to matching `<char> <word>` at the caret when the default matcher fails, wired into both suggestion sites: `createTriggerExtension` (@/#//) and `EmojiExtension` (:).

- Gated on the popup having been **active in the previous state** — read via `pluginKey.getState(this.editor.state)`, which still holds the pre-transaction state during plugin-state application. A manually typed space deactivates the popup on its own transaction, so `ratio : 5` can never reopen it; only a single-transaction multi-char insert landing while the popup is open (the keyboard correction) reaches the fallback.
- Gate-on-previous-active over rewriting the doc (deleting the space in `appendTransaction`) — mutating text the keyboard just inserted risks fighting the IME's composition model; here the text stays `: fire` until the user picks, and the match range covers the space so picking replaces it all.
- The fallback query strips `char + space`, so item filtering sees `fire`, and mirrors the default matcher's `allowedPrefixes`/`startOfLine` handling; it bails when `allowSpaces`/`allowToIncludeChar` are set (unused in this repo).
- Keyboards also append a trailing space (`: shrug `, usually a follow-up transaction — dogfood video showed the popup flash then die on it), so the pattern tolerates one — only in the leading-space form. Plain `:fir ` still dismisses; the one trade-off is that after a correction a single manual space no longer dismisses (a second space, Escape, and click-away do).
- Out of scope: the search-filter suggestion family (`from-filter`, `date-filter`, `in-channel-filter`, …) instantiate `Suggestion` separately and keep today's behavior.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/triggers/keyboard-correction-match.ts` | **new** — space-tolerant matcher, gated on previous active state |
| `apps/frontend/src/components/editor/triggers/create-trigger-extension.ts` | wire matcher into @/#// triggers |
| `apps/frontend/src/components/editor/triggers/emoji-extension.ts` | wire matcher into : trigger |
| `tests/browser/keyboard-correction-suggestion.spec.ts` | **new** — 5 Playwright tests; corrections simulated by direct text-node mutation (the DOM path ProseMirror sees from a real keyboard), not `page.keyboard` |

## Test plan

- [x] `tests/browser/keyboard-correction-suggestion.spec.ts` — 5 pass (emoji survives + picks; trailing-space variant incl. second-space dismissal; manual space still dismisses for good; Escape-dismissed stays closed through a correction; mention survives + picks). Verified they fail with the gate neutralized / the trailing-space tolerance removed.
- [x] Neighboring browser specs (emoji-shortcuts, command-arg-picker, rich-text-editing, markdown-shortcuts, inline-code-boundary-caret) — 54 pass
- [x] `vitest run src/components/editor` — 416 pass; frontend `tsc --noEmit` clean
- [ ] Real-device iOS/Android keyboard — not run; the DOM-mutation simulation is the closest harness equivalent

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
