### PR TITLE
feat(board): card bodies always collapse — the card is an overview surface

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -613,6 +613,10 @@ export function BoardCard({
         rowInsetClassName="-mx-3 sm:-mx-4"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
         onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
+        // The card is an overview surface: one long agent/coding message must
+        // not make it a screen tall. The panel (a reading surface) follows the
+        // viewer's preference instead.
+        alwaysCollapse
       />
     )
   }
@@ -656,6 +660,7 @@ export function BoardCard({
               ? undefined
               : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId, message.settling)
           }
+          alwaysCollapse
         />
       </ConversationReadProvider>
     )

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -169,6 +169,12 @@ interface MessageItemProps {
    * Passed already-gated by the conversation surfaces (set only when the row has
    * a valid target); other surfaces leave it undefined and the action hides. */
   onMoveToSubtopic?: () => void
+  /** Collapse long bodies on this surface regardless of the viewer's global
+   * message-collapse preference. The board card sets it — it's an OVERVIEW
+   * surface, and one long agent/coding message otherwise makes the card a
+   * screen tall. The preference's height tuning still applies; reading surfaces
+   * (panel, label page) keep following the preference alone. */
+  alwaysCollapse?: boolean
 }
 
 /**
@@ -198,6 +204,7 @@ export function MessageItem({
   suppressRowAccent,
   onNewSubtopic,
   onMoveToSubtopic,
+  alwaysCollapse,
 }: MessageItemProps) {
   const { formatTime, formatFull } = useFormattedDate()
   const messageCollapse = useMessageCollapseSettings()
@@ -647,7 +654,7 @@ export function MessageItem({
           content={message.contentMarkdown}
           collapseAtHeight={messageCollapse.collapseAtHeight}
           collapseToHeight={messageCollapse.collapseToHeight}
-          defaultCollapsed={messageCollapse.enabled}
+          defaultCollapsed={messageCollapse.enabled || alwaysCollapse === true}
         >
           <MarkdownContent content={message.contentMarkdown} className="text-sm leading-relaxed" />
         </CollapsibleBody>

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -19,6 +19,7 @@ import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as pointerModule from "@/hooks/use-pointer"
 import * as panelHostModule from "@/components/layout/panel-host"
+import * as collapsibleBodyModule from "@/lib/markdown/collapsible-body"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -258,6 +259,22 @@ describe("BoardPage", () => {
   it("renders the opening-message body", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     expect(await screen.findByText("Rotate the tokens before Friday.")).toBeTruthy()
+  })
+
+  it("collapses long bodies on the card regardless of the global preference (overview surface)", async () => {
+    // jsdom can't measure the clamp itself; assert at the seam — every card body
+    // mounts CollapsibleBody with defaultCollapsed forced on, even though the
+    // viewer's messageCollapseEnabled preference defaults off.
+    const captured: boolean[] = []
+    const realBody = collapsibleBodyModule.CollapsibleBody
+    vi.spyOn(collapsibleBodyModule, "CollapsibleBody").mockImplementation((props) => {
+      captured.push(props.defaultCollapsed === true)
+      return realBody(props)
+    })
+    mountBoard([makePost({}, { contentMarkdown: "Opening message body." })])
+    await screen.findByText("Opening message body.")
+    expect(captured.length).toBeGreaterThan(0)
+    expect(captured.every(Boolean)).toBe(true)
   })
 
   it("shows only the viewer's own conversations on the Mine lens", async () => {


### PR DESCRIPTION
## Problem

Kris uses the board for coding sessions: agent messages are routinely hundreds of lines, one message makes a card a screen tall, and the board loses its point as an overview. Message collapse exists (`CollapsibleBody`, `messageCollapse*` preferences) but defaults off globally — and the board card, the one surface whose job is overview, follows that global default.

## Solution

- `MessageItem` gains `alwaysCollapse`; the board card sets it on both its renderers (main rows + nested branch rows). Long bodies clamp at the preference heights (420px → 240px defaults) with the existing fade + expand affordance; code blocks already auto-collapse past 10 lines independently.
- The conversation panel and label page keep following the viewer's preference — the panel is a reading surface (Kris's "it IS a timeline" ruling).
- Surface-scoped prop over flipping the global default: turning `messageCollapseEnabled` on everywhere would change the timeline reading experience nobody complained about.

## Test plan

- [x] New board test asserts every card body mounts `CollapsibleBody` with `defaultCollapsed` forced on (props-seam assertion — jsdom cannot measure the clamp; verified to fail with the prop removed); board 23 + message-item + panel 81 total pass; typecheck + pre-commit monorepo lint green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788178737&installation_model_id=20758&pr_number=1715&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1715&signature=ee2370f1e32df41e059c3da2568bae28496297c5ef007f7c99ed74feabc0737a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->