### PR TITLE
fix(conversations): panel reveals cached rows while the backfill is in flight

### DIFF
--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -366,6 +366,23 @@ describe("ConversationPanel", () => {
     expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull()
   })
 
+  it("reveals cached rows immediately while the backfill is still in flight (it's a timeline)", async () => {
+    // Rail short of the server's count on a slow network: the old gate held the
+    // whole panel on the backfill until the 1500ms escape. Cached content must
+    // paint well inside that window, with the loading line below it.
+    const post = makePost()
+    post.conversation.messageIds = ["msg_1", "msg_2", "msg_3"]
+    post.totalReplies = 2
+    mountPanel({
+      cached: asCached(post),
+      getBoardMessages: () => new Promise(() => {}),
+    })
+
+    expect(await screen.findByText("Opening message body.", undefined, { timeout: 1000 })).toBeTruthy()
+    expect(screen.getByText("Reply two body.")).toBeTruthy()
+    expect(screen.getByText("Loading messages…")).toBeTruthy()
+  })
+
   it("renders the conversation from the reactive store row without a by-id fetch", async () => {
     const { getBoardPost } = mountPanel({ cached: asCached(makePost()) })
     expect(await screen.findByText("Opening message body.")).toBeTruthy()

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -724,19 +724,22 @@ function ConversationPanelBody({
     }
     return true
   }, [unreadState, streamReadStates, readableRows, conversation.streamId])
-  // One reveal, not three: the header, the rail, the server backfill and the read
-  // state each used to paint as they landed (`post.recentMessages` under a
-  // "Loading messages…" line, then the rest, then the divider). Hold the whole
-  // panel — header included — until all of them are in.
+  // One reveal, not three: the header, the rail and the read state paint
+  // together, never staggered. But the panel is a timeline (Kris's ruling,
+  // 2026-08-01): cached rows render immediately and the server backfill fills
+  // in behind them — `loadingMore` only holds the reveal when there is nothing
+  // local to show, so a slow network never blanks a warm conversation. The
+  // read-state wait stays in the gate (the divider belongs in the first frame,
+  // and it resolves from IDB on a warm device).
   //
-  // Any of these can also fail to settle. `readStateResolved` is the known one:
+  // Either input can also fail to settle. `readStateResolved` is the known one:
   // the bootstrap builds BOTH `unreadCounts` and `streamReadState` from stream
   // MEMBERSHIPS, and a thread gets no `stream_members` row (INV-62), so a
   // conversation spanning a never-read thread leg holds a row decidable by
   // neither map, and no read event ever writes one. Gating on it unbounded would
   // hold a blank panel forever, so the wait is bounded across every input: the
   // divider (or a still-syncing leg) is worth a beat, never the whole panel.
-  const panelLoading = loadingMore || !readStateResolved
+  const panelLoading = (loadingMore && all.length === 0) || !readStateResolved
   const [revealTimedOut, setRevealTimedOut] = useState(false)
   useEffect(() => {
     setRevealTimedOut(false)
@@ -885,10 +888,13 @@ function ConversationPanelBody({
 
   const { scrollContainerRef, handleScroll, isScrolledFarFromBottom, scrollToBottom, disableAutoScroll } =
     useScrollBehavior({
-      // The rows are gated on `revealed`, not on `loadingMore`: on the reveal-timeout
-      // path `loadingMore` is already false while only the skeleton is mounted, and
-      // the hook would spend its one initial pin against an empty container.
-      isLoading: loadingMore || !revealed,
+      // The hook pins once: it must fire on the first frame that has rows, so
+      // "loading" is "no rows on screen yet" — not the backfill's status (rows
+      // now reveal while it is in flight; keying on it would spend the pin
+      // late, yanking a panel the viewer already sees) and not `revealed` alone
+      // (the reveal-timeout path mounts with zero rows, and the pin would land
+      // against an empty container).
+      isLoading: !revealed || rows.length === 0,
       itemCount: rows.length,
       resetKey: conversation.id,
       // Only treat the user as "at the bottom" when they are essentially flush, so


### PR DESCRIPTION
## Problem

The conversation panel held its entire reveal — header included — on the server backfill (`loadingMore`) up to the 1500ms `REVEAL_TIMEOUT_MS` escape. On slow networks that blanks a conversation whose content is almost always already cached, breaking the offline-first rule the timeline follows (render local immediately, network fills in behind). Kris's ruling: the panel IS a timeline — a late-arriving message is fine; a held panel is not.

## Solution

- `panelLoading = (loadingMore && all.length === 0) || !readStateResolved` — the backfill only gates a panel with nothing local to show. The existing "Loading messages…" line (previously only reachable via the timeout path) now shows under cached rows while the fetch runs; the retry affordance is unchanged.
- Read state stays in the gate: the unread divider belongs in the first frame (the one-way marker latch must not anchor early), it resolves from IDB on warm devices, and the 1500ms escape still bounds the INV-62 never-decidable thread-leg case.
- `useScrollBehavior` one-shot pin now keys on rows-on-screen (`!revealed || rows.length === 0`) instead of backfill status — keyed on the fetch it would fire late and yank a panel the viewer is already reading; the rows-empty guard preserves the reveal-timeout case the old comment protected (pin spent against an empty container).
- Known tradeoff: backfilled older rows insert above a reader who has scrolled up mid-fetch — accepted in the ruling; the window is one fetch wide.

## Test plan

- [x] `conversation-panel.test.tsx` 56 pass, incl. new regression "reveals cached rows immediately while the backfill is still in flight" (verified to fail against the old gate); frontend typecheck clean; pre-commit monorepo lint+typecheck green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788162860&installation_model_id=20758&pr_number=1711&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1711&signature=cc897967d0eef9abf85d5b93a88714f392373e3f327b752a1cd37aeadbec517a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->