### PR TITLE
fix(board): seed gate races the skeleton delay instead of a flat 2.5s wait

### DIFF
--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -31,7 +31,7 @@ import {
   collectBranchThreadStreamIds,
 } from "@/hooks/use-conversation-graph"
 import { useBoardDraftsReady } from "@/hooks/use-scope-draft-preview"
-import { useCoordinatedPhase } from "@/contexts/coordinated-loading-context"
+import { SKELETON_DELAY_MS, useCoordinatedPhase } from "@/contexts/coordinated-loading-context"
 import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/components/composer"
 import { BoardCard, BoardCardSkeleton } from "@/components/board/board-card"
 import { BoardFeedList } from "@/components/board/board-feed-list"
@@ -79,7 +79,12 @@ const SELF_POST_VISIBLE_LENSES = new Set<BoardLens>(["all", "mine"])
  *  anything the viewer sees. */
 const REVEAL_PREWARM_CARDS = 12
 
-const SEED_COMMIT_TIMEOUT_MS = 2500
+/** How long the seed gate gives the network page to win before committing the
+ *  cached order (newer content then arrives behind the "N new" pill — the same
+ *  experience as opening offline and coming online). Twice the skeleton delay:
+ *  a fast seed still lands live with no pill flash, a slow one costs at most
+ *  one skeleton-length beat beyond the skeleton's own appearance. */
+const SEED_COMMIT_TIMEOUT_MS = SKELETON_DELAY_MS * 2
 
 /** Empty-state copy per lens — an empty Decisions view isn't "nothing on the board". */
 const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {


### PR DESCRIPTION
## Problem

The board's land-at-top seed gate (#1682) holds the first commit until the network page lands or `SEED_COMMIT_TIMEOUT_MS = 2500` fires. Fully offline the query pauses and the gate opens instantly, but on a slow connection the board sits on a skeleton for the full 2.5s even with a warm IDB cache — the app feels worse mostly-offline than offline (Kris, slow-Wi-Fi session 2026-08-01).

## Solution

- `SEED_COMMIT_TIMEOUT_MS` becomes `SKELETON_DELAY_MS * 2` (1200ms), imported from `coordinated-loading-context` so the two stay coupled — the gate now races the skeleton reveal instead of a flat wait.
- Fast networks are unchanged: a seed landing under 1.2s still commits live order with no "N new" pill flash. Slow networks commit the cached order at 1.2s and the seed arrives behind the pill — the same experience as opening offline and coming online.
- Race-the-network over commit-cache-instantly (timeout 0): instant commit would put the fresh seed behind a pill on every cold load even on fast Wi-Fi.

## Test plan

- [x] `board.test.tsx` + `use-stable-board-view.test.tsx` — 87 pass; frontend typecheck clean; pre-commit full monorepo lint+typecheck green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788161857&installation_model_id=20758&pr_number=1710&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1710&signature=4ec7c38ad4e55c109cb256b343498eb1e7c6ad5d87d5450339f7bf610dac2d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->