### PR TITLE
feat(board): infinite upward scroll over the card gap

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -776,7 +776,7 @@ describe("BoardCard deleted messages", () => {
     ;(post as unknown as { totalReplies: number }).totalReplies = 1
     const { container } = mountCard(post, { getBoardMessages })
 
-    await userEvent.click(await screen.findByText(/1 more message/))
+    await userEvent.click(await screen.findByText(/1 older message/))
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
     expect(container.querySelector('[data-message-id="m_r2"]')).toBeNull()
@@ -802,7 +802,7 @@ describe("BoardCard deleted messages", () => {
 
     // Collapsed the card previews the trailing live replies only; expanding falls
     // through to the complete local rail.
-    await userEvent.click(await screen.findByText(/2 more messages/))
+    await userEvent.click(await screen.findByText(/2 older messages/))
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
     expect(screen.queryByText("The deleted body.")).toBeNull()
@@ -1038,7 +1038,7 @@ describe("BoardCard backfill invalidation", () => {
     ;(post as unknown as { totalReplies: number }).totalReplies = 1
     const { rerenderPost } = mountCard(post, { getBoardMessages })
 
-    await userEvent.click(await screen.findByText(/1 more message/))
+    await userEvent.click(await screen.findByText(/1 older message/))
     await waitFor(() => expect(getBoardMessages).toHaveBeenCalledTimes(1))
 
     const grown = makePost({ messageIds: ["m_open", "m_r1", "m_r2"] })
@@ -1046,5 +1046,220 @@ describe("BoardCard backfill invalidation", () => {
     act(() => rerenderPost(grown))
 
     await waitFor(() => expect(getBoardMessages.mock.calls.length).toBeGreaterThan(1))
+  })
+})
+
+/** The reveal affordances a collapsed card mounts: the seam row (the button
+ *  carrying the divider lines) and any standalone retry button beside it. */
+function revealRowStructure(container: HTMLElement) {
+  const buttons = Array.from(container.querySelectorAll("button"))
+  const seams = buttons.filter((button) => button.querySelector(".border-t"))
+  return {
+    seams: seams.length,
+    standaloneRetries: buttons.filter((button) => !seams.includes(button) && button.textContent?.includes("Retry."))
+      .length,
+  }
+}
+
+describe("BoardCard gap scroll reveal", () => {
+  // The board's owned scroller is what the reveal listens on; the harness mounts
+  // the card inside one, as the real feed does. jsdom has no IntersectionObserver,
+  // so the seam's on-screen state is driven by hand.
+  let seamObservers: { element: Element; fire: (isIntersecting: boolean) => void }[] = []
+  let originalIO: typeof IntersectionObserver | undefined
+
+  beforeEach(() => {
+    seamObservers = []
+    originalIO = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = class {
+      cb: (entries: { isIntersecting: boolean }[]) => void
+      constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
+        this.cb = cb
+      }
+      observe(element: Element) {
+        seamObservers.push({ element, fire: (isIntersecting) => this.cb([{ isIntersecting }]) })
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof IntersectionObserver
+  })
+  afterEach(() => {
+    globalThis.IntersectionObserver = originalIO as typeof IntersectionObserver
+  })
+
+  function mountOnBoard(post: BoardViewPost, conversations: Record<string, unknown> = {}) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const scrollerRef = { current: null as HTMLDivElement | null }
+    const listRef = { current: { scrollBy: vi.fn() } as never }
+    const result = render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <ServicesProvider services={{ conversations: conversations as never }}>
+            <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+              <TraceProvider>
+                <PanelProvider>
+                  <div ref={scrollerRef}>
+                    <BoardCard
+                      workspaceId={WS}
+                      post={post}
+                      contextLabel="#general"
+                      streamType="channel"
+                      scrollerRef={scrollerRef}
+                      listRef={listRef}
+                    />
+                  </div>
+                </PanelProvider>
+              </TraceProvider>
+            </MemoryRouter>
+          </ServicesProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+    /** The reader scrolls up, with the seam on or off screen. */
+    const scrollUp = async (seamLabel: HTMLElement, seamOnScreen = true) => {
+      const seam = seamLabel.closest("button") ?? seamLabel
+      const observer = seamObservers.find((o) => o.element === seam)
+      await act(async () => {
+        observer?.fire(seamOnScreen)
+        scrollerRef.current?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
+      })
+    }
+    return { ...result, scrollUp }
+  }
+
+  /** `replyCount` replies on the local rail; only the trailing window shows. */
+  async function seedRail(replyCount: number) {
+    const ids = Array.from({ length: replyCount }, (_, i) => `m_r${i + 1}`)
+    await db.events.bulkPut([
+      messageEvent("m_open", "Opening body.", 10),
+      ...ids.map((id, i) => messageEvent(id, `Reply ${i + 1}.`, 11 + i)),
+    ])
+    const post = makePost({ messageIds: ["m_open", ...ids] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = replyCount
+    return post
+  }
+
+  it("reveals the older middle when the reader scrolls up onto the seam", async () => {
+    const { scrollUp } = mountOnBoard(await seedRail(9))
+
+    await screen.findByText("Reply 9.")
+    const seam = await screen.findByText("4 older messages")
+    expect(screen.queryByText("Reply 1.")).toBeNull()
+
+    await scrollUp(seam)
+
+    expect(await screen.findByText("Reply 1.")).toBeTruthy()
+    // A page (15 rows) covers this whole middle, so the seam goes with it.
+    await waitFor(() => expect(screen.queryByText(/older message/)).toBeNull())
+  })
+
+  it("leaves the middle alone when the reader scrolls up with the seam off screen", async () => {
+    const { scrollUp } = mountOnBoard(await seedRail(9))
+    await screen.findByText("Reply 9.")
+    const seam = await screen.findByText("4 older messages")
+
+    await scrollUp(seam, false)
+
+    expect(screen.queryByText("Reply 1.")).toBeNull()
+    expect(screen.getByText("4 older messages")).toBeTruthy()
+  })
+
+  it("arms the server backfill on a paged reveal, and says so in the seam row while it loads", async () => {
+    // The rail carries only the newest reply, so the reveal demands rows only the
+    // server has — the same wait the full expand shows, swapped into the seam's
+    // own row so nothing below it shifts.
+    const getBoardMessages = vi.fn(() => new Promise(() => {}))
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r9", "Reply 9.", 30)])
+    const post = makePost({ messageIds: ["m_open", ...Array.from({ length: 9 }, (_, i) => `m_r${i + 1}`)] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 9
+    const { scrollUp } = mountOnBoard(post, { getBoardMessages })
+
+    await screen.findByText("Reply 9.")
+    await scrollUp(await screen.findByText("8 older messages"))
+
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
+    expect(await screen.findByText("Loading older messages…")).toBeTruthy()
+  })
+
+  it("banks at most one outstanding page while the rail can't advance, so the backfill doesn't dump the middle", async () => {
+    // The rail carries only the newest reply and the backfill is in flight, so the
+    // card can't grow and the seam stays under the reader's cursor. Every further
+    // wheel tick of a flick would otherwise buy another page and the whole hidden
+    // middle would land at once when the rows arrive.
+    const backfill = Promise.withResolvers<BoardPostMessage[]>()
+    const getBoardMessages = vi.fn(() => backfill.promise)
+    const ids = Array.from({ length: 40 }, (_, i) => `m_r${i + 1}`)
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r40", "Reply 40.", 50)])
+    const post = makePost({ messageIds: ["m_open", ...ids] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 40
+    const { scrollUp } = mountOnBoard(post, { getBoardMessages })
+
+    await screen.findByText("Reply 40.")
+    const seam = await screen.findByText("39 older messages")
+    for (let i = 0; i < 5; i++) await scrollUp(seam)
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
+
+    await act(async () => {
+      backfill.resolve([
+        openingMessage(),
+        ...ids.map((id, i) => ({
+          ...openingMessage(),
+          id,
+          contentMarkdown: `Reply ${i + 1}.`,
+          createdAt: new Date(Date.parse("2026-06-22T12:00:00.000Z") + (i + 1) * 1000).toISOString(),
+        })),
+      ])
+      await backfill.promise
+    })
+
+    // One page (15 rows) of the middle, not five: 40 - (1 trailing + 15) still hidden.
+    expect(await screen.findByText("24 older messages")).toBeTruthy()
+    expect(screen.getByText("Reply 25.")).toBeTruthy()
+    expect(screen.queryByText("Reply 24.")).toBeNull()
+  })
+
+  it("puts a failed paged reveal inside the seam's own row rather than mounting a retry below it", async () => {
+    const getBoardMessages = vi.fn().mockRejectedValue(new Error("offline"))
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r9", "Reply 9.", 30)])
+    const post = makePost({ messageIds: ["m_open", ...Array.from({ length: 9 }, (_, i) => `m_r${i + 1}`)] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 9
+    const { container, scrollUp } = mountOnBoard(post, { getBoardMessages })
+
+    await screen.findByText("Reply 9.")
+    const rowsBefore = revealRowStructure(container)
+    await scrollUp(await screen.findByText("8 older messages"))
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
+    const rowsLoading = revealRowStructure(container)
+    const failedSeam = await screen.findByText("Couldn't load older messages. Retry.")
+
+    // The failure swaps the seam's label; it never adds a row, so the replies below
+    // stay exactly where the reader left them (INV-21).
+    expect({ ...revealRowStructure(container), rowsBefore, rowsLoading }).toEqual({
+      seams: 1,
+      standaloneRetries: 0,
+      rowsBefore: { seams: 1, standaloneRetries: 0 },
+      rowsLoading: { seams: 1, standaloneRetries: 0 },
+    })
+
+    getBoardMessages.mockClear()
+    await userEvent.click(failedSeam)
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
+  })
+
+  it("keeps the tap path: clicking the seam expands the whole conversation", async () => {
+    mountOnBoard(await seedRail(9))
+
+    await screen.findByText("Reply 9.")
+    await userEvent.click(await screen.findByText("4 older messages"))
+
+    expect(await screen.findByText("Reply 1.")).toBeTruthy()
+    expect(screen.queryByText(/older message/)).toBeNull()
+  })
+
+  it("renders no seam when nothing is hidden, so there is nothing to scroll into", async () => {
+    mountOnBoard(await seedRail(3))
+
+    expect(await screen.findByText("Reply 1.")).toBeTruthy()
+    expect(screen.queryByText(/older message/)).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1115,16 +1115,17 @@ describe("BoardCard gap scroll reveal", () => {
         </TooltipProvider>
       </QueryClientProvider>
     )
-    /** The reader scrolls up, with the seam on or off screen. */
+    /** The reader scrolls up over this card, with the seam on or off screen.
+     *  The wheel goes to the card, as it does under a real pointer. */
     const scrollUp = async (seamLabel: HTMLElement, seamOnScreen = true) => {
       const seam = seamLabel.closest("button") ?? seamLabel
       const observer = seamObservers.find((o) => o.element === seam)
       await act(async () => {
         observer?.fire(seamOnScreen)
-        scrollerRef.current?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
+        seam.closest(".board-card-hover")?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
       })
     }
-    return { ...result, scrollUp }
+    return { ...result, scrollUp, scrollerRef }
   }
 
   /** `replyCount` replies on the local rail; only the trailing window shows. */
@@ -1216,6 +1217,38 @@ describe("BoardCard gap scroll reveal", () => {
     expect(await screen.findByText("24 older messages")).toBeTruthy()
     expect(screen.getByText("Reply 25.")).toBeTruthy()
     expect(screen.queryByText("Reply 24.")).toBeNull()
+  })
+
+  it("gives a flick one page: wheel events with no fresh intersection report in between", async () => {
+    // A trackpad flick emits dozens of wheel events before the observer can report
+    // the seam leaving; without pacing on the report, one gesture dumps the middle.
+    mountOnBoard(await seedRail(40))
+
+    await screen.findByText("Reply 40.")
+    const seam = (await screen.findByText("35 older messages")).closest("button")!
+    seamObservers.find((o) => o.element === seam)?.fire(true)
+    await act(async () => {
+      for (let i = 0; i < 5; i++)
+        seam.closest(".board-card-hover")?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
+    })
+
+    expect(await screen.findByText("20 older messages")).toBeTruthy()
+  })
+
+  it("ignores a scroll over a sibling card: only the card under the pointer pages", async () => {
+    const { scrollerRef } = mountOnBoard(await seedRail(9))
+
+    await screen.findByText("Reply 9.")
+    const seam = (await screen.findByText("4 older messages")).closest("button")!
+    const siblingCard = document.createElement("div")
+    scrollerRef.current?.append(siblingCard)
+    await act(async () => {
+      seamObservers.find((o) => o.element === seam)?.fire(true)
+      siblingCard.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
+    })
+
+    expect(screen.queryByText("Reply 1.")).toBeNull()
+    expect(screen.getByText("4 older messages")).toBeTruthy()
   })
 
   it("puts a failed paged reveal inside the seam's own row rather than mounting a retry below it", async () => {

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -752,7 +752,7 @@ describe("BoardCard deleted messages", () => {
     const { container } = mountCard(post)
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
-    expect(container.querySelector('[data-message-id="m_r1"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="m_r1"]')?.textContent).toBe("This message was deleted")
   })
 
   it("renders a tombstone, not a blank row, for a deleted reply from the expand backfill", async () => {
@@ -779,7 +779,7 @@ describe("BoardCard deleted messages", () => {
     await userEvent.click(await screen.findByText(/1 older message/))
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
-    expect(container.querySelector('[data-message-id="m_r2"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="m_r2"]')?.textContent).toBe("This message was deleted")
   })
 
   it("renders a tombstone for a deleted reply once the rail is complete", async () => {
@@ -935,7 +935,7 @@ describe("BoardCard settling mark", () => {
     const { container } = mountCard(settlingPost(["m_open", "m_r1"], { messageIds: ["m_open", "m_r1"] }))
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
-    expect(container.querySelector('[data-message-id="m_r1"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="m_r1"]')?.textContent).toBe("This message was deleted")
     // The settling id names a row the card doesn't render — it must not conjure one.
     expect(container.querySelectorAll("[data-settling]").length).toBe(1)
   })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -139,17 +139,13 @@ export function BoardCard({
   // replies the reader is on don't jump (the board's `shift`, see the hook).
   const beginReveal = useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef })
   // Rows scrolled out from under the gap so far, one page per upward gesture.
-  // Recycling this card instance onto another conversation resets the count, the
-  // same guard `useStableReplyWindow` puts on its shown set.
+  // Recycling this card instance onto another conversation resets the count —
+  // the conversation id lives IN the state (not a ref) so a discarded render
+  // can't strand the guard past the reset it was meant to trigger.
   const seamRef = useRef<HTMLButtonElement>(null)
-  const [revealedRowsState, setRevealedRows] = useState(0)
-  const revealedForRef = useRef(conversation.id)
-  let revealedRows = revealedRowsState
-  if (revealedForRef.current !== conversation.id) {
-    revealedForRef.current = conversation.id
-    revealedRows = 0
-    setRevealedRows(0)
-  }
+  const [revealed, setRevealed] = useState({ conversationId: conversation.id, rows: 0 })
+  if (revealed.conversationId !== conversation.id) setRevealed({ conversationId: conversation.id, rows: 0 })
+  const revealedRows = revealed.conversationId === conversation.id ? revealed.rows : 0
 
   // Shared graph + structural index, needed BEFORE the rail hook: the inline
   // branch composer derives the branch thread streams (and any pending
@@ -459,10 +455,14 @@ export function BoardCard({
   // dumps at once the moment the rows land.
   const revealPage = useCallback(() => {
     beginReveal({ mode: "scroll" })
-    setRevealedRows(
-      (n) => Math.min(n, Math.max(0, railReplies.length - collapsedReplies.length)) + BOARD_GAP_REVEAL_PAGE_ROWS
-    )
-  }, [beginReveal, railReplies.length, collapsedReplies.length])
+    setRevealed((current) => {
+      const rows = current.conversationId === conversation.id ? current.rows : 0
+      return {
+        conversationId: conversation.id,
+        rows: Math.min(rows, Math.max(0, railReplies.length - collapsedReplies.length)) + BOARD_GAP_REVEAL_PAGE_ROWS,
+      }
+    })
+  }, [beginReveal, conversation.id, railReplies.length, collapsedReplies.length])
   useBoardGapAutoReveal({
     seamRef,
     cardRef,

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -465,6 +465,7 @@ export function BoardCard({
   }, [beginReveal, railReplies.length, collapsedReplies.length])
   useBoardGapAutoReveal({
     seamRef,
+    cardRef,
     scrollerRef,
     enabled: !expanded && hiddenCount > 0 && !removed,
     onReveal: revealPage,

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -579,8 +579,15 @@ export function BoardCard({
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
     // Mirrors the panel: a deleted row is a tombstone, never a blank MessageItem
-    // carrying an author, a timestamp and an action menu.
-    if (message.deletedAt) return <DeletedMessageEvent key={message.id} />
+    // carrying an author, a timestamp and an action menu. It still carries the
+    // row attributes so the reveal anchor can landmark it when it is the first
+    // visible reply.
+    if (message.deletedAt)
+      return (
+        <div key={message.id} data-message-row data-message-id={message.id}>
+          <DeletedMessageEvent />
+        </div>
+      )
     // A conversation can span its root + threads (one root); render each row
     // against its own stream so reactions and the permalink target where the
     // message actually lives, falling back to the card's anchor stream.

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -3,7 +3,11 @@ import type { RefObject } from "react"
 import { Link } from "react-router-dom"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, CircleCheck, PanelRight } from "lucide-react"
-import { DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT, DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT } from "@threa/types"
+import {
+  BOARD_GAP_REVEAL_PAGE_ROWS,
+  DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT,
+  DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT,
+} from "@threa/types"
 import { RelativeTime } from "@/components/relative-time"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
@@ -41,10 +45,16 @@ import { useBoardFlash } from "@/stores/board-flash-store"
 import { usePanel, createConversationPanelId, usePreferences } from "@/contexts"
 import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { useSplitThread } from "@/hooks/use-conversations"
-import { applySettlingAll, useBoardCardMessages, useStableReplyWindow } from "@/hooks/use-board-card-messages"
+import {
+  applySettlingAll,
+  composeRevealedWindow,
+  useBoardCardMessages,
+  useStableReplyWindow,
+} from "@/hooks/use-board-card-messages"
 import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
+import { useBoardGapAutoReveal } from "@/hooks/use-board-gap-auto-reveal"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
@@ -128,6 +138,18 @@ export function BoardCard({
   // content above the trailing replies; hold the card bottom fixed so the newest
   // replies the reader is on don't jump (the board's `shift`, see the hook).
   const beginReveal = useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef })
+  // Rows scrolled out from under the gap so far, one page per upward gesture.
+  // Recycling this card instance onto another conversation resets the count, the
+  // same guard `useStableReplyWindow` puts on its shown set.
+  const seamRef = useRef<HTMLButtonElement>(null)
+  const [revealedRowsState, setRevealedRows] = useState(0)
+  const revealedForRef = useRef(conversation.id)
+  let revealedRows = revealedRowsState
+  if (revealedForRef.current !== conversation.id) {
+    revealedForRef.current = conversation.id
+    revealedRows = 0
+    setRevealedRows(0)
+  }
 
   // Shared graph + structural index, needed BEFORE the rail hook: the inline
   // branch composer derives the branch thread streams (and any pending
@@ -379,7 +401,7 @@ export function BoardCard({
     isError: expandFailed,
     refetch: refetchMessages,
   } = useConversationBackfill(workspaceId, conversation.id, {
-    enabled: expanded,
+    enabled: expanded || revealedRows > 0,
     railCoversMembership,
     memberIds: conversation.messageIds,
     knownMessageIds,
@@ -394,7 +416,9 @@ export function BoardCard({
 
   // Expanded: the hook's merged view (rail > backfill store > projection).
   // Collapsed: the stable window over it.
-  const replies: RenderableMessage[] = expanded ? railReplies : collapsedReplies
+  const replies: RenderableMessage[] = expanded
+    ? railReplies
+    : composeRevealedWindow(railReplies, collapsedReplies, revealedRows)
   // Merge this card's own just-sent replies with the confirmed set, skipping any
   // the rail or a backfill already carries, then sort by time: a pending reply
   // can be OLDER than a confirmed one (someone else's reply lands while yours is
@@ -412,10 +436,39 @@ export function BoardCard({
   // `totalReplies` counts tombstones as zero, so the visible rows must be counted
   // the same way or a drawn tombstone would subtract from the gap it isn't in.
   const hiddenCount = expanded ? 0 : Math.max(0, totalReplies - replies.filter((m) => !m.deletedAt).length)
-  const loadingMore = expanded && incompleteLocally && !allMessages && !expandFailed
+  // Any reveal — a page or the full expand — can outrun the local rail; the same
+  // server backfill fills both, so the wait and its retry show for both.
+  const revealing = expanded || revealedRows > 0
+  const loadingMore = revealing && incompleteLocally && !allMessages && !expandFailed
   // No middle is hidden, so opening + replies form one uninterrupted run that
   // groups across the boundary. Otherwise a gap row sits between them.
   const contiguous = (expanded && (!incompleteLocally || !!allMessages)) || (!expanded && hiddenCount === 0)
+  // The wait and the failure both swap the seam row's own label rather than adding
+  // a line below it, so nothing under the seam shifts through either (INV-21).
+  let seamLabel = `${hiddenCount} older ${hiddenCount === 1 ? "message" : "messages"}`
+  if (loadingMore) seamLabel = "Loading older messages…"
+  if (expandFailed) seamLabel = "Couldn't load older messages. Retry."
+
+  // Scrolling up onto the seam pulls the next page out from under it, the way
+  // reading up past the timeline's unread divider keeps going. Measure the anchor
+  // BEFORE the rows land, exactly as the tap path does.
+  // Demand is clamped to what the rail can actually satisfy plus one outstanding
+  // page: while the backfill is in flight the card doesn't grow, so the seam stays
+  // under the reader's cursor and every further wheel tick would otherwise add
+  // another page — a short flick banks twenty of them and the whole hidden middle
+  // dumps at once the moment the rows land.
+  const revealPage = useCallback(() => {
+    beginReveal({ mode: "scroll" })
+    setRevealedRows(
+      (n) => Math.min(n, Math.max(0, railReplies.length - collapsedReplies.length)) + BOARD_GAP_REVEAL_PAGE_ROWS
+    )
+  }, [beginReveal, railReplies.length, collapsedReplies.length])
+  useBoardGapAutoReveal({
+    seamRef,
+    scrollerRef,
+    enabled: !expanded && hiddenCount > 0 && !removed,
+    onReveal: revealPage,
+  })
 
   // Viewport auto-read: rows that dwell on screen mark themselves read (the menu
   // actions are the override). Every rendered row is eligible — on a collapsed
@@ -790,25 +843,40 @@ export function BoardCard({
                   {/* The opening renders outside the row builder here, so its inline
                     "new sub-topic" composer slot must be placed explicitly. */}
                   {openingMessage && inlineComposer.renderAfterMessage(openingMessage.id)}
-                  {!expanded && hiddenCount > 0 && (
+                  {!expanded && hiddenCount > 0 ? (
                     <button
+                      ref={seamRef}
                       type="button"
                       onClick={() => {
+                        if (expandFailed) {
+                          void refetchMessages()
+                          return
+                        }
                         beginReveal()
                         setExpanded(true)
                       }}
-                      className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      className={cn(
+                        "mt-3 flex w-full items-center gap-3 text-xs transition-colors",
+                        expandFailed ? "text-destructive" : "text-muted-foreground hover:text-foreground"
+                      )}
                     >
-                      <ChevronDown className="h-3.5 w-3.5" />
-                      {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
+                      <span className="flex-1 border-t border-current" />
+                      <span className="flex items-center gap-1 whitespace-nowrap">
+                        <ChevronDown className="h-3.5 w-3.5" />
+                        {seamLabel}
+                      </span>
+                      <span className="flex-1 border-t border-current" />
                     </button>
-                  )}
-                  {loadingMore && (
-                    <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>
+                  ) : (
+                    loadingMore && (
+                      <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>
+                    )
                   )}
                   {/* The backfill loads the older/full window; the recent replies the
                 rail carried are already shown above, so the error names "older"
                 rather than contradicting visible content. */}
+                  {/* Collapsed, the failure lives in the seam's own row; a standalone
+                      button there would add a row and shove the trailing replies. */}
                   {expanded && expandFailed && (
                     <button
                       type="button"

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -47,8 +47,8 @@ import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { useSplitThread } from "@/hooks/use-conversations"
 import {
   applySettlingAll,
-  composeRevealedWindow,
   useBoardCardMessages,
+  useRevealedReplyWindow,
   useStableReplyWindow,
 } from "@/hooks/use-board-card-messages"
 import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
@@ -137,7 +137,19 @@ export function BoardCard({
   // Revealing the hidden middle ("N more messages") grows this card from OLDER
   // content above the trailing replies; hold the card bottom fixed so the newest
   // replies the reader is on don't jump (the board's `shift`, see the hook).
-  const beginReveal = useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef })
+  // Mirrors `loadingMore` (computed below, after the rail) so the anchor hook can
+  // read it at settle time without re-subscribing each render.
+  const loadingMoreRef = useRef(false)
+  // The first row of the current visible window — the reveal anchor's landmark,
+  // read at gesture time. A ref so `revealPage`'s identity doesn't churn per render
+  // (the auto-reveal hook subscribes on it).
+  const firstDisplayedIdRef = useRef<string | undefined>(undefined)
+  const { beginReveal, closeReveal } = useBoardCardRevealAnchor({
+    cardRef,
+    scrollerRef,
+    listRef,
+    shouldHoldOpen: useCallback(() => loadingMoreRef.current, []),
+  })
   // Rows scrolled out from under the gap so far, one page per upward gesture.
   // Recycling this card instance onto another conversation resets the count —
   // the conversation id lives IN the state (not a ref) so a discarded render
@@ -412,9 +424,8 @@ export function BoardCard({
 
   // Expanded: the hook's merged view (rail > backfill store > projection).
   // Collapsed: the stable window over it.
-  const replies: RenderableMessage[] = expanded
-    ? railReplies
-    : composeRevealedWindow(railReplies, collapsedReplies, revealedRows)
+  const revealedReplies = useRevealedReplyWindow(conversation.id, railReplies, collapsedReplies, revealedRows)
+  const replies: RenderableMessage[] = expanded ? railReplies : revealedReplies
   // Merge this card's own just-sent replies with the confirmed set, skipping any
   // the rail or a backfill already carries, then sort by time: a pending reply
   // can be OLDER than a confirmed one (someone else's reply lands while yours is
@@ -429,6 +440,7 @@ export function BoardCard({
     ),
     settlingIds
   )
+  firstDisplayedIdRef.current = displayedReplies[0]?.id
   // `totalReplies` counts tombstones as zero, so the visible rows must be counted
   // the same way or a drawn tombstone would subtract from the gap it isn't in.
   const hiddenCount = expanded ? 0 : Math.max(0, totalReplies - replies.filter((m) => !m.deletedAt).length)
@@ -436,6 +448,7 @@ export function BoardCard({
   // server backfill fills both, so the wait and its retry show for both.
   const revealing = expanded || revealedRows > 0
   const loadingMore = revealing && incompleteLocally && !allMessages && !expandFailed
+  loadingMoreRef.current = loadingMore
   // No middle is hidden, so opening + replies form one uninterrupted run that
   // groups across the boundary. Otherwise a gap row sits between them.
   const contiguous = (expanded && (!incompleteLocally || !!allMessages)) || (!expanded && hiddenCount === 0)
@@ -454,7 +467,14 @@ export function BoardCard({
   // another page — a short flick banks twenty of them and the whole hidden middle
   // dumps at once the moment the rows land.
   const revealPage = useCallback(() => {
-    beginReveal({ mode: "scroll" })
+    // The row directly below the seam as it stands NOW: the revealed page pushes
+    // exactly this row (and everything under it) down, so holding it still holds
+    // the reader's eye-line while a live tail reply below it still pushes normally.
+    const firstVisibleId = firstDisplayedIdRef.current
+    const landmark = firstVisibleId
+      ? cardRef.current?.querySelector<HTMLElement>(`[data-message-row][data-message-id="${firstVisibleId}"]`)
+      : null
+    beginReveal({ mode: "scroll", landmark })
     setRevealed((current) => {
       const rows = current.conversationId === conversation.id ? current.rows : 0
       return {
@@ -521,6 +541,15 @@ export function BoardCard({
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+  // A programmatic jump (the "N new" pill sets scrollTop to 0) doesn't fire the
+  // gesture listeners that disarm the hold, so an armed window on a card that just
+  // left the viewport would scroll the feed back toward it when its growth lands.
+  // A card taller than the viewport keeps intersecting mid-walk, so a genuine walk
+  // is unaffected.
+  useEffect(() => {
+    if (!cardInViewport) closeReveal()
+  }, [cardInViewport, closeReveal])
+
   // The nested branches the card renders count as on-screen too — their content
   // is read right here, so pushes for them must suppress as well.
   const cardVisibleStreamIds = useMemo(

--- a/apps/frontend/src/hooks/scroll-gesture-direction.test.ts
+++ b/apps/frontend/src/hooks/scroll-gesture-direction.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest"
+import { attachScrollGestureDirection } from "./scroll-gesture-direction"
+
+/** jsdom has no Touch constructor, so events carry the two fields the reader uses. */
+function touchEvent(type: string, touches: { identifier: number; clientY: number }[]) {
+  const event = new Event(type, { bubbles: true }) as Event & {
+    touches: { identifier: number; clientY: number }[]
+  }
+  event.touches = touches
+  return event
+}
+
+function setup() {
+  const scroller = document.createElement("div")
+  const onUp = vi.fn()
+  const onDown = vi.fn()
+  const detach = attachScrollGestureDirection(scroller, { onUp, onDown })
+  return { scroller, onUp, onDown, detach }
+}
+
+describe("attachScrollGestureDirection", () => {
+  it("reads a single finger dragging down the screen as scrolling toward older", () => {
+    const { scroller, onUp, onDown } = setup()
+    scroller.dispatchEvent(touchEvent("touchstart", [{ identifier: 1, clientY: 200 }]))
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 1, clientY: 260 }]))
+    expect(onUp).toHaveBeenCalledTimes(1)
+    expect(onDown).not.toHaveBeenCalled()
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 1, clientY: 210 }]))
+    expect(onDown).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a touchmove with no recorded start", () => {
+    const { scroller, onUp, onDown } = setup()
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 1, clientY: 260 }]))
+    expect(onUp).not.toHaveBeenCalled()
+    expect(onDown).not.toHaveBeenCalled()
+  })
+
+  it("re-origins on the surviving finger instead of misreading a multi-touch swap", () => {
+    const { scroller, onUp, onDown } = setup()
+    // A seeds the gesture and drags down the screen (content up).
+    scroller.dispatchEvent(touchEvent("touchstart", [{ identifier: 1, clientY: 200 }]))
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 1, clientY: 260 }]))
+    expect(onUp).toHaveBeenCalledTimes(1)
+
+    // A lifts; B (which was resting far up the screen) is now touches[0]. Comparing
+    // B's coordinate against A's last would read a large DOWNWARD move nobody made.
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 2, clientY: 100 }]))
+    expect(onDown).not.toHaveBeenCalled()
+    expect(onUp).toHaveBeenCalledTimes(1)
+
+    // B's next move reads against B's own origin.
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 2, clientY: 160 }]))
+    expect(onUp).toHaveBeenCalledTimes(2)
+    expect(onDown).not.toHaveBeenCalled()
+  })
+
+  it("clears the tracked finger when it ends, so the next gesture starts fresh", () => {
+    const { scroller, onUp, onDown } = setup()
+    scroller.dispatchEvent(touchEvent("touchstart", [{ identifier: 1, clientY: 200 }]))
+    scroller.dispatchEvent(touchEvent("touchend", []))
+    scroller.dispatchEvent(touchEvent("touchstart", [{ identifier: 2, clientY: 400 }]))
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 2, clientY: 350 }]))
+    expect(onDown).toHaveBeenCalledTimes(1)
+    expect(onUp).not.toHaveBeenCalled()
+  })
+
+  it("reads wheel direction and detaches every listener", () => {
+    const { scroller, onUp, onDown, detach } = setup()
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }))
+    expect(onUp).toHaveBeenCalledTimes(1)
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }))
+    expect(onDown).toHaveBeenCalledTimes(1)
+    detach()
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }))
+    scroller.dispatchEvent(touchEvent("touchstart", [{ identifier: 1, clientY: 200 }]))
+    scroller.dispatchEvent(touchEvent("touchmove", [{ identifier: 1, clientY: 260 }]))
+    expect(onUp).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/hooks/scroll-gesture-direction.ts
+++ b/apps/frontend/src/hooks/scroll-gesture-direction.ts
@@ -10,25 +10,46 @@ interface Handlers {
  * trivial; touch is not, and both the gap auto-reveal and the reveal anchor need
  * exactly the same reading, so it lives here rather than in each hook (INV-35/37).
  *
- * `lastTouchY` starts as `null`, not 0: a listener attached mid-drag (the anchor
- * arms while the finger is already down) would read the first touchmove against a
- * phantom origin at the top of the screen and call ANY move "scrolling up".
- * Direction is unknown until a touchstart records an origin — neither handler fires.
+ * The tracked touch starts as `null`, not 0: a listener attached mid-drag (the
+ * anchor arms while the finger is already down) would read the first touchmove
+ * against a phantom origin at the top of the screen and call ANY move "scrolling
+ * up". Direction is unknown until a touchstart records an origin — neither handler
+ * fires.
+ *
+ * Tracking is BY IDENTIFIER, not by `touches[0]`: with two fingers down, lifting
+ * the first promotes the second into slot 0, and comparing its coordinate against
+ * the departed finger's last one reads a direction that nobody made — often the
+ * opposite one. Adopting the survivor as a fresh origin costs one event of
+ * unknown direction and can't misread.
  */
 export function attachScrollGestureDirection(scroller: HTMLElement, { onUp, onDown }: Handlers): () => void {
-  let lastTouchY: number | null = null
+  let tracked: { id: number; y: number } | null = null
 
   const onTouchStart = (e: TouchEvent) => {
-    lastTouchY = e.touches[0]?.clientY ?? null
+    if (tracked) return
+    const touch = e.touches[0]
+    if (touch) tracked = { id: touch.identifier, y: touch.clientY }
   }
   const onTouchMove = (e: TouchEvent) => {
-    const y = e.touches[0]?.clientY
-    if (y === undefined) return
-    const origin = lastTouchY
-    lastTouchY = y
-    if (origin === null) return
-    if (y > origin) onUp?.()
+    const origin = tracked
+    if (!origin) return
+    const touches = [...e.touches]
+    const same = touches.find((touch) => touch.identifier === origin.id)
+    if (!same) {
+      // The tracked finger lifted mid-gesture; re-origin on whoever is left.
+      const survivor = touches[0]
+      tracked = survivor ? { id: survivor.identifier, y: survivor.clientY } : null
+      return
+    }
+    const y = same.clientY
+    tracked = { id: origin.id, y }
+    if (y > origin.y) onUp?.()
     else onDown?.()
+  }
+  const onTouchEnd = (e: TouchEvent) => {
+    const origin = tracked
+    if (!origin) return
+    if (![...e.touches].some((touch) => touch.identifier === origin.id)) tracked = null
   }
   const onWheel = (e: WheelEvent) => {
     if (e.deltaY < 0) onUp?.()
@@ -38,9 +59,13 @@ export function attachScrollGestureDirection(scroller: HTMLElement, { onUp, onDo
   scroller.addEventListener("wheel", onWheel, { passive: true })
   scroller.addEventListener("touchstart", onTouchStart, { passive: true })
   scroller.addEventListener("touchmove", onTouchMove, { passive: true })
+  scroller.addEventListener("touchend", onTouchEnd, { passive: true })
+  scroller.addEventListener("touchcancel", onTouchEnd, { passive: true })
   return () => {
     scroller.removeEventListener("wheel", onWheel)
     scroller.removeEventListener("touchstart", onTouchStart)
     scroller.removeEventListener("touchmove", onTouchMove)
+    scroller.removeEventListener("touchend", onTouchEnd)
+    scroller.removeEventListener("touchcancel", onTouchEnd)
   }
 }

--- a/apps/frontend/src/hooks/scroll-gesture-direction.ts
+++ b/apps/frontend/src/hooks/scroll-gesture-direction.ts
@@ -1,0 +1,46 @@
+interface Handlers {
+  /** The reader is scrolling content UP (toward older): wheel deltaY < 0, or a
+   *  finger moving DOWN the screen. */
+  onUp?: () => void
+  onDown?: () => void
+}
+
+/**
+ * The one place that reads a scroll gesture's direction off a scroller. Wheel is
+ * trivial; touch is not, and both the gap auto-reveal and the reveal anchor need
+ * exactly the same reading, so it lives here rather than in each hook (INV-35/37).
+ *
+ * `lastTouchY` starts as `null`, not 0: a listener attached mid-drag (the anchor
+ * arms while the finger is already down) would read the first touchmove against a
+ * phantom origin at the top of the screen and call ANY move "scrolling up".
+ * Direction is unknown until a touchstart records an origin — neither handler fires.
+ */
+export function attachScrollGestureDirection(scroller: HTMLElement, { onUp, onDown }: Handlers): () => void {
+  let lastTouchY: number | null = null
+
+  const onTouchStart = (e: TouchEvent) => {
+    lastTouchY = e.touches[0]?.clientY ?? null
+  }
+  const onTouchMove = (e: TouchEvent) => {
+    const y = e.touches[0]?.clientY
+    if (y === undefined) return
+    const origin = lastTouchY
+    lastTouchY = y
+    if (origin === null) return
+    if (y > origin) onUp?.()
+    else onDown?.()
+  }
+  const onWheel = (e: WheelEvent) => {
+    if (e.deltaY < 0) onUp?.()
+    else onDown?.()
+  }
+
+  scroller.addEventListener("wheel", onWheel, { passive: true })
+  scroller.addEventListener("touchstart", onTouchStart, { passive: true })
+  scroller.addEventListener("touchmove", onTouchMove, { passive: true })
+  return () => {
+    scroller.removeEventListener("wheel", onWheel)
+    scroller.removeEventListener("touchstart", onTouchStart)
+    scroller.removeEventListener("touchmove", onTouchMove)
+  }
+}

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -1352,7 +1352,18 @@ describe("useRevealedReplyWindow", () => {
       ...rail.slice(10),
     ]
     rerender({ conversationId: "conv_1", replies: backfilled, stable, revealedRows: 15 })
-    for (const id of before) expect(ids(result.current)).toContain(id)
+    // One whole-window comparison (INV-24): every previously revealed row stays,
+    // in rail order, plus the backfilled rows the trailing window now covers.
+    expect(before).toEqual(ids(rail.slice(5)))
+    expect(ids(result.current)).toEqual([
+      ...ids(rail.slice(5, 10)),
+      "b3",
+      "b4",
+      "b5",
+      "b6",
+      "b7",
+      ...ids(rail.slice(10)),
+    ])
   })
 
   it("resets the shown set when the card is recycled onto another conversation", () => {

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -9,6 +9,7 @@ import {
   useBoardCardMessages,
   useBoardRailsReady,
   useStableReplyWindow,
+  composeRevealedWindow,
   __clearBoardRailRegistry,
   __boardRailRegistrySize,
   type BoardCardMessages,
@@ -1222,5 +1223,59 @@ describe("useBoardCardMessages — backfill-store merge precedence", () => {
     expect(result.current.replies.map((m) => ({ id: m.id, contentMarkdown: m.contentMarkdown }))).toEqual([
       { id: "r1", contentMarkdown: "projection r1" },
     ])
+  })
+})
+
+describe("composeRevealedWindow", () => {
+  const message = (id: string, deletedAt: string | null = null): RenderableMessage =>
+    ({
+      id,
+      streamId: STREAM,
+      authorId: "usr_1",
+      authorType: "user",
+      contentMarkdown: id,
+      reactions: {},
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+      deletedAt,
+    }) as RenderableMessage
+  const rail = ["r1", "r2", "r3", "r4", "r5", "r6"].map((id) => message(id))
+  const ids = (messages: RenderableMessage[]) => messages.map((m) => m.id)
+
+  it("returns the stable window untouched before anything is revealed", () => {
+    const stable = rail.slice(-2)
+    expect(composeRevealedWindow(rail, stable, 0)).toBe(stable)
+  })
+
+  it("pulls a page of older rows out from under the gap", () => {
+    expect(ids(composeRevealedWindow(rail, rail.slice(-2), 2))).toEqual(["r3", "r4", "r5", "r6"])
+  })
+
+  it("clamps to the rail when the reveal outruns what is synced", () => {
+    expect(ids(composeRevealedWindow(rail, rail.slice(-2), 99))).toEqual(["r1", "r2", "r3", "r4", "r5", "r6"])
+  })
+
+  it("keeps a late-syncing older row that the stable window already shows (superset, not a slice)", () => {
+    // `useStableReplyWindow` leaves a row that synced in BELOW the last shown one
+    // under the gap, so its window is not always the trailing run. A blind
+    // trailing slice of the same length would evict the shown row; the union
+    // cannot.
+    const late = [message("r1"), message("late"), message("r2"), message("r3"), message("r4")]
+    const stable = [late[0], late[2], late[3], late[4]]
+    expect(ids(composeRevealedWindow(late, stable, 0))).toEqual(["r1", "r2", "r3", "r4"])
+    expect(ids(composeRevealedWindow(late, stable, 1))).toEqual(["r1", "late", "r2", "r3", "r4"])
+  })
+
+  it("spends page slots on tombstones, which the caller counts as zero toward the gap", () => {
+    const withTombstone = [
+      message("r1"),
+      message("rd", "2026-06-22T12:05:00.000Z"),
+      message("r2"),
+      message("r3"),
+      message("r4"),
+    ]
+    const visible = composeRevealedWindow(withTombstone, withTombstone.slice(-2), 2)
+    expect(ids(visible)).toEqual(["rd", "r2", "r3", "r4"])
+    expect(visible.filter((m) => !m.deletedAt).length).toBe(3)
   })
 })

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -8,6 +8,7 @@ import {
   revokeOptimisticRailEvent,
   useBoardCardMessages,
   useBoardRailsReady,
+  useRevealedReplyWindow,
   useStableReplyWindow,
   composeRevealedWindow,
   __clearBoardRailRegistry,
@@ -1277,5 +1278,95 @@ describe("composeRevealedWindow", () => {
     const visible = composeRevealedWindow(withTombstone, withTombstone.slice(-2), 2)
     expect(ids(visible)).toEqual(["rd", "r2", "r3", "r4"])
     expect(visible.filter((m) => !m.deletedAt).length).toBe(3)
+  })
+
+  it("keeps a previously revealed row visible when a late row sorts in above the trailing region", () => {
+    const stable = rail.slice(-2)
+    const revealed = composeRevealedWindow(rail, stable, 2)
+    expect(ids(revealed)).toEqual(["r3", "r4", "r5", "r6"])
+    // A row sorts into the middle: the positional start advances, so without the
+    // shown-ids union r3 would fall back under the seam.
+    const grown = [...rail.slice(0, 4), message("late"), ...rail.slice(4)]
+    const shown = new Set(ids(revealed))
+    expect(ids(composeRevealedWindow(grown, stable, 2, shown))).toEqual(["r3", "r4", "late", "r5", "r6"])
+  })
+})
+
+describe("useRevealedReplyWindow", () => {
+  const message = (id: string): RenderableMessage =>
+    ({
+      id,
+      streamId: STREAM,
+      authorId: "usr_1",
+      authorType: "user",
+      contentMarkdown: id,
+      reactions: {},
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+      deletedAt: null,
+    }) as RenderableMessage
+  const ids = (messages: RenderableMessage[]) => messages.map((m) => m.id)
+  const rail = Array.from({ length: 25 }, (_, i) => message(`r${i + 1}`))
+
+  interface Props {
+    conversationId: string
+    replies: RenderableMessage[]
+    stable: RenderableMessage[]
+    revealedRows: number
+  }
+  function renderWindow(initialProps: Props) {
+    return renderHook((p: Props) => useRevealedReplyWindow(p.conversationId, p.replies, p.stable, p.revealedRows), {
+      initialProps,
+    })
+  }
+
+  it("holds a revealed row visible when a late reply sorts into the middle of the rail", () => {
+    const stable = rail.slice(-5) // r21…r25
+    const { result, rerender } = renderWindow({
+      conversationId: "conv_1",
+      replies: rail,
+      stable,
+      revealedRows: 15,
+    })
+    expect(result.current[0].id).toBe("r6")
+
+    const late = message("late")
+    const grown = [...rail.slice(0, 20), late, ...rail.slice(20)]
+    rerender({ conversationId: "conv_1", replies: grown, stable, revealedRows: 15 })
+    expect(ids(result.current)).toEqual([...ids(rail.slice(5, 20)), "late", ...ids(rail.slice(20))])
+  })
+
+  it("keeps every revealed row when a backfill lands a whole page in the middle", () => {
+    const stable = rail.slice(-5)
+    const { result, rerender } = renderWindow({
+      conversationId: "conv_1",
+      replies: rail,
+      stable,
+      revealedRows: 15,
+    })
+    const before = ids(result.current)
+
+    const backfilled = [
+      ...rail.slice(0, 10),
+      ...Array.from({ length: 8 }, (_, i) => message(`b${i}`)),
+      ...rail.slice(10),
+    ]
+    rerender({ conversationId: "conv_1", replies: backfilled, stable, revealedRows: 15 })
+    for (const id of before) expect(ids(result.current)).toContain(id)
+  })
+
+  it("resets the shown set when the card is recycled onto another conversation", () => {
+    const stable = rail.slice(-5)
+    const { result, rerender } = renderWindow({
+      conversationId: "conv_1",
+      replies: rail,
+      stable,
+      revealedRows: 15,
+    })
+    expect(result.current[0].id).toBe("r6")
+
+    const next = Array.from({ length: 25 }, (_, i) => message(`n${i + 1}`))
+    rerender({ conversationId: "conv_2", replies: next, stable: next.slice(-5), revealedRows: 2 })
+    expect(ids(result.current)).toEqual(ids(next.slice(-7)))
   })
 })

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -1117,3 +1117,25 @@ export function useStableReplyWindow(conversationId: string, replies: Renderable
 
   return window
 }
+
+/**
+ * The collapsed card's visible replies once the reader has scrolled pages out
+ * from under the gap: the trailing `stable.length + revealedRows` rows, UNIONed
+ * with the stable window rather than replacing it. The union is load-bearing —
+ * {@link useStableReplyWindow} deliberately leaves a late-syncing older reply
+ * under the gap, so its window can hold rows that are not the trailing run, and
+ * a plain trailing slice of the same length would evict one. The result is
+ * always a superset of `stable`, in rail order, and clamps when `revealedRows`
+ * outruns the rail.
+ */
+export function composeRevealedWindow(
+  replies: RenderableMessage[],
+  stable: RenderableMessage[],
+  revealedRows: number
+): RenderableMessage[] {
+  if (revealedRows <= 0) return stable
+  const start = Math.max(0, replies.length - (stable.length + revealedRows))
+  if (start === 0) return replies
+  const stableIds = new Set(stable.map((message) => message.id))
+  return replies.filter((message, index) => index >= start || stableIds.has(message.id))
+}

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -1127,15 +1127,59 @@ export function useStableReplyWindow(conversationId: string, replies: Renderable
  * a plain trailing slice of the same length would evict one. The result is
  * always a superset of `stable`, in rail order, and clamps when `revealedRows`
  * outruns the rail.
+ *
+ * `shownIds` (the rows this card has already revealed — see
+ * {@link useRevealedReplyWindow}) joins the union because the trailing slice is
+ * positional: a row inserting into the rail ABOVE the trailing region (a backfill
+ * landing, a late-syncing reply sorting into the middle) advances `start` and
+ * would push an already-revealed row back under the seam.
  */
 export function composeRevealedWindow(
   replies: RenderableMessage[],
   stable: RenderableMessage[],
-  revealedRows: number
+  revealedRows: number,
+  shownIds?: ReadonlySet<string>
 ): RenderableMessage[] {
+  // `revealedRows` never decreases within a conversation (it resets only when the
+  // card is recycled onto another one, which also clears `shownIds`), so at zero
+  // nothing has ever been revealed and `shownIds` can hold nothing beyond what
+  // `stable` already carries — the identity return can't drop a revealed row.
   if (revealedRows <= 0) return stable
   const start = Math.max(0, replies.length - (stable.length + revealedRows))
   if (start === 0) return replies
   const stableIds = new Set(stable.map((message) => message.id))
-  return replies.filter((message, index) => index >= start || stableIds.has(message.id))
+  return replies.filter(
+    (message, index) => index >= start || stableIds.has(message.id) || shownIds?.has(message.id) === true
+  )
+}
+
+/**
+ * {@link composeRevealedWindow} with memory: the ids it returned stay visible for
+ * the life of the conversation, so the revealed window only ever grows. Same
+ * discipline as {@link useStableReplyWindow} — the shown set is recorded after
+ * commit, never during render, and resets when the card is recycled onto another
+ * conversation.
+ */
+export function useRevealedReplyWindow(
+  conversationId: string,
+  replies: RenderableMessage[],
+  stable: RenderableMessage[],
+  revealedRows: number
+): RenderableMessage[] {
+  const shownRef = useRef<{ conversationId: string; ids: Set<string> }>({ conversationId, ids: new Set() })
+
+  const window = useMemo(() => {
+    const shown = shownRef.current.conversationId === conversationId ? shownRef.current.ids : undefined
+    return composeRevealedWindow(replies, stable, revealedRows, shown)
+  }, [conversationId, replies, stable, revealedRows])
+
+  useEffect(() => {
+    if (shownRef.current.conversationId !== conversationId) {
+      shownRef.current = { conversationId, ids: new Set(window.map((message) => message.id)) }
+      return
+    }
+    for (const message of window) shownRef.current.ids.add(message.id)
+  }, [conversationId, window])
+
+  return window
 }

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -25,7 +25,15 @@ function setup() {
   const scroller = document.createElement("div")
   setRect(scroller, 0, 720)
   setRect(card, 100, 300) // card bottom sits at viewport-Y 300 (scroller top is 0)
-  const scrollBy = vi.fn()
+  scroller.scrollTop = 500
+  // Close the loop the way the browser does: injected scroll moves the offset AND
+  // drags the card's viewport rect with it, so the correction can't silently
+  // double-count its own effect.
+  const scrollBy = vi.fn((delta: number) => {
+    scroller.scrollTop += delta
+    const rect = card.getBoundingClientRect()
+    setRect(card, rect.top - delta, rect.bottom - delta)
+  })
   const listRef = { current: { scrollBy } as unknown as VirtualizerHandle }
   const { result } = renderHook(() =>
     useBoardCardRevealAnchor({ cardRef: { current: card }, scrollerRef: { current: scroller }, listRef })
@@ -109,6 +117,113 @@ describe("useBoardCardRevealAnchor", () => {
     setRect(card, 100, 700)
     roCallback?.() // disarmed → no further correction
     expect(scrollBy).toHaveBeenCalledTimes(1)
+  })
+
+  it("scroll mode keeps holding through the upward gesture that asked for the page", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll" })
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -40 }))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
+  })
+
+  it("scroll mode still hands control back when the reader turns around and scrolls down", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll" })
+    scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("scroll mode holds through a finger dragging down (content up) but not up", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    const touchEvent = (type: string, clientY: number) => {
+      const event = new Event(type, { bubbles: true }) as Event & { touches: { clientY: number }[] }
+      event.touches = [{ clientY }]
+      return event
+    }
+    beginReveal({ mode: "scroll" })
+    scroller.dispatchEvent(touchEvent("touchstart", 200))
+    scroller.dispatchEvent(touchEvent("touchmove", 260))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
+
+    scroller.dispatchEvent(touchEvent("touchmove", 210))
+    setRect(card, 100, 700)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+  })
+
+  it("scroll mode still closes on a keyboard scroll, and still ignores typing", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    const editor = document.createElement("textarea")
+    scroller.appendChild(editor)
+    beginReveal({ mode: "scroll" })
+    editor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
+
+    scroller.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }))
+    setRect(card, 100, 700)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+  })
+
+  it("compensates each page once across a multi-page window, never the growth already undone", () => {
+    const { card, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll" })
+    setRect(card, 100, 632)
+    roCallback?.() // 332px of page 1 undone; the card bottom is back at 300
+    expect(scrollBy).toHaveBeenLastCalledWith(332)
+    // Second page grows another 68 on top of the already-corrected view.
+    beginReveal({ mode: "scroll" })
+    setRect(card, -232, 368)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenLastCalledWith(68)
+  })
+
+  it("re-arming mid-correction keeps the first page's baseline, so the next page can't adopt its growth", () => {
+    const { card, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll" })
+    setRect(card, 100, 432) // page 1 lands; its correction has not run yet
+    beginReveal({ mode: "scroll" }) // second wheel tick asks for page 2
+    setRect(card, 100, 632)
+    roCallback?.()
+    // Both pages' growth since the FIRST arm — re-measuring at 432 would have
+    // compensated only 200 and let the trailing replies leap by a page.
+    expect(scrollBy).toHaveBeenCalledWith(332)
+  })
+
+  it("undoes the card's growth only, letting the reader's own scrolling through", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll" })
+    // The reader keeps flicking upward: the scroller moves 50px and the card rides
+    // down with it, no resize involved.
+    scroller.scrollTop -= 50
+    setRect(card, 150, 350)
+    // Then the page lands: 120px of older middle.
+    setRect(card, 150, 470)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(120)
+  })
+
+  it("ignores a touchmove with no recorded start rather than reading it as a gesture", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    const touchEvent = (type: string, clientY: number) => {
+      const event = new Event(type, { bubbles: true }) as Event & { touches: { clientY: number }[] }
+      event.touches = [{ clientY }]
+      return event
+    }
+    beginReveal() // tap mode: any real gesture would close the window
+    // The listener attached mid-drag, so this move has no origin — direction unknown.
+    scroller.dispatchEvent(touchEvent("touchmove", 260))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
   })
 
   it("closes the window at the hard cap even if no resize ever settles it", () => {

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -20,25 +20,39 @@ function setRect(el: HTMLElement, top: number, bottom: number) {
     ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top, toJSON: () => ({}) }) as DOMRect
 }
 
-function setup() {
+function setup(options?: { shouldHoldOpen?: () => boolean; applied?: (delta: number) => number }) {
   const card = document.createElement("div")
   const scroller = document.createElement("div")
+  // The landmark row lives inside the card; tests that use it control its rect and
+  // hand it to `beginReveal`. Tests that don't keep the card-bottom path.
+  const landmark = document.createElement("div")
+  card.appendChild(landmark)
+  document.body.appendChild(card)
   setRect(scroller, 0, 720)
   setRect(card, 100, 300) // card bottom sits at viewport-Y 300 (scroller top is 0)
+  setRect(landmark, 200, 240)
   scroller.scrollTop = 500
   // Close the loop the way the browser does: injected scroll moves the offset AND
   // drags the card's viewport rect with it, so the correction can't silently
   // double-count its own effect.
   const scrollBy = vi.fn((delta: number) => {
-    scroller.scrollTop += delta
-    const rect = card.getBoundingClientRect()
-    setRect(card, rect.top - delta, rect.bottom - delta)
+    const moved = options?.applied ? options.applied(delta) : delta
+    scroller.scrollTop += moved
+    for (const el of [card, landmark]) {
+      const rect = el.getBoundingClientRect()
+      setRect(el, rect.top - moved, rect.bottom - moved)
+    }
   })
   const listRef = { current: { scrollBy } as unknown as VirtualizerHandle }
   const { result } = renderHook(() =>
-    useBoardCardRevealAnchor({ cardRef: { current: card }, scrollerRef: { current: scroller }, listRef })
+    useBoardCardRevealAnchor({
+      cardRef: { current: card },
+      scrollerRef: { current: scroller },
+      listRef,
+      shouldHoldOpen: options?.shouldHoldOpen,
+    })
   )
-  return { card, scroller, scrollBy, beginReveal: result.current }
+  return { card, scroller, landmark, scrollBy, beginReveal: result.current.beginReveal }
 }
 
 describe("useBoardCardRevealAnchor", () => {
@@ -57,6 +71,7 @@ describe("useBoardCardRevealAnchor", () => {
     globalThis.ResizeObserver = originalRO as typeof ResizeObserver
     vi.restoreAllMocks()
     vi.useRealTimers()
+    document.body.innerHTML = ""
   })
 
   it("holds the card bottom fixed when the middle fills above the trailing replies", () => {
@@ -230,6 +245,111 @@ describe("useBoardCardRevealAnchor", () => {
     const { card, scrollBy, beginReveal } = setup()
     beginReveal()
     vi.advanceTimersByTime(2500) // REVEAL_MAX_MS elapses → close
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("ignores tail growth that leaves the landmark row where it is", () => {
+    const { card, landmark, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll", landmark })
+    // A live reply appends BELOW the trailing: the card's bottom moves, the
+    // landmark does not. Nothing above the reader's eye-line grew, so nothing to undo.
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("corrects by exactly how far the landmark row moved when the page lands above it", () => {
+    const { card, landmark, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll", landmark })
+    // The page lands above the landmark (pushing it down 332) AND a live reply
+    // appends below it, so the card bottom moves further than the landmark did —
+    // only the landmark's movement is the reader's.
+    setRect(card, 100, 700)
+    setRect(landmark, 532, 572)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
+  })
+
+  it("closes rather than correcting against a landmark that left the DOM", () => {
+    const { card, landmark, scrollBy, beginReveal } = setup()
+    beginReveal({ mode: "scroll", landmark })
+    landmark.remove()
+    // A detached element's rect is meaningless; correcting against it would fling
+    // the reader an arbitrary distance.
+    setRect(landmark, -1000, -960)
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+    // Disarmed: later growth passes through uncompensated instead of throwing.
+    setRect(card, 100, 900)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("holds the window open past the settle gap while the backfill is still in flight", () => {
+    let loading = true
+    const { card, scrollBy, beginReveal } = setup({ shouldHoldOpen: () => loading })
+    beginReveal({ mode: "scroll" })
+    setRect(card, 100, 400)
+    roCallback?.() // corrects 100 (card bottom back to 300), arms the settle timer
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(400) // settle fires, but the hold predicate keeps it armed
+    setRect(card, 0, 400) // the backfill's rows land late: another 100
+    roCallback?.()
+    expect(scrollBy).toHaveBeenLastCalledWith(100)
+    // Once the backfill resolves, the next settle closes as usual.
+    loading = false
+    vi.advanceTimersByTime(400)
+    setRect(card, -100, 400)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledTimes(2)
+  })
+
+  it("closes at the held cap even while the backfill claims to still be in flight", () => {
+    const { card, scrollBy, beginReveal } = setup({ shouldHoldOpen: () => true })
+    beginReveal({ mode: "scroll" })
+    setRect(card, 100, 400)
+    roCallback?.() // arms the settle timer, which will hold open from here on
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+    // Well past the plain cap, still armed because the hold predicate keeps saying so.
+    vi.advanceTimersByTime(5_000)
+    setRect(card, 0, 400)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(5_000) // REVEAL_HELD_MAX_MS from arm → closed regardless
+    setRect(card, -100, 400)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledTimes(2)
+  })
+
+  it("re-requests the remainder when the scroller only applies half the correction", () => {
+    const { card, scrollBy, beginReveal } = setup({ applied: (delta) => delta / 2 })
+    beginReveal({ mode: "scroll" })
+    setRect(card, 100, 400) // 100px of growth
+    roCallback?.()
+    expect(scrollBy).toHaveBeenLastCalledWith(100)
+    // Only 50 applied, so the card bottom is still 50 below where it armed; the
+    // next pass asks for the rest instead of booking the growth as compensated.
+    roCallback?.()
+    expect(scrollBy).toHaveBeenLastCalledWith(50)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenLastCalledWith(25)
+  })
+
+  it("stops correcting once the card leaves the viewport (a programmatic feed jump)", () => {
+    const card = document.createElement("div")
+    const scroller = document.createElement("div")
+    setRect(scroller, 0, 720)
+    setRect(card, 100, 300)
+    const scrollBy = vi.fn()
+    const listRef = { current: { scrollBy } as unknown as VirtualizerHandle }
+    const { result } = renderHook(() =>
+      useBoardCardRevealAnchor({ cardRef: { current: card }, scrollerRef: { current: scroller }, listRef })
+    )
+    result.current.beginReveal({ mode: "scroll" })
+    result.current.closeReveal() // what board-card's !cardInViewport effect calls
     setRect(card, 100, 632)
     roCallback?.()
     expect(scrollBy).not.toHaveBeenCalled()

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { RefObject } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { attachScrollGestureDirection } from "./scroll-gesture-direction"
@@ -9,6 +9,11 @@ import { attachScrollGestureDirection } from "./scroll-gesture-direction"
 const REVEAL_SETTLE_MS = 400
 /** Hard cap so a stalled backfill can't leave the window armed forever. */
 const REVEAL_MAX_MS = 2500
+/** The cap while the card says its server backfill is still in flight. An ordinary
+ *  page routinely takes 600ms+, so the plain cap would expire mid-request and let
+ *  the late rows shove the trailing region uncompensated. Past this the window
+ *  closes regardless — that slow a backfill ends in the seam's error label. */
+const REVEAL_HELD_MAX_MS = 10_000
 
 /** A keydown counts as "the reader scrolled" only when it can move the scroller —
  *  not when it's typing. The board composer renders inside the SAME scroller, so
@@ -30,6 +35,10 @@ interface Options {
   scrollerRef?: RefObject<HTMLDivElement | null>
   /** virtua's imperative handle for the board feed. Absent off the board page. */
   listRef?: RefObject<VirtualizerHandle | null>
+  /** Read at each settle check: true while the card's server backfill for this
+   *  reveal is still in flight, so the window waits for the rows it asked for
+   *  instead of expiring just before they land. */
+  shouldHoldOpen?: () => boolean
 }
 
 /**
@@ -52,6 +61,15 @@ interface Options {
  * once rather than fighting a deliberate gesture. `scrollBy` goes through virtua's
  * own machinery (a raw `scrollTop` write is re-asserted away by virtua's per-item
  * resize handling — the library tug-of-war the owned-scroller design avoids).
+ *
+ * WHAT is held still: a LANDMARK row when the caller names one (the first reply of
+ * the visible window, the row directly below the seam), else the card's bottom
+ * edge. The landmark is the better fixed point because it separates the two kinds
+ * of growth a card sees during a reveal: growth ABOVE it (the revealed page, a
+ * mid-region backfill) moves it down and is compensated, while growth BELOW it (a
+ * live tail reply, the composer expanding) doesn't move it and correctly passes
+ * through. Anchoring on the card bottom conflates the two and scrolls the reader
+ * away from their eye-line on any tail growth.
  */
 export interface BeginRevealOptions {
   /** `"tap"` (default): any scroll gesture hands control back to the reader.
@@ -59,16 +77,27 @@ export interface BeginRevealOptions {
    *  — and the ones continuing it — must not disarm the hold, or the inserted page
    *  lands uncompensated and the viewport leaps. Downward scroll still closes. */
   mode?: "tap" | "scroll"
+  /** The row to hold still: the first reply of the window as it stands BEFORE the
+   *  reveal, which the incoming page pushes down. Only read on ARM — the first
+   *  page's landmark stays the fixed point for the whole walk, because re-pointing
+   *  it mid-window re-baselines against an element whose position already includes
+   *  pending, uncompensated growth (the same trap as re-measuring the anchor). */
+  landmark?: HTMLElement | null
 }
 
-export function useBoardCardRevealAnchor({
-  cardRef,
-  scrollerRef,
-  listRef,
-}: Options): (opts?: BeginRevealOptions) => void {
-  // Target viewport-Y of the card's bottom edge while the window is armed; null
-  // when disarmed (the RO correction and gesture-close both key off this).
+export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef, shouldHoldOpen }: Options): {
+  beginReveal: (opts?: BeginRevealOptions) => void
+  closeReveal: () => void
+} {
+  // Target viewport-Y of the anchored target (landmark top, or the card's bottom
+  // edge) while the window is armed; null when disarmed (the RO correction and
+  // gesture-close both key off this).
   const anchorRef = useRef<number | null>(null)
+  const landmarkRef = useRef<HTMLElement | null>(null)
+  const shouldHoldOpenRef = useRef(shouldHoldOpen)
+  shouldHoldOpenRef.current = shouldHoldOpen
+  const armedAtRef = useRef(0)
+  const heldRef = useRef(false)
   // The scroller's own offset when the window armed, and the total scroll we have
   // injected since — together they separate the card's growth from the reader's
   // own scrolling, so the correction only ever undoes the former.
@@ -79,14 +108,20 @@ export function useBoardCardRevealAnchor({
   const detachGestureRef = useRef<(() => void) | null>(null)
 
   const measure = useCallback(() => {
-    const card = cardRef.current
     const scroller = scrollerRef?.current
-    if (!card || !scroller) return null
-    return card.getBoundingClientRect().bottom - scroller.getBoundingClientRect().top
+    if (!scroller) return null
+    const scrollerTop = scroller.getBoundingClientRect().top
+    const landmark = landmarkRef.current
+    if (landmark) return landmark.getBoundingClientRect().top - scrollerTop
+    const card = cardRef.current
+    if (!card) return null
+    return card.getBoundingClientRect().bottom - scrollerTop
   }, [cardRef, scrollerRef])
 
   const close = useCallback(() => {
     anchorRef.current = null
+    landmarkRef.current = null
+    heldRef.current = false
     scrollTopAtArmRef.current = 0
     injectedRef.current = 0
     if (settleTimerRef.current) {
@@ -101,6 +136,28 @@ export function useBoardCardRevealAnchor({
     detachGestureRef.current = null
   }, [])
 
+  /** (Re)arm the hard cap: `REVEAL_MAX_MS` from now normally, or whatever is left
+   *  of `REVEAL_HELD_MAX_MS` since the ARM once a settle check has held the window
+   *  open — a hold extends the ceiling, it never resets it. */
+  const armMaxTimer = useCallback(() => {
+    if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
+    const remaining = heldRef.current ? armedAtRef.current + REVEAL_HELD_MAX_MS - Date.now() : REVEAL_MAX_MS
+    maxTimerRef.current = window.setTimeout(close, Math.max(0, remaining))
+  }, [close])
+
+  const onSettle: () => void = useCallback(() => {
+    settleTimerRef.current = 0
+    if (shouldHoldOpenRef.current?.()) {
+      if (!heldRef.current) {
+        heldRef.current = true
+        armMaxTimer()
+      }
+      settleTimerRef.current = window.setTimeout(onSettle, REVEAL_SETTLE_MS)
+      return
+    }
+    close()
+  }, [close, armMaxTimer])
+
   const beginReveal = useCallback(
     (opts?: BeginRevealOptions) => {
       const scroller = scrollerRef?.current
@@ -112,14 +169,18 @@ export function useBoardCardRevealAnchor({
       // trailing replies would leap by a page. Keep the arm-time baseline; only the
       // deadline and the listeners (the mode may differ) are refreshed.
       if (anchorRef.current === null) {
+        landmarkRef.current = opts?.landmark ?? null
         const anchor = measure()
-        if (anchor === null) return
+        if (anchor === null) {
+          landmarkRef.current = null
+          return
+        }
         anchorRef.current = anchor
         scrollTopAtArmRef.current = scroller.scrollTop
         injectedRef.current = 0
+        armedAtRef.current = Date.now()
       }
-      if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
-      maxTimerRef.current = window.setTimeout(close, REVEAL_MAX_MS)
+      armMaxTimer()
       // A deliberate scroll means the reader took over — stop holding immediately.
       // keydown is gated to non-editable targets so typing in the in-scroller
       // composer (whose keystrokes bubble here) doesn't disarm the hold.
@@ -139,7 +200,7 @@ export function useBoardCardRevealAnchor({
         scroller.removeEventListener("keydown", onKeyGesture)
       }
     },
-    [measure, scrollerRef, listRef, close]
+    [measure, scrollerRef, listRef, close, armMaxTimer]
   )
 
   // Correct on every card resize while armed, re-arming the settle timer so the
@@ -157,31 +218,45 @@ export function useBoardCardRevealAnchor({
         const target = anchorRef.current
         const scroller = scrollerRef?.current
         if (target === null || !scroller) return
+        // A landmark that left the DOM was deleted or re-filed: its rect is
+        // garbage, and correcting against garbage moves the reader somewhere
+        // arbitrary. Bail instead.
+        const landmark = landmarkRef.current
+        if (landmark && !landmark.isConnected) {
+          close()
+          return
+        }
         const after = measure()
         if (after === null) return
-        // A bottom edge's viewport-Y is its document-Y minus the scroll offset, so
-        // the card's GROWTH since arming is what's left once the reader's own
-        // scrolling (and our own injections, which move scrollTop the same way) is
-        // added back in. Driving total injected scroll to total growth holds the
-        // trailing replies still while letting a continuous flick scroll through.
+        // The anchored target's viewport-Y is its document-Y minus the scroll
+        // offset, so the GROWTH above it since arming is what's left once the
+        // reader's own scrolling (and our own injections, which move scrollTop the
+        // same way) is added back in. Driving total injected scroll to total growth
+        // holds it still while letting a continuous flick scroll through.
         const growth = after - target + (scroller.scrollTop - scrollTopAtArmRef.current)
         const correction = growth - injectedRef.current
         if (Math.abs(correction) > 0.5) {
+          // Book what actually APPLIED, not what was asked for: `scrollBy` clamps
+          // at the scroll extents and iOS drops it outright during an active touch.
+          // Recording the request would under-compensate every later pass forever.
+          // If virtua applies asynchronously the sync delta reads 0, we record 0,
+          // and the next RO pass re-requests the remainder — self-healing.
+          const before = scroller.scrollTop
           listRef?.current?.scrollBy(correction)
-          injectedRef.current += correction
+          injectedRef.current += scroller.scrollTop - before
         }
       })
       if (settleTimerRef.current) clearTimeout(settleTimerRef.current)
-      settleTimerRef.current = window.setTimeout(close, REVEAL_SETTLE_MS)
+      settleTimerRef.current = window.setTimeout(onSettle, REVEAL_SETTLE_MS)
     })
     observer.observe(card)
     return () => {
       observer.disconnect()
       cancelAnimationFrame(raf)
     }
-  }, [cardRef, measure, listRef, scrollerRef, close])
+  }, [cardRef, measure, listRef, scrollerRef, close, onSettle])
 
   useEffect(() => () => close(), [close])
 
-  return beginReveal
+  return useMemo(() => ({ beginReveal, closeReveal: close }), [beginReveal, close])
 }

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react"
 import type { RefObject } from "react"
 import type { VirtualizerHandle } from "virtua"
+import { attachScrollGestureDirection } from "./scroll-gesture-direction"
 
 /** No-resize quiet gap after which the reveal window closes on its own. Long
  *  enough to span the sync expand and its async server backfill; short enough that
@@ -52,10 +53,27 @@ interface Options {
  * own machinery (a raw `scrollTop` write is re-asserted away by virtua's per-item
  * resize handling — the library tug-of-war the owned-scroller design avoids).
  */
-export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Options): () => void {
+export interface BeginRevealOptions {
+  /** `"tap"` (default): any scroll gesture hands control back to the reader.
+   *  `"scroll"`: the reveal WAS an upward scroll, so the gesture that triggered it
+   *  — and the ones continuing it — must not disarm the hold, or the inserted page
+   *  lands uncompensated and the viewport leaps. Downward scroll still closes. */
+  mode?: "tap" | "scroll"
+}
+
+export function useBoardCardRevealAnchor({
+  cardRef,
+  scrollerRef,
+  listRef,
+}: Options): (opts?: BeginRevealOptions) => void {
   // Target viewport-Y of the card's bottom edge while the window is armed; null
   // when disarmed (the RO correction and gesture-close both key off this).
   const anchorRef = useRef<number | null>(null)
+  // The scroller's own offset when the window armed, and the total scroll we have
+  // injected since — together they separate the card's growth from the reader's
+  // own scrolling, so the correction only ever undoes the former.
+  const scrollTopAtArmRef = useRef(0)
+  const injectedRef = useRef(0)
   const settleTimerRef = useRef(0)
   const maxTimerRef = useRef(0)
   const detachGestureRef = useRef<(() => void) | null>(null)
@@ -69,6 +87,8 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Opti
 
   const close = useCallback(() => {
     anchorRef.current = null
+    scrollTopAtArmRef.current = 0
+    injectedRef.current = 0
     if (settleTimerRef.current) {
       clearTimeout(settleTimerRef.current)
       settleTimerRef.current = 0
@@ -81,31 +101,46 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Opti
     detachGestureRef.current = null
   }, [])
 
-  const beginReveal = useCallback(() => {
-    const scroller = scrollerRef?.current
-    if (!scroller || !listRef?.current) return
-    const anchor = measure()
-    if (anchor === null) return
-    anchorRef.current = anchor
-    if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
-    maxTimerRef.current = window.setTimeout(close, REVEAL_MAX_MS)
-    // A deliberate scroll means the reader took over — stop holding immediately.
-    // keydown is gated to non-editable targets so typing in the in-scroller
-    // composer (whose keystrokes bubble here) doesn't disarm the hold.
-    detachGestureRef.current?.()
-    const onGesture = () => close()
-    const onKeyGesture = (e: KeyboardEvent) => {
-      if (!isEditableTarget(e.target)) close()
-    }
-    scroller.addEventListener("wheel", onGesture, { passive: true })
-    scroller.addEventListener("touchmove", onGesture, { passive: true })
-    scroller.addEventListener("keydown", onKeyGesture)
-    detachGestureRef.current = () => {
-      scroller.removeEventListener("wheel", onGesture)
-      scroller.removeEventListener("touchmove", onGesture)
-      scroller.removeEventListener("keydown", onKeyGesture)
-    }
-  }, [measure, scrollerRef, listRef, close])
+  const beginReveal = useCallback(
+    (opts?: BeginRevealOptions) => {
+      const scroller = scrollerRef?.current
+      if (!scroller || !listRef?.current) return
+      const scrollMode = opts?.mode === "scroll"
+      // Re-arming mid-window (the next page, one gesture later) must NOT re-baseline:
+      // a correction for the previous page can still be pending (RO → rAF), so a
+      // fresh measurement would adopt growth nobody has compensated yet and the
+      // trailing replies would leap by a page. Keep the arm-time baseline; only the
+      // deadline and the listeners (the mode may differ) are refreshed.
+      if (anchorRef.current === null) {
+        const anchor = measure()
+        if (anchor === null) return
+        anchorRef.current = anchor
+        scrollTopAtArmRef.current = scroller.scrollTop
+        injectedRef.current = 0
+      }
+      if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
+      maxTimerRef.current = window.setTimeout(close, REVEAL_MAX_MS)
+      // A deliberate scroll means the reader took over — stop holding immediately.
+      // keydown is gated to non-editable targets so typing in the in-scroller
+      // composer (whose keystrokes bubble here) doesn't disarm the hold.
+      detachGestureRef.current?.()
+      const detachDirection = attachScrollGestureDirection(scroller, {
+        onUp: () => {
+          if (!scrollMode) close()
+        },
+        onDown: close,
+      })
+      const onKeyGesture = (e: KeyboardEvent) => {
+        if (!isEditableTarget(e.target)) close()
+      }
+      scroller.addEventListener("keydown", onKeyGesture)
+      detachGestureRef.current = () => {
+        detachDirection()
+        scroller.removeEventListener("keydown", onKeyGesture)
+      }
+    },
+    [measure, scrollerRef, listRef, close]
+  )
 
   // Correct on every card resize while armed, re-arming the settle timer so the
   // window spans the expand + its backfill, then closes once growth stops.
@@ -120,11 +155,21 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Opti
       // adjustments don't stack into a double shift.
       raf = requestAnimationFrame(() => {
         const target = anchorRef.current
-        if (target === null) return
+        const scroller = scrollerRef?.current
+        if (target === null || !scroller) return
         const after = measure()
         if (after === null) return
-        const delta = after - target
-        if (Math.abs(delta) > 0.5) listRef?.current?.scrollBy(delta)
+        // A bottom edge's viewport-Y is its document-Y minus the scroll offset, so
+        // the card's GROWTH since arming is what's left once the reader's own
+        // scrolling (and our own injections, which move scrollTop the same way) is
+        // added back in. Driving total injected scroll to total growth holds the
+        // trailing replies still while letting a continuous flick scroll through.
+        const growth = after - target + (scroller.scrollTop - scrollTopAtArmRef.current)
+        const correction = growth - injectedRef.current
+        if (Math.abs(correction) > 0.5) {
+          listRef?.current?.scrollBy(correction)
+          injectedRef.current += correction
+        }
       })
       if (settleTimerRef.current) clearTimeout(settleTimerRef.current)
       settleTimerRef.current = window.setTimeout(close, REVEAL_SETTLE_MS)
@@ -134,7 +179,7 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Opti
       observer.disconnect()
       cancelAnimationFrame(raf)
     }
-  }, [cardRef, measure, listRef, close])
+  }, [cardRef, measure, listRef, scrollerRef, close])
 
   useEffect(() => () => close(), [close])
 

--- a/apps/frontend/src/hooks/use-board-gap-auto-reveal.test.ts
+++ b/apps/frontend/src/hooks/use-board-gap-auto-reveal.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { useBoardGapAutoReveal } from "./use-board-gap-auto-reveal"
+
+// jsdom has no IntersectionObserver and no layout; drive the seam's visibility by
+// hand so the gesture/intersection pairing is what the tests actually assert.
+let observers: FakeIntersectionObserver[] = []
+class FakeIntersectionObserver {
+  cb: (entries: { isIntersecting: boolean }[]) => void
+  disconnected = false
+  constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
+    this.cb = cb
+    observers.push(this)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true
+  }
+}
+
+function setSeamVisible(visible: boolean) {
+  for (const observer of observers) observer.cb([{ isIntersecting: visible }])
+}
+
+function wheel(scroller: HTMLElement, deltaY: number) {
+  scroller.dispatchEvent(new WheelEvent("wheel", { deltaY, bubbles: true }))
+}
+
+function touch(scroller: HTMLElement, type: "touchstart" | "touchmove", clientY: number) {
+  const event = new Event(type, { bubbles: true }) as Event & { touches: { clientY: number }[] }
+  event.touches = [{ clientY }]
+  scroller.dispatchEvent(event)
+}
+
+function setup(options: { enabled?: boolean; withScroller?: boolean } = {}) {
+  const seam = document.createElement("button")
+  const scroller = document.createElement("div")
+  const onReveal = vi.fn()
+  const { rerender, unmount } = renderHook(
+    ({ enabled }: { enabled: boolean }) =>
+      useBoardGapAutoReveal({
+        seamRef: { current: seam },
+        scrollerRef: options.withScroller === false ? undefined : { current: scroller },
+        enabled,
+        onReveal,
+      }),
+    { initialProps: { enabled: options.enabled ?? true } }
+  )
+  return { seam, scroller, onReveal, rerender, unmount }
+}
+
+describe("useBoardGapAutoReveal", () => {
+  let originalIO: typeof IntersectionObserver | undefined
+  beforeEach(() => {
+    observers = []
+    originalIO = globalThis.IntersectionObserver
+    globalThis.IntersectionObserver = FakeIntersectionObserver as unknown as typeof IntersectionObserver
+  })
+  afterEach(() => {
+    globalThis.IntersectionObserver = originalIO as typeof IntersectionObserver
+  })
+
+  it("reveals one page per upward wheel event while the seam is on screen", () => {
+    const { scroller, onReveal } = setup()
+    setSeamVisible(true)
+    wheel(scroller, -40)
+    wheel(scroller, -40)
+    expect(onReveal).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not reveal while the seam is off screen, however far the reader scrolls up", () => {
+    const { scroller, onReveal } = setup()
+    setSeamVisible(false)
+    wheel(scroller, -40)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
+  it("never reveals on intersection alone — a short page must not chain without a fresh gesture", () => {
+    const { onReveal } = setup()
+    setSeamVisible(true)
+    setSeamVisible(true)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
+  it("ignores downward scrolling: reading forward doesn't dig up older messages", () => {
+    const { scroller, onReveal } = setup()
+    setSeamVisible(true)
+    wheel(scroller, 40)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
+  it("fires on a finger moving down the screen (content scrolling up), not up", () => {
+    const { scroller, onReveal } = setup()
+    setSeamVisible(true)
+    touch(scroller, "touchstart", 200)
+    touch(scroller, "touchmove", 260)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+    touch(scroller, "touchmove", 210)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a touchmove with no recorded start (listener attached mid-drag)", () => {
+    const { scroller, onReveal } = setup()
+    setSeamVisible(true)
+    touch(scroller, "touchmove", 260)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when disabled, and detaches when it becomes disabled", () => {
+    const { scroller, onReveal, rerender } = setup({ enabled: false })
+    setSeamVisible(true)
+    wheel(scroller, -40)
+    expect(onReveal).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    setSeamVisible(true)
+    wheel(scroller, -40)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+
+    rerender({ enabled: false })
+    wheel(scroller, -40)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+  })
+
+  it("detaches on unmount", () => {
+    const { scroller, onReveal, unmount } = setup()
+    setSeamVisible(true)
+    unmount()
+    wheel(scroller, -40)
+    expect(onReveal).not.toHaveBeenCalled()
+    expect(observers[0].disconnected).toBe(true)
+  })
+
+  it("no-ops without a scroller (off-board surfaces, tests)", () => {
+    const { scroller, onReveal } = setup({ withScroller: false })
+    expect(observers).toHaveLength(0)
+    wheel(scroller, -40)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-board-gap-auto-reveal.test.ts
+++ b/apps/frontend/src/hooks/use-board-gap-auto-reveal.test.ts
@@ -4,56 +4,73 @@ import { useBoardGapAutoReveal } from "./use-board-gap-auto-reveal"
 
 // jsdom has no IntersectionObserver and no layout; drive the seam's visibility by
 // hand so the gesture/intersection pairing is what the tests actually assert.
+// `observe`/`unobserve` track targets the way the real API does — the hook re-arms
+// by re-observing, and a re-observed target only counts once the harness delivers
+// its (asynchronous, in the browser) entry.
 let observers: FakeIntersectionObserver[] = []
 class FakeIntersectionObserver {
   cb: (entries: { isIntersecting: boolean }[]) => void
+  targets: Element[] = []
   disconnected = false
   constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
     this.cb = cb
     observers.push(this)
   }
-  observe() {}
-  unobserve() {}
+  observe(target: Element) {
+    this.targets.push(target)
+  }
+  unobserve(target: Element) {
+    this.targets = this.targets.filter((t) => t !== target)
+  }
   disconnect() {
+    this.targets = []
     this.disconnected = true
   }
 }
 
-function setSeamVisible(visible: boolean) {
-  for (const observer of observers) observer.cb([{ isIntersecting: visible }])
+/** One intersection report per observed target, as the browser delivers after layout. */
+function deliverIntersection(visible: boolean) {
+  for (const observer of observers) for (const _ of observer.targets) observer.cb([{ isIntersecting: visible }])
 }
 
-function wheel(scroller: HTMLElement, deltaY: number) {
-  scroller.dispatchEvent(new WheelEvent("wheel", { deltaY, bubbles: true }))
+function wheel(target: HTMLElement, deltaY: number) {
+  target.dispatchEvent(new WheelEvent("wheel", { deltaY, bubbles: true }))
 }
 
-function touch(scroller: HTMLElement, type: "touchstart" | "touchmove", clientY: number) {
+function touch(target: HTMLElement, type: "touchstart" | "touchmove", clientY: number) {
   const event = new Event(type, { bubbles: true }) as Event & { touches: { clientY: number }[] }
   event.touches = [{ clientY }]
-  scroller.dispatchEvent(event)
+  target.dispatchEvent(event)
 }
 
 function setup(options: { enabled?: boolean; withScroller?: boolean } = {}) {
-  const seam = document.createElement("button")
   const scroller = document.createElement("div")
+  const card = document.createElement("div")
+  const sibling = document.createElement("div")
+  const seam = document.createElement("button")
+  card.append(seam)
+  scroller.append(card, sibling)
+  document.body.append(scroller)
   const onReveal = vi.fn()
   const { rerender, unmount } = renderHook(
     ({ enabled }: { enabled: boolean }) =>
       useBoardGapAutoReveal({
         seamRef: { current: seam },
+        cardRef: { current: card },
         scrollerRef: options.withScroller === false ? undefined : { current: scroller },
         enabled,
         onReveal,
       }),
     { initialProps: { enabled: options.enabled ?? true } }
   )
-  return { seam, scroller, onReveal, rerender, unmount }
+  return { seam, card, sibling, scroller, onReveal, rerender, unmount }
 }
 
 describe("useBoardGapAutoReveal", () => {
   let originalIO: typeof IntersectionObserver | undefined
   beforeEach(() => {
     observers = []
+    document.body.innerHTML = ""
     originalIO = globalThis.IntersectionObserver
     globalThis.IntersectionObserver = FakeIntersectionObserver as unknown as typeof IntersectionObserver
   })
@@ -61,81 +78,111 @@ describe("useBoardGapAutoReveal", () => {
     globalThis.IntersectionObserver = originalIO as typeof IntersectionObserver
   })
 
-  it("reveals one page per upward wheel event while the seam is on screen", () => {
-    const { scroller, onReveal } = setup()
-    setSeamVisible(true)
-    wheel(scroller, -40)
-    wheel(scroller, -40)
+  it("reveals one page per fresh intersection report, not per wheel event", () => {
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    wheel(card, -40)
+    wheel(card, -40)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+
+    deliverIntersection(true)
+    wheel(card, -40)
     expect(onReveal).toHaveBeenCalledTimes(2)
   })
 
+  it("gives a flick one page: rapid wheel events with no fresh report in between don't dump the middle", () => {
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    for (let i = 0; i < 5; i++) wheel(card, -40)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+  })
+
+  it("stays closed when the re-armed report says the revealed page pushed the seam off screen", () => {
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    wheel(card, -40)
+    deliverIntersection(false)
+    wheel(card, -40)
+    expect(onReveal).toHaveBeenCalledTimes(1)
+  })
+
   it("does not reveal while the seam is off screen, however far the reader scrolls up", () => {
-    const { scroller, onReveal } = setup()
-    setSeamVisible(false)
-    wheel(scroller, -40)
+    const { card, onReveal } = setup()
+    deliverIntersection(false)
+    wheel(card, -40)
     expect(onReveal).not.toHaveBeenCalled()
   })
 
   it("never reveals on intersection alone — a short page must not chain without a fresh gesture", () => {
     const { onReveal } = setup()
-    setSeamVisible(true)
-    setSeamVisible(true)
+    deliverIntersection(true)
+    deliverIntersection(true)
+    expect(onReveal).not.toHaveBeenCalled()
+  })
+
+  it("ignores a gesture over another card: only the card under the pointer pages", () => {
+    const { sibling, scroller, onReveal } = setup()
+    deliverIntersection(true)
+    wheel(sibling, -40)
+    wheel(scroller, -40)
     expect(onReveal).not.toHaveBeenCalled()
   })
 
   it("ignores downward scrolling: reading forward doesn't dig up older messages", () => {
-    const { scroller, onReveal } = setup()
-    setSeamVisible(true)
-    wheel(scroller, 40)
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    wheel(card, 40)
     expect(onReveal).not.toHaveBeenCalled()
   })
 
   it("fires on a finger moving down the screen (content scrolling up), not up", () => {
-    const { scroller, onReveal } = setup()
-    setSeamVisible(true)
-    touch(scroller, "touchstart", 200)
-    touch(scroller, "touchmove", 260)
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    touch(card, "touchstart", 200)
+    touch(card, "touchmove", 260)
     expect(onReveal).toHaveBeenCalledTimes(1)
-    touch(scroller, "touchmove", 210)
+    deliverIntersection(true)
+    touch(card, "touchmove", 210)
     expect(onReveal).toHaveBeenCalledTimes(1)
   })
 
   it("ignores a touchmove with no recorded start (listener attached mid-drag)", () => {
-    const { scroller, onReveal } = setup()
-    setSeamVisible(true)
-    touch(scroller, "touchmove", 260)
+    const { card, onReveal } = setup()
+    deliverIntersection(true)
+    touch(card, "touchmove", 260)
     expect(onReveal).not.toHaveBeenCalled()
   })
 
   it("does nothing when disabled, and detaches when it becomes disabled", () => {
-    const { scroller, onReveal, rerender } = setup({ enabled: false })
-    setSeamVisible(true)
-    wheel(scroller, -40)
+    const { card, onReveal, rerender } = setup({ enabled: false })
+    deliverIntersection(true)
+    wheel(card, -40)
     expect(onReveal).not.toHaveBeenCalled()
 
     rerender({ enabled: true })
-    setSeamVisible(true)
-    wheel(scroller, -40)
+    deliverIntersection(true)
+    wheel(card, -40)
     expect(onReveal).toHaveBeenCalledTimes(1)
 
     rerender({ enabled: false })
-    wheel(scroller, -40)
+    deliverIntersection(true)
+    wheel(card, -40)
     expect(onReveal).toHaveBeenCalledTimes(1)
   })
 
   it("detaches on unmount", () => {
-    const { scroller, onReveal, unmount } = setup()
-    setSeamVisible(true)
+    const { card, onReveal, unmount } = setup()
+    deliverIntersection(true)
     unmount()
-    wheel(scroller, -40)
+    wheel(card, -40)
     expect(onReveal).not.toHaveBeenCalled()
     expect(observers[0].disconnected).toBe(true)
   })
 
   it("no-ops without a scroller (off-board surfaces, tests)", () => {
-    const { scroller, onReveal } = setup({ withScroller: false })
+    const { card, onReveal } = setup({ withScroller: false })
     expect(observers).toHaveLength(0)
-    wheel(scroller, -40)
+    wheel(card, -40)
     expect(onReveal).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/hooks/use-board-gap-auto-reveal.ts
+++ b/apps/frontend/src/hooks/use-board-gap-auto-reveal.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from "react"
+import type { RefObject } from "react"
+import { attachScrollGestureDirection } from "./scroll-gesture-direction"
+
+interface Options {
+  /** The collapsed card's "N older messages" seam row. */
+  seamRef: RefObject<HTMLElement | null>
+  /** The board's owned scroll viewport. Absent off the board page (tests, jsdom). */
+  scrollerRef?: RefObject<HTMLDivElement | null>
+  enabled: boolean
+  onReveal: () => void
+}
+
+/**
+ * Turns scrolling up onto a collapsed board card's seam into a page of older
+ * messages, the way reading up past the timeline's unread divider keeps going.
+ *
+ * A reveal needs BOTH the seam on screen and a fresh upward gesture event — never
+ * intersection alone. That is the cascade guard: a revealed page shorter than the
+ * viewport leaves the seam still intersecting, and an intersection-driven trigger
+ * would chain through the whole hidden middle in one frame. One gesture event
+ * (one wheel tick, one touchmove) buys at most one page, so the reader's own
+ * scrolling paces the walk backward.
+ */
+export function useBoardGapAutoReveal({ seamRef, scrollerRef, enabled, onReveal }: Options): void {
+  // Held in refs so a re-render (every reveal changes the card) doesn't tear the
+  // observer and listeners down and back up mid-gesture.
+  const onRevealRef = useRef(onReveal)
+  onRevealRef.current = onReveal
+  const intersectingRef = useRef(false)
+
+  useEffect(() => {
+    const seam = seamRef.current
+    const scroller = scrollerRef?.current
+    if (!enabled || !seam || !scroller || typeof IntersectionObserver === "undefined") return
+
+    intersectingRef.current = false
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        intersectingRef.current = entry.isIntersecting
+      },
+      { root: scroller }
+    )
+    observer.observe(seam)
+
+    const detachGestures = attachScrollGestureDirection(scroller, {
+      onUp: () => {
+        if (intersectingRef.current) onRevealRef.current()
+      },
+    })
+    return () => {
+      observer.disconnect()
+      detachGestures()
+    }
+  }, [enabled, seamRef, scrollerRef])
+}

--- a/apps/frontend/src/hooks/use-board-gap-auto-reveal.ts
+++ b/apps/frontend/src/hooks/use-board-gap-auto-reveal.ts
@@ -5,6 +5,9 @@ import { attachScrollGestureDirection } from "./scroll-gesture-direction"
 interface Options {
   /** The collapsed card's "N older messages" seam row. */
   seamRef: RefObject<HTMLElement | null>
+  /** This card's root element — the gesture target, so a flick over a sibling
+   *  card never pages this one. */
+  cardRef: RefObject<HTMLElement | null>
   /** The board's owned scroll viewport. Absent off the board page (tests, jsdom). */
   scrollerRef?: RefObject<HTMLDivElement | null>
   enabled: boolean
@@ -18,11 +21,16 @@ interface Options {
  * A reveal needs BOTH the seam on screen and a fresh upward gesture event — never
  * intersection alone. That is the cascade guard: a revealed page shorter than the
  * viewport leaves the seam still intersecting, and an intersection-driven trigger
- * would chain through the whole hidden middle in one frame. One gesture event
- * (one wheel tick, one touchmove) buys at most one page, so the reader's own
- * scrolling paces the walk backward.
+ * would chain through the whole hidden middle in one frame.
+ *
+ * Pacing is per intersection round-trip, not per event: a trackpad flick emits
+ * ~60-120 wheel events a second while IntersectionObserver only reports the seam
+ * leaving asynchronously, so "one page per event" dumps the middle anyway. After
+ * a reveal the gate closes and the seam is re-observed — a freshly observed target
+ * always gets an initial entry delivered after layout, so the next page waits on
+ * the truth (seam pushed off screen, or still visible) rather than on event rate.
  */
-export function useBoardGapAutoReveal({ seamRef, scrollerRef, enabled, onReveal }: Options): void {
+export function useBoardGapAutoReveal({ seamRef, cardRef, scrollerRef, enabled, onReveal }: Options): void {
   // Held in refs so a re-render (every reveal changes the card) doesn't tear the
   // observer and listeners down and back up mid-gesture.
   const onRevealRef = useRef(onReveal)
@@ -31,8 +39,9 @@ export function useBoardGapAutoReveal({ seamRef, scrollerRef, enabled, onReveal 
 
   useEffect(() => {
     const seam = seamRef.current
+    const card = cardRef.current
     const scroller = scrollerRef?.current
-    if (!enabled || !seam || !scroller || typeof IntersectionObserver === "undefined") return
+    if (!enabled || !seam || !card || !scroller || typeof IntersectionObserver === "undefined") return
 
     intersectingRef.current = false
     const observer = new IntersectionObserver(
@@ -43,14 +52,18 @@ export function useBoardGapAutoReveal({ seamRef, scrollerRef, enabled, onReveal 
     )
     observer.observe(seam)
 
-    const detachGestures = attachScrollGestureDirection(scroller, {
+    const detachGestures = attachScrollGestureDirection(card, {
       onUp: () => {
-        if (intersectingRef.current) onRevealRef.current()
+        if (!intersectingRef.current) return
+        intersectingRef.current = false
+        onRevealRef.current()
+        observer.unobserve(seam)
+        observer.observe(seam)
       },
     })
     return () => {
       observer.disconnect()
       detachGestures()
     }
-  }, [enabled, seamRef, scrollerRef])
+  }, [enabled, seamRef, cardRef, scrollerRef])
 }

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -189,6 +189,8 @@ describe("useStreamOrDraft real stream send", () => {
 
     await waitFor(() => {
       expect(result.current.stream?.id).toBe("stream_socket_seen")
+      // Sends throw until the users liveQuery delivers the sender's identity.
+      expect(result.current.currentUserId).toBe("member_1")
     })
 
     return { result, queryClient }
@@ -430,6 +432,12 @@ describe("useStreamOrDraft draft DM send", () => {
 
     await waitFor(() => {
       expect(result.current.stream?.id).toBe("draft_dm_member_2")
+      // Sends throw until the users liveQuery delivers the sender's identity.
+      expect(result.current.currentUserId).toBe("member_1")
+      // The persist path names the DM from the peer row; wait until the draft
+      // itself resolves the peer (users + dmPeers delivered), or the persisted
+      // row races into the "Direct message" placeholder.
+      expect(result.current.stream?.displayName).toBe("Invitee")
     })
 
     await act(async () => {

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -285,6 +285,25 @@ describe("useStreamOrDraft draft DM send", () => {
     await clearAllCachedData()
   })
 
+  it("refuses to send while the viewer's identity is unresolved instead of creating a membershipless DM", async () => {
+    // No user row matches the authed WorkOS id, so currentUserId never
+    // resolves — the send must throw up front rather than create the DM and
+    // silently skip the local membership/bootstrap writes.
+    const createDm = vi.fn()
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useStreamOrDraft("ws_1", "draft_dm_member_2"), {
+      wrapper: createWrapper(queryClient, { messageService: { createDm } }),
+    })
+    await waitFor(() => expect(result.current.stream?.id).toBe("draft_dm_member_2"))
+
+    await expect(
+      result.current.sendMessage({
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] },
+      })
+    ).rejects.toThrow("user identity not resolved")
+    expect(createDm).not.toHaveBeenCalled()
+  })
+
   it("persists the created DM to IndexedDB so the sidebar can switch from the virtual draft immediately", async () => {
     const createdAt = "2026-03-31T12:00:00Z"
     const queryClient = new QueryClient()

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -343,6 +343,9 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
 
   const sendMessage = useCallback(
     async (input: SendMessageInput): Promise<{ navigateTo?: string; replace?: boolean }> => {
+      if (!currentUserId) {
+        throw new Error("Cannot send message: user identity not resolved yet")
+      }
       if (!targetUserId) {
         throw new Error("Invalid DM draft target")
       }

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -386,17 +386,15 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
       await db.transaction("rw", [db.streams, db.streamMemberships, db.dmPeers], async () => {
         await db.streams.put(optimisticStream)
 
-        if (currentUserId) {
-          await db.streamMemberships.put({
-            id: `${workspaceId}:${message.streamId}`,
-            workspaceId,
-            streamId: message.streamId,
-            memberId: currentUserId,
-            notificationLevel: null,
-            joinedAt: message.createdAt,
-            _cachedAt: now,
-          })
-        }
+        await db.streamMemberships.put({
+          id: `${workspaceId}:${message.streamId}`,
+          workspaceId,
+          streamId: message.streamId,
+          memberId: currentUserId,
+          notificationLevel: null,
+          joinedAt: message.createdAt,
+          _cachedAt: now,
+        })
 
         await db.dmPeers.put({
           id: `${workspaceId}:${message.streamId}`,
@@ -419,14 +417,12 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
           lastMessagePreview: optimisticStream.lastMessagePreview ?? null,
         }
 
-        const optimisticMembership: StreamMember | null = currentUserId
-          ? {
-              streamId: message.streamId,
-              memberId: currentUserId,
-              notificationLevel: null,
-              joinedAt: message.createdAt,
-            }
-          : null
+        const optimisticMembership: StreamMember = {
+          streamId: message.streamId,
+          memberId: currentUserId,
+          notificationLevel: null,
+          joinedAt: message.createdAt,
+        }
 
         const hasPeer = old.dmPeers.some((peer) => peer.userId === targetUserId && peer.streamId === message.streamId)
 
@@ -443,10 +439,9 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
               ? { ...stream, displayName: targetUserName ?? stream.displayName }
               : stream
           ),
-          streamMemberships:
-            !membershipExists && optimisticMembership
-              ? [...old.streamMemberships, optimisticMembership]
-              : old.streamMemberships,
+          streamMemberships: membershipExists
+            ? old.streamMemberships
+            : [...old.streamMemberships, optimisticMembership],
         }
       })
 

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -167,6 +167,10 @@ export interface UseStreamOrDraftReturn {
   archive: () => Promise<void>
   unarchive?: () => Promise<void>
   sendMessage: (input: SendMessageInput) => Promise<{ navigateTo?: string; replace?: boolean }>
+  /** The viewer's workspace user id the send path stamps on optimistic rows;
+   *  null until the users liveQuery delivers — `sendMessage` throws before then,
+   *  so callers (and tests) that fire sends programmatically gate on this. */
+  currentUserId: string | null
 }
 
 /**
@@ -250,6 +254,7 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
     rename,
     archive,
     sendMessage,
+    currentUserId,
   }
 }
 
@@ -455,6 +460,7 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
     rename,
     archive,
     sendMessage,
+    currentUserId,
   }
 }
 
@@ -712,6 +718,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
     archive,
     unarchive,
     sendMessage,
+    currentUserId,
   }
 }
 

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -359,7 +359,7 @@ describe("BoardPage", () => {
     expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
   })
 
-  it("collapses the middle as an 'N more messages' expander, pluralizing the count", async () => {
+  it("collapses the middle as an 'N older messages' expander, pluralizing the count", async () => {
     // 5 messages: opening + 3 recent shown + 1 hidden in the middle.
     const recent = [
       makeOpeningMessage({ id: "m3" }),
@@ -386,7 +386,7 @@ describe("BoardPage", () => {
     const recent = [makeOpeningMessage({ id: "m2" }), makeOpeningMessage({ id: "m3" })]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3"] }, { id: "m1" }, recent)])
     await screen.findAllByText("Opening message body.")
-    expect(screen.queryByText(/more messages?$/)).toBeNull()
+    expect(screen.queryByText(/older messages?$/)).toBeNull()
   })
 
   it("renders reactions on the opening message", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -367,8 +367,8 @@ describe("BoardPage", () => {
       makeOpeningMessage({ id: "m5" }),
     ]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)])
-    expect(await screen.findByText("1 more message")).toBeTruthy()
-    expect(screen.queryByText("1 more messages")).toBeNull()
+    expect(await screen.findByText("1 older message")).toBeTruthy()
+    expect(screen.queryByText("1 older messages")).toBeNull()
   })
 
   it("offers a retry when expanding the middle fails", async () => {
@@ -378,7 +378,7 @@ describe("BoardPage", () => {
       makeOpeningMessage({ id: "m5" }),
     ]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)], { failMessages: true })
-    fireEvent.click(await screen.findByText("1 more message"))
+    fireEvent.click(await screen.findByText("1 older message"))
     expect(await screen.findByText("Couldn't load older messages. Retry.")).toBeTruthy()
   })
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -530,6 +530,11 @@ export const BOARD_TAIL_MAX_ROWS = 5
  *  still shows this many trailing rows. */
 export const BOARD_TAIL_MIN_ROWS = 3
 
+/** Rows a single upward-scroll reveal pulls out from under a collapsed card's
+ *  "N older messages" seam. One page per gesture, so reading up a long hidden
+ *  middle walks backward at a readable pace instead of dumping it whole. */
+export const BOARD_GAP_REVEAL_PAGE_ROWS = 15
+
 // How a message's conversation was decided. Absent/null on a message means the
 // async boundary-extractor inferred (clustered) it — the default. A set value
 // records that the sender DECLARED the conversation at send time, so the

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -100,6 +100,7 @@ export {
   BOARD_TAIL_RUNS,
   BOARD_TAIL_MAX_ROWS,
   BOARD_TAIL_MIN_ROWS,
+  BOARD_GAP_REVEAL_PAGE_ROWS,
   CONVERSATION_INTENTS,
   type ConversationIntent,
   ConversationIntents,


### PR DESCRIPTION
## Problem

Reading a collapsed board card's hidden middle takes a tap on the "N more messages" button, which dumps the whole middle at once. Kris's ask: scrolling up over the gap should just keep going — the unread-divider feel — with no tap and no dump.

## Solution

Scrolling up onto the seam reveals older messages a page (`BOARD_GAP_REVEAL_PAGE_ROWS = 15`) at a time; tap keeps today's full expand as the keyboard path.

- `useBoardGapAutoReveal`: IntersectionObserver on the seam (root = board scroller) + upward-gesture detection; one page per gesture event, never on intersection alone — the cascade guard, so a short page can't chain through the middle in one frame.
- Paged window is `composeRevealedWindow` — a union with the stable window, not a trailing slice: `useStableReplyWindow` deliberately leaves a late-syncing older reply under the gap, so a slice of the same length would evict a row the reader already saw.
- `useBoardCardRevealAnchor` gains `beginReveal({ mode: "scroll" })`: the hold must survive the gesture that triggered it. Re-arming mid-window keeps the arm-time baseline (a fresh measure would adopt a page of growth whose correction is still rAF-pending), and the correction is growth-only — `correction = (growth since arm) − (already injected)`, growth separated from the reader's own scrolling via scrollTop bookkeeping — so a continuous flick scrolls through instead of being pinned to the anchor. Downward gestures and keyboard scrolls still close it.
- Demand clamps to what the rail can satisfy plus one outstanding page — without this, a 300 ms flick over an unsynced 200-reply card banks ~20 phantom pages and the backfill dumps the entire middle in one commit.
- Backfill arms at the first page (`enabled: expanded || revealedRows > 0`); loading and error swap the seam's own label (error > loading > count; seam click retries while failed) so no row mounts or unmounts under the reader (INV-21).
- Shared `attachScrollGestureDirection` replaces two would-be duplicate touch trackers (INV-35/37), seeded `null` so a listener attached mid-drag stays neutral until it has two samples.

Out of scope (deliberate): board-feed-level scrolling, conversation panel, any persistent "you were here" marker, run-based paging.

Known limitation: iOS momentum scrolling delivers no touchmove during inertia, so a flick that coasts across the seam does not page — dragging across it does. A scroll-event trigger was rejected (virtua's own adjustments would cause spurious reveals).

Unrelated CI note: `conversation-provisional-attach` (backend, merged stack) flaked once and passed on re-run; `use-stream-or-draft.test.tsx` flakes on main at the same rate as this branch — two of its races narrowed here (identity + peer-name gating), residual recorded in repo memory.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-board-gap-auto-reveal.ts` | **new** — seam intersection + upward gesture → one page |
| `apps/frontend/src/hooks/scroll-gesture-direction.ts` | **new** — the one scroll-direction reader |
| `apps/frontend/src/hooks/use-board-card-reveal-anchor.ts` | scroll mode; growth-only closed-loop compensation |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | `composeRevealedWindow` (union, monotone, clamped) |
| `apps/frontend/src/components/board/board-card.tsx` | paged state (conversation-id-guarded), demand clamp, seam restyle + label precedence |
| `packages/types/src/constants.ts` + `index.ts` | `BOARD_GAP_REVEAL_PAGE_ROWS = 15` |
| tests | 4 files extended + 1 new; copy "N more" → "N older" in 2 pre-existing suites |

## Test plan

- [x] Full frontend suite: 5584 pass / 0 fail; targeted board+hooks: 1105 pass; `tsc --noEmit` + eslint clean
- [x] Adversarial verify (Opus high): 4 findings, all accepted and fixed, each falsification-checked (details in the review evidence)
- [x] External deep review (GPT-5.6 Sol, high, via Pi) + Fable edge-case walk: 6 more accepted (0 refuted) — revealed-window monotonicity under mid-rail inserts (found independently by both), landmark-row anchoring so tail growth passes through, hold-open while the paged backfill is in flight, disarm on viewport exit, applied-delta bookkeeping, touch-identifier tracking; all falsification-checked
- [x] CodeRabbit full review: 2 accepted and fixed (conversation-id reset held in state, revived seam-absence assertion)
- [x] Live scroll-feel pass (dev:test browser, 1440/390): 19-hidden card — one wheel over the seam revealed exactly one 15-row page (seam → "4 older"), continued scrolling walked the rest; 6-wheel burst did not dump; mobile seam clean at 390

<details>
<summary>📋 Full implementation plan</summary>

Plan: https://seer.build/ws_vbyzjvdg6g/b/board-scroll-reveal-ad74e6/

Paged reveal newest-hidden-first (union with the stable window, clamped to the rail); trigger = seam intersecting + fresh upward gesture event; anchor scroll mode holds through the triggering gesture with growth-only compensation; backfill arms on first page; seam styled as an unread-divider-like line, tap = full expand. Not building: feed-level changes, panel changes, persistent marker, run-based paging.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117811&installation_model_id=20758&pr_number=1702&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1702&signature=edd487cd9e92a552e1e45513aa8ab300b2e64f968b24c351ebee2ffa2d1e47d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

