### PR TITLE
fix(board): pill jump disarms reveal windows; backfill bounded for the seam

### DIFF
--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -131,9 +131,14 @@ export const conversationsApi = {
    * post messages (attachments + link previews), so revealed messages render
    * with the same richness as the opening + recent run.
    */
-  async getBoardMessages(workspaceId: string, conversationId: string): Promise<BoardPostMessage[]> {
+  async getBoardMessages(
+    workspaceId: string,
+    conversationId: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ): Promise<BoardPostMessage[]> {
     const res = await api.get<{ messages: BoardPostMessage[] }>(
-      `/api/workspaces/${workspaceId}/conversations/${conversationId}/board-messages`
+      `/api/workspaces/${workspaceId}/conversations/${conversationId}/board-messages`,
+      options
     )
     return res.messages
   },

--- a/apps/frontend/src/hooks/board-reveal-windows.ts
+++ b/apps/frontend/src/hooks/board-reveal-windows.ts
@@ -1,0 +1,22 @@
+/**
+ * Registry of armed board-card reveal windows (see useBoardCardRevealAnchor).
+ *
+ * A programmatic feed jump — the "N new" pill's scroll-to-top, a lens switch's
+ * reset, the own-post jump — fires no wheel/touch event, so the gesture
+ * listeners that normally hand control back to the reader never see it. An
+ * armed window then treats the jump's scroll delta as growth to compensate and
+ * scrolls the viewport right back away from the top. The jump sites close every
+ * window through here BEFORE moving the scroller.
+ */
+const windows = new Set<() => void>()
+
+export function registerRevealWindow(close: () => void): () => void {
+  windows.add(close)
+  return () => {
+    windows.delete(close)
+  }
+}
+
+export function closeAllRevealWindows(): void {
+  for (const close of [...windows]) close()
+}

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
 import { renderHook } from "@testing-library/react"
 import type { VirtualizerHandle } from "virtua"
 import { useBoardCardRevealAnchor } from "./use-board-card-reveal-anchor"
+import { closeAllRevealWindows } from "./board-reveal-windows"
 
 // The hook reacts to card resizes via a ResizeObserver and defers its correction a
 // frame; drive both deterministically. jsdom has no layout, so element rects are
@@ -87,6 +88,19 @@ describe("useBoardCardRevealAnchor", () => {
   it("leaves scroll alone when no reveal is armed, so a live append still pushes normally", () => {
     const { card, scrollBy } = setup()
     setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("disarms through the registry before a programmatic jump, so the pill's scroll-to-top isn't compensated away", () => {
+    // The "N new" pill (and lens-switch resets) move the scroller without any
+    // wheel/touch event. An armed window would fold that jump + the commit's
+    // reorder into its growth math and scroll the viewport back off the top.
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal()
+    closeAllRevealWindows()
+    scroller.scrollTop = 0 // the jump
+    setRect(card, 900, 1432) // commit reordered the feed; the card moved and grew
     roCallback?.()
     expect(scrollBy).not.toHaveBeenCalled()
   })

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { RefObject } from "react"
 import type { VirtualizerHandle } from "virtua"
 import { attachScrollGestureDirection } from "./scroll-gesture-direction"
+import { registerRevealWindow } from "./board-reveal-windows"
 
 /** No-resize quiet gap after which the reveal window closes on its own. Long
  *  enough to span the sync expand and its async server backfill; short enough that
@@ -257,6 +258,11 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef, should
   }, [cardRef, measure, listRef, scrollerRef, close, onSettle])
 
   useEffect(() => () => close(), [close])
+
+  // Programmatic feed jumps (the "N new" pill, lens-switch resets, the own-post
+  // jump) fire no wheel/touch event, so the gesture close never sees them — the
+  // jump site closes every armed window through the registry before it scrolls.
+  useEffect(() => registerRevealWindow(close), [close])
 
   return useMemo(() => ({ beginReveal, closeReveal: close }), [beginReveal, close])
 }

--- a/apps/frontend/src/hooks/use-conversation-backfill.ts
+++ b/apps/frontend/src/hooks/use-conversation-backfill.ts
@@ -51,9 +51,17 @@ export function useConversationBackfill(
     refetch,
   } = useQuery({
     queryKey: conversationKeys.boardMessages(conversationId),
-    queryFn: () => conversationService.getBoardMessages(workspaceId, conversationId),
+    // Tighter bounds than the client's 20s default × 3 retries: this fetch sits
+    // behind a visible "loading…" label (the card seam, the panel's loading
+    // line), and on a bad connection the default cycle keeps that label up for
+    // over a minute. ~10s × 2 attempts reaches the error label — which offers
+    // the tap-to-retry — while a slow-but-alive network still fits comfortably.
+    // TanStack's signal rides along so an unmount cancels the request.
+    queryFn: ({ signal }) =>
+      conversationService.getBoardMessages(workspaceId, conversationId, { signal, timeoutMs: 10_000 }),
     enabled: enabled && railIncomplete,
     staleTime: 60_000,
+    retry: 1,
   })
 
   // Seed, don't render: the response lands in IDB and the merged view reads it

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -379,7 +379,9 @@ describe("BoardPage", () => {
     ]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)], { failMessages: true })
     fireEvent.click(await screen.findByText("1 older message"))
-    expect(await screen.findByText("Couldn't load older messages. Retry.")).toBeTruthy()
+    // The backfill retries once (retry: 1, ~1s backoff) before surfacing the
+    // error label, so the wait must span the retry cycle.
+    expect(await screen.findByText("Couldn't load older messages. Retry.", undefined, { timeout: 4000 })).toBeTruthy()
   })
 
   it("shows no expander when the whole conversation already fits", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -24,6 +24,7 @@ import { useWorkspaceConversations, useBoardExclusions } from "@/hooks/use-conve
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
 import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
+import { closeAllRevealWindows } from "@/hooks/board-reveal-windows"
 import {
   useConversationGraph,
   useConversationGraphReady,
@@ -491,12 +492,17 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // down the All wall who taps Decisions lands past the end of a one-card list.
   const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}|${unreadOnly ? "unread" : ""}`
   useLayoutEffect(() => {
+    closeAllRevealWindows()
     if (scrollerRef.current) scrollerRef.current.scrollTop = 0
   }, [resetKey])
 
   const revealNew = () => {
-    // Jump to the top first so the freshly-committed cards flow in where the
-    // viewer can see them, then commit the buffered order.
+    // Disarm every card's reveal window first: the programmatic jump fires no
+    // gesture event, and an armed window would read the jump + reorder as
+    // growth to compensate — scrolling the viewport right back off the top.
+    closeAllRevealWindows()
+    // Jump to the top so the freshly-committed cards flow in where the viewer
+    // can see them, then commit the buffered order.
     if (scrollerRef.current) scrollerRef.current.scrollTop = 0
     commit()
   }
@@ -545,6 +551,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     // the `resetKey` layout effect.
     const currentViewSurfacesOwnPost = SELF_POST_VISIBLE_LENSES.has(lens) && !hasFilterParams
     if (currentViewSurfacesOwnPost) {
+      closeAllRevealWindows()
       if (scrollerRef.current) scrollerRef.current.scrollTop = 0
     } else {
       navigate(boardEverything)


### PR DESCRIPTION
## Problem

Two live board defects from Kris's slow-Wi-Fi session. (1) Tapping the "N updates" pill didn't land at the top: `revealNew` scrolls programmatically, which fires no wheel/touch event, so an armed reveal-window anchor (#1702) — held open up to 10s while its backfill is in flight — survives the jump. Its next resize correction folds the jump plus the commit's reorder into "growth above the landmark" and `scrollBy`s the viewport back off the top. (2) The gap seam's label sat on "loading" for over a minute: the backfill query rode the API client's 20s default timeout × TanStack's 3 retries before `isError` could flip it to the retry affordance.

## Solution

- `board-reveal-windows.ts`: a module registry of armed reveal windows; `useBoardCardRevealAnchor` registers its `close` on mount. All three programmatic jump sites on the board page (`revealNew`, the `resetKey` lens-switch layout effect, `handlePosted`) call `closeAllRevealWindows()` before moving the scroller — synchronous, so it beats the RO→rAF correction (the existing viewport-exit disarm runs in a passive effect and loses that race).
- `useConversationBackfill`: `timeoutMs: 10_000` + `retry: 1` (error label with tap-to-retry in ~20s worst case instead of a minute-plus) and TanStack's `signal` wired through `getBoardMessages` so unmount cancels the request. Registry over a jump-heuristic in the correction math: a bound on scroll deltas would misfire on legitimate long flick-paging sequences.

## Test plan

- [x] New anchor test "disarms through the registry before a programmatic jump" (verified to fail with registration removed); board.test.tsx retry test extended past the new retry cycle; 100 pass across anchor/board/panel suites; typecheck + pre-commit monorepo lint green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788177036&installation_model_id=20758&pr_number=1714&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1714&signature=abcec013e2f7a59f6b7574bb4e9313c0581f55a7aa02ecc67798241989086726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->