### PR TITLE
fix(sync): re-resolve access-gated snapshot content at catch-up serve

### DIFF
--- a/apps/backend/src/features/memos/embed-summaries.ts
+++ b/apps/backend/src/features/memos/embed-summaries.ts
@@ -35,15 +35,53 @@ export async function resolveMemoEmbedSummaries(
 }
 
 /**
+ * Resolve summaries for memo ids grouped by the STREAM citing them, for
+ * callers that span streams (the board/label batch below, the sync-log
+ * sanitizer). Roots are looked up once for the distinct streams, and memos
+ * once per distinct root (INV-56). Per-root grouping is not an optimisation:
+ * the predicate is "readable by everyone who can see the citing stream", so a
+ * memo id that qualifies under one root may not under another and must be
+ * asked separately. A stream whose row is missing resolves against its own id
+ * — fail closed, only the public leg of the predicate can match.
+ *
+ * Returns one map per input stream id (possibly empty), keyed memoId → summary.
+ */
+export async function resolveMemoSummariesByStream(
+  db: Querier,
+  workspaceId: string,
+  memoIdsByStreamId: Map<string, Iterable<string>>
+): Promise<Map<string, Map<string, MemoEmbedSummary>>> {
+  const result = new Map<string, Map<string, MemoEmbedSummary>>()
+  if (memoIdsByStreamId.size === 0) return result
+
+  const streamIds = [...memoIdsByStreamId.keys()]
+  const streams = await StreamRepository.findByIds(db, streamIds)
+  const rootByStreamId = new Map(streams.map((s) => [s.id, s.rootStreamId ?? s.id]))
+
+  const idsByRoot = new Map<string, Set<string>>()
+  for (const [streamId, ids] of memoIdsByStreamId) {
+    const root = rootByStreamId.get(streamId) ?? streamId
+    const bucket = idsByRoot.get(root) ?? new Set<string>()
+    for (const id of ids) bucket.add(id)
+    idsByRoot.set(root, bucket)
+  }
+
+  const summariesByRoot = new Map<string, Map<string, MemoEmbedSummary>>()
+  for (const [root, ids] of idsByRoot) {
+    summariesByRoot.set(root, await MemoRepository.findEmbedSummaries(db, workspaceId, [...ids], root))
+  }
+
+  for (const streamId of streamIds) {
+    const root = rootByStreamId.get(streamId) ?? streamId
+    result.set(streamId, summariesByRoot.get(root) ?? new Map())
+  }
+  return result
+}
+
+/**
  * The same resolution for a batch of messages that may span streams — the board
  * feed and the label view, which hydrate many messages at once and whose rows
  * are not all from one root.
- *
- * Roots are looked up once for the distinct streams, and memos once per distinct
- * root (INV-56) — normally a single query each, since a board card's messages
- * share a root. Per-root grouping is not an optimisation: the predicate is
- * "readable by everyone who can see the citing stream", so a memo id that
- * qualifies under one root may not under another and must be asked separately.
  */
 export async function resolveMemoEmbedSummariesForMessages(
   db: Querier,
@@ -58,30 +96,20 @@ export async function resolveMemoEmbedSummariesForMessages(
   const result = new Map<string, MemoEmbedSummary[]>()
   if (byMessage.size === 0) return result
 
-  const citingStreamIds = [...new Set(messages.filter((m) => byMessage.has(m.id)).map((m) => m.streamId))]
-  const streams = await StreamRepository.findByIds(db, citingStreamIds)
-  const rootByStreamId = new Map(streams.map((s) => [s.id, s.rootStreamId ?? s.id]))
-
-  const idsByRoot = new Map<string, Set<string>>()
+  const memoIdsByStreamId = new Map<string, Set<string>>()
   for (const message of messages) {
     const ids = byMessage.get(message.id)
     if (!ids) continue
-    const root = rootByStreamId.get(message.streamId) ?? message.streamId
-    const bucket = idsByRoot.get(root) ?? new Set<string>()
+    const bucket = memoIdsByStreamId.get(message.streamId) ?? new Set<string>()
     for (const id of ids) bucket.add(id)
-    idsByRoot.set(root, bucket)
+    memoIdsByStreamId.set(message.streamId, bucket)
   }
-
-  const summariesByRoot = new Map<string, Map<string, MemoEmbedSummary>>()
-  for (const [root, ids] of idsByRoot) {
-    summariesByRoot.set(root, await MemoRepository.findEmbedSummaries(db, workspaceId, [...ids], root))
-  }
+  const summariesByStream = await resolveMemoSummariesByStream(db, workspaceId, memoIdsByStreamId)
 
   for (const message of messages) {
     const ids = byMessage.get(message.id)
     if (!ids) continue
-    const root = rootByStreamId.get(message.streamId) ?? message.streamId
-    const summaries = summariesByRoot.get(root)
+    const summaries = summariesByStream.get(message.streamId)
     if (!summaries) continue
     const resolved = ids.map((id) => summaries.get(id)).filter((s): s is MemoEmbedSummary => s !== undefined)
     if (resolved.length > 0) result.set(message.id, resolved)

--- a/apps/backend/src/features/memos/index.ts
+++ b/apps/backend/src/features/memos/index.ts
@@ -1,5 +1,9 @@
 export { MemoRepository } from "./repository"
-export { resolveMemoEmbedSummaries, resolveMemoEmbedSummariesForMessages } from "./embed-summaries"
+export {
+  resolveMemoEmbedSummaries,
+  resolveMemoEmbedSummariesForMessages,
+  resolveMemoSummariesByStream,
+} from "./embed-summaries"
 export type {
   Memo,
   InsertMemoParams,

--- a/apps/backend/src/features/sync/index.ts
+++ b/apps/backend/src/features/sync/index.ts
@@ -1,5 +1,6 @@
 export { SyncLogRepository, type SyncLogEntryInput, type SyncLogEntry } from "./repository"
 export { SyncService, type CatchUpResult } from "./service"
+export { sanitizeSyncEntries } from "./sanitize"
 export { createSyncHandlers } from "./handlers"
 export { SyncLogReconciliationWorker, type SyncLogReconciliationWorkerConfig } from "./reconciliation-worker"
 export { SyncHeartbeatWorker, type SyncHeartbeatWorkerConfig } from "./heartbeat-worker"

--- a/apps/backend/src/features/sync/sanitize.ts
+++ b/apps/backend/src/features/sync/sanitize.ts
@@ -1,8 +1,7 @@
 import type { Querier } from "../../db"
 import type { MemoEmbedSummary } from "@threa/types"
 import { hydrateSharedMessageIds, type HydratedSharedMessage } from "../messaging"
-import { MemoRepository } from "../memos"
-import { StreamRepository } from "../streams"
+import { resolveMemoSummariesByStream } from "../memos"
 import type { SyncLogEntry } from "./repository"
 
 /**
@@ -49,7 +48,11 @@ export async function sanitizeSyncEntries(
   }
   const collectMemoEmbeds = (holder: Record<string, unknown> | undefined, streamId: unknown) => {
     if (!holder || typeof streamId !== "string") return
-    if (Array.isArray((holder as MemoEmbedHolder).memoEmbeds)) {
+    // Empty arrays carry nothing to leak or refresh — skipping them keeps a
+    // page of plain edits (whose payloads always carry `memoEmbeds: []`) on
+    // the zero-query path.
+    const embeds = (holder as MemoEmbedHolder).memoEmbeds
+    if (Array.isArray(embeds) && embeds.length > 0) {
       memoSites.push({ holder: holder as MemoEmbedHolder, streamId })
     }
   }
@@ -94,46 +97,33 @@ export async function sanitizeSyncEntries(
     }
   }
 
-  // Memo summaries: resolve each citing stream to its root, then one
-  // predicate query per distinct root for the union of cited ids.
-  const citingStreamIds = [
-    ...new Set([...memoSites.map((s) => s.streamId), ...memoUpdatedEntries.map((s) => s.streamId)]),
-  ]
+  // Memo summaries: the shared per-citing-stream resolver (INV-35) groups by
+  // root and runs one predicate query per distinct root.
   const dropped = new Set<SyncLogEntry>()
-  if (citingStreamIds.length > 0) {
-    const streams = await StreamRepository.findByIds(db, citingStreamIds)
-    const rootByStream = new Map(citingStreamIds.map((id) => [id, id]))
-    for (const stream of streams) rootByStream.set(stream.id, stream.rootStreamId ?? stream.id)
+  const memoIdsByStreamId = new Map<string, Set<string>>()
+  const addMemoIds = (streamId: string, ids: string[]) => {
+    const set = memoIdsByStreamId.get(streamId) ?? new Set<string>()
+    for (const id of ids) set.add(id)
+    memoIdsByStreamId.set(streamId, set)
+  }
+  for (const site of memoSites)
+    addMemoIds(
+      site.streamId,
+      (site.holder.memoEmbeds ?? []).map((s) => s.memoId)
+    )
+  for (const site of memoUpdatedEntries) addMemoIds(site.streamId, [site.memoId])
 
-    const memoIdsByRoot = new Map<string, Set<string>>()
-    const addMemoIds = (streamId: string, ids: string[]) => {
-      const root = rootByStream.get(streamId) ?? streamId
-      let set = memoIdsByRoot.get(root)
-      if (!set) memoIdsByRoot.set(root, (set = new Set()))
-      for (const id of ids) set.add(id)
-    }
-    for (const site of memoSites)
-      addMemoIds(
-        site.streamId,
-        (site.holder.memoEmbeds ?? []).map((s) => s.memoId)
-      )
-    for (const site of memoUpdatedEntries) addMemoIds(site.streamId, [site.memoId])
-
-    const summariesByRoot = new Map<string, Map<string, MemoEmbedSummary>>()
-    for (const [root, ids] of memoIdsByRoot) {
-      summariesByRoot.set(root, await MemoRepository.findEmbedSummaries(db, workspaceId, [...ids], root))
-    }
+  if (memoIdsByStreamId.size > 0) {
+    const summariesByStream = await resolveMemoSummariesByStream(db, workspaceId, memoIdsByStreamId)
 
     for (const site of memoSites) {
-      const root = rootByStream.get(site.streamId) ?? site.streamId
-      const summaries = summariesByRoot.get(root)
+      const summaries = summariesByStream.get(site.streamId)
       site.holder.memoEmbeds = (site.holder.memoEmbeds ?? [])
         .map((s) => summaries?.get(s.memoId))
         .filter((s): s is MemoEmbedSummary => s !== undefined)
     }
     for (const site of memoUpdatedEntries) {
-      const root = rootByStream.get(site.streamId) ?? site.streamId
-      const fresh = summariesByRoot.get(root)?.get(site.memoId)
+      const fresh = summariesByStream.get(site.streamId)?.get(site.memoId)
       if (!fresh) {
         dropped.add(site.entry)
       } else {

--- a/apps/backend/src/features/sync/sanitize.ts
+++ b/apps/backend/src/features/sync/sanitize.ts
@@ -1,0 +1,146 @@
+import type { Querier } from "../../db"
+import type { MemoEmbedSummary } from "@threa/types"
+import { hydrateSharedMessageIds, type HydratedSharedMessage } from "../messaging"
+import { MemoRepository } from "../memos"
+import { StreamRepository } from "../streams"
+import type { SyncLogEntry } from "./repository"
+
+/**
+ * Re-resolve access-gated snapshot content in sync-log entries at SERVE time.
+ *
+ * Sync-log payloads are copied verbatim from the outbox and replayed for up to
+ * the retention window. The hydrated shared-message slots and memo-embed
+ * summaries inside them are snapshots of a PAST access decision — replaying
+ * one after its source went private is a fresh delivery of withheld content,
+ * not tolerable staleness (bootstrap already re-resolves; this closes the
+ * catch-up path). Entries with none of that content pass through untouched
+ * with zero extra queries.
+ *
+ * Slots re-hydrate per VIEWER (`hydrateSharedMessageIds`) — catch-up is a
+ * per-user read, and the viewer-scoped resolver is the sharing feature's own
+ * read-path authority. Memo summaries re-resolve per citing ROOT
+ * (`findEmbedSummaries`) — cards are room-gated, not viewer-gated. A
+ * `memo:updated` entry whose summary the room may no longer see is dropped
+ * whole.
+ */
+export async function sanitizeSyncEntries(
+  db: Querier,
+  params: { workspaceId: string; userId: string; entries: SyncLogEntry[] }
+): Promise<SyncLogEntry[]> {
+  const { workspaceId, userId, entries } = params
+
+  type SlotMapHolder = Record<string, unknown> & { slots?: Record<string, HydratedSharedMessage> }
+  type MemoEmbedHolder = Record<string, unknown> & { memoEmbeds?: MemoEmbedSummary[] }
+
+  const slotHolders: SlotMapHolder[] = []
+  const shareIds = new Set<string>()
+  const memoSites: Array<{ holder: MemoEmbedHolder; streamId: string }> = []
+  const memoUpdatedEntries: Array<{ entry: SyncLogEntry; streamId: string; memoId: string }> = []
+
+  const collectSlotMaps = (holder: Record<string, unknown>) => {
+    for (const key of ["slots", "sharedMessages"] as const) {
+      const map = holder[key] as Record<string, HydratedSharedMessage> | undefined
+      if (!map) continue
+      for (const slot of Object.values(map)) {
+        if (slot && typeof slot.messageId === "string") shareIds.add(slot.messageId)
+      }
+      if (Object.keys(map).length > 0) slotHolders.push(holder as SlotMapHolder)
+    }
+  }
+  const collectMemoEmbeds = (holder: Record<string, unknown> | undefined, streamId: unknown) => {
+    if (!holder || typeof streamId !== "string") return
+    if (Array.isArray((holder as MemoEmbedHolder).memoEmbeds)) {
+      memoSites.push({ holder: holder as MemoEmbedHolder, streamId })
+    }
+  }
+
+  for (const entry of entries) {
+    const p = entry.payload as Record<string, unknown>
+    if (!p || typeof p !== "object") continue
+    collectSlotMaps(p)
+    const wrappedEvent = p.event as { payload?: Record<string, unknown> } | undefined
+    collectMemoEmbeds(wrappedEvent?.payload, p.streamId)
+    if (entry.eventType === "messages:moved" && Array.isArray(p.events)) {
+      for (const moved of p.events as Array<{ eventType?: string; payload?: Record<string, unknown> }>) {
+        collectMemoEmbeds(moved?.payload, p.destinationStreamId)
+      }
+    }
+    if (entry.eventType === "memo:updated") {
+      const summary = p.summary as MemoEmbedSummary | undefined
+      if (summary && typeof p.streamId === "string") {
+        memoUpdatedEntries.push({ entry, streamId: p.streamId, memoId: summary.memoId })
+      }
+    }
+  }
+
+  if (slotHolders.length === 0 && memoSites.length === 0 && memoUpdatedEntries.length === 0) {
+    return entries
+  }
+
+  // Slots: one viewer-scoped hydration for the union of source ids; every
+  // stored map entry is REPLACED — a source the viewer may no longer read
+  // comes back as its `private` variant, exactly as a live delivery would.
+  if (shareIds.size > 0) {
+    const rehydrated = await hydrateSharedMessageIds(db, workspaceId, userId, shareIds)
+    for (const holder of slotHolders) {
+      for (const key of ["slots", "sharedMessages"] as const) {
+        const map = holder[key] as Record<string, HydratedSharedMessage> | undefined
+        if (!map) continue
+        for (const [slotKey, slot] of Object.entries(map)) {
+          const fresh = slot && typeof slot.messageId === "string" ? rehydrated[slot.messageId] : undefined
+          if (fresh) map[slotKey] = fresh
+        }
+      }
+    }
+  }
+
+  // Memo summaries: resolve each citing stream to its root, then one
+  // predicate query per distinct root for the union of cited ids.
+  const citingStreamIds = [
+    ...new Set([...memoSites.map((s) => s.streamId), ...memoUpdatedEntries.map((s) => s.streamId)]),
+  ]
+  const dropped = new Set<SyncLogEntry>()
+  if (citingStreamIds.length > 0) {
+    const streams = await StreamRepository.findByIds(db, citingStreamIds)
+    const rootByStream = new Map(citingStreamIds.map((id) => [id, id]))
+    for (const stream of streams) rootByStream.set(stream.id, stream.rootStreamId ?? stream.id)
+
+    const memoIdsByRoot = new Map<string, Set<string>>()
+    const addMemoIds = (streamId: string, ids: string[]) => {
+      const root = rootByStream.get(streamId) ?? streamId
+      let set = memoIdsByRoot.get(root)
+      if (!set) memoIdsByRoot.set(root, (set = new Set()))
+      for (const id of ids) set.add(id)
+    }
+    for (const site of memoSites)
+      addMemoIds(
+        site.streamId,
+        (site.holder.memoEmbeds ?? []).map((s) => s.memoId)
+      )
+    for (const site of memoUpdatedEntries) addMemoIds(site.streamId, [site.memoId])
+
+    const summariesByRoot = new Map<string, Map<string, MemoEmbedSummary>>()
+    for (const [root, ids] of memoIdsByRoot) {
+      summariesByRoot.set(root, await MemoRepository.findEmbedSummaries(db, workspaceId, [...ids], root))
+    }
+
+    for (const site of memoSites) {
+      const root = rootByStream.get(site.streamId) ?? site.streamId
+      const summaries = summariesByRoot.get(root)
+      site.holder.memoEmbeds = (site.holder.memoEmbeds ?? [])
+        .map((s) => summaries?.get(s.memoId))
+        .filter((s): s is MemoEmbedSummary => s !== undefined)
+    }
+    for (const site of memoUpdatedEntries) {
+      const root = rootByStream.get(site.streamId) ?? site.streamId
+      const fresh = summariesByRoot.get(root)?.get(site.memoId)
+      if (!fresh) {
+        dropped.add(site.entry)
+      } else {
+        ;(site.entry.payload as Record<string, unknown>).summary = fresh
+      }
+    }
+  }
+
+  return dropped.size > 0 ? entries.filter((e) => !dropped.has(e)) : entries
+}

--- a/apps/backend/src/features/sync/service.ts
+++ b/apps/backend/src/features/sync/service.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg"
 import { withClient } from "../../db"
 import { SyncLogRepository, type SyncLogEntry } from "./repository"
+import { sanitizeSyncEntries } from "./sanitize"
 
 export interface CatchUpResult {
   entries: SyncLogEntry[]
@@ -50,7 +51,18 @@ export class SyncService {
       if (params.after < retainedFrom) {
         return { entries: [], head, requiresBootstrap: true }
       }
-      return { entries, head }
+      // Stored payloads snapshot access-gated content (hydrated share slots,
+      // memo summaries) at write time; replaying them verbatim within the
+      // retention window would freshly deliver content the viewer or room may
+      // no longer see. Re-resolved here, at serve time.
+      return {
+        entries: await sanitizeSyncEntries(client, {
+          workspaceId: params.workspaceId,
+          userId: params.userId,
+          entries,
+        }),
+        head,
+      }
     })
   }
 }

--- a/apps/backend/tests/integration/sync-log-sanitize.test.ts
+++ b/apps/backend/tests/integration/sync-log-sanitize.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Sync-log entries are sanitized at SERVE time.
+ *
+ * Stored payloads snapshot access-gated content (hydrated share slots, memo
+ * summaries) at write time and replay for up to the retention window —
+ * without re-resolution, a viewer catching up after a source went private
+ * receives content every live path now withholds.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { StreamTypes, Visibilities, sharedMessageSlotKey } from "@threa/types"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { MemoRepository } from "../../src/features/memos"
+import { sanitizeSyncEntries, type SyncLogEntry } from "../../src/features/sync"
+import { userId, workspaceId, streamId, messageId, memoId } from "../../src/lib/id"
+
+describe("sanitizeSyncEntries", () => {
+  let pool: Pool
+  let testWorkspaceId: string
+  let viewer: string
+  let citingChannel: string
+  let privatizedSource: string
+  let privateMemo: string
+  let readableMemo: string
+  let privateSharedMsg: string
+  let readableSharedMsg: string
+  let sequence = 1n
+
+  function entry(eventType: string, payload: unknown): SyncLogEntry {
+    return { syncId: sequence++, eventType, payload, createdAt: new Date() } as SyncLogEntry
+  }
+
+  const summaryOf = (memo: string, title: string) => ({
+    memoId: memo,
+    title,
+    knowledgeType: "decision",
+    memoType: "message",
+    tags: [] as string[],
+    updatedAt: new Date().toISOString(),
+  })
+
+  const staleOkSlot = (msgId: string) => ({
+    type: "sharedMessage" as const,
+    state: "ok" as const,
+    messageId: msgId,
+    streamId: "stream_stale",
+    authorId: viewer,
+    authorType: "user",
+    authorName: "Stale",
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "stale snapshot",
+    editedAt: null,
+    createdAt: new Date(),
+    attachments: [],
+  })
+
+  async function seedMemo(sourceStreamId: string, title: string): Promise<string> {
+    const id = memoId()
+    const msgId = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id: msgId,
+        streamId: sourceStreamId,
+        sequence: sequence++,
+        authorId: viewer,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+      await MemoRepository.insert(client, {
+        id,
+        workspaceId: testWorkspaceId,
+        memoType: "message",
+        sourceMessageId: msgId,
+        title,
+        abstract: "abstract",
+        keyPoints: [],
+        sourceMessageIds: [msgId],
+        participantIds: [viewer],
+        knowledgeType: "decision",
+        tags: [],
+        status: "active",
+      })
+    })
+    return id
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testWorkspaceId = workspaceId()
+    viewer = userId()
+    citingChannel = streamId()
+    privatizedSource = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Sync Sanitize",
+        slug: `sync-sanitize-${testWorkspaceId}`,
+        createdBy: viewer,
+      })
+      viewer = (await addTestMember(client, testWorkspaceId, viewer)).id
+      for (const [id, visibility] of [
+        [citingChannel, "private"],
+        [privatizedSource, "public"],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: testWorkspaceId,
+          type: StreamTypes.CHANNEL,
+          visibility: visibility as (typeof Visibilities)[keyof typeof Visibilities],
+          slug: `s-${id.slice(-8)}`,
+          createdBy: viewer,
+        })
+      }
+      await StreamMemberRepository.insert(client, citingChannel, viewer)
+    })
+
+    privateMemo = await seedMemo(privatizedSource, "Was public when logged")
+    readableMemo = await seedMemo(citingChannel, "Cited in its own room")
+
+    // Shared-message sources: one in the room the viewer belongs to, one in
+    // the stream about to go private.
+    privateSharedMsg = messageId()
+    readableSharedMsg = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id: privateSharedMsg,
+        streamId: privatizedSource,
+        sequence: sequence++,
+        authorId: viewer,
+        authorType: "user",
+        ...testMessageContent("shared while public"),
+      })
+      await MessageRepository.insert(client, {
+        id: readableSharedMsg,
+        streamId: citingChannel,
+        sequence: sequence++,
+        authorId: viewer,
+        authorType: "user",
+        ...testMessageContent("current source content"),
+      })
+    })
+
+    await pool.query(`UPDATE streams SET visibility = 'private' WHERE id = $1`, [privatizedSource])
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("drops a memo:updated entry whose room may no longer see the memo", async () => {
+    const withheld = entry("memo:updated", {
+      workspaceId: testWorkspaceId,
+      streamId: citingChannel,
+      memoId: privateMemo,
+      summary: summaryOf(privateMemo, "Was public when logged"),
+    })
+    const kept = entry("memo:updated", {
+      workspaceId: testWorkspaceId,
+      streamId: citingChannel,
+      memoId: readableMemo,
+      summary: summaryOf(readableMemo, "A title the log froze"),
+    })
+
+    const out = await sanitizeSyncEntries(pool, {
+      workspaceId: testWorkspaceId,
+      userId: viewer,
+      entries: [withheld, kept],
+    })
+
+    expect(out).toHaveLength(1)
+    const payload = out[0].payload as { summary: { memoId: string; title: string } }
+    expect(payload.summary.memoId).toBe(readableMemo)
+    // Re-resolved, not replayed: the serve returns the memo's CURRENT title.
+    expect(payload.summary.title).toBe("Cited in its own room")
+  })
+
+  test("empties stale memoEmbeds inside a replayed message_created payload", async () => {
+    const e = entry("message:created", {
+      workspaceId: testWorkspaceId,
+      streamId: citingChannel,
+      event: {
+        id: "evt_1",
+        eventType: "message_created",
+        payload: { messageId: messageId(), memoEmbeds: [summaryOf(privateMemo, "Was public when logged")] },
+      },
+    })
+
+    const out = await sanitizeSyncEntries(pool, { workspaceId: testWorkspaceId, userId: viewer, entries: [e] })
+
+    const eventPayload = (out[0].payload as { event: { payload: { memoEmbeds: unknown[] } } }).event.payload
+    expect(eventPayload.memoEmbeds).toEqual([])
+  })
+
+  test("re-hydrates slots per viewer: withheld sources turn private, readable ones refresh", async () => {
+    const e = entry("message:created", {
+      workspaceId: testWorkspaceId,
+      streamId: citingChannel,
+      event: { id: "evt_2", eventType: "message_created", payload: { messageId: messageId() } },
+      slots: {
+        [sharedMessageSlotKey(privateSharedMsg)]: staleOkSlot(privateSharedMsg),
+        [sharedMessageSlotKey(readableSharedMsg)]: staleOkSlot(readableSharedMsg),
+      },
+    })
+
+    const out = await sanitizeSyncEntries(pool, { workspaceId: testWorkspaceId, userId: viewer, entries: [e] })
+
+    const slots = (out[0].payload as { slots: Record<string, { state: string; contentMarkdown?: string }> }).slots
+    expect(slots[sharedMessageSlotKey(privateSharedMsg)].state).toBe("private")
+    expect(slots[sharedMessageSlotKey(readableSharedMsg)]).toMatchObject({
+      state: "ok",
+      contentMarkdown: "current source content",
+    })
+  })
+
+  test("entries with no gated content pass through untouched, same array", async () => {
+    const entries = [entry("stream:read_state_updated", { workspaceId: testWorkspaceId, streamId: citingChannel })]
+    const out = await sanitizeSyncEntries(pool, { workspaceId: testWorkspaceId, userId: viewer, entries })
+    expect(out).toBe(entries)
+  })
+})

--- a/apps/backend/tests/integration/sync-log-sanitize.test.ts
+++ b/apps/backend/tests/integration/sync-log-sanitize.test.ts
@@ -218,7 +218,21 @@ describe("sanitizeSyncEntries", () => {
   })
 
   test("entries with no gated content pass through untouched, same array", async () => {
-    const entries = [entry("stream:read_state_updated", { workspaceId: testWorkspaceId, streamId: citingChannel })]
+    // Includes a plain edit: edited payloads ALWAYS carry memoEmbeds (empty
+    // included), and an empty array must not knock the page off the
+    // zero-query identity path.
+    const entries = [
+      entry("stream:read_state_updated", { workspaceId: testWorkspaceId, streamId: citingChannel }),
+      entry("message:edited", {
+        workspaceId: testWorkspaceId,
+        streamId: citingChannel,
+        event: {
+          id: "evt_plain_edit",
+          eventType: "message_edited",
+          payload: { messageId: messageId(), memoEmbeds: [] },
+        },
+      }),
+    ]
     const out = await sanitizeSyncEntries(pool, { workspaceId: testWorkspaceId, userId: viewer, entries })
     expect(out).toBe(entries)
   })


### PR DESCRIPTION
## Problem

`sync_log` copies outbox payloads verbatim and replays them on catch-up for up to the retention window (~30 days), access-checked against the viewer's CURRENT stream visibility — but the content INSIDE those payloads is a snapshot of a past access decision. A viewer catching up after a shared message's source stream went private received the full hydrated snapshot (`slots`); the same held for memo-embed summaries and `memo:updated` payloads. Surfaced by Sol's adversarial review of Stack #1701, which closed the bootstrap path (`enrichBootstrapEvents` re-resolves) but left catch-up serving stale snapshots.

## Solution

`sanitizeSyncEntries` (new, `features/sync/sanitize.ts`), called by `SyncService.catchUp` after `listEntriesForUser`:

- **Slots re-hydrate per viewer** via `hydrateSharedMessageIds` — catch-up is a per-user read and that resolver is the sharing feature's own read-path authority. One batch call for the union of source ids; every stored map entry is replaced, so a now-withheld source comes back as its `private` variant exactly as a live delivery would, and a since-edited readable source comes back current.
- **Memo summaries re-resolve per citing root** via `findEmbedSummaries` (cards are room-gated, not viewer-gated): one query per distinct root for the union of cited ids. Covers `message:created`/`message:edited` wrapped events and `messages:moved` nested destination events.
- **`memo:updated` entries the room may no longer see are dropped whole**; kept ones get the memo's current summary rather than the frozen one.
- Entries with none of that content pass through untouched — the identity path costs zero queries, so typical catch-ups are unaffected.

Re-resolve over strip: stripping would degrade the 99% legitimate replay to skeletons/label-only; re-resolution serves what a live delivery would serve today.

## Test plan

- [x] `sync-log-sanitize.test.ts` (**new**, integration, real schema per INV-68): withheld `memo:updated` dropped while a readable one is kept AND re-titled fresh; stale `memoEmbeds` inside a replayed created-payload emptied after source privatization; slots turn `private` for a withheld source and refresh content for a readable one; a no-content entry array passes through by reference.
- [x] **Mutation-checked:** neutralizing the sanitizer's collection gate reddens exactly the three content tests and leaves the pass-through green.
- [x] Backend unit **3855** · integration **801** · typecheck (src + tests) 0. One unrelated `CursorLock` timing case flaked under full-suite load; 3× isolated and the full rerun are green.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122443&installation_model_id=20758&pr_number=1705&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1705&signature=11ab1df80bb930fc735976a8d3cc57e4b178b1f86dc72eb35d3066830389a192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->