### PR TITLE
fix(pwa): restore the exact page after a crash-relaunch

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1263,7 +1263,9 @@ describe("BoardCard gap scroll reveal", () => {
     await scrollUp(await screen.findByText("8 older messages"))
     await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
     const rowsLoading = revealRowStructure(container)
-    const failedSeam = await screen.findByText("Couldn't load older messages. Retry.")
+    // The failed label lands only after the query's single retry (#1714), which
+    // waits out TanStack's ~1s backoff — past findByText's default timeout.
+    const failedSeam = await screen.findByText("Couldn't load older messages. Retry.", undefined, { timeout: 5000 })
 
     // The failure swaps the seam's label; it never adds a row, so the replies below
     // stay exactly where the reader left them (INV-21).

--- a/apps/frontend/src/contexts/panel-context.tsx
+++ b/apps/frontend/src/contexts/panel-context.tsx
@@ -154,8 +154,15 @@ export function PanelProvider({ children }: PanelProviderProps) {
     if (panelId === null) canPopToClose.current = false
     // A replace leaves the entry below untouched, so the claim carries over.
     else if (navigationType !== "REPLACE")
-      canPopToClose.current = navigationType === "PUSH" && previousLocation === hereWithoutPanel
-  }, [location.key, location.pathname, location.search, navigationType, panelId])
+      canPopToClose.current =
+        navigationType === "PUSH" &&
+        // The exact-restore two-hop (routes/index.tsx ExactRestore) batches
+        // both navigations into one commit, so `previousLocation` never sees
+        // the panel-less entry it pushed on top of — the push carries an
+        // attestation of what its construction guarantees instead.
+        (previousLocation === hereWithoutPanel ||
+          (location.state as { panelPopsToClose?: boolean } | null)?.panelPopsToClose === true)
+  }, [location.key, location.pathname, location.search, location.state, navigationType, panelId])
 
   const closePanel = useCallback(() => {
     if (canPopToClose.current) {

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -208,8 +208,10 @@ describe("usePersistLastLocation", () => {
     })
   })
 
-  it("writes nothing on the transient workspace index route", () => {
-    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1") })
+  it("writes nothing on transient redirect routes (index, delegations, memos)", () => {
+    for (const path of ["/w/ws_1", "/w/ws_1/delegations/deleg_1", "/w/ws_1/memos/memo_1"]) {
+      renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt(path) })
+    }
     expect(getLastLocation(USER, WS)).toBeNull()
   })
 

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
-import { useLastLocation, usePersistLastLocation } from "./use-last-location"
+import { useLastLocation, usePersistLastLocation, resetColdLaunchForTests } from "./use-last-location"
 import { setLastLocation, getLastLocation, EXACT_RESTORE_WINDOW_MS } from "@/lib/last-location"
 import type { CachedStream } from "@/db"
 
@@ -25,6 +25,7 @@ function setup({ streams = [] }: { streams?: CachedStream[] }) {
 beforeEach(() => {
   vi.restoreAllMocks()
   localStorage.clear()
+  resetColdLaunchForTests()
 })
 
 describe("useLastLocation — stream arm", () => {
@@ -136,6 +137,17 @@ describe("useLastLocation — exact arm", () => {
     })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({ exactPath: null, boardHref: "/w/ws_1/board?lens=mine" })
+  })
+
+  it("serves the exact arm only on a cold launch, never after in-app navigation", () => {
+    // A rendered workspace page proves a live session; a later visit to the
+    // index is a deliberate "go home" (back arrows, quick switcher,
+    // StreamErrorView's escape link) and must use the sanitized arms — the
+    // exact arm would bounce the viewer straight back to the page they left.
+    setup({ streams: [stream("stream_a")] })
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_a") })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current).toMatchObject({ exactPath: null, redirectStreamId: "stream_a" })
   })
 
   it("ignores an exact path from another workspace or the bare index", () => {

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import { useLastLocation, usePersistLastLocation } from "./use-last-location"
-import { setLastLocation, getLastLocation } from "@/lib/last-location"
+import { setLastLocation, getLastLocation, EXACT_RESTORE_WINDOW_MS } from "@/lib/last-location"
 import type { CachedStream } from "@/db"
 
 const USER = "usr_1"
@@ -35,14 +35,17 @@ describe("useLastLocation — stream arm", () => {
     expect(result.current).toMatchObject({ redirectStreamId: "stream_a", boardHref: null })
   })
 
-  it("falls back to the most-recent stream and evicts a stale record", () => {
+  it("falls back to the most-recent stream WITHOUT evicting the record", () => {
+    // The cache can't distinguish a deleted stream from a lazily-hydrated
+    // thread/conversation id, so an unknown stored id must never destroy the
+    // record (it self-heals on the next persisted navigation).
     setup({
       streams: [stream("stream_old", "2026-01-01T00:00:00.000Z"), stream("stream_new", "2026-02-01T00:00:00.000Z")],
     })
     setLastLocation(USER, WS, { surface: "stream", streamId: "stream_gone", board: null })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current.redirectStreamId).toBe("stream_new")
-    expect(getLastLocation(USER, WS)).toBeNull()
+    expect(getLastLocation(USER, WS)).toMatchObject({ streamId: "stream_gone" })
   })
 
   it("signals shouldOpenSidebar when no record and no streams", () => {
@@ -94,6 +97,67 @@ describe("useLastLocation — board arm", () => {
   })
 })
 
+describe("useLastLocation — exact arm", () => {
+  it("restores a fresh exact path verbatim, panel and all", () => {
+    setup({ streams: [stream("stream_a")] })
+    setLastLocation(USER, WS, {
+      surface: "board",
+      streamId: "stream_a",
+      board: { search: "?lens=mine" },
+      exact: { path: "/w/ws_1/board?lens=mine&panel=conv:conv_1", at: Date.now() - 60_000 },
+    })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current).toMatchObject({
+      exactPath: "/w/ws_1/board?lens=mine&panel=conv:conv_1",
+      redirectStreamId: null,
+      boardHref: null,
+    })
+  })
+
+  it("restores a non-stream page the sanitized arms don't cover", () => {
+    setup({ streams: [stream("stream_a")] })
+    setLastLocation(USER, WS, {
+      surface: "stream",
+      streamId: "stream_a",
+      board: null,
+      exact: { path: "/w/ws_1/saved/done", at: Date.now() },
+    })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current.exactPath).toBe("/w/ws_1/saved/done")
+  })
+
+  it("falls through to the sanitized arms when the exact record is stale", () => {
+    setup({ streams: [stream("stream_a")] })
+    setLastLocation(USER, WS, {
+      surface: "board",
+      streamId: "stream_a",
+      board: { search: "?lens=mine" },
+      exact: { path: "/w/ws_1/board?lens=mine&panel=conv:conv_1", at: Date.now() - EXACT_RESTORE_WINDOW_MS - 1 },
+    })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current).toMatchObject({ exactPath: null, boardHref: "/w/ws_1/board?lens=mine" })
+  })
+
+  it("ignores an exact path from another workspace or the bare index", () => {
+    setup({ streams: [stream("stream_a")] })
+    setLastLocation(USER, WS, {
+      surface: "stream",
+      streamId: "stream_a",
+      board: null,
+      exact: { path: "/w/ws_OTHER/s/stream_x", at: Date.now() },
+    })
+    expect(renderHook(() => useLastLocation(WS)).result.current.exactPath).toBeNull()
+
+    setLastLocation(USER, WS, {
+      surface: "stream",
+      streamId: "stream_a",
+      board: null,
+      exact: { path: "/w/ws_1/?m=evt_1", at: Date.now() },
+    })
+    expect(renderHook(() => useLastLocation(WS)).result.current.exactPath).toBeNull()
+  })
+})
+
 function routerAt(entry: string) {
   return ({ children }: { children: ReactNode }) => <MemoryRouter initialEntries={[entry]}>{children}</MemoryRouter>
 }
@@ -114,6 +178,7 @@ describe("usePersistLastLocation", () => {
       surface: "board",
       streamId: "stream_prior",
       board: { search: "?lens=mine&in=stream_x" },
+      exact: { path: "/w/ws_1/board?lens=mine&in=stream_x&panel=stream_z", at: expect.any(Number) },
     })
   })
 
@@ -128,6 +193,39 @@ describe("usePersistLastLocation", () => {
       surface: "stream",
       streamId: "stream_new",
       board: { search: "?lens=mine&in=stream_a" },
+      exact: { path: "/w/ws_1/s/stream_new", at: expect.any(Number) },
     })
+  })
+
+  it("records the exact URL of a non-stream page without touching the arms", () => {
+    setLastLocation(USER, WS, { surface: "stream", streamId: "stream_prior", board: { search: "?lens=mine" } })
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/activity/mentions") })
+    expect(getLastLocation(USER, WS)).toEqual({
+      surface: "stream",
+      streamId: "stream_prior",
+      board: { search: "?lens=mine" },
+      exact: { path: "/w/ws_1/activity/mentions", at: expect.any(Number) },
+    })
+  })
+
+  it("writes nothing on the transient workspace index route", () => {
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1") })
+    expect(getLastLocation(USER, WS)).toBeNull()
+  })
+
+  it("bumps the exact timestamp when the page is backgrounded", () => {
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_a") })
+    const before = getLastLocation(USER, WS)?.exact
+    expect(before).toBeDefined()
+
+    const stale = { ...before!, at: before!.at - 10 * 60_000 }
+    setLastLocation(USER, WS, { ...getLastLocation(USER, WS)!, exact: stale })
+
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden")
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    const after = getLastLocation(USER, WS)?.exact
+    expect(after).toEqual({ path: "/w/ws_1/s/stream_a", at: expect.any(Number) })
+    expect(after!.at).toBeGreaterThan(stale.at)
   })
 })

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -150,6 +150,24 @@ describe("useLastLocation — exact arm", () => {
     expect(result.current).toMatchObject({ exactPath: null, redirectStreamId: "stream_a" })
   })
 
+  it("stays cold while the persist hook mounts on the bare index", () => {
+    // WorkspaceLayout mounts the persist hook OUTSIDE CoordinatedLoadingGate,
+    // so on a cold launch its effect runs at the index pathname before the
+    // gated WorkspaceHome ever renders. If that visit warmed the session, the
+    // exact restore would never fire in production — only a page the viewer
+    // actually reached proves a live in-app session.
+    setup({ streams: [stream("stream_a")] })
+    setLastLocation(USER, WS, {
+      surface: "stream",
+      streamId: "stream_a",
+      board: null,
+      exact: { path: "/w/ws_1/saved/done", at: Date.now() },
+    })
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1") })
+    const { result } = renderHook(() => useLastLocation(WS))
+    expect(result.current.exactPath).toBe("/w/ws_1/saved/done")
+  })
+
   it("ignores an exact path from another workspace or the bare index", () => {
     setup({ streams: [stream("stream_a")] })
     setLastLocation(USER, WS, {

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -245,6 +245,27 @@ describe("usePersistLastLocation", () => {
     expect(getLastLocation(USER, WS)).toBeNull()
   })
 
+  it("re-asserts this tab's own page on backgrounding, not a foreign tab's record", () => {
+    // localStorage is shared across tabs. If another tab (an externally-opened
+    // link) wrote its page since, blindly bumping the stored record would
+    // extend the WRONG page's freshness with this tab's backgrounding signal.
+    renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_a") })
+    setLastLocation(USER, WS, {
+      surface: "stream",
+      streamId: "stream_b",
+      board: null,
+      exact: { path: "/w/ws_1/s/stream_b", at: Date.now() - 60_000 },
+    })
+
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden")
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    expect(getLastLocation(USER, WS)).toMatchObject({
+      streamId: "stream_a",
+      exact: { path: "/w/ws_1/s/stream_a", at: expect.any(Number) },
+    })
+  })
+
   it("bumps the exact timestamp when the page is backgrounded", () => {
     renderHook(() => usePersistLastLocation(WS), { wrapper: routerAt("/w/ws_1/s/stream_a") })
     const before = getLastLocation(USER, WS)?.exact

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -4,14 +4,16 @@ import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import {
   buildBoardHref,
+  freshExactPath,
   getLastLocation,
   setLastLocation,
-  clearLastLocation,
   sanitizeBoardSearch,
 } from "@/lib/last-location"
 import type { CachedStream } from "@/db"
 
 interface UseLastLocationResult {
+  /** Exact URL to restore verbatim after a fresh crash/kill relaunch. */
+  exactPath: string | null
   /** Stream ID to redirect to, or null when the board arm or a fallback applies. */
   redirectStreamId: string | null
   /** Explicit board URL to redirect to when the last surface was the board. */
@@ -24,18 +26,24 @@ interface UseLastLocationResult {
  * Resolves where the workspace index route should land, restoring the last
  * surface (stream or board) the viewer was on.
  *
- * Board arm: a stored board record resolves straight to the board URL, with the
- * query sanitized and stale scope ids swept inside {@link buildBoardHref}.
+ * Exact arm: a fresh exact record (the PWA was killed while backgrounded and
+ * relaunched at `start_url` shortly after) restores the URL verbatim —
+ * including `?panel=`/`?m=` and non-stream pages the sanitized arms don't cover.
  *
- * Stream arm (unchanged): stored stream validated against bootstrap, most-
- * recently-active fallback, and `shouldOpenSidebar` only once bootstrap has
- * confirmed zero streams. Evicts a stale record via `useEffect`.
+ * Board arm: a stored board record resolves to the board URL, with the query
+ * sanitized and stale scope ids swept inside {@link buildBoardHref}.
+ *
+ * Stream arm: stored stream validated against bootstrap, most-recently-active
+ * fallback, and `shouldOpenSidebar` only once bootstrap has confirmed zero
+ * streams. A stored id absent from the cache is NOT evicted: the cache can't
+ * distinguish a deleted stream from a lazily-hydrated thread/conversation, and
+ * the record self-heals on the next persisted navigation anyway.
  */
 export function useLastLocation(workspaceId: string): UseLastLocationResult {
   const { user } = useAuth()
   const allStreams = useWorkspaceStreams(workspaceId)
 
-  const result = useMemo(() => {
+  return useMemo(() => {
     // The stream cache durably holds archived rows (archived-stream index).
     // They must not count as landing targets: archiving bumps updated_at, so an
     // unfiltered most-recent fallback would redirect a fresh device INTO the
@@ -44,8 +52,14 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
     const streams = allStreams.filter((s) => !s.archivedAt)
     const record = user ? getLastLocation(user.id, workspaceId) : null
 
+    const exactPath = freshExactPath(record, workspaceId, Date.now())
+    if (exactPath) {
+      return { exactPath, redirectStreamId: null, boardHref: null, shouldOpenSidebar: false }
+    }
+
     if (record?.surface === "board" && record.board) {
       return {
+        exactPath: null,
         redirectStreamId: null,
         boardHref: buildBoardHref(
           workspaceId,
@@ -53,7 +67,6 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
           streams.map((s) => s.id)
         ),
         shouldOpenSidebar: false,
-        staleStoredId: false,
       }
     }
 
@@ -61,85 +74,109 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
     if (storedId) {
       // Deliberately checked against ALL rows: a stored pointer to a stream
       // archived since the last visit is still viewable, so honor it rather
-      // than evicting the record. Only the fallbacks below exclude archived.
+      // than falling back. Only the fallbacks below exclude archived.
       const stillExists = allStreams.some((s) => s.id === storedId)
       if (stillExists) {
         return {
+          exactPath: null,
           redirectStreamId: storedId,
           boardHref: null,
           shouldOpenSidebar: false,
-          staleStoredId: false,
         }
       }
       return {
+        exactPath: null,
         redirectStreamId: streams.length > 0 ? getMostRecentStreamId(streams) : null,
         boardHref: null,
         shouldOpenSidebar: streams.length === 0,
-        staleStoredId: true,
       }
     }
 
     if (streams.length > 0) {
       return {
+        exactPath: null,
         redirectStreamId: getMostRecentStreamId(streams),
         boardHref: null,
         shouldOpenSidebar: false,
-        staleStoredId: false,
       }
     }
 
     return {
+      exactPath: null,
       redirectStreamId: null,
       boardHref: null,
       shouldOpenSidebar: true,
-      staleStoredId: false,
     }
   }, [user, workspaceId, allStreams])
-
-  useEffect(() => {
-    if (result.staleStoredId && user) {
-      clearLastLocation(user.id, workspaceId)
-    }
-  }, [result.staleStoredId, user, workspaceId])
-
-  return result
 }
 
 /**
  * Persists the current surface — a stream page or the board — for
- * restore-on-return. On the board it retains the last visited stream (so the
- * "← Chats" affordance has a target); on a stream it retains the last board
- * state. The board search is sanitized to the filter axes before storage.
+ * restore-on-return, plus the exact URL of every workspace page for verbatim
+ * restore after a crash-relaunch. On the board it retains the last visited
+ * stream (so the "← Chats" affordance has a target); on a stream it retains
+ * the last board state. The board search is sanitized to the filter axes
+ * before storage.
  */
 export function usePersistLastLocation(workspaceId: string | undefined) {
   const { user } = useAuth()
   const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
   const boardMatch = useMatch("/w/:workspaceId/board")
-  const search = useLocation().search
+  const { pathname, search } = useLocation()
 
   const streamId = streamMatch?.params.streamId
   const onBoard = boardMatch !== null
 
   useEffect(() => {
     if (!user || !workspaceId) return
+    // The bare index is a transient redirect hop, never a place to restore to.
+    if (pathname === `/w/${workspaceId}`) return
+    const exact = { path: `${pathname}${search}`, at: Date.now() }
+    const existing = getLastLocation(user.id, workspaceId)
     if (onBoard) {
-      const existing = getLastLocation(user.id, workspaceId)
       setLastLocation(user.id, workspaceId, {
         surface: "board",
         streamId: existing?.streamId ?? null,
         board: { search: sanitizeBoardSearch(search) },
+        exact,
       })
       return
     }
     if (streamId) {
-      const existing = getLastLocation(user.id, workspaceId)
       setLastLocation(user.id, workspaceId, {
         surface: "stream",
         streamId,
         board: existing?.board ?? null,
+        exact,
       })
+      return
     }
-  }, [user, workspaceId, streamId, search, onBoard])
+    // Other workspace pages (activity, saved, memory, …): keep the stream/board
+    // arms as they were, record only the exact URL.
+    setLastLocation(user.id, workspaceId, {
+      surface: existing?.surface ?? "stream",
+      streamId: existing?.streamId ?? null,
+      board: existing?.board ?? null,
+      exact,
+    })
+  }, [user, workspaceId, streamId, search, onBoard, pathname])
+
+  // Backgrounding is the last moment we run before an OS kill — bump `at` so
+  // the exact record's freshness measures time-since-last-seen. Without this a
+  // long reading session ages the record out and a kill minutes later restores
+  // the sanitized arms instead of the page the viewer was on.
+  useEffect(() => {
+    if (!user || !workspaceId) return
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "hidden") return
+      const existing = getLastLocation(user.id, workspaceId)
+      if (existing?.exact) {
+        setLastLocation(user.id, workspaceId, { ...existing, exact: { ...existing.exact, at: Date.now() } })
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange)
+  }, [user, workspaceId])
 }
 
 function getMostRecentStreamId(streams: CachedStream[]): string {

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -11,6 +11,17 @@ import {
 } from "@/lib/last-location"
 import type { CachedStream } from "@/db"
 
+// The exact arm serves only a cold launch — the OS killed the backgrounded PWA
+// and relaunched it at `start_url`. Once this JS context has rendered any
+// workspace page, arriving at the index is a deliberate "go home" (back
+// arrows, the quick switcher, StreamErrorView's escape link); restoring exact
+// there would bounce the viewer straight back to the page they just left.
+let coldLaunch = true
+
+export function resetColdLaunchForTests(): void {
+  coldLaunch = true
+}
+
 interface UseLastLocationResult {
   /** Exact URL to restore verbatim after a fresh crash/kill relaunch. */
   exactPath: string | null
@@ -26,9 +37,10 @@ interface UseLastLocationResult {
  * Resolves where the workspace index route should land, restoring the last
  * surface (stream or board) the viewer was on.
  *
- * Exact arm: a fresh exact record (the PWA was killed while backgrounded and
- * relaunched at `start_url` shortly after) restores the URL verbatim —
- * including `?panel=`/`?m=` and non-stream pages the sanitized arms don't cover.
+ * Exact arm: on a cold launch only (see `coldLaunch`), a fresh exact record
+ * (the PWA was killed while backgrounded and relaunched at `start_url` shortly
+ * after) restores the URL verbatim — including `?panel=`/`?m=` and non-stream
+ * pages the sanitized arms don't cover.
  *
  * Board arm: a stored board record resolves to the board URL, with the query
  * sanitized and stale scope ids swept inside {@link buildBoardHref}.
@@ -52,7 +64,7 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
     const streams = allStreams.filter((s) => !s.archivedAt)
     const record = user ? getLastLocation(user.id, workspaceId) : null
 
-    const exactPath = freshExactPath(record, workspaceId, Date.now())
+    const exactPath = coldLaunch ? freshExactPath(record, workspaceId, Date.now()) : null
     if (exactPath) {
       return { exactPath, redirectStreamId: null, boardHref: null, shouldOpenSidebar: false }
     }
@@ -129,6 +141,9 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
 
   useEffect(() => {
     if (!user || !workspaceId) return
+    // Any rendered workspace page — including the index and transient hops
+    // below — proves a live in-app session; the exact arm is done serving.
+    coldLaunch = false
     // Transient redirect hops are never a place to restore to. The bare index
     // would loop the exact restore; /delegations/:id 404s away to the index
     // (routes/index.tsx DelegationRedirect), so restoring it would loop the

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -152,52 +152,50 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
     // that visit warmed, the exact arm would never serve.
     coldLaunch = false
     if (pathname.startsWith(`/w/${workspaceId}/delegations/`) || pathname.startsWith(`/w/${workspaceId}/memos/`)) return
-    const exact = { path: `${pathname}${search}`, at: Date.now() }
-    const existing = getLastLocation(user.id, workspaceId)
-    if (onBoard) {
+    const persist = () => {
+      const exact = { path: `${pathname}${search}`, at: Date.now() }
+      const existing = getLastLocation(user.id, workspaceId)
+      if (onBoard) {
+        setLastLocation(user.id, workspaceId, {
+          surface: "board",
+          streamId: existing?.streamId ?? null,
+          board: { search: sanitizeBoardSearch(search) },
+          exact,
+        })
+        return
+      }
+      if (streamId) {
+        setLastLocation(user.id, workspaceId, {
+          surface: "stream",
+          streamId,
+          board: existing?.board ?? null,
+          exact,
+        })
+        return
+      }
+      // Other workspace pages (activity, saved, memory, …): keep the
+      // stream/board arms as they were, record only the exact URL.
       setLastLocation(user.id, workspaceId, {
-        surface: "board",
+        surface: existing?.surface ?? "stream",
         streamId: existing?.streamId ?? null,
-        board: { search: sanitizeBoardSearch(search) },
-        exact,
-      })
-      return
-    }
-    if (streamId) {
-      setLastLocation(user.id, workspaceId, {
-        surface: "stream",
-        streamId,
         board: existing?.board ?? null,
         exact,
       })
-      return
     }
-    // Other workspace pages (activity, saved, memory, …): keep the stream/board
-    // arms as they were, record only the exact URL.
-    setLastLocation(user.id, workspaceId, {
-      surface: existing?.surface ?? "stream",
-      streamId: existing?.streamId ?? null,
-      board: existing?.board ?? null,
-      exact,
-    })
-  }, [user, workspaceId, streamId, search, onBoard, pathname])
-
-  // Backgrounding is the last moment we run before an OS kill — bump `at` so
-  // the exact record's freshness measures time-since-last-seen. Without this a
-  // long reading session ages the record out and a kill minutes later restores
-  // the sanitized arms instead of the page the viewer was on.
-  useEffect(() => {
-    if (!user || !workspaceId) return
+    persist()
+    // Backgrounding is the last moment we run before an OS kill — re-persist so
+    // the exact record's freshness measures time-since-last-seen. This tab's
+    // OWN page is re-written, never a bump of whatever is stored: another tab
+    // (an externally-opened link) may have written since, and re-stamping its
+    // record would extend the wrong page's freshness with this tab's signal.
+    // Only the tab transitioning visible→hidden fires; a tab that is already
+    // hidden gets no visibilitychange when the whole browser backgrounds.
     const onVisibilityChange = () => {
-      if (document.visibilityState !== "hidden") return
-      const existing = getLastLocation(user.id, workspaceId)
-      if (existing?.exact) {
-        setLastLocation(user.id, workspaceId, { ...existing, exact: { ...existing.exact, at: Date.now() } })
-      }
+      if (document.visibilityState === "hidden") persist()
     }
     document.addEventListener("visibilitychange", onVisibilityChange)
     return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [user, workspaceId])
+  }, [user, workspaceId, streamId, search, onBoard, pathname])
 }
 
 function getMostRecentStreamId(streams: CachedStream[]): string {

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -141,14 +141,16 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
 
   useEffect(() => {
     if (!user || !workspaceId) return
-    // Any rendered workspace page — including the index and transient hops
-    // below — proves a live in-app session; the exact arm is done serving.
-    coldLaunch = false
     // Transient redirect hops are never a place to restore to. The bare index
     // would loop the exact restore; /delegations/:id 404s away to the index
     // (routes/index.tsx DelegationRedirect), so restoring it would loop the
     // 404 toast; /memos/:id is its sibling alias.
     if (pathname === `/w/${workspaceId}`) return
+    // Only a page beyond the index warms the session: WorkspaceLayout mounts
+    // this hook OUTSIDE CoordinatedLoadingGate, so on a cold launch this effect
+    // runs at the index pathname before the gated WorkspaceHome renders — if
+    // that visit warmed, the exact arm would never serve.
+    coldLaunch = false
     if (pathname.startsWith(`/w/${workspaceId}/delegations/`) || pathname.startsWith(`/w/${workspaceId}/memos/`)) return
     const exact = { path: `${pathname}${search}`, at: Date.now() }
     const existing = getLastLocation(user.id, workspaceId)

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -129,8 +129,12 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
 
   useEffect(() => {
     if (!user || !workspaceId) return
-    // The bare index is a transient redirect hop, never a place to restore to.
+    // Transient redirect hops are never a place to restore to. The bare index
+    // would loop the exact restore; /delegations/:id 404s away to the index
+    // (routes/index.tsx DelegationRedirect), so restoring it would loop the
+    // 404 toast; /memos/:id is its sibling alias.
     if (pathname === `/w/${workspaceId}`) return
+    if (pathname.startsWith(`/w/${workspaceId}/delegations/`) || pathname.startsWith(`/w/${workspaceId}/memos/`)) return
     const exact = { path: `${pathname}${search}`, at: Date.now() }
     const existing = getLastLocation(user.id, workspaceId)
     if (onBoard) {

--- a/apps/frontend/src/lib/last-location.test.ts
+++ b/apps/frontend/src/lib/last-location.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach } from "vitest"
 import {
   sanitizeBoardSearch,
   buildBoardHref,
+  freshExactPath,
   getLastLocation,
   setLastLocation,
   clearLastLocation,
+  EXACT_RESTORE_WINDOW_MS,
   type LastLocation,
 } from "./last-location"
 
@@ -115,6 +117,49 @@ describe("getLastLocation / setLastLocation round-trip", () => {
   it("returns null and does not throw on a malformed record", () => {
     localStorage.setItem(key, "{not json")
     expect(getLastLocation(USER, WS)).toBeNull()
+  })
+
+  it("round-trips the exact record and drops a malformed one", () => {
+    const record: LastLocation = {
+      surface: "stream",
+      streamId: "stream_a",
+      board: null,
+      exact: { path: "/w/ws_1/s/stream_a?panel=conv:c_1", at: 1234 },
+    }
+    setLastLocation(USER, WS, record)
+    expect(getLastLocation(USER, WS)).toEqual(record)
+
+    localStorage.setItem(
+      key,
+      JSON.stringify({ surface: "stream", streamId: "stream_a", board: null, exact: { path: 7 } })
+    )
+    expect(getLastLocation(USER, WS)).toEqual({ surface: "stream", streamId: "stream_a", board: null })
+  })
+})
+
+describe("freshExactPath", () => {
+  const NOW = 1_700_000_000_000
+  const record = (path: string, at: number): LastLocation => ({
+    surface: "stream",
+    streamId: null,
+    board: null,
+    exact: { path, at },
+  })
+
+  it("returns a fresh in-workspace path verbatim", () => {
+    expect(freshExactPath(record("/w/ws_1/board?lens=mine&panel=conv:c_1", NOW - 1000), WS, NOW)).toBe(
+      "/w/ws_1/board?lens=mine&panel=conv:c_1"
+    )
+  })
+
+  it("returns null when stale, missing, cross-workspace, or the bare index", () => {
+    expect(freshExactPath(record("/w/ws_1/s/stream_a", NOW - EXACT_RESTORE_WINDOW_MS - 1), WS, NOW)).toBeNull()
+    expect(freshExactPath({ surface: "stream", streamId: null, board: null }, WS, NOW)).toBeNull()
+    expect(freshExactPath(null, WS, NOW)).toBeNull()
+    expect(freshExactPath(record("/w/ws_2/s/stream_a", NOW), WS, NOW)).toBeNull()
+    expect(freshExactPath(record("/w/ws_1", NOW), WS, NOW)).toBeNull()
+    expect(freshExactPath(record("/w/ws_1/", NOW), WS, NOW)).toBeNull()
+    expect(freshExactPath(record("/w/ws_1/?m=evt_1", NOW), WS, NOW)).toBeNull()
   })
 })
 

--- a/apps/frontend/src/lib/last-location.ts
+++ b/apps/frontend/src/lib/last-location.ts
@@ -15,11 +15,30 @@ export interface LastLocationBoard {
   search: string
 }
 
+/** The exact in-workspace URL last seen, for verbatim restore after a crash or
+ *  OS kill of the backgrounded PWA. `at` is bumped on backgrounding, so it
+ *  measures time-since-last-seen, not time-since-last-navigation. */
+export interface LastLocationExact {
+  path: string
+  at: number
+}
+
 export interface LastLocation {
   surface: LastLocationSurface
   streamId: string | null
   board: LastLocationBoard | null
+  exact?: LastLocationExact
 }
+
+/**
+ * How recent the exact record must be to restore verbatim. Within the window a
+ * relaunch is a crash-restart continuation (the Firefox round-trip that got the
+ * PWA killed), so the viewer gets back exactly what they were looking at —
+ * including `?panel=`/`?m=` and non-stream pages. Beyond it, the sanitized
+ * stream/board arms apply: a cold start into a months-old panel is a worse
+ * default than the filtered feed.
+ */
+export const EXACT_RESTORE_WINDOW_MS = 30 * 60 * 1000
 
 function key(userId: string, workspaceId: string): string {
   return `${STORAGE_PREFIX}:${userId}:${workspaceId}`
@@ -69,10 +88,19 @@ function parseRecord(raw: string): LastLocation | null {
     board = { search: b.search }
   }
 
+  let exact: LastLocationExact | undefined
+  if (record.exact !== null && record.exact !== undefined && typeof record.exact === "object") {
+    const e = record.exact as Record<string, unknown>
+    if (typeof e.path === "string" && typeof e.at === "number") {
+      exact = { path: e.path, at: e.at }
+    }
+  }
+
   return {
     surface: record.surface,
     streamId: (record.streamId as string | null) ?? null,
     board,
+    ...(exact ? { exact } : {}),
   }
 }
 
@@ -101,6 +129,7 @@ export function setLastLocation(userId: string, workspaceId: string, location: L
       surface: location.surface,
       streamId: location.streamId,
       board: location.board ? { search: sanitizeBoardSearch(location.board.search) } : null,
+      ...(location.exact ? { exact: location.exact } : {}),
     }
     localStorage.setItem(key(userId, workspaceId), JSON.stringify(record))
     localStorage.removeItem(legacyKey(userId, workspaceId))
@@ -149,6 +178,22 @@ function sweepStaleStreamScope(search: string, knownStreamIds: readonly string[]
  * `in` axis. An empty stored search restores the bare entry alias, which
  * re-resolves the viewer's home — the meaning of having been there.
  */
+/**
+ * The exact path to restore verbatim, or null when the record is missing,
+ * stale (older than {@link EXACT_RESTORE_WINDOW_MS}), for another workspace, or
+ * the workspace index itself (restoring the index would loop the redirect).
+ */
+export function freshExactPath(record: LastLocation | null, workspaceId: string, now: number): string | null {
+  const exact = record?.exact
+  if (!exact) return null
+  if (now - exact.at > EXACT_RESTORE_WINDOW_MS) return null
+  const prefix = `/w/${workspaceId}`
+  if (!exact.path.startsWith(`${prefix}/`)) return null
+  const rest = exact.path.slice(prefix.length)
+  if (rest === "/" || rest.startsWith("/?")) return null
+  return exact.path
+}
+
 export function buildBoardHref(
   workspaceId: string,
   board: LastLocationBoard,

--- a/apps/frontend/src/routes/index.test.tsx
+++ b/apps/frontend/src/routes/index.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom"
 import { toast } from "sonner"
 import type { DelegationSummary } from "@threa/types"
 import { DelegationRedirect, LegacyMemoRedirect, RootRedirect, WorkspaceHome } from "./index"
@@ -25,6 +25,16 @@ function PathEcho() {
 function PathAndSearchEcho() {
   const location = useLocation()
   return <div data-testid="path">{`${location.pathname}${location.search}`}</div>
+}
+
+function BackProbe() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  return (
+    <button data-testid="back" onClick={() => navigate(-1)}>
+      {`${location.pathname}${location.search}`}
+    </button>
+  )
 }
 
 function makeDelegationSummary(overrides: Partial<DelegationSummary> = {}): DelegationSummary {
@@ -114,6 +124,31 @@ describe("WorkspaceHome", () => {
     )
 
     expect(await screen.findByTestId("path")).toHaveTextContent("/w/ws_123/board?lens=mine&panel=conv:c_1")
+  })
+
+  it("restores a panel URL with an entry beneath, so back closes the panel instead of exiting", async () => {
+    // The relaunched WebAPK starts with a one-entry history; a plain replace
+    // into a `?panel=` URL would make the Android back gesture exit the app
+    // (#1666's pop-to-close needs a same-view entry underneath).
+    mockUseLastLocation.mockReturnValue({
+      exactPath: "/w/ws_123/board?lens=mine&panel=conv:c_1",
+      redirectStreamId: null,
+      boardHref: null,
+      shouldOpenSidebar: false,
+    })
+    render(
+      <MemoryRouter initialEntries={["/w/ws_123"]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<WorkspaceHome />} />
+          <Route path="/w/:workspaceId/board" element={<BackProbe />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    const probe = await screen.findByTestId("back")
+    expect(probe.textContent).toBe("/w/ws_123/board?lens=mine&panel=conv:c_1")
+    fireEvent.click(probe)
+    await waitFor(() => expect(screen.getByTestId("back").textContent).toBe("/w/ws_123/board?lens=mine"))
   })
 
   it("lets index search params win over the exact path", async () => {

--- a/apps/frontend/src/routes/index.test.tsx
+++ b/apps/frontend/src/routes/index.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  createMemoryRouter,
+  MemoryRouter,
+  Route,
+  RouterProvider,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom"
+import { PanelProvider, usePanel } from "@/contexts/panel-context"
 import { toast } from "sonner"
 import type { DelegationSummary } from "@threa/types"
 import { DelegationRedirect, LegacyMemoRedirect, RootRedirect, WorkspaceHome } from "./index"
@@ -25,6 +34,17 @@ function PathEcho() {
 function PathAndSearchEcho() {
   const location = useLocation()
   return <div data-testid="path">{`${location.pathname}${location.search}`}</div>
+}
+
+function CloseProbe() {
+  const { closePanel } = usePanel()
+  const location = useLocation()
+  return (
+    <div>
+      <span data-testid="loc">{`${location.pathname}${location.search}`}</span>
+      <button onClick={closePanel}>close</button>
+    </div>
+  )
 }
 
 function BackProbe() {
@@ -149,6 +169,46 @@ describe("WorkspaceHome", () => {
     expect(probe.textContent).toBe("/w/ws_123/board?lens=mine&panel=conv:c_1")
     fireEvent.click(probe)
     await waitFor(() => expect(screen.getByTestId("back").textContent).toBe("/w/ws_123/board?lens=mine"))
+  })
+
+  it("closing a restored panel pops the pushed entry, leaving no duplicate", async () => {
+    // The two restore hops batch into one commit, so PanelProvider never
+    // observes the panel-less entry beneath; the push carries an attestation
+    // instead. Without it, close rewrites in place and the first back press
+    // after closing is a visual no-op on a duplicate entry.
+    mockUseLastLocation.mockReturnValue({
+      exactPath: "/w/ws_123/board?lens=mine&panel=conv:c_1",
+      redirectStreamId: null,
+      boardHref: null,
+      shouldOpenSidebar: false,
+    })
+    const router = createMemoryRouter(
+      [
+        { path: "/elsewhere", element: <PathAndSearchEcho /> },
+        { path: "/w/:workspaceId", element: <WorkspaceHome /> },
+        {
+          path: "/w/:workspaceId/board",
+          element: (
+            <PanelProvider>
+              <CloseProbe />
+            </PanelProvider>
+          ),
+        },
+      ],
+      { initialEntries: ["/elsewhere", "/w/ws_123"], initialIndex: 1 }
+    )
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => expect(screen.getByTestId("loc").textContent).toBe("/w/ws_123/board?lens=mine&panel=conv:c_1"))
+    fireEvent.click(screen.getByRole("button", { name: "close" }))
+    await waitFor(() => expect(screen.getByTestId("loc").textContent).toBe("/w/ws_123/board?lens=mine"))
+
+    // ONE back leaves the restored view entirely: close consumed the pushed
+    // panel entry instead of stacking a rewrite on top.
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    expect(screen.getByTestId("path").textContent).toBe("/elsewhere")
   })
 
   it("lets index search params win over the exact path", async () => {

--- a/apps/frontend/src/routes/index.test.tsx
+++ b/apps/frontend/src/routes/index.test.tsx
@@ -90,10 +90,52 @@ describe("WorkspaceHome", () => {
     } as unknown as ReturnType<typeof sidebarContextModule.useSidebar>)
 
     mockUseLastLocation.mockReturnValue({
+      exactPath: null,
       redirectStreamId: "stream_123",
       boardHref: null,
       shouldOpenSidebar: false,
     })
+  })
+
+  it("restores a fresh exact path verbatim", async () => {
+    mockUseLastLocation.mockReturnValue({
+      exactPath: "/w/ws_123/board?lens=mine&panel=conv:c_1",
+      redirectStreamId: null,
+      boardHref: null,
+      shouldOpenSidebar: false,
+    })
+    render(
+      <MemoryRouter initialEntries={["/w/ws_123"]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<WorkspaceHome />} />
+          <Route path="/w/:workspaceId/board" element={<PathAndSearchEcho />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("path")).toHaveTextContent("/w/ws_123/board?lens=mine&panel=conv:c_1")
+  })
+
+  it("lets index search params win over the exact path", async () => {
+    // `?ws-settings=` and friends must reach the stream redirect, not be
+    // swallowed by a verbatim restore.
+    mockUseLastLocation.mockReturnValue({
+      exactPath: "/w/ws_123/board?lens=mine",
+      redirectStreamId: "stream_123",
+      boardHref: null,
+      shouldOpenSidebar: false,
+    })
+    render(
+      <MemoryRouter initialEntries={["/w/ws_123?ws-settings=bots"]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<WorkspaceHome />} />
+          <Route path="/w/:workspaceId/s/:streamId" element={<SearchEcho />} />
+          <Route path="/w/:workspaceId/board" element={<PathAndSearchEcho />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByTestId("search")).toHaveTextContent("?ws-settings=bots")
   })
 
   it("preserves workspace search params when redirecting to the last stream", async () => {

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -190,7 +190,7 @@ export function WorkspaceHome() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const location = useLocation()
   const { state, togglePinned } = useSidebar()
-  const { redirectStreamId, boardHref, shouldOpenSidebar } = useLastLocation(workspaceId ?? "")
+  const { exactPath, redirectStreamId, boardHref, shouldOpenSidebar } = useLastLocation(workspaceId ?? "")
   const sidebarOpenedRef = useRef(false)
 
   useEffect(() => {
@@ -199,6 +199,13 @@ export function WorkspaceHome() {
       togglePinned()
     }
   }, [shouldOpenSidebar, state, togglePinned])
+
+  // Verbatim restore after a crash/kill relaunch. Only when the index carries
+  // no search of its own — params like `?ws-settings=` must reach the stream
+  // redirect below, not be silently swallowed by the exact record.
+  if (exactPath && workspaceId && !location.search) {
+    return <Navigate to={exactPath} replace />
+  }
 
   if (boardHref && workspaceId) {
     return <Navigate to={boardHref} replace />

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -202,7 +202,10 @@ function ExactRestore({ path }: { path: string }) {
     if (url.searchParams.has("panel")) {
       url.searchParams.delete("panel")
       navigate(`${url.pathname}${url.search}`, { replace: true })
-      navigate(path)
+      // Both hops batch into ONE commit, so PanelProvider never observes the
+      // panel-less entry this push lands on — the state attestation carries
+      // what the construction guarantees, letting close pop instead of rewrite.
+      navigate(path, { state: { panelPopsToClose: true } })
     } else {
       navigate(path, { replace: true })
     }

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -185,6 +185,31 @@ export function RootRedirect() {
   return <Navigate to="/workspaces" replace />
 }
 
+/**
+ * Restores the pre-kill URL verbatim after a cold relaunch. A `?panel=` URL is
+ * restored in two hops — the panel-less URL replaced in, then the panel pushed
+ * on top — so the relaunched app's one-entry history gains an entry beneath the
+ * panel and the Android back gesture closes it (panel-context pops to the entry
+ * underneath) instead of exiting the WebAPK at the bottom of history.
+ */
+function ExactRestore({ path }: { path: string }) {
+  const navigate = useNavigate()
+  const restored = useRef(false)
+  useEffect(() => {
+    if (restored.current) return
+    restored.current = true
+    const url = new URL(path, window.location.origin)
+    if (url.searchParams.has("panel")) {
+      url.searchParams.delete("panel")
+      navigate(`${url.pathname}${url.search}`, { replace: true })
+      navigate(path)
+    } else {
+      navigate(path, { replace: true })
+    }
+  }, [navigate, path])
+  return null
+}
+
 /** Workspace index route — redirects to a stream or opens the sidebar. */
 export function WorkspaceHome() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
@@ -204,7 +229,7 @@ export function WorkspaceHome() {
   // no search of its own — params like `?ws-settings=` must reach the stream
   // redirect below, not be silently swallowed by the exact record.
   if (exactPath && workspaceId && !location.search) {
-    return <Navigate to={exactPath} replace />
+    return <ExactRestore path={exactPath} />
   }
 
   if (boardHref && workspaceId) {


### PR DESCRIPTION
## Problem

Opening an external link from the installed PWA (Android, default browser Firefox) backgrounds the app; the OS then kills it and the relaunch enters at `start_url` `/` → `RootRedirect` → `WorkspaceHome` → the last-location restore. That restore is lossy three ways:

- `sanitizeBoardSearch` deliberately strips `?panel=`/`?m=`, so a board relaunch drops the conversation that was open — minutes-old context, not the "months-old panel" the sanitizer was designed against.
- A stored stream id absent from the streams cache (any thread/conversation — they're lazily hydrated, never in the sidebar cache) made `useLastLocation` **evict the record** and fall back to most-recent-by-`updatedAt`, landing in a different stream than the one being read.
- Pages other than `/s/:id` and `/board` (activity, saved, memory, …) were never persisted at all.

Net effect: every Firefox round-trip restarted the app somewhere else. (#986 added crash-recovery reloads for the soft-wedge variant; the hard-kill relaunch path was still lossy.)

## Solution

Persist the exact URL and restore it verbatim when the relaunch is a continuation, keeping the sanitized arms for genuinely cold starts.

- `LastLocation` gains `exact: { path, at }`; `usePersistLastLocation` writes it for **every** workspace page (except transient redirect hops: the bare index, `/delegations/:id`, `/memos/:id` — restoring those would loop their own redirects) and bumps `at` on `visibilitychange → hidden`, so freshness measures time-since-last-seen, not time-since-last-navigation.
- `WorkspaceHome` restores `exact.path` verbatim within `EXACT_RESTORE_WINDOW_MS` (30 min) via `freshExactPath` — cross-workspace and bare-index paths rejected. Index search params (`?ws-settings=`) still win over the exact record. Beyond the window, behavior is exactly as before.
- Unknown stored stream id no longer evicts the record — the cache can't distinguish "deleted" from "not-hydrated thread", and the record self-heals on the next persisted navigation. `clearLastLocation` stays exported (storage API symmetry, covered by its own test) though prod no longer calls it.
- Post-review hardening (a3c1a14fc, both from the review below): the exact arm serves **cold launches only** — a module-scoped `coldLaunch` flag, cleared by the first persisted workspace-page render, keeps a fresh record from hijacking deliberate index navigations (back arrows on Board/Saved/Activity/Search, quick-switcher post-delete nav, `StreamErrorView`'s escape link — the last would otherwise loop back into the error page). And `?panel=` URLs restore in two hops (panel-less URL replaced in, panel pushed on top) so the relaunched app's one-entry history gains an entry beneath and the Android back gesture closes the panel (#1666's pop-to-close contract) instead of exiting the WebAPK.
- Second-pass hardening (`bc56ff9a3`, `cc5cd203b`): the bare index never warms the cold-launch gate (WorkspaceLayout mounts the persist hook outside `CoordinatedLoadingGate`, so warming at the index would have silently disabled restore on every real cold launch); backgrounding re-persists **this tab's** page instead of re-stamping whatever localStorage holds (a foreign tab's record would otherwise have its freshness extended by the wrong tab's signal); and the restore push carries a `panelPopsToClose` attestation so closing a restored panel pops the pushed entry instead of rewriting in place (React batches the two hops into one commit, so `canPopToClose` can't observe the entry beneath).
- Out of scope: the OS kill itself (not preventable) and the `navigate-existing` launch handler (inert on Android — `LaunchQueue` is desktop-Chrome-only per MDN BCD).

Also fixes `board-card.test.tsx` "failed paged reveal": #1714 added `retry: 1` to `useConversationBackfill`, so the failure label lands after TanStack's ~1s backoff — past `findByText`'s 1s default timeout. Failing on clean `main`; wait extended to 5s.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/last-location.ts` | `LastLocationExact`, `EXACT_RESTORE_WINDOW_MS`, `freshExactPath`, parse/write `exact` |
| `apps/frontend/src/hooks/use-last-location.ts` | Exact arm first; persist all pages + visibility bump; eviction removed |
| `apps/frontend/src/routes/index.tsx` | `WorkspaceHome` verbatim-restore branch with index-search guard |
| `apps/frontend/src/components/board/board-card.test.tsx` | 5s wait for the post-#1714 retry before the failed-seam label |
| `*.test.*` | Round-trip/freshness/guard coverage; eviction test inverted to retention |

## Test plan

- [x] Frontend suite — 5640 pass (touched files re-run green after the loop-guard commit)
- [x] Falsifiability — `freshExactPath` neutralized → 3 targeted reds, reverted
- [x] `tsc --noEmit`, eslint — clean (pre-commit hook runs monorepo-wide)
- [ ] On-device Android WebAPK kill/relaunch — needs Kris's phone

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788184762&installation_model_id=20758&pr_number=1716&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1716&signature=bb02ec196befae679da8e687b47e9854c3ea9f57c2b0f5f17eb8a8f48b0cca23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
