### PR TITLE
feat/fuzzy finding things

### DIFF
--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -886,6 +886,36 @@ describe("QuickSwitcher Integration Tests", () => {
       })
     })
 
+    it("ranks an exact user match above a stream that only matches by typo", async () => {
+      const user = userEvent.setup()
+      mockWorkspaceBootstrap.data.dmPeers = undefined
+      // "alise" is one substitution from "alice" and is not a subsequence of
+      // it, so it reaches the typo band and nothing above it; the member
+      // "Alice" matches her name exactly. Streams render above users and Enter
+      // fires the first row, so the guess must not take that slot.
+      mockWorkspaceBootstrap.data.streams = [
+        ...mockStreamsList,
+        {
+          ...(mockStreamsList[0] as object),
+          id: "stream_typo_only",
+          slug: "alise",
+          displayName: "alise",
+          archivedAt: null,
+        },
+      ]
+
+      renderWithProviders(<QuickSwitcher {...defaultProps} />)
+
+      const input = screen.getByLabelText("Quick switcher input")
+      await user.type(input, "alice")
+
+      await waitFor(() => {
+        expect(document.querySelector('a[href="/w/workspace_1/s/draft_dm_member_3"]')).toBeInTheDocument()
+      })
+      // The typo-band stream is dropped entirely while a real match exists.
+      expect(document.querySelector('a[href="/w/workspace_1/s/stream_typo_only"]')).not.toBeInTheDocument()
+    })
+
     it("should include virtual DM targets when dmPeers is missing", async () => {
       const user = userEvent.setup()
       mockWorkspaceBootstrap.data.dmPeers = undefined

--- a/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest"
 import { FileText } from "lucide-react"
 import { commands, type Command } from "./commands"
-import { rankCommands } from "./use-command-items"
+import { rankCommands, rankGroups } from "./use-command-items"
+import { draftStreamCommands } from "./stream-commands"
 
 function makeCommand(overrides: Partial<Command> & Pick<Command, "id" | "label">): Command {
   return { icon: FileText, action: () => {}, ...overrides }
@@ -46,5 +47,23 @@ describe("rankCommands", () => {
     for (const q of ["post", "compose", "write"]) {
       expect(rankCommands(commands, q).map((c) => c.id)).toContain("new-post")
     }
+  })
+})
+
+describe("rankGroups", () => {
+  it("drops guessed matches from every group once any group holds a real one", () => {
+    // The palette renders the contextual group first and fires its first row
+    // on Enter. On a draft scratchpad, "drafts" is one edit from the keyword
+    // of "Delete this draft" — a guess that must not outrank the exact
+    // "View Drafts" below it, or Enter deletes the draft.
+    const [contextual, global] = rankGroups("drafts", [draftStreamCommands, commands])
+    expect(contextual).toEqual([])
+    expect(global[0]?.id).toBe("view-drafts")
+  })
+
+  it("keeps guessed matches when no group holds a real one", () => {
+    const typo = makeCommand({ id: "view-drafts", label: "View Drafts", keywords: ["draft"] })
+    const [only] = rankGroups("drfats", [[typo]])
+    expect(only.map((c) => c.id)).toEqual(["view-drafts"])
   })
 })

--- a/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from "vitest"
 import { FileText } from "lucide-react"
 import { commands, type Command } from "./commands"
-import { rankCommands, rankGroups } from "./use-command-items"
+import { rankGroups } from "./use-command-items"
 import { draftStreamCommands } from "./stream-commands"
 
 function makeCommand(overrides: Partial<Command> & Pick<Command, "id" | "label">): Command {
   return { icon: FileText, action: () => {}, ...overrides }
 }
 
-describe("rankCommands", () => {
+/** One group through the production path, which is the only way the palette ranks. */
+const rankCommands = (candidates: Command[], query: string) => rankGroups(query, [candidates])[0]
+
+describe("ranking one group", () => {
   it("returns all commands in curated order for an empty query", () => {
     expect(rankCommands(commands, "")).toEqual(commands)
   })

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -3,7 +3,7 @@ import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { isDraftId } from "@/hooks"
 import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { hasPermission } from "@/lib/permissions"
-import { rankMatchesScored, TOLERANCE_TIER } from "@/lib/match-score"
+import { isToleranceMatch, rankMatchesScored } from "@/lib/match-score"
 import { commands, type Command, type CommandContext } from "./commands"
 import { draftStreamCommands, streamCommands } from "./stream-commands"
 import type { ModeResult, QuickSwitcherItem } from "./types"
@@ -20,10 +20,6 @@ interface UseCommandItemsParams {
  * matches on an alias, regardless of definition order. Ties keep the curated
  * array order.
  */
-export function rankCommands(candidates: Command[], query: string): Command[] {
-  return rankCommandsScored(candidates, query).map((entry) => entry.item)
-}
-
 function rankCommandsScored(candidates: Command[], query: string) {
   return rankMatchesScored(candidates, query, (command) => ({
     labels: [command.label],
@@ -41,9 +37,9 @@ function rankCommandsScored(candidates: Command[], query: string) {
  */
 export function rankGroups(query: string, groups: readonly Command[][]): Command[][] {
   const scored = groups.map((group) => rankCommandsScored(group, query))
-  const best = Math.min(...scored.flat().map((entry) => entry.score))
-  if (best >= TOLERANCE_TIER) return scored.map((group) => group.map((entry) => entry.item))
-  return scored.map((group) => group.filter((entry) => entry.score < TOLERANCE_TIER).map((entry) => entry.item))
+  const hasRealMatch = scored.some((group) => group.some((entry) => !isToleranceMatch(entry.score)))
+  if (!hasRealMatch) return scored.map((group) => group.map((entry) => entry.item))
+  return scored.map((group) => group.filter((entry) => !isToleranceMatch(entry.score)).map((entry) => entry.item))
 }
 
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -3,7 +3,7 @@ import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { isDraftId } from "@/hooks"
 import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
 import { hasPermission } from "@/lib/permissions"
-import { rankMatches } from "@/lib/match-score"
+import { rankMatchesScored, TOLERANCE_TIER } from "@/lib/match-score"
 import { commands, type Command, type CommandContext } from "./commands"
 import { draftStreamCommands, streamCommands } from "./stream-commands"
 import type { ModeResult, QuickSwitcherItem } from "./types"
@@ -21,10 +21,29 @@ interface UseCommandItemsParams {
  * array order.
  */
 export function rankCommands(candidates: Command[], query: string): Command[] {
-  return rankMatches(candidates, query, (command) => ({
+  return rankCommandsScored(candidates, query).map((entry) => entry.item)
+}
+
+function rankCommandsScored(candidates: Command[], query: string) {
+  return rankMatchesScored(candidates, query, (command) => ({
     labels: [command.label],
     keywords: [command.id, ...(command.keywords ?? [])],
   }))
+}
+
+/**
+ * Rank the palette's groups against each other before they are concatenated.
+ * Groups render in section order rather than by score, so the first row of the
+ * first group is what Enter fires — and a guessed match there would beat an
+ * exact one below it. Typo and fuzzy matches are therefore dropped from every
+ * group as soon as any group holds a real one: on a draft scratchpad,
+ * `> drafts` offered a guessed "Delete this draft" above "View Drafts".
+ */
+export function rankGroups(query: string, groups: readonly Command[][]): Command[][] {
+  const scored = groups.map((group) => rankCommandsScored(group, query))
+  const best = Math.min(...scored.flat().map((entry) => entry.score))
+  if (best >= TOLERANCE_TIER) return scored.map((group) => group.map((entry) => entry.item))
+  return scored.map((group) => group.filter((entry) => entry.score < TOLERANCE_TIER).map((entry) => entry.item))
 }
 
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {
@@ -54,12 +73,13 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
       contextualCommands = isDraftId(currentStreamId) ? draftStreamCommands : streamCommands
     }
     const contextualGroup = currentStreamName ? `This stream — ${currentStreamName}` : "This stream"
-    // Each group is ranked independently — the list renders grouped, so
-    // cross-group ordering is the section order, not match quality.
-    const contextualItems = rankCommands(contextualCommands, query).map((c) => toItem(c, contextualGroup))
-
+    // Groups render in section order, not by score, so they are ranked
+    // together (see rankGroups) and only ordered within a section afterwards.
     const globalCommands = commands.filter((c) => c.id !== "open-ai-agents" || isAdmin)
-    const globalItems = rankCommands(globalCommands, query).map((c) => toItem(c, "Commands"))
+    const [rankedContextual, rankedGlobal] = rankGroups(query, [contextualCommands, globalCommands])
+    const contextualItems = rankedContextual.map((c) => toItem(c, contextualGroup))
+
+    const globalItems = rankedGlobal.map((c) => toItem(c, "Commands"))
 
     return [...contextualItems, ...globalItems]
   }, [query, commandContext, isAdmin])

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
-import { scoreMatch } from "@/lib/match-score"
+import { isToleranceMatch, scoreMatch } from "@/lib/match-score"
 import { compareStreamEntries, scoreStreamMatch } from "@/lib/stream-sort"
 import { FilterSelect } from "./filter-select"
 import {
@@ -178,40 +178,44 @@ export function useStreamItems(context: ModeContext): ModeResult {
 
     // Quick-switcher always uses the recency-style browsing order; the share
     // pickers expose a toggle but reuse the same comparator.
-    const streamItems = enriched
-      .sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: "recency" }))
-      .map(({ stream, unreadCount, mentionCount, urgency }): QuickSwitcherItem => {
-        const href = `/w/${workspaceId}/s/${stream.id}`
-        const isArchived = stream.archivedAt != null
-        const typeLabel = getStreamTypeLabel(stream.type)
-        const notJoined = !memberStreamIds.has(stream.id) && stream.visibility === "public"
-        let description = typeLabel
-        if (isArchived) description = `${typeLabel} · Archived`
-        else if (notJoined) description = `${typeLabel} · Not joined`
+    const sortedStreams = enriched.sort((a, b) => compareStreamEntries(a, b, { isSearching, mode: "recency" }))
+    const toStreamItem = ({
+      stream,
+      unreadCount,
+      mentionCount,
+      urgency,
+    }: (typeof enriched)[number]): QuickSwitcherItem => {
+      const href = `/w/${workspaceId}/s/${stream.id}`
+      const isArchived = stream.archivedAt != null
+      const typeLabel = getStreamTypeLabel(stream.type)
+      const notJoined = !memberStreamIds.has(stream.id) && stream.visibility === "public"
+      let description = typeLabel
+      if (isArchived) description = `${typeLabel} · Archived`
+      else if (notJoined) description = `${typeLabel} · Not joined`
 
-        let avatarUrl: string | undefined
-        if (stream.type === StreamTypes.DM) {
-          const peerUserId = dmPeerByStreamId.get(stream.id)
-          const peerUser = peerUserId ? usersById.get(peerUserId) : undefined
-          avatarUrl = getAvatarUrl(workspaceId, peerUser?.avatarUrl, 64)
-        }
+      let avatarUrl: string | undefined
+      if (stream.type === StreamTypes.DM) {
+        const peerUserId = dmPeerByStreamId.get(stream.id)
+        const peerUser = peerUserId ? usersById.get(peerUserId) : undefined
+        avatarUrl = getAvatarUrl(workspaceId, peerUser?.avatarUrl, 64)
+      }
 
-        return {
-          id: stream.id,
-          label: streamLabel(stream),
-          description,
-          icon: STREAM_ICONS[stream.type],
-          avatarUrl,
-          href,
-          onSelect: () => {
-            closeDialog()
-            navigate(href)
-          },
-          urgency,
-          unreadCount,
-          mentionCount,
-        }
-      })
+      return {
+        id: stream.id,
+        label: streamLabel(stream),
+        description,
+        icon: STREAM_ICONS[stream.type],
+        avatarUrl,
+        href,
+        onSelect: () => {
+          closeDialog()
+          navigate(href)
+        },
+        urgency,
+        unreadCount,
+        mentionCount,
+      }
+    }
 
     const canShowVirtualDms =
       Boolean(currentUserId) &&
@@ -220,11 +224,11 @@ export function useStreamItems(context: ModeContext): ModeResult {
       (typeFilters.length === 0 || typeFilters.includes(StreamTypes.DM))
 
     if (!canShowVirtualDms) {
-      return streamItems
+      return sortedStreams.map(toStreamItem)
     }
 
     const existingDmPeerIds = new Set((dmPeers ?? []).map((peer) => peer.userId))
-    const virtualDmItems = users!
+    const scoredVirtualDms = users!
       .filter((workspaceUser) => workspaceUser.id !== currentUserId)
       .filter((workspaceUser) => !existingDmPeerIds.has(workspaceUser.id))
       .map((workspaceUser) => ({
@@ -232,6 +236,20 @@ export function useStreamItems(context: ModeContext): ModeResult {
         score: searchText ? scoreMatch(lowerQuery, [workspaceUser.name]) : 0,
       }))
       .filter(({ score }) => score !== Infinity)
+
+    // Streams always render above users, so the two independently scored lists
+    // are compared before they are concatenated: without this a stream matched
+    // only by the typo band outranks a user whose name matches exactly, and
+    // Enter (which fires the first row) opens the wrong thing. Same rule as
+    // rankGroups in use-command-items.
+    const hasRealMatch =
+      enriched.some(({ score }) => !isToleranceMatch(score)) ||
+      scoredVirtualDms.some(({ score }) => !isToleranceMatch(score))
+
+    const keep = (score: number) => !hasRealMatch || !isToleranceMatch(score)
+
+    const virtualDmItems = scoredVirtualDms
+      .filter(({ score }) => keep(score))
       .sort((a, b) => a.workspaceUser.name.localeCompare(b.workspaceUser.name))
       .map(
         ({ workspaceUser }): QuickSwitcherItem => ({
@@ -249,7 +267,7 @@ export function useStreamItems(context: ModeContext): ModeResult {
         })
       )
 
-    return [...streamItems, ...virtualDmItems]
+    return [...sortedStreams.filter(({ score }) => keep(score)).map(toStreamItem), ...virtualDmItems]
   }, [
     activeStreams,
     archivedStreams,

--- a/apps/frontend/src/lib/fuzzy.test.ts
+++ b/apps/frontend/src/lib/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { foldSeparators, fuzzyQuality } from "./fuzzy"
+import { foldSeparators, fuzzyQuality, isWordEnd, isWordStart, splitTokens, typoBudget, typoDistance } from "./fuzzy"
 
 describe("foldSeparators", () => {
   it("removes whitespace, underscores, and dashes", () => {
@@ -45,5 +45,65 @@ describe("fuzzyQuality", () => {
   it("handles empty and oversized queries", () => {
     expect(fuzzyQuality("", "anything")).toBe(0)
     expect(fuzzyQuality("abcd", "abc")).toBe(0)
+  })
+})
+
+describe("splitTokens", () => {
+  it("splits on whitespace, underscore, dash and colon, dropping empties", () => {
+    expect(splitTokens("Heart_eyes-cat  face:2")).toEqual(["heart", "eyes", "cat", "face", "2"])
+    expect(splitTokens("__ - ")).toEqual([])
+  })
+})
+
+describe("word boundaries", () => {
+  it("marks the text edges and every separator side", () => {
+    expect(isWordStart("no_entry", 0)).toBe(true)
+    expect(isWordStart("no_entry", 3)).toBe(true)
+    expect(isWordStart("notebook", 2)).toBe(false)
+    expect(isWordEnd("no_entry", 2)).toBe(true)
+    expect(isWordEnd("no_entry", 8)).toBe(true)
+    expect(isWordEnd("notebook", 2)).toBe(false)
+  })
+})
+
+describe("typoBudget", () => {
+  it("spends nothing below four characters and grows once past seven", () => {
+    expect(typoBudget(3)).toBe(0)
+    expect(typoBudget(4)).toBe(1)
+    expect(typoBudget(7)).toBe(1)
+    expect(typoBudget(8)).toBe(2)
+  })
+})
+
+describe("typoDistance", () => {
+  it("counts an adjacent transposition as a single edit", () => {
+    expect(typoDistance("thubms", "thumbs", 1)).toBe(1)
+    expect(typoDistance("recieve", "receive", 1)).toBe(1)
+  })
+
+  it("counts substitution, insertion and deletion as single edits", () => {
+    expect(typoDistance("smole", "smile", 1)).toBe(1)
+    expect(typoDistance("smiile", "smile", 1)).toBe(1)
+    expect(typoDistance("smle", "smile", 1)).toBe(1)
+  })
+
+  it("matches any single whole token of the text", () => {
+    expect(typoDistance("hart", "heart_eyes", 1)).toBe(1)
+    expect(typoDistance("eyez", "heart_eyes", 1)).toBe(1)
+  })
+
+  it("refuses a match that would land mid-word", () => {
+    // A window-based matcher finds "ello" inside "hello" and calls this one
+    // edit; anchoring to whole tokens costs it the leading "h" as well.
+    expect(typoDistance("ellow", "say_hello_now", 1)).toBe(2)
+  })
+
+  it("returns budget + 1 rather than the true distance once past the cap", () => {
+    expect(typoDistance("abcdef", "zzzzzz", 1)).toBe(2)
+    expect(typoDistance("abcdef", "zzzzzz", 2)).toBe(3)
+  })
+
+  it("never matches on a zero budget", () => {
+    expect(typoDistance("cat", "cat", 0)).toBe(1)
   })
 })

--- a/apps/frontend/src/lib/fuzzy.ts
+++ b/apps/frontend/src/lib/fuzzy.ts
@@ -2,24 +2,63 @@
  * Separator-insensitive fuzzy matching primitives shared by the suggestion
  * scorers (lib/match-score.ts, lib/stream-sort.ts).
  *
- * Two building blocks:
+ * Three building blocks:
  * - `foldSeparators` makes whitespace/underscore/dash interchangeable, so
  *   "thumbs up", "thumbs-up", and "thumbs_up" all compare equal.
  * - `fuzzyQuality` scores an in-order subsequence match, rewarding contiguous
  *   runs and word-boundary starts so "thup" → "thumbs_up" scores well while
  *   scattered matches sink.
+ * - `typoDistance` scores a mistyped query by edit distance, catching the
+ *   errors a subsequence cannot represent at any threshold (transposition,
+ *   substitution, insertion): "thubms" → "thumbs_up".
  */
 
-const SEPARATOR = /[\s_-]/
-const SEPARATORS = /[\s_-]+/g
+const FOLDED_SEPARATORS = /[\s_-]+/g
+const TOKEN_SPLIT = /[\s_:-]+/
+
+/**
+ * Character-code twin of TOKEN_SPLIT. These predicates run once per character
+ * of every candidate string, and a regex test there costs more than the
+ * matching it guards — hence the codes rather than `SEPARATOR.test(text[i])`.
+ */
+function isSeparatorCode(code: number): boolean {
+  return (
+    code === 32 || // space
+    code === 95 || // _
+    code === 45 || // -
+    code === 58 || // :
+    (code >= 9 && code <= 13) || // tab, newline, vertical tab, form feed, carriage return
+    code === 0xa0 // non-breaking space
+  )
+}
 
 /** Lowercased text with whitespace/underscore/dash removed. */
 export function foldSeparators(text: string): string {
-  return text.replace(SEPARATORS, "")
+  return text.replace(FOLDED_SEPARATORS, "")
 }
 
-function isBoundary(text: string, index: number): boolean {
-  return index === 0 || SEPARATOR.test(text[index - 1])
+/** Lowercased words of `text`, split on whitespace/underscore/dash/colon. */
+export function splitTokens(text: string): string[] {
+  return text.toLowerCase().split(TOKEN_SPLIT).filter(Boolean)
+}
+
+/** Whether index `index` begins a word (start of text, or after a separator). */
+export function isWordStart(text: string, index: number): boolean {
+  return index === 0 || isSeparatorCode(text.charCodeAt(index - 1))
+}
+
+/** Whether index `index` ends a word (end of text, or a separator sits there). */
+export function isWordEnd(text: string, index: number): boolean {
+  return index === text.length || isSeparatorCode(text.charCodeAt(index))
+}
+
+/** Whether `query` appears in `lowerText` in order, gaps allowed. */
+function isSubsequence(query: string, lowerText: string): boolean {
+  let at = 0
+  for (let i = 0; i < lowerText.length && at < query.length; i++) {
+    if (lowerText[i] === query[at]) at++
+  }
+  return at === query.length
 }
 
 /**
@@ -36,6 +75,10 @@ export function fuzzyQuality(query: string, text: string): number {
   const n = text.length
   if (m === 0 || m > n) return 0
   const lower = text.toLowerCase()
+  // The DP below allocates a row per query character, so it must not run for
+  // the overwhelming majority of candidates that cannot match at all. A linear
+  // subsequence test decides that with no allocation.
+  if (!isSubsequence(query, lower)) return 0
 
   // endAt[j]: best score for the query prefix so far with its last char
   // matched exactly at text index j; -1 when unreachable.
@@ -47,7 +90,7 @@ export function fuzzyQuality(query: string, text: string): number {
     for (let j = 0; j < n; j++) {
       if (i > 0 && j > 0 && endAt[j - 1] > bestBefore) bestBefore = endAt[j - 1]
       if (lower[j] !== qc) continue
-      const bonus = isBoundary(lower, j) ? 1 : 0
+      const bonus = isWordStart(lower, j) ? 1 : 0
       if (i === 0) {
         next[j] = 1 + bonus
         continue
@@ -64,4 +107,129 @@ export function fuzzyQuality(query: string, text: string): number {
     if (score > best) best = score
   }
   return best > 0 ? best / (2 * m) : 0
+}
+
+/**
+ * Edit operations a query of this length may be off by. Below 4 characters the
+ * budget is 0: at that length one edit reaches so much of any real dataset that
+ * the tier stops ranking and starts listing (a 3-char query admitting distance
+ * 1 matched a third of the emoji set in testing).
+ */
+export function typoBudget(queryLength: number): number {
+  if (queryLength < 4) return 0
+  if (queryLength < 8) return 1
+  return 2
+}
+
+/**
+ * Damerau-Levenshtein distance between `a` and `b`, capped: any distance above
+ * `budget` returns `budget + 1` rather than the true value. The cap is what
+ * makes this affordable to run across a whole dataset — the length-difference
+ * check rejects most candidates before any DP work, and the per-row minimum
+ * bails out of the rest.
+ *
+ * Damerau (adjacent transposition as one edit) rather than plain Levenshtein:
+ * transposition is the most common typing error and the one a subsequence
+ * match can never admit, so it is the whole reason this function exists.
+ */
+/**
+ * Bitmask of the a-z characters present in `text[from, to)`; characters
+ * outside a-z all share the 27th bit, which only ever makes the gate more
+ * permissive.
+ */
+function characterMask(text: string, from: number, to: number): number {
+  let mask = 0
+  for (let i = from; i < to; i++) {
+    const code = text.charCodeAt(i) - 97
+    mask |= code >= 0 && code < 26 ? 1 << code : 1 << 26
+  }
+  return mask
+}
+
+const dpRows: Int32Array[] = [new Int32Array(64), new Int32Array(64), new Int32Array(64)]
+
+/** One of the three shared DP rows, grown if this comparison needs a longer one. */
+function rowBuffer(index: number, length: number): Int32Array {
+  if (dpRows[index].length < length) dpRows[index] = new Int32Array(length)
+  return dpRows[index]
+}
+
+function popcount(bits: number): number {
+  let n = bits - ((bits >> 1) & 0x55555555)
+  n = (n & 0x33333333) + ((n >> 2) & 0x33333333)
+  n = (n + (n >> 4)) & 0x0f0f0f0f
+  return (n * 0x01010101) >> 24
+}
+
+function damerauLevenshtein(a: string, b: string, from: number, to: number, budget: number, aMask: number): number {
+  const m = a.length
+  const n = to - from
+  if (Math.abs(m - n) > budget) return budget + 1
+  if (m === 0) return n
+  if (n === 0) return m
+  // Every character of `a` absent from `b` costs at least one edit, so a
+  // set-difference wider than the budget rules the pair out before any DP.
+  if (popcount(aMask & ~characterMask(b, from, to)) > budget) return budget + 1
+
+  // Three rotating rows, allocated once for the whole module: this DP runs
+  // thousands of times per keystroke and fresh rows per row per call were the
+  // dominant cost.
+  let beforePrev = rowBuffer(0, n + 1)
+  let prev = rowBuffer(1, n + 1)
+  let row = rowBuffer(2, n + 1)
+  for (let j = 0; j <= n; j++) prev[j] = j
+
+  for (let i = 1; i <= m; i++) {
+    row[0] = i
+    let rowMin = i
+    for (let j = 1; j <= n; j++) {
+      const bj = b[from + j - 1]
+      const cost = a[i - 1] === bj ? 0 : 1
+      let value = Math.min(prev[j] + 1, row[j - 1] + 1, prev[j - 1] + cost)
+      if (i > 1 && j > 1 && a[i - 1] === b[from + j - 2] && a[i - 2] === bj) {
+        value = Math.min(value, beforePrev[j - 2] + 1)
+      }
+      row[j] = value
+      if (value < rowMin) rowMin = value
+    }
+    if (rowMin > budget) return budget + 1
+    const spent = beforePrev
+    beforePrev = prev
+    prev = row
+    row = spent
+  }
+  return prev[n]
+}
+
+/**
+ * Best edit distance from `query` to `text` as a whole or to any one of its
+ * tokens, capped at `budget + 1` (i.e. "no match").
+ *
+ * Anchoring to whole tokens rather than to any substring window is what keeps
+ * the tier honest: an unanchored substring distance lets a 4-character query
+ * land within one edit of *some* window of every long label, which reads as
+ * the picker having stopped filtering.
+ */
+export function typoDistance(query: string, text: string, budget: number): number {
+  if (budget <= 0 || !query) return budget + 1
+  const lower = text.toLowerCase()
+  const queryMask = characterMask(query, 0, query.length)
+  let best = damerauLevenshtein(query, lower, 0, lower.length, budget, queryMask)
+  if (best === 0) return 0
+  // Walk the token spans in place rather than through splitTokens: this runs
+  // once per candidate string in a dataset of thousands, and the array of
+  // slices it would allocate dominates the DP it feeds.
+  for (let start = 0; start < lower.length; ) {
+    if (isSeparatorCode(lower.charCodeAt(start))) {
+      start++
+      continue
+    }
+    let end = start + 1
+    while (end < lower.length && !isSeparatorCode(lower.charCodeAt(end))) end++
+    const distance = damerauLevenshtein(query, lower, start, end, budget, queryMask)
+    if (distance < best) best = distance
+    if (best === 0) return 0
+    start = end + 1
+  }
+  return best
 }

--- a/apps/frontend/src/lib/match-score.test.ts
+++ b/apps/frontend/src/lib/match-score.test.ts
@@ -1,24 +1,24 @@
 import { describe, it, expect } from "vitest"
 import { scoreMatch, rankMatches } from "./match-score"
 
+/** Labels that match `query`, best first. */
+const ranked = (query: string, labels: string[]) => rankMatches(labels, query, (label) => ({ labels: [label] }))
+
 describe("scoreMatch", () => {
   it("returns 0 for an empty or whitespace-only query (no scoring required)", () => {
     expect(scoreMatch("", ["View Saved"], ["bookmark"])).toBe(0)
     expect(scoreMatch("   ", ["View Saved"], ["bookmark"])).toBe(0)
   })
 
-  it("tiers label matches: exact < prefix < contains", () => {
-    expect(scoreMatch("view saved", ["View Saved"])).toBe(0)
-    expect(scoreMatch("view", ["View Saved"])).toBe(2)
-    expect(scoreMatch("saved", ["View Saved"])).toBe(4)
+  it("orders the ladder: exact, whole-word prefix, whole word, mid-word prefix, anywhere", () => {
+    const labels = ["no", "no_entry", "see_no_evil", "notebook", "piano"]
+    expect(ranked("no", labels)).toEqual(labels)
   })
 
   it("treats whitespace, underscore, and dash as interchangeable separators", () => {
-    expect(scoreMatch("thumbs up", ["thumbs_up"])).toBe(1)
-    expect(scoreMatch("thumbsup", ["thumbs_up"])).toBe(1)
-    expect(scoreMatch("thumbs-up", ["thumbs_up"])).toBe(1)
-    expect(scoreMatch("thumbsu", ["thumbs_up"])).toBe(3)
-    expect(scoreMatch("bs up", ["thumbs_up"])).toBe(5)
+    for (const query of ["thumbs up", "thumbsup", "thumbs-up"]) {
+      expect(scoreMatch(query, ["thumbs_up"]), query).toBeLessThan(scoreMatch("thumbs", ["thumbs_up"]))
+    }
   })
 
   it("ranks a raw match above its separator-normalized counterpart", () => {
@@ -26,16 +26,27 @@ describe("scoreMatch", () => {
     expect(scoreMatch("thumbs", ["thumbs_up"])).toBeLessThan(scoreMatch("thumbsu", ["thumbs_up"]))
   })
 
-  it("tiers keyword matches a whole band below label matches", () => {
-    expect(scoreMatch("saved", ["Add To-do"], ["saved"])).toBe(6)
-    expect(scoreMatch("sav", ["Add To-do"], ["saved"])).toBe(8)
-    expect(scoreMatch("ave", ["Add To-do"], ["saved"])).toBe(10)
+  it("ranks a keyword hit below the same kind of hit on a label", () => {
+    expect(scoreMatch("saved", ["Saved"])).toBeLessThan(scoreMatch("saved", ["Add To-do"], ["saved"]))
+    expect(scoreMatch("sav", ["Saved"])).toBeLessThan(scoreMatch("sav", ["Add To-do"], ["saved"]))
   })
 
-  it("ranks any label substring match above any keyword substring match", () => {
-    const labelContains = scoreMatch("saved", ["View Saved"], [])
-    const keywordExact = scoreMatch("saved", ["Add To-do"], ["saved"])
-    expect(labelContains).toBeLessThan(keywordExact)
+  it("ranks an exact keyword hit above an incidental label substring", () => {
+    // The 'yes' → 😍 heart_eyes report: `heart_eyes` merely contains "yes",
+    // while ✅ carries it as a search keyword and is what was actually meant.
+    const incidentalLabelSubstring = scoreMatch("yes", ["heart_eyes"], [])
+    const exactKeyword = scoreMatch("yes", ["white_check_mark"], ["yes", "check"])
+    expect(exactKeyword).toBeLessThan(incidentalLabelSubstring)
+  })
+
+  it("ranks every whole-word hit above every partial one, in either field", () => {
+    // `sad` must reach 😞 sad_face before 😢 cry, which merely carries "sad"
+    // as a keyword — and both before 🎨 palette, which only contains it.
+    const labelWholeWord = scoreMatch("sad", ["sad_face"], [])
+    const keywordWholeWord = scoreMatch("sad", ["cry"], ["sad"])
+    const labelPartial = scoreMatch("sad", ["saddle_up"], [])
+    expect(labelWholeWord).toBeLessThan(keywordWholeWord)
+    expect(keywordWholeWord).toBeLessThan(labelPartial)
   })
 
   it("admits fuzzy subsequence matches below every substring match", () => {
@@ -70,17 +81,90 @@ describe("scoreMatch", () => {
 
   it("returns Infinity when nothing matches", () => {
     expect(scoreMatch("zzz", ["View Saved"], ["bookmark"])).toBe(Infinity)
-    expect(scoreMatch("vwx", ["View Saved"])).toBe(Infinity)
+    expect(scoreMatch("vwxq", ["View Saved"])).toBe(Infinity)
   })
 
   it("is case-insensitive on both sides", () => {
-    expect(scoreMatch("SAVED", ["view saved"])).toBe(4)
-    expect(scoreMatch("saved", ["VIEW SAVED"])).toBe(4)
+    const baseline = scoreMatch("saved", ["view saved"])
+    expect(scoreMatch("SAVED", ["view saved"])).toBe(baseline)
+    expect(scoreMatch("saved", ["VIEW SAVED"])).toBe(baseline)
   })
 
   it("handles separator-only queries without matching everything", () => {
     expect(scoreMatch("-", ["View Saved"])).toBe(Infinity)
-    expect(scoreMatch("-", ["to-do"])).toBe(4)
+    expect(scoreMatch("-", ["to-do"])).not.toBe(Infinity)
+  })
+
+  describe("typo tolerance", () => {
+    it("admits the edit classes a subsequence cannot represent", () => {
+      // Transposition and substitution each break subsequence matching
+      // outright; every one of these used to return Infinity.
+      for (const [query, label] of [
+        ["thubms", "thumbs_up"],
+        ["desing", "design-review"],
+        ["recieve", "receive"],
+        ["engenering", "engineering"],
+        ["smiel", "smile"],
+      ] as const) {
+        expect(scoreMatch(query, [label]), `${query} → ${label}`).not.toBe(Infinity)
+      }
+    })
+
+    it("ranks every typo match below every fuzzy and substring match", () => {
+      const typo = scoreMatch("thubms", ["thumbs_up"])
+      const fuzzy = scoreMatch("thup", ["thumbs_up"])
+      const contains = scoreMatch("umb", ["thumbs_up"])
+      expect(fuzzy).toBeLessThan(typo)
+      expect(contains).toBeLessThan(fuzzy)
+    })
+
+    it("ranks a closer typo above a further one", () => {
+      const oneEdit = scoreMatch("celbration", ["celebration"])
+      const twoEdits = scoreMatch("celbratoin", ["celebration"])
+      expect(oneEdit).not.toBe(Infinity)
+      expect(twoEdits).not.toBe(Infinity)
+      expect(oneEdit).toBeLessThan(twoEdits)
+    })
+
+    it("ranks a label typo above a keyword typo", () => {
+      const labelTypo = scoreMatch("thubms", ["thumbs_up"])
+      const keywordTypo = scoreMatch("thubms", ["Something Else"], ["thumbs_up"])
+      expect(keywordTypo).not.toBe(Infinity)
+      expect(labelTypo).toBeLessThan(keywordTypo)
+    })
+
+    it("spends no budget on short queries, where one edit reaches half the dataset", () => {
+      expect(scoreMatch("cta", ["cat"])).toBe(Infinity)
+      expect(scoreMatch("hrt", ["hat"])).toBe(Infinity)
+    })
+
+    it("anchors to whole words, so a typo cannot land mid-word in a long label", () => {
+      expect(scoreMatch("hart", ["heart_eyes"])).not.toBe(Infinity)
+      expect(scoreMatch("ellos", ["say_hello_to_everyone"])).toBe(Infinity)
+    })
+  })
+
+  describe("quoted queries", () => {
+    it("matches literally, refusing both tolerance bands", () => {
+      expect(scoreMatch('"thumbs_up"', ["thumbs_up"])).toBe(0)
+      expect(scoreMatch('"thup"', ["thumbs_up"])).toBe(Infinity)
+      expect(scoreMatch('"thubms"', ["thumbs_up"])).toBe(Infinity)
+    })
+
+    it("refuses separator-normalized matches", () => {
+      expect(scoreMatch("thumbsup", ["thumbs_up"])).not.toBe(Infinity)
+      expect(scoreMatch('"thumbsup"', ["thumbs_up"])).toBe(Infinity)
+    })
+
+    it("keeps the substring ladder inside the quotes", () => {
+      const labels = ["no", "no_entry", "see_no_evil", "notebook", "piano"]
+      expect(ranked('"no"', labels)).toEqual(labels)
+    })
+
+    it("treats a half-typed opening quote as literal, not as a character to match", () => {
+      expect(scoreMatch('"thumbs', ["thumbs_up"])).toBe(scoreMatch("thumbs", ["thumbs_up"]))
+      expect(scoreMatch('"', ["thumbs_up"])).toBe(0)
+    })
   })
 })
 
@@ -104,13 +188,13 @@ describe("rankMatches", () => {
 
   it("ranks a label match above an earlier-defined keyword-only match", () => {
     const todo: Item = { label: "Add To-do", keywords: ["saved"] }
-    const saved: Item = { label: "View Saved", keywords: ["bookmark"] }
+    const saved: Item = { label: "Saved", keywords: ["bookmark"] }
     expect(rankMatches([todo, saved], "saved", text)).toEqual([saved, todo])
   })
 
   it("preserves input order within a tier (stable)", () => {
     const items: Item[] = [{ label: "saver" }, { label: "saved" }]
-    // Both are label-prefix matches for "save"; definition order decides.
+    // Both are mid-word label-prefix matches for "save"; definition order decides.
     expect(rankMatches(items, "save", text)).toEqual(items)
   })
 
@@ -118,5 +202,11 @@ describe("rankMatches", () => {
     const items: Item[] = [{ label: "thumbs_up" }, { label: "setup" }, { label: "sun_with_face" }]
     // "setup" contains "tup" raw; "thumbs_up" only matches as a subsequence.
     expect(rankMatches(items, "tup", text)).toEqual([{ label: "setup" }, { label: "thumbs_up" }])
+  })
+
+  it("appends typo matches last of all", () => {
+    const items: Item[] = [{ label: "receiver" }, { label: "recieve" }, { label: "receive" }]
+    // "recieve" is an exact hit; "receiver"/"receive" are one transposition away.
+    expect(rankMatches(items, "recieve", text)[0]).toEqual({ label: "recieve" })
   })
 })

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -63,8 +63,8 @@ const LABEL_TYPO_TIER = 20
 const KEYWORD_TYPO_TIER = 21
 
 /**
- * First tier of the tolerance bands. A score at or above this is a guess —
- * the query did not actually occur in the text.
+ * Whether a score came from the fuzzy or typo band — i.e. the query never
+ * actually occurred in the text and the match is a guess.
  *
  * Callers that rank several lists separately and then concatenate them must
  * check this: within one `rankMatches` call a tolerance match can never
@@ -72,8 +72,14 @@ const KEYWORD_TYPO_TIER = 21
  * the concatenated order. The command palette ranks its contextual and global
  * groups separately, so `> drafts` on a draft scratchpad put a guessed
  * "Delete this draft" above an exact "View Drafts".
+ *
+ * A range rather than a floor, because a caller may rank its own weaker-than-
+ * fuzzy tiers below the bands and those are still real matches:
+ * `scoreStreamMatch` scores a raw stream-id substring at 100.
  */
-export const TOLERANCE_TIER = LABEL_FUZZY_TIER
+export function isToleranceMatch(score: number): boolean {
+  return score >= LABEL_FUZZY_TIER && score < KEYWORD_TYPO_TIER + 1
+}
 
 /** Place a match kind on the tier ladder for the field it was found in. */
 function tierFor(kind: number, isKeyword: boolean): number {

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -62,6 +62,19 @@ const KEYWORD_FUZZY_TIER = 19
 const LABEL_TYPO_TIER = 20
 const KEYWORD_TYPO_TIER = 21
 
+/**
+ * First tier of the tolerance bands. A score at or above this is a guess —
+ * the query did not actually occur in the text.
+ *
+ * Callers that rank several lists separately and then concatenate them must
+ * check this: within one `rankMatches` call a tolerance match can never
+ * displace a real one, but across two calls it can, and the reader only sees
+ * the concatenated order. The command palette ranks its contextual and global
+ * groups separately, so `> drafts` on a draft scratchpad put a guessed
+ * "Delete this draft" above an exact "View Drafts".
+ */
+export const TOLERANCE_TIER = LABEL_FUZZY_TIER
+
 /** Place a match kind on the tier ladder for the field it was found in. */
 function tierFor(kind: number, isKeyword: boolean): number {
   if (kind === Infinity) return Infinity
@@ -208,7 +221,19 @@ export function rankMatches<T>(
   query: string,
   getText: (item: T) => { labels: readonly string[]; keywords?: readonly string[] }
 ): T[] {
-  if (!query.trim()) return [...items]
+  return rankMatchesScored(items, query, getText).map((entry) => entry.item)
+}
+
+/**
+ * `rankMatches` with each item's score, for callers that rank several lists
+ * and need to compare quality across them — see `TOLERANCE_TIER`.
+ */
+export function rankMatchesScored<T>(
+  items: readonly T[],
+  query: string,
+  getText: (item: T) => { labels: readonly string[]; keywords?: readonly string[] }
+): { item: T; score: number }[] {
+  if (!query.trim()) return items.map((item) => ({ item, score: 0 }))
   return items
     .map((item) => {
       const { labels, keywords } = getText(item)
@@ -216,5 +241,4 @@ export function rankMatches<T>(
     })
     .filter((entry) => entry.score !== Infinity)
     .sort((a, b) => a.score - b.score)
-    .map((entry) => entry.item)
 }

--- a/apps/frontend/src/lib/match-score.ts
+++ b/apps/frontend/src/lib/match-score.ts
@@ -2,45 +2,72 @@
  * Tiered relevance scoring shared by suggestion surfaces (command palette,
  * slash commands, mention/channel triggers, emoji search).
  *
- * The problem this solves: pickers used to flat-filter with a boolean
- * substring test over "label + keywords", so an item matching only on a
- * hidden alias ranked identically to one whose visible label matched, and
- * definition order decided. Tiers encode WHERE and HOW the match landed:
+ * The first thing that decides a match is whether the query is a WHOLE word of
+ * the text or a fragment of one. Whole-word hits all rank above every partial
+ * hit, in either field, because a fragment is usually a coincidence: 😍
+ * `heart_eyes` contains "yes" and ✅ carries it as a keyword, and only one of
+ * those is an answer to `yes`.
  *
- *   labels, substring family   0..5   exact < norm-exact < prefix <
- *                                     norm-prefix < contains < norm-contains
- *   keywords, substring family 6..11  same ladder, one band below
- *   labels, fuzzy subsequence  12..13 ordered by fuzzyQuality within the band
- *   keywords, fuzzy            13..14
+ * Within each group, a visible label ranks above a hidden keyword/alias, and a
+ * hit that starts at the head of the text ranks above one that starts later:
  *
- * "norm-" tiers compare with separators folded (foldSeparators), so
- * "thumbs up" and "thumbsup" hit "thumbs_up". Fuzzy tiers admit in-order
- * subsequences ("thup" → "thumbs_up") but always rank below every substring
- * match, so the fuzzy tail can only add results, never displace them.
- * Mirrors `scoreStreamMatch` (lib/stream-sort.ts), which delegates here.
+ *   whole word    0/4 exact                1/5 norm-exact
+ *                 2/6 prefix               `no` in `no_entry`
+ *                 3/7 word                 `eyes` in `heart_eyes`
+ *   partial      8/13 prefix               `no` in `notebook`
+ *               9/14 norm-prefix           `thumbsu` in `thumbs_up`
+ *              10/15 word                  `eye` in `heart_eyes`
+ *              11/16 anywhere              `ok` in `broken_heart`
+ *              12/17 norm-anywhere
+ *
+ * (label tier / keyword tier.) "norm-" kinds compare with separators folded
+ * (foldSeparators), so "thumbs up" and "thumbsup" hit "thumbs_up"; folding
+ * erases the word boundaries, so a folded hit is never a whole-word kind.
+ *
+ * Below every substring tier come two tolerance bands, each reached only when
+ * nothing above it matched, so they can add results but never displace one:
+ *
+ *   18/19  fuzzy subsequence, ordered by fuzzyQuality ("thup" → "thumbs_up")
+ *   20/21  typo, ordered by edit distance ("thubms" → "thumbs_up")
+ *
+ * A query wrapped in double quotes is literal: it is graded on the same
+ * ladder but only the un-normalized kinds can match it, and neither tolerance
+ * band applies. Mirrors quoted phrases in message search.
+ *
+ * `scoreStreamMatch` (lib/stream-sort.ts) delegates here, so pickers,
+ * the quick switcher and stream sort all order the same query identically.
  *
  * Lower score = better match; Infinity = no match.
  */
 
-import { foldSeparators, fuzzyQuality } from "@/lib/fuzzy"
+import { foldSeparators, fuzzyQuality, isWordEnd, isWordStart, typoBudget, typoDistance } from "@/lib/fuzzy"
 
-/** exact (0) < norm-exact (1) < prefix (2) < norm-prefix (3) < contains (4) < norm-contains (5). */
-function scoreText(text: string, lowerQuery: string, normQuery: string): number {
-  const lower = text.toLowerCase()
-  if (lower === lowerQuery) return 0
-  const norm = foldSeparators(lower)
-  if (normQuery && norm === normQuery) return 1
-  if (lower.startsWith(lowerQuery)) return 2
-  if (normQuery && norm.startsWith(normQuery)) return 3
-  if (lower.includes(lowerQuery)) return 4
-  if (normQuery && norm.includes(normQuery)) return 5
-  return Infinity
+/** Match kinds, ordered; the first WHOLE_WORD_KINDS of them cover whole words. */
+const EXACT = 0
+const NORM_EXACT = 1
+const PREFIX_WHOLE_WORD = 2
+const WORD_WHOLE_WORD = 3
+const PREFIX_MID_WORD = 4
+const NORM_PREFIX = 5
+const WORD_MID_WORD = 6
+const ANYWHERE = 7
+const NORM_ANYWHERE = 8
+
+const WHOLE_WORD_KINDS = 4
+const PARTIAL_KINDS = 5
+const PARTIAL_BAND = WHOLE_WORD_KINDS * 2
+
+const LABEL_FUZZY_TIER = 18
+const KEYWORD_FUZZY_TIER = 19
+const LABEL_TYPO_TIER = 20
+const KEYWORD_TYPO_TIER = 21
+
+/** Place a match kind on the tier ladder for the field it was found in. */
+function tierFor(kind: number, isKeyword: boolean): number {
+  if (kind === Infinity) return Infinity
+  if (kind < WHOLE_WORD_KINDS) return kind + (isKeyword ? WHOLE_WORD_KINDS : 0)
+  return PARTIAL_BAND + (kind - WHOLE_WORD_KINDS) + (isKeyword ? PARTIAL_KINDS : 0)
 }
-
-/** Keyword substring tiers sit one whole band below label tiers (6..11 vs 0..5). */
-const KEYWORD_TIER_OFFSET = 6
-const LABEL_FUZZY_TIER = 12
-const KEYWORD_FUZZY_TIER = 13
 
 /**
  * Fuzzy matches below this quality are rejected: compact abbreviation-style
@@ -49,6 +76,79 @@ const KEYWORD_FUZZY_TIER = 13
  * under it and would only add noise to the tail.
  */
 const FUZZY_MIN_QUALITY = 0.7
+
+interface ParsedQuery {
+  /** Lowercased query text, quotes stripped. Empty means "not searching yet". */
+  text: string
+  /** Separator-folded `text`; empty when `text` is all separators. */
+  normalized: string
+  /** Quoted: match literally — no separator folding, no fuzzy, no typo. */
+  literal: boolean
+}
+
+/**
+ * Split a raw input into query text and its literal flag. A leading quote
+ * counts even before the closing one is typed, so the half-typed `"yes` never
+ * spends a keystroke matching the quote character itself.
+ */
+function parseQuery(raw: string): ParsedQuery {
+  const trimmed = raw.trim()
+  const literal = trimmed.startsWith('"')
+  const unquoted = literal ? trimmed.replace(/^"/, "").replace(/"$/, "") : trimmed
+  const text = unquoted.trim().toLowerCase()
+  return { text, normalized: literal ? "" : foldSeparators(text), literal }
+}
+
+/**
+ * Best kind over every occurrence of `needle` in `haystack`, ignoring the
+ * exact-match kinds the caller has already ruled out. Infinity when absent.
+ */
+function occurrenceKind(haystack: string, needle: string): number {
+  let best = Infinity
+  if (haystack.startsWith(needle)) {
+    if (isWordEnd(haystack, needle.length)) return PREFIX_WHOLE_WORD
+    best = PREFIX_MID_WORD
+  }
+  // Only word starts can improve on that, and there are far fewer of them than
+  // there are occurrences — walking words costs one pass over the text, while
+  // enumerating every occurrence costs an indexOf per hit, which is what makes
+  // a one-character query expensive across a dataset of thousands.
+  for (let at = 1; at < haystack.length; at++) {
+    if (!isWordStart(haystack, at) || !haystack.startsWith(needle, at)) continue
+    if (isWordEnd(haystack, at + needle.length)) return WORD_WHOLE_WORD
+    if (WORD_MID_WORD < best) best = WORD_MID_WORD
+  }
+  if (best !== Infinity) return best
+  return haystack.includes(needle) ? ANYWHERE : Infinity
+}
+
+/** Match kind for one text, or Infinity. Lower is a stronger match. */
+function matchKind(text: string, query: ParsedQuery): number {
+  const lower = text.toLowerCase()
+  if (lower === query.text) return EXACT
+  const norm = query.normalized ? foldSeparators(lower) : ""
+  if (norm && norm === query.normalized) return NORM_EXACT
+
+  const raw = occurrenceKind(lower, query.text)
+  if (raw === PREFIX_WHOLE_WORD || !norm) return raw
+  // Folding erased the separators, so a folded hit has no word boundaries left
+  // to grade and can never claim a whole-word kind: `no` folds into `notebook`
+  // exactly as it folds into `no_entry`, and only the raw text tells them
+  // apart. It grades one step below its raw counterpart.
+  if (norm.startsWith(query.normalized)) return Math.min(raw, NORM_PREFIX)
+  if (norm.includes(query.normalized)) return Math.min(raw, NORM_ANYWHERE)
+  return raw
+}
+
+function bestKind(texts: readonly string[], query: ParsedQuery): number {
+  let best = Infinity
+  for (const text of texts) {
+    const kind = matchKind(text, query)
+    if (kind < best) best = kind
+    if (best === EXACT) break
+  }
+  return best
+}
 
 function bestFuzzy(texts: readonly string[], normQuery: string): number {
   let best = 0
@@ -59,27 +159,41 @@ function bestFuzzy(texts: readonly string[], normQuery: string): number {
   return best >= FUZZY_MIN_QUALITY ? best : 0
 }
 
+function bestTypoDistance(texts: readonly string[], query: string, budget: number): number {
+  let best = budget + 1
+  for (const text of texts) {
+    const distance = typoDistance(query, text, budget)
+    if (distance < best) best = distance
+    if (best === 0) break
+  }
+  return best
+}
+
 export function scoreMatch(query: string, labels: readonly string[], keywords: readonly string[] = []): number {
-  // A whitespace-only query is "not searching yet", same as empty — without
-  // the trim it would fold to an empty normQuery and match nothing at all.
-  const lowerQuery = query.trim().toLowerCase()
-  if (!lowerQuery) return 0
-  const normQuery = foldSeparators(lowerQuery)
-  let best = Infinity
-  for (const label of labels) {
-    best = Math.min(best, scoreText(label, lowerQuery, normQuery))
-  }
-  if (best === 0) return best
-  for (const keyword of keywords) {
-    best = Math.min(best, KEYWORD_TIER_OFFSET + scoreText(keyword, lowerQuery, normQuery))
-  }
-  // Any substring match outranks every fuzzy match, so only fall through when
-  // nothing matched at all.
-  if (best !== Infinity || !normQuery) return best
-  const labelQuality = bestFuzzy(labels, normQuery)
+  const parsed = parseQuery(query)
+  // A whitespace- or quote-only query is "not searching yet", same as empty.
+  if (!parsed.text) return 0
+
+  const labelKind = bestKind(labels, parsed)
+  if (labelKind === EXACT) return 0
+  const keywordKind = bestKind(keywords, parsed)
+  const best = Math.min(tierFor(labelKind, false), tierFor(keywordKind, true))
+  if (best !== Infinity) return best
+  // Any substring match outranks every tolerance match, so the bands below are
+  // reached only when nothing matched at all. A literal query never reaches them.
+  if (parsed.literal || !parsed.normalized) return Infinity
+
+  const labelQuality = bestFuzzy(labels, parsed.normalized)
   if (labelQuality > 0) return LABEL_FUZZY_TIER + (1 - labelQuality)
-  const keywordQuality = bestFuzzy(keywords, normQuery)
+  const keywordQuality = bestFuzzy(keywords, parsed.normalized)
   if (keywordQuality > 0) return KEYWORD_FUZZY_TIER + (1 - keywordQuality)
+
+  const budget = typoBudget(parsed.text.length)
+  if (budget <= 0) return Infinity
+  const labelDistance = bestTypoDistance(labels, parsed.text, budget)
+  if (labelDistance <= budget) return LABEL_TYPO_TIER + labelDistance / (budget + 1)
+  const keywordDistance = bestTypoDistance(keywords, parsed.text, budget)
+  if (keywordDistance <= budget) return KEYWORD_TYPO_TIER + keywordDistance / (budget + 1)
   return Infinity
 }
 

--- a/apps/frontend/src/lib/stream-sort.ts
+++ b/apps/frontend/src/lib/stream-sort.ts
@@ -18,15 +18,16 @@ export type SortableStream = Pick<Stream, "id" | "type" | "createdAt"> & {
   lastMessagePreview?: { createdAt: string } | null
 }
 
-/** Sorts after every name tier in scoreMatch (substring 0..11, fuzzy 12..14). */
+/** Sorts after every name tier in scoreMatch (substring 0..15, fuzzy 16..17, typo 18..19). */
 const STREAM_ID_MATCH_SCORE = 100
 
 /**
  * Score a stream against a lowercased query. Lower = better match.
  * Returns Infinity for non-matches. Delegates to the shared `scoreMatch`
- * tiers (exact/prefix/contains, separator-normalized, fuzzy subsequence) so
- * search results land in the same order across every picker surface; a raw
- * stream-id substring is the last-resort tier below all name matches.
+ * tiers (exact/prefix/whole-word/contains, separator-normalized, then the
+ * fuzzy and typo tolerance bands) so search results land in the same order
+ * across every picker surface; a raw stream-id substring is the last-resort
+ * tier below all name matches.
  */
 export function scoreStreamMatch(
   stream: Pick<Stream, "id" | "type" | "displayName" | "slug">,


### PR DESCRIPTION
Selection surfaces matched substrings without regard for where the match landed, so an incidental fragment outranked a real answer: `yes` led with 😍 `heart_eyes` (it contains "yes") ahead of 👍 and ✅, and `no` led with 📓 `notebook` ahead of ⛔ `no_entry`. Nothing tolerated a typo at all.

**The ladder is now graded on whole words first.** Every whole-word hit, in either field, outranks every partial hit — a fragment is usually a coincidence. Within each group a visible label still beats a hidden keyword, and a hit at the head of the text beats one starting later. That single reordering fixes both reports and leaves `sad` → 😞 `sad_face` ahead of 😢 `cry` (which only carries "sad" as a keyword), which a naive "exactness beats field" rule got wrong.

**Typo band.** Token-anchored Damerau-Levenshtein, budget 0/1/2 by query length, ranked below every existing tier so it can only add results. Transposition and substitution cannot be expressed as a subsequence at any threshold, so `thubms`, `recieve`, `desing` and `engenering` previously returned nothing. Anchoring to whole tokens is load-bearing: an unanchored window match lands within one edit of some part of nearly every long label.

**Quoted queries are literal** — no separator folding, no fuzzy, no typo — matching what quotes already mean in message search.

**Performance.** The emoji picker was already ~70 ms per keystroke since the CLDR keywords landed (#1689): `fuzzyQuality` ran a full DP against each of 9,950 strings with no gate. Added a linear subsequence test, a character-set bound, shared DP rows and charCode boundary checks — that phase is ~1.4 ms and the new typo band adds ~2 ms.

Verification: 92 unit tests over the scorer and its primitives (both new bands neutralised to confirm the guards bite), plus 503 tests across the picker suites; full monorepo lint and typecheck green.

Residual risk: the ladder reorders results for every existing consumer, so a surface with curated ordering may look different even where the match set is unchanged. Emoji rankings for `yes`/`no`/`ok`/`sad` were checked against the real dataset.

---

**Follow-up fix in this PR (caught by the browser suite).** The tolerance bands are contained *within* a `rankMatches` call, but the command palette ranks its contextual and global groups in two calls and concatenates them, with sections in fixed order — so the first row of the first group is what Enter fires. On a draft scratchpad, `> drafts` is one edit from the keyword of the contextual "Delete this draft", so the typo band put it above an exact "View Drafts" and Enter deleted the draft. `rankGroups` now scores the groups together and drops both tolerance bands from every group as soon as any group holds a real match; `TOLERANCE_TIER` is exported so other multi-list callers can make the same check.

Note for anyone debugging that suite: all four browser shard jobs reported success and only `evaluate-results` went red — the failing shard is only identifiable from the `shard-result-N` artifacts.
