### PR TITLE
feat(memos): stamp the memo card's content onto the composer node

### DIFF
--- a/apps/frontend/src/components/editor/memo-embed-extension.test.ts
+++ b/apps/frontend/src/components/editor/memo-embed-extension.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, it, expect } from "vitest"
+import { Editor } from "@tiptap/core"
+import type { MemoEmbedSummary } from "@threa/types"
+import { createEditorExtensions } from "./editor-extensions"
+
+/**
+ * The `summary` attr is what lets a memo card render complete in the two places
+ * the server's copy can't reach it: a sealed stream (the server sees only the
+ * placeholder body) and an optimistic or offline send (no round trip yet). So
+ * what matters here is that it survives the trip through the document.
+ */
+
+const editors: Editor[] = []
+
+const SUMMARY: MemoEmbedSummary = {
+  memoId: "memo_01ABC",
+  title: "Switched theme to light",
+  knowledgeType: "decision",
+  memoType: "conversation",
+  tags: ["settings", "preferences"],
+  updatedAt: "2026-07-02T10:00:00.000Z",
+}
+
+function makeEditor(content = "") {
+  const el = document.createElement("div")
+  document.body.appendChild(el)
+  const editor = new Editor({ element: el, extensions: createEditorExtensions({ placeholder: "x" }), content })
+  editor.on("destroy", () => el.remove())
+  editors.push(editor)
+  return editor
+}
+
+function memoNodeAttrs(editor: Editor): Record<string, unknown> | null {
+  let found: Record<string, unknown> | null = null
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "memoEmbed") found = node.attrs
+    return !found
+  })
+  return found
+}
+
+// vitest keeps the jsdom document between cases, so an editor left mounted
+// leaks its DOM into the next one.
+afterEach(() => {
+  while (editors.length) editors.pop()?.destroy()
+})
+
+describe("MemoEmbedExtension summary attr", () => {
+  it("carries the summary given at insert time", () => {
+    const editor = makeEditor()
+    editor.commands.insertMemoEmbed({ memoId: "memo_01ABC", title: "Theme", summary: SUMMARY })
+
+    expect(memoNodeAttrs(editor)).toMatchObject({ memoId: "memo_01ABC", title: "Theme", summary: SUMMARY })
+  })
+
+  it("defaults to no summary when inserted without one", () => {
+    const editor = makeEditor()
+    editor.commands.insertMemoEmbed({ memoId: "memo_01ABC" })
+
+    expect(memoNodeAttrs(editor)).toMatchObject({ memoId: "memo_01ABC", summary: null })
+  })
+
+  // A chip copied out of one composer and pasted into another goes through HTML,
+  // which is where a non-string attr silently becomes "[object Object]".
+  it("round-trips the summary through HTML", () => {
+    const source = makeEditor()
+    source.commands.insertMemoEmbed({ memoId: "memo_01ABC", title: "Theme", summary: SUMMARY })
+
+    const pasted = makeEditor(source.getHTML())
+
+    expect(memoNodeAttrs(pasted)).toMatchObject({ memoId: "memo_01ABC", summary: SUMMARY })
+  })
+
+  it("survives a malformed summary attribute rather than failing to parse the document", () => {
+    const pasted = makeEditor(
+      '<p><span data-type="memo-embed" data-memo-id="memo_01ABC" data-title="Theme" data-summary="{not json"></span></p>'
+    )
+
+    expect(memoNodeAttrs(pasted)).toMatchObject({ memoId: "memo_01ABC", summary: null })
+  })
+})

--- a/apps/frontend/src/components/editor/memo-embed-extension.ts
+++ b/apps/frontend/src/components/editor/memo-embed-extension.ts
@@ -1,4 +1,5 @@
 import { Node, mergeAttributes } from "@tiptap/core"
+import type { MemoEmbedSummary } from "@threa/types"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { MemoEmbedView } from "./memo-embed-view"
 
@@ -7,13 +8,28 @@ export interface MemoEmbedAttrs {
   memoId: string
   /** Memo title cached at insert time so the chip renders before hydration */
   title: string
+  /**
+   * The card's content, stamped at insert time and carried INSIDE the message
+   * body rather than beside it.
+   *
+   * The server writes the authoritative copy onto the message payload and that
+   * wins wherever it exists. This one covers the two cases where it can't: a
+   * sealed (E2E) stream, where the server only ever sees the placeholder body,
+   * and an optimistic or queued-offline send, which renders before any server
+   * round trip. Both would otherwise show a label-only card.
+   *
+   * It is a snapshot. For a sealed stream it is also permanent — `memo:updated`
+   * cannot patch what lives inside ciphertext — so a retitled memo keeps its old
+   * card there until the message is edited.
+   */
+  summary?: MemoEmbedSummary | null
 }
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     memoEmbed: {
       /** Insert an inline memo-embed chip for the given memo. */
-      insertMemoEmbed: (attrs: { memoId: string; title?: string }) => ReturnType
+      insertMemoEmbed: (attrs: { memoId: string; title?: string; summary?: MemoEmbedSummary | null }) => ReturnType
     }
   }
 }
@@ -46,6 +62,21 @@ export const MemoEmbedExtension = Node.create({
         parseHTML: (element) => element.getAttribute("data-title"),
         renderHTML: (attrs) => ({ "data-title": attrs.title }),
       },
+      summary: {
+        default: null,
+        // Round-trips through HTML as JSON so a chip survives a copy/paste
+        // between composers with its card content intact.
+        parseHTML: (element) => {
+          const raw = element.getAttribute("data-summary")
+          if (!raw) return null
+          try {
+            return JSON.parse(raw) as MemoEmbedSummary
+          } catch {
+            return null
+          }
+        },
+        renderHTML: (attrs) => (attrs.summary ? { "data-summary": JSON.stringify(attrs.summary) } : {}),
+      },
     }
   },
 
@@ -75,7 +106,11 @@ export const MemoEmbedExtension = Node.create({
           const marks = currentMarks.map((mark) => ({ type: mark.type.name, attrs: mark.attrs }))
           return chain()
             .insertContent([
-              { type: this.name, attrs: { memoId: attrs.memoId, title: attrs.title ?? "" }, marks },
+              {
+                type: this.name,
+                attrs: { memoId: attrs.memoId, title: attrs.title ?? "", summary: attrs.summary ?? null },
+                marks,
+              },
               { type: "text", text: " ", marks },
             ])
             .run()

--- a/apps/frontend/src/components/editor/memo-embed-view.tsx
+++ b/apps/frontend/src/components/editor/memo-embed-view.tsx
@@ -2,33 +2,42 @@ import { useEffect } from "react"
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
 import { useMemoEmbedSource } from "@/hooks/use-memo-embed-source"
 import { MemoChip } from "@/components/memo-embed/memo-chip"
+import { memoEmbedSummaryFromResolved } from "@/lib/memo-embed-summary"
 import type { MemoEmbedAttrs } from "./memo-embed-extension"
 
 /**
  * In-composer memo-embed chip (TipTap NodeView). Resolves the live memo from
- * the detail API and renders the shared inline `MemoChip`. When the node was
- * inserted without a cached title (e.g. pasted memo link), the resolved title
- * is written back to the node so serialization carries a real label instead of
- * the generic "Memo" fallback.
+ * the detail API and renders the shared inline `MemoChip`.
+ *
+ * A node inserted through the picker already carries its title and card content.
+ * A node from a pasted memo link carries neither, so both are written back onto
+ * the node once resolved — the card content because it has to ride inside the
+ * body to survive a sealed stream or an offline send, and the title so
+ * serialization carries a real label instead of the generic "Memo" fallback.
+ * Fetching here is fine: this is the composer, not the stream.
  */
 export function MemoEmbedView({ node, updateAttributes }: NodeViewProps) {
   const attrs = node.attrs as MemoEmbedAttrs
   const source = useMemoEmbedSource(attrs.memoId)
 
-  const resolvedTitle = source.status === "resolved" ? source.title : null
+  const resolved = source.status === "resolved" ? source : null
+  const needsTitle = !attrs.title
+  const needsSummary = !attrs.summary
 
-  // Stamp the resolved title onto the node only when it was inserted without
-  // one (pasted memo link). A user-cached title is left as-is so the write-back
-  // doesn't fight the editor or churn the undo history on every render.
+  // Stamp only what the node is missing, so a user-cached title isn't fought
+  // over and the undo history doesn't churn on every render.
   useEffect(() => {
-    if (resolvedTitle && !attrs.title) {
-      updateAttributes({ title: resolvedTitle })
-    }
-  }, [resolvedTitle, attrs.title, updateAttributes])
+    if (!resolved) return
+    if (!needsTitle && !needsSummary) return
+    updateAttributes({
+      ...(needsTitle && { title: resolved.title }),
+      ...(needsSummary && { summary: memoEmbedSummaryFromResolved(attrs.memoId, resolved) }),
+    })
+  }, [resolved, needsTitle, needsSummary, attrs.memoId, updateAttributes])
 
   return (
     <NodeViewWrapper as="span" data-type="memo-embed">
-      <MemoChip label={resolvedTitle || attrs.title || "Memo"} />
+      <MemoChip label={resolved?.title || attrs.title || "Memo"} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/triggers/memo-search-extension.ts
+++ b/apps/frontend/src/components/editor/triggers/memo-search-extension.ts
@@ -14,6 +14,7 @@
  * (`/memo ` or `/memo <query>`), which is also how the palette hands off.
  */
 import { Extension } from "@tiptap/core"
+import { memoEmbedSummary } from "@/lib/memo-embed-summary"
 import Suggestion from "@tiptap/suggestion"
 import { PluginKey } from "@tiptap/pm/state"
 import type { ResolvedPos } from "@tiptap/pm/model"
@@ -116,7 +117,12 @@ export const MemoSearchExtension = Extension.create<MemoSearchOptions>({
             .focus()
             .deleteRange(range)
             .insertContent([
-              { type: "memoEmbed", attrs: { memoId: memo.id, title: memo.title } },
+              {
+                type: "memoEmbed",
+                // The card's content rides inside the body, so a sealed stream
+                // or an offline send still renders a complete card.
+                attrs: { memoId: memo.id, title: memo.title, summary: memoEmbedSummary(memo) },
+              },
               { type: "text", text: " " },
             ])
             .run()

--- a/apps/frontend/src/lib/memo-embed-summary.ts
+++ b/apps/frontend/src/lib/memo-embed-summary.ts
@@ -1,0 +1,46 @@
+import type { Memo, MemoEmbedSummary } from "@threa/types"
+
+/**
+ * The card content to stamp onto a `memoEmbed` node at insert time — the same
+ * shape the server puts on the message payload, so the card reads one type
+ * whichever source it came from.
+ *
+ * One mapping, shared by the picker and the paste write-back: they insert the
+ * same node and a difference between them would show up as a card that changes
+ * when the message round-trips.
+ */
+export function memoEmbedSummary(memo: Memo): MemoEmbedSummary {
+  return {
+    memoId: memo.id,
+    title: memo.title,
+    knowledgeType: memo.knowledgeType,
+    memoType: memo.memoType,
+    tags: memo.tags,
+    updatedAt: memo.updatedAt,
+  }
+}
+
+/**
+ * Same mapping from a resolved embed source (which carries no id of its own —
+ * the caller holds it). Kept beside {@link memoEmbedSummary} so the shape has
+ * one home, not one per caller.
+ */
+export function memoEmbedSummaryFromResolved(
+  memoId: string,
+  resolved: {
+    title: string
+    knowledgeType: Memo["knowledgeType"]
+    memoType: Memo["memoType"]
+    tags: string[]
+    updatedAt: string
+  }
+): MemoEmbedSummary {
+  return {
+    memoId,
+    title: resolved.title,
+    knowledgeType: resolved.knowledgeType,
+    memoType: resolved.memoType,
+    tags: resolved.tags,
+    updatedAt: resolved.updatedAt,
+  }
+}


### PR DESCRIPTION
## Problem

C2 ([#1688](https://github.com/threahq/threa/pull/1688)) puts a memo's card content on the message payload. Two paths can never get it there:

- **A sealed (E2E) stream.** The server stores `E2E_PLACEHOLDER_CONTENT_MARKDOWN` and placeholder JSON; the real body exists only inside the ciphertext. There are no memo ids for the server to see, so there is nothing it can summarise.
- **An optimistic or offline-queued send.** The card renders before any server round trip, and the queued payload carries markdown, JSON and attachments only.

Both render today because the card fetches. C4 deletes that fetch — so without this chunk, memo cards in scratchpads (the solo-first surface, where sealed streams live) would regress from a full card to a label-only one, permanently.

## Solution

The `memoEmbed` node carries its own `summary`, stamped at insert time, so the card content rides **inside** the body — through the ciphertext, through the offline queue, through the optimistic render.

- **Both insertion points stamp it.** The `/memo` picker maps from the `Memo` it already holds; a pasted bare memo link resolves in the NodeView and writes it back, alongside the title write-back that already existed there. One mapping module, so the two can't drift into showing different cards for the same memo.
- **The server's copy still wins** wherever it exists (C4 wires that). This is the floor, not the source of truth.
- **It round-trips through HTML as JSON**, so a chip copied between composers keeps its card. A malformed `data-summary` parses to `null` rather than throwing — a bad paste should cost the card's eyebrow, not the document.
- Fetching in the NodeView stays. That is the composer, not the stream; the rule is about what the stream renders.

**Known and deliberate:** in a sealed stream this snapshot is permanent — `memo:updated` (C5) cannot patch what lives inside ciphertext, so a retitled memo keeps its old card there until the message is edited. Outside sealed streams the payload refresh and the update event both reach it.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/memo-embed-extension.ts` | the `summary` attr + its HTML round-trip |
| `apps/frontend/src/components/editor/triggers/memo-search-extension.ts` | picker stamps it |
| `apps/frontend/src/components/editor/memo-embed-view.tsx` | paste write-back, now title + summary |
| `apps/frontend/src/lib/memo-embed-summary.ts` | **new** — the one mapping, from a `Memo` or a resolved source |
| `apps/frontend/src/components/editor/memo-embed-extension.test.ts` | **new** — insert, default, HTML round-trip, malformed attr |

## Test plan

- [x] `apps/frontend` vitest — **5462 pass** whole suite · `bun run typecheck` 0 · `bun run lint` 0
- [x] New extension tests — 4 pass, including the HTML round-trip (where a non-string attr silently becomes `"[object Object]"`) and a malformed `data-summary`
- [ ] **The picker's stamp has no unit test.** Its `command` runs inside the suggestion plugin and isn't reachable without driving the whole picker; TypeScript catches a field missed in the mapping but not the call being dropped entirely. C4's browser test covers it end-to-end — a picker-inserted memo rendering a full card in a sealed stream is the assertion that matters, and it belongs there.
- [ ] Nothing renders from this attr yet; C4 reads it.
- One full-suite run while the backend suite ran alongside timed out unrelated tests (calls, gallery, draft-sync, e2e-session-store) at the 5s default, with a different set each time. Those four files pass 117/117 in isolation, and a clean run with the machine quiet is 5462/5462. Load flake, not this diff — recorded rather than quietly re-run until green.

## Notes for the stack

#1688 → #1686 → #1681. Design: https://seer.build/ws_vbyzjvdg6g/b/memo-cards-scope-d842fe/ (v3)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
