### PR TITLE
feat(perf): closed-registry client capture, inert until armed

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -28,6 +28,7 @@ import {
 } from "./triggers"
 import type { CommandItem } from "./triggers/types"
 import { parseMemoUrl } from "@/lib/memo-url"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { classifyDraftLink } from "@/lib/in-app-links"
 import { MentionPluginKey } from "./triggers/mention-extension"
 import { CommandPluginKey } from "./triggers/command-extension"
@@ -878,14 +879,19 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
 
+    const stopExternalSync = getPerfCapture().time("editor.externalSync")
+
     const currentJson = JSON.stringify(editor.getJSON())
     const newJson = JSON.stringify(editableValue)
     if (newJson === currentJson) {
       externalSyncFailuresRef.current = 0
+      stopExternalSync()
       return
     }
 
-    if (applyExternalEditorContent(editor, editableValue, isInternalUpdate)) {
+    const applied = applyExternalEditorContent(editor, editableValue, isInternalUpdate)
+    stopExternalSync()
+    if (applied) {
       externalSyncFailuresRef.current = 0
       return
     }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -131,6 +131,7 @@ import { useStreamSearch } from "@/hooks/use-stream-search"
 import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { localStartOfDayMs } from "@/lib/dates"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { addStartBatchSelectListener, type BatchSelectIntent } from "@/lib/batch-selection-events"
 import { addMarkReadUpToHereListener, addMarkUnreadListener } from "@/lib/mark-read-events"
 import { ReadFrontierContext, type ReadFrontier } from "./read-frontier-context"
@@ -1381,6 +1382,11 @@ export function StreamContent({
     const base = injectDayDividers(filtered)
     return showOlderSkeletons ? [...OLDER_SKELETON_ITEMS, ...base] : base
   }, [timelineItems, useVirtualized, isChannel, showOlderSkeletons])
+
+  const visibleItemCount = visibleItems.length
+  useEffect(() => {
+    getPerfCapture().mark("timeline.windowItems", visibleItemCount)
+  }, [visibleItemCount])
 
   // Collected from the PRE-filter `timelineItems`: the zero-height
   // `agent:follow_up_cancelled` events are dropped by `filterVisibleItems`, so

--- a/apps/frontend/src/lib/drafts/draft-staging.perf.test.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.perf.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest"
+import type { JSONContent } from "@threa/types"
+import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
+import { stageDraftContent } from "./draft-staging"
+
+const doc: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "the quick brown fox" }] }],
+}
+
+const key = "threa:draft-stage:ws_1:scope_1"
+
+afterEach(() => {
+  armPerfCapture(NO_CAPTURE)
+  localStorage.clear()
+})
+
+describe("draft staging instrumentation", () => {
+  it("records the serialized character count and the staging duration when armed", () => {
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
+
+    stageDraftContent("ws_1", "scope_1", doc)
+
+    const samples = capture.snapshot()
+    const staged = samples.find((s) => s.name === "draft.stagedChars")
+    expect(staged?.value).toBe(localStorage.getItem(key)!.length)
+    expect(samples.some((s) => s.name === "draft.staging")).toBe(true)
+  })
+
+  it("stages an identical payload whether armed or not", () => {
+    stageDraftContent("ws_1", "scope_1", doc)
+    const unarmed = localStorage.getItem(key)!
+    localStorage.clear()
+
+    armPerfCapture(new PerfCapture())
+    stageDraftContent("ws_1", "scope_1", doc)
+    const armed = localStorage.getItem(key)!
+
+    // `clientUpdatedAt` is a wall clock; everything else must match byte for byte.
+    const strip = (raw: string) => JSON.stringify(JSON.parse(raw).contentJson)
+    expect(strip(armed)).toBe(strip(unarmed))
+    expect(armed.length).toBe(unarmed.length)
+  })
+})

--- a/apps/frontend/src/lib/drafts/draft-staging.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.ts
@@ -88,8 +88,8 @@ export function stageDraftContent(workspaceId: string, scope: string, contentJso
       localStorage.removeItem(keyFor(workspaceId, scope))
       return
     }
-    capture.mark("draft.stagedChars", raw.length)
     localStorage.setItem(keyFor(workspaceId, scope), raw)
+    capture.mark("draft.stagedChars", raw.length)
   } catch {
     // Quota exceeded / storage disabled — never interrupt typing. The local
     // copy reaches IDB on the debounce regardless.

--- a/apps/frontend/src/lib/drafts/draft-staging.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.ts
@@ -31,6 +31,7 @@
 
 import type { JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { getPerfCapture } from "@/lib/perf/capture"
 
 const PREFIX = "threa:draft-stage:"
 
@@ -73,6 +74,8 @@ function storageAvailable(): boolean {
  */
 export function stageDraftContent(workspaceId: string, scope: string, contentJson: JSONContent): void {
   if (!storageAvailable()) return
+  const capture = getPerfCapture()
+  const stopStaging = capture.time("draft.staging")
   try {
     if (isEmptyContent(contentJson)) {
       localStorage.removeItem(keyFor(workspaceId, scope))
@@ -85,10 +88,13 @@ export function stageDraftContent(workspaceId: string, scope: string, contentJso
       localStorage.removeItem(keyFor(workspaceId, scope))
       return
     }
+    capture.mark("draft.stagedChars", raw.length)
     localStorage.setItem(keyFor(workspaceId, scope), raw)
   } catch {
     // Quota exceeded / storage disabled — never interrupt typing. The local
     // copy reaches IDB on the debounce regardless.
+  } finally {
+    stopStaging()
   }
 }
 

--- a/apps/frontend/src/lib/perf/capture.off.test.ts
+++ b/apps/frontend/src/lib/perf/capture.off.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { stageDraftContent } from "@/lib/drafts/draft-staging"
+import { NO_CAPTURE, getPerfCapture } from "./capture"
+import { PerfCaptureProvider, usePerfCapture } from "./context"
+import { startObservers } from "./observers"
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(PerfCaptureProvider, null, children)
+}
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe("perf capture when unarmed", () => {
+  it("usePerfCapture returns the NO_CAPTURE singleton", () => {
+    const { result } = renderHook(() => usePerfCapture(), { wrapper })
+    expect(result.current).toBe(NO_CAPTURE)
+    expect(getPerfCapture()).toBe(NO_CAPTURE)
+  })
+
+  it("records nothing when every instrumented helper is driven", () => {
+    const capture = getPerfCapture()
+    expect(capture).toBe(NO_CAPTURE)
+    capture.mark("bootstrap.tx", 1)
+    capture.count("stream.idbTransaction")
+    capture.time("catchup.entryApply")()
+    expect(capture.snapshot()).toEqual([])
+
+    startObservers(capture)()
+    stageDraftContent("ws_1", "scope_1", {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }],
+    })
+
+    expect(capture.snapshot()).toEqual([])
+  })
+})

--- a/apps/frontend/src/lib/perf/capture.test.ts
+++ b/apps/frontend/src/lib/perf/capture.test.ts
@@ -69,3 +69,18 @@ describe("PerfCapture ring buffer", () => {
     expect(typeof sample?.value).toBe("number")
   })
 })
+
+describe("draft mark timestamp quantization", () => {
+  it("coarsens draft.* timestamps to whole seconds and leaves values precise", () => {
+    const capture = new PerfCapture()
+    capture.mark("draft.stagedChars", 1234)
+    capture.mark("bootstrap.tx", 1)
+
+    const samples = capture.snapshot()
+    const draft = samples.find((s) => s.name === "draft.stagedChars")
+    const other = samples.find((s) => s.name === "bootstrap.tx")
+    expect(draft && draft.at % 1000).toBe(0)
+    expect(draft?.value).toBe(1234)
+    expect(other && other.at % 1000).not.toBe(0)
+  })
+})

--- a/apps/frontend/src/lib/perf/capture.test.ts
+++ b/apps/frontend/src/lib/perf/capture.test.ts
@@ -1,0 +1,71 @@
+import { PERF_CAPTURE_MAX_SAMPLES } from "@threa/types"
+import { describe, expect, it } from "vitest"
+import { PerfCapture } from "./capture"
+
+describe("PerfCapture ring buffer", () => {
+  it("evicts the oldest samples past the cap", () => {
+    const capture = new PerfCapture()
+    for (let i = 0; i < 2100; i++) capture.mark("catchup.entryApply", i)
+
+    const samples = capture.snapshot()
+    expect(samples).toHaveLength(2000)
+    expect(samples[0]?.value).toBe(100)
+    expect(samples[samples.length - 1]?.value).toBe(2099)
+  })
+
+  it("keeps one-shot bootstrap marks that the ring would have evicted", () => {
+    const capture = new PerfCapture()
+    capture.mark("bootstrap.rowsWritten", 7)
+    for (let i = 0; i < 5000; i++) capture.mark("catchup.entryApply", i)
+
+    const samples = capture.snapshot()
+    expect(samples.find((s) => s.name === "bootstrap.rowsWritten")?.value).toBe(7)
+    expect(samples.length).toBeLessThanOrEqual(PERF_CAPTURE_MAX_SAMPLES)
+  })
+
+  it("never exceeds the schema sample cap", () => {
+    const capture = new PerfCapture()
+    for (let i = 0; i < 200; i++) capture.mark("bootstrap.tx", i)
+    for (let i = 0; i < 6000; i++) capture.mark("catchup.entryApply", i)
+
+    expect(capture.snapshot().length).toBeLessThanOrEqual(PERF_CAPTURE_MAX_SAMPLES)
+  })
+
+  it("returns a copy, not the live buffer", () => {
+    const capture = new PerfCapture()
+    capture.mark("stream.eventApply", 1)
+
+    const first = capture.snapshot()
+    capture.mark("stream.eventApply", 2)
+
+    expect(first).toHaveLength(1)
+    expect(capture.snapshot()).toHaveLength(2)
+    expect(capture.snapshot()).not.toBe(first)
+  })
+
+  it("clear empties both the ring and the pinned bootstrap samples", () => {
+    const capture = new PerfCapture()
+    capture.count("liveQuery.rerun")
+    capture.mark("bootstrap.tx", 1)
+    capture.clear()
+    expect(capture.snapshot()).toEqual([])
+  })
+
+  it("re-stamps startedAt on clear", async () => {
+    const capture = new PerfCapture()
+    const first = capture.startedAt
+    await new Promise((resolve) => setTimeout(resolve, 2))
+    capture.clear()
+    expect(capture.startedAt).not.toBe(first)
+  })
+
+  it("time() records the elapsed duration under the mark name", () => {
+    const capture = new PerfCapture()
+    const stop = capture.time("bootstrap.fetch")
+    stop()
+
+    const [sample] = capture.snapshot()
+    expect(sample?.name).toBe("bootstrap.fetch")
+    expect(typeof sample?.value).toBe("number")
+  })
+})

--- a/apps/frontend/src/lib/perf/capture.ts
+++ b/apps/frontend/src/lib/perf/capture.ts
@@ -64,6 +64,10 @@ export class PerfCapture implements PerfCaptureLike {
   }
 
   private push(sample: PerformanceSample): void {
+    // Draft marks fire per keystroke; precise timestamps would upload
+    // keystroke-dynamics-grade cadence, a content proxy the schema's
+    // no-free-text rule cannot see. Durations/sizes keep full precision.
+    if (sample.name.startsWith("draft.")) sample = { ...sample, at: Math.floor(sample.at / 1000) * 1000 }
     // Bootstrap marks fire once per session; the ring would evict them long
     // before an export, so they live outside it.
     if (sample.name.startsWith("bootstrap.")) {
@@ -103,14 +107,17 @@ function armedFromSearchParams(): boolean | null {
 export function isCaptureArmed(): boolean {
   if (typeof window === "undefined") return false
 
-  const paramFlag = armedFromSearchParams()
-  if (paramFlag !== null) return paramFlag
+  // try/catch is load-bearing: reading window.localStorage itself throws a
+  // SecurityError under blocked-storage policies, and this runs at module load.
+  try {
+    const paramFlag = armedFromSearchParams()
+    if (paramFlag !== null) return paramFlag
 
-  const getItem = window.localStorage?.getItem
-  if (typeof getItem !== "function") return false
-
-  const stored = getItem.call(window.localStorage, CAPTURE_STORAGE_KEY)
-  return stored === "1" || stored === "true"
+    const stored = window.localStorage.getItem(CAPTURE_STORAGE_KEY)
+    return stored === "1" || stored === "true"
+  } catch {
+    return false
+  }
 }
 
 let moduleCapture: PerfCaptureLike = NO_CAPTURE

--- a/apps/frontend/src/lib/perf/capture.ts
+++ b/apps/frontend/src/lib/perf/capture.ts
@@ -1,0 +1,130 @@
+import { PERF_CAPTURE_MAX_SAMPLES, type PerfMarkName, type PerformanceSample } from "@threa/types"
+
+const CAPTURE_STORAGE_KEY = "threa:perf:capture"
+const PINNED_MAX = 48
+const RING_CAPACITY = PERF_CAPTURE_MAX_SAMPLES - PINNED_MAX
+
+export interface PerfCaptureLike {
+  readonly startedAt: string
+  mark(name: PerfMarkName, value?: number): void
+  count(name: PerfMarkName): void
+  time(name: PerfMarkName): () => void
+  snapshot(): PerformanceSample[]
+  clear(): void
+}
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now()
+}
+
+/**
+ * Fixed-size ring of samples. Oldest entries are overwritten rather than
+ * dropped at the tail: a long session must keep measuring, and the recent
+ * window is the one worth reading.
+ */
+export class PerfCapture implements PerfCaptureLike {
+  private buffer: PerformanceSample[] = new Array(RING_CAPACITY)
+  private pinned: PerformanceSample[] = []
+  private next = 0
+  private filled = false
+  private startedAtValue = new Date().toISOString()
+
+  get startedAt(): string {
+    return this.startedAtValue
+  }
+
+  mark(name: PerfMarkName, value?: number): void {
+    this.push(value === undefined ? { name, at: now() } : { name, at: now(), value })
+  }
+
+  count(name: PerfMarkName): void {
+    this.push({ name, at: now(), count: 1 })
+  }
+
+  time(name: PerfMarkName): () => void {
+    const startedAt = now()
+    return () => {
+      this.push({ name, at: startedAt, value: now() - startedAt })
+    }
+  }
+
+  snapshot(): PerformanceSample[] {
+    const ring = this.filled
+      ? [...this.buffer.slice(this.next), ...this.buffer.slice(0, this.next)]
+      : this.buffer.slice(0, this.next)
+    return [...this.pinned, ...ring].sort((a, b) => a.at - b.at)
+  }
+
+  clear(): void {
+    this.buffer = new Array(RING_CAPACITY)
+    this.pinned = []
+    this.next = 0
+    this.filled = false
+    this.startedAtValue = new Date().toISOString()
+  }
+
+  private push(sample: PerformanceSample): void {
+    // Bootstrap marks fire once per session; the ring would evict them long
+    // before an export, so they live outside it.
+    if (sample.name.startsWith("bootstrap.")) {
+      if (this.pinned.length < PINNED_MAX) this.pinned.push(sample)
+      return
+    }
+    this.buffer[this.next] = sample
+    this.next = (this.next + 1) % RING_CAPACITY
+    if (this.next === 0) this.filled = true
+  }
+}
+
+const NO_OP_STOP = (): void => {}
+
+/**
+ * The disarmed capture. Every instrumentation call site holds one of these
+ * unless capture is armed, so the off path is a frozen method call and nothing
+ * else — no allocation, no timestamp, no buffer.
+ */
+export const NO_CAPTURE: PerfCaptureLike = Object.freeze({
+  startedAt: "",
+  mark: (): void => {},
+  count: (): void => {},
+  time: (): (() => void) => NO_OP_STOP,
+  snapshot: (): PerformanceSample[] => [],
+  clear: (): void => {},
+})
+
+function armedFromSearchParams(): boolean | null {
+  if (typeof window === "undefined") return null
+  const value = new URLSearchParams(window.location.search).get("perfCapture")
+  if (value === "1" || value === "true") return true
+  if (value === "0" || value === "false") return false
+  return null
+}
+
+export function isCaptureArmed(): boolean {
+  if (typeof window === "undefined") return false
+
+  const paramFlag = armedFromSearchParams()
+  if (paramFlag !== null) return paramFlag
+
+  const getItem = window.localStorage?.getItem
+  if (typeof getItem !== "function") return false
+
+  const stored = getItem.call(window.localStorage, CAPTURE_STORAGE_KEY)
+  return stored === "1" || stored === "true"
+}
+
+let moduleCapture: PerfCaptureLike = NO_CAPTURE
+
+/**
+ * Arming has exactly one production caller: the provider in `context.tsx`,
+ * which decides once per mount. Non-React modules (sync engine,
+ * draft staging) read `getPerfCapture()` instead of taking the capture through
+ * a constructor, so instrumenting a hot path never changes its signature.
+ */
+export function armPerfCapture(capture: PerfCaptureLike): void {
+  moduleCapture = capture
+}
+
+export function getPerfCapture(): PerfCaptureLike {
+  return moduleCapture
+}

--- a/apps/frontend/src/lib/perf/context.tsx
+++ b/apps/frontend/src/lib/perf/context.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useRef, type ReactNode } from "react"
+import { NO_CAPTURE, PerfCapture, armPerfCapture, isCaptureArmed, type PerfCaptureLike } from "./capture"
+import { installCaptureWindowHandle } from "./export"
+import { startObservers } from "./observers"
+
+const PerfCaptureContext = createContext<PerfCaptureLike>(NO_CAPTURE)
+
+/**
+ * Decides armed-or-not once per mount and never again, so the context value is
+ * referentially stable and this provider adds no renders to the tree it wraps.
+ */
+export function PerfCaptureProvider({ children }: { children: ReactNode }) {
+  const captureRef = useRef<PerfCaptureLike | null>(null)
+  if (captureRef.current === null) {
+    captureRef.current = isCaptureArmed() ? new PerfCapture() : NO_CAPTURE
+  }
+  const capture = captureRef.current
+
+  useEffect(() => {
+    if (capture === NO_CAPTURE) return
+    armPerfCapture(capture)
+    installCaptureWindowHandle(capture)
+    const dispose = startObservers(capture)
+    return () => {
+      dispose()
+      armPerfCapture(NO_CAPTURE)
+      if (typeof window !== "undefined") delete (window as Window & { __threaPerfCapture?: unknown }).__threaPerfCapture
+    }
+  }, [capture])
+
+  return <PerfCaptureContext.Provider value={capture}>{children}</PerfCaptureContext.Provider>
+}
+
+export function usePerfCapture(): PerfCaptureLike {
+  return useContext(PerfCaptureContext)
+}

--- a/apps/frontend/src/lib/perf/export.ts
+++ b/apps/frontend/src/lib/perf/export.ts
@@ -1,0 +1,40 @@
+import { type PerfDeviceClass, type PerformanceCapture, performanceCaptureSchema } from "@threa/types"
+import { ulid } from "ulid"
+import { currentAppVersion } from "@/lib/app-build"
+import { type PerfCaptureLike } from "./capture"
+
+/**
+ * Coarse buckets from core count and memory only. Neither value is reported
+ * verbatim: a raw `(cores, memory)` pair is a fingerprint, a bucket is not.
+ */
+export function deviceClass(): PerfDeviceClass {
+  const nav = typeof navigator === "undefined" ? undefined : (navigator as Navigator & { deviceMemory?: number })
+  const cores = nav?.hardwareConcurrency ?? 0
+  const memory = nav?.deviceMemory ?? 0
+  if (cores >= 8 && memory >= 8) return "high"
+  if (cores >= 4 || memory >= 4) return "mid"
+  return "low"
+}
+
+export function exportCapture(capture: PerfCaptureLike): PerformanceCapture {
+  return performanceCaptureSchema.parse({
+    captureId: `cap_${ulid()}`,
+    appVersion: currentAppVersion() ?? "unknown",
+    deviceClass: deviceClass(),
+    startedAt: capture.startedAt,
+    samples: capture.snapshot(),
+  })
+}
+
+interface PerfCaptureWindowHandle {
+  export: () => PerformanceCapture
+  clear: () => void
+}
+
+export function installCaptureWindowHandle(capture: PerfCaptureLike): void {
+  if (typeof window === "undefined") return
+  ;(window as Window & { __threaPerfCapture?: PerfCaptureWindowHandle }).__threaPerfCapture = {
+    export: () => exportCapture(capture),
+    clear: () => capture.clear(),
+  }
+}

--- a/apps/frontend/src/lib/perf/no-direct-performance-marks.test.ts
+++ b/apps/frontend/src/lib/perf/no-direct-performance-marks.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+// All performance instrumentation goes through `lib/perf` — the facade is what
+// keeps the emitted mark names a closed set (`PERF_MARK_NAMES`), keeps free
+// text out of samples, and keeps the whole thing inert when unarmed. A direct
+// `performance.mark`/`measure` or a hand-rolled PerformanceObserver bypasses
+// all three at once, so it fails here rather than at review time.
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
+const perfDir = resolve(dirname(fileURLToPath(import.meta.url)))
+
+/** Files allowed to touch the browser performance API directly, with the reason. */
+const allowlist = new Set<string>([
+  // (empty — lib/perf itself is excluded by directory, not by entry)
+])
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      files.push(...collectSourceFiles(full))
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.(ts|tsx)$/.test(entry)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe("performance instrumentation goes through lib/perf", () => {
+  it("has no direct performance.mark/measure or PerformanceObserver outside lib/perf", () => {
+    const violations: string[] = []
+    for (const file of collectSourceFiles(srcRoot)) {
+      if (file.startsWith(perfDir)) continue
+      const rel = relative(srcRoot, file)
+      if (allowlist.has(rel)) continue
+
+      const lines = readFileSync(file, "utf8").split("\n")
+      lines.forEach((line, i) => {
+        if (/\bperformance\.(mark|measure)\s*\(/.test(line) || /\bnew PerformanceObserver\s*\(/.test(line)) {
+          violations.push(`${rel}:${i + 1}`)
+        }
+      })
+    }
+
+    expect(
+      violations,
+      `Direct performance-API use outside lib/perf. Route the measurement through ` +
+        `\`getPerfCapture()\` / \`usePerfCapture()\` with a name from PERF_MARK_NAMES, ` +
+        `or add the file to the allowlist with a reason:\n${violations.join("\n")}`
+    ).toEqual([])
+  })
+})

--- a/apps/frontend/src/lib/perf/observers.test.ts
+++ b/apps/frontend/src/lib/perf/observers.test.ts
@@ -9,6 +9,7 @@ const constructed: FakeObserver[] = []
 class FakeObserver {
   disconnected = false
   observedTypes: string[] = []
+  observedOptions: object[] = []
 
   constructor(public callback: ObserverCallback) {
     constructed.push(this)
@@ -16,6 +17,7 @@ class FakeObserver {
 
   observe(options: { type: string }) {
     this.observedTypes.push(options.type)
+    this.observedOptions.push(options)
   }
 
   disconnect() {
@@ -89,5 +91,34 @@ describe("startObservers", () => {
 
     expect(constructed.every((o) => o.disconnected)).toBe(true)
     expect(cancelled).toEqual([7])
+  })
+})
+
+describe("consent hygiene", () => {
+  it("does not request buffered entries", () => {
+    installFakes()
+    const dispose = startObservers(new PerfCapture())
+    expect(constructed.map((o) => o.observedOptions.map((opt) => (opt as { buffered?: boolean }).buffered))).toEqual([
+      [undefined],
+      [undefined],
+    ])
+    dispose()
+  })
+
+  it("records no frame gap across a hidden interval", () => {
+    const { runFrame } = installFakes()
+    const capture = new PerfCapture()
+    const dispose = startObservers(capture)
+
+    runFrame(0)
+    Object.defineProperty(document, "hidden", { configurable: true, value: true })
+    runFrame(5000)
+    Object.defineProperty(document, "hidden", { configurable: true, value: false })
+    runFrame(5016)
+    runFrame(5216)
+
+    expect(capture.snapshot().map((s) => s.value)).toEqual([200])
+    dispose()
+    Object.defineProperty(document, "hidden", { configurable: true, value: false })
   })
 })

--- a/apps/frontend/src/lib/perf/observers.test.ts
+++ b/apps/frontend/src/lib/perf/observers.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { NO_CAPTURE, PerfCapture } from "./capture"
+import { startObservers } from "./observers"
+
+type ObserverCallback = (list: { getEntries: () => { duration: number }[] }) => void
+
+const constructed: FakeObserver[] = []
+
+class FakeObserver {
+  disconnected = false
+  observedTypes: string[] = []
+
+  constructor(public callback: ObserverCallback) {
+    constructed.push(this)
+  }
+
+  observe(options: { type: string }) {
+    this.observedTypes.push(options.type)
+  }
+
+  disconnect() {
+    this.disconnected = true
+  }
+}
+
+function installFakes() {
+  constructed.length = 0
+  vi.stubGlobal("PerformanceObserver", FakeObserver)
+
+  const cancelled: number[] = []
+  let frameCallback: FrameRequestCallback | null = null
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frameCallback = cb
+    return 7
+  })
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+    cancelled.push(handle)
+  })
+
+  return { cancelled, runFrame: (t: number) => frameCallback?.(t) }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("startObservers", () => {
+  it("constructs no PerformanceObserver when unarmed", () => {
+    installFakes()
+    const dispose = startObservers(NO_CAPTURE)
+    expect(constructed).toHaveLength(0)
+    dispose()
+  })
+
+  it("records long tasks and event durations when armed", () => {
+    installFakes()
+    const capture = new PerfCapture()
+    const dispose = startObservers(capture)
+
+    expect(constructed.map((o) => o.observedTypes)).toEqual([["longtask"], ["event"]])
+    constructed[0].callback({ getEntries: () => [{ duration: 123 }] })
+    constructed[1].callback({ getEntries: () => [{ duration: 45 }] })
+
+    expect(capture.snapshot().map((s) => [s.name, s.value])).toEqual([
+      ["observer.longTask", 123],
+      ["observer.eventDuration", 45],
+    ])
+    dispose()
+  })
+
+  it("records a frame gap only past the threshold", () => {
+    const { runFrame } = installFakes()
+    const capture = new PerfCapture()
+    const dispose = startObservers(capture)
+
+    runFrame(0)
+    runFrame(10)
+    runFrame(200)
+
+    expect(capture.snapshot()).toEqual([{ name: "observer.frameGap", at: expect.any(Number), value: 190 }])
+    dispose()
+  })
+
+  it("disposer disconnects every observer and cancels the rAF loop", () => {
+    const { cancelled } = installFakes()
+    const dispose = startObservers(new PerfCapture())
+
+    dispose()
+
+    expect(constructed.every((o) => o.disconnected)).toBe(true)
+    expect(cancelled).toEqual([7])
+  })
+})

--- a/apps/frontend/src/lib/perf/observers.ts
+++ b/apps/frontend/src/lib/perf/observers.ts
@@ -1,6 +1,9 @@
 import { NO_CAPTURE, type PerfCaptureLike } from "./capture"
 
-const FRAME_GAP_THRESHOLD_MS = 50
+// 25ms is ~1.5 missed frames at 60Hz: real misses record, per-frame jitter does
+// not. The distribution is censored below this floor — the reproduction matrix
+// states its frame-gap targets in these terms.
+const FRAME_GAP_THRESHOLD_MS = 25
 
 /**
  * Only durations are read off browser performance entries. Names, target
@@ -18,7 +21,9 @@ export function startObservers(capture: PerfCaptureLike): () => void {
         const observer = new PerformanceObserver((list) => {
           for (const entry of list.getEntries()) capture.mark(mark, entry.duration)
         })
-        observer.observe({ type, buffered: true })
+        // durationThreshold applies to "event" only (16 is the API minimum;
+        // the default 104 would sit above the INP target this exists to verify).
+        observer.observe({ type, buffered: true, durationThreshold: 16 } as PerformanceObserverInit)
         observers.push(observer)
       } catch {
         // Entry type unsupported in this browser — the other observers still run.

--- a/apps/frontend/src/lib/perf/observers.ts
+++ b/apps/frontend/src/lib/perf/observers.ts
@@ -23,7 +23,9 @@ export function startObservers(capture: PerfCaptureLike): () => void {
         })
         // durationThreshold applies to "event" only (16 is the API minimum;
         // the default 104 would sit above the INP target this exists to verify).
-        observer.observe({ type, buffered: true, durationThreshold: 16 } as PerformanceObserverInit)
+        // NOT buffered: the browser's own entry buffer predates arming, and a
+        // consent-armed capture must never import pre-consent activity.
+        observer.observe({ type, durationThreshold: 16 } as PerformanceObserverInit)
         observers.push(observer)
       } catch {
         // Entry type unsupported in this browser — the other observers still run.
@@ -36,16 +38,27 @@ export function startObservers(capture: PerfCaptureLike): () => void {
   let frameHandle: number | null = null
   let lastFrameAt: number | null = null
 
+  // A hidden tab suspends/throttles rAF; those pauses are not jank. Reset the
+  // baseline on visibility changes so the first frame back records nothing.
+  const onVisibility = () => {
+    lastFrameAt = null
+  }
+
   if (typeof requestAnimationFrame === "function") {
     const tick = (timestamp: number) => {
-      if (lastFrameAt !== null) {
-        const gap = timestamp - lastFrameAt
-        if (gap >= FRAME_GAP_THRESHOLD_MS) capture.mark("observer.frameGap", gap)
+      if (typeof document !== "undefined" && document.hidden) {
+        lastFrameAt = null
+      } else {
+        if (lastFrameAt !== null) {
+          const gap = timestamp - lastFrameAt
+          if (gap >= FRAME_GAP_THRESHOLD_MS) capture.mark("observer.frameGap", gap)
+        }
+        lastFrameAt = timestamp
       }
-      lastFrameAt = timestamp
       frameHandle = requestAnimationFrame(tick)
     }
     frameHandle = requestAnimationFrame(tick)
+    if (typeof document !== "undefined") document.addEventListener("visibilitychange", onVisibility)
   }
 
   return () => {
@@ -53,5 +66,6 @@ export function startObservers(capture: PerfCaptureLike): () => void {
     observers.length = 0
     if (frameHandle !== null && typeof cancelAnimationFrame === "function") cancelAnimationFrame(frameHandle)
     frameHandle = null
+    if (typeof document !== "undefined") document.removeEventListener("visibilitychange", onVisibility)
   }
 }

--- a/apps/frontend/src/lib/perf/observers.ts
+++ b/apps/frontend/src/lib/perf/observers.ts
@@ -1,0 +1,52 @@
+import { NO_CAPTURE, type PerfCaptureLike } from "./capture"
+
+const FRAME_GAP_THRESHOLD_MS = 50
+
+/**
+ * Only durations are read off browser performance entries. Names, target
+ * selectors, and URLs stay in the browser — a capture carries numbers.
+ */
+export function startObservers(capture: PerfCaptureLike): () => void {
+  if (capture === NO_CAPTURE) return () => {}
+  if (typeof window === "undefined") return () => {}
+
+  const observers: PerformanceObserver[] = []
+
+  if (typeof PerformanceObserver === "function") {
+    const observe = (type: string, mark: "observer.longTask" | "observer.eventDuration") => {
+      try {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) capture.mark(mark, entry.duration)
+        })
+        observer.observe({ type, buffered: true })
+        observers.push(observer)
+      } catch {
+        // Entry type unsupported in this browser — the other observers still run.
+      }
+    }
+    observe("longtask", "observer.longTask")
+    observe("event", "observer.eventDuration")
+  }
+
+  let frameHandle: number | null = null
+  let lastFrameAt: number | null = null
+
+  if (typeof requestAnimationFrame === "function") {
+    const tick = (timestamp: number) => {
+      if (lastFrameAt !== null) {
+        const gap = timestamp - lastFrameAt
+        if (gap >= FRAME_GAP_THRESHOLD_MS) capture.mark("observer.frameGap", gap)
+      }
+      lastFrameAt = timestamp
+      frameHandle = requestAnimationFrame(tick)
+    }
+    frameHandle = requestAnimationFrame(tick)
+  }
+
+  return () => {
+    for (const observer of observers) observer.disconnect()
+    observers.length = 0
+    if (frameHandle !== null && typeof cancelAnimationFrame === "function") cancelAnimationFrame(frameHandle)
+    frameHandle = null
+  }
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -80,6 +80,7 @@ import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
 import { SyncStatusStore, SyncStatusContext } from "@/sync/sync-status"
 import { copyStreamLink, copyConversationLink } from "@/lib/stream-links"
+import { PerfCaptureProvider } from "@/lib/perf/context"
 import { useResolveOrBounce } from "./use-resolve-or-bounce"
 import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 
@@ -463,81 +464,83 @@ export function WorkspaceLayout() {
 
   return (
     <SyncStatusContext.Provider value={syncStatusStore}>
-      <SocketProvider workspaceId={workspaceId}>
-        <WorkspaceSyncHandler workspaceId={workspaceId} visibleStreamIds={streamIds}>
-          <UnreadTabIndicator workspaceId={workspaceId} />
-          <NotificationSweeper workspaceId={workspaceId} />
-          <VisibleStreamPresence streamIds={streamIds} />
-          <AppUpdateChecker />
-          <FreshnessWatchers />
-          <MessageQueueHandler />
-          <StreamNameDecryptor workspaceId={workspaceId} />
-          <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={coordinatedStreamIds}>
-            <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>
-              <CallLaunchProvider>
-                <UserProfileProvider>
-                  <MentionableWrapper mentionables={mentionables}>
-                    <WorkspaceCommandListProvider workspaceId={workspaceId}>
-                      <WorkspaceEmojiProvider workspaceId={workspaceId}>
-                        <PreferencesProvider workspaceId={workspaceId}>
-                          <SettingsProvider>
-                            <WorkspaceKeyboardHandler onOpenSwitcher={openSwitcher} currentStreamId={streamId}>
-                              <E2eUnlockProvider workspaceId={workspaceId}>
-                                <QuickSwitcherProvider openSwitcher={openSwitcher}>
-                                  <PanelProvider>
-                                    <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
-                                    <EnclaveRewrapNudgeListener workspaceId={workspaceId} />
-                                    <MediaGalleryProvider>
-                                      <TraceProvider>
-                                        <SidebarProvider>
-                                          <SearchPanelProvider workspaceId={workspaceId}>
-                                            <SidebarKeyboardHandler />
-                                            <SearchKeyboardHandler />
-                                            <CoordinatedLoadingGate>
-                                              <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
-                                                <MainContentGate>
-                                                  <Outlet />
-                                                </MainContentGate>
-                                              </AppShell>
-                                            </CoordinatedLoadingGate>
-                                            <QuickSwitcher
-                                              workspaceId={workspaceId}
-                                              open={switcherOpen}
-                                              onOpenChange={setSwitcherOpen}
-                                              initialMode={switcherMode}
-                                              currentStreamId={streamId}
-                                            />
-                                            <ComposeOverlayMount workspaceId={workspaceId} />
-                                          </SearchPanelProvider>
-                                        </SidebarProvider>
-                                        <SettingsDialog />
-                                        <WorkspaceSettingsDialog workspaceId={workspaceId} />
-                                        <AccountSwitcherDialog />
-                                        <LogoutScopeDialog />
-                                        <StreamSettingsDialog workspaceId={workspaceId} />
-                                        <CreateChannelDialog workspaceId={workspaceId} />
-                                        <AttachmentExplorer workspaceId={workspaceId} />
-                                        <TraceDialogContainer />
-                                        <Toaster />
-                                      </TraceProvider>
-                                    </MediaGalleryProvider>
-                                  </PanelProvider>
-                                </QuickSwitcherProvider>
-                              </E2eUnlockProvider>
-                            </WorkspaceKeyboardHandler>
-                          </SettingsProvider>
-                        </PreferencesProvider>
-                      </WorkspaceEmojiProvider>
-                    </WorkspaceCommandListProvider>
-                  </MentionableWrapper>
-                </UserProfileProvider>
-                <CallDock />
-                <IncomingCallOverlay workspaceId={workspaceId} />
-              </CallLaunchProvider>
-            </ChannelLinkProvider>
-          </CoordinatedLoadingProvider>
-        </WorkspaceSyncHandler>
-      </SocketProvider>
+      <PerfCaptureProvider>
+        <SocketProvider workspaceId={workspaceId}>
+          <WorkspaceSyncHandler workspaceId={workspaceId} visibleStreamIds={streamIds}>
+            <UnreadTabIndicator workspaceId={workspaceId} />
+            <NotificationSweeper workspaceId={workspaceId} />
+            <VisibleStreamPresence streamIds={streamIds} />
+            <AppUpdateChecker />
+            <FreshnessWatchers />
+            <MessageQueueHandler />
+            <StreamNameDecryptor workspaceId={workspaceId} />
+            <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={coordinatedStreamIds}>
+              <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>
+                <CallLaunchProvider>
+                  <UserProfileProvider>
+                    <MentionableWrapper mentionables={mentionables}>
+                      <WorkspaceCommandListProvider workspaceId={workspaceId}>
+                        <WorkspaceEmojiProvider workspaceId={workspaceId}>
+                          <PreferencesProvider workspaceId={workspaceId}>
+                            <SettingsProvider>
+                              <WorkspaceKeyboardHandler onOpenSwitcher={openSwitcher} currentStreamId={streamId}>
+                                <E2eUnlockProvider workspaceId={workspaceId}>
+                                  <QuickSwitcherProvider openSwitcher={openSwitcher}>
+                                    <PanelProvider>
+                                      <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
+                                      <EnclaveRewrapNudgeListener workspaceId={workspaceId} />
+                                      <MediaGalleryProvider>
+                                        <TraceProvider>
+                                          <SidebarProvider>
+                                            <SearchPanelProvider workspaceId={workspaceId}>
+                                              <SidebarKeyboardHandler />
+                                              <SearchKeyboardHandler />
+                                              <CoordinatedLoadingGate>
+                                                <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
+                                                  <MainContentGate>
+                                                    <Outlet />
+                                                  </MainContentGate>
+                                                </AppShell>
+                                              </CoordinatedLoadingGate>
+                                              <QuickSwitcher
+                                                workspaceId={workspaceId}
+                                                open={switcherOpen}
+                                                onOpenChange={setSwitcherOpen}
+                                                initialMode={switcherMode}
+                                                currentStreamId={streamId}
+                                              />
+                                              <ComposeOverlayMount workspaceId={workspaceId} />
+                                            </SearchPanelProvider>
+                                          </SidebarProvider>
+                                          <SettingsDialog />
+                                          <WorkspaceSettingsDialog workspaceId={workspaceId} />
+                                          <AccountSwitcherDialog />
+                                          <LogoutScopeDialog />
+                                          <StreamSettingsDialog workspaceId={workspaceId} />
+                                          <CreateChannelDialog workspaceId={workspaceId} />
+                                          <AttachmentExplorer workspaceId={workspaceId} />
+                                          <TraceDialogContainer />
+                                          <Toaster />
+                                        </TraceProvider>
+                                      </MediaGalleryProvider>
+                                    </PanelProvider>
+                                  </QuickSwitcherProvider>
+                                </E2eUnlockProvider>
+                              </WorkspaceKeyboardHandler>
+                            </SettingsProvider>
+                          </PreferencesProvider>
+                        </WorkspaceEmojiProvider>
+                      </WorkspaceCommandListProvider>
+                    </MentionableWrapper>
+                  </UserProfileProvider>
+                  <CallDock />
+                  <IncomingCallOverlay workspaceId={workspaceId} />
+                </CallLaunchProvider>
+              </ChannelLinkProvider>
+            </CoordinatedLoadingProvider>
+          </WorkspaceSyncHandler>
+        </SocketProvider>
+      </PerfCaptureProvider>
     </SyncStatusContext.Provider>
   )
 }

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -2,6 +2,7 @@ import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { useRef } from "react"
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
+import { getPerfCapture } from "@/lib/perf/capture"
 
 /**
  * Cap the number of events loaded from IDB per stream when no sequence floor
@@ -152,7 +153,11 @@ export function useStreamEvents(
 ): CachedEvent[] | undefined {
   const result = useLiveQuery(async () => {
     if (!streamId) return []
+    const capture = getPerfCapture()
+    capture.count("liveQuery.rerun")
+    const stopLoad = capture.time("liveQuery.load")
     const events = await loadStreamEvents(streamId, fromSequenceNum ?? null)
+    stopLoad()
     // Stamp the result with the streamId it was fetched for so the caller
     // can distinguish a fresh empty result from a stale empty result left
     // over from the previous stream.

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -16,6 +16,7 @@ import {
   type SlotMap,
   type SharedMessageSlot,
 } from "@threa/types"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { writeSlotCarrier } from "@/stores/slot-store"
 import { patchConversationMessage } from "@/stores/conversation-messages-store"
 import { seedDecryption } from "@/lib/crypto/decrypt-cache"
@@ -1184,145 +1185,151 @@ export function registerStreamSocketHandlers(
   const handleMessageCreated = async (payload: MessageEventPayload) => {
     if (payload.streamId !== streamId) return
 
-    // E2E payloads stay as ciphertext + envelope at rest; decryption runs on
-    // demand in the render path. The wire `contentMarkdown` / `contentJson`
-    // for E2E messages is the backend placeholder, so the sidebar preview
-    // write below is a placeholder-by-placeholder substitution — the sidebar
-    // surfaces it as the sentinel via `stream.e2eEnabled`.
-    const newEvent = payload.event
-    const newPayload = newEvent.payload as {
-      contentJson: unknown
-      clientMessageId?: string
-    }
-    const now = Date.now()
-
-    // When this is the echo of a message we sent, the optimistic row still holds
-    // the plaintext we just encrypted. Capture it so we can seed the decrypt
-    // cache for the server event id below — otherwise the encrypted server event
-    // would flash "decrypting" as the optimistic row is swapped for the sent row.
-    let optimisticPlaintext: {
-      contentMarkdown: string
-      contentJson: JSONContent
-      attachmentRefs: AttachmentRef[]
-    } | null = null
-
-    // Set when this event's sequence reveals missed events behind it; reported
-    // after the transaction commits so the backfill never runs inside it.
-    let gapAfterSequence: string | null = null
-
-    await db.transaction("rw", [db.events, db.pendingMessages, db.slots], async () => {
-      // Merge the carrier's slots in the same transaction as the event. A
-      // map-less carrier is a no-op; the merge is idempotent so it runs even
-      // when the event already exists (heals a pre-slots row on replay).
-      await writeSlotCarrier({ database: db, workspaceId, streamId, carrier: payload, mode: "merge", cachedAt: now })
-
-      const existing = await db.events.get(newEvent.id)
-      if (existing) return
-
-      // Tail-gap check must read the latest BEFORE this write advances it.
-      if (onSequenceGap) {
-        gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), newEvent)
+    const stopApply = getPerfCapture().time("stream.eventApply")
+    try {
+      // E2E payloads stay as ciphertext + envelope at rest; decryption runs on
+      // demand in the render path. The wire `contentMarkdown` / `contentJson`
+      // for E2E messages is the backend placeholder, so the sidebar preview
+      // write below is a placeholder-by-placeholder substitution — the sidebar
+      // surfaces it as the sentinel via `stream.e2eEnabled`.
+      const newEvent = payload.event
+      const newPayload = newEvent.payload as {
+        contentJson: unknown
+        clientMessageId?: string
       }
+      const now = Date.now()
 
-      // Read the optimistic row (keyed by the client id the server echoes back)
-      // BEFORE writing the real event, so we can carry forward state the server
-      // event doesn't itself carry.
-      let carriedConversationId: string | undefined
-      let optimistic: CachedEvent | undefined
-      if (newPayload.clientMessageId) {
-        optimistic = await db.events.get(newPayload.clientMessageId)
-        optimisticPlaintext = readPlaintextContent(optimistic?.payload)
-        // A board reply tags its optimistic event with the conversation it
-        // attaches to; the server `message:created` does NOT carry that (the
-        // conversation aggregate rides a separate `conversation:updated`). Carry
-        // it onto the real event so the board card keeps showing the reply in the
-        // window between this swap and the aggregate update — otherwise the row
-        // would blink out (its id isn't in `conversation.messageIds` yet, and the
-        // optimistic copy is about to be deleted). Read-side only; ignored by the
-        // timeline. See `useBoardCardMessages`.
-        carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
-      }
+      // When this is the echo of a message we sent, the optimistic row still holds
+      // the plaintext we just encrypted. Capture it so we can seed the decrypt
+      // cache for the server event id below — otherwise the encrypted server event
+      // would flash "decrypting" as the optimistic row is swapped for the sent row.
+      let optimisticPlaintext: {
+        contentMarkdown: string
+        contentJson: JSONContent
+        attachmentRefs: AttachmentRef[]
+      } | null = null
 
-      // Add the real event BEFORE deleting the optimistic one so that
-      // Dexie live-query observers never see a frame with neither event.
-      const eventToStore = carriedConversationId
-        ? {
-            ...newEvent,
-            payload: { ...(newEvent.payload as Record<string, unknown>), conversationId: carriedConversationId },
+      // Set when this event's sequence reveals missed events behind it; reported
+      // after the transaction commits so the backfill never runs inside it.
+      let gapAfterSequence: string | null = null
+
+      getPerfCapture().count("stream.idbTransaction")
+      await db.transaction("rw", [db.events, db.pendingMessages, db.slots], async () => {
+        // Merge the carrier's slots in the same transaction as the event. A
+        // map-less carrier is a no-op; the merge is idempotent so it runs even
+        // when the event already exists (heals a pre-slots row on replay).
+        await writeSlotCarrier({ database: db, workspaceId, streamId, carrier: payload, mode: "merge", cachedAt: now })
+
+        const existing = await db.events.get(newEvent.id)
+        if (existing) return
+
+        // Tail-gap check must read the latest BEFORE this write advances it.
+        if (onSequenceGap) {
+          gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), newEvent)
+        }
+
+        // Read the optimistic row (keyed by the client id the server echoes back)
+        // BEFORE writing the real event, so we can carry forward state the server
+        // event doesn't itself carry.
+        let carriedConversationId: string | undefined
+        let optimistic: CachedEvent | undefined
+        if (newPayload.clientMessageId) {
+          optimistic = await db.events.get(newPayload.clientMessageId)
+          optimisticPlaintext = readPlaintextContent(optimistic?.payload)
+          // A board reply tags its optimistic event with the conversation it
+          // attaches to; the server `message:created` does NOT carry that (the
+          // conversation aggregate rides a separate `conversation:updated`). Carry
+          // it onto the real event so the board card keeps showing the reply in the
+          // window between this swap and the aggregate update — otherwise the row
+          // would blink out (its id isn't in `conversation.messageIds` yet, and the
+          // optimistic copy is about to be deleted). Read-side only; ignored by the
+          // timeline. See `useBoardCardMessages`.
+          carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
+        }
+
+        // Add the real event BEFORE deleting the optimistic one so that
+        // Dexie live-query observers never see a frame with neither event.
+        const eventToStore = carriedConversationId
+          ? {
+              ...newEvent,
+              payload: { ...(newEvent.payload as Record<string, unknown>), conversationId: carriedConversationId },
+            }
+          : newEvent
+        await db.events.put({
+          ...eventToStore,
+          workspaceId,
+          _sequenceNum: sequenceToNum(newEvent.sequence),
+          _cachedAt: now,
+        })
+        await resolveUnknownOptimisticAnchors(streamId)
+
+        if (newPayload.clientMessageId) {
+          if (optimistic) {
+            await bumpLaterOptimisticAnchors(
+              streamId,
+              optimistic._sequenceNum,
+              sequenceToNum(newEvent.sequence),
+              optimistic.id
+            )
           }
-        : newEvent
-      await db.events.put({
-        ...eventToStore,
+          await db.events.delete(newPayload.clientMessageId).catch(() => {})
+          await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
+        }
+      })
+
+      if (gapAfterSequence !== null) {
+        onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+      }
+
+      await applyContextRowsForEvent(workspaceId, streamId, {
+        ...newEvent,
         workspaceId,
         _sequenceNum: sequenceToNum(newEvent.sequence),
         _cachedAt: now,
       })
-      await resolveUnknownOptimisticAnchors(streamId)
 
-      if (newPayload.clientMessageId) {
-        if (optimistic) {
-          await bumpLaterOptimisticAnchors(
-            streamId,
-            optimistic._sequenceNum,
-            sequenceToNum(newEvent.sequence),
-            optimistic.id
-          )
+      // Seed the decrypt cache so the encrypted server event renders its content
+      // immediately. Only meaningful for E2E events (the wire payload carries a
+      // ciphertext); for plaintext sends the render path ignores the cache.
+      if (optimisticPlaintext && isEncryptedPayload(newEvent.payload)) {
+        seedDecryption(newEvent.id, optimisticPlaintext)
+      }
+
+      // Update sidebar preview in both TanStack cache and IDB so the sort order
+      // and preview text survive cold starts (offline-first).
+      const newPreview: LastMessagePreview = {
+        authorId: newEvent.actorId ?? "",
+        authorType: newEvent.actorType ?? "user",
+        content: newPayload.contentJson as string,
+        createdAt: newEvent.createdAt,
+      }
+
+      await db.streams.update(streamId, {
+        lastMessagePreview: newPreview,
+        _cachedAt: Date.now(),
+      })
+
+      queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+        if (!old) return old
+        return {
+          ...old,
+          streams: old.streams.map((stream) => {
+            if (stream.id !== streamId) return stream
+            return { ...stream, lastMessagePreview: newPreview }
+          }),
         }
-        await db.events.delete(newPayload.clientMessageId).catch(() => {})
-        await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
+      })
+
+      if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(newPayload.contentJson)) {
+        // Deploy skew (D-Fallback): a share-bearing event with NEITHER map —
+        // pre-hydration outbox rows / old backends — refetch so the pointer still
+        // hydrates (the bootstrap apply repopulates db.slots). A legacy map is
+        // data, not map-less, so it never lands here.
+        await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
+        await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
       }
-    })
-
-    if (gapAfterSequence !== null) {
-      onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
-    }
-
-    await applyContextRowsForEvent(workspaceId, streamId, {
-      ...newEvent,
-      workspaceId,
-      _sequenceNum: sequenceToNum(newEvent.sequence),
-      _cachedAt: now,
-    })
-
-    // Seed the decrypt cache so the encrypted server event renders its content
-    // immediately. Only meaningful for E2E events (the wire payload carries a
-    // ciphertext); for plaintext sends the render path ignores the cache.
-    if (optimisticPlaintext && isEncryptedPayload(newEvent.payload)) {
-      seedDecryption(newEvent.id, optimisticPlaintext)
-    }
-
-    // Update sidebar preview in both TanStack cache and IDB so the sort order
-    // and preview text survive cold starts (offline-first).
-    const newPreview: LastMessagePreview = {
-      authorId: newEvent.actorId ?? "",
-      authorType: newEvent.actorType ?? "user",
-      content: newPayload.contentJson as string,
-      createdAt: newEvent.createdAt,
-    }
-
-    await db.streams.update(streamId, {
-      lastMessagePreview: newPreview,
-      _cachedAt: Date.now(),
-    })
-
-    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-      if (!old) return old
-      return {
-        ...old,
-        streams: old.streams.map((stream) => {
-          if (stream.id !== streamId) return stream
-          return { ...stream, lastMessagePreview: newPreview }
-        }),
-      }
-    })
-
-    if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(newPayload.contentJson)) {
-      // Deploy skew (D-Fallback): a share-bearing event with NEITHER map —
-      // pre-hydration outbox rows / old backends — refetch so the pointer still
-      // hydrates (the bootstrap apply repopulates db.slots). A legacy map is
-      // data, not map-less, so it never lands here.
-      await queryClient.invalidateQueries({ queryKey: streamKeys.bootstrap(workspaceId, streamId) })
-      await queryClient.invalidateQueries({ queryKey: streamKeys.events(workspaceId, streamId) })
+    } finally {
+      stopApply()
     }
   }
 

--- a/apps/frontend/src/sync/sync-engine.perf.test.ts
+++ b/apps/frontend/src/sync/sync-engine.perf.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { SyncCatchUpResponse } from "@threa/types"
+import { db } from "@/db"
+import { NO_CAPTURE, PerfCapture, armPerfCapture, getPerfCapture } from "@/lib/perf/capture"
+import { resetApplyWindow } from "@/stores/apply-window"
+import { resetRevealGate } from "./reveal-gate"
+import { SyncEngine } from "./sync-engine"
+import { asSocket, makeDeps, MockSocket } from "@/test/fixtures/sync-engine"
+
+function makeActiveDeps(catchUp: ReturnType<typeof vi.fn>) {
+  return {
+    ...makeDeps(),
+    syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+  }
+}
+
+function emptyPage(head: string): SyncCatchUpResponse {
+  return { entries: [], head }
+}
+
+function userAddedEntry(syncId: string, userId: string): SyncCatchUpResponse["entries"][number] {
+  return {
+    syncId,
+    eventType: "workspace_user:added",
+    payload: { workspaceId: "ws_1", user: { id: userId, workspaceId: "ws_1", name: `User ${userId}` } },
+    createdAt: new Date().toISOString(),
+  }
+}
+
+/** The small-gap replay fixture: three missed entries, per-entry replay, no collapse. */
+function smallGapEngine() {
+  const smallPage = Array.from({ length: 3 }, (_, i) => userAddedEntry(String(11 + i), `small_user_${i}`))
+  const catchUp = vi.fn().mockResolvedValueOnce({ entries: smallPage, head: "13" }).mockResolvedValue(emptyPage("13"))
+  return new SyncEngine(makeActiveDeps(catchUp))
+}
+
+beforeEach(async () => {
+  resetRevealGate()
+  resetApplyWindow()
+  await Promise.all([
+    db.workspaces.clear(),
+    db.syncCursors.clear(),
+    db.workspaceUsers.clear(),
+    db.unreadState.clear(),
+    db.streams.clear(),
+  ])
+  await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+})
+
+afterEach(() => {
+  armPerfCapture(NO_CAPTURE)
+})
+
+describe("catch-up replay instrumentation", () => {
+  it("records one apply mark per replayed entry", async () => {
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
+    const engine = smallGapEngine()
+
+    await engine.onConnect(asSocket(new MockSocket()))
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("small_user_2")).toBeDefined())
+
+    const names = capture.snapshot().map((s) => s.name)
+    expect(names.filter((n) => n === "catchup.entryApply")).toHaveLength(3)
+    expect(names.filter((n) => n === "catchup.serialReplay")).toHaveLength(1)
+    expect(names).not.toContain("catchup.collapse")
+    engine.destroy()
+  })
+
+  it("leaves the capture empty when unarmed, with the replay itself unchanged", async () => {
+    const engine = smallGapEngine()
+
+    await engine.onConnect(asSocket(new MockSocket()))
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("small_user_2")).toBeDefined())
+
+    expect(engine.getSyncCursor()).toBe("13")
+    expect(getPerfCapture()).toBe(NO_CAPTURE)
+    expect(getPerfCapture().snapshot()).toEqual([])
+    engine.destroy()
+  })
+})

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1,230 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import type { Socket } from "socket.io-client"
-import { QueryClient } from "@tanstack/react-query"
 import { SyncEngine, isSyncEngineCurrent, CATCHUP_COLLAPSE_THRESHOLD } from "./sync-engine"
 import { isApplyWindowOpen, resetApplyWindow, subscribeApplyWindow } from "@/stores/apply-window"
-import { SyncStatusStore } from "./sync-status"
 import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import { conversationKeys } from "@/hooks/use-conversations"
 import { db } from "@/db"
 import {
-  DEFAULT_USER_PREFERENCES,
-  DEFAULT_WORKSPACE_SETTINGS,
   DEFAULT_SIDEBAR_CONFIG,
   type WorkspaceBootstrap,
   type StreamBootstrap,
   type SyncCatchUpResponse,
 } from "@threa/types"
 
-type EventHandler = (...args: unknown[]) => void
-
-class MockSocket {
-  connected = true
-  /** null = never ack; true = ack immediately with ok; false = reserved */
-  ackBehavior: "immediate" | "never" | "delayed" = "immediate"
-  ackDelayMs = 0
-  disconnectCalls = 0
-  connectCalls = 0
-  emittedEvents: Array<{ event: string; args: unknown[] }> = []
-  /** Runs before a join is acked — lets tests simulate live events landing
-   *  while the room join is in flight. */
-  joinInterceptor: ((room: string) => Promise<void>) | null = null
-  private listeners = new Map<string, Set<EventHandler>>()
-  private anyListeners = new Set<(event: string, ...args: unknown[]) => void>()
-
-  on(event: string, handler: EventHandler) {
-    const handlers = this.listeners.get(event)
-    if (handlers) handlers.add(handler)
-    else this.listeners.set(event, new Set([handler]))
-    return this
-  }
-
-  off(event: string, handler: EventHandler) {
-    this.listeners.get(event)?.delete(handler)
-    return this
-  }
-
-  onAny(listener: (event: string, ...args: unknown[]) => void) {
-    this.anyListeners.add(listener)
-    return this
-  }
-
-  offAny(listener?: (event: string, ...args: unknown[]) => void) {
-    if (listener) this.anyListeners.delete(listener)
-    else this.anyListeners.clear()
-    return this
-  }
-
-  emit(event: string, ...args: unknown[]) {
-    this.emittedEvents.push({ event, args })
-
-    if (event === "health:ping") {
-      const callback = args[0] as (() => void) | undefined
-      if (!callback) return this
-      if (this.ackBehavior === "never") return this
-      if (this.ackBehavior === "immediate") {
-        callback()
-      } else {
-        setTimeout(callback, this.ackDelayMs)
-      }
-      return this
-    }
-
-    // join ack: reply ok so onConnect's workspace join succeeds in tests
-    if (event === "join") {
-      const room = args[0] as string
-      const callback = args[1] as ((result?: { ok: boolean }) => void) | undefined
-      if (this.joinInterceptor) {
-        // Ack on both paths so a rejecting interceptor can't hang an awaited join.
-        void this.joinInterceptor(room)
-          .then(() => callback?.({ ok: true }))
-          .catch(() => callback?.({ ok: false }))
-      } else {
-        callback?.({ ok: true })
-      }
-      return this
-    }
-
-    return this
-  }
-
-  trigger(event: string, ...args: unknown[]) {
-    for (const listener of this.anyListeners) listener(event, ...args)
-    const handlers = this.listeners.get(event)
-    if (!handlers) return
-    for (const handler of handlers) handler(...args)
-  }
-
-  disconnect() {
-    this.disconnectCalls += 1
-    this.connected = false
-    return this
-  }
-
-  connect() {
-    this.connectCalls += 1
-    return this
-  }
-}
-
-function asSocket(mock: MockSocket): Socket {
-  return mock as unknown as Socket
-}
-
-function makeWorkspaceBootstrap(): WorkspaceBootstrap {
-  const now = new Date().toISOString()
-  return {
-    workspace: {
-      id: "ws_1",
-      name: "Test",
-      slug: "test",
-      createdBy: "user_1",
-      createdAt: now,
-      updatedAt: now,
-    },
-    users: [],
-    streams: [],
-    streamMemberships: [],
-    dmPeers: [],
-    personas: [],
-    bots: [],
-    emojis: [],
-    emojiWeights: {},
-    commands: [],
-    unreadCounts: {},
-    mentionCounts: {},
-    activityCounts: {},
-    unreadActivityCount: 0,
-    mutedStreamIds: [],
-    labels: [],
-    labelAssignments: [],
-    viewerPermissions: [],
-    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
-    userPreferences: {
-      ...DEFAULT_USER_PREFERENCES,
-      workspaceId: "ws_1",
-      userId: "user_1",
-      createdAt: now,
-      updatedAt: now,
-    },
-    featureFlags: { workspace: {}, user: {} },
-    workspaceSettings: {
-      ...DEFAULT_WORKSPACE_SETTINGS,
-      workspaceId: "ws_1",
-      createdAt: now,
-      updatedAt: now,
-    },
-  } satisfies WorkspaceBootstrap
-}
-
-function makeStreamBootstrap(streamId = "stream_1", sequence = "2"): StreamBootstrap {
-  const now = new Date().toISOString()
-  return {
-    stream: {
-      id: streamId,
-      workspaceId: "ws_1",
-      type: "dm",
-      displayName: null,
-      slug: null,
-      description: null,
-      visibility: "private",
-      parentStreamId: null,
-      rootStreamId: null,
-      companionMode: "off",
-      companionPersonaId: null,
-      createdBy: "user_1",
-      createdAt: now,
-      updatedAt: now,
-      archivedAt: null,
-    },
-    events: [
-      {
-        id: `evt_${sequence}`,
-        streamId,
-        sequence,
-        eventType: "message_created",
-        payload: {
-          messageId: `msg_${sequence}`,
-          contentMarkdown: "new",
-          contentJson: { type: "doc", content: [{ type: "paragraph" }] },
-        },
-        actorId: "user_1",
-        actorType: "user",
-        createdAt: now,
-      },
-    ],
-    members: [],
-    botMemberIds: [],
-    membership: {
-      streamId,
-      memberId: "user_1",
-      notificationLevel: null,
-      joinedAt: now,
-    },
-    latestSequence: sequence,
-    hasOlderEvents: false,
-    syncMode: "append",
-    unreadCount: 0,
-    mentionCount: 0,
-    activityCount: 0,
-    sharedMessages: {},
-    contextBag: { bag: null, refs: [] },
-  } satisfies StreamBootstrap
-}
-
-function makeDeps() {
-  const workspaceBootstrap = vi.fn(async () => makeWorkspaceBootstrap())
-  const streamBootstrap = vi.fn(async (_workspaceId: string, streamId: string) => makeStreamBootstrap(streamId))
-  return {
-    workspaceId: "ws_1",
-    syncStatus: new SyncStatusStore(),
-    queryClient: new QueryClient(),
-    workspaceService: { bootstrap: workspaceBootstrap },
-    streamService: { bootstrap: streamBootstrap },
-  }
-}
+import {
+  MockSocket,
+  asSocket,
+  makeWorkspaceBootstrap,
+  makeStreamBootstrap,
+  makeDeps,
+} from "@/test/fixtures/sync-engine"
 
 async function primeConnectedEngine(engine: SyncEngine, socket: MockSocket): Promise<void> {
   await engine.onConnect(asSocket(socket))

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -24,6 +24,7 @@ import { SyncLogCursor } from "./sync-log-cursor"
 import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { CatchUpBatch } from "./catch-up-batch"
 import { beginApplyWindow, endApplyWindow } from "@/stores/apply-window"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -486,6 +487,7 @@ export class SyncEngine {
     if (cleanup) {
       cleanup()
       this.streamHandlerCleanups.delete(streamId)
+      getPerfCapture().mark("stream.subscriptions", this.streamHandlerCleanups.size)
     }
   }
 
@@ -782,7 +784,9 @@ export class SyncEngine {
         // forceFull runs from the catch-up fallbacks, which stamp the cursor at
         // a head they read themselves — so this snapshot must not be the
         // service worker's lock-time copy (see workspaceService.bootstrap).
+        const stopFetch = getPerfCapture().time("bootstrap.fetch")
         bootstrap = await workspaceService.bootstrap(workspaceId, { fresh: forceFull })
+        stopFetch()
 
         // On the very first connect of a warm start, hold the IndexedDB write
         // until the cached reveal has painted. applyWorkspaceBootstrap writes the
@@ -825,7 +829,9 @@ export class SyncEngine {
         bootstrap = await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)
 
         // Write to TanStack cache (bridge for coordinated-loading, sidebar loading/error)
+        const stopPublish = getPerfCapture().time("bootstrap.publish")
         queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), bootstrap)
+        stopPublish()
 
         // Cold-boot single bootstrap: this first-connect snapshot is the
         // authority for everything <= its sync head (read-before-stamp on the
@@ -1086,6 +1092,7 @@ export class SyncEngine {
         }
       )
       this.streamHandlerCleanups.set(streamId, cleanup)
+      getPerfCapture().mark("stream.subscriptions", this.streamHandlerCleanups.size)
     }
 
     const room = `ws:${this.deps.workspaceId}:stream:${streamId}`
@@ -1482,6 +1489,9 @@ export class SyncEngine {
     const catchUpBatch = new CatchUpBatch(this.deps.queryClient, this.workspaceId)
     this.activeCatchUpBatch = catchUpBatch
 
+    const capture = getPerfCapture()
+    const stopReplay = capture.time("catchup.replay")
+
     try {
       await cursorStore.load()
       const cursorBefore = cursorStore.get()
@@ -1567,6 +1577,7 @@ export class SyncEngine {
         // gate.resume splices the buffered events on top — fire-and-forget would
         // let the snapshot finish after the splice and regress events above head.
         if (pages === 0 && response.entries.length >= CATCHUP_COLLAPSE_THRESHOLD) {
+          capture.mark("catchup.collapse", response.entries.length)
           console.info("Sync catch-up gap large; collapsing to a full bootstrap", {
             workspaceId: this.workspaceId,
             trigger,
@@ -1593,6 +1604,7 @@ export class SyncEngine {
           applyWindowOpen = true
         }
 
+        if (pages === 0) capture.mark("catchup.serialReplay", response.entries.length)
         pages += 1
         fetched += response.entries.length
         for (const entry of response.entries) {
@@ -1604,7 +1616,9 @@ export class SyncEngine {
             typeof entry.payload === "object" && entry.payload !== null
               ? { ...entry.payload, syncId: entry.syncId }
               : entry.payload
+          const stopEntry = capture.time("catchup.entryApply")
           await gate.dispatch(entry.eventType, payload)
+          stopEntry()
           cursorStore.advance(entry.syncId)
           appliedThrough = BigInt(entry.syncId)
           cursor = entry.syncId
@@ -1666,6 +1680,7 @@ export class SyncEngine {
       // reflects the replay's final state plus the spliced live events together.
       // Unconditional (even on destroy/throw) so the window never strands open.
       if (applyWindowOpen) endApplyWindow()
+      stopReplay()
     }
   }
 
@@ -1679,6 +1694,7 @@ export class SyncEngine {
   private cleanupStreamHandlers(): void {
     for (const cleanup of this.streamHandlerCleanups.values()) cleanup()
     this.streamHandlerCleanups.clear()
+    getPerfCapture().mark("stream.subscriptions", this.streamHandlerCleanups.size)
     this.subscribedStreams.clear()
   }
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -5,6 +5,7 @@ import {
   type CachedStreamReadState,
   type CachedUnreadState,
 } from "@/db"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import {
   seedAgentActivity,
@@ -2417,6 +2418,7 @@ export async function applyWorkspaceBootstrap(
   fetchStartedAt?: number
 ): Promise<WorkspaceBootstrap> {
   const now = Date.now()
+  const capture = getPerfCapture()
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -2427,8 +2429,10 @@ export async function applyWorkspaceBootstrap(
   // a refresh — without this merge, opening any bag-attached scratchpad
   // after a fresh load shows the message badge briefly, then loses it when
   // workspace bootstrap clobbers the field.
+  const stopPreRead = capture.time("bootstrap.preRead")
   const existingStreams = await db.streams.where("workspaceId").equals(workspaceId).toArray()
   const existingByStreamId = new Map(existingStreams.map((s) => [s.id, s]))
+  stopPreRead()
 
   // Effective sidebar config for the in-memory seed below. If a newer
   // `sidebar_config:updated` landed during the fetch window we keep the local
@@ -2449,6 +2453,10 @@ export async function applyWorkspaceBootstrap(
   let effectiveReadStateMap = bootstrap.streamReadState
   let seedReadStates: CachedStreamReadState[] | undefined
 
+  // Counts only the conditional writes; the unconditional ones are summed at
+  // the mark below.
+  let conditionalRowsWritten = 0
+
   // One transaction over every table so they commit together and each table's
   // `useLiveQuery` fires once — one settle, not a per-table trickle. Parallel
   // independent writes (the previous shape) commit a micro-transaction each, so
@@ -2457,6 +2465,7 @@ export async function applyWorkspaceBootstrap(
   // cold first connect). Mirrors applyReconnectBootstrapBatch. The conditional
   // unread/prefs/sidebar writes are inlined (read→check→write stays atomic,
   // INV-20) rather than nested transactions.
+  const stopTx = capture.time("bootstrap.tx")
   await db.transaction(
     "rw",
     [
@@ -2574,12 +2583,16 @@ export async function applyWorkspaceBootstrap(
             _cachedAt: now,
           })
         }
-        if (serverRows.length > 0) await db.streamReadState.bulkPut(serverRows)
+        if (serverRows.length > 0) {
+          await db.streamReadState.bulkPut(serverRows)
+          conditionalRowsWritten += serverRows.length
+        }
         seedReadStates = mergeLocalAndServerReadStates(existingRows, serverRows)
       }
 
       const existingPrefs = await db.userPreferences.get(workspaceId)
       if (!existingPrefs || !fetchStartedAt || existingPrefs._cachedAt < fetchStartedAt) {
+        conditionalRowsWritten += 1
         await db.userPreferences.put({
           ...bootstrap.userPreferences,
           id: workspaceId,
@@ -2590,6 +2603,7 @@ export async function applyWorkspaceBootstrap(
 
       const existingSidebar = await db.sidebarConfigs.get(workspaceId)
       if (!existingSidebar || !fetchStartedAt || existingSidebar._cachedAt < fetchStartedAt) {
+        conditionalRowsWritten += 1
         await db.sidebarConfigs.put({
           id: workspaceId,
           workspaceId,
@@ -2602,6 +2616,23 @@ export async function applyWorkspaceBootstrap(
     }
   )
 
+  stopTx()
+  capture.mark(
+    "bootstrap.rowsWritten",
+    bootstrap.users.length +
+      bootstrap.streams.length +
+      (bootstrap.archivedStreams?.length ?? 0) +
+      bootstrap.streamMemberships.length +
+      bootstrap.dmPeers.length +
+      bootstrap.personas.length +
+      bootstrap.bots.length +
+      bootstrap.labels.length +
+      bootstrap.labelAssignments.length +
+      // workspace + workspaceMetadata + unreadState
+      3 +
+      conditionalRowsWritten
+  )
+
   // Clean up stale entities: anything in IDB for this workspace that
   // wasn't in the bootstrap AND was written before this bootstrap.
   // Entities with _cachedAt >= now were written concurrently by socket
@@ -2611,12 +2642,15 @@ export async function applyWorkspaceBootstrap(
   // survive. Only truly stale entities (from before we started fetching)
   // are removed. If no fetchStartedAt provided, skip cleanup entirely.
   if (fetchStartedAt !== undefined) {
+    const stopCleanup = capture.time("bootstrap.cleanup")
     await cleanupStaleEntities(workspaceId, bootstrap, fetchStartedAt)
+    stopCleanup()
   }
 
   // Populate in-memory cache so useLiveQuery hooks return real data on first
   // synchronous render (the default value). Without this, every component sees
   // empty arrays for one render cycle until the async IDB read resolves.
+  const stopSeed = capture.time("bootstrap.seed")
   seedWorkspaceCache(workspaceId, {
     workspace: { ...bootstrap.workspace, _cachedAt: now },
     users: bootstrap.users.map((u) => ({ ...u, _cachedAt: now })),
@@ -2681,6 +2715,7 @@ export async function applyWorkspaceBootstrap(
       _cachedAt: now,
     },
   })
+  stopSeed()
 
   // Seed the sidebar agent-activity store so a session already running on cold
   // load paints its stream row without waiting for a live event.

--- a/apps/frontend/src/test/fixtures/sync-engine.ts
+++ b/apps/frontend/src/test/fixtures/sync-engine.ts
@@ -1,0 +1,219 @@
+import { vi } from "vitest"
+import type { Socket } from "socket.io-client"
+import { QueryClient } from "@tanstack/react-query"
+import { SyncStatusStore } from "@/sync/sync-status"
+import {
+  DEFAULT_USER_PREFERENCES,
+  DEFAULT_WORKSPACE_SETTINGS,
+  DEFAULT_SIDEBAR_CONFIG,
+  type WorkspaceBootstrap,
+  type StreamBootstrap,
+} from "@threa/types"
+
+type EventHandler = (...args: unknown[]) => void
+
+export class MockSocket {
+  connected = true
+  /** null = never ack; true = ack immediately with ok; false = reserved */
+  ackBehavior: "immediate" | "never" | "delayed" = "immediate"
+  ackDelayMs = 0
+  disconnectCalls = 0
+  connectCalls = 0
+  emittedEvents: Array<{ event: string; args: unknown[] }> = []
+  /** Runs before a join is acked — lets tests simulate live events landing
+   *  while the room join is in flight. */
+  joinInterceptor: ((room: string) => Promise<void>) | null = null
+  private listeners = new Map<string, Set<EventHandler>>()
+  private anyListeners = new Set<(event: string, ...args: unknown[]) => void>()
+
+  on(event: string, handler: EventHandler) {
+    const handlers = this.listeners.get(event)
+    if (handlers) handlers.add(handler)
+    else this.listeners.set(event, new Set([handler]))
+    return this
+  }
+
+  off(event: string, handler: EventHandler) {
+    this.listeners.get(event)?.delete(handler)
+    return this
+  }
+
+  onAny(listener: (event: string, ...args: unknown[]) => void) {
+    this.anyListeners.add(listener)
+    return this
+  }
+
+  offAny(listener?: (event: string, ...args: unknown[]) => void) {
+    if (listener) this.anyListeners.delete(listener)
+    else this.anyListeners.clear()
+    return this
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    this.emittedEvents.push({ event, args })
+
+    if (event === "health:ping") {
+      const callback = args[0] as (() => void) | undefined
+      if (!callback) return this
+      if (this.ackBehavior === "never") return this
+      if (this.ackBehavior === "immediate") {
+        callback()
+      } else {
+        setTimeout(callback, this.ackDelayMs)
+      }
+      return this
+    }
+
+    // join ack: reply ok so onConnect's workspace join succeeds in tests
+    if (event === "join") {
+      const room = args[0] as string
+      const callback = args[1] as ((result?: { ok: boolean }) => void) | undefined
+      if (this.joinInterceptor) {
+        // Ack on both paths so a rejecting interceptor can't hang an awaited join.
+        void this.joinInterceptor(room)
+          .then(() => callback?.({ ok: true }))
+          .catch(() => callback?.({ ok: false }))
+      } else {
+        callback?.({ ok: true })
+      }
+      return this
+    }
+
+    return this
+  }
+
+  trigger(event: string, ...args: unknown[]) {
+    for (const listener of this.anyListeners) listener(event, ...args)
+    const handlers = this.listeners.get(event)
+    if (!handlers) return
+    for (const handler of handlers) handler(...args)
+  }
+
+  disconnect() {
+    this.disconnectCalls += 1
+    this.connected = false
+    return this
+  }
+
+  connect() {
+    this.connectCalls += 1
+    return this
+  }
+}
+
+export function asSocket(mock: MockSocket): Socket {
+  return mock as unknown as Socket
+}
+
+export function makeWorkspaceBootstrap(): WorkspaceBootstrap {
+  const now = new Date().toISOString()
+  return {
+    workspace: {
+      id: "ws_1",
+      name: "Test",
+      slug: "test",
+      createdBy: "user_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+    users: [],
+    streams: [],
+    streamMemberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    mutedStreamIds: [],
+    labels: [],
+    labelAssignments: [],
+    viewerPermissions: [],
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
+    userPreferences: {
+      ...DEFAULT_USER_PREFERENCES,
+      workspaceId: "ws_1",
+      userId: "user_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+    featureFlags: { workspace: {}, user: {} },
+    workspaceSettings: {
+      ...DEFAULT_WORKSPACE_SETTINGS,
+      workspaceId: "ws_1",
+      createdAt: now,
+      updatedAt: now,
+    },
+  } satisfies WorkspaceBootstrap
+}
+
+export function makeStreamBootstrap(streamId = "stream_1", sequence = "2"): StreamBootstrap {
+  const now = new Date().toISOString()
+  return {
+    stream: {
+      id: streamId,
+      workspaceId: "ws_1",
+      type: "dm",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: null,
+      rootStreamId: null,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "user_1",
+      createdAt: now,
+      updatedAt: now,
+      archivedAt: null,
+    },
+    events: [
+      {
+        id: `evt_${sequence}`,
+        streamId,
+        sequence,
+        eventType: "message_created",
+        payload: {
+          messageId: `msg_${sequence}`,
+          contentMarkdown: "new",
+          contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: now,
+      },
+    ],
+    members: [],
+    botMemberIds: [],
+    membership: {
+      streamId,
+      memberId: "user_1",
+      notificationLevel: null,
+      joinedAt: now,
+    },
+    latestSequence: sequence,
+    hasOlderEvents: false,
+    syncMode: "append",
+    unreadCount: 0,
+    mentionCount: 0,
+    activityCount: 0,
+    sharedMessages: {},
+    contextBag: { bag: null, refs: [] },
+  } satisfies StreamBootstrap
+}
+
+export function makeDeps() {
+  const workspaceBootstrap = vi.fn(async () => makeWorkspaceBootstrap())
+  const streamBootstrap = vi.fn(async (_workspaceId: string, streamId: string) => makeStreamBootstrap(streamId))
+  return {
+    workspaceId: "ws_1",
+    syncStatus: new SyncStatusStore(),
+    queryClient: new QueryClient(),
+    workspaceService: { bootstrap: workspaceBootstrap },
+    streamService: { bootstrap: streamBootstrap },
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -966,6 +966,19 @@ export {
   resolveFeatureFlags,
 } from "./feature-flags"
 
+// Client performance capture (closed mark registry + wire schema)
+export {
+  PERF_MARK_NAMES,
+  PERF_DEVICE_CLASSES,
+  PERF_CAPTURE_MAX_SAMPLES,
+  performanceSampleSchema,
+  performanceCaptureSchema,
+  type PerfMarkName,
+  type PerfDeviceClass,
+  type PerformanceSample,
+  type PerformanceCapture,
+} from "./performance-capture"
+
 // User statuses (cosmetic emoji + text shown beside the avatar)
 export {
   type StatusDuration,

--- a/packages/types/src/performance-capture.test.ts
+++ b/packages/types/src/performance-capture.test.ts
@@ -37,8 +37,6 @@ describe("performance capture schema", () => {
           { name: "observer.longTask", at: 20, value: 78 },
           { name: "liveQuery.rerun", at: 30, count: 1 },
         ],
-        workspaceStreamCount: 42,
-        retainedEventCount: 12000,
       })
     )
     expect(parsed.samples).toHaveLength(3)

--- a/packages/types/src/performance-capture.test.ts
+++ b/packages/types/src/performance-capture.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import { PERF_CAPTURE_MAX_SAMPLES, performanceCaptureSchema, performanceSampleSchema } from "./performance-capture"
+
+const sample = { name: "bootstrap.tx" as const, at: 1234.5, value: 12 }
+
+function capture(overrides: Record<string, unknown> = {}) {
+  return {
+    captureId: "cap_01J",
+    appVersion: "abc1234",
+    deviceClass: "mid" as const,
+    startedAt: "2026-08-02T10:00:00.000Z",
+    samples: [sample],
+    ...overrides,
+  }
+}
+
+describe("performance capture schema", () => {
+  it("rejects a sample with an unknown mark name", () => {
+    expect(performanceSampleSchema.safeParse({ name: "bootstrap.unknown", at: 1 }).success).toBe(false)
+  })
+
+  it("rejects free-text fields via .strict()", () => {
+    expect(performanceSampleSchema.safeParse({ ...sample, streamId: "stream_1" }).success).toBe(false)
+    expect(performanceCaptureSchema.safeParse(capture({ userAgent: "Mozilla/5.0" })).success).toBe(false)
+  })
+
+  it("rejects a capture over the sample cap", () => {
+    const samples = Array.from({ length: PERF_CAPTURE_MAX_SAMPLES + 1 }, () => sample)
+    expect(performanceCaptureSchema.safeParse(capture({ samples })).success).toBe(false)
+  })
+
+  it("accepts a realistic capture", () => {
+    const parsed = performanceCaptureSchema.parse(
+      capture({
+        samples: [
+          sample,
+          { name: "observer.longTask", at: 20, value: 78 },
+          { name: "liveQuery.rerun", at: 30, count: 1 },
+        ],
+        workspaceStreamCount: 42,
+        retainedEventCount: 12000,
+      })
+    )
+    expect(parsed.samples).toHaveLength(3)
+    expect(parsed.deviceClass).toBe("mid")
+  })
+})

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -1,0 +1,72 @@
+// Client performance capture: a closed registry of what the frontend may
+// measure, plus the wire schema for one capture session.
+//
+// The registry is closed on purpose. A sample carries a name from this tuple, a
+// timestamp, and at most one number — there is no free-text field anywhere, so a
+// capture can never carry a stream id, a message body, a URL, or a user agent.
+// Adding a measurement means adding a name here first; nothing else can emit.
+
+import { z } from "zod"
+
+/** Every mark the client may emit. Closed tuple — the union is derived from it (INV-31). */
+export const PERF_MARK_NAMES = [
+  "bootstrap.fetch",
+  "bootstrap.preRead",
+  "bootstrap.tx",
+  "bootstrap.cleanup",
+  "bootstrap.seed",
+  "bootstrap.publish",
+  "bootstrap.rowsWritten",
+  "catchup.entryApply",
+  "catchup.replay",
+  "catchup.collapse",
+  "catchup.serialReplay",
+  "stream.subscriptions",
+  "stream.eventApply",
+  "stream.idbTransaction",
+  "liveQuery.rerun",
+  "liveQuery.load",
+  "draft.staging",
+  "draft.stagedChars",
+  "editor.externalSync",
+  "timeline.windowItems",
+  "observer.longTask",
+  "observer.eventDuration",
+  "observer.frameGap",
+] as const
+
+/** One emittable measurement name. */
+export type PerfMarkName = (typeof PERF_MARK_NAMES)[number]
+
+/** Coarse device buckets derived from `hardwareConcurrency` + `deviceMemory` only. */
+export const PERF_DEVICE_CLASSES = ["low", "mid", "high"] as const
+
+export type PerfDeviceClass = (typeof PERF_DEVICE_CLASSES)[number]
+
+/** Upper bound on samples in one uploaded capture. */
+export const PERF_CAPTURE_MAX_SAMPLES = 2048
+
+export const performanceSampleSchema = z
+  .object({
+    name: z.enum(PERF_MARK_NAMES),
+    at: z.number(),
+    value: z.number().optional(),
+    count: z.number().optional(),
+  })
+  .strict()
+
+export type PerformanceSample = z.infer<typeof performanceSampleSchema>
+
+export const performanceCaptureSchema = z
+  .object({
+    captureId: z.string().min(1),
+    appVersion: z.string().min(1),
+    deviceClass: z.enum(PERF_DEVICE_CLASSES),
+    startedAt: z.string().min(1),
+    samples: z.array(performanceSampleSchema).max(PERF_CAPTURE_MAX_SAMPLES),
+    workspaceStreamCount: z.number().optional(),
+    retainedEventCount: z.number().optional(),
+  })
+  .strict()
+
+export type PerformanceCapture = z.infer<typeof performanceCaptureSchema>

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -2,9 +2,11 @@
 // measure, plus the wire schema for one capture session.
 //
 // The registry is closed on purpose. A sample carries a name from this tuple, a
-// timestamp, and at most one number — there is no free-text field anywhere, so a
-// capture can never carry a stream id, a message body, a URL, or a user agent.
-// Adding a measurement means adding a name here first; nothing else can emit.
+// timestamp, and at most one number — there is no free-text field anywhere, so
+// the APP can never record a stream id, a message body, a URL, or a user agent.
+// (A hostile client can encode data it already owns into numbers; the guarantee
+// is about what the app collects, not what a consented user could smuggle out
+// of their own session.) Adding a measurement means adding a name here first.
 
 import { z } from "zod"
 

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -64,8 +64,6 @@ export const performanceCaptureSchema = z
     deviceClass: z.enum(PERF_DEVICE_CLASSES),
     startedAt: z.string().min(1),
     samples: z.array(performanceSampleSchema).max(PERF_CAPTURE_MAX_SAMPLES),
-    workspaceStreamCount: z.number().optional(),
-    retainedEventCount: z.number().optional(),
   })
   .strict()
 


### PR DESCRIPTION
## Problem

The frontend has zero performance telemetry — no `performance.mark`, no `PerformanceObserver`, nothing measuring the paths the mobile-jank analysis blames (bootstrap apply wave, catch-up replay, per-keystroke draft staging, editor external sync, live-query reruns). Every later optimization PR in this stack needs before/after numbers from a real device, and there is currently nothing to capture them with. This is chunk 2/4 of PR-1 in the performance effort: the capture machinery, deliberately inert — no consent surface, no upload (both chunk 3).

## Solution

A closed-registry capture module that is provably a no-op until armed.

- `PERF_MARK_NAMES` (23 names) + strict Zod schemas in `packages/types/src/performance-capture.ts`: a sample is `{ name, at, value?, count? }` with `name` from the closed tuple and `.strict()` everywhere — a stream id, message body, URL, or UA is unrepresentable, so privacy is a type property, not a review promise. `PERF_CAPTURE_MAX_SAMPLES` (2048) is the single cap; the ring derives from it.
- `PerfCapture` ring buffer (2000) with a pinned side array for one-shot `bootstrap.*` phase marks — a multi-page catch-up emits thousands of samples and would otherwise evict the eight bootstrap marks before anyone exports. `NO_CAPTURE` is a frozen singleton whose `time()` returns one shared no-op: the entire off path is a module-variable read + frozen method call, verified per call site by the adversarial pass.
- Observers (`longtask`, `event`, rAF frame-gap ≥50ms) constructed only when armed; only `entry.duration` is read — never names, targets, or URLs.
- Hot-path marks: bootstrap phases (fetch/preRead/tx/cleanup/seed/publish + rowsWritten), catch-up (`collapse` vs `serialReplay` mutually exclusive per run, per-entry apply, subscription count on every subscribe/unsubscribe), stream event apply (try/finally so failures stay in the distribution), live-query load, draft staging duration + staged chars (marked only when actually staged), editor external-sync duration, timeline window items.
- Arming: `?perfCapture=1` / `localStorage["threa:perf:capture"]` — the `bootstrap-debug.ts` pattern, local dev only; chunk 3 adds the flag+consent double gate as the upload-permitting source; dev arming stays available in any build for local measurement and never permits upload. Export: `window.__threaPerfCapture.export()`, schema-validated.
- Guard test: source scan fails any direct `performance.mark/measure`/`new PerformanceObserver` outside `lib/perf`. Known limitation: per-line regex — an aliased `const p = performance; p.mark()` slips it; the guard targets the naive addition, not adversarial bypass.
- `sync-engine.test.ts` fixtures (MockSocket, bootstrap factories) extracted to `src/test/fixtures/sync-engine.ts` for reuse by the new perf test — verified import-only (test bodies byte-unchanged); not re-exported from the fixtures barrel to keep vitest out of unrelated test graphs.

Mark names were renamed where the first draft measured something other than the name claimed (`liveQuery.load` not "derivation", `timeline.windowItems` not "mountedRows", `stream.subscriptions` not "listeners") — honest names over aspirational ones, so later PRs' before/after claims can't rest on a number that doesn't move.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/performance-capture.ts` + test | **new** — closed mark registry + strict wire schema |
| `apps/frontend/src/lib/perf/capture.ts` | **new** — ring + pinned marks, NO_CAPTURE, arming accessor |
| `apps/frontend/src/lib/perf/observers.ts` | **new** — longtask/event/frame-gap, armed-only |
| `apps/frontend/src/lib/perf/context.tsx` | **new** — provider; arms module accessor, installs/removes window handle |
| `apps/frontend/src/lib/perf/export.ts` | **new** — schema-validated export, bucketed device class |
| `apps/frontend/src/lib/perf/*.test.ts` ×4 | **new** — ring/off-path/observers/scan-guard |
| `apps/frontend/src/sync/{sync-engine,stream-sync,workspace-sync}.ts` | hot-path marks |
| `apps/frontend/src/stores/stream-store.ts`, `lib/drafts/draft-staging.ts`, `components/editor/rich-editor.tsx`, `components/timeline/stream-content.tsx` | hot-path marks |
| `apps/frontend/src/pages/workspace-layout.tsx` | `PerfCaptureProvider` wrap (pure reindent otherwise) |
| `apps/frontend/src/test/fixtures/sync-engine.ts` | **new** — fixtures extracted from sync-engine.test.ts |
| `apps/frontend/src/sync/sync-engine.perf.test.ts`, `lib/drafts/draft-staging.perf.test.ts` | **new** — replay marks + staging byte-identity proofs |

## Test plan

- [x] frontend typecheck + eslint — clean
- [x] frontend vitest — 5664 pass / 0 fail (incl. armed-vs-unarmed byte-identity of staged drafts, NO_CAPTURE identity, observer lifecycle, scan guard)
- [x] packages/types — 151 pass / 0 fail + typecheck clean
- [x] backend unit 3865/0 + e2e 371/0 (untouched, regression check)
- [x] every new test neutralized → red → restored (fixer re-verified after assertion changes)
- [ ] real-device armed capture exercised end-to-end — arrives with chunk 4's browser spec

<details>
<summary>📋 Full implementation plan</summary>

Plan: https://seer.build/ws_vbyzjvdg6g/b/perf-plan-cc262f/ — Part B, chunk 2 of 4. Adversarial verify: 14 findings, all fixed in-branch — the theme was measurement honesty (three renamed marks, pinned bootstrap samples so eviction can't wipe the evidence, per-run vs per-page mark semantics, a tautological off-test rewritten against what actually distinguishes the off path).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788271962&installation_model_id=20758&pr_number=1719&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1719&signature=ba41078820267d9fe0f4a202e6e31098ccfe317fd4a93ff421832cdf5d56ec32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
