### PR TITLE
test: eliminate recurring CI flakes

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -58,23 +58,32 @@ jobs:
       matrix:
         shard_index: [1, 2, 3, 4]
 
-    services:
-      postgres:
-        image: pgvector/pgvector:pg17
-        env:
-          POSTGRES_USER: threa
-          POSTGRES_PASSWORD: threa
-          POSTGRES_DB: threa
-        ports:
-          - 5454:5432
-        options: >-
-          --health-cmd "pg_isready -U threa -d threa"
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if docker pull pgvector/pgvector:pg17; then
+              break
+            fi
+            echo "docker pull pgvector failed (attempt $attempt/5) — retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          docker run -d --name postgres -p 5454:5432 \
+            -e POSTGRES_USER=threa \
+            -e POSTGRES_PASSWORD=threa \
+            -e POSTGRES_DB=threa \
+            pgvector/pgvector:pg17
+          for i in {1..30}; do
+            if docker exec postgres pg_isready -U threa -d threa; then
+              exit 0
+            fi
+            echo "Waiting for PostgreSQL... ($i/30)"
+            sleep 2
+          done
+          docker logs postgres
+          exit 1
 
       - name: Start MinIO
         run: |
@@ -205,11 +214,14 @@ jobs:
         if: steps.initial-run.outcome == 'failure'
         continue-on-error: true
         run: |
-          if [ ! -f test-results/.last-run.json ]; then
-            echo "::warning::No .last-run.json found — skipping retry (likely an infra failure)"
-            exit 1
+          if [ -f test-results/.last-run.json ] && \
+            bun -e 'const r = await Bun.file("test-results/.last-run.json").json(); process.exit(r.failedTests?.length ? 0 : 1)'; then
+            retry_target=(--last-failed)
+          else
+            echo "::warning::No failed-test IDs found — retrying the shard after the infrastructure failure"
+            retry_target=(--shard=${{ matrix.shard_index }}/${{ env.TOTAL_SHARDS }})
           fi
-          bun run test:browser -- --reporter=line,blob --last-failed --retries=0
+          bun run test:browser -- --reporter=line,blob "${retry_target[@]}" --retries=0
         env:
           CI: true
           PLAYWRIGHT_TEST_DB_NAME: ${{ env.PLAYWRIGHT_TEST_DB_NAME }}

--- a/apps/backend/tests/integration/conversation-provisional-attach.test.ts
+++ b/apps/backend/tests/integration/conversation-provisional-attach.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, afterEach, spyOn } from "bun:test"
 import { Pool } from "pg"
-import { withTransaction, addTestMember, setupTestDatabase, testMessageContent } from "./setup"
+import { withTransaction, addTestMember, setupIsolatedTestDatabase, testMessageContent } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
@@ -37,6 +37,7 @@ class StubExtractor implements BoundaryExtractor {
 
 describe("provisional conversation attach", () => {
   let pool: Pool
+  let cleanupDatabase: () => Promise<void>
   let eventService: EventService
   let extractor: StubExtractor
   let extraction: BoundaryExtractionService
@@ -113,7 +114,9 @@ describe("provisional conversation attach", () => {
   }
 
   beforeAll(async () => {
-    pool = await setupTestDatabase()
+    const isolated = await setupIsolatedTestDatabase("provisional_attach")
+    pool = isolated.pool
+    cleanupDatabase = isolated.cleanup
     testUserId = userId()
     testWorkspaceId = workspaceId()
     testStreamId = streamId()
@@ -152,11 +155,11 @@ describe("provisional conversation attach", () => {
     extractor = new StubExtractor()
     extraction = new BoundaryExtractionService(pool, extractor)
     conversationService = new ConversationService(pool)
-  })
+  }, 120_000)
 
   afterAll(async () => {
-    await pool.end()
-  })
+    await cleanupDatabase()
+  }, 120_000)
 
   afterEach(async () => {
     await withTransaction(pool, async (client) => {

--- a/apps/backend/tests/integration/conversation-reassign.test.ts
+++ b/apps/backend/tests/integration/conversation-reassign.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test"
 import { Pool } from "pg"
-import { withTransaction, addTestMember, setupTestDatabase, testMessageContent } from "./setup"
+import { withTransaction, addTestMember, setupIsolatedTestDatabase, testMessageContent } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
@@ -18,13 +18,16 @@ import { userId, workspaceId, streamId, messageId, conversationId } from "../../
 
 describe("ConversationService.reassignMessage", () => {
   let pool: Pool
+  let cleanupDatabase: () => Promise<void>
   let service: ConversationService
   let testUserId: string
   let testWorkspaceId: string
   let testStreamId: string
 
   beforeAll(async () => {
-    pool = await setupTestDatabase()
+    const isolated = await setupIsolatedTestDatabase("conversation_reassign")
+    pool = isolated.pool
+    cleanupDatabase = isolated.cleanup
 
     testUserId = userId()
     testWorkspaceId = workspaceId()
@@ -49,11 +52,11 @@ describe("ConversationService.reassignMessage", () => {
     })
 
     service = new ConversationService(pool)
-  })
+  }, 120_000)
 
   afterAll(async () => {
-    await pool.end()
-  })
+    await cleanupDatabase()
+  }, 120_000)
 
   afterEach(async () => {
     await withTransaction(pool, async (client) => {

--- a/apps/backend/tests/integration/sync-reconciliation.test.ts
+++ b/apps/backend/tests/integration/sync-reconciliation.test.ts
@@ -6,18 +6,18 @@ import { SyncLogRepository, SyncLogReconciliationWorker } from "../../src/featur
 
 describe("SyncLogReconciliationWorker", () => {
   let pool: Pool
-  let cleanupDatabase: () => Promise<void>
+  let cleanupDatabase: (() => Promise<void>) | undefined
 
   beforeAll(async () => {
     const isolated = await setupIsolatedTestDatabase("sync_reconciliation")
     pool = isolated.pool
     cleanupDatabase = isolated.cleanup
     await SyncLogRepository.ensureSweepState(pool)
-  })
+  }, 120_000)
 
   afterAll(async () => {
-    await cleanupDatabase()
-  })
+    await cleanupDatabase?.()
+  }, 120_000)
 
   function uniqueId(prefix: string): string {
     return `${prefix}_${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -231,7 +231,7 @@ describe("CallManager", () => {
   afterEach(async () => {
     vi.useRealTimers()
     for (const manager of managers.splice(0)) {
-      if (manager.isActive()) await manager.leaveCall()
+      await manager.leaveCall()
     }
   })
 

--- a/scripts/test-silent.ts
+++ b/scripts/test-silent.ts
@@ -46,7 +46,7 @@ const modeConfigs: Record<Mode, ModeConfig> = {
   "backend-integration": {
     runner: "bun",
     cwd: path.join(rootDir, "apps/backend"),
-    baseOptions: ["--preload", "./tests/setup.ts"],
+    baseOptions: ["--preload", "./tests/setup.ts", "--max-concurrency", "1"],
     defaultPatterns: ["tests/integration/"],
   },
   "backend-e2e": {

--- a/tests/browser/helpers.ts
+++ b/tests/browser/helpers.ts
@@ -137,10 +137,11 @@ export async function setSmartSidebarPreset(page: Page): Promise<void> {
 export async function expandCollapsedSidebarSections(page: Page): Promise<void> {
   const sidebar = page.getByRole("navigation", { name: "Sidebar navigation" })
   for (let i = 0; i < 6; i += 1) {
-    const collapsed = sidebar.getByRole("button", { expanded: false })
+    const collapsed = sidebar.locator('[role="button"][aria-expanded="false"]')
     if ((await collapsed.count()) === 0) break
-    await collapsed.first().click()
-    await page.waitForTimeout(100)
+    const section = collapsed.first()
+    await section.click()
+    await expect(section).toHaveAttribute("aria-expanded", "true")
   }
 }
 


### PR DESCRIPTION
## Problem

Recent CI logs showed recurring failures rather than product regressions: backend integration files shared one database with each other and the preloaded server's background workers, producing deadlocks and foreign outbox rows; browser shards could fail before tests when Docker Hub pulls or server startup stalled. The sidebar expansion helper also selected nested stream-action buttons, and call-manager cleanup could retain listeners from inactive managers.

## Solution

- Run backend integration tests with `--max-concurrency 1`; move conversation attachment/reassignment suites to isolated databases so live workers cannot consume their rows.
- Give isolated database hooks 120-second setup/teardown budgets and make failed sync-reconciliation setup safe to tear down.
- Pull pgvector with retries before starting browser shards. If Playwright has no failed test IDs after an infrastructure failure, retry the full shard instead of invoking `--last-failed` with an empty set.
- Target only sidebar section controls and wait for their expanded state; always tear down call managers after each test.

## Files

| Area | Change |
| ---- | ------ |
| Browser workflow/helpers | Retry PostgreSQL pulls, recover startup failures, and scope sidebar expansion |
| Backend integration harness | Serialize shared-database execution and isolate worker-sensitive suites |
| Frontend call tests | Remove every manager during teardown |

## Test plan

- [x] Backend integration suite — 800 passed
- [x] Conversation attachment, reassignment, and sync suites — 3 consecutive passes each
- [x] Call manager suite — 58 passed, 3 consecutive runs
- [x] Thread breadcrumbs browser suite — 2 passed
- [x] Full repository lint, typecheck, migration checks, and generated API check (commit hooks)
- [x] Browser workflow YAML parse and retry-target branch simulation

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788158133&installation_model_id=20758&pr_number=1709&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1709&signature=f267719deacddc4296386362c3fdf2bf456afd27f214313c842f7506457832d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->