### PR TITLE
fix(markdown): render a fence with no language as a code block

### DIFF
--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -306,6 +306,13 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
   )
 }
 
+/** A fence's text, flattened: remark may hand back a string, or an array of strings. */
+function codeText(children: ReactNode): string {
+  return Children.toArray(children)
+    .map((child) => (typeof child === "string" || typeof child === "number" ? String(child) : ""))
+    .join("")
+}
+
 export const markdownComponents: Components = {
   // Headers - scaled for message context, process @mentions, #channels, and :emoji:
   h1: ({ children }) => (
@@ -366,21 +373,24 @@ export const markdownComponents: Components = {
   // [&_span] ensures inline-flex elements like TriggerChips inherit underline decoration
   a: ({ href, children }) => <MarkdownLink href={href}>{children}</MarkdownLink>,
 
-  // Code - inline and blocks
-  code: ({ className, children }) => {
-    const isCodeBlock = className?.includes("language-")
+  // Inline only. Blocks are detected in `pre`, never here: remark sets
+  // `language-*` on the inner <code> only when the fence declared one, so a bare
+  // ``` fence reaches this branch and loses `white-space: pre`.
+  //
+  // break-all so long identifiers, paths, or tokens inside backticks wrap inside
+  // the message column instead of overflowing.
+  code: ({ children }) => (
+    <code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono break-all">{children}</code>
+  ),
 
-    if (isCodeBlock) {
-      const language = className?.replace("language-", "") || "text"
-      return <CodeBlock language={language}>{String(children)}</CodeBlock>
-    }
-
-    // Inline code — break-all so long identifiers, paths, or tokens inside
-    // backticks wrap inside the message column instead of overflowing.
-    return <code className="bg-muted px-1.5 py-0.5 rounded text-sm font-mono break-all">{children}</code>
+  pre: ({ children }) => {
+    const inner = Children.toArray(children).find(isValidElement) as
+      | { props?: { className?: string; children?: ReactNode } }
+      | undefined
+    const className = inner?.props?.className ?? ""
+    const language = /language-([\w-]+)/.exec(className)?.[1] ?? "text"
+    return <CodeBlock language={language}>{codeText(inner?.props?.children)}</CodeBlock>
   },
-
-  pre: ({ children }) => <>{children}</>,
 
   strong: ({ children }) => (
     <strong className="font-semibold">

--- a/apps/frontend/src/lib/markdown/fence-render.test.tsx
+++ b/apps/frontend/src/lib/markdown/fence-render.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest"
+import { render } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+
+const PANE = "▐▛███▜▌   Claude Code v2.1.220\n▝▜█████▛▘  Opus 5\n  ▘▘ ▝▝    ~/dev/personal/threa"
+
+function renderMarkdown(markdown: string) {
+  return render(
+    <MemoryRouter>
+      <MarkdownContent content={markdown} />
+    </MemoryRouter>
+  ).container
+}
+
+describe("fenced code blocks", () => {
+  it("renders a bare fence as a block, not as inline code", () => {
+    // remark only sets `language-*` when the fence carries an info string, so a
+    // bare ``` fence used to reach the inline-code branch: monospace, no
+    // `white-space: pre`, and the newlines collapsed. `/status` posts its tmux
+    // pane capture through exactly this path.
+    const container = renderMarkdown(`**Current pane**\n\n\`\`\`\n${PANE}\n\`\`\`\n`)
+
+    expect(container.querySelectorAll("pre")).toHaveLength(1)
+    expect(container.querySelector("pre")?.textContent).toContain("Claude Code v2.1.220")
+    expect(container.querySelector("code")?.className).not.toContain("break-all")
+  })
+
+  it("keeps the language when the fence declares one", () => {
+    const container = renderMarkdown("```ts\nconst a = 1\n```\n")
+
+    expect(container.querySelectorAll("pre")).toHaveLength(1)
+    expect(container.textContent).toContain("const a = 1")
+  })
+
+  it("still renders single-backtick spans as inline code", () => {
+    const container = renderMarkdown("a `token` here")
+
+    expect(container.querySelectorAll("pre")).toHaveLength(0)
+    expect(container.querySelector("code")?.className).toContain("break-all")
+  })
+
+  it("preserves every line of a captured pane", () => {
+    const container = renderMarkdown(`\`\`\`\n${PANE}\n\`\`\`\n`)
+
+    for (const line of PANE.split("\n")) {
+      expect(container.querySelector("pre")?.textContent).toContain(line.trim())
+    }
+  })
+})


### PR DESCRIPTION
## Problem

A fenced code block whose fence declares **no language** rendered as *inline* code — monospace, `break-all`, and no `white-space: pre`. The newlines were in the DOM the whole time; the browser collapsed them. So `/status`'s tmux pane capture arrived as one reflowed, wrapped blob instead of a pane.


`markdownComponents.code` decided "is this a block?" with `className?.includes("language-")` on the inner `<code>`. remark sets that class **only when the fence carried an info string**, so a bare ` ``` ` fence had no className and fell to the inline branch — while `pre` was unwrapped to a fragment, so nothing restored the whitespace either.

Reported as "why is it fine as a snippet but not as a message?" — the answer is that the two use different renderers, not that the content differs. I checked both halves before touching anything:

- `parseMarkdown` on the real message: proper `codeBlock`, 57 lines, newlines intact.
- `parseMarkdown` → `serializeToMarkdown` round-trip: **byte-identical**.

So the markdown and the `contentJson` were always right; only this component was wrong. The snippet looked correct because the attachment viewer renders text directly.

## Solution

`pre` fires for every fence, labelled or not — so the block renders there and `code` becomes inline-only. The language still comes off the inner `<code>`'s class when the fence declared one.

This is not specific to `/status`: every bare fence in the product was affected, including ones typed by hand.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/markdown/components.tsx` | block rendering moves `code` → `pre`; `codeText` flattens the fence children |
| `apps/frontend/src/lib/markdown/fence-render.test.tsx` | **new** — 4 tests |

## Test plan

- [x] `vitest run src/lib/markdown src/components/ui/markdown-content.test.tsx` — 192 pass / 0 fail across 15 files
- [x] Verified the new tests can fail: with the old `code`/`pre` restored, 2 of the 4 go red (`renders a bare fence as a block`, `preserves every line of a captured pane`)
- [x] `bun run typecheck` clean; full pre-commit monorepo gates pass
- [ ] Not checked on a real device — the repro was a mobile screenshot, and the fix is renderer-level rather than viewport-dependent

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
