### PR TITLE
feat(conversations): provisional assignment at send — membership becomes provisional-then-settled

### DIFF
--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -21,9 +21,16 @@ import { resolveConversationDelivery } from "./conversation-delivery"
  */
 export async function emitAssignmentEvents(
   client: PoolClient,
-  params: { workspaceId: string; message: Message; conversationId: string; created: boolean; reason: string }
+  params: {
+    workspaceId: string
+    message: Message
+    conversationId: string
+    created: boolean
+    reason: string
+    settling?: boolean
+  }
 ): Promise<Conversation> {
-  const { workspaceId, message, conversationId, created, reason } = params
+  const { workspaceId, message, conversationId, created, reason, settling = false } = params
 
   const stream = await StreamRepository.findById(client, message.streamId)
   const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
@@ -34,8 +41,8 @@ export async function emitAssignmentEvents(
     throw new Error(`Conversation ${conversationId} vanished during assignment`)
   }
 
-  // The declared/agent assignment itself is never settling, but the conversation
-  // it joins may hold provisional members — the payload must carry the full set.
+  // The conversation may hold provisional members beyond this assignment — the
+  // payload must carry the full set.
   const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
     client,
     workspaceId,
@@ -59,7 +66,7 @@ export async function emitAssignmentEvents(
     conversationId: refreshed.id,
     isPrimary: true,
     reason,
-    settling: false,
+    settling,
   })
 
   return refreshed

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -484,6 +484,11 @@ export class BoundaryExtractionService {
         workspaceId,
         candidateReassignments.map((r) => r.messageId)
       )
+      const stateByMessageId = await MessageConversationStateRepository.findByMessageIds(
+        client,
+        workspaceId,
+        candidateReassignments.map((r) => r.messageId)
+      )
 
       const messagesById = new Map<string, Message>([[message.id, message]])
 
@@ -538,11 +543,7 @@ export class BoundaryExtractionService {
         // Engagement can freeze a send-time structural guess no model ever
         // evaluated — accepted by design: the freeze binds the machine only, a
         // human re-file remains available, and the pass itself always runs.
-        if (
-          isPlacementFrozenByHuman(
-            await MessageConversationStateRepository.findByMessageId(client, workspaceId, r.messageId)
-          )
-        ) {
+        if (isPlacementFrozenByHuman(stateByMessageId.get(r.messageId) ?? null)) {
           logger.debug({ messageId: r.messageId }, "Skipping reassignment of a human-settled message")
           continue
         }

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from "pg"
 import { sql, withTransaction, withClient } from "../../db"
-import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationRepository, distinctAuthors, type Conversation } from "./repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository, StreamEventRepository, type Stream } from "../streams"
 import { OutboxRepository } from "../../lib/outbox"
@@ -24,14 +24,9 @@ import { MessageConversationStateRepository } from "./settling-repository"
 import { SETTLING_CONFIDENCE_THRESHOLD } from "./boundary-extraction/config"
 import { resolveConversationDelivery } from "./conversation-delivery"
 import { emitAssignmentEvents } from "./assignment-events"
+import { isClusteredAuthorType, isClusteredStreamType } from "./extraction-eligibility"
 import { conversationId } from "../../lib/id"
-import {
-  AuthorTypes,
-  ConversationStatuses,
-  LinkPreviewStatuses,
-  StreamTypes,
-  THREAD_ANCHORABLE_EVENT_TYPES,
-} from "@threa/types"
+import { ConversationStatuses, LinkPreviewStatuses, StreamTypes, THREAD_ANCHORABLE_EVENT_TYPES } from "@threa/types"
 import { logger } from "../../lib/logger"
 
 const MESSAGES_BEFORE = 5
@@ -129,11 +124,21 @@ export class BoundaryExtractionService {
         return { message: null, stream: null, extractionContextBase: null }
       }
 
-      // A message that DECLARED its conversation was assigned synchronously in
-      // the send transaction. The message:created outbox still fires, but the
-      // async pass must never re-cluster or move a human-declared assignment
-      // (INV-20) — short-circuit with the conversation it already owns.
-      if (message.conversationIntent !== null) {
+      // A message that DECLARED its conversation, or whose placement a human
+      // has since frozen, is human-assigned: the async pass never re-clusters or
+      // moves it (INV-20) — short-circuit with the conversation it already owns.
+      // Engagement freezes placement exactly as an explicit re-file does: a
+      // human acting on a message where it sits ratifies where it sits.
+      // A message merely attached PROVISIONALLY at send time (intent NULL, state
+      // `settling`), or settled only because the window moved on (`llm-window`),
+      // is NOT skipped: the pass evaluates it and re-files it below when it
+      // disagrees. The heuristic never becomes gospel.
+      const frozen =
+        message.conversationIntent === null &&
+        isPlacementFrozenByHuman(
+          await MessageConversationStateRepository.findByMessageId(client, workspaceId, message.id)
+        )
+      if (message.conversationIntent !== null || frozen) {
         const declaredPrimary = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, message.id)
         return {
           message,
@@ -150,7 +155,7 @@ export class BoundaryExtractionService {
       // (the stream's active conversation, created if none), NOT LLM-clustered:
       // a reply continues the conversation it's posted within. Handled after the
       // connection is released so the assignment runs in its own transaction.
-      if (message.authorType !== AuthorTypes.USER) {
+      if (!isClusteredAuthorType(message.authorType)) {
         return {
           message,
           stream,
@@ -160,7 +165,7 @@ export class BoundaryExtractionService {
         }
       }
 
-      if (stream.type === StreamTypes.SCRATCHPAD) {
+      if (!isClusteredStreamType(stream.type)) {
         const existingConversations = await ConversationRepository.findByStream(client, stream.id)
         return {
           message,
@@ -541,6 +546,17 @@ export class BoundaryExtractionService {
           continue
         }
 
+        // Same freeze as the triggering message: a human ruling — an explicit
+        // re-file or engagement where it sits — outranks a later pass.
+        if (
+          isPlacementFrozenByHuman(
+            await MessageConversationStateRepository.findByMessageId(client, workspaceId, r.messageId)
+          )
+        ) {
+          logger.debug({ messageId: r.messageId }, "Skipping reassignment of a human-settled message")
+          continue
+        }
+
         await ConversationRepository.removePrimaryMessage(client, workspaceId, fromConvId, r.messageId)
         await ConversationRepository.addPrimaryMessage(
           client,
@@ -565,9 +581,45 @@ export class BoundaryExtractionService {
         })
       }
 
+      // The triggering message may already hold a PROVISIONAL primary from its
+      // send transaction (structural guess, marked settling). If the pass lands
+      // it elsewhere, it must LEAVE that conversation — otherwise it would sit
+      // in two `message_ids` arrays and the guess would be permanent.
+      const priorPrimary = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
+
       const reopenedConversationIds = new Set<string>()
       for (const a of resolvedAssignments) {
         if (a.isPrimary) {
+          if (priorPrimary && priorPrimary.id !== a.conversationId) {
+            // Participants are recomputed from who REMAINS: the send-time
+            // attach added this author to the guess, and an overturn must not
+            // leave them listed in a conversation they never spoke in.
+            const remainingIds = priorPrimary.messageIds.filter((id) => id !== messageId)
+            const remainingMessages = await MessageRepository.findByIds(client, remainingIds)
+            await ConversationRepository.removePrimaryMessages(
+              client,
+              workspaceId,
+              priorPrimary.id,
+              [messageId],
+              distinctAuthors(remainingIds, remainingMessages)
+            )
+            await ConversationRepository.resolveIfEmpty(client, workspaceId, priorPrimary.id)
+            // The still-settling row follows the message to its new home.
+            await MessageConversationStateRepository.moveConversation(
+              client,
+              workspaceId,
+              [messageId],
+              a.conversationId
+            )
+            touchedConversationIds.add(priorPrimary.id)
+            reassignmentEvents.push({
+              messageId,
+              streamId: message.streamId,
+              fromConversationId: priorPrimary.id,
+              toConversationId: a.conversationId,
+              reason: "extraction",
+            })
+          }
           await ConversationRepository.addPrimaryMessage(
             client,
             workspaceId,
@@ -599,6 +651,16 @@ export class BoundaryExtractionService {
           streamId,
           conversationId: primaryConversationId,
         })
+      } else if (primaryConversationId) {
+        // A confident ruling on a message whose send-time attach was provisional
+        // settles that row where the pass put it. No-op when nothing is settling.
+        await MessageConversationStateRepository.settleForConversationTarget(
+          client,
+          workspaceId,
+          messageId,
+          primaryConversationId,
+          "llm-window"
+        )
       }
 
       // Anything of this stream the pass could no longer see will never be
@@ -868,6 +930,15 @@ export class BoundaryExtractionService {
     }
     return { replyTargets, quotedConversations }
   }
+}
+
+/**
+ * Engagement freezes placement: a human who re-filed a message (`'user'`) or
+ * engaged with it where it sits (`'engagement'`) has ruled, and no later pass
+ * re-files it. `'llm-window'` settles are machine-made and stay decidable.
+ */
+function isPlacementFrozenByHuman(row: { state: string; settledBy: string | null } | null): boolean {
+  return row?.state === "settled" && (row.settledBy === "user" || row.settledBy === "engagement")
 }
 
 /** Append `extra` conversations not already present in `primary`, deduped by id. */

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -124,21 +124,10 @@ export class BoundaryExtractionService {
         return { message: null, stream: null, extractionContextBase: null }
       }
 
-      // A message that DECLARED its conversation, or whose placement a human
-      // has since frozen, is human-assigned: the async pass never re-clusters or
-      // moves it (INV-20) — short-circuit with the conversation it already owns.
-      // Engagement freezes placement exactly as an explicit re-file does: a
-      // human acting on a message where it sits ratifies where it sits.
-      // A message merely attached PROVISIONALLY at send time (intent NULL, state
-      // `settling`), or settled only because the window moved on (`llm-window`),
-      // is NOT skipped: the pass evaluates it and re-files it below when it
-      // disagrees. The heuristic never becomes gospel.
-      const frozen =
-        message.conversationIntent === null &&
-        isPlacementFrozenByHuman(
-          await MessageConversationStateRepository.findByMessageId(client, workspaceId, message.id)
-        )
-      if (message.conversationIntent !== null || frozen) {
+      // A message that DECLARED its conversation is human-assigned: the async
+      // pass never re-clusters or moves it (INV-20) — short-circuit with the
+      // conversation it already owns.
+      if (message.conversationIntent !== null) {
         const declaredPrimary = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, message.id)
         return {
           message,
@@ -546,8 +535,9 @@ export class BoundaryExtractionService {
           continue
         }
 
-        // Same freeze as the triggering message: a human ruling — an explicit
-        // re-file or engagement where it sits — outranks a later pass.
+        // Engagement can freeze a send-time structural guess no model ever
+        // evaluated — accepted by design: the freeze binds the machine only, a
+        // human re-file remains available, and the pass itself always runs.
         if (
           isPlacementFrozenByHuman(
             await MessageConversationStateRepository.findByMessageId(client, workspaceId, r.messageId)
@@ -586,15 +576,35 @@ export class BoundaryExtractionService {
       // it elsewhere, it must LEAVE that conversation — otherwise it would sit
       // in two `message_ids` arrays and the guess would be permanent.
       const priorPrimary = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
+      const triggerPlacementFrozen = isPlacementFrozenByHuman(
+        await MessageConversationStateRepository.findByMessageId(client, workspaceId, messageId)
+      )
+
+      // Engagement can freeze a send-time structural guess no model ever
+      // evaluated — accepted by design. The pass still ran and its other outputs
+      // (clustering, context reassignments, completeness, window settling) stand;
+      // only THIS message's placement is held against the machine, and a human
+      // re-file remains available.
+      if (triggerPlacementFrozen && priorPrimary) {
+        for (const a of resolvedAssignments) {
+          if (a.isPrimary) a.conversationId = priorPrimary.id
+        }
+      }
 
       const reopenedConversationIds = new Set<string>()
       for (const a of resolvedAssignments) {
         if (a.isPrimary) {
           if (priorPrimary && priorPrimary.id !== a.conversationId) {
+            // Recomputed from who REMAINS in the LOCKED row (INV-20): a
+            // concurrent send's attach must not be dropped by a wholesale SET
+            // of participant_ids from a stale snapshot. One conversation row is
+            // locked at a time here and on the send path, so no lock cycle.
+            const lockedPrior =
+              (await ConversationRepository.findByIdForUpdate(client, workspaceId, priorPrimary.id)) ?? priorPrimary
             // Participants are recomputed from who REMAINS: the send-time
             // attach added this author to the guess, and an overturn must not
             // leave them listed in a conversation they never spoke in.
-            const remainingIds = priorPrimary.messageIds.filter((id) => id !== messageId)
+            const remainingIds = lockedPrior.messageIds.filter((id) => id !== messageId)
             const remainingMessages = await MessageRepository.findByIds(client, remainingIds)
             await ConversationRepository.removePrimaryMessages(
               client,

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -2,11 +2,20 @@ import type { PoolClient } from "pg"
 import { sql } from "../../db"
 import { ConversationRepository } from "./repository"
 import type { ConversationAssigner, Message } from "../messaging"
-import { checkStreamAccess, StreamRepository } from "../streams"
+import { checkStreamAccess, StreamRepository, type Stream } from "../streams"
 import { emitAssignmentEvents } from "./assignment-events"
 import { conversationId } from "../../lib/id"
-import { ConversationIntents, ConversationStatuses } from "@threa/types"
+import { ConversationIntents, ConversationStatuses, StreamTypes, type AuthorType } from "@threa/types"
 import { HttpError } from "../../lib/errors"
+import { MessageConversationStateRepository } from "./settling-repository"
+import { isClusteredSend } from "./extraction-eligibility"
+
+/**
+ * How far back a root-stream send looks for a conversation to provisionally
+ * join. Past it the stream has gone quiet and the new message is likelier to
+ * open a topic than continue one — no attach, and the extractor decides.
+ */
+export const PROVISIONAL_ATTACH_WINDOW_MINUTES = 30
 
 /**
  * Assigns a message that DECLARED its conversation at send time, synchronously,
@@ -92,6 +101,68 @@ export const conversationAssigner: ConversationAssigner = {
     })
     return target.id
   },
+
+  async attachProvisionalInTransaction(client, { workspaceId, message, stream, authorType }) {
+    if (!stream) return null
+    if (
+      !(await isClusteredSend(client, {
+        workspaceId,
+        streamId: stream.id,
+        streamType: stream.type,
+        authorType,
+      }))
+    ) {
+      return null
+    }
+
+    const candidate = await findProvisionalCandidate(client, workspaceId, stream)
+    if (!candidate) return null
+
+    // Same lock order as the declared `existing` path (INV-20): the candidate
+    // row is locked before any membership write.
+    const target = await ConversationRepository.findByIdForUpdate(client, workspaceId, candidate.id)
+    if (!target || target.status !== ConversationStatuses.ACTIVE) return null
+
+    await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, message.id, message.authorId)
+    // Before the events: the payload's `settlingMessageIds` is read back from
+    // this row.
+    await MessageConversationStateRepository.insertSettling(client, {
+      messageId: message.id,
+      workspaceId,
+      streamId: message.streamId,
+      conversationId: target.id,
+    })
+    await ConversationRepository.bumpActivityForIds(client, workspaceId, [target.id])
+    await emitAssignmentEvents(client, {
+      workspaceId,
+      message,
+      conversationId: target.id,
+      created: false,
+      reason: "provisional",
+      settling: true,
+    })
+    return target.id
+  },
+}
+
+/**
+ * The structural guess a send can make without an LLM. A thread reply continues
+ * the conversation its anchor belongs to (structural, so no time bound); a root
+ * message continues the stream's most recent conversation, but only while that
+ * conversation is still warm. Never mints — no candidate means the extractor
+ * assigns later, exactly as before.
+ */
+async function findProvisionalCandidate(
+  client: PoolClient,
+  workspaceId: string,
+  stream: Stream
+): Promise<{ id: string } | null> {
+  if (stream.type === StreamTypes.THREAD) {
+    if (!stream.parentAnchorId?.startsWith("msg_")) return null
+    return ConversationRepository.findPrimaryByMessageId(client, workspaceId, stream.parentAnchorId)
+  }
+  const activeSince = new Date(Date.now() - PROVISIONAL_ATTACH_WINDOW_MINUTES * 60_000)
+  return ConversationRepository.findLatestActiveByStream(client, workspaceId, stream.id, activeSince)
 }
 
 /** Mint a fresh conversation in the message's stream, seeded with the message.

--- a/apps/backend/src/features/conversations/extraction-eligibility.ts
+++ b/apps/backend/src/features/conversations/extraction-eligibility.ts
@@ -1,0 +1,34 @@
+import type { Querier } from "../../db"
+import { AuthorTypes, StreamTypes, type AuthorType, type StreamType } from "@threa/types"
+import { E2eStreamsRepository } from "../e2e-streams"
+
+/**
+ * Which sends boundary extraction LLM-clusters. The dispatch (E2E streams),
+ * `BoundaryExtractionService.processMessage` (agent replies, scratchpads) and
+ * the send-time provisional attach all read this one place, so a stream or
+ * author the extractor never clusters can't be provisionally attached either
+ * (INV-35).
+ */
+
+/** Agent (persona/bot) replies are assigned deterministically, never clustered. */
+export function isClusteredAuthorType(authorType: AuthorType | string): boolean {
+  return authorType === AuthorTypes.USER
+}
+
+/** A scratchpad is one conversation by decision — no clustering. */
+export function isClusteredStreamType(streamType: StreamType | string): boolean {
+  return streamType !== StreamTypes.SCRATCHPAD
+}
+
+/**
+ * The full send-time gate: everything the extractor would LLM-cluster, and
+ * nothing it wouldn't. E2E streams carry ciphertext, so extraction skips them
+ * at dispatch.
+ */
+export async function isClusteredSend(
+  db: Querier,
+  params: { workspaceId: string; streamId: string; streamType: StreamType | string; authorType: AuthorType | string }
+): Promise<boolean> {
+  if (!isClusteredAuthorType(params.authorType) || !isClusteredStreamType(params.streamType)) return false
+  return !(await E2eStreamsRepository.isE2eStream(db, params.workspaceId, params.streamId))
+}

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -1,6 +1,6 @@
 export { createConversationHandlers } from "./handlers"
 
-export { conversationAssigner } from "./conversation-assigner"
+export { conversationAssigner, PROVISIONAL_ATTACH_WINDOW_MINUTES } from "./conversation-assigner"
 
 export { ConversationService } from "./service"
 export type { ConversationWithStaleness, ListConversationsOptions } from "./service"

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -417,6 +417,33 @@ export const ConversationRepository = {
     return result.rows.map(mapRowToConversation)
   },
 
+  /**
+   * The stream's most recently active NON-EMPTY active conversation, bounded by
+   * `activeSince`. Workspace-scoped (INV-8). Empty shells are excluded so a
+   * provisional attach can't resurrect a conversation whose messages all moved
+   * away, and the time bound keeps a long-dormant conversation from swallowing
+   * an unrelated new message.
+   */
+  async findLatestActiveByStream(
+    db: Querier,
+    workspaceId: string,
+    streamId: string,
+    activeSince: Date
+  ): Promise<Conversation | null> {
+    const result = await db.query<ConversationRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)} FROM conversations
+      WHERE workspace_id = ${workspaceId}
+        AND stream_id = ${streamId}
+        AND status = ${ConversationStatuses.ACTIVE}
+        AND cardinality(message_ids) > 0
+        AND last_activity_at >= ${activeSince}
+      ORDER BY last_activity_at DESC
+      LIMIT 1
+    `)
+    if (!result.rows[0]) return null
+    return mapRowToConversation(result.rows[0])
+  },
+
   async findActiveByStream(db: Querier, streamId: string, limit = 50): Promise<Conversation[]> {
     return this.findByStream(db, streamId, { status: "active", limit })
   },
@@ -1033,4 +1060,19 @@ export const ConversationRepository = {
     const result = await db.query(sql`DELETE FROM conversations WHERE id = ${id}`)
     return result.rowCount !== null && result.rowCount > 0
   },
+}
+
+/** Distinct non-null author ids of `ids`, in first-appearance order — the
+ *  recomputed `participant_ids` for a membership move. */
+export function distinctAuthors(ids: string[], messages: Map<string, { authorId: string | null }>): string[] {
+  const seen = new Set<string>()
+  const authors: string[] = []
+  for (const id of ids) {
+    const authorId = messages.get(id)?.authorId
+    if (authorId && !seen.has(authorId)) {
+      seen.add(authorId)
+      authors.push(authorId)
+    }
+  }
+  return authors
 }

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -1,6 +1,6 @@
 import { Pool } from "pg"
 import { withClient, withTransaction, type Querier } from "../../db"
-import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationRepository, distinctAuthors, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageConversationStateRepository } from "./settling-repository"
 import { MessageRepository, type Message } from "../messaging"
@@ -1619,21 +1619,6 @@ export class ConversationService {
     // Map keys are unique, so a strict less-than comparator totally orders them.
     return [...groups.entries()].sort(([a], [b]) => (a < b ? -1 : 1))
   }
-}
-
-/** Distinct non-null author ids of `ids`, in first-appearance order — the
- *  recomputed `participant_ids` for a membership move. */
-function distinctAuthors(ids: string[], messages: Map<string, Message>): string[] {
-  const seen = new Set<string>()
-  const authors: string[] = []
-  for (const id of ids) {
-    const authorId = messages.get(id)?.authorId
-    if (authorId && !seen.has(authorId)) {
-      seen.add(authorId)
-      authors.push(authorId)
-    }
-  }
-  return authors
 }
 
 /** Project a full message + its hydrated rich content down to a board post message. */

--- a/apps/backend/src/features/conversations/settling-repository.ts
+++ b/apps/backend/src/features/conversations/settling-repository.ts
@@ -72,6 +72,17 @@ export const MessageConversationStateRepository = {
     return row ? mapRow(row) : null
   },
 
+  /** State rows for `messageIds`, keyed by message id. Absent = never provisional. */
+  async findByMessageIds(db: Querier, workspaceId: string, messageIds: string[]): Promise<Map<string, SettlingRow>> {
+    if (messageIds.length === 0) return new Map()
+    const result = await db.query<SettlingDbRow>(sql`
+      SELECT message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+      FROM message_conversation_state
+      WHERE workspace_id = ${workspaceId} AND message_id = ANY(${messageIds}::text[])
+    `)
+    return new Map(result.rows.map((row) => [row.message_id, mapRow(row)]))
+  },
+
   /** Settle every still-settling row among `messageIds`. Returns the rows it flipped. */
   async settle(
     db: Querier,

--- a/apps/backend/src/features/conversations/settling-repository.ts
+++ b/apps/backend/src/features/conversations/settling-repository.ts
@@ -183,6 +183,7 @@ export const MessageConversationStateRepository = {
             settled_by = 'user',
             settled_at = NOW(),
             updated_at = NOW()
+        WHERE message_conversation_state.workspace_id = ${workspaceId}
         RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
       `)
       return upserted.rows.map(mapRow)

--- a/apps/backend/src/features/conversations/settling-repository.ts
+++ b/apps/backend/src/features/conversations/settling-repository.ts
@@ -61,6 +61,17 @@ export const MessageConversationStateRepository = {
     `)
   },
 
+  /** The message's state row, or null when its assignment was never provisional. */
+  async findByMessageId(db: Querier, workspaceId: string, messageId: string): Promise<SettlingRow | null> {
+    const result = await db.query<SettlingDbRow>(sql`
+      SELECT message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+      FROM message_conversation_state
+      WHERE workspace_id = ${workspaceId} AND message_id = ${messageId}
+    `)
+    const row = result.rows[0]
+    return row ? mapRow(row) : null
+  },
+
   /** Settle every still-settling row among `messageIds`. Returns the rows it flipped. */
   async settle(
     db: Querier,
@@ -128,8 +139,15 @@ export const MessageConversationStateRepository = {
   },
 
   /**
-   * Re-file AND settle in one statement: the user moved the message, so the row
-   * must follow it rather than keep pointing at the conversation it left.
+   * Re-file AND settle: the row must follow the message rather than keep
+   * pointing at the conversation it left.
+   *
+   * A human placement (`'user'`) UPSERTS — the extractor skips a `'user'` row
+   * forever, so the mark has to exist even when the message was never
+   * provisional, and has to carry the CURRENT conversation even when the row
+   * was already settled. Machine settles stay update-only against a still
+   * settling row: absence of a row means "not provisional", and a settle must
+   * not manufacture one.
    */
   async settleForConversationTarget(
     db: Querier,
@@ -138,18 +156,8 @@ export const MessageConversationStateRepository = {
     conversationId: string,
     settledBy: SettledByReason
   ): Promise<SettlingRow | null> {
-    const result = await db.query<SettlingDbRow>(sql`
-      UPDATE message_conversation_state
-      SET conversation_id = ${conversationId},
-          state = 'settled',
-          settled_by = ${settledBy},
-          settled_at = NOW(),
-          updated_at = NOW()
-      WHERE workspace_id = ${workspaceId} AND message_id = ${messageId} AND state = 'settling'
-      RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
-    `)
-    const row = result.rows[0]
-    return row ? mapRow(row) : null
+    const rows = await this.settleForConversationTargets(db, workspaceId, [messageId], conversationId, settledBy)
+    return rows[0] ?? null
   },
 
   /** Set-based counterpart of {@link settleForConversationTarget} (INV-56). */
@@ -161,6 +169,24 @@ export const MessageConversationStateRepository = {
     settledBy: SettledByReason
   ): Promise<SettlingRow[]> {
     if (messageIds.length === 0) return []
+    if (settledBy === "user") {
+      // `stream_id` comes from the message itself — `messages` carries no
+      // workspace_id, so the workspace scope (INV-8) rides the literal below.
+      const upserted = await db.query<SettlingDbRow>(sql`
+        INSERT INTO message_conversation_state (message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at)
+        SELECT m.id, ${workspaceId}, m.stream_id, ${conversationId}, 'settled', 'user', NOW()
+        FROM messages m
+        WHERE m.id = ANY(${messageIds}::text[])
+        ON CONFLICT (message_id) DO UPDATE
+        SET conversation_id = EXCLUDED.conversation_id,
+            state = 'settled',
+            settled_by = 'user',
+            settled_at = NOW(),
+            updated_at = NOW()
+        RETURNING message_id, workspace_id, stream_id, conversation_id, state, settled_by, settled_at
+      `)
+      return upserted.rows.map(mapRow)
+    }
     const result = await db.query<SettlingDbRow>(sql`
       UPDATE message_conversation_state
       SET conversation_id = ${conversationId},

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -1138,10 +1138,12 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
   }
 
   const assignInTransaction = mock(async () => "conv_assigned")
-  const conversationAssigner = { assignInTransaction }
+  const attachProvisionalInTransaction = mock(async (): Promise<string | null> => null)
+  const conversationAssigner = { assignInTransaction, attachProvisionalInTransaction }
 
   beforeEach(() => {
     assignInTransaction.mockClear()
+    attachProvisionalInTransaction.mockClear()
     spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
       callback({})) as any)
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", type: "scratchpad" } as any)
@@ -1216,7 +1218,7 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
     expect(assignInTransaction).toHaveBeenCalled()
   })
 
-  it("omits declaredConversationId and skips the assigner when the send declares no conversation", async () => {
+  it("omits declaredConversationId and takes the provisional path when the send declares no conversation", async () => {
     const service = new EventService({} as any, conversationAssigner)
 
     await service.createMessage({ ...baseParams })
@@ -1224,6 +1226,7 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
     const eventPayload = (StreamEventRepository.insert as any).mock.calls[0][1].payload
     expect(eventPayload).not.toHaveProperty("declaredConversationId")
     expect(assignInTransaction).not.toHaveBeenCalled()
+    expect(attachProvisionalInTransaction).toHaveBeenCalled()
   })
 
   it("surfaces the assigner's conversation id from createMessageReturningConversation for an optimistic board card", async () => {

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1,7 +1,7 @@
 import type { Pool, PoolClient } from "pg"
 import { withTransaction, withClient, sql } from "../../db"
 import { StreamEventRepository, type StreamEvent, type MoveEventIdSequenceUpdate } from "../streams"
-import { StreamRepository } from "../streams"
+import { StreamRepository, type Stream } from "../streams"
 import { StreamMemberRepository, SparseReadRepository, ReadStateRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
@@ -44,6 +44,7 @@ import { HttpError, MessageNotFoundError, StreamNotFoundError } from "../../lib/
 import { OperationLeaseRepository } from "../../lib/operation-leases"
 import { resolveMentionContent } from "../mentions"
 import { deriveContentMarkdown } from "./content"
+import { logger } from "../../lib/logger"
 import {
   AttachmentSafetyStatuses,
   AuthorTypes,
@@ -413,6 +414,20 @@ export interface ConversationAssigner {
     client: PoolClient,
     params: { workspaceId: string; message: Message; directive: ConversationDirective }
   ): Promise<string>
+
+  /** Attaches an UNDECLARED message to a cheap structural candidate, marked
+   *  settling, so board viewers see it before the debounced extractor runs.
+   *  Returns null when nothing suitable exists (the extractor assigns later) or
+   *  the send isn't one extraction would cluster. Never mints. */
+  attachProvisionalInTransaction(
+    client: PoolClient,
+    params: {
+      workspaceId: string
+      message: Message
+      stream: Stream | null
+      authorType: CreateMessageParams["authorType"]
+    }
+  ): Promise<string | null>
 }
 
 /**
@@ -933,6 +948,31 @@ export class EventService {
         message,
         directive: params.conversation,
       })
+    } else if (this.conversationAssigner) {
+      // Undeclared: attach to a structural candidate, marked settling, so the
+      // board isn't blind to the message until the debounced extractor runs.
+      // The extractor still decides — `conversation_intent` stays NULL, so the
+      // pass evaluates the message and re-files it when it disagrees.
+      // The attach is an optimization; the send is the contract. A savepoint
+      // (`withTransaction` on the client) so a failure rolls back only the
+      // attach's writes — a bare try/catch would commit them half-done — and
+      // the send completes exactly as if no candidate existed.
+      try {
+        conversationId =
+          (await withTransaction(client, (tx) =>
+            this.conversationAssigner!.attachProvisionalInTransaction(tx, {
+              workspaceId: params.workspaceId,
+              message,
+              stream: stream ?? null,
+              authorType: params.authorType,
+            })
+          )) ?? undefined
+      } catch (err) {
+        logger.warn(
+          { err, messageId: message.id, streamId: params.streamId },
+          "Provisional conversation attach failed; sending without it"
+        )
+      }
     }
 
     return { message, conversationId, created: true }

--- a/apps/backend/tests/integration/conversation-provisional-attach.test.ts
+++ b/apps/backend/tests/integration/conversation-provisional-attach.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Send-time provisional conversation attach: an UNDECLARED human message joins
+ * the stream's most recent conversation in the send transaction, marked
+ * settling, so the board sees it before the debounced extractor runs — and the
+ * extractor can still overturn it. Real schema (INV-68).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach, spyOn } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, addTestMember, setupTestDatabase, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import {
+  ConversationRepository,
+  MessageConversationStateRepository,
+  ConversationService,
+  BoundaryExtractionService,
+  conversationAssigner,
+  PROVISIONAL_ATTACH_WINDOW_MINUTES,
+} from "../../src/features/conversations"
+import { sql } from "../../src/db"
+import { userId, workspaceId, streamId, conversationId } from "../../src/lib/id"
+import { ConversationIntents } from "@threa/types"
+import type { BoundaryExtractor, ExtractionContext, ExtractionResult } from "../../src/features/conversations"
+
+class StubExtractor implements BoundaryExtractor {
+  next: ExtractionResult = {
+    assignments: [{ conversationId: null, isPrimary: true }],
+    newConversationTopic: "Topic",
+    confidence: 0.9,
+  }
+  async extract(_context: ExtractionContext): Promise<ExtractionResult> {
+    return this.next
+  }
+}
+
+describe("provisional conversation attach", () => {
+  let pool: Pool
+  let eventService: EventService
+  let extractor: StubExtractor
+  let extraction: BoundaryExtractionService
+  let conversationService: ConversationService
+  let testUserId: string
+  let testWorkspaceId: string
+  let testStreamId: string
+  let scratchpadId: string
+  let otherUserId: string
+
+  const send = async (
+    text: string,
+    overrides: {
+      streamId?: string
+      authorId?: string
+      authorType?: "user" | "persona"
+      conversation?: { intent: "existing"; conversationId: string }
+    } = {}
+  ) => {
+    return eventService.createMessageReturningConversation({
+      workspaceId: testWorkspaceId,
+      streamId: overrides.streamId ?? testStreamId,
+      authorId: overrides.authorId ?? testUserId,
+      authorType: overrides.authorType ?? "user",
+      ...testMessageContent(text),
+      ...(overrides.conversation ? { conversation: overrides.conversation } : {}),
+    })
+  }
+
+  const seedConversation = async (params: {
+    streamId?: string
+    messageIds?: string[]
+    lastActivityAt?: string
+    authorId?: string
+  }) => {
+    const id = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, {
+        id,
+        streamId: params.streamId ?? testStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Seeded",
+      })
+      if (params.messageIds?.length) {
+        for (const messageId of params.messageIds) {
+          await ConversationRepository.addPrimaryMessage(
+            client,
+            testWorkspaceId,
+            id,
+            messageId,
+            params.authorId ?? testUserId
+          )
+        }
+      }
+      if (params.lastActivityAt) {
+        await client.query(sql`
+          UPDATE conversations SET last_activity_at = NOW() - ${params.lastActivityAt}::interval WHERE id = ${id}
+        `)
+      }
+    })
+    return id
+  }
+
+  const settlingRow = async (id: string) => {
+    const result = await pool.query(sql`SELECT * FROM message_conversation_state WHERE message_id = ${id}`)
+    return result.rows[0] ?? null
+  }
+
+  const conversationUpdatedPayloads = async () => {
+    const result = await pool.query<{
+      payload: { conversationId: string; settlingMessageIds: string[] }
+    }>(sql`SELECT payload FROM outbox WHERE event_type = 'conversation:updated'`)
+    return result.rows.map((r) => r.payload)
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+    testStreamId = streamId()
+    scratchpadId = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Provisional Workspace",
+        slug: `provisional-ws-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      otherUserId = (await addTestMember(client, testWorkspaceId, userId())).id
+      await StreamRepository.insert(client, {
+        id: testStreamId,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+      await StreamMemberRepository.insert(client, testStreamId, testUserId)
+      await StreamRepository.insert(client, {
+        id: scratchpadId,
+        workspaceId: testWorkspaceId,
+        type: "scratchpad",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+      })
+      await StreamMemberRepository.insert(client, scratchpadId, testUserId)
+    })
+
+    eventService = new EventService(pool, conversationAssigner)
+    extractor = new StubExtractor()
+    extraction = new BoundaryExtractionService(pool, extractor)
+    conversationService = new ConversationService(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  afterEach(async () => {
+    await withTransaction(pool, async (client) => {
+      await client.query("DELETE FROM message_conversation_state")
+      await client.query("DELETE FROM outbox")
+      await client.query("DELETE FROM conversation_feedback")
+      await client.query("DELETE FROM conversations")
+      await client.query("DELETE FROM stream_events")
+      await client.query("DELETE FROM messages")
+      await client.query(sql`DELETE FROM streams WHERE type = 'thread'`)
+    })
+    extractor.next = {
+      assignments: [{ conversationId: null, isPrimary: true }],
+      newConversationTopic: "Topic",
+      confidence: 0.9,
+    }
+  })
+
+  test("an undeclared channel message joins the stream's recent conversation, settling, in the send transaction", async () => {
+    const opener = await send("Opening message")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+    await pool.query("DELETE FROM outbox")
+
+    const sent = await send("Undeclared follow-up")
+
+    const conversation = await ConversationRepository.findById(pool, convId)
+    const row = await settlingRow(sent.message.id)
+    expect({
+      returnedConversationId: sent.conversationId,
+      memberIds: conversation!.messageIds,
+      state: row?.state,
+      rowConversationId: row?.conversation_id,
+      intent: (
+        await pool.query<{ conversation_intent: string | null }>(
+          sql`SELECT conversation_intent FROM messages WHERE id = ${sent.message.id}`
+        )
+      ).rows[0]!.conversation_intent,
+    }).toEqual({
+      returnedConversationId: convId,
+      memberIds: [opener.message.id, sent.message.id],
+      state: "settling",
+      rowConversationId: convId,
+      intent: null,
+    })
+
+    // Activity bumped and the aggregate broadcast carries the settling member.
+    expect(conversation!.lastActivityAt.getTime()).toBeGreaterThan(0)
+    expect(await conversationUpdatedPayloads()).toContainEqual(
+      expect.objectContaining({ conversationId: convId, settlingMessageIds: [sent.message.id] })
+    )
+  })
+
+  test("a candidate whose activity fell outside the window is not joined", async () => {
+    const opener = await send("Old opener")
+    const convId = await seedConversation({
+      messageIds: [opener.message.id],
+      lastActivityAt: `${PROVISIONAL_ATTACH_WINDOW_MINUTES + 5} minutes`,
+    })
+
+    const sent = await send("Much later message")
+
+    const conversation = await ConversationRepository.findById(pool, convId)
+    expect({
+      returnedConversationId: sent.conversationId,
+      memberIds: conversation!.messageIds,
+      settling: await settlingRow(sent.message.id),
+    }).toEqual({
+      returnedConversationId: undefined,
+      memberIds: [opener.message.id],
+      settling: null,
+    })
+  })
+
+  test("a stream with no conversation mints nothing", async () => {
+    const sent = await send("First ever message")
+
+    const conversations = await ConversationRepository.findByStream(pool, testStreamId)
+    expect({
+      returnedConversationId: sent.conversationId,
+      conversationCount: conversations.length,
+      settling: await settlingRow(sent.message.id),
+    }).toEqual({ returnedConversationId: undefined, conversationCount: 0, settling: null })
+  })
+
+  test("a declared send takes the declared path and is never settling", async () => {
+    const opener = await send("Opener")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+
+    const sent = await send("Declared follow-up", {
+      conversation: { intent: ConversationIntents.EXISTING, conversationId: convId },
+    })
+
+    const intent = await pool.query<{ conversation_intent: string | null }>(
+      sql`SELECT conversation_intent FROM messages WHERE id = ${sent.message.id}`
+    )
+    expect({
+      returnedConversationId: sent.conversationId,
+      intent: intent.rows[0]!.conversation_intent,
+      settling: await settlingRow(sent.message.id),
+    }).toEqual({ returnedConversationId: convId, intent: ConversationIntents.EXISTING, settling: null })
+  })
+
+  test("a scratchpad message is never provisionally attached", async () => {
+    const opener = await send("Scratch opener", { streamId: scratchpadId })
+    const convId = await seedConversation({ streamId: scratchpadId, messageIds: [opener.message.id] })
+
+    const sent = await send("Scratch follow-up", { streamId: scratchpadId })
+
+    const conversation = await ConversationRepository.findById(pool, convId)
+    expect({
+      returnedConversationId: sent.conversationId,
+      memberIds: conversation!.messageIds,
+      settling: await settlingRow(sent.message.id),
+    }).toEqual({ returnedConversationId: undefined, memberIds: [opener.message.id], settling: null })
+  })
+
+  test("an agent reply is never provisionally attached — its own assignment path is unchanged", async () => {
+    const opener = await send("Human opener")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+
+    const reply = await send("Agent reply", { authorType: "persona" })
+
+    expect({
+      returnedConversationId: reply.conversationId,
+      settling: await settlingRow(reply.message.id),
+    }).toEqual({ returnedConversationId: undefined, settling: null })
+
+    // The deterministic agent-reply path still assigns it.
+    const assigned = await extraction.processMessage(reply.message.id, testStreamId, testWorkspaceId)
+    expect(assigned!.id).toBe(convId)
+    expect(await settlingRow(reply.message.id)).toBeNull()
+  })
+
+  test("an undeclared thread reply joins the anchor message's conversation, settling", async () => {
+    const anchor = await send("Anchor message")
+    const convId = await seedConversation({ messageIds: [anchor.message.id] })
+    const threadId = streamId()
+    await withTransaction(pool, async (client) => {
+      await StreamRepository.insert(client, {
+        id: threadId,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+        parentStreamId: testStreamId,
+        parentAnchorId: anchor.message.id,
+        rootStreamId: testStreamId,
+      })
+    })
+
+    const reply = await send("Thread reply", { streamId: threadId })
+
+    const conversation = await ConversationRepository.findById(pool, convId)
+    const row = await settlingRow(reply.message.id)
+    expect({
+      returnedConversationId: reply.conversationId,
+      memberIds: conversation!.messageIds,
+      state: row?.state,
+    }).toEqual({
+      returnedConversationId: convId,
+      memberIds: [anchor.message.id, reply.message.id],
+      state: "settling",
+    })
+  })
+
+  test("the extractor overturns a provisional attach — membership, participants, the settling row and the events all move", async () => {
+    const opener = await send("Opener", { authorId: otherUserId })
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id], authorId: otherUserId })
+    const otherConvId = await seedConversation({})
+
+    const sent = await send("Actually a different topic")
+    expect(sent.conversationId).toBe(guessedConvId)
+    await pool.query("DELETE FROM outbox")
+
+    extractor.next = {
+      assignments: [{ conversationId: otherConvId, isPrimary: true }],
+      confidence: 0.4,
+    }
+    const decided = await extraction.processMessage(sent.message.id, testStreamId, testWorkspaceId)
+
+    const guessed = await ConversationRepository.findById(pool, guessedConvId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    const row = await settlingRow(sent.message.id)
+    expect({
+      decidedConversationId: decided?.id,
+      guessedMembers: guessed!.messageIds,
+      guessedParticipants: guessed!.participantIds,
+      otherMembers: other!.messageIds,
+      rowConversationId: row?.conversation_id,
+      state: row?.state,
+    }).toEqual({
+      decidedConversationId: otherConvId,
+      guessedMembers: [opener.message.id],
+      // The evicted author is gone; the remaining message's author stays.
+      guessedParticipants: [otherUserId],
+      otherMembers: [sent.message.id],
+      rowConversationId: otherConvId,
+      state: "settling",
+    })
+
+    // INV-23: the move is announced, and both sides' aggregates are refreshed.
+    const reassigned = await pool.query<{ payload: Record<string, unknown> }>(
+      sql`SELECT payload FROM outbox WHERE event_type = 'conversation:message_reassigned'`
+    )
+    expect(reassigned.rows.map((r) => r.payload)).toContainEqual(
+      expect.objectContaining({
+        messageId: sent.message.id,
+        streamId: testStreamId,
+        fromConversationId: guessedConvId,
+        toConversationId: otherConvId,
+      })
+    )
+    const updated = await conversationUpdatedPayloads()
+    expect(updated).toContainEqual(expect.objectContaining({ conversationId: guessedConvId, settlingMessageIds: [] }))
+    expect(updated).toContainEqual(
+      expect.objectContaining({ conversationId: otherConvId, settlingMessageIds: [sent.message.id] })
+    )
+  })
+
+  test("an engagement-settled placement is not re-filed by a later pass, an llm-window one still is", async () => {
+    const opener = await send("Opener")
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+
+    const engaged = await send("Someone reacted to this where it sits")
+    await MessageConversationStateRepository.settle(pool, testWorkspaceId, [engaged.message.id], "engagement")
+
+    extractor.next = { assignments: [{ conversationId: otherConvId, isPrimary: true }], confidence: 0.9 }
+    const engagedDecision = await extraction.processMessage(engaged.message.id, testStreamId, testWorkspaceId)
+
+    const machineSettled = await send("Machine-settled placement")
+    await MessageConversationStateRepository.settle(pool, testWorkspaceId, [machineSettled.message.id], "llm-window")
+    const machineDecision = await extraction.processMessage(machineSettled.message.id, testStreamId, testWorkspaceId)
+
+    const guessed = await ConversationRepository.findById(pool, guessedConvId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    expect({
+      engagedDecision: engagedDecision?.id,
+      machineDecision: machineDecision?.id,
+      guessedMembers: guessed!.messageIds,
+      otherMembers: other!.messageIds,
+    }).toEqual({
+      engagedDecision: guessedConvId,
+      machineDecision: otherConvId,
+      guessedMembers: [opener.message.id, engaged.message.id],
+      otherMembers: [machineSettled.message.id],
+    })
+  })
+
+  test("a human re-file of a message with NO state row leaves a durable 'user' row, and a later pass is immune", async () => {
+    const opener = await send("Opener")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+    // No provisional attach: the stream's only conversation is out of window.
+    await pool.query(sql`UPDATE conversations SET last_activity_at = NOW() - INTERVAL '2 hours'`)
+    const sent = await send("Never provisional")
+    expect(await settlingRow(sent.message.id)).toBeNull()
+
+    await conversationService.reassignMessage({
+      workspaceId: testWorkspaceId,
+      messageId: sent.message.id,
+      conversationId: convId,
+      userId: testUserId,
+    })
+
+    const row = await settlingRow(sent.message.id)
+    expect({ state: row?.state, settledBy: row?.settled_by, conversationId: row?.conversation_id }).toEqual({
+      state: "settled",
+      settledBy: "user",
+      conversationId: convId,
+    })
+
+    extractor.next = { assignments: [{ conversationId: otherConvId, isPrimary: true }], confidence: 0.9 }
+    const decided = await extraction.processMessage(sent.message.id, testStreamId, testWorkspaceId)
+    expect(decided?.id).toBe(convId)
+  })
+
+  test("a human re-file flips an llm-window-settled row to 'user' with the new conversation", async () => {
+    const opener = await send("Opener")
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const userChoiceId = await seedConversation({})
+
+    const sent = await send("Provisional, settled by the window, then moved")
+    await MessageConversationStateRepository.settle(pool, testWorkspaceId, [sent.message.id], "llm-window")
+
+    await conversationService.reassignMessage({
+      workspaceId: testWorkspaceId,
+      messageId: sent.message.id,
+      conversationId: userChoiceId,
+      userId: testUserId,
+    })
+
+    const row = await settlingRow(sent.message.id)
+    expect({ state: row?.state, settledBy: row?.settled_by, conversationId: row?.conversation_id }).toEqual({
+      state: "settled",
+      settledBy: "user",
+      conversationId: userChoiceId,
+    })
+  })
+
+  test("a failing provisional attach does not fail the send and leaves no partial writes", async () => {
+    const opener = await send("Opener")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+
+    const spy = spyOn(MessageConversationStateRepository, "insertSettling").mockImplementation(async () => {
+      throw new Error("boom")
+    })
+    let sent: Awaited<ReturnType<typeof send>>
+    try {
+      sent = await send("Send must survive")
+    } finally {
+      spy.mockRestore()
+    }
+
+    const conversation = await ConversationRepository.findById(pool, convId)
+    const persisted = await pool.query(sql`SELECT id FROM messages WHERE id = ${sent!.message.id}`)
+    expect({
+      messagePersisted: persisted.rows.length,
+      returnedConversationId: sent!.conversationId,
+      // The membership write inside the failed block rolled back with it.
+      memberIds: conversation!.messageIds,
+      settling: await settlingRow(sent!.message.id),
+    }).toEqual({
+      messagePersisted: 1,
+      returnedConversationId: undefined,
+      memberIds: [opener.message.id],
+      settling: null,
+    })
+  })
+
+  test("a DECLARED message is not re-filed by the same drive", async () => {
+    const opener = await send("Opener")
+    const declaredConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+
+    const sent = await send("Declared, and it stays put", {
+      conversation: { intent: ConversationIntents.EXISTING, conversationId: declaredConvId },
+    })
+
+    extractor.next = {
+      assignments: [{ conversationId: otherConvId, isPrimary: true }],
+      confidence: 0.9,
+    }
+    await extraction.processMessage(sent.message.id, testStreamId, testWorkspaceId)
+
+    const declared = await ConversationRepository.findById(pool, declaredConvId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    expect({ declaredMembers: declared!.messageIds, otherMembers: other!.messageIds }).toEqual({
+      declaredMembers: [opener.message.id, sent.message.id],
+      otherMembers: [],
+    })
+  })
+
+  test("a message a human re-filed is not re-filed again by a later pass", async () => {
+    const opener = await send("Opener")
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const userChoiceId = await seedConversation({})
+    const otherConvId = await seedConversation({})
+
+    const sent = await send("Provisional, then moved by a human")
+    await conversationService.reassignMessage({
+      workspaceId: testWorkspaceId,
+      messageId: sent.message.id,
+      conversationId: userChoiceId,
+      userId: testUserId,
+    })
+
+    extractor.next = {
+      assignments: [{ conversationId: otherConvId, isPrimary: true }],
+      confidence: 0.9,
+    }
+    const decided = await extraction.processMessage(sent.message.id, testStreamId, testWorkspaceId)
+
+    const userChoice = await ConversationRepository.findById(pool, userChoiceId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    expect({
+      decidedConversationId: decided?.id,
+      userChoiceMembers: userChoice!.messageIds,
+      otherMembers: other!.messageIds,
+    }).toEqual({
+      decidedConversationId: userChoiceId,
+      userChoiceMembers: [sent.message.id],
+      otherMembers: [],
+    })
+  })
+
+  test("a provisional member still settles when the extraction window moves past it", async () => {
+    const opener = await send("Opener")
+    const convId = await seedConversation({ messageIds: [opener.message.id] })
+    const provisional = await send("Provisional member")
+    expect((await settlingRow(provisional.message.id))?.state).toBe("settling")
+
+    // Push it well out of the surrounding-message window (MESSAGES_BEFORE = 5).
+    for (let i = 0; i < 8; i++) await send(`Filler ${i}`)
+    const far = await send("Far later message")
+    extractor.next = {
+      assignments: [{ conversationId: convId, isPrimary: true }],
+      confidence: 0.95,
+    }
+    await extraction.processMessage(far.message.id, testStreamId, testWorkspaceId)
+
+    const row = await settlingRow(provisional.message.id)
+    expect({ state: row?.state, settledBy: row?.settled_by }).toEqual({ state: "settled", settledBy: "llm-window" })
+  })
+})

--- a/apps/backend/tests/integration/conversation-provisional-attach.test.ts
+++ b/apps/backend/tests/integration/conversation-provisional-attach.test.ts
@@ -407,6 +407,98 @@ describe("provisional conversation attach", () => {
     })
   })
 
+  test("the pass still RUNS for an engagement-settled trigger — only that message's placement is frozen", async () => {
+    const opener = await send("Opener")
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+
+    const engaged = await send("Engaged where it sits")
+    await MessageConversationStateRepository.settle(pool, testWorkspaceId, [engaged.message.id], "engagement")
+
+    extractor.next = {
+      assignments: [{ conversationId: otherConvId, isPrimary: true }],
+      completenessUpdates: [{ conversationId: guessedConvId, score: 7, status: "active" }],
+      confidence: 0.9,
+    }
+    const decided = await extraction.processMessage(engaged.message.id, testStreamId, testWorkspaceId)
+
+    const guessed = await ConversationRepository.findById(pool, guessedConvId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    expect({
+      decided: decided?.id,
+      guessedMembers: guessed!.messageIds,
+      otherMembers: other!.messageIds,
+      // The whole-pass short-circuit would have skipped this write entirely.
+      guessedScore: guessed!.completenessScore,
+    }).toEqual({
+      decided: guessedConvId,
+      guessedMembers: [opener.message.id, engaged.message.id],
+      otherMembers: [],
+      guessedScore: 7,
+    })
+  })
+
+  test("a declared trigger short-circuits the whole pass — no reassignments, no completeness updates", async () => {
+    const opener = await send("Opener")
+    const declaredConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+
+    const declared = await send("Declared", {
+      conversation: { intent: ConversationIntents.EXISTING, conversationId: declaredConvId },
+    })
+
+    extractor.next = {
+      assignments: [{ conversationId: otherConvId, isPrimary: true }],
+      completenessUpdates: [{ conversationId: declaredConvId, score: 7, status: "active" }],
+      confidence: 0.9,
+    }
+    const decided = await extraction.processMessage(declared.message.id, testStreamId, testWorkspaceId)
+
+    const declaredConv = await ConversationRepository.findById(pool, declaredConvId)
+    const other = await ConversationRepository.findById(pool, otherConvId)
+    expect({
+      decided: decided?.id,
+      declaredMembers: declaredConv!.messageIds,
+      otherMembers: other!.messageIds,
+      // Untouched: the pass never ran.
+      declaredScore: declaredConv!.completenessScore,
+    }).toEqual({
+      decided: declaredConvId,
+      declaredMembers: [opener.message.id, declared.message.id],
+      otherMembers: [],
+      declaredScore: 1,
+    })
+  })
+
+  test("an overturn recomputes participants from the CURRENT source row, keeping a concurrently-attached author", async () => {
+    const opener = await send("Opener")
+    const guessedConvId = await seedConversation({ messageIds: [opener.message.id] })
+    const otherConvId = await seedConversation({})
+
+    const sent = await send("Provisionally attached")
+    // Simulates a concurrent send landing in the source conversation after the
+    // pass read its snapshot: a new author joins message_ids/participant_ids.
+    const concurrent = await send("Concurrent send", { authorId: otherUserId })
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.addPrimaryMessage(
+        client,
+        testWorkspaceId,
+        guessedConvId,
+        concurrent.message.id,
+        otherUserId
+      )
+    })
+
+    extractor.next = { assignments: [{ conversationId: otherConvId, isPrimary: true }], confidence: 0.9 }
+    await extraction.processMessage(sent.message.id, testStreamId, testWorkspaceId)
+
+    const guessed = await ConversationRepository.findById(pool, guessedConvId)
+    expect({ members: guessed!.messageIds, participants: guessed!.participantIds.sort() }).toEqual({
+      members: [opener.message.id, concurrent.message.id],
+      participants: [testUserId, otherUserId].sort(),
+    })
+  })
+
   test("a human re-file of a message with NO state row leaves a durable 'user' row, and a later pass is immune", async () => {
     const opener = await send("Opener")
     const convId = await seedConversation({ messageIds: [opener.message.id] })


### PR DESCRIPTION
## Problem

An undeclared message joins no conversation until the debounced boundary extractor runs, so a board viewer can't see it for seconds while a timeline viewer can — the board's deepest reactivity gap (inventory: https://seer.build/ws_vbyzjvdg6g/b/board-reactivity-aa1f62/ ; plan chunk 4, https://seer.build/ws_vbyzjvdg6g/b/board-stack-plan-105043/). The redesign's substance is membership that is provisional-then-settled, and the settling machinery (#1678–#1680) already carries it — no schema change needed.

## Solution

- In the send transaction, an undeclared human message on an extraction-eligible stream attaches to a structural candidate: the stream's most recently active non-empty active conversation within `PROVISIONAL_ATTACH_WINDOW_MINUTES = 30` (`findLatestActiveByStream`); a thread message attaches to its anchor's primary conversation. `addPrimaryMessage` + `insertSettling` + activity bump + the existing `conversation:updated` emit with `settlingMessageIds`, one txn — the board draws the message with the settling rail the moment it lands. No candidate → exactly today's behavior. Nothing is ever minted; no LLM in the send path.
- Eligibility is the extraction predicate, shared by construction (`extraction-eligibility.ts`): scratchpads, agent/bot authors, and E2E streams are excluded by the same code that excludes them from extraction.
- **The extractor keeps deciding.** `conversation_intent` stays NULL, so a provisional member is fully decidable. Its overturn now removes the prior primary properly: membership, recomputed source `participant_ids`, `moveConversation` on the settling row, `conversation:message_reassigned` + `conversation:updated` for both conversations. A confident confirming pass settles the row (`llm-window`) so the mark fades without waiting for the sweep.
- **Frozen placements** (`isPlacementFrozenByHuman`): `settled_by IN ('user','engagement')` is immune at both re-file entry points — engagement freezes placement, per the settling model. Human placements upsert a durable `'user'` row (previously update-if-settling, so a re-file of an untracked or already-settled message was unprotected — pre-existing gap, fixed here; the same round fixed the pre-existing double-primary overturn hole).
- The attach is savepoint-guarded (`withTransaction` on the client): any failure rolls back only the attach, logs a warning, and the send completes as if no candidate existed.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/conversation-assigner.ts` | `attachProvisionalInTransaction`, candidate lookup, window constant |
| `apps/backend/src/features/conversations/extraction-eligibility.ts` | **new** — shared predicate |
| `apps/backend/src/features/conversations/repository.ts` | `findLatestActiveByStream`, `distinctAuthors` centralized |
| `apps/backend/src/features/conversations/settling-repository.ts` | `findByMessageId`; user-reason upsert |
| `apps/backend/src/features/conversations/boundary-extraction-service.ts` | frozen-placement skip, overturn removal branch, confident-confirm settle |
| `apps/backend/src/features/messaging/event-service.ts` | undeclared dispatch, savepoint guard |
| `apps/backend/tests/integration/conversation-provisional-attach.test.ts` | **new** — 15 tests |

## Test plan

- [x] Backend unit 3832 / integration 767 (15 new) / e2e 371, all green; typecheck + lint clean
- [x] Adversarial verify: 5 findings (participant pollution 87, engagement immunity 85, durable user mark 84, event-less overturn test 82, send coupling 80) — all fixed; overturn-emit neutralization verified red; forced attach failure leaves no partial writes
- Extractor prompt/schema/thresholds untouched (INV-44/45); the settling mark renders from existing frontend

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098569&installation_model_id=20758&pr_number=1692&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1692&signature=c88458129d7aafbe4ff88c5ef3e631ced6795b397acd4cde010a4f8e6e378f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->