### PR TITLE
feat(memos): repaint memo cards on a real memo edit, and only then

### DIFF
--- a/apps/backend/src/features/memos/explorer-service.test.ts
+++ b/apps/backend/src/features/memos/explorer-service.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Pool } from "pg"
 import { MemoExplorerService } from "./explorer-service"
 import { MemoRepository, type Memo } from "./repository"
@@ -79,6 +79,14 @@ afterEach(() => {
 })
 
 describe("MemoExplorerService.update (roadmap 6.1)", () => {
+  // An edit now also pushes the memo's new card content to the streams citing
+  // it. These cases are about the embedding, and their fake transaction client
+  // has no `query`, so the citation lookup is stubbed empty — the publish path
+  // itself is covered against real rows in tests/integration/memo-card-updates.
+  beforeEach(() => {
+    spyOn(MemoRepository, "findCitingStreamIds").mockResolvedValue([])
+  })
+
   it("re-embeds when the abstract changes and persists both in one transaction", async () => {
     const { service, embed } = buildService()
     stubSourceStreamResolution()

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -1,9 +1,10 @@
-import type { Pool } from "pg"
+import type { Pool, PoolClient } from "pg"
 import type { AuthorType, KnowledgeType, MemoScope, MemoStatus, MemoType } from "@threa/types"
 import { MemoScopes } from "@threa/types"
 import { withTransaction } from "../../db"
 import { logger } from "../../lib/logger"
 import { ConversationRepository } from "../conversations"
+import { OutboxRepository } from "../../lib/outbox"
 import { MessageRepository, type Message } from "../messaging"
 import { MemoRepository, type Memo, type MemoSearchFilters } from "./repository"
 import { classifyMemoQueryIntent } from "./query-intent"
@@ -260,6 +261,7 @@ export class MemoExplorerService {
       if (row && embedding) {
         await MemoRepository.updateEmbedding(client, memoId, embedding)
       }
+      if (row) await this.publishCardUpdates(client, workspaceId, row)
       return row
     })
 
@@ -267,6 +269,39 @@ export class MemoExplorerService {
       return null
     }
     return this.buildDetail(workspaceId, updated, resolved.sourceContext, permissions)
+  }
+
+  /**
+   * Push the memo's new card content to the streams that cite it, in the same
+   * transaction as the edit (INV-4/7).
+   *
+   * Per citing stream, gated by the same room-uniform predicate the write path
+   * uses — a room that could never be shown this memo does not get told about
+   * it, and a stream that has since been privatized stops receiving updates
+   * without any bookkeeping of its own. Streams whose rooms may not see it are
+   * simply skipped, which leaves their cards showing what they already had.
+   *
+   * Deliberately NOT workspace-scoped: `memo:created` broadcasts a whole
+   * `WireMemo` (abstract and key points included) to every workspace member,
+   * which is a wider exposure than this event is willing to inherit.
+   */
+  private async publishCardUpdates(client: PoolClient, workspaceId: string, memo: Memo): Promise<void> {
+    const citingStreamIds = await MemoRepository.findCitingStreamIds(client, workspaceId, memo.id)
+    if (citingStreamIds.length === 0) return
+
+    const streams = await StreamRepository.findByIds(client, citingStreamIds)
+    for (const stream of streams) {
+      const root = stream.rootStreamId ?? stream.id
+      const allowed = await MemoRepository.findEmbedSummaries(client, workspaceId, [memo.id], root)
+      const summary = allowed.get(memo.id)
+      if (!summary) continue
+      await OutboxRepository.insert(client, "memo:updated", {
+        workspaceId,
+        streamId: stream.id,
+        memoId: memo.id,
+        summary,
+      })
+    }
   }
 
   async archive(

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -382,6 +382,30 @@ export const MemoRepository = {
     )
   },
 
+  /**
+   * Streams whose live messages cite `memoId`, so an update to the memo can be
+   * pushed to exactly those rooms.
+   *
+   * Matches on the markdown pointer (`(memo:<id>)`), which every authored form
+   * serializes to — the picker's node, a pasted link, an API-written body. The
+   * id is a prefixed ULID, so the pattern cannot collide with a longer id, and
+   * it is passed as a parameter rather than interpolated.
+   *
+   * Workspace scoping goes through `streams`: `messages` carries no
+   * `workspace_id` (INV-8's exemption is the join, not the column).
+   */
+  async findCitingStreamIds(db: Querier, workspaceId: string, memoId: string): Promise<string[]> {
+    const result = await db.query<{ stream_id: string }>(sql`
+      SELECT DISTINCT m.stream_id
+      FROM messages m
+      JOIN streams s ON s.id = m.stream_id
+      WHERE s.workspace_id = ${workspaceId}
+        AND m.deleted_at IS NULL
+        AND m.content_markdown LIKE ${"%(memo:" + memoId + ")%"}
+    `)
+    return result.rows.map((row) => row.stream_id)
+  },
+
   async findByWorkspace(
     db: Querier,
     workspaceId: string,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1708,6 +1708,32 @@ export class EventService {
           return a.id.localeCompare(b.id)
         }
       )
+
+      // Stored message payloads snapshot their memo summaries at send time; the
+      // destination bulkPut would repaint a memo:updated patch backwards with
+      // that snapshot. Re-resolve against the destination root at move time —
+      // the same room-uniform shape as the share hydration below. Must run
+      // BEFORE serializeBigInt, which deep-copies the payloads.
+      const movedMemoIdsByMessage = new Map(selectedMessages.map((m) => [m.id, collectMemoEmbedIds(m.contentJson)]))
+      const movedMemoIds = [...new Set([...movedMemoIdsByMessage.values()].flat())]
+      if (movedMemoIds.length > 0) {
+        const movedSummaries = await MemoRepository.findEmbedSummaries(
+          client,
+          params.workspaceId,
+          movedMemoIds,
+          destinationThread.rootStreamId ?? destinationThread.id
+        )
+        for (const event of orderedDestinationEvents) {
+          if (event.eventType !== "message_created") continue
+          const payload = event.payload as { messageId?: string; memoEmbeds?: MemoEmbedSummary[] }
+          const ids = payload.messageId ? movedMemoIdsByMessage.get(payload.messageId) : undefined
+          if (!ids) continue
+          const resolved = ids.map((id) => movedSummaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
+          if (resolved.length > 0) payload.memoEmbeds = resolved
+          else delete payload.memoEmbeds
+        }
+      }
+
       const serializedDestinationEvents = orderedDestinationEvents.map(
         (event) => serializeBigInt(event) as unknown as WireStreamEvent
       )

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -390,3 +390,33 @@ describe("resolveDeliveryGroups — activity:read", () => {
     expect(groups).toEqual([userGroup("usr_alice")])
   })
 })
+
+describe("resolveDeliveryGroups — memo:updated", () => {
+  // The event carries a memo's card content to the streams that cite it, and
+  // the server decided per room which of those may see it. Routing is driven by
+  // the STREAM_SCOPED_EVENTS list, not by the payload's shape, so an event whose
+  // type is missing from that list falls through to the whole-workspace group —
+  // handing the content to every member regardless of stream access, and
+  // undoing the per-room gate at the point of delivery. The outbox-row tests
+  // cannot see this: the rows are correct either way.
+  it("delivers only to the citing stream, never the whole workspace", () => {
+    const groups = resolveDeliveryGroups(
+      event("memo:updated", {
+        workspaceId: "ws_1",
+        streamId: "stream_citing",
+        memoId: "memo_1",
+        summary: {
+          memoId: "memo_1",
+          title: "Launch in June",
+          knowledgeType: "decision",
+          memoType: "conversation",
+          tags: [],
+          updatedAt: "2026-07-31T10:00:00.000Z",
+        },
+      })
+    )
+
+    expect(groups).toEqual([streamGroup("stream_citing")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+  })
+})

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -136,6 +136,7 @@ export type OutboxEventType =
 
 /** Events that are scoped to a stream (have streamId) */
 export type StreamScopedEventType =
+  | "memo:updated"
   | "message:created"
   | "message:edited"
   | "message:deleted"
@@ -1307,6 +1308,12 @@ export function isOneOfOutboxEventType<T extends OutboxEventType>(
 }
 
 const STREAM_SCOPED_EVENTS: StreamScopedEventType[] = [
+  // Routing is driven by THIS list, not by the payload extending
+  // `StreamScopedPayload` — `resolveDeliveryGroups` only takes the stream
+  // branch when `isStreamScopedEvent` finds the type here. Omitted, an event
+  // falls through to the whole-workspace group, which for this one would hand
+  // a memo's card content to every member regardless of stream access.
+  "memo:updated",
   "message:created",
   "message:edited",
   "message:deleted",

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -6,6 +6,7 @@ import type { ConversationWithStaleness } from "../../features/conversations"
 import type { HydratedSharedMessage } from "../../features/messaging/sharing"
 import type {
   Memo as WireMemo,
+  MemoEmbedSummary,
   StreamEvent as WireStreamEvent,
   UserPreferences,
   SidebarConfig,
@@ -61,6 +62,7 @@ export type OutboxEventType =
   | "board:conversation_hide_changed"
   | "board:stream_mute_changed"
   | "memo:created"
+  | "memo:updated"
   | "command:dispatched"
   | "command:completed"
   | "command:failed"
@@ -595,6 +597,23 @@ export interface ConversationMessageReassignedOutboxPayload extends StreamScoped
 export interface MemoCreatedOutboxPayload extends WorkspaceScopedPayload {
   memoId: string
   memo: WireMemo
+}
+
+/**
+ * A memo's card content changed, for the streams that cite it.
+ *
+ * STREAM-scoped, one event per citing stream, and it carries only the card's
+ * fields — never the abstract or key points. Both are deliberate: the summary a
+ * room may see is decided per room (`findEmbedSummaries`), so a workspace-wide
+ * broadcast would hand it to people who can't open the memo, and the card needs
+ * nothing beyond what it draws.
+ *
+ * This is the ONLY thing allowed to change a rendered memo card. Content may
+ * change when the memo changed; it may not change because it hadn't loaded.
+ */
+export interface MemoUpdatedOutboxPayload extends StreamScopedPayload {
+  memoId: string
+  summary: MemoEmbedSummary
 }
 
 // Author-scoped event payloads (only visible to the author)
@@ -1196,6 +1215,7 @@ export interface OutboxEventPayloadMap {
   "board:conversation_hide_changed": BoardConversationHideChangedOutboxPayload
   "board:stream_mute_changed": BoardStreamMuteChangedOutboxPayload
   "memo:created": MemoCreatedOutboxPayload
+  "memo:updated": MemoUpdatedOutboxPayload
   "command:dispatched": CommandDispatchedOutboxPayload
   "command:completed": CommandCompletedOutboxPayload
   "command:failed": CommandFailedOutboxPayload

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -1,0 +1,265 @@
+/**
+ * `memo:updated` — the only thing allowed to change a rendered memo card.
+ *
+ * The card no longer fetches, so this event is how a retitle reaches a reader
+ * who already has the message on screen. It is stream-scoped and gated per
+ * citing room by the same predicate the write path uses, which is what stops it
+ * becoming a workspace-wide broadcast of a memo's title. (`memo:created` IS
+ * that broadcast today, carrying the whole memo including its abstract — noted,
+ * pre-existing, and deliberately not inherited here.)
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { MemoExplorerService, MemoRepository } from "../../src/features/memos"
+import type { EmbeddingServiceLike } from "../../src/features/memos"
+import { userId, workspaceId, streamId, messageId, memoId } from "../../src/lib/id"
+import type { JSONContent } from "@threa/types"
+
+function bodyCiting(text: string, id: string): { contentJson: JSONContent; contentMarkdown: string } {
+  return {
+    contentJson: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text },
+            { type: "memoEmbed", attrs: { memoId: id, title: "Cited" } },
+          ],
+        },
+      ],
+    },
+    contentMarkdown: `${text} [Cited](memo:${id})`,
+  }
+}
+
+describe("memo:updated", () => {
+  let pool: Pool
+  let eventService: EventService
+  let explorer: MemoExplorerService
+  let testWorkspaceId: string
+  let testUserId: string
+  let sourceChannel: string
+  let otherPrivateChannel: string
+  let publicChannel: string
+  let memo: string
+  let sequence = 1n
+
+  async function outboxFor(memoIdToFind: string): Promise<Array<{ stream_id: string; title: string }>> {
+    const result = await pool.query<{ payload: { streamId: string; summary: { title: string } } }>(
+      `SELECT payload FROM outbox WHERE event_type = 'memo:updated' ORDER BY id ASC`
+    )
+    return result.rows
+      .filter((row) => (row.payload as unknown as { memoId: string }).memoId === memoIdToFind)
+      .map((row) => ({ stream_id: row.payload.streamId, title: row.payload.summary.title }))
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    eventService = new EventService(pool)
+    explorer = new MemoExplorerService({
+      pool,
+      embeddingService: { embed: async () => [0.1] } as unknown as EmbeddingServiceLike,
+      reranker: undefined,
+    })
+    testWorkspaceId = workspaceId()
+    testUserId = userId()
+    sourceChannel = streamId()
+    otherPrivateChannel = streamId()
+    publicChannel = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Memo Card Updates",
+        slug: `memo-updates-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      for (const [id, visibility] of [
+        [sourceChannel, "public"],
+        [otherPrivateChannel, "private"],
+        [publicChannel, "public"],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: testWorkspaceId,
+          type: "channel",
+          visibility,
+          slug: `s-${id.slice(-8)}`,
+          createdBy: testUserId,
+        })
+      }
+    })
+
+    // A memo sourced in a PUBLIC channel, so every room may see its summary.
+    memo = memoId()
+    const sourceMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      const { MessageRepository } = await import("../../src/features/messaging")
+      await MessageRepository.insert(client, {
+        id: sourceMsg,
+        streamId: sourceChannel,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: memo,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: sourceMsg,
+        title: "Launch in May",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [sourceMsg],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: ["launch"],
+        status: "active",
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("reaches every stream that cites the memo, once each, with the new card content", async () => {
+    await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: publicChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("see", memo),
+    })
+    await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: otherPrivateChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("also see", memo),
+    })
+
+    await explorer.update(
+      testWorkspaceId,
+      memo,
+      { accessibleStreamIds: [sourceChannel, publicChannel, otherPrivateChannel], userId: testUserId },
+      { title: "Launch in June" }
+    )
+
+    const events = await outboxFor(memo)
+    expect(events.map((e) => e.title)).toEqual(["Launch in June", "Launch in June"])
+    expect(events.map((e) => e.stream_id).sort()).toEqual([otherPrivateChannel, publicChannel].sort())
+  })
+
+  test("skips a citing stream whose room may not see the memo", async () => {
+    // A second memo, this one sourced in a PRIVATE channel, cited from a public
+    // one. The citation exists; the public room may not be told what it says.
+    const privateMemo = memoId()
+    const sourceMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      const { MessageRepository } = await import("../../src/features/messaging")
+      await MessageRepository.insert(client, {
+        id: sourceMsg,
+        streamId: otherPrivateChannel,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: privateMemo,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: sourceMsg,
+        title: "Acquisition target",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [sourceMsg],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+
+    await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: publicChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("pasted", privateMemo),
+    })
+    await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: otherPrivateChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("in its own room", privateMemo),
+    })
+
+    await explorer.update(
+      testWorkspaceId,
+      privateMemo,
+      { accessibleStreamIds: [otherPrivateChannel, publicChannel], userId: testUserId },
+      { title: "Acquisition target: Initech" }
+    )
+
+    const events = await outboxFor(privateMemo)
+    expect(events.map((e) => e.stream_id)).toEqual([otherPrivateChannel])
+  })
+
+  test("emits nothing when no stream cites the memo", async () => {
+    const uncited = memoId()
+    const sourceMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      const { MessageRepository } = await import("../../src/features/messaging")
+      await MessageRepository.insert(client, {
+        id: sourceMsg,
+        streamId: publicChannel,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: uncited,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: sourceMsg,
+        title: "Nobody links this",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [sourceMsg],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+
+    await explorer.update(
+      testWorkspaceId,
+      uncited,
+      { accessibleStreamIds: [publicChannel], userId: testUserId },
+      { title: "Still nobody" }
+    )
+
+    expect(await outboxFor(uncited)).toEqual([])
+  })
+
+  test("carries only the card's fields — never the memo's substance", async () => {
+    const events = await pool.query<{ payload: Record<string, unknown> }>(
+      `SELECT payload FROM outbox WHERE event_type = 'memo:updated' LIMIT 1`
+    )
+    const summary = events.rows[0]?.payload.summary as Record<string, unknown>
+    expect(Object.keys(summary).sort()).toEqual(["knowledgeType", "memoId", "memoType", "tags", "title", "updatedAt"])
+  })
+})

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -262,4 +262,64 @@ describe("memo:updated", () => {
     const summary = events.rows[0]?.payload.summary as Record<string, unknown>
     expect(Object.keys(summary).sort()).toEqual(["knowledgeType", "memoId", "memoType", "tags", "title", "updatedAt"])
   })
+
+  // findCitingStreamIds scans content_markdown with LIKE '%(memo:<id>)%' — a
+  // string tie to the wire format. This canary routes a memoEmbed node through
+  // the REAL serializer and the real create path, so if the serialized shape
+  // ever drifts from the pattern, this reddens instead of memo:updated silently
+  // reaching no one. The other tests hand-write their markdown and cannot see
+  // that drift.
+  test("the citation scan matches what the real serializer stores", async () => {
+    const { serializeToMarkdown } = await import("@threa/prosemirror")
+    const canary = memoId()
+    const sourceMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      const { MessageRepository } = await import("../../src/features/messaging")
+      await MessageRepository.insert(client, {
+        id: sourceMsg,
+        streamId: publicChannel,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: canary,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: sourceMsg,
+        title: "Serializer canary",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [sourceMsg],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+
+    const contentJson: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "canary " },
+            { type: "memoEmbed", attrs: { memoId: canary, title: "Serializer canary" } },
+          ],
+        },
+      ],
+    }
+    await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: publicChannel,
+      authorId: testUserId,
+      authorType: "user",
+      contentJson,
+      contentMarkdown: serializeToMarkdown(contentJson),
+    })
+
+    expect(await MemoRepository.findCitingStreamIds(pool, testWorkspaceId, canary)).toEqual([publicChannel])
+  })
 })

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -263,6 +263,83 @@ describe("memo:updated", () => {
     expect(Object.keys(summary).sort()).toEqual(["knowledgeType", "memoId", "memoType", "tags", "title", "updatedAt"])
   })
 
+  // The destination side of a move bulkPuts server payloads over the client's
+  // cache — a memo:updated patch the client applied would be repainted
+  // backwards by the stored snapshot. The move re-resolves at move time.
+  test("a move ships current summaries, not the stored snapshot", async () => {
+    const moved = memoId()
+    const srcMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      const { MessageRepository } = await import("../../src/features/messaging")
+      await MessageRepository.insert(client, {
+        id: srcMsg,
+        streamId: publicChannel,
+        sequence: sequence++,
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id: moved,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: srcMsg,
+        title: "Before the move",
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [srcMsg],
+        participantIds: [testUserId],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+
+    const { StreamMemberRepository } = await import("../../src/features/streams")
+    await StreamMemberRepository.insert(pool, publicChannel, testUserId)
+
+    const target = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: publicChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("thread anchor"),
+    })
+    const citing = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: publicChannel,
+      authorId: testUserId,
+      authorType: "user",
+      ...bodyCiting("citing, about to move", moved),
+    })
+    await pool.query(`UPDATE memos SET title = 'Retitled before the move' WHERE id = $1`, [moved])
+
+    const validation = await eventService.validateMoveMessagesToThread({
+      workspaceId: testWorkspaceId,
+      sourceStreamId: publicChannel,
+      targetMessageId: target.id,
+      messageIds: [citing.id],
+      actorId: testUserId,
+    })
+    await eventService.moveMessagesToThread({
+      workspaceId: testWorkspaceId,
+      sourceStreamId: publicChannel,
+      targetMessageId: target.id,
+      messageIds: [citing.id],
+      actorId: testUserId,
+      leaseKey: validation.leaseKey,
+    })
+
+    const movedOutbox = await pool.query<{ payload: { events: Array<{ eventType: string; payload: unknown }> } }>(
+      `SELECT payload FROM outbox WHERE event_type = 'messages:moved' ORDER BY id DESC LIMIT 1`
+    )
+    const movedCreated = movedOutbox.rows[0].payload.events.find(
+      (e) => e.eventType === "message_created" && (e.payload as { messageId?: string }).messageId === citing.id
+    )
+    const embeds = (movedCreated?.payload as { memoEmbeds?: Array<{ title: string }> }).memoEmbeds
+    expect(embeds?.map((s) => s.title)).toEqual(["Retitled before the move"])
+  })
+
   // findCitingStreamIds scans content_markdown with LIKE '%(memo:<id>)%' — a
   // string tie to the wire format. This canary routes a memoEmbed node through
   // the REAL serializer and the real create path, so if the serialized shape

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -11,6 +11,7 @@ import {
   registerStreamSocketHandlers,
   toCachedStreamBootstrap,
   updateMessageEvent,
+  updateMemoEmbedSummary,
   type CachedStreamBootstrap,
 } from "./stream-sync"
 import { streamKeys } from "@/hooks/use-streams"
@@ -1120,6 +1121,74 @@ describe("applyStreamBootstrap — read-state freshness (stale response guard)",
       lastReadSequence: "50",
       lastReadAt: "2026-01-01T00:00:05.000Z",
     })
+  })
+})
+
+describe("updateMemoEmbedSummary", () => {
+  const SUMMARY = {
+    memoId: "memo_a",
+    title: "Launch in June",
+    knowledgeType: "decision" as const,
+    memoType: "conversation" as const,
+    tags: ["launch"],
+    updatedAt: "2026-07-31T10:00:00.000Z",
+  }
+
+  async function seed(streamId: string, id: string, memoEmbeds: unknown) {
+    await db.events.put({
+      ...makeEvent({
+        id,
+        streamId,
+        sequence: "100",
+        payload: { messageId: `msg_${id}`, contentMarkdown: "cites a memo", memoEmbeds },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 100,
+      _cachedAt: Date.now(),
+    })
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("replaces the summary on every message citing that memo", async () => {
+    const streamId = "stream_memo_patch"
+    await seed(streamId, "evt_1", [{ ...SUMMARY, title: "Launch in May" }])
+    await seed(streamId, "evt_2", [
+      { memoId: "memo_other", title: "Untouched" },
+      { ...SUMMARY, title: "Launch in May" },
+    ])
+
+    await updateMemoEmbedSummary(streamId, SUMMARY)
+
+    const first = await db.events.get("evt_1")
+    expect((first?.payload as { memoEmbeds: Array<{ title: string }> }).memoEmbeds[0].title).toBe("Launch in June")
+    const second = await db.events.get("evt_2")
+    const embeds = (second?.payload as { memoEmbeds: Array<{ memoId: string; title: string }> }).memoEmbeds
+    expect(embeds.map((e) => e.title)).toEqual(["Untouched", "Launch in June"])
+  })
+
+  // The event says a memo changed, not that this reader may see it. The server
+  // already decided per room which messages carry a summary; adding one here
+  // would put a card in front of someone the write path withheld it from.
+  it("does not add a summary to a message that never carried one", async () => {
+    const streamId = "stream_memo_absent"
+    await seed(streamId, "evt_bare", undefined)
+
+    await updateMemoEmbedSummary(streamId, SUMMARY)
+
+    expect((await db.events.get("evt_bare"))?.payload).not.toHaveProperty("memoEmbeds.0")
+  })
+
+  it("leaves other streams alone", async () => {
+    await seed("stream_a", "evt_a", [{ ...SUMMARY, title: "Launch in May" }])
+    await seed("stream_b", "evt_b", [{ ...SUMMARY, title: "Launch in May" }])
+
+    await updateMemoEmbedSummary("stream_a", SUMMARY)
+
+    const untouched = await db.events.get("evt_b")
+    expect((untouched?.payload as { memoEmbeds: Array<{ title: string }> }).memoEmbeds[0].title).toBe("Launch in May")
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -3110,6 +3110,80 @@ describe("registerStreamSocketHandlers — shared-message slot ingestion (Amendm
     }
   })
 
+  // An edit event can arrive AFTER a memo:updated patch it predates — the edit
+  // resolved its summaries before the memo changed. Per memo, the strictly
+  // newer updatedAt wins, so the card never repaints backwards; the edit still
+  // decides WHICH memos have cards at all.
+  it("message:edited does not repaint a summary backwards past a newer memo:updated patch", async () => {
+    const streamId = "stream_memo_edit_race"
+    const queryClient = new QueryClient()
+    const base = {
+      memoId: "memo_raced",
+      knowledgeType: "decision" as const,
+      memoType: "conversation" as const,
+      tags: [],
+    }
+    const patched = { ...base, title: "Launch in June", updatedAt: "2026-07-31T12:00:00.000Z" }
+    const preUpdate = { ...base, title: "Launch in May", updatedAt: "2026-07-31T11:00:00.000Z" }
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_raced",
+        streamId,
+        sequence: "50",
+        payload: { messageId: "msg_raced", contentMarkdown: "old", memoEmbeds: [patched] },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 50,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    await emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_raced_edit",
+        streamId,
+        sequence: "101",
+        eventType: "message_edited",
+        payload: { messageId: "msg_raced", contentJson: {}, contentMarkdown: "edited", memoEmbeds: [preUpdate] },
+      }),
+    })
+    cleanup()
+
+    const row = await db.events.get("evt_raced")
+    expect((row?.payload as { memoEmbeds: Array<{ title: string }> }).memoEmbeds).toEqual([patched])
+  })
+
+  // Label pages render from their own query, not db.events; the backend
+  // resolves their summaries fresh at read, so invalidation IS their repaint.
+  it("memo:updated invalidates label message queries but not the label list", async () => {
+    const streamId = "stream_memo_labels"
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(["labels", "ws_1", "label_1", "messages"], [])
+    queryClient.setQueryData(["labels", "ws_1"], [])
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    await emit("memo:updated", {
+      streamId,
+      memoId: "memo_a",
+      summary: {
+        memoId: "memo_a",
+        title: "Launch in June",
+        knowledgeType: "decision",
+        memoType: "conversation",
+        tags: [],
+        updatedAt: "2026-07-31T12:00:00.000Z",
+      },
+    })
+    cleanup()
+
+    expect(queryClient.getQueryState(["labels", "ws_1", "label_1", "messages"])?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(["labels", "ws_1"])?.isInvalidated).toBe(false)
+  })
+
   it("message:edited rekeys a legacy-only payload to canonical keys", async () => {
     const streamId = "stream_wire_edit_legacy"
     const queryClient = new QueryClient()

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1334,6 +1334,11 @@ export function registerStreamSocketHandlers(
     if (payload.streamId !== streamId) return
     await updateMemoEmbedSummary(streamId, payload.summary)
     await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
+    // Label pages render from their own query, not db.events, and the backend
+    // resolves their summaries fresh at read — an invalidation IS the repaint.
+    await queryClient.invalidateQueries({
+      predicate: (q) => q.queryKey[0] === "labels" && q.queryKey[1] === workspaceId && q.queryKey[3] === "messages",
+    })
   }
 
   const handleMessageEdited = async (payload: MessageEventPayload) => {
@@ -1352,12 +1357,15 @@ export function registerStreamSocketHandlers(
         ...p,
         contentJson: editPayload.contentJson,
         contentMarkdown: editPayload.contentMarkdown,
-        // REPLACED, not merged: the edit payload always carries this array,
-        // empty included, so a reference the edit removed loses its card rather
-        // than keeping the pre-edit one. Without this the cached row holds the
-        // old summaries for the life of the session — and since the card no
-        // longer fetches, nothing else would ever correct it.
-        memoEmbeds: editPayload.memoEmbeds ?? [],
+        // The edit payload's array decides WHICH memos have cards (always
+        // carried, empty included, so a removed reference loses its card).
+        // Per memo, though, a `memo:updated` patch may have landed while this
+        // edit event was in flight carrying the pre-update summary — the
+        // strictly newer updatedAt wins so the card never repaints backwards.
+        memoEmbeds: (editPayload.memoEmbeds ?? []).map((entry) => {
+          const prior = (p.memoEmbeds as MemoEmbedSummary[] | undefined)?.find((x) => x.memoId === entry.memoId)
+          return prior && Date.parse(prior.updatedAt) > Date.parse(entry.updatedAt) ? prior : entry
+        }),
         editedAt: editEvent.createdAt,
       }))
       await writeSlotCarrier({ database: db, workspaceId, streamId, carrier: payload, mode: "merge", cachedAt: now })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -907,6 +907,36 @@ export function preserveBakedInAppData(
 // Helper: find and update a message_created event in IndexedDB
 // ============================================================================
 
+/**
+ * Replace one memo's card content across every cached message in a stream that
+ * cites it — the client half of `memo:updated`.
+ *
+ * A memo card renders from the message payload and never fetches, so this is the
+ * only path by which a retitle reaches a reader who already has the message on
+ * screen. It patches ONLY messages that already carry a summary for this memo:
+ * the server decided per room what may be shown, and an event arriving for a
+ * stream is not permission to add a card to a message that never had one.
+ */
+export async function updateMemoEmbedSummary(streamId: string, summary: MemoEmbedSummary): Promise<void> {
+  await db.events
+    .where("[streamId+eventType]")
+    .equals([streamId, "message_created"])
+    .filter((e) => {
+      const embeds = (e.payload as { memoEmbeds?: MemoEmbedSummary[] })?.memoEmbeds
+      return Array.isArray(embeds) && embeds.some((entry) => entry.memoId === summary.memoId)
+    })
+    .modify((event) => {
+      const payload = event.payload as { memoEmbeds?: MemoEmbedSummary[] }
+      event.payload = {
+        ...payload,
+        memoEmbeds: (payload.memoEmbeds ?? []).map((entry) => (entry.memoId === summary.memoId ? summary : entry)),
+      }
+      const now = Date.now()
+      event._cachedAt = now
+      event._patchedAt = now
+    })
+}
+
 export async function updateMessageEvent(
   streamId: string,
   messageId: string,
@@ -1295,6 +1325,17 @@ export function registerStreamSocketHandlers(
     }
   }
 
+  /**
+   * A memo's card content changed. The server sends this only to streams whose
+   * room may see the memo, and only for a real edit — it is the one thing that
+   * may redraw a card, since nothing here loads late.
+   */
+  const handleMemoUpdated = async (payload: { streamId: string; memoId: string; summary: MemoEmbedSummary }) => {
+    if (payload.streamId !== streamId) return
+    await updateMemoEmbedSummary(streamId, payload.summary)
+    await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
+  }
+
   const handleMessageEdited = async (payload: MessageEventPayload) => {
     if (payload.streamId !== streamId) return
     const editEvent = payload.event
@@ -1314,8 +1355,8 @@ export function registerStreamSocketHandlers(
         // REPLACED, not merged: the edit payload always carries this array,
         // empty included, so a reference the edit removed loses its card rather
         // than keeping the pre-edit one. Without this the cached row holds the
-        // old summaries for the life of the session — and since this PR deletes
-        // the per-card fetch, nothing else would ever correct it.
+        // old summaries for the life of the session — and since the card no
+        // longer fetches, nothing else would ever correct it.
         memoEmbeds: editPayload.memoEmbeds ?? [],
         editedAt: editEvent.createdAt,
       }))
@@ -1755,6 +1796,7 @@ export function registerStreamSocketHandlers(
 
   socket.on("message:created", handleMessageCreated)
   socket.on("message:edited", handleMessageEdited)
+  socket.on("memo:updated", handleMemoUpdated)
   socket.on("message:deleted", handleMessageDeleted)
   socket.on("messages:moved", handleMessagesMoved)
   socket.on("reaction:added", handleReactionAdded)
@@ -1797,6 +1839,7 @@ export function registerStreamSocketHandlers(
   return () => {
     socket.off("message:created", handleMessageCreated)
     socket.off("message:edited", handleMessageEdited)
+    socket.off("memo:updated", handleMemoUpdated)
     socket.off("message:deleted", handleMessageDeleted)
     socket.off("messages:moved", handleMessagesMoved)
     socket.off("reaction:added", handleReactionAdded)


### PR DESCRIPTION
## Problem

C4 deleted the memo card's fetch, which is what made it stop moving. It also means a retitled memo can no longer reach a card already on screen — the payload it rendered from was written when the message was.

The rule the stack is built on allows exactly this one thing to change a card: *content may change when the memo changed, never because it hadn't loaded yet.* This is that path.

## Solution

`memo:updated`, emitted in the same transaction as the edit (INV-4/7).

- **Stream-scoped, one event per citing stream**, found by matching the markdown pointer every authored form serializes to. Workspace scoping goes through `streams`, since `messages` carries no `workspace_id`. Stream-scoping is only real once the event is registered in `STREAM_SCOPED_EVENTS` — routing keys off that list, not the payload shape, and the first cut missed it, so the event fell through to the workspace group. `/code-review` caught it (scored 95); the fix registers the event and adds a delivery-group routing assertion the outbox-row tests demonstrably could not make.
- **Gated per room** by the same `findEmbedSummaries` predicate the write path uses. A room that could never be shown this memo is not told it exists; a stream privatized since the citation stops receiving updates with no bookkeeping of its own; a memo moved out of reach simply stops emitting there.
- **Carries only the card's fields.** Never the abstract or key points. Deliberately *not* workspace-scoped — worth knowing that `memo:created` broadcasts a whole `WireMemo`, abstract included, to every workspace member today. That is pre-existing, wider than this event is willing to inherit, and probably worth its own look.
- **The client patches only messages that already carry a summary for that memo.** The event says the memo changed, not that this reader may see it — adding a card here would put content in front of someone the write path withheld it from.
- **Raced edits can't repaint backwards** (Sol finding): a `message:edited` payload resolved before a memo edit can arrive after that memo's `memo:updated` patch; per memo, the strictly newer `updatedAt` wins while the edit still decides which memos have cards at all.
- **Label pages hear the repaint** (Sol finding): they render from `labelKeys.messages`, not `db.events`, and their backend resolves summaries fresh at read — `memo:updated` now invalidates those queries, which IS their repaint. Residual: a label page whose citing streams have no live subscription refreshes on the query's own refetch triggers, as before.
- **Moves ship current summaries** (Sol finding): the destination side of `messages:moved` bulkPuts server payloads over the client cache, which would repaint a `memo:updated` patch backwards with the send-time snapshot. The move re-resolves against the destination root at move time — same room-uniform shape as its share hydration.

**Accepted residuals, with reasoning** (Sol recheck):
- Stored summaries replay through `sync_log` for up to the retention window under CURRENT citing-stream access. This is exact parity with shared messages — hydrated slots ride the same outbox payloads into the same log — and summaries are strictly stronger: bootstrap re-resolves and retracts them (#1688); slots don't. Sanitizing sync-log serves for both is its own piece of work.
- The newer-wins guard compares ms-precision `updatedAt`: two memo edits inside the same millisecond plus an in-flight message edit can still repaint backwards, healing at the next bootstrap. A monotonic memo version column (INV-66 shape) would close it absolutely; migration-scale, not taken here.

**Also fixed here:** the edit handler spread the stored payload and dropped `memoEmbeds` entirely, so a reference an edit removed kept its card until a reload. C2 made the server always send the field; this makes the client honour it.

## Files

| File | Change |
| ---- | ------ |
| `features/memos/repository.ts` | `findCitingStreamIds` |
| `features/memos/explorer-service.ts` | `publishCardUpdates`, per citing stream, inside the edit transaction |
| `lib/outbox/repository.ts` | `MemoUpdatedOutboxPayload`; `memo:updated` registered in `STREAM_SCOPED_EVENTS` |
| `lib/outbox/delivery-groups.test.ts` | routing: `memo:updated` delivers to the stream room, never the workspace group |
| `frontend/src/sync/stream-sync.ts` | `updateMemoEmbedSummary` + the socket handler; edit handler now carries `memoEmbeds` |
| `tests/integration/memo-card-updates.test.ts` | **new** — fan-out, gating, payload shape |
| `frontend/src/sync/stream-sync.test.ts` | patch semantics |

## Test plan

- [x] **Integration — 6 pass.** Two citing streams each get one event with the new title; a memo sourced in a private channel and cited from a public one emits **only** to the private room; an uncited memo emits nothing; the payload's keys are exactly the card's six fields; a move re-resolves a retitled memo into its destination payloads; a serializer canary routes a memoEmbed node through the REAL markdown serializer and asserts the `LIKE '%(memo:<id>)%'` scan finds it — wire-shape drift reddens it (mutation-checked by changing the serializer's href shape).
- [x] **Unit — 5 pass.** Replaces the summary across citing messages, leaves other memos and other streams alone, does **not** add a summary to a message that never carried one, keeps the newer patch when a raced edit arrives late, and invalidates label message queries but not the label list.
- [x] frontend **5463 pass** · backend unit **3833** · integration **778** · typecheck 0 · lint 0
- [x] **Mutation-checked.** Emitting regardless of the room predicate reddens the private-memo case; patching messages that never carried a summary reddens the "does not add" case; dropping the newer-wins guard and the label invalidation reddens exactly their two cases; disabling the move overlay reddens exactly the move case; mutating the serializer's href shape reddens the canary.
- [x] Three existing `MemoExplorerService.update` unit tests went red on the new DB call (their fake transaction client has no `query`) — stubbed the citation lookup there rather than left failing (INV-22), with the reason in the test.
- [ ] No browser test for the live repaint: it needs a second client editing a memo while the first watches, which the harness has no shape for. The wiring is covered on both sides; the feel needs staging.
- Full-suite runs while another suite is running time out unrelated tests at the 5s default, a different set each time. Isolated: 140/140. Clean run: 5464/5464.

## Notes for the stack

Top of #1693 → #1688 → #1686 → #1681. Design: https://seer.build/ws_vbyzjvdg6g/b/memo-cards-scope-d842fe/ (v3)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
