### PR TITLE
feat(memos): card_version orders memo-card patches absolutely

### DIFF
--- a/apps/backend/src/db/migrations/20260731210000_memo_version.sql
+++ b/apps/backend/src/db/migrations/20260731210000_memo_version.sql
@@ -1,0 +1,19 @@
+-- Add `card_version` to memos so memo-embed card patches order absolutely.
+-- The client's newer-wins guard (a raced message:edited payload vs a
+-- memo:updated patch) compared millisecond `updatedAt` values, which tie when
+-- two memo edits land inside one millisecond — an integer bumped on every
+-- card-field update has no tie (INV-66, same shape as
+-- scheduled_messages.version).
+--
+-- NOT the existing `version` column: that one is the supersession REVISION
+-- number (chains order on it via ORDER BY version DESC), so bumping it on a
+-- title edit would let an edited old revision outrank the capture that
+-- superseded it. Card ordering gets its own counter.
+--
+-- Only MemoRepository.update (the sole path that changes card fields — title,
+-- knowledge_type, tags) increments it. Embedding refreshes, supersession and
+-- archive status flips bump `updated_at` but not the card version: the card
+-- renders none of those.
+
+ALTER TABLE memos
+  ADD COLUMN IF NOT EXISTS card_version INTEGER NOT NULL DEFAULT 1;

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -353,8 +353,9 @@ export const MemoRepository = {
       memo_type: string
       tags: string[]
       updated_at: Date
+      card_version: number
     }>(sql`
-      SELECT m.id, m.title, m.knowledge_type, m.memo_type, m.tags, m.updated_at
+      SELECT m.id, m.title, m.knowledge_type, m.memo_type, m.tags, m.updated_at, m.card_version
       FROM memos m
       LEFT JOIN messages src_msg ON src_msg.id = m.source_message_id
       LEFT JOIN conversations src_conv ON src_conv.id = m.source_conversation_id
@@ -377,6 +378,7 @@ export const MemoRepository = {
           memoType: row.memo_type as MemoType,
           tags: row.tags,
           updatedAt: row.updated_at.toISOString(),
+          version: row.card_version,
         },
       ])
     )
@@ -723,6 +725,10 @@ export const MemoRepository = {
       return this.findById(db, id)
     }
 
+    // Card ordering: every field update bumps the card version so a
+    // memo:updated patch can never be repainted backwards by a raced,
+    // pre-update edit payload (ms `updatedAt` ties; this cannot).
+    updates.push(`card_version = card_version + 1`)
     updates.push(`updated_at = NOW()`)
     values.push(id)
 

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -260,7 +260,15 @@ describe("memo:updated", () => {
       `SELECT payload FROM outbox WHERE event_type = 'memo:updated' LIMIT 1`
     )
     const summary = events.rows[0]?.payload.summary as Record<string, unknown>
-    expect(Object.keys(summary).sort()).toEqual(["knowledgeType", "memoId", "memoType", "tags", "title", "updatedAt"])
+    expect(Object.keys(summary).sort()).toEqual([
+      "knowledgeType",
+      "memoId",
+      "memoType",
+      "tags",
+      "title",
+      "updatedAt",
+      "version",
+    ])
   })
 
   // The destination side of a move bulkPuts server payloads over the client's
@@ -338,6 +346,28 @@ describe("memo:updated", () => {
     )
     const embeds = (movedCreated?.payload as { memoEmbeds?: Array<{ title: string }> }).memoEmbeds
     expect(embeds?.map((s) => s.title)).toEqual(["Retitled before the move"])
+  })
+
+  // The card version is what lets the client order a raced edit payload
+  // against a memo:updated patch absolutely — ms updatedAt can tie.
+  test("every card-field update bumps the card version monotonically", async () => {
+    await explorer.update(
+      testWorkspaceId,
+      memo,
+      { accessibleStreamIds: [sourceChannel, publicChannel, otherPrivateChannel], userId: testUserId },
+      { title: "Launch in July" }
+    )
+
+    const result = await pool.query<{ payload: { summary: { version: number } } }>(
+      `SELECT payload FROM outbox WHERE event_type = 'memo:updated' AND payload->>'memoId' = $1 ORDER BY id ASC`,
+      [memo]
+    )
+    // Two updates so far (test 1's retitle, this one); each fans out to two
+    // citing streams with the SAME version — monotone across updates, equal
+    // within one.
+    const versions = result.rows.map((r) => r.payload.summary.version)
+    expect([...versions].sort((a, b) => a - b)).toEqual(versions)
+    expect(versions.at(-1)).toBeGreaterThan(versions[0])
   })
 
   // findCitingStreamIds scans content_markdown with LIKE '%(memo:<id>)%' — a

--- a/apps/backend/tests/integration/memo-embed-payloads.test.ts
+++ b/apps/backend/tests/integration/memo-embed-payloads.test.ts
@@ -147,6 +147,7 @@ describe("memo embed summaries on message payloads", () => {
         memoType: "message",
         tags: ["settings"],
         updatedAt: expect.any(String),
+        version: expect.any(Number),
       },
     ])
   })

--- a/apps/backend/tests/integration/memo-embed-summaries.test.ts
+++ b/apps/backend/tests/integration/memo-embed-summaries.test.ts
@@ -149,6 +149,7 @@ describe("MemoRepository.findEmbedSummaries", () => {
       memoType: "message",
       tags: ["settings", "preferences"],
       updatedAt: expect.any(String),
+      version: expect.any(Number),
     })
   })
 

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -3156,6 +3156,52 @@ describe("registerStreamSocketHandlers — shared-message slot ingestion (Amendm
     expect((row?.payload as { memoEmbeds: Array<{ title: string }> }).memoEmbeds).toEqual([patched])
   })
 
+  // Two memo edits inside the same millisecond tie on updatedAt — the card
+  // version is what still orders them. Same-timestamp fixtures on purpose:
+  // an updatedAt comparison alone would let the older edit win here.
+  it("message:edited defers to the card version when updatedAt ties", async () => {
+    const streamId = "stream_memo_version_tie"
+    const queryClient = new QueryClient()
+    const base = {
+      memoId: "memo_tied",
+      knowledgeType: "decision" as const,
+      memoType: "conversation" as const,
+      tags: [],
+      updatedAt: "2026-07-31T12:00:00.000Z",
+    }
+    const patched = { ...base, title: "Second edit", version: 3 }
+    const preUpdate = { ...base, title: "First edit", version: 2 }
+    await db.events.put({
+      ...makeEvent({
+        id: "evt_tied",
+        streamId,
+        sequence: "50",
+        payload: { messageId: "msg_tied", contentMarkdown: "old", memoEmbeds: [patched] },
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: 50,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    await emit("message:edited", {
+      workspaceId: "ws_1",
+      streamId,
+      event: makeEvent({
+        id: "evt_tied_edit",
+        streamId,
+        sequence: "101",
+        eventType: "message_edited",
+        payload: { messageId: "msg_tied", contentJson: {}, contentMarkdown: "edited", memoEmbeds: [preUpdate] },
+      }),
+    })
+    cleanup()
+
+    const row = await db.events.get("evt_tied")
+    expect((row?.payload as { memoEmbeds: Array<{ title: string }> }).memoEmbeds).toEqual([patched])
+  })
+
   // Label pages render from their own query, not db.events; the backend
   // resolves their summaries fresh at read, so invalidation IS their repaint.
   it("memo:updated invalidates label message queries but not the label list", async () => {

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1362,10 +1362,18 @@ export function registerStreamSocketHandlers(
         // carried, empty included, so a removed reference loses its card).
         // Per memo, though, a `memo:updated` patch may have landed while this
         // edit event was in flight carrying the pre-update summary — the
-        // strictly newer updatedAt wins so the card never repaints backwards.
+        // strictly newer one wins so the card never repaints backwards.
+        // `card_version` orders absolutely; ms `updatedAt` (which can tie on
+        // two same-millisecond edits) is the fallback for summaries stored
+        // before the version shipped.
         memoEmbeds: (editPayload.memoEmbeds ?? []).map((entry) => {
           const prior = (p.memoEmbeds as MemoEmbedSummary[] | undefined)?.find((x) => x.memoId === entry.memoId)
-          return prior && Date.parse(prior.updatedAt) > Date.parse(entry.updatedAt) ? prior : entry
+          if (!prior) return entry
+          const priorIsNewer =
+            prior.version !== undefined && entry.version !== undefined
+              ? prior.version > entry.version
+              : Date.parse(prior.updatedAt) > Date.parse(entry.updatedAt)
+          return priorIsNewer ? prior : entry
         }),
         editedAt: editEvent.createdAt,
       }))

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1245,6 +1245,14 @@ export interface MemoEmbedSummary {
   memoType: MemoType
   tags: string[]
   updatedAt: string
+  /**
+   * Monotonic card-content version (`memos.version`), bumped on every
+   * card-field update. The client's newer-wins guard orders on it absolutely —
+   * `updatedAt` is ms-precision and can tie. Optional only for summaries
+   * stored before it shipped (IDB rows, sync-log replays); comparisons fall
+   * back to `updatedAt` when either side lacks it.
+   */
+  version?: number
 }
 
 /**


### PR DESCRIPTION
## Problem

The memo-card newer-wins guard (a raced `message:edited` payload vs a `memo:updated` patch, #1695) compares millisecond `updatedAt` strings — two memo edits inside the same millisecond tie, and the older edit payload can then repaint an on-screen card backwards. Documented residual of Stack #1701; this closes it absolutely.

## Solution

`memos.card_version` — an integer bumped on every card-field update, carried on `MemoEmbedSummary.version` (INV-66 shape, `scheduled_messages.version` precedent).

- **Own column, deliberately not `memos.version`:** that one is the supersession REVISION number and chains order on it (`ORDER BY version DESC` in `findLatestRevision`) — bumping it on a title edit would let an edited old revision outrank the capture that superseded it.
- Only `MemoRepository.update` (the sole path changing title/knowledgeType/tags — verified: `explorer-service.ts:255` is its one caller) increments it; embedding refreshes, supersession and archive flips bump `updated_at` but not the card version.
- Client compare (`stream-sync.ts`): versions when both sides carry one, `updatedAt` fallback when either lacks it — pre-version summaries live in IDB rows and ≤30-day sync-log replays, so the mixed window is real and handled, not assumed away.
- Migration `20260731210000_memo_version.sql`, append-only, `DEFAULT 1`.

## Test plan

- [x] Integration: outbox `memo:updated` summaries carry monotonically increasing versions across two updates, equal within one fan-out; payload key-set assertion updated (7 keys).
- [x] Frontend: same-`updatedAt` fixtures where only the version differs — the newer version wins where a timestamp compare would tie. **Mutation-checked:** reverting the compare to updatedAt-only reddens exactly that test (119/120).
- [x] Backend unit **3855** · integration full-suite green (one unrelated `conversation-provisional-attach` case flaked under load; 3× isolated + full rerun green) · frontend **5568** · `check:migrations` 249 clean · typechecks 0.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788123187&installation_model_id=20758&pr_number=1707&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1707&signature=e365bdb8d3fd6d8518552e8521289ef1272f78b64d9a8aa8611846457d9ec89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->