### PR TITLE
feat(board): LedgerRow — lead rows with expand-in-place, event rows, chips

### DIFF
--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -14,6 +14,7 @@ import * as userProfileModule from "@/components/user-profile"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as emojiModule from "@/hooks/use-workspace-emoji"
 import * as touchCapableModule from "@/hooks/use-touch-capable"
+import * as useMobileModule from "@/hooks/use-mobile"
 import * as messageHistoryDialogModule from "@/components/timeline/message-history-dialog"
 import * as conversationsModule from "@/hooks/use-conversations"
 import { spyOnExport } from "@/test/spy"
@@ -205,6 +206,46 @@ describe("LedgerRow touch long-press", () => {
     expect(onToggle).not.toHaveBeenCalled()
   })
 
+  it("still toggles on the next real tap when the hold produced no synthetic click", () => {
+    vi.useFakeTimers()
+    const { onToggle } = renderRow({ onNewSubtopic: vi.fn() })
+    const rowButton = screen.getByRole("button", { name: /Pierre:/ })
+
+    fireEvent.touchStart(rowButton, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+    fireEvent.touchCancel(rowButton)
+    // No click follows this hold (drawer dismissed / touchcancel / scroll-away).
+    act(() => vi.advanceTimersByTime(1000))
+
+    fireEvent.click(rowButton)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it("opens only the drawer from a long press on the attachment chip — no gallery", () => {
+    vi.useFakeTimers()
+    const openMedia = vi.fn()
+    vi.spyOn(contextsModule, "useMediaGallery").mockReturnValue({
+      mediaAttachmentId: null,
+      openMedia,
+      closeMedia: vi.fn(),
+    })
+    const { onToggle } = renderRow({
+      onNewSubtopic: vi.fn(),
+      message: message({
+        attachments: [{ id: "att_pdf", filename: "spec.pdf", mimeType: "application/pdf" } as never],
+      }),
+    })
+    const chip = screen.getByRole("button", { name: "Open 1 attachment" })
+
+    fireEvent.touchStart(chip, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+    expect(screen.getByRole("button", { name: /New sub-topic/i })).toBeInTheDocument()
+
+    fireEvent.click(chip)
+    expect(openMedia).not.toHaveBeenCalled()
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
   it("leaves a long press on the link chip to the browser", () => {
     vi.useFakeTimers()
     renderRow({
@@ -269,6 +310,53 @@ describe("LedgerRow attachment chip", () => {
     await user.click(screen.getByRole("button", { name: "Open 1 attachment" }))
     expect(onToggle).toHaveBeenCalledTimes(1)
     expect(openMedia).not.toHaveBeenCalled()
+  })
+
+  it("only expands for a video that is still processing", async () => {
+    const user = userEvent.setup()
+    const { openMedia, onToggle } = renderWithGallery({
+      id: "att_vid",
+      filename: "clip.mp4",
+      mimeType: "video/mp4",
+      processingStatus: "pending",
+    })
+    await user.click(screen.getByRole("button", { name: "Open 1 attachment" }))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(openMedia).not.toHaveBeenCalled()
+  })
+
+  it("opens the gallery for a completed video", async () => {
+    const user = userEvent.setup()
+    const { openMedia } = renderWithGallery({
+      id: "att_vid",
+      filename: "clip.mp4",
+      mimeType: "video/mp4",
+      processingStatus: "completed",
+    })
+    await user.click(screen.getByRole("button", { name: "Open 1 attachment" }))
+    expect(openMedia).toHaveBeenCalledWith("att_vid")
+  })
+})
+
+describe("LedgerRow narrow viewport", () => {
+  it("keeps the native menu and hides the trigger cluster below sm", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const { container } = renderRow({ onNewSubtopic: vi.fn() })
+
+    expect(container.querySelector(".reveal-actions-hover-only")).toHaveClass("hidden")
+    await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("button", { name: /Pierre:/ }) })
+    expect(screen.queryByRole("menuitem", { name: /New sub-topic/i })).not.toBeInTheDocument()
+  })
+
+  it("shows the cluster and opens the menu on right-click at sm and up", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    const { container } = renderRow({ onNewSubtopic: vi.fn() })
+
+    expect(container.querySelector(".reveal-actions-hover-only")).not.toHaveClass("hidden")
+    await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("button", { name: /Pierre:/ }) })
+    expect(await screen.findByRole("menuitem", { name: /New sub-topic/i })).toBeInTheDocument()
   })
 })
 

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MediaGalleryProvider, PanelProvider, ServicesProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { RenderableMessage } from "@/components/message/message-item"
+import * as contextsModule from "@/contexts"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as emojiModule from "@/hooks/use-workspace-emoji"
+import * as touchCapableModule from "@/hooks/use-touch-capable"
+import * as messageHistoryDialogModule from "@/components/timeline/message-history-dialog"
+import * as conversationsModule from "@/hooks/use-conversations"
+import { spyOnExport } from "@/test/spy"
+import { LedgerEventGroup, LedgerRow } from "./ledger-row"
+
+const WS = "ws_1"
+const STREAM = "stream_1"
+const CONV = "conv_1"
+
+function message(overrides: Partial<RenderableMessage> = {}): RenderableMessage {
+  return {
+    id: "msg_1",
+    authorId: "usr_other",
+    authorType: "user",
+    contentMarkdown: "Ledger rows compress a message to one line",
+    reactions: {},
+    createdAt: "2026-07-28T10:04:00.000Z",
+    ...overrides,
+  }
+}
+
+function renderRow(overrides: Partial<Parameters<typeof LedgerRow>[0]> = {}) {
+  const onToggle = overrides.onToggle ?? vi.fn()
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <MediaGalleryProvider>
+              <TraceProvider>
+                <PanelProvider>
+                  <LedgerRow
+                    workspaceId={WS}
+                    streamId={STREAM}
+                    message={message()}
+                    authorName="Pierre"
+                    currentUserId="usr_me"
+                    expanded={false}
+                    leadLineLength={80}
+                    conversationId={CONV}
+                    conversationRootStreamId={STREAM}
+                    {...overrides}
+                    onToggle={onToggle}
+                  />
+                </PanelProvider>
+              </TraceProvider>
+            </MediaGalleryProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+  return { ...result, onToggle }
+}
+
+beforeEach(() => {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US", timeFormat: "24h" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("LedgerRow collapsed", () => {
+  it("shows the lead line, the time and the artifact chips", () => {
+    renderRow({
+      message: message({
+        attachments: [{ id: "att_1", filename: "spec.pdf" } as never],
+        linkPreviews: [
+          { url: "https://example.com/postgres", contentType: "website", title: "Postgres upsert docs" } as never,
+        ],
+      }),
+    })
+    expect(screen.getByText("Ledger rows compress a message to one line")).toBeInTheDocument()
+    expect(screen.getByText(/^\d{2}:\d{2}$/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open 1 attachment" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Postgres upsert docs" })).toHaveAttribute(
+      "href",
+      "https://example.com/postgres"
+    )
+  })
+
+  it("renders emoji shortcodes in the lead line as emoji", () => {
+    vi.spyOn(emojiModule, "useWorkspaceEmoji").mockReturnValue({
+      toEmoji: (shortcode: string) => (shortcode === "tada" ? "🎉" : null),
+    } as unknown as ReturnType<typeof emojiModule.useWorkspaceEmoji>)
+    renderRow({ message: message({ contentMarkdown: ":tada: shipped" }) })
+    expect(screen.getByText("🎉 shipped")).toBeInTheDocument()
+  })
+
+  it("renders a tombstone with no chips and no expand affordance", () => {
+    renderRow({
+      message: message({ contentMarkdown: "", deletedAt: "2026-07-28T11:00:00.000Z", attachments: [] }),
+    })
+    expect(screen.getByText("This message was deleted")).toBeInTheDocument()
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the attachment count, then to a no-text marker, when the lead is empty", () => {
+    const { unmount } = renderRow({
+      message: message({ contentMarkdown: "", attachments: [{ id: "att_1" } as never, { id: "att_2" } as never] }),
+    })
+    expect(screen.getByText("📎 2")).toBeInTheDocument()
+    unmount()
+    renderRow({ message: message({ contentMarkdown: "---" }) })
+    expect(screen.getByText("(no text)")).toBeInTheDocument()
+  })
+
+  it("keeps the link chip outside the expand button (no nested interactive element)", () => {
+    renderRow({
+      message: message({
+        linkPreviews: [{ url: "https://example.com/x", contentType: "website", title: "Docs" } as never],
+      }),
+    })
+    const rowButton = screen.getByRole("button", { name: /Pierre/ })
+    expect(rowButton.querySelector("a")).toBeNull()
+    expect(rowButton.querySelector("button")).toBeNull()
+  })
+})
+
+describe("LedgerRow toggle", () => {
+  it("fires onToggle on click and on Enter", async () => {
+    const user = userEvent.setup()
+    const { onToggle } = renderRow()
+    const rowButton = screen.getByRole("button", { name: /Pierre:/ })
+    await user.click(rowButton)
+    rowButton.focus()
+    await user.keyboard("{Enter}")
+    expect(onToggle).toHaveBeenCalledTimes(2)
+  })
+
+  it("renders the full message body when expanded, and minimizes from the header strip", async () => {
+    const user = userEvent.setup()
+    const { onToggle } = renderRow({ expanded: true })
+    expect(screen.getByText("Ledger rows compress a message to one line")).toBeInTheDocument()
+    expect(screen.getByText("Pierre")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Collapse message" }))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("LedgerRow actions", () => {
+  it("opens the shared message menu on right-click", async () => {
+    const user = userEvent.setup()
+    renderRow({ onNewSubtopic: vi.fn(), onMoveToSubtopic: vi.fn() })
+    await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("button", { name: /Pierre:/ }) })
+    expect(await screen.findByRole("menuitem", { name: /New sub-topic/i })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: /Move to sub-topic/i })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: /Label message/i })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: /Save for later/i })).toBeInTheDocument()
+  })
+})
+
+describe("LedgerRow touch long-press", () => {
+  beforeEach(() => {
+    vi.spyOn(touchCapableModule, "useTouchCapable").mockReturnValue(true)
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it("opens the action drawer from a long press on the row's own expand button", () => {
+    vi.useFakeTimers()
+    const { onToggle } = renderRow({ onNewSubtopic: vi.fn() })
+    const rowButton = screen.getByRole("button", { name: /Pierre:/ })
+
+    fireEvent.touchStart(rowButton, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.getByRole("button", { name: /New sub-topic/i })).toBeInTheDocument()
+    // The synthetic click that follows the hold must not also expand the row.
+    fireEvent.click(rowButton)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it("leaves a long press on the link chip to the browser", () => {
+    vi.useFakeTimers()
+    renderRow({
+      onNewSubtopic: vi.fn(),
+      message: message({
+        linkPreviews: [{ url: "https://example.com/x", contentType: "website", title: "Docs" } as never],
+      }),
+    })
+
+    fireEvent.touchStart(screen.getByRole("link", { name: "Docs" }), { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(screen.queryByRole("button", { name: /New sub-topic/i })).not.toBeInTheDocument()
+  })
+})
+
+describe("LedgerRow revisions", () => {
+  it("opens the edit-history dialog from See revisions", async () => {
+    const user = userEvent.setup()
+    spyOnExport(messageHistoryDialogModule, "MessageHistoryDialog").mockReturnValue((({ open }: { open: boolean }) =>
+      open ? <div>stub-history</div> : null) as unknown as typeof messageHistoryDialogModule.MessageHistoryDialog)
+    renderRow({ message: message({ editedAt: "2026-07-28T10:30:00.000Z" }) })
+
+    await user.pointer({ keys: "[MouseRight]", target: screen.getByRole("button", { name: /Pierre:/ }) })
+    await user.click(await screen.findByRole("menuitem", { name: /See revisions/i }))
+
+    expect(await screen.findByText("stub-history")).toBeInTheDocument()
+  })
+})
+
+describe("LedgerRow attachment chip", () => {
+  function renderWithGallery(attachment: Record<string, unknown>) {
+    const openMedia = vi.fn()
+    vi.spyOn(contextsModule, "useMediaGallery").mockReturnValue({
+      mediaAttachmentId: null,
+      openMedia,
+      closeMedia: vi.fn(),
+    })
+    const rendered = renderRow({ message: message({ attachments: [attachment as never] }) })
+    return { ...rendered, openMedia }
+  }
+
+  it("opens the gallery for a previewable first attachment", async () => {
+    const user = userEvent.setup()
+    const { openMedia, onToggle } = renderWithGallery({
+      id: "att_pdf",
+      filename: "spec.pdf",
+      mimeType: "application/pdf",
+    })
+    await user.click(screen.getByRole("button", { name: "Open 1 attachment" }))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(openMedia).toHaveBeenCalledWith("att_pdf")
+  })
+
+  it("only expands for a file the gallery cannot open — no ?media= param", async () => {
+    const user = userEvent.setup()
+    const { openMedia, onToggle } = renderWithGallery({
+      id: "att_zip",
+      filename: "build.zip",
+      mimeType: "application/zip",
+    })
+    await user.click(screen.getByRole("button", { name: "Open 1 attachment" }))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(openMedia).not.toHaveBeenCalled()
+  })
+})
+
+describe("LedgerRow settling", () => {
+  it("offers the settling pair instead of Move to sub-topic, and wears the settling texture", async () => {
+    const user = userEvent.setup()
+    const mutate = vi.fn()
+    vi.spyOn(conversationsModule, "useSettleConversationMessage").mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof conversationsModule.useSettleConversationMessage>)
+    renderRow({ message: message({ settling: true }), onMoveToSubtopic: vi.fn(), onNewSubtopic: vi.fn() })
+
+    const rowButton = screen.getByRole("button", { name: /Pierre:/ })
+    expect(rowButton.closest("[data-ledger-row]")).toHaveAttribute("data-settling")
+    expect(rowButton.closest("[data-ledger-row]")).toHaveClass("opacity-70")
+
+    await user.pointer({ keys: "[MouseRight]", target: rowButton })
+    expect(await screen.findByRole("menuitem", { name: "Keep here" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Not this topic…" })).toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: /Move to sub-topic/i })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("menuitem", { name: "Keep here" }))
+    expect(mutate).toHaveBeenCalledWith({ messageId: "msg_1", conversationId: CONV }, expect.anything())
+  })
+
+  it("keeps Move to sub-topic and no settling texture on a settled row", async () => {
+    const user = userEvent.setup()
+    renderRow({ onMoveToSubtopic: vi.fn(), onNewSubtopic: vi.fn() })
+    const rowButton = screen.getByRole("button", { name: /Pierre:/ })
+    expect(rowButton.closest("[data-ledger-row]")).not.toHaveAttribute("data-settling")
+
+    await user.pointer({ keys: "[MouseRight]", target: rowButton })
+    expect(await screen.findByRole("menuitem", { name: /Move to sub-topic/i })).toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "Keep here" })).not.toBeInTheDocument()
+  })
+})
+
+describe("LedgerEventGroup", () => {
+  const events = [
+    { key: "e1", icon: null, label: "memo captured" },
+    { key: "e2", icon: null, label: "thread split" },
+    { key: "e3", icon: null, label: "call" },
+  ]
+
+  it("coalesces to one composite row, expands to the individual rows, and re-coalesces", async () => {
+    const user = userEvent.setup()
+    render(<LedgerEventGroup events={events} />)
+    const summary = screen.getByRole("button", { name: /3 events/ })
+    expect(summary).toHaveTextContent("3 events — memo captured · thread split · call")
+    await user.click(summary)
+    expect(screen.getAllByRole("button")).toHaveLength(3)
+    expect(screen.getByText("memo captured")).toBeInTheDocument()
+    await user.click(screen.getByText("thread split"))
+    expect(screen.getByRole("button", { name: /3 events/ })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -172,6 +172,27 @@ describe("LedgerRow toggle", () => {
     await user.click(screen.getByRole("button", { name: "Collapse message" }))
     expect(onToggle).toHaveBeenCalledTimes(1)
   })
+
+  it("colorizes the rail beside an expanded agent body instead of a flush inner stripe", () => {
+    // A colored actor overlays its 2px border ON the ledger rail (the branch-rows
+    // idiom: -ml-2.5 pulls it over the wrapper's border, pl-2 pads the avatar off
+    // it) and the row's own inner accent — the flush-against-the-avatar bug — is
+    // suppressed.
+    const { container } = renderRow({ expanded: true, message: message({ authorType: "persona" }) })
+    const overlay = container.querySelector(".border-primary.border-l-2")
+    expect(overlay).toBeTruthy()
+    expect(overlay!.className).toContain("pl-2")
+    // The inset that pulls the colored border over the wrapper's neutral rail
+    // sits on the row's break-out wrapper, an ancestor of the surface element.
+    expect(overlay!.closest("[class*='-ml-2.5']")).toBeTruthy()
+    expect(container.querySelector("[class*='shadow-[inset_3px']")).toBeNull()
+  })
+
+  it("keeps a user-authored expanded body plain against the neutral rail", () => {
+    const { container } = renderRow({ expanded: true })
+    expect(container.querySelector(".border-primary")).toBeNull()
+    expect(container.querySelector(".-ml-2\\.5")).toBeNull()
+  })
 })
 
 describe("LedgerRow actions", () => {

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -1,0 +1,524 @@
+import { useCallback, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react"
+import { useNavigate } from "react-router-dom"
+import { toast } from "sonner"
+import { ChevronUp, ChevronRight, Paperclip, Link2 } from "lucide-react"
+import { LabelableResourceTypes, LinkPreviewContentTypes } from "@threa/types"
+import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
+import { actorRowTheme } from "@/components/message/actor-row-theme"
+import { MessageContextMenu } from "@/components/timeline/message-context-menu"
+import { MessageActionDrawer } from "@/components/timeline/message-action-drawer"
+import { MessageHistoryDialog } from "@/components/timeline/message-history-dialog"
+import { isGalleryPreviewableAttachment } from "@/components/timeline/attachment-list"
+import { ReactionEmojiPicker } from "@/components/timeline/reaction-emoji-picker"
+import { ReminderPickerSheet } from "@/components/timeline/reminder-picker-sheet"
+import type { MessageActionContext } from "@/components/timeline/message-actions"
+import { LabelPicker } from "@/components/labels/label-picker"
+import { useMediaGallery } from "@/contexts"
+import { useFormattedDate } from "@/hooks/use-formatted-date"
+import { useLongPress } from "@/hooks/use-long-press"
+import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
+import { useTouchCapable } from "@/hooks/use-touch-capable"
+import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
+import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
+import { useSettleConversationMessage } from "@/hooks/use-conversations"
+import { leadLine, rowArtifacts } from "@/lib/board/ledger"
+import { resolveInternalAppPath } from "@/lib/internal-url"
+import { getInitials } from "@/lib/initials"
+import { cn } from "@/lib/utils"
+
+const TOMBSTONE_LEAD = "This message was deleted"
+const EMPTY_LEAD = "(no text)"
+
+interface LedgerRowProps {
+  workspaceId: string
+  streamId: string
+  message: RenderableMessage
+  authorName: string
+  currentUserId: string | null
+  expanded: boolean
+  onToggle: () => void
+  /** Tints the row's left rail — the reader hasn't seen this one yet. */
+  unread?: boolean
+  /** Lead-line budget in characters (the user's ledger density preference). */
+  leadLineLength: number
+  conversationId: string
+  conversationRootStreamId: string
+  onNewSubtopic?: () => void
+  onMoveToSubtopic?: () => void
+  /** Nested-branch placement: the row indents and drops its own left rail width. */
+  indent?: "branch"
+}
+
+/**
+ * One ledger line: a message compressed to a single row — actor glyph, lead
+ * line, artifact chips, time — that expands in place into the full
+ * {@link MessageItem} (same body, same action surface, same reactions). The
+ * collapsed row keeps the message's action surface through the SAME components
+ * the timeline and card rows use (`MessageContextMenu` / `MessageActionDrawer`
+ * over one `MessageActionContext`), so nothing is a ledger-only affordance.
+ *
+ * Expansion grows downward only — the header strip occupies the collapsed row's
+ * own line — so nothing above the row moves (INV-21).
+ */
+export function LedgerRow({
+  workspaceId,
+  streamId,
+  message,
+  authorName,
+  currentUserId,
+  expanded,
+  onToggle,
+  unread,
+  leadLineLength,
+  conversationId,
+  conversationRootStreamId,
+  onNewSubtopic,
+  onMoveToSubtopic,
+  indent,
+}: LedgerRowProps) {
+  const { formatTime, formatFull } = useFormattedDate()
+  const { openMedia } = useMediaGallery()
+  const touchCapable = useTouchCapable()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [labelPickerOpen, setLabelPickerOpen] = useState(false)
+  const [reminderSheetOpen, setReminderSheetOpen] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [historyOpen, setHistoryOpen] = useState(false)
+
+  const theme = actorRowTheme(message.authorType)
+  const tombstone = Boolean(message.deletedAt)
+  const sentAt = useMemo(() => new Date(message.createdAt), [message.createdAt])
+  const artifacts = rowArtifacts(message)
+  // The URL behind `firstLinkLabel`. `rowArtifacts` returns the label only, so
+  // the preview is re-selected here with its own predicate — keep the two in
+  // step if the selection ever changes.
+  const linkPreview = artifacts.firstLinkLabel
+    ? (message.linkPreviews ?? []).find((p) => p.contentType !== LinkPreviewContentTypes.STREAM_LINK)
+    : undefined
+  const firstAttachment = message.attachments?.[0] ?? null
+  const settling = Boolean(message.settling) && !tombstone
+
+  const { toEmoji } = useWorkspaceEmoji(workspaceId)
+  const lead = tombstone ? TOMBSTONE_LEAD : ledgerLead(message.contentMarkdown, leadLineLength, artifacts, toEmoji)
+
+  // The whole collapsed row is one <button> (tap = expand, Enter/Space = expand),
+  // so deferring to interactive descendants would kill long-press everywhere on
+  // the row. Defer to real links only — the link chip keeps the browser's native
+  // "Copy link" menu — and swallow the synthetic click that follows the hold so
+  // the drawer doesn't also expand the row.
+  const suppressToggleRef = useRef(false)
+  const openDrawer = useCallback(() => {
+    suppressToggleRef.current = true
+    setDrawerOpen(true)
+  }, [])
+  const longPress = useLongPress({
+    onLongPress: openDrawer,
+    enabled: touchCapable && !tombstone,
+    deferToNativeLinks: true,
+  })
+  const handleToggle = useCallback(() => {
+    if (suppressToggleRef.current) {
+      suppressToggleRef.current = false
+      return
+    }
+    onToggle()
+  }, [onToggle])
+
+  // Reactions, save, reminder and label are the collapsed row's own state; every
+  // other entry the menu shows is derived from the context below, exactly as on
+  // the full row.
+  const { toggleByEmoji } = useMessageReactions(workspaceId, message.id)
+  const handleAddReaction = useCallback(
+    (emoji: string) => toggleByEmoji(emoji, message.reactions, currentUserId),
+    [toggleByEmoji, message.reactions, currentUserId]
+  )
+  const activeReactionShortcodes = useMemo(() => {
+    if (!currentUserId) return new Set<string>()
+    const active = new Set<string>()
+    for (const [shortcode, userIds] of Object.entries(message.reactions)) {
+      if (userIds.includes(currentUserId)) active.add(stripColons(shortcode))
+    }
+    return active
+  }, [currentUserId, message.reactions])
+  const allReactionShortcodes = useMemo(() => reactionShortcodes(message.reactions), [message.reactions])
+
+  const savedForMessage = useSavedForMessage(workspaceId, message.id)
+  const saveMessageMutation = useSaveMessage(workspaceId)
+  const unsaveMessageMutation = useDeleteSaved(workspaceId)
+  const isSaved = !!savedForMessage && savedForMessage.status === "saved"
+  const handleToggleSave = useCallback(() => {
+    if (saveMessageMutation.isPending || unsaveMessageMutation.isPending) return
+    if (!savedForMessage || savedForMessage.status !== "saved") {
+      saveMessageMutation.mutate(
+        { messageId: message.id, conversationId },
+        { onError: () => toast.error("Could not save message") }
+      )
+      return
+    }
+    unsaveMessageMutation.mutate(savedForMessage.id, { onError: () => toast.error("Could not remove saved item") })
+  }, [savedForMessage, saveMessageMutation, unsaveMessageMutation, message.id, conversationId])
+
+  // The settling pair, exactly as the full row derives it: wired only while the
+  // row is still settling, and "Not this topic…" reuses the move picker rather
+  // than adding a second entry for the same dialog (INV-35).
+  const settleMessage = useSettleConversationMessage(workspaceId, conversationRootStreamId)
+  const isSettling = Boolean(message.settling && conversationId)
+  const handleKeepInConversation = useCallback(() => {
+    if (settleMessage.isPending) return
+    settleMessage.mutate(
+      { messageId: message.id, conversationId },
+      { onError: () => toast.error("Couldn't confirm the message. Please try again.") }
+    )
+  }, [settleMessage, conversationId, message.id])
+
+  const menuContext: MessageActionContext = {
+    contentMarkdown: message.contentMarkdown,
+    actorType: message.authorType,
+    authorId: message.authorId,
+    currentUserId: currentUserId ?? undefined,
+    isThreadParent: true,
+    replyUrl: "",
+    messageId: message.id,
+    workspaceId,
+    streamId,
+    conversationId,
+    reactions: message.reactions,
+    editedAt: message.editedAt ?? undefined,
+    // Defer so the closing menu/drawer doesn't fight the dialog open (as MessageItem).
+    onShowHistory: () => setTimeout(() => setHistoryOpen(true), 0),
+    onReact: handleAddReaction,
+    onOpenFullPicker: () => setPickerOpen(true),
+    isSaved,
+    onToggleSave: handleToggleSave,
+    onRequestReminder: () => setReminderSheetOpen(true),
+    onLabelMessage: () => setLabelPickerOpen(true),
+    onNewSubtopic,
+    onMoveToSubtopic: isSettling ? undefined : onMoveToSubtopic,
+    onKeepInConversation: isSettling ? handleKeepInConversation : undefined,
+    onNotThisTopic: isSettling ? onMoveToSubtopic : undefined,
+  }
+
+  const overlays = tombstone ? null : (
+    <>
+      {touchCapable && (
+        <MessageActionDrawer
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+          context={menuContext}
+          authorName={authorName}
+        />
+      )}
+      {labelPickerOpen && (
+        <LabelPicker
+          workspaceId={workspaceId}
+          resourceType={LabelableResourceTypes.MESSAGE}
+          resourceId={message.id}
+          open={labelPickerOpen}
+          onOpenChange={setLabelPickerOpen}
+        />
+      )}
+      {reminderSheetOpen && (
+        <ReminderPickerSheet
+          open={reminderSheetOpen}
+          onOpenChange={setReminderSheetOpen}
+          workspaceId={workspaceId}
+          messageId={message.id}
+          conversationId={conversationId}
+          saved={savedForMessage ?? null}
+        />
+      )}
+      {historyOpen && (
+        <MessageHistoryDialog
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+          messageId={message.id}
+          workspaceId={workspaceId}
+          messageCreatedAt={String(message.createdAt)}
+          currentContent={{
+            contentMarkdown: message.contentMarkdown,
+            editedAt: message.editedAt ?? undefined,
+          }}
+        />
+      )}
+      {pickerOpen && (
+        <ReactionEmojiPicker
+          workspaceId={workspaceId}
+          onSelect={handleAddReaction}
+          activeShortcodes={activeReactionShortcodes}
+          allReactionShortcodes={allReactionShortcodes}
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+        />
+      )}
+    </>
+  )
+
+  const railClassName = cn(
+    "border-l-2 pl-2",
+    unread ? "border-destructive/70" : "border-muted-foreground/20",
+    indent === "branch" && "ml-3"
+  )
+
+  const glyph = (
+    <span
+      aria-hidden
+      className={cn(
+        "grid size-4 shrink-0 place-items-center rounded-full bg-muted text-[9px] font-semibold",
+        theme.nameClassName
+      )}
+    >
+      {getInitials(authorName).slice(0, 1)}
+    </span>
+  )
+
+  const time = (
+    <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/70" title={formatFull(sentAt)}>
+      {formatTime(sentAt)}
+    </span>
+  )
+
+  if (expanded) {
+    return (
+      <div className={railClassName}>
+        {/* Minimize strip: the collapsed row's own line, so the body grows below
+            it and nothing above the row moves (INV-21). */}
+        <div className="flex items-center gap-2 py-0.5">
+          {glyph}
+          {time}
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-label="Collapse message"
+            className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronUp className="size-3.5" />
+          </button>
+        </div>
+        <MessageItem
+          workspaceId={workspaceId}
+          streamId={streamId}
+          message={message}
+          authorName={authorName}
+          currentUserId={currentUserId}
+          conversationId={conversationId}
+          conversationRootStreamId={conversationRootStreamId}
+          onNewSubtopic={onNewSubtopic}
+          onMoveToSubtopic={onMoveToSubtopic}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-ledger-row=""
+      data-message-id={message.id}
+      data-settling={settling ? "" : undefined}
+      className={cn(
+        "reveal-host group relative flex items-center gap-2 py-0.5 transition-opacity duration-300",
+        railClassName,
+        // Provisional placement wears the same texture as the full row: muted
+        // content plus the always-mounted dashed rail below (INV-21).
+        settling && "opacity-70"
+      )}
+      onContextMenu={
+        tombstone
+          ? undefined
+          : (e) => {
+              if (touchCapable) {
+                longPress.handlers.onContextMenu(e)
+                return
+              }
+              e.preventDefault()
+              setMenuOpen(true)
+            }
+      }
+      {...(touchCapable && !tombstone
+        ? {
+            onTouchStart: longPress.handlers.onTouchStart,
+            onTouchMove: longPress.handlers.onTouchMove,
+            onTouchEnd: longPress.handlers.onTouchEnd,
+            onTouchCancel: longPress.handlers.onTouchCancel,
+          }
+        : {})}
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-0 left-0 w-0 border-l-[2px] border-dashed transition-colors duration-300",
+          settling ? "border-muted-foreground/40" : "border-transparent"
+        )}
+      />
+      {settling && <span className="sr-only">Still settling — this message may move to another topic</span>}
+      {tombstone ? (
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {glyph}
+          <span className="min-w-0 flex-1 truncate text-xs italic text-muted-foreground">{lead}</span>
+        </div>
+      ) : (
+        // Text only — the chips beside it are their own controls, so the row's
+        // expand button never nests an interactive element.
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-expanded={false}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {glyph}
+          <span className="sr-only">{authorName}: </span>
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground/85">{lead}</span>
+        </button>
+      )}
+      {!tombstone && artifacts.attachmentCount > 0 && firstAttachment && (
+        <button
+          type="button"
+          onClick={() => {
+            // The gallery lives in the expanded row's `AttachmentList` (the one
+            // attachment-open path); expanding is what mounts it. A file the
+            // gallery can't open (a zip, an installer) only expands — writing
+            // `?media=` for it would leave a param nothing claims, which breaks
+            // the NEXT gallery open's history.
+            handleToggle()
+            if (isGalleryPreviewableAttachment(firstAttachment)) openMedia(firstAttachment.id)
+          }}
+          aria-label={`Open ${artifacts.attachmentCount} attachment${artifacts.attachmentCount === 1 ? "" : "s"}`}
+          className="flex shrink-0 items-center gap-0.5 rounded px-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Paperclip className="size-3" />
+          {artifacts.attachmentCount}
+        </button>
+      )}
+      {!tombstone && linkPreview && artifacts.firstLinkLabel && (
+        <LedgerLinkChip url={linkPreview.url} label={artifacts.firstLinkLabel} />
+      )}
+      {time}
+      {!tombstone && (
+        <div className="reveal-actions-hover-only hidden shrink-0 sm:block">
+          <MessageContextMenu context={menuContext} open={menuOpen} onOpenChange={setMenuOpen} />
+        </div>
+      )}
+      {overlays}
+    </div>
+  )
+}
+
+/** The collapsed lead, with the artifact-only and empty fallbacks. */
+function ledgerLead(
+  contentMarkdown: string,
+  leadLineLength: number,
+  artifacts: { attachmentCount: number },
+  toEmoji?: (shortcode: string) => string | null
+): string {
+  const lead = leadLine(contentMarkdown, leadLineLength, toEmoji)
+  if (lead) return lead
+  if (artifacts.attachmentCount > 0) return `📎 ${artifacts.attachmentCount}`
+  return EMPTY_LEAD
+}
+
+/**
+ * The link artifact chip — a real anchor (so middle-click/copy-link work), with
+ * same-origin targets routed through the router instead of a full page load
+ * (the shared `resolveInternalAppPath` path).
+ */
+function LedgerLinkChip({ url, label }: { url: string; label: string }) {
+  const navigate = useNavigate()
+  const internalPath = resolveInternalAppPath(url)
+  return (
+    <a
+      href={internalPath ?? url}
+      {...(internalPath
+        ? {
+            onClick: (e: MouseEvent<HTMLAnchorElement>) => {
+              if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+              e.preventDefault()
+              navigate(internalPath)
+            },
+          }
+        : { target: "_blank", rel: "noreferrer" })}
+      className="flex max-w-[10rem] shrink-0 items-center gap-0.5 rounded px-1 text-[10px] text-muted-foreground no-underline transition-colors hover:text-foreground"
+    >
+      <Link2 className="size-3 shrink-0" />
+      <span className="truncate">{label}</span>
+    </a>
+  )
+}
+
+/**
+ * A non-message ledger line (agent session, memo capture, call…): hair-thin,
+ * muted, tighter than a message row so the eye skips it unless it's looking.
+ * Purely presentational — the surface supplies the icon, label and meta.
+ */
+export function LedgerEventRow({
+  icon,
+  label,
+  meta,
+  onToggle,
+  expanded,
+}: {
+  icon: ReactNode
+  label: string
+  meta?: string
+  onToggle?: () => void
+  expanded?: boolean
+}) {
+  const content = (
+    <>
+      <span aria-hidden className="flex size-3 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <span className="min-w-0 truncate">{label}</span>
+      {meta && <span className="shrink-0 text-muted-foreground/70">· {meta}</span>}
+    </>
+  )
+  const className = "flex w-full items-center gap-1.5 py-px text-left text-xs text-muted-foreground"
+  if (!onToggle) return <div className={className}>{content}</div>
+  return (
+    <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={className}>
+      {content}
+    </button>
+  )
+}
+
+export interface LedgerEventDescriptor {
+  key: string
+  icon: ReactNode
+  label: string
+  meta?: string
+}
+
+/**
+ * A coalesced run of events (the `coalesceLedgerItems` grouping): one thin
+ * summary row that expands in place into the individual rows and re-coalesces
+ * on a second tap.
+ */
+export function LedgerEventGroup({ events }: { events: LedgerEventDescriptor[] }) {
+  const [expanded, setExpanded] = useState(false)
+  const toggle = useCallback(() => setExpanded((e) => !e), [])
+  if (expanded) {
+    return (
+      <div>
+        {events.map((event) => (
+          <LedgerEventRow
+            key={event.key}
+            icon={event.icon}
+            label={event.label}
+            meta={event.meta}
+            // Any of the rows re-coalesces the group — the reader's way back is
+            // wherever their eye landed.
+            onToggle={toggle}
+            expanded
+          />
+        ))}
+      </div>
+    )
+  }
+  return (
+    <LedgerEventRow
+      icon={<ChevronRight className="size-3" />}
+      label={`${events.length} events — ${events.map((e) => e.label).join(" · ")}`}
+      onToggle={toggle}
+      expanded={false}
+    />
+  )
+}

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -286,6 +286,13 @@ export function LedgerRow({
   )
 
   if (expanded) {
+    // A colored actor (persona gold / bot green / system) colorizes the LEDGER
+    // RAIL beside its body — the branch-rows idiom: its 2px border overlays the
+    // wrapper's neutral rail at the same x (`-ml-2.5` = border + pl-2), content
+    // re-padded (`pl-2`) so the avatar sits off the rail, and the row's own
+    // inner accent stripe is suppressed (flush-against-the-avatar was the bug).
+    // A user row stays plain, so the neutral rail shows through.
+    const actorRail = theme.railClassName
     return (
       <div className={railClassName}>
         {/* Minimize strip: the collapsed row's own line, so the body grows below
@@ -312,6 +319,9 @@ export function LedgerRow({
           conversationRootStreamId={conversationRootStreamId}
           onNewSubtopic={onNewSubtopic}
           onMoveToSubtopic={onMoveToSubtopic}
+          suppressRowAccent
+          surfaceClassName={actorRail ? cn("bg-card border-l-2 pl-2", actorRail) : undefined}
+          rowInsetClassName={actorRail ? "-ml-2.5" : undefined}
         />
       </div>
     )

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -18,6 +18,7 @@ import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useLongPress } from "@/hooks/use-long-press"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { useSettleConversationMessage } from "@/hooks/use-conversations"
@@ -28,6 +29,8 @@ import { cn } from "@/lib/utils"
 
 const TOMBSTONE_LEAD = "This message was deleted"
 const EMPTY_LEAD = "(no text)"
+/** Window after a long press in which the synthetic click it produces is ignored. */
+const SYNTHETIC_CLICK_SUPPRESS_MS = 700
 
 interface LedgerRowProps {
   workspaceId: string
@@ -79,6 +82,9 @@ export function LedgerRow({
   const { formatTime, formatFull } = useFormattedDate()
   const { openMedia } = useMediaGallery()
   const touchCapable = useTouchCapable()
+  // One signal for both the menu trigger's visibility and the right-click branch
+  // that anchors to it — matches the `sm:` breakpoint the cluster used to hide at.
+  const narrow = useIsMobile()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
@@ -107,9 +113,13 @@ export function LedgerRow({
   // the row. Defer to real links only — the link chip keeps the browser's native
   // "Copy link" menu — and swallow the synthetic click that follows the hold so
   // the drawer doesn't also expand the row.
-  const suppressToggleRef = useRef(false)
+  // A time window, not a one-shot latch: an iOS hold that produces no synthetic
+  // click (drawer dismissed, touchcancel, scroll-away) would leave a boolean
+  // latched and swallow the next real tap.
+  const suppressClicksUntilRef = useRef(0)
+  const clickSuppressed = useCallback(() => Date.now() < suppressClicksUntilRef.current, [])
   const openDrawer = useCallback(() => {
-    suppressToggleRef.current = true
+    suppressClicksUntilRef.current = Date.now() + SYNTHETIC_CLICK_SUPPRESS_MS
     setDrawerOpen(true)
   }, [])
   const longPress = useLongPress({
@@ -118,12 +128,9 @@ export function LedgerRow({
     deferToNativeLinks: true,
   })
   const handleToggle = useCallback(() => {
-    if (suppressToggleRef.current) {
-      suppressToggleRef.current = false
-      return
-    }
+    if (clickSuppressed()) return
     onToggle()
-  }, [onToggle])
+  }, [clickSuppressed, onToggle])
 
   // Reactions, save, reminder and label are the collapsed row's own state; every
   // other entry the menu shows is derived from the context below, exactly as on
@@ -330,6 +337,10 @@ export function LedgerRow({
                 longPress.handlers.onContextMenu(e)
                 return
               }
+              // The menu's trigger is the same cluster hidden below `sm`;
+              // anchoring Radix to a zero-rect trigger would put the menu in the
+              // corner, so narrow non-touch keeps the browser's native menu.
+              if (narrow) return
               e.preventDefault()
               setMenuOpen(true)
             }
@@ -374,6 +385,10 @@ export function LedgerRow({
         <button
           type="button"
           onClick={() => {
+            // The hold that opened the drawer bubbled from this chip, so the
+            // synthetic click that follows must open nothing at all — gallery
+            // included, not just the expand.
+            if (clickSuppressed()) return
             // The gallery lives in the expanded row's `AttachmentList` (the one
             // attachment-open path); expanding is what mounts it. A file the
             // gallery can't open (a zip, an installer) only expands — writing
@@ -394,7 +409,7 @@ export function LedgerRow({
       )}
       {time}
       {!tombstone && (
-        <div className="reveal-actions-hover-only hidden shrink-0 sm:block">
+        <div className={cn("reveal-actions-hover-only shrink-0", narrow ? "hidden" : "block")}>
           <MessageContextMenu context={menuContext} open={menuOpen} onOpenChange={setMenuOpen} />
         </div>
       )}

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -607,11 +607,12 @@ function FileAttachment({ attachment, workspaceId, isHighlighted }: AttachmentIt
  * classification the lists in {@link AttachmentList} are built from. Collapsed
  * surfaces (the board ledger row) ask before writing a `?media=` param, so a
  * non-previewable file falls to the expanded list's download chip instead of
- * leaving a dead param behind.
+ * leaving a dead param behind. A video only enters `galleryItems` once its
+ * transcode is terminal-and-playable, so a still-processing one answers false.
  */
 export function isGalleryPreviewableAttachment(a: AttachmentSummary): boolean {
   if (a.mimeType.startsWith("image/")) return true
-  if (a.processingStatus) return a.processingStatus !== "failed"
+  if (a.processingStatus) return a.processingStatus === "completed" || a.processingStatus === "skipped"
   return isMarkdownAttachment(a) || isHtmlAttachment(a) || isPdfAttachment(a) || isTextPreviewableAttachment(a)
 }
 

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -602,6 +602,19 @@ function FileAttachment({ attachment, workspaceId, isHighlighted }: AttachmentIt
   )
 }
 
+/**
+ * Whether this attachment is one the gallery below can actually open — the same
+ * classification the lists in {@link AttachmentList} are built from. Collapsed
+ * surfaces (the board ledger row) ask before writing a `?media=` param, so a
+ * non-previewable file falls to the expanded list's download chip instead of
+ * leaving a dead param behind.
+ */
+export function isGalleryPreviewableAttachment(a: AttachmentSummary): boolean {
+  if (a.mimeType.startsWith("image/")) return true
+  if (a.processingStatus) return a.processingStatus !== "failed"
+  return isMarkdownAttachment(a) || isHtmlAttachment(a) || isPdfAttachment(a) || isTextPreviewableAttachment(a)
+}
+
 export function AttachmentList({ attachments, workspaceId, className, deferHydration = false }: AttachmentListProps) {
   const attachmentContext = useAttachmentContext()
   const hoveredAttachmentId = attachmentContext?.hoveredAttachmentId ?? null

--- a/apps/frontend/src/components/timeline/message-context-menu.tsx
+++ b/apps/frontend/src/components/timeline/message-context-menu.tsx
@@ -24,10 +24,19 @@ import {
 
 interface MessageContextMenuProps {
   context: MessageActionContext
+  /** Drive the menu from outside (the ledger row opens it on right-click).
+   *  Omitted ⇒ the trigger owns the state, as every existing caller expects. */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
-export function MessageContextMenu({ context }: MessageContextMenuProps) {
-  const [open, setOpen] = useState(false)
+export function MessageContextMenu({ context, open: openProp, onOpenChange }: MessageContextMenuProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = openProp ?? uncontrolledOpen
+  const setOpen = (next: boolean) => {
+    setUncontrolledOpen(next)
+    onOpenChange?.(next)
+  }
   const actions = getVisibleActions(context)
   const groupedActions = useMemo(() => groupVisibleActions(actions), [actions])
 


### PR DESCRIPTION
## Problem

Chunk 3 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): the row primitives every ledger surface renders — before the card can become a ledger (chunk 4), the row itself must carry the full message action surface in one line.

## Solution

- `LedgerRow` (new): collapsed = actor glyph + `leadLine` + artifact chips + time, the row a single button (Enter/Space toggles); expanded = the full `MessageItem` inline under a minimize strip — growth strictly downward (INV-21). Tombstones render as static deleted-lead rows.
- Full action parity with MessageItem on the COLLAPSED row: `MessageContextMenu` (right-click/hover) + `MessageActionDrawer` (touch long-press via `deferToNativeLinks`, so the row-button does not swallow the hold), See-revisions wired to `MessageHistoryDialog`, settling gates mirrored (`Keep here`/`Not this topic…` while settling, `Move to sub-topic…` withheld, dashed settling rail position-only).
- Attachment chip expands and opens the gallery only for gallery-eligible files (new exported `isGalleryPreviewableAttachment` from attachment-list — its own classification, no parallel MIME table); a zip-first message just expands, no dead `?media=` param. Link chips: in-app kind nouns / web titles from chunk 2.
- `LedgerEventRow` + `LedgerEventGroup`: hair-thin presentational event rows; coalesced runs expand in place (chunk 6 feeds real events).
- `MessageContextMenu` gains additive `open`/`onOpenChange` (existing callers unchanged) so the row can drive the same menu.
- Known duplication, deliberate: ~50 lines of action wiring mirrored from MessageItem rather than editing it mid-stack; extraction is a whole-stack-review candidate.

## Test plan

- [x] 627 tests green across board/timeline/message suites (13 new row tests incl. touch drawer, settling menu, zip-vs-pdf chip, history dialog — every verifier fix falsification-checked); tsc + lint clean. Adversarial verify (Opus high): 4 findings, 4 accepted+fixed, 0 refuted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788283689&installation_model_id=20758&pr_number=1726&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1726&signature=36e4f9a0db45cd3533dc7f72d39905926bb96870dcbd6f4f46d4b9b379010f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->