### PR TITLE
fix(search): one scroll authority for the highlighted row

### DIFF
--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1008,12 +1008,6 @@ function SentMessageEvent({
     })
   }, [payload.messageId, registerMessage, startEditing])
 
-  useEffect(() => {
-    if (isHighlighted && containerRef.current) {
-      containerRef.current.scrollIntoView({ behavior: "smooth", block: "center" })
-    }
-  }, [isHighlighted])
-
   // Shared thread affordance wiring, keyed on this message's canonical id.
   // `activity.threadStreamId` lets us link to the real thread immediately when
   // an agent response is in flight, before the slower stream:created event.

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1562,13 +1562,21 @@ export function StreamContent({
   // Scroll to a specific timeline row — addressed by message id or event id
   // (any row `findTimelineTargetIndex` resolves, including session/command
   // group cards) — and keep re-scrolling until the target element is actually
-  // visible in the scroller viewport. Items rendered with estimated heights
-  // cause the target to drift after the first scroll as surrounding items are
-  // measured; this loop keeps correcting until stable (or a short timeout).
+  // visible in the scroller viewport. Items rendered with estimated heights —
+  // and link previews / long-message toggles that resolve later — drift the
+  // target after the first scroll; this loop keeps correcting for a bounded
+  // window rather than stopping at the first frame that looks right.
   // User input (wheel / touch / key) aborts the loop immediately so manual
   // scrolling always wins. `align: "center"` (default) centers the target
   // (deep links); `align: "start"` pins its top near the viewport top (the
   // unread marker open).
+  //
+  // This is the *only* thing that scrolls a highlighted row into view, on both
+  // scroll modes: the plain thread scroller renders every row, so it just takes
+  // the DOM branch and never reaches virtua. A second, ungated
+  // `scrollIntoView({behavior:"smooth"})` on the row itself used to race this
+  // loop — it re-fired every time virtua remounted the row, dragging a reader
+  // who had scrolled away back to the match.
   //
   // Implementation notes: Virtuoso's scrollToIndex expects the 0-based
   // index within the current data array (NOT firstItemIndex + idx). Once
@@ -1589,10 +1597,6 @@ export function StreamContent({
   const scrollToMessage = useCallback(
     (targetId: string, opts?: { align?: "center" | "start" }) => {
       const align = opts?.align ?? "center"
-      if (!useVirtualized) {
-        deepLinkDebug("scrollToMessage bail: not virtualized", targetId)
-        return false
-      }
       if (findTimelineTargetIndex(visibleItems, targetId) < 0) {
         deepLinkDebug("scrollToMessage bail: target not a timeline item yet", targetId)
         return false
@@ -1618,7 +1622,7 @@ export function StreamContent({
       // while we're trying to scroll the target into view.
       disableAutoScroll()
 
-      const scroller = virtuosoScrollerRef.current
+      const scroller = scrollContainerRef.current
       if (!scroller) {
         deepLinkDebug("scrollToMessage bail: scroller not attached yet", targetId)
         return false
@@ -1643,8 +1647,13 @@ export function StreamContent({
       scroller.addEventListener("keydown", abort)
 
       const started = performance.now()
+      // The loop watches for the whole window rather than stopping the moment
+      // the target first looks settled: a link preview card resolving above the
+      // target lands ~800ms after the window renders and shoves the target down
+      // under a reader already looking at it. Any real input aborts within one
+      // tick (the listeners above plus the shared gesture stamp, which also
+      // covers a scrollbar drag), so watching costs the user nothing.
       const MAX_MS = 1200
-      let stableFrames = 0
 
       const attempt = () => {
         if (aborted) return
@@ -1669,38 +1678,12 @@ export function StreamContent({
           const er = el.getBoundingClientRect()
           const scCenter = (sr.top + sr.bottom) / 2
           // "start" pins the target's top near the viewport top (the unread
-          // marker open: a long first-unread message must read from its start,
-          // and centering can never satisfy fullyVisible for a row taller than
-          // the viewport). "center" is the deep-link behavior, unchanged.
+          // marker open: a long first-unread message must read from its start).
+          // "center" is the deep-link behavior, unchanged.
           const desiredTop = sr.top + UNREAD_MARKER_TOP_GAP_PX
           const delta = align === "start" ? er.top - desiredTop : (er.top + er.bottom) / 2 - scCenter
           if (Math.abs(delta) > 2) {
             scroller.scrollTop += delta
-          }
-
-          // Re-measure after the scroll
-          const er2 = el.getBoundingClientRect()
-          const hasScrollRoom = scroller.scrollHeight > scroller.clientHeight + 8
-          let settled: boolean
-          if (align === "start") {
-            // A target too close to the tail can't reach the top — the scroller
-            // clamps at max scroll. Visible-at-clamp counts as settled.
-            const atMaxScroll = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
-            const topAligned = Math.abs(er2.top - desiredTop) < 4
-            settled = !hasScrollRoom || topAligned || (atMaxScroll && er2.top >= sr.top && er2.top <= sr.bottom)
-          } else {
-            const fullyVisible = er2.top >= sr.top - 1 && er2.bottom <= sr.bottom + 1
-            const centered = !hasScrollRoom || Math.abs((er2.top + er2.bottom) / 2 - scCenter) < 40
-            settled = fullyVisible && centered
-          }
-          if (settled) {
-            stableFrames += 1
-            if (stableFrames >= 2) {
-              abort()
-              return
-            }
-          } else {
-            stableFrames = 0
           }
         } else {
           // Target is virtualized out — ask Virtuoso to render it (0-based
@@ -1727,7 +1710,6 @@ export function StreamContent({
               // renders.
             }
           }
-          stableFrames = 0
         }
 
         const elapsed = performance.now() - started
@@ -1741,7 +1723,7 @@ export function StreamContent({
       attempt()
       return true
     },
-    [useVirtualized, visibleItems, listRef, disableAutoScroll]
+    [visibleItems, listRef, disableAutoScroll, scrollContainerRef]
   )
 
   useEffect(() => {
@@ -1905,14 +1887,6 @@ export function StreamContent({
     if (!pendingScrollTarget.current || isLoading) return
     const target = pendingScrollTarget.current
 
-    if (!useVirtualized) {
-      // Threads use plain scroll, not this jump-then-virtualized-scroll path.
-      pendingScrollTarget.current = null
-      searchNavPhaseRef.current = "idle"
-      setIsSearchNavigating(false)
-      return
-    }
-
     const started = performance.now()
     // Generous bound: a cold push-notification deep-link can spend ~1s in
     // jumpToEvent + the skeleton hold before Virtuoso even mounts. Must
@@ -1974,7 +1948,7 @@ export function StreamContent({
         pendingScrollRafRef.current = 0
       }
     }
-  }, [events, isLoading, scrollToMessage, useVirtualized, setDeepLinkGaveUp, pendingScrollRequestVersion])
+  }, [events, isLoading, scrollToMessage, setDeepLinkGaveUp, pendingScrollRequestVersion])
 
   // Reset jump and search state when switching streams (component stays mounted).
   // Also abort any in-flight scrollToMessage retry loop so its stale closure

--- a/tests/browser/stream-search-cycling.spec.ts
+++ b/tests/browser/stream-search-cycling.spec.ts
@@ -9,6 +9,12 @@ import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
  * (hasNewer=false). jumpToEvent used to early-return without exiting jump
  * mode there, leaving the timeline frozen on the old window while the match
  * counter kept advancing.
+ *
+ * The tail of the test guards the other half of the contract, which also needs
+ * a real scroller: once the reader scrolls away from the active match, nothing
+ * may scroll it back. Rows carrying the search highlight used to self-center on
+ * mount, so the yank arrived seconds later, whenever virtua happened to
+ * re-render the row.
  */
 
 test.describe.configure({ timeout: 600_000 })
@@ -52,7 +58,29 @@ async function seedMessages(page: Page, workspaceId: string, streamId: string): 
   }
 }
 
-test("cycles through matches in both directions across jump windows", async ({ page }) => {
+/**
+ * Whether the active match overlaps the scroller viewport. Measured against the
+ * scroller found from a rendered row rather than a test id — it is whichever
+ * ancestor actually scrolls, which differs between the virtualized channel list
+ * and the plain thread list. `toBeVisible` is no substitute: it counts an
+ * element that has been scrolled clean out of the viewport as visible.
+ */
+async function activeMatchInView(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const row = document.querySelector("[data-message-id]")
+    let el = row?.parentElement ?? null
+    while (el && el.scrollHeight <= el.clientHeight + 4) el = el.parentElement
+    const match = Array.from(document.querySelectorAll<HTMLElement>("[data-message-id]")).find((n) =>
+      n.textContent?.includes("the pelican lands here (match 1 ")
+    )
+    if (!el || !match) return false
+    const sr = el.getBoundingClientRect()
+    const mr = match.getBoundingClientRect()
+    return mr.bottom > sr.top && mr.top < sr.bottom
+  })
+}
+
+test("cycles through matches in both directions, and a scroll away is never overridden", async ({ page }) => {
   await loginAndCreateWorkspace(page, "search-cycle")
   await createChannel(page, `search-cycle-${Date.now().toString(36)}`)
 
@@ -96,4 +124,16 @@ test("cycles through matches in both directions across jump windows", async ({ p
   // And back up through the same windows.
   await input.press("Shift+Enter")
   await matchVisible(1)
+
+  // A manual scroll always wins. Nothing may pull the reader back to the active
+  // match afterwards — the row leaving and re-entering the virtualized window
+  // used to re-fire a scrollIntoView on it seconds after the navigation.
+  await page.mouse.move(640, 400)
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.wheel(0, -400)
+    await page.waitForTimeout(80)
+  }
+  expect(await activeMatchInView(page)).toBe(false)
+  await page.waitForTimeout(4000)
+  expect(await activeMatchInView(page)).toBe(false)
 })


### PR DESCRIPTION
## Problem

Two scroll defects Kris caught on video after #1712 landed, both from a second, ungated scroller fighting the one the timeline actually owns.

`MessageEvent` self-centered on `isHighlighted` with `scrollIntoView({ behavior: "smooth", block: "center" })` (`message-event.tsx:1011`, unchanged since the original search UI in #34). `stream-content.tsx:2598` feeds that prop `streamSearch.activeMessageId`, so in the virtualized timeline the effect re-fires every time virtua remounts the active match's row — with no user-interaction gate. Scroll away from a match to read older context and the timeline smooth-scrolls you back, seconds later, unprompted. Measured on a 175-message channel: after a manual wheel scroll to `scrollTop: 0`, the scroller was back at `569` within 200ms.

The same effect also raced the first landing. `scrollToMessage`'s refine loop positions with native `scrollTop` writes, then aborts two frames after the target first looks settled (~120ms) — while the smooth animation is still running toward a target computed from a stale position. Post-jump probe before the fix: match top `478 → 451`, scroller height swinging `1792 → 1598 → 1714`.

Underneath that, the early abort left a real gap of its own: a link preview card resolving above the target lands ~800ms after the window renders, well after the loop is dead. Measured with previews seeded above the match: the match dropped 56px (`matchTop 450 → 506`) with `scrollTop` unmoved.

## Solution

`scrollToMessage` becomes the only thing that scrolls a highlighted row into view, and it stops giving up early.

- Deleted the `scrollIntoView` effect from `MessageEvent`. Every path that scrolls to a highlight now goes through the loop that already honours `userInteractedAtRef` and its own wheel/touch/key aborts.
- `scrollToMessage` no longer bails on `!useVirtualized`, and reads `scrollContainerRef` instead of `virtuosoScrollerRef`. The plain thread scroller renders every row, so it takes the DOM branch and never reaches virtua (`listRef.current` is null there, so the `scrollToIndex` branch no-ops). Widening the one authority over deleting the effect outright — threads had no other scroll-to-highlight path, and prop-drilling a `selfScroll` flag through `EventList → EventItem → MessageEvent` would have kept two mechanisms alive.
- Dropped the matching `!useVirtualized` early-out in the post-jump driver, so a thread's out-of-window search jump lands through the same driver.
- The refine loop no longer aborts on `stableFrames >= 2`; it corrects for the full `MAX_MS = 1200` window. `MAX_MS` is unchanged — 1200ms already covers the ~800ms preview arrival, so raising it would have been speculative.

Residual risk: threads get no `userInteractedAtRef` stamp (`useTimelineScroll` attaches it to the virtualized scroller only), so a thread reader is protected by `scrollToMessage`'s own abort listeners during the 1.2s window rather than by the sticky stamp. Same protection threads had before; no regression, no improvement.

Not fixed here: the post-jump driver now runs for threads, so a thread deep-link whose target never becomes placeable takes the 4s deadline path to `setDeepLinkGaveUp(true)` instead of clearing instantly. `DEEP_LINK_HOLD_MAX_MS` (600ms) already releases the skeleton, so nothing hangs.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-event.tsx` | **Deleted** the `isHighlighted` → `scrollIntoView` effect |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `scrollToMessage` serves both scroll modes; refine loop watches the whole window; post-jump driver loses its non-virtualized early-out |
| `tests/browser/stream-search-cycling.spec.ts` | Asserts a manual scroll away from the active match is never overridden |

## Test plan

- [x] `tests/browser/stream-search-cycling.spec.ts` — 1 pass; **verified failing** with the `scrollIntoView` effect restored (`matchInView` true again 4s after the manual scroll)
- [x] `vitest run src/components/timeline src/hooks` — 128 files, 1515 pass
- [x] `bun run lint` + frontend `tsc --noEmit` — clean
- [x] Measured on `dev:test` with a scripted Playwright driver (sampling `scrollTop` / match rect every 150–200ms): yank drift `+569 → 0` over 12s; post-jump match top stable from t+150ms; preview-induced shift `56px → 0` across 8s
- [ ] Preview-induced drift is **not** guarded by the spec. Reproducing it needs link previews above the match, which means outbound scraping from CI; a synthetic row-growth injection didn't reproduce it (virtua compensates for that case on its own), so the assertion would have passed on broken code and was dropped rather than left in as false coverage.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788245422&installation_model_id=20758&pr_number=1717&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1717&signature=0e779eb49c99c287987212cc87fdb839d1e4fe6507617c8e5f3c189199d84446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->