### PR TITLE
fix(search): exit jump mode on near-tail navigation and show a spinner while cycling results

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -568,6 +568,12 @@ export function StreamContent({
   const [deepLinkHoldExpired, setDeepLinkHoldExpired] = useState(false)
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  // True while an out-of-window search navigation is fetching its event window —
+  // drives the search bar's spinner so a tap that needs a round-trip is visibly
+  // loading instead of appearing dead. Versioned so a superseding navigation's
+  // completion doesn't clear a newer one's spinner.
+  const [isSearchNavigating, setIsSearchNavigating] = useState(false)
+  const searchNavVersionRef = useRef(0)
   const [batchMode, setBatchMode] = useState(false)
   // What the current batch selection is for. `moveToThread` (default) drags the
   // selection onto a target message; `splitConversation` reassigns the selection's
@@ -1746,7 +1752,24 @@ export function StreamContent({
       // Message not in current window — load events around it, then scroll after load
       disableAutoScroll()
       pendingScrollTarget.current = messageId
+      const version = ++searchNavVersionRef.current
+      setIsSearchNavigating(true)
+      // On success the spinner stays up until the post-jump driver engages the
+      // scroll (or gives up) — the fetch is the smaller half of the wait; the
+      // window swap + scroll placement is the rest of it.
       jumpToEvent(messageId)
+        .then((success) => {
+          if (searchNavVersionRef.current !== version) return
+          if (!success) {
+            setIsSearchNavigating(false)
+            if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
+          }
+        })
+        .catch(() => {
+          if (searchNavVersionRef.current !== version) return
+          setIsSearchNavigating(false)
+          if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
+        })
     },
     [events, jumpToEvent, disableAutoScroll, scrollToMessage]
   )
@@ -1811,6 +1834,7 @@ export function StreamContent({
     if (!useVirtualized) {
       // Threads use plain scroll, not this jump-then-virtualized-scroll path.
       pendingScrollTarget.current = null
+      setIsSearchNavigating(false)
       return
     }
 
@@ -1834,11 +1858,13 @@ export function StreamContent({
       if (phase === "user-abort") {
         deepLinkDebug("post-jump: user interacted, abandoning", target)
         pendingScrollTarget.current = null
+        setIsSearchNavigating(false)
         return
       }
       if (phase === "deadline") {
         deepLinkDebug("post-jump: deadline exceeded, giving up", target)
         pendingScrollTarget.current = null
+        setIsSearchNavigating(false)
         // The jump window loaded but the target never became placeable (e.g. a
         // mid-flight window swap). Mark the deep-link as conclusively failed so
         // the holdForDeepLink skeleton releases and the gated ?m= clear can
@@ -1854,6 +1880,7 @@ export function StreamContent({
         // + user-abort from here, so this driver is done.
         deepLinkDebug("post-jump: scrollToMessage engaged", target)
         pendingScrollTarget.current = null
+        setIsSearchNavigating(false)
         return
       }
 
@@ -1942,6 +1969,8 @@ export function StreamContent({
     setDeepLinkHoldExpired(false)
     exitJumpMode()
     setIsSearchOpen(false)
+    searchNavVersionRef.current++
+    setIsSearchNavigating(false)
     clearSearch()
   }, [streamId, exitJumpMode, clearSearch])
 
@@ -2371,6 +2400,7 @@ export function StreamContent({
                     {isSearchOpen && (
                       <StreamSearchBar
                         search={streamSearch}
+                        isNavigating={isSearchNavigating}
                         onClose={handleSearchClose}
                         onNavigate={handleSearchNavigate}
                       />

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -574,6 +574,9 @@ export function StreamContent({
   // completion doesn't clear a newer one's spinner.
   const [isSearchNavigating, setIsSearchNavigating] = useState(false)
   const searchNavVersionRef = useRef(0)
+  // Target of the most recent out-of-window search navigation — lets close
+  // distinguish the search's own pendingScrollTarget from a deep-link's.
+  const searchNavTargetRef = useRef<string | null>(null)
   const [batchMode, setBatchMode] = useState(false)
   // What the current batch selection is for. `moveToThread` (default) drags the
   // selection onto a target message; `splitConversation` reassigns the selection's
@@ -778,6 +781,7 @@ export function StreamContent({
     jumpToEvent,
     jumpToEventByDate,
     exitJumpMode,
+    cancelPendingJump,
     isJumpMode,
   } = useEvents(workspaceId, streamId, { enabled: !isDraft, loadAll: isThread })
 
@@ -863,6 +867,20 @@ export function StreamContent({
     }
   }, [isDraft, isThread, openOrFocusSearch])
 
+  const handleSearchClose = useCallback(() => {
+    setIsSearchOpen(false)
+    // Closing abandons any in-flight search navigation. Without this the jump
+    // resolves up to seconds later and swaps/scrolls the window under a user
+    // who has moved on.
+    cancelPendingJump()
+    searchNavVersionRef.current++
+    setIsSearchNavigating(false)
+    if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
+      pendingScrollTarget.current = null
+    }
+    clearSearch()
+  }, [clearSearch, cancelPendingJump])
+
   // Escape closes search when focus is outside the search input.
   useEffect(() => {
     if (!isSearchOpen) return
@@ -872,19 +890,13 @@ export function StreamContent({
       const isInput = target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable
 
       if (event.key === "Escape" && !isInput) {
-        setIsSearchOpen(false)
-        clearSearch()
+        handleSearchClose()
       }
     }
 
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [isSearchOpen, clearSearch])
-
-  const handleSearchClose = useCallback(() => {
-    setIsSearchOpen(false)
-    clearSearch()
-  }, [clearSearch])
+  }, [isSearchOpen, handleSearchClose])
 
   // Compute timeline items in StreamContent so the virtualizer can use count + keys.
   // After grouping commands/sessions, annotate consecutive same-author message runs
@@ -1003,10 +1015,9 @@ export function StreamContent({
       setDragGhost(null)
       // Selection and search share the same flush-top strip; keep one open at a
       // time so they can't stack. Search bar's own listeners handle the reverse.
-      setIsSearchOpen(false)
-      clearSearch()
+      handleSearchClose()
     },
-    [clearSearch]
+    [handleSearchClose]
   )
 
   const toggleBatchMessage = useCallback((messageId: string) => {
@@ -1752,23 +1763,32 @@ export function StreamContent({
       // Message not in current window — load events around it, then scroll after load
       disableAutoScroll()
       pendingScrollTarget.current = messageId
+      searchNavTargetRef.current = messageId
       const version = ++searchNavVersionRef.current
       setIsSearchNavigating(true)
       // On success the spinner stays up until the post-jump driver engages the
       // scroll (or gives up) — the fetch is the smaller half of the wait; the
       // window swap + scroll placement is the rest of it.
       jumpToEvent(messageId)
-        .then((success) => {
+        .then((result) => {
           if (searchNavVersionRef.current !== version) return
-          if (!success) {
+          if (result === "superseded") {
+            // A date jump or deep link took over mid-flight; it owns the
+            // window and the spinner semantics now.
+            setIsSearchNavigating(false)
+            return
+          }
+          if (!result) {
             setIsSearchNavigating(false)
             if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
+            toast.error("Couldn't load that search result")
           }
         })
         .catch(() => {
           if (searchNavVersionRef.current !== version) return
           setIsSearchNavigating(false)
           if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
+          toast.error("Couldn't load that search result")
         })
     },
     [events, jumpToEvent, disableAutoScroll, scrollToMessage]
@@ -1791,6 +1811,9 @@ export function StreamContent({
       }
       resetShiftBaseline()
       const anchorId = await jumpToEventByDate(new Date(targetDayMs).toISOString())
+      // A newer jump (another date pick, a search navigation) superseded this
+      // one mid-flight — it owns the window and pendingScrollTarget now.
+      if (anchorId === "superseded") return
       if (anchorId) {
         pendingScrollTarget.current = anchorId
         setPendingScrollRequestVersion((version) => version + 1)
@@ -1968,11 +1991,15 @@ export function StreamContent({
     setDeepLinkGaveUp(false)
     setDeepLinkHoldExpired(false)
     exitJumpMode()
+    // An in-flight jump for the previous stream must not apply its window to
+    // this one — jumpState carries no streamId, so a late resolution would
+    // render the old stream's events here.
+    cancelPendingJump()
     setIsSearchOpen(false)
     searchNavVersionRef.current++
     setIsSearchNavigating(false)
     clearSearch()
-  }, [streamId, exitJumpMode, clearSearch])
+  }, [streamId, exitJumpMode, cancelPendingJump, clearSearch])
 
   // Auto-mark stream as read when viewing. The stream opens at the live bottom;
   // read state advances only through the contiguous run the viewer scrolls

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -577,6 +577,14 @@ export function StreamContent({
   // Target of the most recent out-of-window search navigation — lets close
   // distinguish the search's own pendingScrollTarget from a deep-link's.
   const searchNavTargetRef = useRef<string | null>(null)
+  // Lifecycle of that navigation: "fetching" until jumpToEvent resolves,
+  // "swapped" once the window changed (the post-jump driver owns the landing
+  // from there), "idle" otherwise. Abandoning paths cancel a "fetching"
+  // navigation outright but let a "swapped" one finish landing — killing it
+  // mid-way would strand the swapped window unanchored at an arbitrary
+  // position. The cancel itself is gated on "fetching" so it can never hit an
+  // unrelated in-flight jump (deep link, date) that search doesn't own.
+  const searchNavPhaseRef = useRef<"idle" | "fetching" | "swapped">("idle")
   const [batchMode, setBatchMode] = useState(false)
   // What the current batch selection is for. `moveToThread` (default) drags the
   // selection onto a target message; `splitConversation` reassigns the selection's
@@ -869,15 +877,20 @@ export function StreamContent({
 
   const handleSearchClose = useCallback(() => {
     setIsSearchOpen(false)
-    // Closing abandons any in-flight search navigation. Without this the jump
+    // Closing abandons a still-fetching navigation. Without this the jump
     // resolves up to seconds later and swaps/scrolls the window under a user
-    // who has moved on.
-    cancelPendingJump()
+    // who has moved on. A "swapped" navigation is past the point of no return
+    // — keep its pendingScrollTarget so the post-jump driver finishes landing
+    // instead of stranding the swapped window unanchored.
+    if (searchNavPhaseRef.current === "fetching") {
+      cancelPendingJump()
+      if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
+        pendingScrollTarget.current = null
+      }
+    }
+    searchNavPhaseRef.current = "idle"
     searchNavVersionRef.current++
     setIsSearchNavigating(false)
-    if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
-      pendingScrollTarget.current = null
-    }
     clearSearch()
   }, [clearSearch, cancelPendingJump])
 
@@ -1755,6 +1768,16 @@ export function StreamContent({
       const isInCurrentEvents = events.some((e) => matchesDeepLinkTarget(e, messageId))
 
       if (isInCurrentEvents) {
+        // A previous out-of-window navigation may still be pending; this newer
+        // navigation supersedes it — otherwise its window swap or landing
+        // arrives later, under a user who is already at this match.
+        if (searchNavPhaseRef.current === "fetching") cancelPendingJump()
+        if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
+          pendingScrollTarget.current = null
+        }
+        searchNavPhaseRef.current = "idle"
+        searchNavVersionRef.current++
+        setIsSearchNavigating(false)
         // Message is loaded — scroll to it (handles both in-DOM and virtualized-out items)
         scrollToMessage(messageId)
         return
@@ -1764,6 +1787,7 @@ export function StreamContent({
       disableAutoScroll()
       pendingScrollTarget.current = messageId
       searchNavTargetRef.current = messageId
+      searchNavPhaseRef.current = "fetching"
       const version = ++searchNavVersionRef.current
       setIsSearchNavigating(true)
       // On success the spinner stays up until the post-jump driver engages the
@@ -1775,23 +1799,28 @@ export function StreamContent({
           if (result === "superseded") {
             // A date jump or deep link took over mid-flight; it owns the
             // window and the spinner semantics now.
+            searchNavPhaseRef.current = "idle"
             setIsSearchNavigating(false)
             return
           }
           if (!result) {
+            searchNavPhaseRef.current = "idle"
             setIsSearchNavigating(false)
             if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
             toast.error("Couldn't load that search result")
+            return
           }
+          searchNavPhaseRef.current = "swapped"
         })
         .catch(() => {
           if (searchNavVersionRef.current !== version) return
+          searchNavPhaseRef.current = "idle"
           setIsSearchNavigating(false)
           if (pendingScrollTarget.current === messageId) pendingScrollTarget.current = null
           toast.error("Couldn't load that search result")
         })
     },
-    [events, jumpToEvent, disableAutoScroll, scrollToMessage]
+    [events, jumpToEvent, cancelPendingJump, disableAutoScroll, scrollToMessage]
   )
 
   // Jump to a calendar date from the floating date header. Scrolls to the first
@@ -1857,6 +1886,7 @@ export function StreamContent({
     if (!useVirtualized) {
       // Threads use plain scroll, not this jump-then-virtualized-scroll path.
       pendingScrollTarget.current = null
+      searchNavPhaseRef.current = "idle"
       setIsSearchNavigating(false)
       return
     }
@@ -1881,12 +1911,14 @@ export function StreamContent({
       if (phase === "user-abort") {
         deepLinkDebug("post-jump: user interacted, abandoning", target)
         pendingScrollTarget.current = null
+        searchNavPhaseRef.current = "idle"
         setIsSearchNavigating(false)
         return
       }
       if (phase === "deadline") {
         deepLinkDebug("post-jump: deadline exceeded, giving up", target)
         pendingScrollTarget.current = null
+        searchNavPhaseRef.current = "idle"
         setIsSearchNavigating(false)
         // The jump window loaded but the target never became placeable (e.g. a
         // mid-flight window swap). Mark the deep-link as conclusively failed so
@@ -1903,6 +1935,7 @@ export function StreamContent({
         // + user-abort from here, so this driver is done.
         deepLinkDebug("post-jump: scrollToMessage engaged", target)
         pendingScrollTarget.current = null
+        searchNavPhaseRef.current = "idle"
         setIsSearchNavigating(false)
         return
       }
@@ -1920,6 +1953,37 @@ export function StreamContent({
       }
     }
   }, [events, isLoading, scrollToMessage, useVirtualized, setDeepLinkGaveUp, pendingScrollRequestVersion])
+
+  // Reset jump and search state when switching streams (component stays mounted).
+  // Also abort any in-flight scrollToMessage retry loop so its stale closure
+  // (holding an index from the previous stream) doesn't scroll the new stream
+  // to the wrong position.
+  //
+  // Declared BEFORE the highlight deep-link effect below: effects run in
+  // declaration order, and a navigation that changes stream and ?m= together
+  // must reset first, then start the new stream's deep-link jump — the other
+  // order cancels the jump this same commit just started.
+  useEffect(() => {
+    jumpTriggeredKeyRef.current = null
+    scrollAbortRef.current?.()
+    if (pendingScrollRafRef.current) {
+      cancelAnimationFrame(pendingScrollRafRef.current)
+      pendingScrollRafRef.current = 0
+    }
+    pendingScrollTarget.current = null
+    setDeepLinkGaveUp(false)
+    setDeepLinkHoldExpired(false)
+    exitJumpMode()
+    // An in-flight jump for the previous stream must not apply its window to
+    // this one — jumpState carries no streamId, so a late resolution would
+    // render the old stream's events here.
+    cancelPendingJump()
+    setIsSearchOpen(false)
+    searchNavPhaseRef.current = "idle"
+    searchNavVersionRef.current++
+    setIsSearchNavigating(false)
+    clearSearch()
+  }, [streamId, exitJumpMode, cancelPendingJump, clearSearch])
 
   // Jump to highlighted message if it's not in the current event window.
   // The guard uses location.key so repeat clicks on the same message link
@@ -1963,6 +2027,14 @@ export function StreamContent({
         // release the new mount hold.
         if (jumpTriggeredKeyRef.current !== navigationKey) return
         deepLinkDebug("highlight: jumpToEvent resolved", targetMessageId, "success=", success)
+        if (success === "superseded") {
+          // Another navigation (search, date, jump-to-latest) took over while
+          // this deep link loaded. Release the ?m= hold so the param and
+          // highlight don't hang; the superseding action owns the window now.
+          if (pendingScrollTarget.current === targetMessageId) pendingScrollTarget.current = null
+          setDeepLinkGaveUp(true)
+          return
+        }
         if (!success) {
           pendingScrollTarget.current = null
           setDeepLinkGaveUp(true)
@@ -1975,31 +2047,6 @@ export function StreamContent({
         setDeepLinkGaveUp(true)
       })
   }, [highlightMessageId, location.key, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
-
-  // Reset jump and search state when switching streams (component stays mounted).
-  // Also abort any in-flight scrollToMessage retry loop so its stale closure
-  // (holding an index from the previous stream) doesn't scroll the new stream
-  // to the wrong position.
-  useEffect(() => {
-    jumpTriggeredKeyRef.current = null
-    scrollAbortRef.current?.()
-    if (pendingScrollRafRef.current) {
-      cancelAnimationFrame(pendingScrollRafRef.current)
-      pendingScrollRafRef.current = 0
-    }
-    pendingScrollTarget.current = null
-    setDeepLinkGaveUp(false)
-    setDeepLinkHoldExpired(false)
-    exitJumpMode()
-    // An in-flight jump for the previous stream must not apply its window to
-    // this one — jumpState carries no streamId, so a late resolution would
-    // render the old stream's events here.
-    cancelPendingJump()
-    setIsSearchOpen(false)
-    searchNavVersionRef.current++
-    setIsSearchNavigating(false)
-    clearSearch()
-  }, [streamId, exitJumpMode, cancelPendingJump, clearSearch])
 
   // Auto-mark stream as read when viewing. The stream opens at the live bottom;
   // read state advances only through the contiguous run the viewer scrolls
@@ -2216,6 +2263,14 @@ export function StreamContent({
   )
 
   const handleJumpToLatest = useCallback(() => {
+    // Explicit "go to latest": abandon any pending navigation — a
+    // late-resolving jump would otherwise re-enter jump mode and scroll back
+    // to the abandoned target, overriding this click.
+    cancelPendingJump()
+    pendingScrollTarget.current = null
+    searchNavPhaseRef.current = "idle"
+    searchNavVersionRef.current++
+    setIsSearchNavigating(false)
     if (isJumpMode) {
       exitJumpMode()
       // The event window is about to be replaced wholesale (jump window →
@@ -2228,7 +2283,7 @@ export function StreamContent({
     } else {
       scrollToBottom({ force: true })
     }
-  }, [isJumpMode, exitJumpMode, resetShiftBaseline, scrollToBottom])
+  }, [isJumpMode, exitJumpMode, cancelPendingJump, resetShiftBaseline, scrollToBottom])
 
   // Jump up to the first unread (the "New" divider) and stop following the tail
   // so a live message doesn't yank the reader back down. Lands the divider near

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -582,9 +582,12 @@ export function StreamContent({
   // from there), "idle" otherwise. Abandoning paths cancel a "fetching"
   // navigation outright but let a "swapped" one finish landing — killing it
   // mid-way would strand the swapped window unanchored at an arbitrary
-  // position. The cancel itself is gated on "fetching" so it can never hit an
-  // unrelated in-flight jump (deep link, date) that search doesn't own.
+  // position. The phase alone can go stale (a foreign jump superseding the
+  // search nav doesn't reset it), so cancels also pass the generation the
+  // search's own jump claimed (searchNavGenRef) — an ownership-checked
+  // cancel no-ops when the in-flight jump isn't search's.
   const searchNavPhaseRef = useRef<"idle" | "fetching" | "swapped">("idle")
+  const searchNavGenRef = useRef(0)
   const [batchMode, setBatchMode] = useState(false)
   // What the current batch selection is for. `moveToThread` (default) drags the
   // selection onto a target message; `splitConversation` reassigns the selection's
@@ -790,6 +793,7 @@ export function StreamContent({
     jumpToEventByDate,
     exitJumpMode,
     cancelPendingJump,
+    currentJumpGeneration,
     isJumpMode,
   } = useEvents(workspaceId, streamId, { enabled: !isDraft, loadAll: isThread })
 
@@ -883,7 +887,7 @@ export function StreamContent({
     // — keep its pendingScrollTarget so the post-jump driver finishes landing
     // instead of stranding the swapped window unanchored.
     if (searchNavPhaseRef.current === "fetching") {
-      cancelPendingJump()
+      cancelPendingJump(searchNavGenRef.current)
       if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
         pendingScrollTarget.current = null
       }
@@ -1771,7 +1775,7 @@ export function StreamContent({
         // A previous out-of-window navigation may still be pending; this newer
         // navigation supersedes it — otherwise its window swap or landing
         // arrives later, under a user who is already at this match.
-        if (searchNavPhaseRef.current === "fetching") cancelPendingJump()
+        if (searchNavPhaseRef.current === "fetching") cancelPendingJump(searchNavGenRef.current)
         if (pendingScrollTarget.current && pendingScrollTarget.current === searchNavTargetRef.current) {
           pendingScrollTarget.current = null
         }
@@ -1793,7 +1797,11 @@ export function StreamContent({
       // On success the spinner stays up until the post-jump driver engages the
       // scroll (or gives up) — the fetch is the smaller half of the wait; the
       // window swap + scroll placement is the rest of it.
-      jumpToEvent(messageId)
+      const navPromise = jumpToEvent(messageId)
+      // jumpToEvent claims its generation synchronously — capture it as the
+      // ownership token for phase-gated cancels.
+      searchNavGenRef.current = currentJumpGeneration()
+      navPromise
         .then((result) => {
           if (searchNavVersionRef.current !== version) return
           if (result === "superseded") {
@@ -1820,7 +1828,7 @@ export function StreamContent({
           toast.error("Couldn't load that search result")
         })
     },
-    [events, jumpToEvent, cancelPendingJump, disableAutoScroll, scrollToMessage]
+    [events, jumpToEvent, cancelPendingJump, currentJumpGeneration, disableAutoScroll, scrollToMessage]
   )
 
   // Jump to a calendar date from the floating date header. Scrolls to the first
@@ -1834,7 +1842,13 @@ export function StreamContent({
       disableAutoScroll()
       const inWindowMessageId = resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents })
       if (inWindowMessageId) {
+        // Explicit navigation: abandon whatever jump is in flight — a
+        // late-resolving one would swap the window under this scroll.
+        cancelPendingJump()
         pendingScrollTarget.current = null
+        searchNavPhaseRef.current = "idle"
+        searchNavVersionRef.current++
+        setIsSearchNavigating(false)
         scrollToMessage(inWindowMessageId)
         return
       }
@@ -1851,7 +1865,15 @@ export function StreamContent({
         toast.info("No messages on or after that date")
       }
     },
-    [events, hasOlderEvents, disableAutoScroll, scrollToMessage, jumpToEventByDate, resetShiftBaseline]
+    [
+      events,
+      hasOlderEvents,
+      cancelPendingJump,
+      disableAutoScroll,
+      scrollToMessage,
+      jumpToEventByDate,
+      resetShiftBaseline,
+    ]
   )
 
   // Highlight search matches in the DOM via CSS Custom Highlight API

--- a/apps/frontend/src/components/timeline/stream-search-bar.tsx
+++ b/apps/frontend/src/components/timeline/stream-search-bar.tsx
@@ -7,6 +7,8 @@ import type { useStreamSearch } from "@/hooks/use-stream-search"
 
 interface StreamSearchBarProps {
   search: ReturnType<typeof useStreamSearch>
+  /** True while an out-of-window navigation is loading its event window */
+  isNavigating: boolean
   onClose: () => void
   /** Called when the active result changes (navigate to that message) */
   onNavigate: (messageId: string) => void
@@ -15,7 +17,7 @@ interface StreamSearchBarProps {
 /** Debounce delay in milliseconds for auto-search on typing */
 const DEBOUNCE_MS = 300
 
-export function StreamSearchBar({ search, onClose, onNavigate }: StreamSearchBarProps) {
+export function StreamSearchBar({ search, isNavigating, onClose, onNavigate }: StreamSearchBarProps) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const prevActiveResultIdRef = useRef<string | null>(null)
 
@@ -108,7 +110,7 @@ export function StreamSearchBar({ search, onClose, onNavigate }: StreamSearchBar
             {search.activeMatchIndex + 1}/{search.matchCount}
           </span>
         )}
-        {search.isSearching && <Loader2 className="h-3 w-3 animate-spin" />}
+        {(search.isSearching || isNavigating) && <Loader2 className="h-3 w-3 animate-spin" />}
         {hasQuery && !search.isSearching && search.hasSearched && search.matchCount === 0 && <span>No results</span>}
       </div>
 

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -620,6 +620,13 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     return true
   }, [jumpState, isFetchingNewer, hasNewerPage, queryClient, workspaceId, streamId, fetchNewerPage])
 
+  /** Exit jump mode and return to live tail (latest messages from IDB). */
+  const exitJumpMode = useCallback(() => {
+    setJumpState(null)
+    queryClient.removeQueries({ queryKey: eventKeys.list(workspaceId, streamId) })
+    queryClient.removeQueries({ queryKey: eventKeys.newer(workspaceId, streamId) })
+  }, [queryClient, workspaceId, streamId])
+
   /**
    * Jump to a specific event (e.g. from search or push notification deep link).
    * Loads events around it and switches to bidirectional pagination mode.
@@ -638,8 +645,14 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
       await cacheToIndexedDB(workspaceId, streamId, result.events, result)
 
       // If there are no newer events, the target is already at the bottom —
-      // skip jump mode and let the live tail render from IDB.
-      if (!result.hasNewer) return true
+      // skip jump mode and let the live tail render from IDB. A previous jump
+      // may still be active; its window renders instead of IDB, so exit it —
+      // otherwise the timeline stays frozen on the old window and this
+      // navigation silently does nothing.
+      if (!result.hasNewer) {
+        exitJumpMode()
+        return true
+      }
 
       const sorted = sortBySequence([...result.events])
       setJumpState({
@@ -656,7 +669,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
 
       return true
     },
-    [streamService, workspaceId, streamId, queryClient]
+    [streamService, workspaceId, streamId, queryClient, exitJumpMode]
   )
 
   /**
@@ -674,7 +687,11 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
 
       // No newer events means the anchor sits at the live tail — skip jump mode
       // and let IDB render the tail; the caller still scrolls to the anchor.
-      if (!result.hasNewer) return result.anchorMessageId
+      // Exit any active jump first: its window would render instead of IDB.
+      if (!result.hasNewer) {
+        exitJumpMode()
+        return result.anchorMessageId
+      }
 
       const sorted = sortBySequence([...result.events])
       setJumpState({
@@ -690,15 +707,8 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
 
       return result.anchorMessageId
     },
-    [streamService, workspaceId, streamId, queryClient]
+    [streamService, workspaceId, streamId, queryClient, exitJumpMode]
   )
-
-  /** Exit jump mode and return to live tail (latest messages from IDB). */
-  const exitJumpMode = useCallback(() => {
-    setJumpState(null)
-    queryClient.removeQueries({ queryKey: eventKeys.list(workspaceId, streamId) })
-    queryClient.removeQueries({ queryKey: eventKeys.newer(workspaceId, streamId) })
-  }, [queryClient, workspaceId, streamId])
 
   // addEvent and updateEvent write directly to IDB; useLiveQuery picks up
   // changes automatically — no TanStack cache needed.

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -635,10 +635,27 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   // resolution is routine under rapid result cycling.
   const jumpGenerationRef = useRef(0)
 
-  /** Invalidate any in-flight jump so its resolution can't mutate window state. */
-  const cancelPendingJump = useCallback(() => {
+  /**
+   * Invalidate an in-flight jump so its resolution can't mutate window state.
+   * With `expectedGeneration` (from `currentJumpGeneration()` right after the
+   * jump call), the cancel is ownership-checked: it no-ops when a newer jump
+   * has already claimed the generation — cancelling unconditionally there
+   * would kill the *newer* navigation, not the caller's own stale one. Omit
+   * the argument only for actions that mean "abandon whatever is in flight"
+   * (stream switch, jump-to-latest, an explicit in-window navigation).
+   */
+  const cancelPendingJump = useCallback((expectedGeneration?: number) => {
+    if (expectedGeneration !== undefined && expectedGeneration !== jumpGenerationRef.current) return
     jumpGenerationRef.current++
   }, [])
+
+  /**
+   * The generation of the most recently started jump. A jump function bumps
+   * the generation synchronously before its first await, so reading this
+   * immediately after calling `jumpToEvent`/`jumpToEventByDate` yields the
+   * generation that call claimed — the token for an ownership-checked cancel.
+   */
+  const currentJumpGeneration = useCallback(() => jumpGenerationRef.current, [])
 
   /**
    * Jump to a specific event (e.g. from search or push notification deep link).
@@ -764,6 +781,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     jumpToEventByDate,
     exitJumpMode,
     cancelPendingJump,
+    currentJumpGeneration,
     isJumpMode: !!jumpState,
     addEvent,
     updateEvent,

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -627,22 +627,38 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     queryClient.removeQueries({ queryKey: eventKeys.newer(workspaceId, streamId) })
   }, [queryClient, workspaceId, streamId])
 
+  // Generation counter for jump requests. A jump that resolves after a newer
+  // jump has started (or after cancelPendingJump) must not mutate window
+  // state: a stale exitJumpMode() would snap an already-landed newer window
+  // back to the live tail, and a stale setJumpState would resurrect an
+  // abandoned window. The fetches have no cancellation, so out-of-order
+  // resolution is routine under rapid result cycling.
+  const jumpGenerationRef = useRef(0)
+
+  /** Invalidate any in-flight jump so its resolution can't mutate window state. */
+  const cancelPendingJump = useCallback(() => {
+    jumpGenerationRef.current++
+  }, [])
+
   /**
    * Jump to a specific event (e.g. from search or push notification deep link).
    * Loads events around it and switches to bidirectional pagination mode.
    */
   const jumpToEvent = useCallback(
-    async (targetMessageId: string): Promise<boolean> => {
+    async (targetMessageId: string): Promise<boolean | "superseded"> => {
+      const generation = ++jumpGenerationRef.current
       const result: EventsAroundResponse = await streamService.getEventsAround(
         workspaceId,
         streamId,
         targetMessageId,
         EVENT_PAGE_SIZE
       )
+      if (generation !== jumpGenerationRef.current) return "superseded"
       if (result.events.length === 0) return false
 
       // Write to IDB so they persist across sessions
       await cacheToIndexedDB(workspaceId, streamId, result.events, result)
+      if (generation !== jumpGenerationRef.current) return "superseded"
 
       // If there are no newer events, the target is already at the bottom —
       // skip jump mode and let the live tail render from IDB. A previous jump
@@ -679,11 +695,14 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
    * (the date is past the last message — caller stays on the live tail).
    */
   const jumpToEventByDate = useCallback(
-    async (isoDate: string): Promise<string | null> => {
+    async (isoDate: string): Promise<string | null | "superseded"> => {
+      const generation = ++jumpGenerationRef.current
       const result = await streamService.getEventsAroundDate(workspaceId, streamId, isoDate, EVENT_PAGE_SIZE)
+      if (generation !== jumpGenerationRef.current) return "superseded"
       if (result.events.length === 0) return null
 
       await cacheToIndexedDB(workspaceId, streamId, result.events, result)
+      if (generation !== jumpGenerationRef.current) return "superseded"
 
       // No newer events means the anchor sits at the live tail — skip jump mode
       // and let IDB render the tail; the caller still scrolls to the anchor.
@@ -744,6 +763,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     jumpToEvent,
     jumpToEventByDate,
     exitJumpMode,
+    cancelPendingJump,
     isJumpMode: !!jumpState,
     addEvent,
     updateEvent,

--- a/tests/browser/stream-search-cycling.spec.ts
+++ b/tests/browser/stream-search-cycling.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * Cycling through in-stream search results across jump windows — the part no
+ * component test reaches: each navigation swaps the timeline's event window
+ * via /events/around, and the regression this guards only appears once a
+ * previous jump's window is live and the next target sits near the live tail
+ * (hasNewer=false). jumpToEvent used to early-return without exiting jump
+ * mode there, leaving the timeline frozen on the old window while the match
+ * counter kept advancing.
+ */
+
+test.describe.configure({ timeout: 600_000 })
+
+/** The gap between the two matches must exceed a jump window (25 each side)
+ *  plus two newer-pagination pages (50 each) — the scroll-edge recheck after a
+ *  window swap can append newer pages and silently heal a smaller gap, which
+ *  would let the frozen-window regression pass unexercised. The tail match
+ *  sits inside the last ~25 events so its /events/around answers
+ *  hasNewer=false. */
+const TOTAL = 175
+const MATCH_POSITIONS = [30, 165]
+
+async function seedMessages(page: Page, workspaceId: string, streamId: string): Promise<void> {
+  const BATCH_SIZE = 10
+  const send = async (i: number) => {
+    const matchIndex = MATCH_POSITIONS.indexOf(i)
+    const content =
+      matchIndex >= 0
+        ? `Note ${i}: the pelican lands here (match ${matchIndex + 1} of ${MATCH_POSITIONS.length}).`
+        : `Filler ${i}: routine update about nothing in particular.`
+    // TOTAL exceeds the 120/min message-create rate limit — wait out 429s.
+    // The workspace-router worker occasionally restarts mid-request (503);
+    // retry those too.
+    for (let attempt = 0; ; attempt++) {
+      const r = await page.request.post(`/api/workspaces/${workspaceId}/messages`, { data: { streamId, content } })
+      if (r.ok()) return
+      if ((r.status() === 429 || r.status() >= 500) && attempt < 30) {
+        await new Promise((resolve) => setTimeout(resolve, 5000))
+        continue
+      }
+      await expectApiOk(r, `Send message ${i}`)
+    }
+  }
+  for (let start = 1; start <= TOTAL; start += BATCH_SIZE) {
+    const batch: Promise<void>[] = []
+    for (let i = start; i <= Math.min(start + BATCH_SIZE - 1, TOTAL); i++) batch.push(send(i))
+    await Promise.all(batch)
+  }
+}
+
+test("cycles through matches in both directions across jump windows", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "search-cycle")
+  await createChannel(page, `search-cycle-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  // Seed with the stream CLOSED. Sitting in the channel would stream every
+  // seeded message into IndexedDB over the socket; a bootstrap hiccup on the
+  // later load can then fall back to rendering the full cached history, which
+  // puts every match in-window and silently skips the jump path this test
+  // exists to exercise.
+  await page.goto(`/w/${workspaceId}`)
+  await seedMessages(page, workspaceId!, streamId!)
+  await page.goto(url)
+  await expect(page.locator("[data-message-id]").getByText(`Filler ${TOTAL - 1}:`)).toBeVisible({ timeout: 30_000 })
+
+  await page.keyboard.press("ControlOrMeta+f")
+  const input = page.getByPlaceholder("Search in conversation...")
+  await input.waitFor()
+  await input.pressSequentially("pelican", { delay: 30 })
+  // Local phase may briefly count only the in-window match; wait for the server
+  // merge to count both.
+  await expect(page.getByText("2/2", { exact: true })).toBeVisible({ timeout: 15_000 })
+
+  // Scoped to timeline rows: preview surfaces (sidebar rows, offscreen
+  // drawers) can carry the same text and count as "visible" while offscreen.
+  const matchVisible = (k: number) =>
+    expect(
+      page.locator("[data-message-id]").getByText(`(match ${k} of ${MATCH_POSITIONS.length})`).first()
+    ).toBeVisible({ timeout: 15_000 })
+
+  // Down from the newest match wraps to the oldest — an out-of-window jump.
+  await input.press("Enter")
+  await matchVisible(1)
+  // The regression: this target is near the live tail (hasNewer=false) while a
+  // jump window is active — it must render, not freeze on match 1's window.
+  await input.press("Enter")
+  await matchVisible(2)
+  // And back up through the same windows.
+  await input.press("Shift+Enter")
+  await matchVisible(1)
+})

--- a/tests/browser/stream-search-cycling.spec.ts
+++ b/tests/browser/stream-search-cycling.spec.ts
@@ -34,13 +34,15 @@ async function seedMessages(page: Page, workspaceId: string, streamId: string): 
     // The workspace-router worker occasionally restarts mid-request (503);
     // retry those too.
     for (let attempt = 0; ; attempt++) {
-      const r = await page.request.post(`/api/workspaces/${workspaceId}/messages`, { data: { streamId, content } })
-      if (r.ok()) return
-      if ((r.status() === 429 || r.status() >= 500) && attempt < 30) {
+      const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+        data: { streamId, content },
+      })
+      if (response.ok()) return
+      if ((response.status() === 429 || response.status() >= 500) && attempt < 30) {
         await new Promise((resolve) => setTimeout(resolve, 5000))
         continue
       }
-      await expectApiOk(r, `Send message ${i}`)
+      await expectApiOk(response, `Send message ${i}`)
     }
   }
   for (let start = 1; start <= TOTAL; start += BATCH_SIZE) {
@@ -79,9 +81,9 @@ test("cycles through matches in both directions across jump windows", async ({ p
 
   // Scoped to timeline rows: preview surfaces (sidebar rows, offscreen
   // drawers) can carry the same text and count as "visible" while offscreen.
-  const matchVisible = (k: number) =>
+  const matchVisible = (matchNumber: number) =>
     expect(
-      page.locator("[data-message-id]").getByText(`(match ${k} of ${MATCH_POSITIONS.length})`).first()
+      page.locator("[data-message-id]").getByText(`(match ${matchNumber} of ${MATCH_POSITIONS.length})`).first()
     ).toBeVisible({ timeout: 15_000 })
 
   // Down from the newest match wraps to the oldest — an out-of-window jump.


### PR DESCRIPTION
## Problem

Cycling in-stream search results (Enter / Shift+Enter or the chevrons in `StreamSearchBar`) was unreliable in the down direction and felt dead in both. Two distinct defects, reproduced with a Playwright driver against a 260-message stream with 6 scattered matches:

1. **Frozen timeline.** `jumpToEvent`'s `hasNewer=false` early return (target within ~25 events of the live tail) skipped jump mode but never *exited* an already-active one. In jump mode `useEvents` renders exclusively from `jumpState` + pagination caches — the IDB write the jump performed is invisible — so navigating from an older match to a near-tail match did nothing, forever, while the counter kept advancing (measured: matches 5/6 and 6/6 never rendered; the view stayed on match 4's window). Same latent bug in `jumpToEventByDate`.
2. **No loading signal.** `handleSearchNavigate` fired `jumpToEvent` fire-and-forget; the bar's only spinner covered the search query. The counter flips in ~25ms but the view moves 300–1900ms later (fetch + window swap + Virtuoso remount + refine loop) with zero indication.

## Solution

- `use-events.ts`: the `hasNewer=false` branch of `jumpToEvent`/`jumpToEventByDate` now calls `exitJumpMode()` (moved above the two callbacks; it was already the exact triple needed) so the live tail — which the around-fetch just wrote to IDB — actually renders.
- `stream-content.tsx`: `isSearchNavigating` state drives a `Loader2` in `StreamSearchBar`, set when an out-of-window navigation starts and cleared when the post-jump driver engages `scrollToMessage` (or aborts/deadlines/fails) — covering the whole dead window, not just the fetch. Versioned via `searchNavVersionRef` so a superseded navigation can't clear a newer one's spinner.

Post-review hardening (532cde0af, from the /code-review findings on this PR):

- **Jump ordering guard**: `jumpToEvent`/`jumpToEventByDate` share a `jumpGenerationRef`; a jump resolving after a newer one started returns `"superseded"` without mutating window state. Without this, a slow near-tail resolution could `exitJumpMode()` *after* a newer jump's window landed, snapping the view back to the tail — newly reachable via this PR's fix. Callers treat `"superseded"` as a hand-off (no toast, no cleanup).
- **Close cancels navigation**: one `handleSearchClose` (X, both Escape paths, batch-mode entry) calls `cancelPendingJump()`, clears the spinner, and drops the search-owned `pendingScrollTarget` — previously the viewport could yank to the target up to 4s after the bar closed. Stream switches cancel in-flight jumps too (`jumpState` carries no streamId; a late old-stream resolution would render the wrong stream's window).
- **Failure feedback**: failed/rejected navigations `toast.error` (INV-63) instead of silently clearing the spinner while the counter had already advanced. Counter rollback deliberately not attempted — it would couple the search hook to navigation outcomes.

Re-review hardening (1fc5c50fd, from the second /code-review pass — the first hardening's shared generation counter lacked an ownership model):

- `searchNavPhaseRef` (idle/fetching/swapped): abandoning paths (close, in-window navigation, jump-to-latest) cancel only a still-**fetching** search jump; a **swapped** one finishes landing via the driver instead of stranding the new window unanchored. Close no longer cancels unrelated in-flight jumps (deep link, date).
- Deep-link `.then` handles `"superseded"` explicitly (a truthy string previously read as success) — releases the `?m=` hold instead of hanging the param/highlight.
- "Jump to latest" abandons pending navigations instead of being overridden by their late resolution.
- Stream-switch reset effect moved above the deep-link effect: a navigation changing stream and `?m=` together no longer cancels the jump it just started (effects run in declaration order).

Third-pass hardening (5e439d840): `cancelPendingJump(expectedGeneration)` — phase-gated cancels pass the generation the search's own jump claimed (`searchNavGenRef` via `currentJumpGeneration()`), so a stale "fetching" phase can no longer cancel a foreign date/deep-link jump that superseded it; `handleJumpToDate`'s in-window fast path (the one abandoning path the sweep missed) now abandons pending jumps like jump-to-latest. Post-fix adversarial verification across six attack angles: holds.

Known remaining (reported, out of scope): first Down from the newest match wraps to the oldest (a big but wrap-correct jump); Enter during the 300ms debounce can re-run the search and reset selection to newest; multiple occurrences inside one message advance the counter without re-scrolling.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-events.ts` | `hasNewer=false` jump paths exit jump mode; `jumpGenerationRef` + `cancelPendingJump`; `"superseded"` result on stale resolutions |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `isSearchNavigating` lifecycle around `jumpToEvent` + post-jump driver; unified `handleSearchClose` with navigation cancel; failure toasts; date-jump supersession guard |
| `apps/frontend/src/components/timeline/stream-search-bar.tsx` | Spinner also shown while `isNavigating` |
| `tests/browser/stream-search-cycling.spec.ts` | **new** — seeds 175 messages, matches 30/165 (gap sized so edge-pagination can't heal the freeze), cycles both directions |

## Test plan

- [x] `tests/browser/stream-search-cycling.spec.ts` — passes with fix, fails at match 2 with the fix neutralized (verified both ways; assertion scoped to `[data-message-id]` because offscreen preview surfaces count as "visible"); re-passed after the hardening commit
- [x] Frontend vitest — 5622 pass (full suite); timeline+hooks subset re-run after hardening (607 pass)
- [x] Monorepo typecheck + lint clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


