### PR TITLE
feat(search): one ranker for every picker, and stop double-filtering

### DIFF
--- a/apps/frontend/src/components/create-channel/user-picker.tsx
+++ b/apps/frontend/src/components/create-channel/user-picker.tsx
@@ -7,6 +7,7 @@ import { UserPlus, X } from "lucide-react"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { getInitials } from "@/lib/initials"
 import { getAvatarColor } from "@/lib/avatar-color"
+import { rankMatches } from "@/lib/match-score"
 
 interface UserPickerProps {
   workspaceId: string
@@ -22,21 +23,14 @@ export function UserPicker({ workspaceId, currentUserId, selectedUserIds, onChan
 
   const availableToAdd = useMemo((): UserListItem[] => {
     if (!search) return []
-    const q = search.toLowerCase()
-    return workspaceUsers
-      .filter(
-        (m) =>
-          m.id !== currentUserId &&
-          !selectedSet.has(m.id) &&
-          (m.name.toLowerCase().includes(q) || m.slug.toLowerCase().includes(q))
-      )
-      .map((m) => ({
-        id: m.id,
-        label: m.name || m.slug,
-        description: `@${m.slug}`,
-        slug: m.slug,
-        name: m.name,
-      }))
+    const candidates = workspaceUsers.filter((m) => m.id !== currentUserId && !selectedSet.has(m.id))
+    return rankMatches(candidates, search, (m) => ({ labels: [m.name, m.slug] })).map((m) => ({
+      id: m.id,
+      label: m.name || m.slug,
+      description: `@${m.slug}`,
+      slug: m.slug,
+      name: m.name,
+    }))
   }, [workspaceUsers, currentUserId, selectedSet, search])
 
   const selectedUsers = useMemo(() => {

--- a/apps/frontend/src/components/create-channel/user-picker.tsx
+++ b/apps/frontend/src/components/create-channel/user-picker.tsx
@@ -22,7 +22,10 @@ export function UserPicker({ workspaceId, currentUserId, selectedUserIds, onChan
   const selectedSet = useMemo(() => new Set(selectedUserIds), [selectedUserIds])
 
   const availableToAdd = useMemo((): UserListItem[] => {
-    if (!search) return []
+    // Trimmed: rankMatches treats a whitespace-only query as "not searching
+    // yet" and returns every candidate, which here would dump the whole
+    // member list the moment a stray space is typed.
+    if (!search.trim()) return []
     const candidates = workspaceUsers.filter((m) => m.id !== currentUserId && !selectedSet.has(m.id))
     return rankMatches(candidates, search, (m) => ({ labels: [m.name, m.slug] })).map((m) => ({
       id: m.id,

--- a/apps/frontend/src/components/editor/triggers/use-date-filter-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-date-filter-suggestion.tsx
@@ -4,6 +4,7 @@ import type { SuggestionProps, SuggestionKeyDownProps } from "@tiptap/suggestion
 import { DateFilterList } from "./date-filter-list"
 import { getDateFilterOptions, type DateFilterItem, type DateFilterType } from "./date-filter-extension"
 import type { SuggestionListRef } from "./suggestion-list"
+import { rankMatches } from "@/lib/match-score"
 
 interface DateFilterState {
   items: DateFilterItem[]
@@ -19,8 +20,6 @@ interface DateFilterState {
 export function filterDateOptions(items: DateFilterItem[], query: string): DateFilterItem[] {
   if (!query) return items
 
-  const lowerQuery = query.toLowerCase()
-
   const isDateLike = /^\d{4}(-\d{0,2})?(-\d{0,2})?$/.test(query)
   if (isDateLike) {
     const filterType = items[0]?.filterType ?? "after"
@@ -34,7 +33,7 @@ export function filterDateOptions(items: DateFilterItem[], query: string): DateF
     return [customOption, ...items.filter((item) => item.value.startsWith(query))]
   }
 
-  return items.filter((item) => item.label.toLowerCase().includes(lowerQuery) || item.value.includes(query))
+  return rankMatches(items, query, (item) => ({ labels: [item.label], keywords: [item.value] }))
 }
 
 function detectFilterType(text: string): DateFilterType {

--- a/apps/frontend/src/components/quick-switcher/filter-select.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/filter-select.integration.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { FilterSelect } from "./filter-select"
+import { mockUsersList } from "@/test/fixtures/users"
+import { mockStreamsList } from "@/test/fixtures"
+
+const noop = () => {}
+
+function renderUserFilter() {
+  return render(
+    <FilterSelect type="from" users={mockUsersList} streams={[]} streamTypes={[]} onSelect={vi.fn()} onCancel={noop} />
+  )
+}
+
+describe("FilterSelect", () => {
+  it("keeps matching users listed once a query is typed", async () => {
+    const user = userEvent.setup()
+    renderUserFilter()
+    const target = mockUsersList[0]
+
+    await user.type(screen.getByPlaceholderText("Search users..."), target.name.slice(0, 3))
+
+    // The rows are ranked by this component and rendered by cmdk. cmdk filters
+    // again by each item's `value`, which here is a ULID no query can match —
+    // so a second ranker silently empties a list its owner had already filtered.
+    expect(screen.getByText(target.name)).toBeInTheDocument()
+    expect(screen.queryByText("No users found.")).not.toBeInTheDocument()
+  })
+
+  it("keeps matching streams listed once a query is typed", async () => {
+    const user = userEvent.setup()
+    const target = mockStreamsList.find((stream) => stream.slug)
+    if (!target?.slug) throw new Error("fixture needs a stream with a slug")
+    render(
+      <FilterSelect
+        type="in"
+        users={[]}
+        streams={mockStreamsList}
+        streamTypes={[]}
+        onSelect={vi.fn()}
+        onCancel={noop}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText("Search streams..."), target.slug.slice(0, 3))
+
+    expect(screen.queryByText("No streams found.")).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/quick-switcher/filter-select.tsx
+++ b/apps/frontend/src/components/quick-switcher/filter-select.tsx
@@ -90,7 +90,9 @@ function UserSelect({ users, onSelect }: UserSelectProps) {
 
   return (
     <div className="w-48">
-      <Command className="border rounded-md">
+      {/* Ranked above; each row's cmdk value is an id, so a second filter pass
+          over it would match nothing and empty the list. */}
+      <Command className="border rounded-md" shouldFilter={false}>
         <CommandInput placeholder="Search users..." value={search} onValueChange={setSearch} className="h-8" />
         <CommandList className="max-h-32">
           <CommandEmpty>No users found.</CommandEmpty>
@@ -174,7 +176,8 @@ function StreamSelect({ streams, onSelect }: StreamSelectProps) {
 
   return (
     <div className="w-48">
-      <Command className="border rounded-md">
+      {/* Ranked above; see UserSelect for why cmdk must not filter again. */}
+      <Command className="border rounded-md" shouldFilter={false}>
         <CommandInput placeholder="Search streams..." value={search} onValueChange={setSearch} className="h-8" />
         <CommandList className="max-h-32">
           <CommandEmpty>No streams found.</CommandEmpty>

--- a/apps/frontend/src/components/ui/command.tsx
+++ b/apps/frontend/src/components/ui/command.tsx
@@ -7,6 +7,22 @@ import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { scoreMatch } from "@/lib/match-score"
+
+/**
+ * Rank cmdk lists with the same scorer every other picker uses, so one query
+ * orders the same way wherever it is typed. cmdk ships its own subsequence
+ * scorer, which ranked seven surfaces differently from the rest of the app.
+ *
+ * cmdk's `value` doubles as the selection identity, and our pickers put an id
+ * there and the searchable text in `keywords` — so keywords, when present, are
+ * the text to match; `value` is only a fallback for lists that never set them.
+ * Higher is better here, the inverse of scoreMatch, and 0 hides the item.
+ */
+const commandFilter = (value: string, search: string, keywords?: string[]): number => {
+  const score = scoreMatch(search, keywords?.length ? keywords : [value])
+  return score === Infinity ? 0 : 1 / (1 + score)
+}
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -14,6 +30,7 @@ const Command = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
     ref={ref}
+    filter={commandFilter}
     className={cn(
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
       className


### PR DESCRIPTION
Two rankers were live at once. `cmdk` filters with its own subsequence scorer unless a list opts out, and only four call sites did — so `searchable-select` (and its three consumers), the timezone and locale pickers, the quick-switcher filter picker and the memory page ordered a query differently from every other picker in the app.

`ui/command` now passes the shared `scoreMatch`, so one query orders the same way wherever it is typed. Where a row carries `keywords`, those are the text to match: our pickers put an id in cmdk's `value`, which doubles as the selection identity, so `value` is only the fallback for lists that never set keywords.

**That id convention was also a live bug.** The quick switcher's `from:`, `with:` and `in:` pickers rank their own rows and then hand cmdk `value={user.id}`. cmdk's second pass scored the ULID against the query, matched nothing, and emptied the list — typing anything into those pickers showed "No users found." while the ranked rows sat behind it. Both now pass `shouldFilter={false}`. The regression test mounts `FilterSelect` and types; it fails on the previous behaviour.

Also ports the last two surfaces off raw substring filtering — the create-channel user picker and the composer's `after:`/`before:` date suggestions — so nothing in the app still hand-rolls `toLowerCase().includes()` for ranking. The two deliberate exceptions are unchanged and stay that way: in-stream find needs exact offsets to highlight, and the stream-context filter must mirror the server's predicate.

Verification: new integration test for the double-filter bug, plus 503 tests across the picker, ui, editor-trigger and quick-switcher suites; full monorepo lint and typecheck green.

Residual risk: any cmdk list that relied on the old scorer's looser matching will now filter slightly differently — the ranking is stricter about where a match landed, not about whether one exists.
