### PR TITLE
fix(streams): public checks resolve the root's visibility (INV-62)

### DIFF
--- a/apps/backend/src/features/api-keys/service.ts
+++ b/apps/backend/src/features/api-keys/service.ts
@@ -37,7 +37,12 @@ export class BotChannelService {
     const stream = await StreamRepository.findByIdForWorkspace(this.pool, streamId, workspaceId)
     if (!stream || stream.archivedAt) return false
 
-    if (stream.visibility === "public") return true
+    // Publicness is the ROOT's visibility (INV-62) — a thread's own row can
+    // hold a stale copied "public" long after its root went private.
+    const accessStream = stream.rootStreamId
+      ? await StreamRepository.findByIdForWorkspace(this.pool, stream.rootStreamId, workspaceId)
+      : stream
+    if (accessStream?.visibility === "public") return true
 
     const grantStreamId = stream.type === StreamTypes.THREAD && stream.rootStreamId ? stream.rootStreamId : stream.id
 

--- a/apps/backend/src/features/api-keys/service.ts
+++ b/apps/backend/src/features/api-keys/service.ts
@@ -2,7 +2,7 @@ import type { Pool } from "pg"
 import { StreamTypes } from "@threa/types"
 import { BotChannelAccessRepository } from "./repository"
 import { SearchRepository } from "../search"
-import { StreamRepository } from "../streams"
+import { StreamRepository, resolveEffectiveAccessStream } from "../streams"
 
 interface BotChannelServiceDeps {
   pool: Pool
@@ -38,11 +38,12 @@ export class BotChannelService {
     if (!stream || stream.archivedAt) return false
 
     // Publicness is the ROOT's visibility (INV-62) — a thread's own row can
-    // hold a stale copied "public" long after its root went private.
-    const accessStream = stream.rootStreamId
-      ? await StreamRepository.findByIdForWorkspace(this.pool, stream.rootStreamId, workspaceId)
-      : stream
-    if (accessStream?.visibility === "public") return true
+    // hold a stale copied "public" long after its root went private. A
+    // dangling root (INV-1, FK-less) resolves back to the thread itself:
+    // fail closed to the grant check, never the stale copied value.
+    const effective = await resolveEffectiveAccessStream(this.pool, stream)
+    const rootResolved = !stream.rootStreamId || effective.id === stream.rootStreamId
+    if (rootResolved && effective.visibility === "public") return true
 
     const grantStreamId = stream.type === StreamTypes.THREAD && stream.rootStreamId ? stream.rootStreamId : stream.id
 

--- a/apps/backend/src/features/search/repository.ts
+++ b/apps/backend/src/features/search/repository.ts
@@ -432,6 +432,11 @@ export const SearchRepository = {
   /**
    * Get public stream IDs in a workspace.
    * Used by agent access control for public_only access spec.
+   *
+   * Publicness is the ROOT's visibility (INV-62): threads copy the root's
+   * visibility at creation and are never re-synced, so a thread's own row can
+   * say "public" long after its root went private — trusting it leaked those
+   * threads into agent research and bot scopes.
    */
   async getPublicStreams(
     db: Querier,
@@ -442,11 +447,12 @@ export const SearchRepository = {
     const { includeActive, includeArchived, filterAll } = parseArchiveStatusFilter(options?.archiveStatus)
 
     const result = await db.query<{ id: string }>(sql`
-      SELECT id FROM streams
-      WHERE workspace_id = ${workspaceId}
-        AND visibility = ${Visibilities.PUBLIC}
-        AND (${!hasTypeFilter} OR type = ANY(${options?.streamTypes ?? []}))
-        AND (${filterAll} OR (${includeArchived} AND archived_at IS NOT NULL) OR (${!includeArchived} AND archived_at IS NULL))
+      SELECT s.id FROM streams s
+      JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)
+      WHERE s.workspace_id = ${workspaceId}
+        AND root.visibility = ${Visibilities.PUBLIC}
+        AND (${!hasTypeFilter} OR s.type = ANY(${options?.streamTypes ?? []}))
+        AND (${filterAll} OR (${includeArchived} AND s.archived_at IS NOT NULL) OR (${!includeArchived} AND s.archived_at IS NULL))
     `)
 
     return result.rows.map((r) => r.id)

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -211,11 +211,18 @@ export class StreamNamingService {
         displayNameGeneratedAt: new Date(),
       })
 
+      // The payload's visibility gates workspace-wide fanout in
+      // delivery-groups. A thread's own row can hold a stale copied "public"
+      // under a since-privatized root (INV-62) — resolve the effective root so
+      // a private tree's thread names never broadcast workspace-wide.
+      const namingAccessRoot = currentStream.rootStreamId
+        ? await StreamRepository.findById(client, currentStream.rootStreamId)
+        : null
       await OutboxRepository.insert(client, "stream:display_name_updated", {
         workspaceId: stream.workspaceId,
         streamId,
         displayName: cleanName,
-        visibility: currentStream.visibility,
+        visibility: namingAccessRoot?.visibility ?? currentStream.visibility,
       })
 
       logger.info({ streamId, displayName: cleanName, requireName }, "Auto-generated stream display name")

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -1,6 +1,8 @@
 import { Pool } from "pg"
+import { Visibilities } from "@threa/types"
 import { withTransaction, withClient } from "../../db"
 import { StreamRepository } from "./repository"
+import { resolveEffectiveAccessStream } from "./access"
 import { MessageRepository } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import { AttachmentRepository, type AttachmentWithExtraction } from "../attachments"
@@ -214,15 +216,19 @@ export class StreamNamingService {
       // The payload's visibility gates workspace-wide fanout in
       // delivery-groups. A thread's own row can hold a stale copied "public"
       // under a since-privatized root (INV-62) — resolve the effective root so
-      // a private tree's thread names never broadcast workspace-wide.
-      const namingAccessRoot = currentStream.rootStreamId
-        ? await StreamRepository.findById(client, currentStream.rootStreamId)
-        : null
+      // a private tree's thread names never broadcast workspace-wide. A
+      // dangling root (INV-1) resolves back to the thread itself: fail closed
+      // to stream-scoped fanout rather than trust the stale copied value.
+      const effective = await resolveEffectiveAccessStream(client, currentStream)
+      const fanoutVisibility =
+        currentStream.rootStreamId && effective.id !== currentStream.rootStreamId
+          ? Visibilities.PRIVATE
+          : effective.visibility
       await OutboxRepository.insert(client, "stream:display_name_updated", {
         workspaceId: stream.workspaceId,
         streamId,
         displayName: cleanName,
-        visibility: namingAccessRoot?.visibility ?? currentStream.visibility,
+        visibility: fanoutVisibility,
       })
 
       logger.info({ streamId, displayName: cleanName, requireName }, "Auto-generated stream display name")

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -1037,17 +1037,6 @@ export const StreamRepository = {
     return result.rows.length > 0
   },
 
-  async isPublic(db: Querier, workspaceId: string, streamId: string): Promise<boolean> {
-    const result = await db.query(sql`
-      SELECT EXISTS(
-        SELECT 1 FROM streams
-        WHERE id = ${streamId} AND workspace_id = ${workspaceId} AND archived_at IS NULL
-          AND visibility = 'public'
-      ) AS accessible
-    `)
-    return result.rows[0].accessible
-  },
-
   /**
    * Insert a system stream for a member.
    * System streams are created atomically with the member in the same transaction,

--- a/apps/backend/tests/integration/public-streams-root-visibility.test.ts
+++ b/apps/backend/tests/integration/public-streams-root-visibility.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Publicness resolves through the ROOT (INV-62).
+ *
+ * Threads copy the root's visibility at creation and are never re-synced, so a
+ * thread row can say "public" long after its root went private (and vice
+ * versa). Every "is this stream public" consumer has to resolve the root —
+ * trusting the thread's own row leaked stale-public threads into agent
+ * research scopes (`public_only` / `public_plus_stream`) and bot access.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { StreamTypes, Visibilities } from "@threa/types"
+import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { SearchRepository } from "../../src/features/search"
+import { BotChannelService } from "../../src/features/api-keys"
+import { userId, workspaceId, streamId, messageId, botId } from "../../src/lib/id"
+
+describe("public checks resolve the root's visibility", () => {
+  let pool: Pool
+  let testWorkspaceId: string
+  let testUserId: string
+  let privatizedRoot: string
+  let stalePublicThread: string
+  let publicizedRoot: string
+  let stalePrivateThread: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testWorkspaceId = workspaceId()
+    testUserId = userId()
+    privatizedRoot = streamId()
+    stalePublicThread = streamId()
+    publicizedRoot = streamId()
+    stalePrivateThread = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Root Visibility",
+        slug: `root-vis-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+
+      for (const [rootId, threadId, rootVisibility, threadVisibility] of [
+        // Born public, thread copied "public", root privatized below.
+        [privatizedRoot, stalePublicThread, Visibilities.PUBLIC, Visibilities.PUBLIC],
+        // Born private, thread copied "private", root made public below.
+        [publicizedRoot, stalePrivateThread, Visibilities.PRIVATE, Visibilities.PRIVATE],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id: rootId,
+          workspaceId: testWorkspaceId,
+          type: StreamTypes.CHANNEL,
+          visibility: rootVisibility,
+          slug: `s-${rootId.slice(-8)}`,
+          createdBy: testUserId,
+        })
+        await StreamRepository.insert(client, {
+          id: threadId,
+          workspaceId: testWorkspaceId,
+          type: StreamTypes.THREAD,
+          visibility: threadVisibility,
+          parentStreamId: rootId,
+          parentAnchorId: messageId(),
+          rootStreamId: rootId,
+          createdBy: testUserId,
+        })
+      }
+    })
+
+    // The stale-copy premise: only the ROOT's row changes on a visibility
+    // flip; the thread keeps whatever it copied at creation.
+    await pool.query(`UPDATE streams SET visibility = 'private' WHERE id = $1`, [privatizedRoot])
+    await pool.query(`UPDATE streams SET visibility = 'public' WHERE id = $1`, [publicizedRoot])
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("getPublicStreams drops a stale-public thread under a privatized root and picks up a stale-private thread under a publicized root", async () => {
+    const publicIds = await SearchRepository.getPublicStreams(pool, testWorkspaceId)
+    expect(publicIds).not.toContain(stalePublicThread)
+    expect(publicIds).not.toContain(privatizedRoot)
+    expect(publicIds).toContain(publicizedRoot)
+    expect(publicIds).toContain(stalePrivateThread)
+  })
+
+  test("bot access to a thread follows the root, not the thread's copied visibility", async () => {
+    const service = new BotChannelService({ pool })
+    const strangerBot = botId()
+    expect(await service.isStreamAccessibleForBot(testWorkspaceId, strangerBot, stalePublicThread)).toBe(false)
+    expect(await service.isStreamAccessibleForBot(testWorkspaceId, strangerBot, stalePrivateThread)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

Threads copy the root's visibility at creation and are never re-synced — `messaging/sharing/access-check.ts` documents the hazard and resolves through the root, but three consumers still trusted the thread's own row. A thread born under a public channel keeps `visibility = 'public'` after the channel is privatized, so `getPublicStreams` kept feeding it to agent research scopes (`public_only`, `public_plus_stream`) and bot access lists, `isStreamAccessibleForBot` granted bot reads on it point-blank, and the auto-naming `stream:display_name_updated` event used it to broadcast the thread's generated name workspace-wide. Surfaced by the Fable/Sol adversarial review of the memo-card stack (Stack #1701), which had to route around it in `findEmbedSummaries`.

## Solution

Publicness is the ROOT's visibility, everywhere.

- `SearchRepository.getPublicStreams` joins to the effective root (`COALESCE(s.root_stream_id, s.id)`) and filters on `root.visibility`. This also fixes the inverse miss: a stale-`private` thread under a since-publicized root is now included.
- `BotChannelService.isStreamAccessibleForBot` resolves the root before the public check — same shape as the scheduled/saved-messages access checks; the grant path already mapped thread → root.
- `naming-service` resolves the effective root's visibility into the rename payload, since `delivery-groups` gates workspace-wide fanout on it. Threads ARE auto-named (`needsAutoNaming`), so this path was reachable.
- `StreamRepository.isPublic` had zero callers — deleted (INV-38) rather than fixed.

Not touched: the visibility-change endpoint still updates only the root's row — that stale-copy behavior is the documented model (INV-62 says resolve, not re-sync), and every known consumer now resolves.

## Test plan

- [x] `public-streams-root-visibility.test.ts` (**new**, integration, real schema per INV-68): a stale-public thread under a privatized root is dropped from `getPublicStreams` and denied to a grant-less bot; a stale-private thread under a publicized root is included and allowed.
- [x] **Mutation-checked:** reverting either fix to own-row visibility reddens exactly its test.
- [x] Backend unit **3855** · integration **799** · typecheck 0.
- [ ] The naming-service payload change has no automated test — the naming path needs the LLM harness; the predicate is identical to the two tested sites.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788121853&installation_model_id=20758&pr_number=1703&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1703&signature=b5450cbac330330386a0ed674f8c40ab5015fc676ca595ce4a77eae1d0128f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->