### PR TITLE
fix(recovery): never wipe caches on an unverified chunk or CSS failure

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -135,7 +135,7 @@
       ;(function () {
         var attempts = parseInt(sessionStorage.getItem("sw-recovery-attempts") || "0", 10)
         if (attempts >= 2) return
-        setTimeout(function () {
+        var check = function () {
           var hasStyles = false
           var sheets = document.styleSheets
           for (var i = 0; i < sheets.length; i++) {
@@ -160,6 +160,35 @@
               sessionStorage.removeItem("sw-recovery-attempts")
               sessionStorage.removeItem("sw-recovery-last")
             }
+            return
+          }
+          // No styles yet — but "missing" has two very different causes. A
+          // stylesheet request that COMPLETED and still produced no rules is the
+          // poisoned-cache state this watchdog exists for (an immutable-cached
+          // HTML-as-CSS response). One still IN FLIGHT is just a slow network —
+          // wiping then destroys the only cached copy exactly when the network
+          // can't replace it, and each reload starts colder than the last (the
+          // reload-to-white loop). Wait and re-check instead; if the CSS never
+          // completes the network is down and a wipe wouldn't help either.
+          var cssFinished = false
+          try {
+            var entries = performance.getEntriesByType("resource")
+            for (var j = 0; j < entries.length; j++) {
+              if (
+                entries[j].initiatorType === "link" &&
+                /\.css(\?|$)/.test(entries[j].name) &&
+                entries[j].responseEnd > 0
+              ) {
+                cssFinished = true
+                break
+              }
+            }
+          } catch (e) {
+            // No Performance API — assume completed so the recovery still runs.
+            cssFinished = true
+          }
+          if (!cssFinished) {
+            setTimeout(check, 3000)
             return
           }
           sessionStorage.setItem("sw-recovery-attempts", String(attempts + 1))
@@ -191,8 +220,15 @@
           // which the unregister + caches.delete above can't evict and
           // location.reload() won't revalidate. Re-fetch the shell and its
           // asset URLs with `cache: "reload"` to bypass and overwrite them.
+          // Bounded fetches: a hung bust request on a dead connection must not
+          // stall the reload this recovery exists to deliver.
+          var bustFetch = function (url) {
+            var opts = { cache: "reload" }
+            if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) opts.signal = AbortSignal.timeout(10000)
+            return fetch(url, opts)
+          }
           tasks.push(
-            fetch("/index.html", { cache: "reload" })
+            bustFetch("/index.html")
               .then(function (res) {
                 return res.text()
               })
@@ -202,7 +238,7 @@
                 })
                 return Promise.all(
                   urls.map(function (u) {
-                    return fetch(u, { cache: "reload" }).catch(function () {})
+                    return bustFetch(u).catch(function () {})
                   })
                 )
               })
@@ -211,7 +247,8 @@
           Promise.all(tasks).then(function () {
             location.reload()
           })
-        }, 3000)
+        }
+        setTimeout(check, 3000)
       })()
     </script>
   </body>

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -366,6 +366,23 @@ describe("ConversationPanel", () => {
     expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull()
   })
 
+  it("reveals cached rows immediately while the backfill is still in flight (it's a timeline)", async () => {
+    // Rail short of the server's count on a slow network: the old gate held the
+    // whole panel on the backfill until the 1500ms escape. Cached content must
+    // paint well inside that window, with the loading line below it.
+    const post = makePost()
+    post.conversation.messageIds = ["msg_1", "msg_2", "msg_3"]
+    post.totalReplies = 2
+    mountPanel({
+      cached: asCached(post),
+      getBoardMessages: () => new Promise(() => {}),
+    })
+
+    expect(await screen.findByText("Opening message body.", undefined, { timeout: 1000 })).toBeTruthy()
+    expect(screen.getByText("Reply two body.")).toBeTruthy()
+    expect(screen.getByText("Loading messages…")).toBeTruthy()
+  })
+
   it("renders the conversation from the reactive store row without a by-id fetch", async () => {
     const { getBoardPost } = mountPanel({ cached: asCached(makePost()) })
     expect(await screen.findByText("Opening message body.")).toBeTruthy()

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -724,19 +724,22 @@ function ConversationPanelBody({
     }
     return true
   }, [unreadState, streamReadStates, readableRows, conversation.streamId])
-  // One reveal, not three: the header, the rail, the server backfill and the read
-  // state each used to paint as they landed (`post.recentMessages` under a
-  // "Loading messages…" line, then the rest, then the divider). Hold the whole
-  // panel — header included — until all of them are in.
+  // One reveal, not three: the header, the rail and the read state paint
+  // together, never staggered. But the panel is a timeline (Kris's ruling,
+  // 2026-08-01): cached rows render immediately and the server backfill fills
+  // in behind them — `loadingMore` only holds the reveal when there is nothing
+  // local to show, so a slow network never blanks a warm conversation. The
+  // read-state wait stays in the gate (the divider belongs in the first frame,
+  // and it resolves from IDB on a warm device).
   //
-  // Any of these can also fail to settle. `readStateResolved` is the known one:
+  // Either input can also fail to settle. `readStateResolved` is the known one:
   // the bootstrap builds BOTH `unreadCounts` and `streamReadState` from stream
   // MEMBERSHIPS, and a thread gets no `stream_members` row (INV-62), so a
   // conversation spanning a never-read thread leg holds a row decidable by
   // neither map, and no read event ever writes one. Gating on it unbounded would
   // hold a blank panel forever, so the wait is bounded across every input: the
   // divider (or a still-syncing leg) is worth a beat, never the whole panel.
-  const panelLoading = loadingMore || !readStateResolved
+  const panelLoading = (loadingMore && all.length === 0) || !readStateResolved
   const [revealTimedOut, setRevealTimedOut] = useState(false)
   useEffect(() => {
     setRevealTimedOut(false)
@@ -885,10 +888,13 @@ function ConversationPanelBody({
 
   const { scrollContainerRef, handleScroll, isScrolledFarFromBottom, scrollToBottom, disableAutoScroll } =
     useScrollBehavior({
-      // The rows are gated on `revealed`, not on `loadingMore`: on the reveal-timeout
-      // path `loadingMore` is already false while only the skeleton is mounted, and
-      // the hook would spend its one initial pin against an empty container.
-      isLoading: loadingMore || !revealed,
+      // The hook pins once: it must fire on the first frame that has rows, so
+      // "loading" is "no rows on screen yet" — not the backfill's status (rows
+      // now reveal while it is in flight; keying on it would spend the pin
+      // late, yanking a panel the viewer already sees) and not `revealed` alone
+      // (the reveal-timeout path mounts with zero rows, and the pin would land
+      // against an empty container).
+      isLoading: !revealed || rows.length === 0,
       itemCount: rows.length,
       resetKey: conversation.id,
       // Only treat the user as "at the bottom" when they are essentially flush, so

--- a/apps/frontend/src/components/error-boundary.test.tsx
+++ b/apps/frontend/src/components/error-boundary.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { ErrorBoundary } from "./error-boundary"
+import * as swRecoveryModule from "@/lib/sw-recovery"
+import * as appUpdateModule from "@/hooks/use-app-update"
+import * as appBuildModule from "@/lib/app-build"
+
+function renderWithChunkError() {
+  const Thrower = () => {
+    throw new Error("Failed to fetch dynamically imported module: https://app.threa.io/assets/board-AbC123.js")
+  }
+  const router = createMemoryRouter([{ path: "/", element: <Thrower />, errorElement: <ErrorBoundary /> }])
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("ErrorBoundary chunk-load recovery gating", () => {
+  it("wipes only on a confirmed newer deploy", async () => {
+    vi.spyOn(appBuildModule, "currentAppVersion").mockReturnValue("build-1")
+    vi.spyOn(appUpdateModule, "fetchLatestVersion").mockResolvedValue("build-2")
+    const recover = vi.spyOn(swRecoveryModule, "runSwRecovery").mockResolvedValue(true)
+
+    renderWithChunkError()
+
+    await waitFor(() => expect(recover).toHaveBeenCalled())
+    expect(recover).toHaveBeenCalledWith({ bustUrls: ["https://app.threa.io/assets/board-AbC123.js"] })
+    // Recovery in flight — the lightweight status, never the scary card.
+    expect(screen.getByText("Updating Threa")).toBeTruthy()
+  })
+
+  it("keeps the cache when the version probe can't confirm a newer deploy (slow network, same message)", async () => {
+    // A slow-network dynamic-import failure carries the SAME browser message as
+    // a stale-deploy 404. Same version = not a deploy — the wipe would destroy
+    // the precached shell exactly when the network can't rebuild it.
+    vi.spyOn(appBuildModule, "currentAppVersion").mockReturnValue("build-1")
+    vi.spyOn(appUpdateModule, "fetchLatestVersion").mockResolvedValue("build-1")
+    const recover = vi.spyOn(swRecoveryModule, "runSwRecovery").mockResolvedValue(true)
+
+    renderWithChunkError()
+
+    expect(await screen.findByText("Something Went Wrong")).toBeTruthy()
+    expect(recover).not.toHaveBeenCalled()
+  })
+
+  it("keeps the cache when the version probe itself fails (offline)", async () => {
+    vi.spyOn(appBuildModule, "currentAppVersion").mockReturnValue("build-1")
+    vi.spyOn(appUpdateModule, "fetchLatestVersion").mockResolvedValue(null)
+    const recover = vi.spyOn(swRecoveryModule, "runSwRecovery").mockResolvedValue(true)
+
+    renderWithChunkError()
+
+    expect(await screen.findByText("Something Went Wrong")).toBeTruthy()
+    expect(recover).not.toHaveBeenCalled()
+  })
+
+  it("shows the update-needed escape when recovery is confirmed but capped", async () => {
+    vi.spyOn(appBuildModule, "currentAppVersion").mockReturnValue("build-1")
+    vi.spyOn(appUpdateModule, "fetchLatestVersion").mockResolvedValue("build-2")
+    vi.spyOn(swRecoveryModule, "runSwRecovery").mockResolvedValue(false)
+
+    renderWithChunkError()
+
+    expect(await screen.findByText("Update needed")).toBeTruthy()
+  })
+})

--- a/apps/frontend/src/components/error-boundary.tsx
+++ b/apps/frontend/src/components/error-boundary.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from "@/components/ui/empty"
 import { ErrorDetails } from "./error-details"
 import { chunkUrlFromError, isChunkLoadError, runSwRecovery } from "@/lib/sw-recovery"
+import { fetchLatestVersion, shouldRecoverForVersion } from "@/hooks/use-app-update"
+import { currentAppVersion } from "@/lib/app-build"
 
 function formatError(error: unknown): string | null {
   if (error instanceof Error) {
@@ -28,26 +30,49 @@ export function ErrorBoundary() {
   const error = useRouteError()
   const chunkLoadFailed = isChunkLoadError(error)
 
-  // Flips to true only when runSwRecovery declines to reload because the
-  // per-session attempt cap is reached. Until then we render the "Updating"
-  // spinner instead of the error UI, so we don't flash the scary card for a
-  // few hundred ms before the reload kicks in.
-  const [recoveryDeclined, setRecoveryDeclined] = useState(false)
+  // "checking" while the staleness probe runs, "recovering" once the wipe is
+  // in flight (both render the "Updating" spinner so the scary card doesn't
+  // flash before the reload). "declined_unverified" falls through to the
+  // ordinary error card; "declined_cap" to the update-needed copy.
+  const [chunkRecovery, setChunkRecovery] = useState<
+    "checking" | "recovering" | "declined_unverified" | "declined_cap"
+  >("checking")
 
   // Stale-deploy auto-recovery: when a lazy route's dynamic import 404s, old
   // JS is trying to fetch a chunk whose filename has been replaced by a newer
   // build. Unregister the SW, clear caches, and hard-reload so the tab picks
   // up the current asset manifest. Gated by a shared sessionStorage counter
   // (see lib/sw-recovery.ts) so we can't loop past the cap.
+  //
+  // The browser reports a slow-network fetch failure and a stale-deploy 404
+  // with the SAME generic dynamic-import message, so the error alone never
+  // justifies the wipe: destroying the precached shell on a flaky connection
+  // makes the next load fully network-bound — the reload-to-white loop. Wipe
+  // only on a CONFIRMED newer deploy (shouldRecoverForVersion: both versions
+  // known and different — a successful probe also proves we're online enough
+  // for the recovery refetch to land); otherwise fall through to the error
+  // card, whose plain reload serves from the intact cache.
   useEffect(() => {
     if (!chunkLoadFailed) return
-    // Pass the failing chunk URL so recovery force-refetches it past the
-    // browser HTTP cache — an immutable-cached bad response (HTML served as JS
-    // at an /assets/* URL) is what unregister + caches.delete can't evict.
-    const bustUrl = chunkUrlFromError(error)
-    void runSwRecovery({ bustUrls: bustUrl ? [bustUrl] : undefined }).then((triggered) => {
-      if (!triggered) setRecoveryDeclined(true)
-    })
+    let cancelled = false
+    void (async () => {
+      const latest = await fetchLatestVersion()
+      if (cancelled) return
+      if (!shouldRecoverForVersion(currentAppVersion(), latest)) {
+        setChunkRecovery("declined_unverified")
+        return
+      }
+      setChunkRecovery("recovering")
+      // Pass the failing chunk URL so recovery force-refetches it past the
+      // browser HTTP cache — an immutable-cached bad response (HTML served as JS
+      // at an /assets/* URL) is what unregister + caches.delete can't evict.
+      const bustUrl = chunkUrlFromError(error)
+      const triggered = await runSwRecovery({ bustUrls: bustUrl ? [bustUrl] : undefined })
+      if (!cancelled && !triggered) setChunkRecovery("declined_cap")
+    })()
+    return () => {
+      cancelled = true
+    }
   }, [chunkLoadFailed, error])
 
   let title = "Something Went Wrong"
@@ -61,7 +86,7 @@ export function ErrorBoundary() {
       title = "Access Denied"
       description = "The gates to this part of the labyrinth are sealed."
     }
-  } else if (chunkLoadFailed && recoveryDeclined) {
+  } else if (chunkLoadFailed && chunkRecovery === "declined_cap") {
     title = "Update needed"
     description =
       "A newer version of Threa was deployed, and we couldn't auto-update this tab. Visit /recover to force a full reset."
@@ -78,9 +103,10 @@ export function ErrorBoundary() {
 
   const errorText = formatError(error)
 
-  // Recovery is imminent — show a lightweight status instead of the scary
-  // error UI, which would flash for a few hundred ms before the reload.
-  if (chunkLoadFailed && !recoveryDeclined) {
+  // Recovery is imminent (or the staleness probe is still deciding) — show a
+  // lightweight status instead of the scary error UI, which would flash for a
+  // few hundred ms before the reload.
+  if (chunkLoadFailed && (chunkRecovery === "checking" || chunkRecovery === "recovering")) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-background p-4">
         <Empty className="border-0 max-w-md w-full">

--- a/apps/frontend/src/lib/sw-recovery.test.ts
+++ b/apps/frontend/src/lib/sw-recovery.test.ts
@@ -115,14 +115,14 @@ describe("runSwRecovery", () => {
 
   it("force-refetches the app shell past the browser HTTP cache", async () => {
     await runSwRecovery({ force: true })
-    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload" })
+    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload", signal: expect.any(AbortSignal) })
   })
 
   it("force-refetches the failing chunk URL so an immutable-cached bad response is overwritten", async () => {
     const bad = "https://app.threa.io/assets/workspace-layout-D6MDsthX.js"
     await runSwRecovery({ force: true, bustUrls: [bad] })
-    expect(fetch).toHaveBeenCalledWith(bad, { cache: "reload" })
-    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload" })
+    expect(fetch).toHaveBeenCalledWith(bad, { cache: "reload", signal: expect.any(AbortSignal) })
+    expect(fetch).toHaveBeenCalledWith("/index.html", { cache: "reload", signal: expect.any(AbortSignal) })
   })
 
   it("clears CacheStorage before refetching a poisoned chunk", async () => {

--- a/apps/frontend/src/lib/sw-recovery.ts
+++ b/apps/frontend/src/lib/sw-recovery.ts
@@ -102,8 +102,12 @@ export async function runSwRecovery(options?: { force?: boolean; bustUrls?: stri
   }
   // Overwrite any immutable-cached bad responses in the browser HTTP cache.
   // Always bust the app shell; bust the specific failing chunk when we have it.
+  // Bounded: a hung bust fetch on a dead connection must not stall the reload
+  // that recovery exists to deliver.
   const bustUrls = new Set(["/index.html", ...(options?.bustUrls ?? [])])
-  await Promise.all([...bustUrls].map((url) => fetch(url, { cache: "reload" }).catch(() => {})))
+  await Promise.all(
+    [...bustUrls].map((url) => fetch(url, { cache: "reload", signal: AbortSignal.timeout(10_000) }).catch(() => {}))
+  )
   window.location.reload()
   return true
 }


### PR DESCRIPTION
## Problem

Kris's flaky-Wi-Fi session today: the app "kept reloading — all content away, white, then skeleton". Two auto-recovery paths wipe the service worker + all CacheStorage on signals that a slow network produces innocently: (1) the router error boundary treats every "Failed to fetch dynamically imported module" as a stale deploy — but a network timeout carries the identical browser message; (2) the index.html watchdog wipes when no stylesheet has rules after 3s — which a cold load on slow 3G hits legitimately. Each wipe destroys the precached shell exactly when the network cannot rebuild it, making the next load fully network-bound (slower → more failures → the loop; the 60s counter-reset cooldown re-arms it each healthy minute). `use-app-update.ts` already states the doctrine — "never wipe when we can't verify, or we'd brick an offline launch" — and ships the guard (`shouldRecoverForVersion`); these two paths just bypassed it. Three deploys landed today, seeding genuine chunk 404s that started the cycle.

## Solution

- Error boundary: chunk-load recovery now probes `/version.json` and wipes only on a confirmed newer deploy (`shouldRecoverForVersion` — both versions known and different; a successful probe also proves the recovery refetch can land). Same or unknown version falls through to the ordinary error card, whose Try Again is a plain cache-served reload. The capped case keeps the "Update needed" `/recover` escape copy.
- index.html watchdog: distinguishes a stylesheet request that COMPLETED empty (poisoned immutable-cached response — the case the watchdog exists for, still recovers) from one still IN FLIGHT (slow network — reschedules the check instead of wiping). No Performance API → assumes completed, preserving old behavior.
- Recovery bust fetches bounded with `AbortSignal.timeout(10s)` so recovery cannot hang before the reload it exists to deliver.

## Test plan

- [x] New `error-boundary.test.tsx` (4 cases: confirmed-newer wipes with bustUrls; same-version and probe-failure keep the cache; capped shows the escape) — the two cache-keeping cases verified to fail against the ungated code; `sw-recovery.test.ts` + `use-app-update.test.ts` 49 pass total; typecheck + pre-commit monorepo lint green. The watchdog change is inline JS — logic-reviewed, not unit-tested (no harness loads index.html).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788176704&installation_model_id=20758&pr_number=1713&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1713&signature=3d3f8855f14936fa86b926f20b948ce2cf522d8d0942cb538aa67d64ba7bf167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->