### PR TITLE
fix(memos): scope memo:created to its source stream and strip the memo from the payload

### DIFF
--- a/apps/backend/src/db/migrations/20260731224238_purge_leaked_memo_created_sync_log.sql
+++ b/apps/backend/src/db/migrations/20260731224238_purge_leaked_memo_created_sync_log.sql
@@ -1,0 +1,18 @@
+-- Drop the `memo:created` tail from the sync log.
+--
+-- Until this deploy the event was workspace-group routed and carried the whole
+-- memo (title, abstract, key points, tags). Every one of those payloads was
+-- copied into `sync_log`, which replays to any member on catch-up for weeks and
+-- does NOT access-check workspace-group entries — so the retained log holds
+-- every workspace member a readable copy of memos extracted from streams they
+-- cannot open. Fixing the emitter stops new rows; these are the ones already
+-- written.
+--
+-- Deleted rather than re-scoped: the event is a pure cache-invalidation signal
+-- (the client only invalidates its memo searches), so a replay that never
+-- arrives costs nothing the explorer's own bootstrap doesn't already cover.
+-- Deleting mid-range sync ids is safe — heads come from
+-- `workspace_sync_sequences`, not from the log, and catch-up returns entries
+-- after a cursor rather than requiring a dense run.
+
+DELETE FROM sync_log WHERE event_type = 'memo:created';

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -281,9 +281,6 @@ export class MemoExplorerService {
    * without any bookkeeping of its own. Streams whose rooms may not see it are
    * simply skipped, which leaves their cards showing what they already had.
    *
-   * Deliberately NOT workspace-scoped: `memo:created` broadcasts a whole
-   * `WireMemo` (abstract and key points included) to every workspace member,
-   * which is a wider exposure than this event is willing to inherit.
    */
   private async publishCardUpdates(client: PoolClient, workspaceId: string, memo: Memo): Promise<void> {
     const citingStreamIds = await MemoRepository.findCitingStreamIds(client, workspaceId, memo.id)

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -414,7 +414,7 @@ describe("MemoService.processBatch — memo scope write policy (roadmap 6.4)", (
   })
 
   it("keeps channel and public-scratchpad memos workspace-scoped", async () => {
-    const { service } = setupService({ memoContents: [memoContent] })
+    const { service, outboxInsert } = setupService({ memoContents: [memoContent] })
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream({ type: "channel", visibility: "public" }))
     const insert = spyOn(MemoRepository, "insert").mockResolvedValue(undefined as never)
 
@@ -424,10 +424,34 @@ describe("MemoService.processBatch — memo scope write policy (roadmap 6.4)", (
       expect.anything(),
       expect.objectContaining({ scope: "workspace", scopeUserId: null })
     )
+    // The whole payload: the source stream to route by, the id to invalidate on,
+    // and nothing of the memo's content — it is replayed from `sync_log` for
+    // weeks, so anything here outlives the emit. No scopeUserId ⇒ the room.
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "memo:created", {
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      memoId: expect.stringMatching(/^memo_/),
+    })
+  })
+
+  it("routes a user-scoped memo's memo:created to its owner, not the stream", async () => {
+    const { service, outboxInsert } = setupService({ memoContents: [memoContent] })
+    spyOn(StreamRepository, "findById").mockResolvedValue(
+      fakeStream({ type: "scratchpad", visibility: "private", createdBy: "usr_owner" })
+    )
+
+    await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "memo:created", {
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      memoId: expect.stringMatching(/^memo_/),
+      scopeUserId: "usr_owner",
+    })
   })
 
   it("resolves the root stream so a thread inside a private scratchpad inherits user scope", async () => {
-    const { service } = setupService({ memoContents: [memoContent] })
+    const { service, outboxInsert } = setupService({ memoContents: [memoContent] })
     // The batch's stream is a thread; its root is the owner's private scratchpad.
     // Without root resolution the thread's own type (not SCRATCHPAD) would fall
     // through to workspace scope, leaking the private memo.
@@ -447,6 +471,14 @@ describe("MemoService.processBatch — memo scope write policy (roadmap 6.4)", (
     expect(insert).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ scope: "user", scopeUserId: "usr_owner" })
+    )
+    // The same resolved root carries the routing: memo:created names the root,
+    // never the thread, so it reaches the root's audience rather than whoever
+    // has the thread open.
+    expect(outboxInsert).toHaveBeenCalledWith(
+      expect.anything(),
+      "memo:created",
+      expect.objectContaining({ streamId: "stream_root" })
     )
   })
 })
@@ -660,12 +692,12 @@ describe("MemoService.saveMemo — agent-authored memo (roadmap 6.2)", () => {
         status: "active",
       })
     )
-    // memo:created rides the outbox.
-    expect(outboxInsert).toHaveBeenCalledWith(
-      expect.anything(),
-      "memo:created",
-      expect.objectContaining({ workspaceId: WORKSPACE_ID })
-    )
+    // memo:created rides the outbox, carrying the source room and the id alone.
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "memo:created", {
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      memoId: expect.stringMatching(/^memo_/),
+    })
     // Visible in situ (INV-62): capture event on the stream, no conversationId.
     expect(streamEventInsertMany).toHaveBeenCalledWith(expect.anything(), [
       expect.objectContaining({
@@ -951,11 +983,11 @@ describe("MemoService.captureSessionReflection — reflective capture (roadmap 6
         status: "active",
       })
     )
-    expect(outboxInsert).toHaveBeenCalledWith(
-      expect.anything(),
-      "memo:created",
-      expect.objectContaining({ workspaceId: WORKSPACE_ID })
-    )
+    expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "memo:created", {
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      memoId: expect.stringMatching(/^memo_/),
+    })
     // Visible in situ (INV-62): capture event on the session's stream, no conversationId.
     expect(streamEventInsertMany).toHaveBeenCalledWith(expect.anything(), [
       expect.objectContaining({

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -29,7 +29,6 @@ import {
   type KnowledgeType,
   type MemoScope,
   type MemosCapturedEventPayload,
-  type Memo as WireMemo,
 } from "@threa/types"
 import {
   MEMO_GEM_CONFIDENCE_FLOOR,
@@ -94,14 +93,18 @@ function resolveExtractedMemoScope(stream: Stream | null): { scope: MemoScope; s
  * private scratchpad; resolving to the root first keeps their memos in the
  * owner's private tier instead of silently falling through to `workspace`. The
  * batch path already passes a top-level stream, so this is a no-op there.
+ *
+ * `rootStreamId` is that same resolved root, returned so callers routing a
+ * memo's `memo:created` reach the root's audience rather than whoever happens
+ * to have a thread open.
  */
 export async function resolveMemoScopeForStreamId(
   db: Querier,
   streamId: string
-): Promise<{ scope: MemoScope; scopeUserId: string | null }> {
+): Promise<{ scope: MemoScope; scopeUserId: string | null; rootStreamId: string }> {
   const stream = await StreamRepository.findById(db, streamId)
   const root = stream?.rootStreamId ? await StreamRepository.findById(db, stream.rootStreamId) : stream
-  return resolveExtractedMemoScope(root)
+  return { ...resolveExtractedMemoScope(root), rootStreamId: root?.id ?? streamId }
 }
 
 export interface ProcessResult {
@@ -743,8 +746,9 @@ export class MemoService implements MemoServiceLike {
         await MemoRepository.updateEmbedding(client, memoData.id, embedding)
         await OutboxRepository.insert(client, "memo:created", {
           workspaceId,
+          streamId: fetchedData.memoScope.rootStreamId,
           memoId: memoData.id,
-          memo: this.toWireMemoFromData(memoData),
+          ...(memoData.scopeUserId ? { scopeUserId: memoData.scopeUserId } : {}),
         })
         createdMemos.push(memoData)
       }
@@ -1016,7 +1020,7 @@ export class MemoService implements MemoServiceLike {
         return { ok: true, memoId: duplicate.memo.id, title: duplicate.memo.title, deduped: true }
       }
 
-      const inserted = await MemoRepository.insert(client, {
+      await MemoRepository.insert(client, {
         id: newMemoId,
         workspaceId,
         memoType: MemoTypes.MESSAGE,
@@ -1037,8 +1041,9 @@ export class MemoService implements MemoServiceLike {
       await MemoRepository.updateEmbedding(client, newMemoId, embedding)
       await OutboxRepository.insert(client, "memo:created", {
         workspaceId,
+        streamId: natural.rootStreamId,
         memoId: newMemoId,
-        memo: this.toWireMemo(inserted),
+        ...(resolvedScopeUserId ? { scopeUserId: resolvedScopeUserId } : {}),
       })
 
       // Visible in situ (INV-62): one broadcast timeline event on the stream the
@@ -1212,7 +1217,7 @@ export class MemoService implements MemoServiceLike {
         }
 
         const newMemoId = memoId()
-        const inserted = await MemoRepository.insert(client, {
+        await MemoRepository.insert(client, {
           id: newMemoId,
           workspaceId,
           memoType: MemoTypes.MESSAGE,
@@ -1233,8 +1238,9 @@ export class MemoService implements MemoServiceLike {
         await MemoRepository.updateEmbedding(client, newMemoId, embedding)
         await OutboxRepository.insert(client, "memo:created", {
           workspaceId,
+          streamId: context.memoScope.rootStreamId,
           memoId: newMemoId,
-          memo: this.toWireMemo(inserted),
+          ...(context.memoScope.scopeUserId ? { scopeUserId: context.memoScope.scopeUserId } : {}),
         })
         capturedMemos.push({
           memoId: newMemoId,
@@ -1294,64 +1300,5 @@ export class MemoService implements MemoServiceLike {
       )
       return { classified: true, captured: capturedMemos.length, deduped }
     })
-  }
-
-  /** Wire format for a persisted memo row (repository `Memo` → `@threa/types` `Memo`). */
-  private toWireMemo(memo: Memo): WireMemo {
-    return {
-      id: memo.id,
-      workspaceId: memo.workspaceId,
-      memoType: memo.memoType,
-      sourceMessageId: memo.sourceMessageId,
-      sourceConversationId: memo.sourceConversationId,
-      title: memo.title,
-      abstract: memo.abstract,
-      keyPoints: memo.keyPoints,
-      sourceMessageIds: memo.sourceMessageIds,
-      participantIds: memo.participantIds,
-      knowledgeType: memo.knowledgeType,
-      tags: memo.tags,
-      parentMemoId: memo.parentMemoId,
-      status: memo.status,
-      version: memo.version,
-      revisionReason: memo.revisionReason,
-      authoredByKind: memo.authoredByKind,
-      sourceSessionId: memo.sourceSessionId,
-      scope: memo.scope,
-      scopeUserId: memo.scopeUserId,
-      createdAt: memo.createdAt.toISOString(),
-      updatedAt: memo.updatedAt.toISOString(),
-      archivedAt: memo.archivedAt ? memo.archivedAt.toISOString() : null,
-    }
-  }
-
-  /** Wire format for a memo not yet inserted, so timestamps are synthesized as now. */
-  private toWireMemoFromData(memoData: MemoToCreate): WireMemo {
-    const now = new Date().toISOString()
-    return {
-      id: memoData.id,
-      workspaceId: memoData.workspaceId,
-      memoType: memoData.memoType,
-      sourceMessageId: memoData.sourceMessageId ?? null,
-      sourceConversationId: memoData.sourceConversationId ?? null,
-      title: memoData.title,
-      abstract: memoData.abstract,
-      keyPoints: memoData.keyPoints,
-      sourceMessageIds: memoData.sourceMessageIds,
-      participantIds: memoData.participantIds,
-      knowledgeType: memoData.knowledgeType,
-      tags: memoData.tags,
-      parentMemoId: memoData.parentMemoId ?? null,
-      status: memoData.status,
-      version: 1,
-      revisionReason: null,
-      authoredByKind: AuthoredByKinds.PIPELINE,
-      sourceSessionId: null,
-      scope: memoData.scope,
-      scopeUserId: memoData.scopeUserId,
-      createdAt: now,
-      updatedAt: now,
-      archivedAt: null,
-    }
   }
 }

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -420,3 +420,34 @@ describe("resolveDeliveryGroups — memo:updated", () => {
     expect(groups).not.toContain(WORKSPACE_GROUP)
   })
 })
+
+describe("resolveDeliveryGroups — memo:created", () => {
+  // Same blindness as memo:updated above, one event earlier: this one announces
+  // that a memo exists at all, and every payload is copied into `sync_log` and
+  // replayed on catch-up for weeks — so a workspace group here is a standing
+  // record of every capture, readable by members with no access to the stream
+  // it came from. The outbox row is identical either way.
+  it("delivers only to the memo's source stream, never the whole workspace", () => {
+    const groups = resolveDeliveryGroups(
+      event("memo:created", { workspaceId: "ws_1", streamId: "stream_source", memoId: "memo_1" })
+    )
+
+    expect(groups).toEqual([streamGroup("stream_source")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+  })
+
+  // save_memo can file a `user`-scoped memo from a shared stream. Its owner is
+  // the only one who will ever see it, so the room must not even learn it exists.
+  it("delivers a user-scoped memo to its owner instead of the source stream", () => {
+    const groups = resolveDeliveryGroups(
+      event("memo:created", {
+        workspaceId: "ws_1",
+        streamId: "stream_source",
+        memoId: "memo_1",
+        scopeUserId: "usr_owner",
+      })
+    )
+
+    expect(groups).toEqual([userGroup("usr_owner")])
+  })
+})

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -450,4 +450,19 @@ describe("resolveDeliveryGroups — memo:created", () => {
 
     expect(groups).toEqual([userGroup("usr_owner")])
   })
+
+  // Rollout window: a replica still on the old code writes the old payload —
+  // no streamId, whole memo inline. Dropping it keeps that content out of the
+  // log; routing it by shape would file it under `stream:undefined`.
+  it("drops a pre-cutover payload instead of routing it anywhere", () => {
+    const groups = resolveDeliveryGroups(
+      event("memo:created", {
+        workspaceId: "ws_1",
+        memoId: "memo_1",
+        memo: { id: "memo_1", title: "Launch in June", abstract: "…" },
+      })
+    )
+
+    expect(groups).toEqual([])
+  })
 })

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -28,6 +28,7 @@ import {
   type MessagesMovedOutboxPayload,
   type ConversationCreatedOutboxPayload,
   type ConversationUpdatedOutboxPayload,
+  type MemoCreatedOutboxPayload,
   type LabelUpsertedOutboxPayload,
   type LabelDeletedOutboxPayload,
   type LabelAssignedOutboxPayload,
@@ -343,6 +344,16 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
     return rootStreamId && rootStreamId !== streamId
       ? [streamGroup(streamId), streamGroup(rootStreamId)]
       : [streamGroup(streamId)]
+  }
+
+  // memo:created — the source stream's room, so a member of the room the memo
+  // came from refreshes the explorer live. A `user`-scoped memo is private to
+  // its owner even when captured in a shared stream (save_memo can file one
+  // there), so it goes to the owner alone: the room must not learn that a memo
+  // it will never be shown exists.
+  if (isOutboxEventType(event, "memo:created")) {
+    const payload = event.payload as MemoCreatedOutboxPayload
+    return payload.scopeUserId ? [userGroup(payload.scopeUserId)] : [streamGroup(payload.streamId)]
   }
 
   // Permission-scoped events (e.g. invitation lifecycle → members:write) go to

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -351,9 +351,13 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
   // its owner even when captured in a shared stream (save_memo can file one
   // there), so it goes to the owner alone: the room must not learn that a memo
   // it will never be shown exists.
+  // A row written by a pre-cutover replica has no streamId and carries the whole
+  // memo; it is dropped (no audience, so neither logged nor emitted) rather than
+  // routed to `stream:undefined`, which would park that content in the log.
   if (isOutboxEventType(event, "memo:created")) {
     const payload = event.payload as MemoCreatedOutboxPayload
-    return payload.scopeUserId ? [userGroup(payload.scopeUserId)] : [streamGroup(payload.streamId)]
+    if (payload.scopeUserId) return [userGroup(payload.scopeUserId)]
+    return payload.streamId ? [streamGroup(payload.streamId)] : []
   }
 
   // Permission-scoped events (e.g. invitation lifecycle → members:write) go to

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -5,7 +5,6 @@ import type { User } from "../../features/workspaces"
 import type { ConversationWithStaleness } from "../../features/conversations"
 import type { HydratedSharedMessage } from "../../features/messaging/sharing"
 import type {
-  Memo as WireMemo,
   MemoEmbedSummary,
   StreamEvent as WireStreamEvent,
   UserPreferences,
@@ -136,6 +135,7 @@ export type OutboxEventType =
 
 /** Events that are scoped to a stream (have streamId) */
 export type StreamScopedEventType =
+  | "memo:created"
   | "memo:updated"
   | "message:created"
   | "message:edited"
@@ -595,9 +595,18 @@ export interface ConversationMessageReassignedOutboxPayload extends StreamScoped
   reason: string
 }
 
-export interface MemoCreatedOutboxPayload extends WorkspaceScopedPayload {
+/**
+ * A memo was captured, for the room it was captured from.
+ *
+ * STREAM-scoped to the memo's source root and carries the id alone — the memory
+ * explorer only invalidates on it, and every payload is copied verbatim into
+ * `sync_log` and replayed on catch-up for weeks, so content here would outlive
+ * the emit. `scopeUserId` is set for a `user`-scoped memo (private to its owner
+ * even inside a shared stream), which routes to that user instead of the room.
+ */
+export interface MemoCreatedOutboxPayload extends StreamScopedPayload {
   memoId: string
-  memo: WireMemo
+  scopeUserId?: string
 }
 
 /**
@@ -1311,8 +1320,10 @@ const STREAM_SCOPED_EVENTS: StreamScopedEventType[] = [
   // Routing is driven by THIS list, not by the payload extending
   // `StreamScopedPayload` — `resolveDeliveryGroups` only takes the stream
   // branch when `isStreamScopedEvent` finds the type here. Omitted, an event
-  // falls through to the whole-workspace group, which for this one would hand
-  // a memo's card content to every member regardless of stream access.
+  // falls through to the whole-workspace group, which for these two would hand
+  // a memo's existence and card content to every member regardless of stream
+  // access — the shape that shipped a leak on each of them in turn.
+  "memo:created",
   "memo:updated",
   "message:created",
   "message:edited",

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -4,9 +4,8 @@
  * The card no longer fetches, so this event is how a retitle reaches a reader
  * who already has the message on screen. It is stream-scoped and gated per
  * citing room by the same predicate the write path uses, which is what stops it
- * becoming a workspace-wide broadcast of a memo's title. (`memo:created` IS
- * that broadcast today, carrying the whole memo including its abstract — noted,
- * pre-existing, and deliberately not inherited here.)
+ * becoming a workspace-wide broadcast of a memo's title. (`memo:created` is
+ * scoped the same way, per `memo-created-routing.test.ts`.)
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"

--- a/apps/backend/tests/integration/memo-created-routing.test.ts
+++ b/apps/backend/tests/integration/memo-created-routing.test.ts
@@ -1,0 +1,246 @@
+/**
+ * `memo:created` — who is told a memo exists, and what they are told.
+ *
+ * The event fires whenever GAM captures knowledge, and its payload is copied
+ * verbatim into `sync_log`, where catch-up replays it for weeks. Routing is
+ * decided by the event TYPE (`STREAM_SCOPED_EVENTS`), never by the payload's
+ * shape, so an outbox row can look perfectly stream-scoped while being
+ * delivered to the whole workspace — which is why these tests run the row
+ * through `resolveDeliveryGroups` and then through the catch-up read, rather
+ * than asserting on the row alone.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { MemoService } from "../../src/features/memos"
+import type { EmbeddingServiceLike } from "../../src/features/memos"
+import { SyncLogRepository } from "../../src/features/sync"
+import { resolveDeliveryGroups, streamGroup, userGroup, WORKSPACE_GROUP, type OutboxEvent } from "../../src/lib/outbox"
+import { userId, workspaceId, streamId, messageId } from "../../src/lib/id"
+
+const EMBEDDING_DIMENSIONS = 1536
+
+/** Distinct unit vectors per abstract, so nothing in a suite of one-line memos
+ *  lands inside the dedup radius of the memo before it. */
+function fakeEmbedding(index: number): number[] {
+  const vector = new Array(EMBEDDING_DIMENSIONS).fill(0)
+  vector[index % EMBEDDING_DIMENSIONS] = 1
+  return vector
+}
+
+describe("memo:created delivery", () => {
+  let pool: Pool
+  let service: MemoService
+  let testWorkspaceId: string
+  /** Member of the private channel every memo below is captured from. */
+  let insider: string
+  /** A workspace member with no access to it. */
+  let outsider: string
+  let privateChannel: string
+  let sequence = 1n
+  let embeddingsIssued = 0
+
+  /** The `memo:created` outbox row for one memo, as the dispatcher reads it. */
+  async function outboxEventFor(memoId: string): Promise<OutboxEvent> {
+    const result = await pool.query<{ id: string; event_type: string; payload: Record<string, unknown> }>(
+      `SELECT id, event_type, payload FROM outbox WHERE event_type = 'memo:created' AND payload->>'memoId' = $1`,
+      [memoId]
+    )
+    expect(result.rows).toHaveLength(1)
+    const row = result.rows[0]
+    return { id: BigInt(row.id), eventType: row.event_type, payload: row.payload, createdAt: new Date() } as OutboxEvent
+  }
+
+  /** Logs the event under its resolved groups, exactly as the BroadcastHandler
+   *  does, and answers who catch-up hands it back to. */
+  async function catchUpReceivers(event: OutboxEvent, groups: string[], users: string[]): Promise<string[]> {
+    await SyncLogRepository.appendForWorkspace(pool, testWorkspaceId, [
+      { outboxEventId: event.id, eventType: event.eventType, groups, payload: event.payload },
+    ])
+    const received: string[] = []
+    for (const user of users) {
+      const entries = await SyncLogRepository.listEntriesForUser(pool, {
+        workspaceId: testWorkspaceId,
+        userId: user,
+        permissionGroups: [],
+        after: 0n,
+        limit: 100,
+      })
+      if (
+        entries.some((e) => (e.payload as { memoId?: string }).memoId === (event.payload as { memoId: string }).memoId)
+      ) {
+        received.push(user)
+      }
+    }
+    return received
+  }
+
+  /** A real message in `stream` for the memo to anchor to. */
+  async function anchorMessage(stream: string): Promise<string> {
+    const id = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id,
+        streamId: stream,
+        sequence: sequence++,
+        authorId: insider,
+        authorType: "user",
+        ...testMessageContent("source"),
+      })
+    })
+    return id
+  }
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    service = new MemoService({
+      pool,
+      classifier: {} as never,
+      memorizer: {} as never,
+      messageFormatter: {} as never,
+      embeddingService: {
+        embedBatch: async (texts: string[]) => texts.map(() => fakeEmbedding(embeddingsIssued++)),
+      } as unknown as EmbeddingServiceLike,
+    })
+
+    testWorkspaceId = workspaceId()
+    insider = userId()
+    privateChannel = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Memo Created Routing",
+        slug: `memo-created-${testWorkspaceId}`,
+        createdBy: insider,
+      })
+      insider = (await addTestMember(client, testWorkspaceId, insider)).id
+      outsider = (await addTestMember(client, testWorkspaceId, userId())).id
+
+      await StreamRepository.insert(client, {
+        id: privateChannel,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        slug: `s-${privateChannel.slice(-8)}`,
+        createdBy: insider,
+      })
+      await StreamMemberRepository.insert(client, privateChannel, insider)
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("a memo from a private channel reaches that channel's room and no one else", async () => {
+    const anchor = await anchorMessage(privateChannel)
+    const saved = await service.saveMemo({
+      workspaceId: testWorkspaceId,
+      streamId: privateChannel,
+      sessionId: null,
+      sourceStreamIds: [privateChannel],
+      title: "Ship the migration on Tuesday",
+      abstract: "The team agreed to ship the migration on Tuesday.",
+      keyPoints: ["Tuesday"],
+      tags: ["release"],
+      knowledgeType: "decision",
+      sourceMessageIds: [anchor],
+      invokingUserId: insider,
+    })
+    expect(saved).toMatchObject({ ok: true, deduped: false })
+
+    const event = await outboxEventFor((saved as { memoId: string }).memoId)
+
+    // The whole payload: nothing of what the memo says survives onto the wire,
+    // so the ~30-day sync_log tail holds an id and a room, not knowledge.
+    expect(event.payload).toEqual({
+      workspaceId: testWorkspaceId,
+      streamId: privateChannel,
+      memoId: (saved as { memoId: string }).memoId,
+    })
+
+    const groups = resolveDeliveryGroups(event)
+    expect(groups).toEqual([streamGroup(privateChannel)])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+
+    expect(await catchUpReceivers(event, groups!, [insider, outsider])).toEqual([insider])
+  })
+
+  test("a user-scoped memo saved into a shared stream reaches only its owner", async () => {
+    // save_memo can file privately from a stream whose audience is wider than
+    // the owner. The room must not learn that a memo it will never be shown
+    // exists — so this one routes to the owner, not to the channel.
+    const anchor = await anchorMessage(privateChannel)
+    const saved = await service.saveMemo({
+      workspaceId: testWorkspaceId,
+      streamId: privateChannel,
+      sessionId: null,
+      sourceStreamIds: [privateChannel],
+      title: "Kris prefers terse status replies",
+      abstract: "Kris prefers status replies to lead with the result and stay under six lines.",
+      keyPoints: ["terse"],
+      tags: ["preferences"],
+      knowledgeType: "context",
+      sourceMessageIds: [anchor],
+      invokingUserId: insider,
+      scope: "user",
+    })
+    expect(saved).toMatchObject({ ok: true, deduped: false })
+
+    const event = await outboxEventFor((saved as { memoId: string }).memoId)
+    expect(event.payload).toMatchObject({ streamId: privateChannel, scopeUserId: insider })
+
+    const groups = resolveDeliveryGroups(event)
+    expect(groups).toEqual([userGroup(insider)])
+  })
+
+  test("a memo saved from a thread routes to the thread's root, whose members it belongs to", async () => {
+    // The capture stream can be a thread; a thread room holds only whoever has
+    // it open, while access is the root's (INV-62). Routing to the thread would
+    // silently starve the members the memo actually belongs to.
+    const thread = streamId()
+    const parentMessage = await anchorMessage(privateChannel)
+    await withTransaction(pool, async (client) => {
+      await StreamRepository.insert(client, {
+        id: thread,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        slug: `s-${thread.slice(-8)}`,
+        createdBy: insider,
+        parentStreamId: privateChannel,
+        parentAnchorId: parentMessage,
+        rootStreamId: privateChannel,
+      })
+    })
+    const anchor = await anchorMessage(thread)
+
+    const saved = await service.saveMemo({
+      workspaceId: testWorkspaceId,
+      streamId: thread,
+      sessionId: null,
+      sourceStreamIds: [thread],
+      title: "The retry budget is three attempts",
+      abstract: "The queue retries a failed job three times before dead-lettering it.",
+      keyPoints: ["three"],
+      tags: ["queue"],
+      knowledgeType: "decision",
+      sourceMessageIds: [anchor],
+      invokingUserId: insider,
+    })
+    expect(saved).toMatchObject({ ok: true, deduped: false })
+
+    const event = await outboxEventFor((saved as { memoId: string }).memoId)
+    expect(event.payload).toEqual({
+      workspaceId: testWorkspaceId,
+      streamId: privateChannel,
+      memoId: (saved as { memoId: string }).memoId,
+    })
+    expect(resolveDeliveryGroups(event)).toEqual([streamGroup(privateChannel)])
+  })
+})

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1830,13 +1830,16 @@ describe("registerWorkspaceSocketHandlers", () => {
     gate.dispose()
   })
 
+  // The event is delivered to the memo's source stream room, not the workspace
+  // room — but registration is per event type on the one workspace socket, so
+  // the handler must still fire on the room-delivered payload.
   it("invalidates the memo search queries when a memo:created event lands", () => {
     const queryClient = new QueryClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
     const { socket, emit } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
-    emit("memo:created", { workspaceId: "ws_1", memoId: "memo_1" })
+    emit("memo:created", { workspaceId: "ws_1", streamId: "stream_1", memoId: "memo_1" })
 
     expect(invalidate).toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })
     cleanup()
@@ -1848,7 +1851,7 @@ describe("registerWorkspaceSocketHandlers", () => {
     const { socket, emit } = createTestSocket()
     const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
 
-    emit("memo:created", { workspaceId: "ws_other", memoId: "memo_1" })
+    emit("memo:created", { workspaceId: "ws_other", streamId: "stream_1", memoId: "memo_1" })
 
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_other") })
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1780,11 +1780,12 @@ export function registerWorkspaceSocketHandlers(
   }
 
   // GAM memo extraction: surface new memos in the memory explorer without a
-  // manual refresh. memo:created is workspace-group routed (sync log + emit),
-  // so registering here puts memos on the sync catch-up path like every
-  // other workspace-level event — a reconnect replay invalidates the same
-  // queries a live emit does. The in-situ timeline row rides the separate
-  // stream:memos_captured event (stream-sync).
+  // manual refresh. memo:created is routed to the memo's source root (or its
+  // owner, for a user-scoped memo) — never workspace-wide — but registration
+  // is per event type on the one workspace socket/gate, so a room-delivered
+  // event and its catch-up replay both land here. Registering per stream would
+  // only duplicate the invalidation. The in-situ timeline row rides the
+  // separate stream:memos_captured event (stream-sync).
   const handleMemoCreated = (payload: { workspaceId: string; memoId: string }) => {
     if (payload.workspaceId !== workspaceId) return
     queryClient.invalidateQueries({ queryKey: memoKeys.searches(workspaceId) })


### PR DESCRIPTION
## Problem

`memo:created` was missing from `STREAM_SCOPED_EVENTS` (`apps/backend/src/lib/outbox/repository.ts`), so `resolveDeliveryGroups` fell through to the workspace group — and the payload carried a whole `WireMemo`: title, abstract, key points, tags. Every member of a workspace received the full text of memos GAM extracted from streams they cannot open. The payload is also copied verbatim into `sync_log`, whose workspace-group entries are **not** access-checked at read time, so the exposure persisted in the retained log for weeks, replayed to anyone on catch-up. The sole consumer, `handleMemoCreated` (`apps/frontend/src/sync/workspace-sync.ts`), reads `{workspaceId, memoId}` and invalidates `memoKeys.searches` — the memo on the wire was never used.

Same blindness that shipped a leak on `memo:updated` before it was registered: routing keys off the event type, never the payload's shape, so an outbox-row test sees nothing wrong.

## Solution

Two halves, both required — dropping the content without fixing routing still broadcasts "a memo exists" workspace-wide; fixing routing without dropping the content still hands the abstract to the source room's `sync_log` tail forever.

- Payload is `{workspaceId, streamId, memoId}` (+ `scopeUserId`), nothing of what the memo says. All three emitters in `features/memos/service.ts` (batch, `save_memo`, reflective capture) updated; `toWireMemo` / `toWireMemoFromData` deleted with their last caller (INV-38).
- Registered in `STREAM_SCOPED_EVENTS` and given an explicit branch in `resolveDeliveryGroups`: the source stream's room, or `user:<owner>` when the memo is `user`-scoped. `save_memo` can file a private memo from a shared stream — the room must not learn it exists, mirroring the `captureLeaksToStream` suppression already there for the `memos:captured` timeline event.
- The **root**, not the capture stream, goes on the payload: `resolveMemoScopeForStreamId` already loaded the effective root for the scope decision, so it now returns `rootStreamId` too. A thread room holds only whoever has it open while access is the root's (INV-62) — routing to the thread would starve the members the memo belongs to.
- `20260731224238_purge_leaked_memo_created_sync_log.sql` deletes the leaked tail. Deleted over re-scoped: the event is a pure invalidation signal, so a replay that never arrives costs nothing the explorer's bootstrap doesn't cover. Mid-range sync-id deletion is safe — heads come from `workspace_sync_sequences`, not from the log.
- Rollout window: a pre-cutover replica writes the old payload, so `resolveDeliveryGroups` returns `[]` for a `memo:created` with no `streamId` (neither logged nor emitted) rather than filing that content under `stream:undefined`.
- `handleMemoCreated` stays in workspace-sync: registration is per event type on the one workspace socket/gate, and the gate applies catch-up entries through the same handlers — a room-delivered event lands there either way. Non-members lose the live invalidation for memos they can't see; that is the point.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/outbox/repository.ts` | `MemoCreatedOutboxPayload` → stream-scoped, id-only; type added to `StreamScopedEventType` + `STREAM_SCOPED_EVENTS` |
| `apps/backend/src/lib/outbox/delivery-groups.ts` | `memo:created` branch: source room / owner / drop-if-legacy |
| `apps/backend/src/features/memos/service.ts` | Three emitters; `rootStreamId` on the scope resolver; two wire mappers deleted |
| `apps/backend/src/db/migrations/20260731224238_purge_leaked_memo_created_sync_log.sql` | **new** — deletes retained `memo:created` entries |
| `apps/backend/tests/integration/memo-created-routing.test.ts` | **new** — real `saveMemo` → outbox row → `resolveDeliveryGroups` → catch-up read |
| `apps/frontend/src/sync/workspace-sync.ts` | Comment corrected (routing changed, registration didn't) |

## Test plan

- [x] backend unit — 3858 pass
- [x] backend integration — 800 pass (a first run showed 21 failures across untouched suites; a clean re-run was green, so shared-test-DB contention, not this change)
- [x] frontend `workspace-sync.test.ts` — 94 pass
- [x] Neutralisation check: removing `memo:created` from `STREAM_SCOPED_EVENTS` turns all five new routing tests red
- [x] typecheck, lint, `check:migrations`
- [ ] Not verified in a running app — asserted through the delivery path (groups + `listEntriesForUser`) instead

Assertions are on DELIVERY, not the outbox row: the integration test resolves the row's groups, appends to `sync_log` under them, and checks that the source-stream member gets it back from catch-up and the non-member does not. Row-only tests were blind to exactly this bug.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788123090&installation_model_id=20758&pr_number=1706&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1706&signature=19c8fc34dca2f000d30d45c849db4ea69921feafa9a8b832b6d596c489a65e06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->