### PR TITLE
feat(perf): reproduction fixture harness and matrix

### DIFF
--- a/docs/monitoring-connection-pool.md
+++ b/docs/monitoring-connection-pool.md
@@ -79,7 +79,7 @@ curl http://localhost:3001/readyz | jq
 
 ### 4. Load Fixtures
 
-No load-fixture script is checked in yet; seed a workspace by hand when reproducing load locally.
+`scripts/perf-seed.ts` seeds the load fixtures (large streams, deep threads, missed sync-log entries, large drafts, wide boards) into a local stack. Profiles and the scenarios they serve: [`docs/perf/reproduction-matrix.md`](perf/reproduction-matrix.md).
 
 ## Pool Configuration
 

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -4,8 +4,9 @@ Twelve scenarios, each with the exact `perf-seed` invocation that builds its
 fixture and the capture marks that prove it ran. Operator-run: nothing here is
 asserted in CI, because every threshold worth measuring is device-dependent.
 
-The one automated check is `tests/browser/perf-capture.spec.ts`, which proves
-the capture plumbing works end to end and carries no content. It asserts no
+Two things are automated: `scripts/perf-seed-plan.test.ts` (32 unit tests over
+the pure planning logic) and `tests/browser/perf-capture.spec.ts`, which proves
+the capture plumbing works end to end and carries no content. Neither asserts
 timings.
 
 ## Running a scenario
@@ -41,13 +42,13 @@ measures locally and never uploads — upload requires the consent preference.
 
 ## Profiles
 
-| Profile                                     | Builds                                                                             |
-| ------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `large-stream`                              | `#perf-large-stream` with 5,000 messages                                           |
-| `thread-100` / `thread-500` / `thread-2000` | a channel with one anchor message, and a thread under it with N replies            |
-| `missed-entries=<N>`                        | advances the sync log by N entries in `#perf-missed-entries`                       |
-| `drafts`                                    | four empty channels, each holding a staged draft of 1 KB / 10 KB / 100 KB / 256 KB |
-| `board-large`                               | 24 channels (four full `BOARD_SYNC_CONCURRENCY = 6` waves), 3 messages each        |
+| Profile                                     | Builds                                                                                                                        |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `large-stream`                              | `#perf-large-stream` with 5,000 messages                                                                                      |
+| `thread-100` / `thread-500` / `thread-2000` | a channel with one anchor message, and a thread under it with N replies                                                       |
+| `missed-entries=<N>`                        | advances the sync log by at least N entries (batches overshoot; the printed delta is authoritative) in `#perf-missed-entries` |
+| `drafts`                                    | four empty channels, each holding a staged draft of 1 KB / 10 KB / 100 KB / 256 KB                                            |
+| `board-large`                               | 24 channels (four full `BOARD_SYNC_CONCURRENCY = 6` waves), 3 messages each                                                   |
 
 ### Hitting a missed-entry boundary
 

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -100,8 +100,8 @@ From the performance handover — read these against a capture, never against
 desktop feel:
 
 - No bootstrap or catch-up task over 50 ms.
-- p95 frame gap under 32 ms during bootstrap, under 20 ms while typing.
-- Typing INP p95 under 100 ms on the target mobile device.
+- Frame gaps ≥25 ms (the observer's recording floor — the distribution is censored below it): near zero during bootstrap, none while typing.
+- Typing INP p95 under 100 ms on the target mobile device (`observer.eventDuration` records interactions ≥16 ms, so the target is measurable).
 - Listener count independent of stream count.
 - An unchanged warm bootstrap does zero semantic writes and causes no broad commit.
 - Catch-up publishes at most once per bounded chunk.

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -1,0 +1,116 @@
+# Performance reproduction matrix
+
+Twelve scenarios, each with the exact `perf-seed` invocation that builds its
+fixture and the capture marks that prove it ran. Operator-run: nothing here is
+asserted in CI, because every threshold worth measuring is device-dependent.
+
+The one automated check is `tests/browser/perf-capture.spec.ts`, which proves
+the capture plumbing works end to end and carries no content. It asserts no
+timings.
+
+## Running a scenario
+
+```bash
+# 1. Start the local stack with pinned ports (pin all six — unpinned ports shadow).
+#    GLOBAL_RATE_LIMIT_MAX lifts the per-IP cap that binds seeding (playwright.config.ts
+#    starts its stack the same way); without it the seeder retries into failure.
+GLOBAL_RATE_LIMIT_MAX=10000 \
+DEV_TEST_BACKEND_PORT=4001 DEV_TEST_CONTROL_PLANE_PORT=4002 DEV_TEST_ROUTER_PORT=4003 \
+DEV_TEST_FRONTEND_PORT=4004 DEV_TEST_BACKOFFICE_ROUTER_PORT=4005 DEV_TEST_BACKOFFICE_PORT=4006 \
+  bun run dev:test
+
+# 2. Seed. Idempotent — re-run to top a fixture up.
+DEV_TEST_BACKEND_PORT=4001 bun scripts/perf-seed.ts --workspace <workspaceId> --profile large-stream
+
+# 3. Measure. Arm the dev capture, drive the scenario, export.
+open 'http://localhost:4004/w/<workspaceId>?perfCapture=1'
+#    then in the devtools console:  copy(JSON.stringify(__threaPerfCapture.export()))
+```
+
+`--dry-run` prints the outstanding operations without writing. `--help` lists
+every profile. The script targets a local stack only; it has no API-key path.
+
+Message creation is rate-limited per user (120/min), so seeding posts as six
+stub authors derived from `--email` (`--authors` to change it). The global
+per-IP cap (300/min) binds regardless of author count — hence
+`GLOBAL_RATE_LIMIT_MAX` above. `large-stream` still takes several minutes; the
+rest are seconds to a minute.
+
+Dev arming (`?perfCapture=1`, or `localStorage['threa:perf:capture'] = '1'`)
+measures locally and never uploads — upload requires the consent preference.
+
+## Profiles
+
+| Profile                                     | Builds                                                                             |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `large-stream`                              | `#perf-large-stream` with 5,000 messages                                           |
+| `thread-100` / `thread-500` / `thread-2000` | a channel with one anchor message, and a thread under it with N replies            |
+| `missed-entries=<N>`                        | advances the sync log by N entries in `#perf-missed-entries`                       |
+| `drafts`                                    | four empty channels, each holding a staged draft of 1 KB / 10 KB / 100 KB / 256 KB |
+| `board-large`                               | 24 channels (four full `BOARD_SYNC_CONCURRENCY = 6` waves), 3 messages each        |
+
+### Hitting a missed-entry boundary
+
+`missed-entries=<N>` is head-delta driven, not arithmetic. The seeder reads the
+workspace sync head, posts batches, re-reads the head, and stops once the head
+has advanced by **at least N**; it prints the delta it actually achieved.
+
+There is no fixed entries-per-message factor to compute against. One posted
+message writes three or more sync-log entries (the message projection, the
+user-scoped `activity:created` row, and the conversation attach's stream-scoped
+rows), and the count is workload-dependent. Anything that needs an exact
+boundary — the 200-entry collapse case in scenario 2 — should read the printed
+delta and adjust N, not predict it.
+
+Repeating the profile opens a **fresh** gap: each run marks its messages with a
+per-run marker, so `missed-entries=50` twice advances the head by ≥50 twice.
+(The other profiles keep top-up idempotency.)
+
+Seed while the client under test is disconnected (close the tab, or seed from a
+terminal while parked on another workspace), or the entries arrive live and
+there is no gap to catch up on.
+
+## The twelve scenarios
+
+| #   | Scenario                                                  | Seed                                                                  | Marks that prove it                                                                                                                         |
+| --- | --------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Warm cached hard refresh, no gap                          | `--profile large-stream`                                              | `bootstrap.fetch`, `bootstrap.preRead`, `bootstrap.tx`, `bootstrap.cleanup`, `bootstrap.seed`, `bootstrap.publish`, `bootstrap.rowsWritten` |
+| 2   | Warm refresh with 10 / 50 / 199 / 200 missed entries      | `--profile missed-entries=10` (then 50, 199, 200)                     | `catchup.entryApply`, `catchup.replay`, `catchup.collapse`, `catchup.serialReplay` — collapse should appear only at the boundary case       |
+| 3   | Cold start, empty IDB                                     | `--profile large-stream`, then clear site data                        | `bootstrap.*` (all phases), `bootstrap.rowsWritten`                                                                                         |
+| 4   | Live 10 msg/s burst while typing                          | `--profile large-stream`, then post from a second client while typing | `stream.eventApply`, `stream.idbTransaction`, `draft.staging`, `observer.eventDuration`, `observer.frameGap`                                |
+| 5   | Drafts 1 KB / 10 KB / 100 KB / 256 KB                     | `--profile drafts`, then type into each channel's composer            | `draft.staging`, `draft.stagedChars` (absent above the staging cap — that is the signal, not a gap), `editor.externalSync`                  |
+| 6   | Shallow vs deep retained history                          | `--profile large-stream` vs a freshly created channel                 | `bootstrap.fetch`, `bootstrap.tx`, `bootstrap.rowsWritten`                                                                                  |
+| 7   | Threads 100 / 500 / 2000 events                           | `--profile thread-100` / `thread-500` / `thread-2000`                 | `timeline.windowItems` (must stay viewport-bounded as N grows), `stream.eventApply`, `liveQuery.load`                                       |
+| 8   | Board, small vs large stream sets                         | `--profile board-large` vs the default workspace                      | `stream.subscriptions`, `liveQuery.rerun`, `catchup.replay`                                                                                 |
+| 9   | Resume with keyboard open, board and panels mounted       | `--profile board-large`                                               | `observer.frameGap`, `observer.eventDuration`, `timeline.windowItems`                                                                       |
+| 10  | First code-heavy message vs warmed highlighter            | none — paste a large fenced code block by hand                        | `observer.longTask` (the first paint should be the outlier), `timeline.windowItems`                                                         |
+| 11  | Large stash restore through real TipTap                   | `--profile drafts`, reload on the 256 KB channel, then type into it   | `editor.externalSync`, `draft.staging`, `observer.longTask`                                                                                 |
+| 12  | Restore → switch stream → return → navigate away and back | `--profile drafts` plus `--profile large-stream`                      | `editor.externalSync`, `stream.subscriptions`, `liveQuery.rerun`, `bootstrap.publish`                                                       |
+
+Scenario 10 has no profile on purpose: what it exercises is one pasted document,
+not a seeded shape.
+
+Scenarios 5 and 11 need the operator at the keyboard: `draft.staging` and
+`draft.stagedChars` are recorded by `stageDraftContent` on keystrokes. The seed
+only builds the bodies to type against — a seeded draft alone emits neither mark.
+
+## Targets
+
+From the performance handover — read these against a capture, never against
+desktop feel:
+
+- No bootstrap or catch-up task over 50 ms.
+- p95 frame gap under 32 ms during bootstrap, under 20 ms while typing.
+- Typing INP p95 under 100 ms on the target mobile device.
+- Listener count independent of stream count.
+- An unchanged warm bootstrap does zero semantic writes and causes no broad commit.
+- Catch-up publishes at most once per bounded chunk.
+- Staging duration is not O(document) per keystroke.
+- Thread mounted-row count is bounded by the viewport.
+- A failed draft restore is visible and recoverable.
+
+## What is deliberately absent
+
+No CI perf assertions, no device-throttling harness (use Chrome DevTools CPU
+throttling by hand), no load generator, and nothing that points at staging or
+production.

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -30,6 +30,8 @@ open 'http://localhost:4004/w/<workspaceId>?perfCapture=1'
 
 `--dry-run` prints the outstanding operations without writing. `--help` lists
 every profile. The script targets a local stack only; it has no API-key path.
+Fixture streams are matched by their `perf-*` slug alone — run against a
+throwaway workspace, not one holding channels that happen to share those names.
 
 Message creation is rate-limited per user (120/min), so seeding posts as six
 stub authors derived from `--email` (`--authors` to change it). The global

--- a/scripts/lib/perf-seed-plan.ts
+++ b/scripts/lib/perf-seed-plan.ts
@@ -1,0 +1,251 @@
+/**
+ * Pure planning logic for `scripts/perf-seed.ts`, extracted so profile → work
+ * mapping is unit-testable without a network. Keep this module side-effect free.
+ *
+ * A plan is derived twice: once to learn what a profile wants (`seedSpec`) and
+ * once against what the workspace already holds (`planSeed`). Topping up rather
+ * than re-seeding is what makes re-running a profile safe.
+ */
+
+/** Profiles that take no argument. */
+export const PERF_SEED_FIXED_PROFILES = [
+  "large-stream",
+  "thread-100",
+  "thread-500",
+  "thread-2000",
+  "drafts",
+  "board-large",
+] as const
+
+export type PerfSeedFixedProfile = (typeof PERF_SEED_FIXED_PROFILES)[number]
+
+/** The one parameterised profile: `missed-entries=<N>`. */
+export const PERF_SEED_PARAMETERISED_PROFILE = "missed-entries"
+
+/**
+ * Batch-sizing heuristic only — NOT an exact factor. A posted message writes at
+ * least three sync-log entries (message projection, the user-scoped
+ * `activity:created` row, and the conversation attach's two stream-scoped rows),
+ * and the real count is workload-dependent. The driver measures the actual
+ * sync-log head delta and stops when it reaches the requested count; this
+ * constant only decides how many messages a batch posts before re-reading.
+ */
+export const SYNC_LOG_ENTRIES_PER_MESSAGE = 3
+
+/** Draft body sizes staged by the `drafts` profile, in characters of body text. */
+export const DRAFT_PROFILE_SIZES = [1_024, 10_240, 102_400, 262_144] as const
+
+/** Messages seeded into every `board-large` channel so each board row has content. */
+export const BOARD_LARGE_MESSAGES_PER_STREAM = 3
+
+/**
+ * Channels seeded by `board-large`. The board fans out its per-stream sync with
+ * `BOARD_SYNC_CONCURRENCY = 6` lanes (`apps/frontend/src/sync/sync-engine.ts`),
+ * so four full waves is the smallest count that makes lane queueing — not lane
+ * width — the thing under observation.
+ */
+export const BOARD_LARGE_STREAM_COUNT = 24
+
+export interface ParsedProfile {
+  readonly name: PerfSeedFixedProfile | typeof PERF_SEED_PARAMETERISED_PROFILE
+  /** Requested sync-log entry count; only set for `missed-entries`. */
+  readonly entries?: number
+}
+
+/**
+ * A stream the profile requires. `key` is deterministic: it is both the channel
+ * slug and the marker prefix for messages seeded into it, which is what lets a
+ * re-run recognise its own earlier work.
+ */
+export interface PlannedStreamSlot {
+  readonly key: string
+  readonly kind: "channel" | "thread"
+  /** Channel slot key this thread hangs off. Threads only. */
+  readonly parentKey?: string
+  /** Marker-bearing messages this slot must hold when seeding is done. */
+  readonly messageTarget: number
+}
+
+export interface PlannedDraft {
+  readonly key: string
+  /** Characters of body text staged in the draft. */
+  readonly chars: number
+}
+
+export interface PerfSeedSpec {
+  readonly profile: string
+  readonly slots: readonly PlannedStreamSlot[]
+  readonly drafts: readonly PlannedDraft[]
+}
+
+/**
+ * What the workspace already holds. A slot key absent from `messageCounts`
+ * means the stream itself does not exist yet; `0` means it exists and is empty.
+ */
+export interface ExistingState {
+  readonly messageCounts: Readonly<Record<string, number | undefined>>
+  readonly draftKeys?: readonly string[]
+}
+
+export type SeedOperation =
+  | {
+      readonly kind: "createStream"
+      readonly key: string
+      readonly streamKind: "channel" | "thread"
+      readonly parentKey?: string
+    }
+  | { readonly kind: "postMessages"; readonly key: string; readonly from: number; readonly count: number }
+  | {
+      /**
+       * Post into `key` until the workspace sync head has advanced by at least
+       * `entries`. Message bodies carry `runMarker`, which is unique per
+       * invocation, so repeating the profile opens a fresh gap instead of
+       * short-circuiting on its own earlier rows.
+       */
+      readonly kind: "advanceSyncLog"
+      readonly key: string
+      readonly entries: number
+      readonly runMarker: string
+    }
+  | { readonly kind: "upsertDraft"; readonly key: string; readonly chars: number }
+
+export class UnknownPerfProfileError extends Error {
+  constructor(raw: string) {
+    super(
+      `Unknown perf-seed profile "${raw}". Known: ${[...PERF_SEED_FIXED_PROFILES, `${PERF_SEED_PARAMETERISED_PROFILE}=<N>`].join(", ")}`
+    )
+    this.name = "UnknownPerfProfileError"
+  }
+}
+
+/** `--profile large-stream` / `--profile missed-entries=200`. Throws on anything else (INV-11). */
+export function parseProfile(raw: string): ParsedProfile {
+  const trimmed = raw.trim()
+  if ((PERF_SEED_FIXED_PROFILES as readonly string[]).includes(trimmed)) {
+    return { name: trimmed as PerfSeedFixedProfile }
+  }
+
+  const match = /^missed-entries=(\d+)$/.exec(trimmed)
+  if (match) {
+    const entries = Number(match[1])
+    if (entries <= 0) throw new UnknownPerfProfileError(raw)
+    return { name: PERF_SEED_PARAMETERISED_PROFILE, entries }
+  }
+
+  throw new UnknownPerfProfileError(raw)
+}
+
+/** Messages a batch posts before re-reading the head. Heuristic, never a promise. */
+export function messagesForMissedEntries(entries: number): number {
+  return Math.max(1, Math.ceil(entries / SYNC_LOG_ENTRIES_PER_MESSAGE))
+}
+
+function threadSpec(profile: PerfSeedFixedProfile, replies: number): PerfSeedSpec {
+  const channelKey = `perf-${profile}`
+  return {
+    profile,
+    slots: [
+      // The thread anchor is a real message in the parent channel.
+      { key: channelKey, kind: "channel", messageTarget: 1 },
+      { key: `${channelKey}-thread`, kind: "thread", parentKey: channelKey, messageTarget: replies },
+    ],
+    drafts: [],
+  }
+}
+
+/** What a profile wants, independent of what already exists. */
+export function seedSpec(profile: ParsedProfile): PerfSeedSpec {
+  switch (profile.name) {
+    case "large-stream":
+      return {
+        profile: "large-stream",
+        slots: [{ key: "perf-large-stream", kind: "channel", messageTarget: 5_000 }],
+        drafts: [],
+      }
+    case "thread-100":
+      return threadSpec("thread-100", 100)
+    case "thread-500":
+      return threadSpec("thread-500", 500)
+    case "thread-2000":
+      return threadSpec("thread-2000", 2_000)
+    case "missed-entries": {
+      const entries = profile.entries
+      if (entries === undefined) throw new UnknownPerfProfileError("missed-entries")
+      // The channel is reused across runs; the gap comes from the head delta the
+      // driver measures, so the slot itself has no message target.
+      return {
+        profile: `missed-entries=${entries}`,
+        slots: [{ key: "perf-missed-entries", kind: "channel", messageTarget: 0 }],
+        drafts: [],
+      }
+    }
+    case "drafts":
+      // A draft is keyed by scope (`stream:<id>`), so the four sizes need four
+      // host channels rather than four drafts in one.
+      return {
+        profile: "drafts",
+        slots: DRAFT_PROFILE_SIZES.map((chars) => ({
+          key: `perf-draft-${chars}`,
+          kind: "channel" as const,
+          messageTarget: 0,
+        })),
+        drafts: DRAFT_PROFILE_SIZES.map((chars) => ({ key: `perf-draft-${chars}`, chars })),
+      }
+    case "board-large":
+      return {
+        profile: "board-large",
+        slots: Array.from({ length: BOARD_LARGE_STREAM_COUNT }, (_, i) => ({
+          key: `perf-board-${String(i + 1).padStart(2, "0")}`,
+          kind: "channel" as const,
+          messageTarget: BOARD_LARGE_MESSAGES_PER_STREAM,
+        })),
+        drafts: [],
+      }
+  }
+}
+
+/**
+ * The operations still outstanding for `profile` given `existing`. Re-running a
+ * fully-seeded profile plans nothing; a partial seed plans only the remainder.
+ * `missed-entries` is the exception: it always plans work, and needs the
+ * caller's per-run marker (an input, so this module stays pure).
+ */
+export function planSeed(profile: ParsedProfile, existing: ExistingState, runMarker?: string): SeedOperation[] {
+  const spec = seedSpec(profile)
+  const operations: SeedOperation[] = []
+
+  for (const slot of spec.slots) {
+    const have = existing.messageCounts[slot.key]
+    if (have === undefined) {
+      operations.push({
+        kind: "createStream",
+        key: slot.key,
+        streamKind: slot.kind,
+        ...(slot.parentKey ? { parentKey: slot.parentKey } : {}),
+      })
+    }
+    const seeded = have ?? 0
+    if (seeded < slot.messageTarget) {
+      operations.push({ kind: "postMessages", key: slot.key, from: seeded + 1, count: slot.messageTarget - seeded })
+    }
+  }
+
+  if (profile.name === PERF_SEED_PARAMETERISED_PROFILE) {
+    const entries = profile.entries
+    if (entries === undefined) throw new UnknownPerfProfileError("missed-entries")
+    if (!runMarker) throw new Error("planSeed needs a runMarker for missed-entries — each run must open a fresh gap.")
+    operations.push({ kind: "advanceSyncLog", key: "perf-missed-entries", entries, runMarker })
+  }
+
+  const draftKeys = new Set(existing.draftKeys ?? [])
+  for (const draft of spec.drafts) {
+    if (!draftKeys.has(draft.key)) operations.push({ kind: "upsertDraft", key: draft.key, chars: draft.chars })
+  }
+
+  return operations
+}
+
+/** Deterministic message body. The `key` prefix is the marker a re-run counts on. */
+export function messageContent(key: string, ordinal: number): string {
+  return `${key} #${String(ordinal).padStart(5, "0")}`
+}

--- a/scripts/lib/perf-seed-plan.ts
+++ b/scripts/lib/perf-seed-plan.ts
@@ -234,7 +234,7 @@ export function planSeed(profile: ParsedProfile, existing: ExistingState, runMar
     const entries = profile.entries
     if (entries === undefined) throw new UnknownPerfProfileError("missed-entries")
     if (!runMarker) throw new Error("planSeed needs a runMarker for missed-entries — each run must open a fresh gap.")
-    operations.push({ kind: "advanceSyncLog", key: "perf-missed-entries", entries, runMarker })
+    operations.push({ kind: "advanceSyncLog", key: spec.slots[0]!.key, entries, runMarker })
   }
 
   const draftKeys = new Set(existing.draftKeys ?? [])

--- a/scripts/lib/perf-seed-plan.ts
+++ b/scripts/lib/perf-seed-plan.ts
@@ -128,7 +128,9 @@ export function parseProfile(raw: string): ParsedProfile {
   const match = /^missed-entries=(\d+)$/.exec(trimmed)
   if (match) {
     const entries = Number(match[1])
-    if (entries <= 0) throw new UnknownPerfProfileError(raw)
+    // 100k entries is far above any collapse-boundary experiment; anything
+    // bigger is a typo, not a fixture.
+    if (entries <= 0 || entries > 100_000) throw new UnknownPerfProfileError(raw)
     return { name: PERF_SEED_PARAMETERISED_PROFILE, entries }
   }
 

--- a/scripts/perf-seed-plan.test.ts
+++ b/scripts/perf-seed-plan.test.ts
@@ -91,7 +91,9 @@ describe("planSeed — each profile plans the documented operation counts", () =
 
   test("board-large: 24 channels — four full BOARD_SYNC_CONCURRENCY waves — each with 3 messages", () => {
     const plan = planSeed(parseProfile("board-large"), empty)
-    expect(plan.filter((op) => op.kind === "createStream").length).toBe(BOARD_LARGE_STREAM_COUNT)
+    expect(plan.filter((op) => op.kind === "createStream").map((op) => op.key)).toEqual(
+      Array.from({ length: BOARD_LARGE_STREAM_COUNT }, (_, i) => `perf-board-${String(i + 1).padStart(2, "0")}`)
+    )
     expect(plan.filter((op) => op.kind === "postMessages")).toEqual(
       Array.from({ length: BOARD_LARGE_STREAM_COUNT }, (_, i) => ({
         kind: "postMessages" as const,
@@ -145,7 +147,10 @@ describe("planSeed — a partially seeded workspace tops up rather than duplicat
     expect(plan.filter((op) => op.key === "perf-board-02")).toEqual([
       { kind: "postMessages", key: "perf-board-02", from: 2, count: BOARD_LARGE_MESSAGES_PER_STREAM - 1 },
     ])
-    expect(plan.filter((op) => op.kind === "createStream").length).toBe(BOARD_LARGE_STREAM_COUNT - 2)
+    const createdKeys = plan.filter((op) => op.kind === "createStream").map((op) => op.key)
+    expect(createdKeys).toHaveLength(BOARD_LARGE_STREAM_COUNT - 2)
+    expect(createdKeys).not.toContain("perf-board-01")
+    expect(createdKeys).not.toContain("perf-board-02")
   })
 })
 

--- a/scripts/perf-seed-plan.test.ts
+++ b/scripts/perf-seed-plan.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test"
+import {
+  BOARD_LARGE_MESSAGES_PER_STREAM,
+  BOARD_LARGE_STREAM_COUNT,
+  DRAFT_PROFILE_SIZES,
+  UnknownPerfProfileError,
+  messageContent,
+  messagesForMissedEntries,
+  parseProfile,
+  planSeed,
+  seedSpec,
+  type ExistingState,
+} from "./lib/perf-seed-plan"
+
+const empty: ExistingState = { messageCounts: {} }
+
+describe("parseProfile", () => {
+  test("accepts each fixed profile", () => {
+    expect(parseProfile("large-stream")).toEqual({ name: "large-stream" })
+    expect(parseProfile("thread-2000")).toEqual({ name: "thread-2000" })
+    expect(parseProfile(" drafts ")).toEqual({ name: "drafts" })
+  })
+
+  test("parses the parameterised missed-entries profile", () => {
+    expect(parseProfile("missed-entries=200")).toEqual({ name: "missed-entries", entries: 200 })
+  })
+
+  test("an unknown profile fails loudly (INV-11)", () => {
+    expect(() => parseProfile("thread-9000")).toThrow(UnknownPerfProfileError)
+    expect(() => parseProfile("missed-entries")).toThrow(UnknownPerfProfileError)
+    expect(() => parseProfile("missed-entries=0")).toThrow(UnknownPerfProfileError)
+    expect(() => parseProfile("")).toThrow(UnknownPerfProfileError)
+  })
+})
+
+describe("messagesForMissedEntries", () => {
+  test("sizes a batch off the >=3-entries-per-message floor, never below one message", () => {
+    expect([1, 10, 50, 199, 200].map(messagesForMissedEntries)).toEqual([1, 4, 17, 67, 67])
+  })
+})
+
+describe("planSeed — each profile plans the documented operation counts", () => {
+  test("large-stream: one channel and 5,000 messages", () => {
+    expect(planSeed(parseProfile("large-stream"), empty)).toEqual([
+      { kind: "createStream", key: "perf-large-stream", streamKind: "channel" },
+      { kind: "postMessages", key: "perf-large-stream", from: 1, count: 5000 },
+    ])
+  })
+
+  test("thread-500: an anchor message in a channel, then 500 replies in a thread under it", () => {
+    expect(planSeed(parseProfile("thread-500"), empty)).toEqual([
+      { kind: "createStream", key: "perf-thread-500", streamKind: "channel" },
+      { kind: "postMessages", key: "perf-thread-500", from: 1, count: 1 },
+      { kind: "createStream", key: "perf-thread-500-thread", streamKind: "thread", parentKey: "perf-thread-500" },
+      { kind: "postMessages", key: "perf-thread-500-thread", from: 1, count: 500 },
+    ])
+  })
+
+  test("thread-100 / thread-2000 differ only in reply count", () => {
+    const replies = (profile: string) =>
+      planSeed(parseProfile(profile), empty).filter((op) => op.kind === "postMessages" && op.key.endsWith("-thread"))
+    expect(replies("thread-100")).toEqual([
+      { kind: "postMessages", key: "perf-thread-100-thread", from: 1, count: 100 },
+    ])
+    expect(replies("thread-2000")).toEqual([
+      { kind: "postMessages", key: "perf-thread-2000-thread", from: 1, count: 2000 },
+    ])
+  })
+
+  test("missed-entries plans a head-delta advance carrying the run marker", () => {
+    expect(planSeed(parseProfile("missed-entries=199"), empty, "run-a")).toEqual([
+      { kind: "createStream", key: "perf-missed-entries", streamKind: "channel" },
+      { kind: "advanceSyncLog", key: "perf-missed-entries", entries: 199, runMarker: "run-a" },
+    ])
+  })
+
+  test("missed-entries without a run marker fails loudly (INV-11)", () => {
+    expect(() => planSeed(parseProfile("missed-entries=10"), empty)).toThrow(/runMarker/)
+  })
+
+  test("drafts: one empty host channel per documented size, plus its draft", () => {
+    expect(planSeed(parseProfile("drafts"), empty)).toEqual([
+      ...DRAFT_PROFILE_SIZES.map((chars) => ({
+        kind: "createStream" as const,
+        key: `perf-draft-${chars}`,
+        streamKind: "channel" as const,
+      })),
+      ...DRAFT_PROFILE_SIZES.map((chars) => ({ kind: "upsertDraft" as const, key: `perf-draft-${chars}`, chars })),
+    ])
+  })
+
+  test("board-large: 24 channels — four full BOARD_SYNC_CONCURRENCY waves — each with 3 messages", () => {
+    const plan = planSeed(parseProfile("board-large"), empty)
+    expect(plan.filter((op) => op.kind === "createStream").length).toBe(BOARD_LARGE_STREAM_COUNT)
+    expect(plan.filter((op) => op.kind === "postMessages")).toEqual(
+      Array.from({ length: BOARD_LARGE_STREAM_COUNT }, (_, i) => ({
+        kind: "postMessages" as const,
+        key: `perf-board-${String(i + 1).padStart(2, "0")}`,
+        from: 1,
+        count: BOARD_LARGE_MESSAGES_PER_STREAM,
+      }))
+    )
+  })
+})
+
+describe("planSeed — a partially seeded workspace tops up rather than duplicating", () => {
+  test("an existing stream is not recreated and only the shortfall is posted", () => {
+    expect(planSeed(parseProfile("large-stream"), { messageCounts: { "perf-large-stream": 4990 } })).toEqual([
+      { kind: "postMessages", key: "perf-large-stream", from: 4991, count: 10 },
+    ])
+  })
+
+  test("a fully seeded profile plans nothing", () => {
+    expect(
+      planSeed(parseProfile("thread-100"), {
+        messageCounts: { "perf-thread-100": 1, "perf-thread-100-thread": 100 },
+      })
+    ).toEqual([])
+  })
+
+  test("missed-entries reuses an existing channel and still opens a fresh gap on every run", () => {
+    const existing = { messageCounts: { "perf-missed-entries": 9_000 } }
+    expect(planSeed(parseProfile("missed-entries=10"), existing, "run-b")).toEqual([
+      { kind: "advanceSyncLog", key: "perf-missed-entries", entries: 10, runMarker: "run-b" },
+    ])
+  })
+
+  test("already-staged drafts are skipped, missing ones are staged", () => {
+    expect(
+      planSeed(parseProfile("drafts"), {
+        messageCounts: Object.fromEntries(DRAFT_PROFILE_SIZES.map((chars) => [`perf-draft-${chars}`, 0])),
+        draftKeys: ["perf-draft-1024", "perf-draft-10240"],
+      })
+    ).toEqual([
+      { kind: "upsertDraft", key: "perf-draft-102400", chars: 102400 },
+      { kind: "upsertDraft", key: "perf-draft-262144", chars: 262144 },
+    ])
+  })
+
+  test("a half-seeded board tops up only the missing channels", () => {
+    const plan = planSeed(parseProfile("board-large"), {
+      messageCounts: { "perf-board-01": BOARD_LARGE_MESSAGES_PER_STREAM, "perf-board-02": 1 },
+    })
+    expect(plan.filter((op) => op.key === "perf-board-01")).toEqual([])
+    expect(plan.filter((op) => op.key === "perf-board-02")).toEqual([
+      { kind: "postMessages", key: "perf-board-02", from: 2, count: BOARD_LARGE_MESSAGES_PER_STREAM - 1 },
+    ])
+    expect(plan.filter((op) => op.kind === "createStream").length).toBe(BOARD_LARGE_STREAM_COUNT - 2)
+  })
+})
+
+describe("seedSpec", () => {
+  test("names the resolved profile, including the parameterised one", () => {
+    expect(seedSpec(parseProfile("missed-entries=50")).profile).toBe("missed-entries=50")
+    expect(seedSpec(parseProfile("board-large")).slots.length).toBe(BOARD_LARGE_STREAM_COUNT)
+  })
+})
+
+describe("messageContent", () => {
+  test("prefixes the slot key so a re-run recognises its own rows", () => {
+    expect(messageContent("perf-large-stream", 7)).toBe("perf-large-stream #00007")
+  })
+})

--- a/scripts/perf-seed-plan.test.ts
+++ b/scripts/perf-seed-plan.test.ts
@@ -29,6 +29,7 @@ describe("parseProfile", () => {
     expect(() => parseProfile("thread-9000")).toThrow(UnknownPerfProfileError)
     expect(() => parseProfile("missed-entries")).toThrow(UnknownPerfProfileError)
     expect(() => parseProfile("missed-entries=0")).toThrow(UnknownPerfProfileError)
+    expect(() => parseProfile("missed-entries=100001")).toThrow(UnknownPerfProfileError)
     expect(() => parseProfile("")).toThrow(UnknownPerfProfileError)
   })
 })

--- a/scripts/perf-seed.ts
+++ b/scripts/perf-seed.ts
@@ -161,12 +161,19 @@ class SeedClient {
 
   constructor(private readonly baseUrl: string) {}
 
-  /** True when the caller can already read the workspace, i.e. is a member. */
+  /**
+   * True when the caller can already read the workspace, i.e. is a member.
+   * Only auth-shaped statuses mean "not a member" — a 429/5xx must not be
+   * mistaken for one and trigger a join.
+   */
   async canReach(path: string): Promise<boolean> {
     const response = await fetch(`${this.baseUrl}${path}`, {
       headers: { ...(this.cookie ? { cookie: this.cookie } : {}) },
     })
-    return response.ok
+    if (response.ok) return true
+    if ([401, 403, 404].includes(response.status)) return false
+    const text = await response.text().catch(() => "<unreadable body>")
+    throw new Error(`GET ${path} failed: ${response.status} ${response.statusText} — ${text}`)
   }
 
   async request(method: string, path: string, body?: unknown, attempt = 0): Promise<unknown> {
@@ -321,6 +328,8 @@ async function joinStream(authors: SeedClient[], workspaceId: string, streamId: 
  * shape — round-robining authors so the per-user create limit is not the
  * bottleneck.
  */
+const joinedStreams = new Set<string>()
+
 async function postMessages(
   authors: SeedClient[],
   workspaceId: string,
@@ -329,7 +338,10 @@ async function postMessages(
   from: number,
   count: number
 ): Promise<void> {
-  await joinStream(authors, workspaceId, streamId)
+  if (!joinedStreams.has(streamId)) {
+    await joinStream(authors, workspaceId, streamId)
+    joinedStreams.add(streamId)
+  }
   const last = from + count - 1
   for (let start = from; start <= last; start += BATCH_SIZE) {
     const end = Math.min(start + BATCH_SIZE - 1, last)

--- a/scripts/perf-seed.ts
+++ b/scripts/perf-seed.ts
@@ -44,7 +44,9 @@ const HEAD_PROBE_CURSOR = "9223372036854775807"
 function authorCount(raw: string | undefined): number {
   if (raw === undefined) return DEFAULT_AUTHORS
   const parsed = Number(raw)
-  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`--authors must be a positive integer, got "${raw}".`)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 24) {
+    throw new Error(`--authors must be an integer between 1 and 24, got "${raw}".`)
+  }
   return parsed
 }
 
@@ -140,6 +142,12 @@ function parseArgs(argv: string[]): Args {
   const baseUrl = flags.get("base-url") ?? (backendPort ? `http://localhost:${backendPort}` : undefined)
   if (!baseUrl) {
     throw new Error("No --base-url and no DEV_TEST_BACKEND_PORT in the environment. See --help.")
+  }
+  // Local-only tool. Any non-loopback deployment running stub auth (a preview
+  // env, a misconfigured staging) would happily accept the whole fixture.
+  const host = new URL(baseUrl).hostname
+  if (!["localhost", "127.0.0.1", "::1", "[::1]"].includes(host)) {
+    throw new Error(`perf-seed only targets a local stack; refusing host "${host}".`)
   }
 
   return {
@@ -390,7 +398,9 @@ async function advanceSyncLog(
   let posted = 0
   while (head - startHead < BigInt(entries)) {
     const remaining = entries - Number(head - startHead)
-    const batch = messagesForMissedEntries(remaining)
+    // Bounded rounds: the head is re-read between them, so a huge target can
+    // never turn into one unbounded posting loop.
+    const batch = Math.min(messagesForMissedEntries(remaining), 100)
     await postMessages(authors, workspaceId, streamId, runMarker, posted + 1, batch)
     posted += batch
     const next = await readSyncHead(authors[0]!, workspaceId)

--- a/scripts/perf-seed.ts
+++ b/scripts/perf-seed.ts
@@ -1,0 +1,495 @@
+#!/usr/bin/env bun
+/**
+ * Seeds the reproduction fixtures behind `docs/perf/reproduction-matrix.md`.
+ *
+ * Thin driver: the profile → work mapping lives in `lib/perf-seed-plan.ts` and
+ * is unit-tested without a network. This file only resolves the plan's keys to
+ * real ids and pushes the operations over the REST API.
+ *
+ * Every profile but `missed-entries` is idempotent — it counts what its own
+ * marker prefix already put in the workspace and tops up. Re-running is safe;
+ * it is the intended way to grow a fixture. `missed-entries` instead marks each
+ * run separately and drives the workspace sync head forward by the requested
+ * delta, so every invocation opens a fresh gap.
+ */
+
+import {
+  PERF_SEED_FIXED_PROFILES,
+  PERF_SEED_PARAMETERISED_PROFILE,
+  messageContent,
+  messagesForMissedEntries,
+  parseProfile,
+  planSeed,
+  seedSpec,
+  type ExistingState,
+  type ParsedProfile,
+  type PlannedStreamSlot,
+} from "./lib/perf-seed-plan"
+
+const BATCH_SIZE = 5
+const EVENT_PAGE_SIZE = 200
+/** `stream_events.event_type` for a posted message — not the socket/outbox `message:created` name. */
+const MESSAGE_EVENT_TYPE = "message_created"
+const DEFAULT_EMAIL = "perf-seed@example.com"
+/**
+ * Message creation is rate-limited per user (120/min, `middleware/rate-limit.ts`),
+ * which alone would put `large-stream` at ~42 minutes. Seeding round-robins over
+ * this many stub authors instead — a busy channel has many authors anyway.
+ */
+const DEFAULT_AUTHORS = 6
+const RATE_LIMIT_RETRIES = 6
+/** Past any real sync id, so the head probe returns the head and no entries. */
+const HEAD_PROBE_CURSOR = "9223372036854775807"
+
+function authorCount(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_AUTHORS
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error(`--authors must be a positive integer, got "${raw}".`)
+  return parsed
+}
+
+/** `perf-seed@example.com` + index 2 → `perf-seed+2@example.com`. */
+function authorEmail(base: string, index: number): string {
+  if (index === 0) return base
+  const [local, domain] = base.split("@")
+  if (!domain) throw new Error(`--email must be an address, got "${base}".`)
+  return `${local}+${index}@${domain}`
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+const USAGE = `
+perf-seed — seed performance reproduction fixtures into a running stack.
+
+Usage:
+  bun scripts/perf-seed.ts --workspace <workspaceId> --profile <name> [options]
+
+Profiles:
+  ${PERF_SEED_FIXED_PROFILES.join("\n  ")}
+  ${PERF_SEED_PARAMETERISED_PROFILE}=<N>   advance the sync log by N entries
+
+Options:
+  --workspace <id>    Target workspace (required).
+  --profile <name>    Profile to seed (required).
+  --base-url <url>    Backend base URL. Default: http://localhost:$DEV_TEST_BACKEND_PORT
+  --email <address>   Base stub-auth identity. Default: perf-seed@example.com
+  --authors <n>       Stub authors to spread posting over. Default: 6
+  --dry-run           Log in once (read-only) and print the plan without writing.
+                      A workspace the seed user is not a member of is not joined
+                      on a dry run, so existing counts print as unknown and the
+                      plan is the one for an empty workspace.
+  --help
+
+Auth: the dev:test stack's stub auth (POST /api/dev/login), the same path the
+browser suite uses. This script targets a local stack only — it has no API-key
+path and must never be pointed at staging or production.
+
+Rate limits: message creation is capped per user, so seeding posts as N stub
+authors (--authors, default 6) derived from --email as base+1@, base+2@, and so on.
+The binding limit on a dev stack is the GLOBAL per-IP cap (300/min), which no
+number of authors escapes — start the stack with GLOBAL_RATE_LIMIT_MAX=10000
+(the same value playwright.config.ts uses). A 429 is retried with backoff first.
+
+Missed entries: \`missed-entries=<N>\` reads the workspace sync head, posts
+batches carrying a per-run marker, and stops once the head has advanced by at
+least N. A message writes three or more entries and the exact number is
+workload-dependent, so the achieved delta is measured and printed — read it,
+do not compute it. Each run opens a fresh gap.
+
+Start the stack first:
+  GLOBAL_RATE_LIMIT_MAX=10000 DEV_TEST_BACKEND_PORT=4001 bun run dev:test
+`
+
+interface Args {
+  workspaceId: string
+  profile: ParsedProfile
+  baseUrl: string
+  email: string
+  authors: number
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const flags = new Map<string, string>()
+  let dryRun = false
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === "--help" || arg === "-h") {
+      console.log(USAGE)
+      process.exit(0)
+    }
+    if (arg === "--dry-run") {
+      dryRun = true
+      continue
+    }
+    if (!arg.startsWith("--")) throw new Error(`Unexpected argument "${arg}". See --help.`)
+    const value = argv[i + 1]
+    if (value === undefined || value.startsWith("--")) throw new Error(`Flag ${arg} needs a value. See --help.`)
+    flags.set(arg.slice(2), value)
+    i++
+  }
+
+  const workspaceId = flags.get("workspace")
+  if (!workspaceId) throw new Error("--workspace is required. See --help.")
+  const profileRaw = flags.get("profile")
+  if (!profileRaw) throw new Error("--profile is required. See --help.")
+
+  const backendPort = process.env.DEV_TEST_BACKEND_PORT
+  const baseUrl = flags.get("base-url") ?? (backendPort ? `http://localhost:${backendPort}` : undefined)
+  if (!baseUrl) {
+    throw new Error("No --base-url and no DEV_TEST_BACKEND_PORT in the environment. See --help.")
+  }
+
+  return {
+    workspaceId,
+    profile: parseProfile(profileRaw),
+    baseUrl: baseUrl.replace(/\/$/, ""),
+    email: flags.get("email") ?? DEFAULT_EMAIL,
+    authors: authorCount(flags.get("authors")),
+    dryRun,
+  }
+}
+
+/**
+ * Minimal cookie-carrying client. Bun's fetch does not keep a jar, and the stub
+ * session rides a cookie, so every later request has to replay it.
+ */
+class SeedClient {
+  private cookie = ""
+
+  constructor(private readonly baseUrl: string) {}
+
+  /** True when the caller can already read the workspace, i.e. is a member. */
+  async canReach(path: string): Promise<boolean> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      headers: { ...(this.cookie ? { cookie: this.cookie } : {}) },
+    })
+    return response.ok
+  }
+
+  async request(method: string, path: string, body?: unknown, attempt = 0): Promise<unknown> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        ...(this.cookie ? { cookie: this.cookie } : {}),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    })
+
+    const setCookie = response.headers.getSetCookie?.() ?? []
+    if (setCookie.length > 0) {
+      this.cookie = setCookie.map((c) => c.split(";")[0]).join("; ")
+    }
+
+    // A 429 is expected under sustained seeding and is retryable; everything
+    // else is not.
+    if (response.status === 429) {
+      if (attempt < RATE_LIMIT_RETRIES) {
+        await response.text().catch(() => "")
+        await sleep(2_000 * 2 ** attempt)
+        return this.request(method, path, body, attempt + 1)
+      }
+      throw new Error(
+        `${method} ${path} still 429 after ${RATE_LIMIT_RETRIES} retries. The per-IP global limiter is the usual cause — restart the stack with GLOBAL_RATE_LIMIT_MAX=10000.`
+      )
+    }
+
+    // Fail loudly (INV-11): a half-seeded fixture that reported success is
+    // worse than no fixture, because every later measurement is against a
+    // silently wrong shape.
+    if (!response.ok) {
+      const text = await response.text().catch(() => "<unreadable body>")
+      throw new Error(`${method} ${path} failed: ${response.status} ${response.statusText} — ${text}`)
+    }
+
+    const text = await response.text()
+    return text.length === 0 ? undefined : JSON.parse(text)
+  }
+}
+
+interface StreamRow {
+  id: string
+  slug?: string | null
+  displayName?: string | null
+  type: string
+}
+
+async function loginOnly(client: SeedClient, email: string): Promise<void> {
+  await client.request("POST", "/api/dev/login", { email, name: "perf-seed" })
+}
+
+async function login(client: SeedClient, workspaceId: string, email: string): Promise<void> {
+  await loginOnly(client, email)
+  // The stub join is an add, not an upsert: it errors for a user who is already
+  // a member (the common case — the workspace's creator). Only join when the
+  // workspace is out of reach.
+  if (!(await client.canReach(`/api/workspaces/${workspaceId}`))) {
+    await client.request("POST", `/api/dev/workspaces/${workspaceId}/join`, {})
+  }
+}
+
+async function listStreams(client: SeedClient, workspaceId: string): Promise<StreamRow[]> {
+  const channels = (await client.request("GET", `/api/workspaces/${workspaceId}/streams`)) as {
+    streams: StreamRow[]
+  }
+  const threads = (await client.request("GET", `/api/workspaces/${workspaceId}/streams?stream_type=thread`)) as {
+    streams: StreamRow[]
+  }
+  return [...channels.streams, ...threads.streams]
+}
+
+/** A slot's stream is identified by slug for channels and by display name for threads (threads have no slug). */
+function findSlotStream(streams: StreamRow[], slot: PlannedStreamSlot): StreamRow | undefined {
+  return slot.kind === "channel"
+    ? streams.find((s) => s.slug === slot.key)
+    : streams.find((s) => s.type === "thread" && s.displayName === slot.key)
+}
+
+/** Marker-bearing messages already in a stream. Pages backwards through the event log. */
+async function countMarkedMessages(
+  client: SeedClient,
+  workspaceId: string,
+  streamId: string,
+  marker: string
+): Promise<number> {
+  let before: string | undefined
+  let count = 0
+  for (;;) {
+    const query = new URLSearchParams({ type: MESSAGE_EVENT_TYPE, limit: String(EVENT_PAGE_SIZE) })
+    if (before) query.set("before", before)
+    const page = (await client.request(
+      "GET",
+      `/api/workspaces/${workspaceId}/streams/${streamId}/events?${query}`
+    )) as { events: { sequence: string; payload?: { contentMarkdown?: string | null } }[] }
+
+    if (page.events.length === 0) return count
+    for (const event of page.events) {
+      if (event.payload?.contentMarkdown?.startsWith(marker)) count++
+    }
+    if (page.events.length < EVENT_PAGE_SIZE) return count
+    before = page.events[0]!.sequence
+  }
+}
+
+async function readExistingState(
+  client: SeedClient,
+  workspaceId: string,
+  profile: ParsedProfile
+): Promise<{ existing: ExistingState; streamIds: Map<string, string> }> {
+  const spec = seedSpec(profile)
+  const streams = await listStreams(client, workspaceId)
+  const messageCounts: Record<string, number | undefined> = {}
+  const streamIds = new Map<string, string>()
+
+  for (const slot of spec.slots) {
+    const found = findSlotStream(streams, slot)
+    if (!found) continue
+    streamIds.set(slot.key, found.id)
+    // A slot with no message target has nothing to top up, and paging its whole
+    // event log to learn that costs more the longer the fixture lives.
+    messageCounts[slot.key] =
+      slot.messageTarget === 0 ? 0 : await countMarkedMessages(client, workspaceId, found.id, slot.key)
+  }
+
+  const draftKeys: string[] = []
+  if (spec.drafts.length > 0) {
+    const { drafts } = (await client.request("GET", `/api/workspaces/${workspaceId}/drafts`)) as {
+      drafts: { scope: string }[]
+    }
+    const scopedStreamIds = new Set(drafts.map((d) => d.scope.replace(/^stream:/, "")))
+    for (const draft of spec.drafts) {
+      const streamId = streamIds.get(draft.key)
+      if (streamId && scopedStreamIds.has(streamId)) draftKeys.push(draft.key)
+    }
+  }
+
+  return { existing: { messageCounts, draftKeys }, streamIds }
+}
+
+/** Give every author a membership so it can post into `streamId`. Idempotent server-side. */
+async function joinStream(authors: SeedClient[], workspaceId: string, streamId: string): Promise<void> {
+  for (const author of authors) {
+    await author.request("POST", `/api/dev/workspaces/${workspaceId}/streams/${streamId}/join`, {})
+  }
+}
+
+/**
+ * Post messages in bounded parallel batches — the `infinite-scroll.spec.ts`
+ * shape — round-robining authors so the per-user create limit is not the
+ * bottleneck.
+ */
+async function postMessages(
+  authors: SeedClient[],
+  workspaceId: string,
+  streamId: string,
+  key: string,
+  from: number,
+  count: number
+): Promise<void> {
+  await joinStream(authors, workspaceId, streamId)
+  const last = from + count - 1
+  for (let start = from; start <= last; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE - 1, last)
+    const batch: Promise<unknown>[] = []
+    for (let ordinal = start; ordinal <= end; ordinal++) {
+      batch.push(
+        authors[ordinal % authors.length]!.request("POST", `/api/workspaces/${workspaceId}/messages`, {
+          streamId,
+          content: messageContent(key, ordinal),
+        })
+      )
+    }
+    await Promise.all(batch)
+    if ((end - from + 1) % 500 === 0 || end === last) {
+      console.log(`  ${key}: ${end - from + 1}/${count} messages`)
+    }
+  }
+}
+
+/**
+ * The workspace sync head. Catch-up returns it regardless of the cursor, so a
+ * cursor far past the end is the cheapest probe: no entries come back.
+ */
+async function readSyncHead(client: SeedClient, workspaceId: string): Promise<bigint> {
+  const response = (await client.request(
+    "GET",
+    `/api/workspaces/${workspaceId}/sync?after=${HEAD_PROBE_CURSOR}&limit=1`
+  )) as { head: string }
+  return BigInt(response.head)
+}
+
+/**
+ * Post batches until the sync head has advanced by `entries`, re-reading the
+ * head between batches. Entries per message are workload-dependent, so the only
+ * honest stopping condition is the measured delta. Returns what was achieved.
+ */
+async function advanceSyncLog(
+  authors: SeedClient[],
+  workspaceId: string,
+  streamId: string,
+  runMarker: string,
+  entries: number
+): Promise<{ delta: bigint; messages: number }> {
+  const startHead = await readSyncHead(authors[0]!, workspaceId)
+  let head = startHead
+  let posted = 0
+  while (head - startHead < BigInt(entries)) {
+    const remaining = entries - Number(head - startHead)
+    const batch = messagesForMissedEntries(remaining)
+    await postMessages(authors, workspaceId, streamId, runMarker, posted + 1, batch)
+    posted += batch
+    const next = await readSyncHead(authors[0]!, workspaceId)
+    if (next === head) {
+      throw new Error(`Sync head did not move after posting ${batch} message(s) to ${streamId}.`)
+    }
+    head = next
+  }
+  return { delta: head - startHead, messages: posted }
+}
+
+async function latestMessageId(client: SeedClient, workspaceId: string, streamId: string): Promise<string> {
+  const page = (await client.request(
+    "GET",
+    `/api/workspaces/${workspaceId}/streams/${streamId}/events?type=${MESSAGE_EVENT_TYPE}&limit=1`
+  )) as { events: { payload?: { messageId?: string } }[] }
+  const id = page.events[0]?.payload?.messageId
+  if (!id) throw new Error(`Stream ${streamId} has no message to anchor a thread on`)
+  return id
+}
+
+function draftBody(chars: number): { type: "doc"; content: unknown[] } {
+  return { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "x".repeat(chars) }] }] }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  const spec = seedSpec(args.profile)
+  const runMarker = `perf-missed-entries-run-${Date.now().toString(36)}`
+
+  if (args.dryRun) {
+    const reader = new SeedClient(args.baseUrl)
+    await loginOnly(reader, authorEmail(args.email, 0))
+    let existing: ExistingState = { messageCounts: {} }
+    if (await reader.canReach(`/api/workspaces/${args.workspaceId}`)) {
+      ;({ existing } = await readExistingState(reader, args.workspaceId, args.profile))
+    } else {
+      console.log(`(dry run: ${authorEmail(args.email, 0)} is not in ${args.workspaceId} — existing counts unknown)`)
+    }
+    const operations = planSeed(args.profile, existing, runMarker)
+    console.log(`profile ${spec.profile} → ${operations.length} operation(s) outstanding`)
+    for (const op of operations) console.log(`  ${JSON.stringify(op)}`)
+    return
+  }
+
+  const authors: SeedClient[] = []
+  for (let i = 0; i < args.authors; i++) {
+    const author = new SeedClient(args.baseUrl)
+    await login(author, args.workspaceId, authorEmail(args.email, i))
+    authors.push(author)
+  }
+  // Reads, stream creation and drafts all run as the first author, so the
+  // fixture has one owner and one draft scope regardless of --authors.
+  const client = authors[0]!
+
+  const { existing, streamIds } = await readExistingState(client, args.workspaceId, args.profile)
+  const operations = planSeed(args.profile, existing, runMarker)
+
+  console.log(`profile ${spec.profile} → ${operations.length} operation(s) outstanding`)
+  if (operations.length === 0) {
+    console.log("Already seeded — nothing to do.")
+    return
+  }
+
+  const slotsByKey = new Map(spec.slots.map((slot) => [slot.key, slot]))
+
+  for (const op of operations) {
+    if (op.kind === "createStream") {
+      const slot = slotsByKey.get(op.key)!
+      const body =
+        slot.kind === "channel"
+          ? { type: "channel", slug: op.key, displayName: op.key }
+          : {
+              type: "thread",
+              displayName: op.key,
+              parentStreamId: streamIds.get(slot.parentKey!),
+              parentAnchorId: await latestMessageId(client, args.workspaceId, streamIds.get(slot.parentKey!)!),
+            }
+      const { stream } = (await client.request("POST", `/api/workspaces/${args.workspaceId}/streams`, body)) as {
+        stream: StreamRow
+      }
+      streamIds.set(op.key, stream.id)
+      console.log(`  created ${slot.kind} ${op.key} → ${stream.id}`)
+      continue
+    }
+
+    const streamId = streamIds.get(op.key)
+    if (!streamId) throw new Error(`No stream resolved for slot "${op.key}"`)
+
+    if (op.kind === "postMessages") {
+      await postMessages(authors, args.workspaceId, streamId, op.key, op.from, op.count)
+      continue
+    }
+
+    if (op.kind === "advanceSyncLog") {
+      const { delta, messages } = await advanceSyncLog(authors, args.workspaceId, streamId, op.runMarker, op.entries)
+      console.log(`  ${op.runMarker}: ${messages} message(s) → sync head advanced by ${delta} (asked ${op.entries})`)
+      continue
+    }
+
+    await client.request("PUT", `/api/workspaces/${args.workspaceId}/drafts/${op.key}`, {
+      scope: `stream:${streamId}`,
+      expectedVersion: 0,
+      writeId: `write_perfseed_${op.key}`,
+      clientUpdatedAt: new Date().toISOString(),
+      contentJson: draftBody(op.chars),
+    })
+    console.log(`  staged draft ${op.key} (${op.chars} chars)`)
+  }
+
+  console.log(`Done. profile ${spec.profile} is seeded.`)
+}
+
+await main()

--- a/tests/browser/perf-capture.spec.ts
+++ b/tests/browser/perf-capture.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel } from "./helpers"
+import { armCapture, readCapture, seedStream } from "./perf-fixtures"
+
+/**
+ * The end-to-end proof for the client capture: it records real phases through a
+ * reload, and what it records carries no content. Deliberately free of timing
+ * assertions — thresholds are device-dependent and the reproduction matrix is
+ * operator-run (`docs/perf/reproduction-matrix.md`).
+ */
+
+// Seeding 60 messages over the API plus a cold reload needs headroom in CI.
+test.describe.configure({ timeout: 120_000 })
+
+const MESSAGE_COUNT = 60
+
+test.describe("Performance capture", () => {
+  test("an armed capture records bootstrap phases across a reload and carries no content", async ({ page }) => {
+    const { testId } = await loginAndCreateWorkspace(page, "perf-capture")
+    const channelName = `perf-cap-${testId}`
+    await createChannel(page, channelName)
+
+    const url = page.url()
+    const workspaceId = url.match(/\/w\/([^/]+)/)![1]!
+    const streamId = url.match(/\/s\/([^/?]+)/)![1]!
+
+    // A token that exists nowhere but in the seeded message bodies, so finding
+    // it in the capture can only mean content leaked.
+    const token = `perfleak${testId}zzz`
+    await seedStream(page, workspaceId, streamId, MESSAGE_COUNT, token)
+
+    // Arm before the reload so the provider mounts armed and the bootstrap it
+    // measures is a genuinely cold one.
+    await armCapture(page)
+    await page.reload()
+    await expect(page.getByRole("main").locator(".message-item").first()).toBeVisible({ timeout: 30_000 })
+
+    // (a) The bootstrap phases. Each is recorded when its phase ENDS, so a
+    // first paint (which the cached reveal can produce) does not mean the
+    // bootstrap write has landed — poll rather than exporting once. The phases
+    // are pinned outside the ring buffer, so nothing evicts them once recorded.
+    const BOOTSTRAP_PHASES = ["bootstrap.fetch", "bootstrap.tx", "bootstrap.seed"] as const
+    await expect
+      .poll(async () => [...new Set((await readCapture(page)).samples.map((s) => s.name))].sort(), {
+        timeout: 30_000,
+        message: "capture should record every bootstrap phase",
+      })
+      .toEqual(expect.arrayContaining([...BOOTSTRAP_PHASES]))
+
+    const capture = await readCapture(page)
+
+    // (b) Observer output is machine-dependent — a fast runner may produce no
+    // long task at all — so this only asserts something was recorded. Name
+    // validity and wire shape are enforced where they can actually fail:
+    // `exportCapture` parses `performanceCaptureSchema`, and the schema's
+    // rejection cases are covered in packages/types.
+    expect(capture.samples.length).toBeGreaterThan(0)
+
+    // (c) The privacy proof, over the serialized payload the upload would send.
+    const serialized = JSON.stringify(capture)
+    expect(serialized).not.toContain(token)
+    expect(serialized).not.toContain(channelName)
+    expect(serialized).not.toContain(workspaceId)
+    expect(serialized).not.toContain(streamId)
+  })
+})

--- a/tests/browser/perf-capture.spec.ts
+++ b/tests/browser/perf-capture.spec.ts
@@ -54,7 +54,6 @@ test.describe("Performance capture", () => {
     // validity and wire shape are enforced where they can actually fail:
     // `exportCapture` parses `performanceCaptureSchema`, and the schema's
     // rejection cases are covered in packages/types.
-    expect(capture.samples.length).toBeGreaterThan(0)
 
     // (c) The privacy proof, over the serialized payload the upload would send.
     const serialized = JSON.stringify(capture)

--- a/tests/browser/perf-fixtures.ts
+++ b/tests/browser/perf-fixtures.ts
@@ -44,14 +44,6 @@ export async function seedStream(
 }
 
 /**
- * Requested body size clamped so the SERIALIZED entry stays within the staging
- * cap. `stageDraftContent` measures `MAX_STAGED_CHARS` against the whole JSON
- * envelope, not the text node, so the largest documented draft size (256 KB)
- * would otherwise write a buffer the app itself would have refused to write.
- */
-const MAX_STAGED_CHARS = 256 * 1024
-
-/**
  * Arm the dev capture for every subsequent navigation in this context. Dev
  * arming is local-only and never uploads (`isUploadPermitted` requires
  * consent), so a spec can measure without touching the consent path.

--- a/tests/browser/perf-fixtures.ts
+++ b/tests/browser/perf-fixtures.ts
@@ -44,58 +44,12 @@ export async function seedStream(
 }
 
 /**
- * Create a thread anchored on `anchorMessageId` under `parentStreamId` and seed
- * it with `count` replies. Returns the thread's stream id.
- */
-export async function seedThread(
-  page: Page,
-  workspaceId: string,
-  parentStreamId: string,
-  anchorMessageId: string,
-  count: number,
-  prefix: string
-): Promise<string> {
-  const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
-    data: { type: "thread", displayName: prefix, parentStreamId, parentAnchorId: anchorMessageId },
-  })
-  await expectApiOk(response, "Create thread")
-  const { stream } = (await response.json()) as { stream: { id: string } }
-  await seedStream(page, workspaceId, stream.id, count, prefix)
-  return stream.id
-}
-
-/**
  * Requested body size clamped so the SERIALIZED entry stays within the staging
  * cap. `stageDraftContent` measures `MAX_STAGED_CHARS` against the whole JSON
  * envelope, not the text node, so the largest documented draft size (256 KB)
  * would otherwise write a buffer the app itself would have refused to write.
  */
 const MAX_STAGED_CHARS = 256 * 1024
-
-/**
- * Write a staged draft body straight into the composer's localStorage staging
- * buffer for `scope` — the same key and envelope `stageDraftContent` writes.
- * `chars` is a count of UTF-16 code units of body text, matching the unit the
- * cap is measured in; it is reduced when the envelope would push the serialized
- * entry over `MAX_STAGED_CHARS`, so what lands is always a buffer the app could
- * have produced. The over-cap path (where `stageDraftContent` drops the entry
- * instead) is deliberately not exercised here. Must run before the page that
- * reads it loads.
- */
-export async function stageLargeDraft(page: Page, workspaceId: string, scope: string, chars: number): Promise<void> {
-  await page.evaluate(
-    ({ workspaceId, scope, chars, cap }) => {
-      const envelope = (text: string) => ({
-        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] },
-        clientUpdatedAt: Date.now(),
-      })
-      const overhead = JSON.stringify(envelope("")).length
-      const text = "x".repeat(Math.min(chars, cap - overhead))
-      localStorage.setItem(`threa:draft-stage:${workspaceId}:${scope}`, JSON.stringify(envelope(text)))
-    },
-    { workspaceId, scope, chars, cap: MAX_STAGED_CHARS }
-  )
-}
 
 /**
  * Arm the dev capture for every subsequent navigation in this context. Dev

--- a/tests/browser/perf-fixtures.ts
+++ b/tests/browser/perf-fixtures.ts
@@ -1,0 +1,130 @@
+import { type Page } from "@playwright/test"
+// Relative, not `@threa/types`: the repo root does not depend on the package,
+// so the bare specifier does not resolve here. Type-only, so nothing of the
+// package is pulled in at runtime.
+import { type PerformanceCapture } from "../../packages/types/src/performance-capture"
+import { expectApiOk } from "./helpers"
+
+/**
+ * Fixture helpers for performance reproduction specs. Helpers only — no new
+ * Playwright project, no timing assertions. Seeding mirrors
+ * `infinite-scroll.spec.ts`: batched API posts, batch size 5.
+ *
+ * The equivalent out-of-band harness is `scripts/perf-seed.ts`; the profiles it
+ * exposes and the marks each one proves are in `docs/perf/reproduction-matrix.md`.
+ */
+
+const BATCH_SIZE = 5
+
+/** Dev-only arming switch read by `apps/frontend/src/lib/perf/capture.ts`. */
+const CAPTURE_STORAGE_KEY = "threa:perf:capture"
+
+/** Post `count` messages carrying `prefix` into a stream, in bounded parallel batches. */
+export async function seedStream(
+  page: Page,
+  workspaceId: string,
+  streamId: string,
+  count: number,
+  prefix: string
+): Promise<void> {
+  for (let start = 1; start <= count; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE - 1, count)
+    const batch: Promise<void>[] = []
+    for (let i = start; i <= end; i++) {
+      batch.push(
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix} msg-${String(i).padStart(4, "0")}` },
+          })
+          .then((r) => expectApiOk(r, `Seed message ${i}`))
+      )
+    }
+    await Promise.all(batch)
+  }
+}
+
+/**
+ * Create a thread anchored on `anchorMessageId` under `parentStreamId` and seed
+ * it with `count` replies. Returns the thread's stream id.
+ */
+export async function seedThread(
+  page: Page,
+  workspaceId: string,
+  parentStreamId: string,
+  anchorMessageId: string,
+  count: number,
+  prefix: string
+): Promise<string> {
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/streams`, {
+    data: { type: "thread", displayName: prefix, parentStreamId, parentAnchorId: anchorMessageId },
+  })
+  await expectApiOk(response, "Create thread")
+  const { stream } = (await response.json()) as { stream: { id: string } }
+  await seedStream(page, workspaceId, stream.id, count, prefix)
+  return stream.id
+}
+
+/**
+ * Requested body size clamped so the SERIALIZED entry stays within the staging
+ * cap. `stageDraftContent` measures `MAX_STAGED_CHARS` against the whole JSON
+ * envelope, not the text node, so the largest documented draft size (256 KB)
+ * would otherwise write a buffer the app itself would have refused to write.
+ */
+const MAX_STAGED_CHARS = 256 * 1024
+
+/**
+ * Write a staged draft body straight into the composer's localStorage staging
+ * buffer for `scope` — the same key and envelope `stageDraftContent` writes.
+ * `chars` is a count of UTF-16 code units of body text, matching the unit the
+ * cap is measured in; it is reduced when the envelope would push the serialized
+ * entry over `MAX_STAGED_CHARS`, so what lands is always a buffer the app could
+ * have produced. The over-cap path (where `stageDraftContent` drops the entry
+ * instead) is deliberately not exercised here. Must run before the page that
+ * reads it loads.
+ */
+export async function stageLargeDraft(page: Page, workspaceId: string, scope: string, chars: number): Promise<void> {
+  await page.evaluate(
+    ({ workspaceId, scope, chars, cap }) => {
+      const envelope = (text: string) => ({
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] },
+        clientUpdatedAt: Date.now(),
+      })
+      const overhead = JSON.stringify(envelope("")).length
+      const text = "x".repeat(Math.min(chars, cap - overhead))
+      localStorage.setItem(`threa:draft-stage:${workspaceId}:${scope}`, JSON.stringify(envelope(text)))
+    },
+    { workspaceId, scope, chars, cap: MAX_STAGED_CHARS }
+  )
+}
+
+/**
+ * Arm the dev capture for every subsequent navigation in this context. Dev
+ * arming is local-only and never uploads (`isUploadPermitted` requires
+ * consent), so a spec can measure without touching the consent path.
+ */
+export async function armCapture(page: Page): Promise<void> {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(key, "1")
+  }, CAPTURE_STORAGE_KEY)
+}
+
+/** The window handle installed by the provider while armed. */
+interface PerfCaptureWindowHandle {
+  export: () => PerformanceCapture
+  clear: () => void
+}
+
+/**
+ * Export the armed capture. Waits for the handle: the provider installs it in
+ * an effect, so it is not present at first evaluate on a cold load.
+ */
+export async function readCapture(page: Page, timeout = 20_000): Promise<PerformanceCapture> {
+  await page.waitForFunction(
+    () => (window as Window & { __threaPerfCapture?: unknown }).__threaPerfCapture !== undefined,
+    undefined,
+    { timeout }
+  )
+  return await page.evaluate(() =>
+    (window as Window & { __threaPerfCapture?: PerfCaptureWindowHandle }).__threaPerfCapture!.export()
+  )
+}


### PR DESCRIPTION
## Problem

The reproduction matrix in the perf analysis names twelve scenarios (large streams, deep threads, missed-entry catch-up at the 200-entry collapse boundary, large drafts, wide boards), but nothing builds those fixtures — `docs/monitoring-connection-pool.md` pointed at a `scripts/stress-test.ts` that never existed (removed in chunk 1), and no test proves the chunks 2–3 capture pipeline works end to end or that an exported capture carries no content. Chunk 4/4 of the instrumentation PR.

## Solution

Operator-run tooling; nothing timing-asserted in CI.

- `scripts/perf-seed.ts` + pure `scripts/lib/perf-seed-plan.ts` (unit-tested planning, no network). Profiles: `large-stream` (5,000 msgs), `thread-100/500/2000`, `drafts` (four host channels, one staged size each), `board-large` (24 channels = four full `BOARD_SYNC_CONCURRENCY=6` waves). Idempotent per marker prefix — re-runs top up, never duplicate; every non-2xx fails loudly (INV-11).
- `missed-entries=<N>` is **head-delta-driven**: the analysis assumed 2 sync-log entries per message, but the real factor is ≥3 and workload-dependent (`activity:created` self-rows are user-scoped-sequenced; conversation attach adds `conversation:updated` + `conversation:message_assigned`) — measured live at ~3–3.4. So the seeder reads the workspace sync head, posts batches under a per-run marker, stops at delta ≥ N, and prints the achieved delta; each invocation opens a fresh gap (run 1: +21, run 2: +24, verified on dev:test). Boundary work reads the printed delta, not a table of fiction.
- Rate limits: message creation is 120/min/user, so posting round-robins 6 stub authors (`--authors`); the binding cap on dev:test is the per-IP global limiter (300/min), so the documented stack-start sets `GLOBAL_RATE_LIMIT_MAX=10000` (the `playwright.config.ts` precedent) and retry exhaustion names that variable. `--dry-run` is read-only (one login, no joins, no writes).
- `tests/browser/perf-capture.spec.ts` — the end-to-end proof: seed 60 messages carrying a unique token, arm the dev capture, reload, then poll for the pinned `bootstrap.*` phase marks and assert the serialized export contains neither the token, the channel name, the workspace id, nor the stream id. Schema/registry validity assertions were deliberately dropped as green-by-construction (`exportCapture` parses the same schema); the poll + privacy checks are the load-bearing ones. Green 7× across implementer/orchestrator/fixer runs.
- `docs/perf/reproduction-matrix.md` — 12 scenarios → exact invocation + the marks that prove each, with the operator steps that a seed alone can't produce (staging marks come from keystrokes). Seeding path is `/api/dev/*`, registered only under `StubAuthService` — a stray `--base-url` at staging/prod 404s.

## Files

| File | Change |
| ---- | ------ |
| `scripts/perf-seed.ts` | **new** — seeding driver (stub-auth, batched, rate-limit-aware) |
| `scripts/lib/perf-seed-plan.ts` + `scripts/perf-seed-plan.test.ts` | **new** — pure planning + 32 tests |
| `tests/browser/perf-capture.spec.ts` | **new** — capture plumbing + privacy proof |
| `tests/browser/perf-fixtures.ts` | **new** — seed/arm/read helpers |
| `docs/perf/reproduction-matrix.md` | **new** — 12 scenarios, invocations, proving marks, targets |
| `docs/monitoring-connection-pool.md` | §Load Fixtures now points at the real script |

## Test plan

- [x] `bun run test:scripts` — 32 pass / 0 fail (top-up, boundary, unknown-profile, run-marker semantics; neutralize→red→restore verified)
- [x] browser spec — 7 green runs total (incl. `--repeat-each=3`); privacy assertions neutralization-verified (arming off → timeout; off-registry name → red; injected workspace id → red)
- [x] every profile executed for real against dev:test, incl. two fresh missed-entries gaps and 0-op re-runs of the idempotent profiles
- [x] root lint + 251 migrations clean
- [ ] full 12-scenario matrix on a real phone — that is the operator work this chunk exists to enable, not part of CI

<details>
<summary>📋 Full implementation plan</summary>

Plan: https://seer.build/ws_vbyzjvdg6g/b/perf-plan-cc262f/ — Part B, chunk 4 of 4. Adversarial verify: 9 findings, all fixed in-branch — headline: the 2-entries-per-message premise underlying the collapse-boundary table was wrong (real factor ≥3, measured ~3–3.4), so the seeder now measures instead of assumes; missed-entries idempotency would have made repeat runs seed no gap at all.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788279437&installation_model_id=20758&pr_number=1722&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1722&signature=96e1e65d8651cb168aeac832b53688b3c7d3b9da010095295f3414bfaa67168e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->