### PR TITLE
feat(board): the card renders the ledger

### DIFF
--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, act } from "@testing-library/react"
+import { cleanup, render, screen, act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPostMessage } from "@threa/types"
@@ -75,6 +75,10 @@ class FakeIntersectionObserver {
   }
 }
 
+// The card's ledger wants the whole conversation window, so it arms the backfill
+// whenever the local rail is short — the harness answers it (an absent method
+// would throw inside the query, off the test's own await path).
+const getBoardMessages = vi.fn().mockResolvedValue([])
 const markRead = vi.fn().mockResolvedValue({ streams: [] })
 const markUnread = vi.fn().mockResolvedValue({ streams: [] })
 
@@ -83,7 +87,7 @@ function mountCard(onSeen?: () => void) {
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ServicesProvider services={{ conversations: { markRead, markUnread } as never }}>
+        <ServicesProvider services={{ conversations: { markRead, markUnread, getBoardMessages } as never }}>
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <PanelProvider>
               <BoardCard
@@ -166,6 +170,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // Unmount BEFORE the mocks are restored: the card's backfill settles
+  // asynchronously, and a still-mounted card re-rendering against restored (real)
+  // hooks blows up on the hook-count difference.
+  cleanup()
   vi.runOnlyPendingTimers()
   vi.useRealTimers()
   vi.unstubAllGlobals()

--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { StreamTypes } from "@threa/types"
 import { BoardCard } from "./board-card"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
-import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
@@ -141,7 +141,14 @@ function mount(post: CachedBoardPost) {
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <TraceProvider>
               <PanelProvider>
-                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+                <MediaGalleryProvider>
+                  <BoardCard
+                    workspaceId={WS}
+                    post={post as BoardViewPost}
+                    contextLabel="#general"
+                    streamType="channel"
+                  />
+                </MediaGalleryProvider>
               </PanelProvider>
             </TraceProvider>
           </MemoryRouter>
@@ -306,8 +313,9 @@ describe("BoardCard branches", () => {
     const { container } = mount(post)
     await screen.findByText("Moved into the thread.")
     expect(await screen.findByText(/continued in/)).toBeTruthy()
-    // Soft renders flat: no indent wrapper (the spanning left rail).
-    expect(container.querySelector(".border-l-2")).toBeNull()
+    // Soft renders flat: no indent wrapper (the spanning left rail). A ledger row
+    // carries its own `border-l-2` rail, so the assertion names the indent classes.
+    expect(container.querySelector(".ml-3.border-l-2, .ml-6.border-l-2")).toBeNull()
   })
 
   it("renders a convert-to-thread continuation with no seam or split chrome", async () => {

--- a/apps/frontend/src/components/board/board-card.split.test.tsx
+++ b/apps/frontend/src/components/board/board-card.split.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { StreamTypes } from "@threa/types"
 import { BoardCard } from "./board-card"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
-import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
@@ -128,7 +128,14 @@ function mount(post: CachedBoardPost) {
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <TraceProvider>
               <PanelProvider>
-                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+                <MediaGalleryProvider>
+                  <BoardCard
+                    workspaceId={WS}
+                    post={post as BoardViewPost}
+                    contextLabel="#general"
+                    streamType="channel"
+                  />
+                </MediaGalleryProvider>
               </PanelProvider>
             </TraceProvider>
           </MemoryRouter>

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPostMessage } from "@threa/types"
 import { BoardCard } from "./board-card"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
-import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
@@ -26,9 +26,10 @@ import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as inlineComposerModule from "@/components/board/board-inline-composer"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import * as boardStoreModule from "@/stores/board-store"
+import * as revealAnchorModule from "@/hooks/use-board-card-reveal-anchor"
 import { setBoardFlash, resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { spyOnExport } from "@/test/spy"
-import { MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
+import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 import { formatDayDivider, localStartOfDayMs } from "@/lib/dates"
 
 const WS = "ws_1"
@@ -91,7 +92,9 @@ function cardTree(post: BoardViewPost, conversations: Record<string, unknown>, q
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <TraceProvider>
               <PanelProvider>
-                <BoardCard workspaceId={WS} post={post} contextLabel="#general" streamType="channel" />
+                <MediaGalleryProvider>
+                  <BoardCard workspaceId={WS} post={post} contextLabel="#general" streamType="channel" />
+                </MediaGalleryProvider>
               </PanelProvider>
             </TraceProvider>
           </MemoryRouter>
@@ -755,7 +758,7 @@ describe("BoardCard deleted messages", () => {
     expect(container.querySelector('[data-message-id="m_r1"]')?.textContent).toBe("This message was deleted")
   })
 
-  it("renders a tombstone, not a blank row, for a deleted reply from the expand backfill", async () => {
+  it("renders a tombstone, not a blank row, for a deleted reply from the backfill", async () => {
     const getBoardMessages = vi.fn().mockResolvedValue([
       openingMessage(),
       {
@@ -772,12 +775,14 @@ describe("BoardCard deleted messages", () => {
         deletedAt: "2026-06-22T12:11:00.000Z",
       },
     ])
+    // The rail has READ and holds the opening — the backfill only arms on a
+    // rail-resolved card — but the reply member is out of its window.
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10)])
     const post = makePost({ messageIds: ["m_open", "m_r2"] })
     ;(post as unknown as { totalReplies: number }).totalReplies = 1
     const { container } = mountCard(post, { getBoardMessages })
 
-    await userEvent.click(await screen.findByText(/1 older message/))
-
+    // The ledger wants the whole window, so the backfill arms on its own.
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
     expect(container.querySelector('[data-message-id="m_r2"]')?.textContent).toBe("This message was deleted")
   })
@@ -799,10 +804,6 @@ describe("BoardCard deleted messages", () => {
     const post = makePost({ messageIds: ["m_open", "m_r1", "m_r2", "m_rd", "m_r3", "m_r4", "m_r5"] })
     ;(post as unknown as { totalReplies: number }).totalReplies = 5
     mountCard(post)
-
-    // Collapsed the card previews the trailing live replies only; expanding falls
-    // through to the complete local rail.
-    await userEvent.click(await screen.findByText(/2 older messages/))
 
     expect(await screen.findByText("This message was deleted")).toBeTruthy()
     expect(screen.queryByText("The deleted body.")).toBeNull()
@@ -1025,20 +1026,19 @@ describe("BoardCard settling actions", () => {
 
 describe("BoardCard backfill invalidation", () => {
   it("refetches when membership gains an id neither the rail nor the store can render", async () => {
-    // The card shares `useConversationBackfill` with the panel, so an expanded
-    // card revalidates on a genuinely new member instead of waiting out the 60s
-    // `staleTime`.
+    // The card shares `useConversationBackfill` with the panel, so it revalidates
+    // on a genuinely new member instead of waiting out the 60s `staleTime`.
     const getBoardMessages = vi
       .fn()
       .mockResolvedValue([
         openingMessage(),
         openingMessage({ id: "m_r1", contentMarkdown: "Reply body.", createdAt: "2026-06-22T12:00:10.000Z" }),
       ])
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10)])
     const post = makePost({ messageIds: ["m_open", "m_r1"] })
     ;(post as unknown as { totalReplies: number }).totalReplies = 1
     const { rerenderPost } = mountCard(post, { getBoardMessages })
 
-    await userEvent.click(await screen.findByText(/1 older message/))
     await waitFor(() => expect(getBoardMessages).toHaveBeenCalledTimes(1))
 
     const grown = makePost({ messageIds: ["m_open", "m_r1", "m_r2"] })
@@ -1049,252 +1049,315 @@ describe("BoardCard backfill invalidation", () => {
   })
 })
 
-/** The reveal affordances a collapsed card mounts: the seam row (the button
- *  carrying the divider lines) and any standalone retry button beside it. */
-function revealRowStructure(container: HTMLElement) {
-  const buttons = Array.from(container.querySelectorAll("button"))
-  const seams = buttons.filter((button) => button.querySelector(".border-t"))
-  return {
-    seams: seams.length,
-    standaloneRetries: buttons.filter((button) => !seams.includes(button) && button.textContent?.includes("Retry."))
-      .length,
-  }
+/** `count` replies on the local rail, each a two-line body: the first line is
+ *  what a collapsed ledger row leads with, the second only exists on the full
+ *  message row — so "collapsed" and "expanded" are distinguishable by text. */
+async function seedLedgerRail(count: number, options: { deletedIndex?: number } = {}) {
+  const ids = Array.from({ length: count }, (_, i) => `m_r${i + 1}`)
+  await db.events.bulkPut([
+    messageEvent("m_open", "Opening body.", 10),
+    ...ids.map((id, i) =>
+      messageEvent(
+        id,
+        `Reply ${i + 1}.\n\nBody of reply ${i + 1}.`,
+        11 + i,
+        options.deletedIndex === i ? "2026-06-22T12:05:00.000Z" : undefined
+      )
+    ),
+  ])
+  const post = makePost({ messageIds: ["m_open", ...ids] })
+  ;(post as unknown as { totalReplies: number }).totalReplies = options.deletedIndex === undefined ? count : count - 1
+  return post
 }
 
-describe("BoardCard gap scroll reveal", () => {
-  // The board's owned scroller is what the reveal listens on; the harness mounts
-  // the card inside one, as the real feed does. jsdom has no IntersectionObserver,
-  // so the seam's on-screen state is driven by hand.
-  let seamObservers: { element: Element; fire: (isIntersecting: boolean) => void }[] = []
-  let originalIO: typeof IntersectionObserver | undefined
+function withPreferences(preferences: Record<string, unknown>) {
+  vi.mocked(contextsModule.usePreferences).mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US", ...preferences },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+}
 
-  beforeEach(() => {
-    seamObservers = []
-    originalIO = globalThis.IntersectionObserver
-    globalThis.IntersectionObserver = class {
-      cb: (entries: { isIntersecting: boolean }[]) => void
-      constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
-        this.cb = cb
-      }
-      observe(element: Element) {
-        seamObservers.push({ element, fire: (isIntersecting) => this.cb([{ isIntersecting }]) })
-      }
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof IntersectionObserver
-  })
-  afterEach(() => {
-    globalThis.IntersectionObserver = originalIO as typeof IntersectionObserver
+const ledgerRows = (container: HTMLElement) => container.querySelectorAll("[data-ledger-row]")
+
+describe("BoardCard ledger", () => {
+  it("keeps the newest reply full and renders every older one as a lead line", async () => {
+    const { container } = mountCard(await seedLedgerRail(8))
+
+    // The newest reply is the full row: its body is on screen.
+    expect(await screen.findByText("Body of reply 8.")).toBeTruthy()
+    // The seven older ones are leads — first line only, body withheld.
+    await waitFor(() => expect(ledgerRows(container).length).toBe(7))
+    expect(screen.getByText("Reply 7.")).toBeTruthy()
+    expect(screen.queryByText("Body of reply 7.")).toBeNull()
+    expect(screen.queryByText("Body of reply 1.")).toBeNull()
+    // Everything fits the ledger window, so there is no earlier-mass head row.
+    expect(screen.queryByText(/earlier/)).toBeNull()
   })
 
-  function mountOnBoard(post: BoardViewPost, conversations: Record<string, unknown> = {}) {
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    const scrollerRef = { current: null as HTMLDivElement | null }
-    const listRef = { current: { scrollBy: vi.fn() } as never }
-    const result = render(
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <ServicesProvider services={{ conversations: conversations as never }}>
-            <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
-              <TraceProvider>
-                <PanelProvider>
-                  <div ref={scrollerRef}>
-                    <BoardCard
-                      workspaceId={WS}
-                      post={post}
-                      contextLabel="#general"
-                      streamType="channel"
-                      scrollerRef={scrollerRef}
-                      listRef={listRef}
-                    />
-                  </div>
-                </PanelProvider>
-              </TraceProvider>
-            </MemoryRouter>
-          </ServicesProvider>
-        </TooltipProvider>
-      </QueryClientProvider>
+  it("keeps `boardFullTailCount` newest replies full", async () => {
+    withPreferences({ boardFullTailCount: 2 })
+    const { container } = mountCard(await seedLedgerRail(8))
+
+    expect(await screen.findByText("Body of reply 8.")).toBeTruthy()
+    expect(screen.getByText("Body of reply 7.")).toBeTruthy()
+    await waitFor(() => expect(ledgerRows(container).length).toBe(6))
+    expect(screen.queryByText("Body of reply 6.")).toBeNull()
+  })
+
+  it("collapses the mass above the ledger window into one head row linking to the panel", async () => {
+    // 20 replies: 1 stays full, 15 ledger rows, the remaining 4 are earlier mass.
+    const { container } = mountCard(await seedLedgerRail(20))
+
+    const head = await screen.findByText(/^4 earlier · /)
+    expect(ledgerRows(container).length).toBe(15)
+    expect(head.closest("a")?.getAttribute("href")).toBe(`/w/${WS}/board?panel=conv%3Aconv_1`)
+    // The head row stands for the oldest four; the fifth is the ledger's first row.
+    expect(screen.queryByText("Reply 4.")).toBeNull()
+    expect(screen.getByText("Reply 5.")).toBeTruthy()
+  })
+
+  it("opens a ledger row into the full message in place, and minimizes it back to a lead", async () => {
+    mountCard(await seedLedgerRail(8))
+
+    await userEvent.click(await screen.findByText("Reply 3."))
+    expect(await screen.findByText("Body of reply 3.")).toBeTruthy()
+
+    await userEvent.click(screen.getByLabelText("Collapse message"))
+    await waitFor(() => expect(screen.queryByText("Body of reply 3.")).toBeNull())
+    expect(screen.getByText("Reply 3.")).toBeTruthy()
+  })
+
+  it("renders a mid-ledger tombstone as a deleted lead", async () => {
+    const { container } = mountCard(await seedLedgerRail(8, { deletedIndex: 2 }))
+
+    expect(await screen.findByText("This message was deleted")).toBeTruthy()
+    expect(screen.queryByText("Reply 3.")).toBeNull()
+    expect(container.querySelector('[data-ledger-row][data-message-id="m_r3"]')).toBeTruthy()
+  })
+
+  it("gives a lead no observable row (only a mounted MessageItem carries one), while leads stay inside the card's whole-card read scope", async () => {
+    // Auto-read observes `data-message-row` (use-conversation-auto-read), so a lead
+    // never DWELLS as an observed row; expanding mounts the real MessageItem, which
+    // brings the attribute with it. That is NOT lead-level unread protection: read
+    // mechanics are unchanged by the ledger — the leads are still in the card's read
+    // set, so the cutoff through a read tail row marks them read exactly as before
+    // (whole-card read; lead-granular read waits for sparse-read).
+    const hasUnread = vi.fn().mockReturnValue(false)
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+    const { container } = mountCard(await seedLedgerRail(8))
+
+    await screen.findByText("Body of reply 8.")
+    expect(container.querySelector('[data-message-row][data-message-id="m_r3"]')).toBeNull()
+    expect(container.querySelector('[data-ledger-row][data-message-id="m_r3"]')).toBeTruthy()
+    // The lead is a rendering choice, not a read-scope one: m_r3 is still one of the
+    // card's known messages, so it lights the dot and the cutoff can clear it.
+    await waitFor(() =>
+      expect(hasUnread.mock.calls.some((call) => (call[0] as { id: string }[]).some((m) => m.id === "m_r3"))).toBe(true)
     )
-    /** The reader scrolls up over this card, with the seam on or off screen.
-     *  The wheel goes to the card, as it does under a real pointer. */
-    const scrollUp = async (seamLabel: HTMLElement, seamOnScreen = true) => {
-      const seam = seamLabel.closest("button") ?? seamLabel
-      const observer = seamObservers.find((o) => o.element === seam)
-      await act(async () => {
-        observer?.fire(seamOnScreen)
-        seam.closest(".board-card-hover")?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
-      })
-    }
-    return { ...result, scrollUp, scrollerRef }
-  }
 
-  /** `replyCount` replies on the local rail; only the trailing window shows. */
-  async function seedRail(replyCount: number) {
-    const ids = Array.from({ length: replyCount }, (_, i) => `m_r${i + 1}`)
+    await userEvent.click(screen.getByText("Reply 3."))
+
+    await waitFor(() => expect(container.querySelector('[data-message-row][data-message-id="m_r3"]')).toBeTruthy())
+  })
+
+  it("gives the first full row after the leads its own header, even when the lead above shares its author", async () => {
+    // Adjacency runs over the raw reply run, so the tail's first row would inherit
+    // `continuation` from a row that renders as a headerless lead line.
+    const { container } = mountCard(await seedLedgerRail(8))
+
+    await screen.findByText("Body of reply 8.")
+    const row = container.querySelector('[data-message-row][data-message-id="m_r8"]')
+    expect(row).toBeTruthy()
+    const accent = row!.querySelector(".reveal-host")
+    for (const cls of MESSAGE_ROW_HEAD_PADDING.split(" ")) expect(accent!.className).toContain(cls)
+    // ...and not the continuation row's, which carries neither avatar nor author.
+    expect(accent!.className).not.toContain(MESSAGE_ROW_CONTINUATION_PADDING)
+  })
+
+  it("never demotes a full row to a lead: a newer reply extends the tail instead of rolling it", async () => {
+    const post = await seedLedgerRail(8)
+    const { container, rerenderPost } = mountCard(post)
+
+    await screen.findByText("Body of reply 8.")
+    await waitFor(() => expect(ledgerRows(container).length).toBe(7))
+
+    // A newer reply lands on the rail. A rolling window would demote m_r8 (its
+    // MessageItem unmounting, taking any open edit buffer with it); the monotone
+    // tail keeps it full and appends the new row.
+    await db.events.bulkPut([messageEvent("m_r9", "Reply 9.\n\nBody of reply 9.", 19)])
+    const grown = makePost({ messageIds: ["m_open", ...Array.from({ length: 9 }, (_, i) => `m_r${i + 1}`)] })
+    ;(grown as unknown as { totalReplies: number }).totalReplies = 9
+    act(() => rerenderPost(grown))
+
+    expect(await screen.findByText("Body of reply 9.")).toBeTruthy()
+    expect(screen.getByText("Body of reply 8.")).toBeTruthy()
+    expect(container.querySelector('[data-message-row][data-message-id="m_r8"]')).toBeTruthy()
+    expect(container.querySelector('[data-ledger-row][data-message-id="m_r8"]')).toBeNull()
+    expect(ledgerRows(container).length).toBe(7)
+  })
+
+  it("re-partitions from scratch when the card is recycled onto another conversation", async () => {
+    const { container, rerenderPost } = mountCard(await seedLedgerRail(8))
+    await screen.findByText("Body of reply 8.")
+    await waitFor(() => expect(ledgerRows(container).length).toBe(7))
+
     await db.events.bulkPut([
-      messageEvent("m_open", "Opening body.", 10),
-      ...ids.map((id, i) => messageEvent(id, `Reply ${i + 1}.`, 11 + i)),
+      messageEvent("m2_open", "Other opening.", 40),
+      messageEvent("m2_r1", "Other reply 1.\n\nOther body 1.", 41),
+      messageEvent("m2_r2", "Other reply 2.\n\nOther body 2.", 42),
     ])
-    const post = makePost({ messageIds: ["m_open", ...ids] })
-    ;(post as unknown as { totalReplies: number }).totalReplies = replyCount
-    return post
-  }
+    const other = makePost({ id: "conv_2", messageIds: ["m2_open", "m2_r1", "m2_r2"] }) as BoardViewPost
+    ;(other.conversation as unknown as { id: string }).id = "conv_2"
+    ;(other as unknown as { openingMessage: BoardPostMessage }).openingMessage = openingMessage({ id: "m2_open" })
+    ;(other as unknown as { totalReplies: number }).totalReplies = 2
+    act(() => rerenderPost(other))
 
-  it("reveals the older middle when the reader scrolls up onto the seam", async () => {
-    const { scrollUp } = mountOnBoard(await seedRail(9))
-
-    await screen.findByText("Reply 9.")
-    const seam = await screen.findByText("4 older messages")
-    expect(screen.queryByText("Reply 1.")).toBeNull()
-
-    await scrollUp(seam)
-
-    expect(await screen.findByText("Reply 1.")).toBeTruthy()
-    // A page (15 rows) covers this whole middle, so the seam goes with it.
-    await waitFor(() => expect(screen.queryByText(/older message/)).toBeNull())
+    // Fresh newest-N partition on the new conversation: one full row, one lead.
+    expect(await screen.findByText("Other body 2.")).toBeTruthy()
+    await waitFor(() => expect(ledgerRows(container).length).toBe(1))
+    expect(screen.queryByText("Other body 1.")).toBeNull()
   })
 
-  it("leaves the middle alone when the reader scrolls up with the seam off screen", async () => {
-    const { scrollUp } = mountOnBoard(await seedRail(9))
-    await screen.findByText("Reply 9.")
-    const seam = await screen.findByText("4 older messages")
-
-    await scrollUp(seam, false)
-
-    expect(screen.queryByText("Reply 1.")).toBeNull()
-    expect(screen.getByText("4 older messages")).toBeTruthy()
-  })
-
-  it("arms the server backfill on a paged reveal, and says so in the seam row while it loads", async () => {
-    // The rail carries only the newest reply, so the reveal demands rows only the
-    // server has — the same wait the full expand shows, swapped into the seam's
-    // own row so nothing below it shifts.
-    const getBoardMessages = vi.fn(() => new Promise(() => {}))
-    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r9", "Reply 9.", 30)])
-    const post = makePost({ messageIds: ["m_open", ...Array.from({ length: 9 }, (_, i) => `m_r${i + 1}`)] })
-    ;(post as unknown as { totalReplies: number }).totalReplies = 9
-    const { scrollUp } = mountOnBoard(post, { getBoardMessages })
-
-    await screen.findByText("Reply 9.")
-    await scrollUp(await screen.findByText("8 older messages"))
-
-    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
-    expect(await screen.findByText("Loading older messages…")).toBeTruthy()
-  })
-
-  it("banks at most one outstanding page while the rail can't advance, so the backfill doesn't dump the middle", async () => {
-    // The rail carries only the newest reply and the backfill is in flight, so the
-    // card can't grow and the seam stays under the reader's cursor. Every further
-    // wheel tick of a flick would otherwise buy another page and the whole hidden
-    // middle would land at once when the rows arrive.
-    const backfill = Promise.withResolvers<BoardPostMessage[]>()
-    const getBoardMessages = vi.fn(() => backfill.promise)
-    const ids = Array.from({ length: 40 }, (_, i) => `m_r${i + 1}`)
-    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r40", "Reply 40.", 50)])
-    const post = makePost({ messageIds: ["m_open", ...ids] })
-    ;(post as unknown as { totalReplies: number }).totalReplies = 40
-    const { scrollUp } = mountOnBoard(post, { getBoardMessages })
-
-    await screen.findByText("Reply 40.")
-    const seam = await screen.findByText("39 older messages")
-    for (let i = 0; i < 5; i++) await scrollUp(seam)
-    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
-
-    await act(async () => {
-      backfill.resolve([
-        openingMessage(),
-        ...ids.map((id, i) => ({
-          ...openingMessage(),
-          id,
-          contentMarkdown: `Reply ${i + 1}.`,
-          createdAt: new Date(Date.parse("2026-06-22T12:00:00.000Z") + (i + 1) * 1000).toISOString(),
-        })),
-      ])
-      await backfill.promise
-    })
-
-    // One page (15 rows) of the middle, not five: 40 - (1 trailing + 15) still hidden.
-    expect(await screen.findByText("24 older messages")).toBeTruthy()
-    expect(screen.getByText("Reply 25.")).toBeTruthy()
-    expect(screen.queryByText("Reply 24.")).toBeNull()
-  })
-
-  it("gives a flick one page: wheel events with no fresh intersection report in between", async () => {
-    // A trackpad flick emits dozens of wheel events before the observer can report
-    // the seam leaving; without pacing on the report, one gesture dumps the middle.
-    mountOnBoard(await seedRail(40))
-
-    await screen.findByText("Reply 40.")
-    const seam = (await screen.findByText("35 older messages")).closest("button")!
-    seamObservers.find((o) => o.element === seam)?.fire(true)
-    await act(async () => {
-      for (let i = 0; i < 5; i++)
-        seam.closest(".board-card-hover")?.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
-    })
-
-    expect(await screen.findByText("20 older messages")).toBeTruthy()
-  })
-
-  it("ignores a scroll over a sibling card: only the card under the pointer pages", async () => {
-    const { scrollerRef } = mountOnBoard(await seedRail(9))
-
-    await screen.findByText("Reply 9.")
-    const seam = (await screen.findByText("4 older messages")).closest("button")!
-    const siblingCard = document.createElement("div")
-    scrollerRef.current?.append(siblingCard)
-    await act(async () => {
-      seamObservers.find((o) => o.element === seam)?.fire(true)
-      siblingCard.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }))
-    })
-
-    expect(screen.queryByText("Reply 1.")).toBeNull()
-    expect(screen.getByText("4 older messages")).toBeTruthy()
-  })
-
-  it("puts a failed paged reveal inside the seam's own row rather than mounting a retry below it", async () => {
+  it("says it is loading, then offers a retry, when the earlier mass is only on the server", async () => {
+    // The rail carries the newest reply only, so the ledger's older rows have to
+    // come from the backfill — the wait and its failure take the head row's slot.
     const getBoardMessages = vi.fn().mockRejectedValue(new Error("offline"))
     await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r9", "Reply 9.", 30)])
     const post = makePost({ messageIds: ["m_open", ...Array.from({ length: 9 }, (_, i) => `m_r${i + 1}`)] })
     ;(post as unknown as { totalReplies: number }).totalReplies = 9
-    const { container, scrollUp } = mountOnBoard(post, { getBoardMessages })
+    mountCard(post, { getBoardMessages })
 
-    await screen.findByText("Reply 9.")
-    const rowsBefore = revealRowStructure(container)
-    await scrollUp(await screen.findByText("8 older messages"))
-    await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
-    const rowsLoading = revealRowStructure(container)
-    // The failed label lands only after the query's single retry (#1714), which
-    // waits out TanStack's ~1s backoff — past findByText's default timeout.
-    const failedSeam = await screen.findByText("Couldn't load older messages. Retry.", undefined, { timeout: 5000 })
-
-    // The failure swaps the seam's label; it never adds a row, so the replies below
-    // stay exactly where the reader left them (INV-21).
-    expect({ ...revealRowStructure(container), rowsBefore, rowsLoading }).toEqual({
-      seams: 1,
-      standaloneRetries: 0,
-      rowsBefore: { seams: 1, standaloneRetries: 0 },
-      rowsLoading: { seams: 1, standaloneRetries: 0 },
-    })
+    expect(await screen.findByText("Loading older messages…")).toBeTruthy()
+    // The label lands only after the query's single retry (#1714), which waits out
+    // TanStack's ~1s backoff — past findByText's default timeout.
+    const failed = await screen.findByText("Couldn't load older messages. Retry.", undefined, { timeout: 5000 })
+    // One row, whatever it says: no head row beside the failure (INV-21).
+    expect(screen.queryByText(/earlier/)).toBeNull()
 
     getBoardMessages.mockClear()
-    await userEvent.click(failedSeam)
+    await userEvent.click(failed)
     await waitFor(() => expect(getBoardMessages).toHaveBeenCalled())
   })
+})
 
-  it("keeps the tap path: clicking the seam expands the whole conversation", async () => {
-    mountOnBoard(await seedRail(9))
+/** Installs a controllable IntersectionObserver: jsdom ships none, and the card
+ *  fails open without one. Returns a setter that drives every live observer. */
+function stubIntersectionObserver(initiallyIntersecting: boolean) {
+  type Entry = { isIntersecting: boolean; target: Element }
+  const live = new Set<{ cb: (entries: Entry[]) => void; targets: Set<Element> }>()
+  let intersecting = initiallyIntersecting
+  class Stub {
+    private entry = { cb: (_: Entry[]) => {}, targets: new Set<Element>() }
+    constructor(cb: (entries: Entry[]) => void) {
+      this.entry.cb = cb
+      live.add(this.entry)
+    }
+    observe(target: Element) {
+      this.entry.targets.add(target)
+      this.entry.cb([{ isIntersecting: intersecting, target }])
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target)
+    }
+    disconnect() {
+      live.delete(this.entry)
+    }
+  }
+  vi.stubGlobal("IntersectionObserver", Stub)
+  return (next: boolean) => {
+    intersecting = next
+    act(() => {
+      for (const { cb, targets } of live) cb([...targets].map((target) => ({ isIntersecting: next, target })))
+    })
+  }
+}
 
-    await screen.findByText("Reply 9.")
-    await userEvent.click(await screen.findByText("4 older messages"))
+describe("BoardCard backfill arming", () => {
+  afterEach(() => vi.unstubAllGlobals())
 
-    expect(await screen.findByText("Reply 1.")).toBeTruthy()
-    expect(screen.queryByText(/older message/)).toBeNull()
+  /** A card whose rail has READ and holds the opening, but whose one reply member
+   *  is outside the rail's window — the only shape that wants a backfill. */
+  async function railResolvedIncompletePost() {
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10)])
+    const post = makePost({ messageIds: ["m_open", "m_r1"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 1
+    return post
+  }
+
+  it("does not fetch on a projection-sourced card: its rail hasn't read yet", async () => {
+    // No IDB events at all → `source === "projection"`. Every mounted card firing
+    // here was the whole board's mount-time fetch storm.
+    stubIntersectionObserver(true)
+    const getBoardMessages = vi.fn().mockResolvedValue([])
+    const post = makePost({ messageIds: ["m_open", "m_r1"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 1
+    mountCard(post, { getBoardMessages })
+
+    await screen.findByText("Opening body.")
+    await waitFor(() => expect(screen.getByText(/1 earlier/)).toBeTruthy())
+    expect(getBoardMessages).not.toHaveBeenCalled()
+    // ...and it says so honestly: no "Loading…" label with no request behind it.
+    expect(screen.queryByText("Loading older messages…")).toBeNull()
   })
 
-  it("renders no seam when nothing is hidden, so there is nothing to scroll into", async () => {
-    mountOnBoard(await seedRail(3))
+  it("does not fetch for a rail-resolved incomplete card while it is off screen", async () => {
+    stubIntersectionObserver(false)
+    const getBoardMessages = vi.fn().mockResolvedValue([])
+    mountCard(await railResolvedIncompletePost(), { getBoardMessages })
 
-    expect(await screen.findByText("Reply 1.")).toBeTruthy()
-    expect(screen.queryByText(/older message/)).toBeNull()
+    await screen.findByText("Opening body.")
+    await waitFor(() => expect(screen.getByText(/1 earlier/)).toBeTruthy())
+    expect(getBoardMessages).not.toHaveBeenCalled()
+  })
+
+  it("fetches once a rail-resolved incomplete card enters the viewport", async () => {
+    const setIntersecting = stubIntersectionObserver(false)
+    const getBoardMessages = vi.fn().mockResolvedValue([openingMessage()])
+    mountCard(await railResolvedIncompletePost(), { getBoardMessages })
+
+    await screen.findByText("Opening body.")
+    expect(getBoardMessages).not.toHaveBeenCalled()
+
+    setIntersecting(true)
+    await waitFor(() => expect(getBoardMessages).toHaveBeenCalledTimes(1))
+  })
+
+  it("arms the reveal window on the backfill's rising edge, landmarked on a real row, and never while idle", async () => {
+    const beginReveal = vi.fn()
+    const closeReveal = vi.fn()
+    spyOnExport(revealAnchorModule, "useBoardCardRevealAnchor").mockReturnValue((() => ({
+      beginReveal,
+      closeReveal,
+    })) as never)
+    stubIntersectionObserver(true)
+    // Idle: a complete rail wants no backfill, so nothing arms — a live tail reply
+    // must still push the view normally.
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r1", "Reply 1.", 11)])
+    const complete = makePost({ messageIds: ["m_open", "m_r1"] })
+    ;(complete as unknown as { totalReplies: number }).totalReplies = 1
+    const idle = mountCard(complete, { getBoardMessages: vi.fn() })
+    await screen.findByText("Reply 1.")
+    expect(beginReveal).not.toHaveBeenCalled()
+    idle.unmount()
+
+    // In flight: armed, holding a row element that is actually in the document.
+    await db.events.clear()
+    const getBoardMessages = vi.fn(() => new Promise<never>(() => {}))
+    // The rail holds the opening and the newest reply; the older member (m_r1) is
+    // only on the server, so it lands ABOVE the tail — the jump this compensates.
+    await db.events.bulkPut([messageEvent("m_open", "Opening body.", 10), messageEvent("m_r2", "Reply 2.", 12)])
+    const post = makePost({ messageIds: ["m_open", "m_r1", "m_r2"] })
+    ;(post as unknown as { totalReplies: number }).totalReplies = 2
+    const { container } = mountCard(post, { getBoardMessages })
+
+    await waitFor(() => expect(beginReveal).toHaveBeenCalled())
+    const [options] = beginReveal.mock.calls.at(-1) as [{ mode: string; landmark: HTMLElement | null }]
+    expect(options.mode).toBe("scroll")
+    expect(options.landmark).toBe(container.querySelector('[data-message-row][data-message-id="m_r2"]'))
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -4,9 +4,11 @@ import { Link } from "react-router-dom"
 import type { VirtualizerHandle } from "virtua"
 import { ChevronDown, ChevronRight, CircleCheck, PanelRight } from "lucide-react"
 import {
-  BOARD_GAP_REVEAL_PAGE_ROWS,
   DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT,
   DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT,
+  DEFAULT_BOARD_FULL_TAIL_COUNT,
+  DEFAULT_BOARD_LEDGER_ROWS,
+  DEFAULT_BOARD_LEAD_LINE_LENGTH,
 } from "@threa/types"
 import { RelativeTime } from "@/components/relative-time"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -45,16 +47,13 @@ import { useBoardFlash } from "@/stores/board-flash-store"
 import { usePanel, createConversationPanelId, usePreferences } from "@/contexts"
 import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { useSplitThread } from "@/hooks/use-conversations"
-import {
-  applySettlingAll,
-  useBoardCardMessages,
-  useRevealedReplyWindow,
-  useStableReplyWindow,
-} from "@/hooks/use-board-card-messages"
+import { applySettlingAll, useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
-import { useBoardGapAutoReveal } from "@/hooks/use-board-gap-auto-reveal"
+import { LedgerRow } from "@/components/board/ledger-row"
+import { useFormattedDate } from "@/hooks/use-formatted-date"
+import { localStartOfDayMs } from "@/lib/dates"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
@@ -69,8 +68,9 @@ interface BoardCardProps {
   /** For a DM post, the peer's user id — resolves the peer avatar shown over the
    *  locator tile, matching the sidebar. Absent for non-DM streams. */
   dmPeerUserId?: string | null
-  /** The board's owned scroll viewport — lets a middle-gap expand hold the newest
-   *  replies still instead of shoving them down (`useBoardCardRevealAnchor`).
+  /** The board's owned scroll viewport — lets a card that grows from older content
+   *  hold the newest replies still instead of shoving them down
+   *  (`useBoardCardRevealAnchor`).
    *  Absent when the card renders outside the virtualized board (tests). */
   scrollerRef?: RefObject<HTMLDivElement | null>
   /** virtua's imperative handle for the board feed, paired with `scrollerRef`. */
@@ -93,6 +93,8 @@ interface BoardCardProps {
  *  hidden rest sits behind an "N more replies" link into the child's panel. */
 const BRANCH_PREVIEW_CAP = 2
 
+const EMPTY_EXPANDED: Set<string> = new Set()
+
 // Softens the collapsed card's raw `max-height` clip so it doesn't slice a
 // message mid-line/mid-image. Masks the content transparent at the cut (like
 // CollapsibleBody) rather than painting a colored gradient — the rows carry the
@@ -105,8 +107,9 @@ const COLLAPSED_FADE_MASK = "linear-gradient(to bottom, black calc(100% - 2rem),
  * stream timeline. Messages use the same primitives (`ActorAvatar`,
  * `MarkdownContent`, `MessageReactions`) and the same same-author grouping, so a
  * board message is indistinguishable from a real one. The card delimits the
- * conversation (no reply indentation); a collapsed "N more messages" gap fills
- * in on click. The stream it lives in is the header locator, not a topic line.
+ * conversation (no reply indentation); the reply region is the ledger — the
+ * newest replies stay full rows, older ones collapse to lead lines that expand
+ * in place. The stream it lives in is the header locator, not a topic line.
  */
 export function BoardCard({
   workspaceId,
@@ -124,7 +127,6 @@ export function BoardCard({
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const { openPanel, getPanelUrl } = usePanel()
-  const [expanded, setExpanded] = useState(false)
   // A running session's Redirect bumps this nonce to expand + focus the card's
   // reply composer in place (its editor is collapsed until opened, so there's no
   // DOM zone to walk to). A counter, not a boolean, so a repeat Redirect re-opens
@@ -134,30 +136,52 @@ export function BoardCard({
   // Scopes text-selection quoting to this card so a selection routes into this
   // card's composer, not a sibling card's provider.
   const cardRef = useRef<HTMLDivElement>(null)
-  // Revealing the hidden middle ("N more messages") grows this card from OLDER
-  // content above the trailing replies; hold the card bottom fixed so the newest
-  // replies the reader is on don't jump (the board's `shift`, see the hook).
-  // Mirrors `loadingMore` (computed below, after the rail) so the anchor hook can
-  // read it at settle time without re-subscribing each render.
+  // Older rows landing above the full tail (backfill / late sync) insert INSIDE
+  // one virtua item, so nothing compensates the jump. The card arms the reveal
+  // window for exactly the backfill's flight (`beginReveal` on the in-flight
+  // rising edge below, landmarked on the first full-tail row) and holds it open
+  // through `loadingMoreRef` — which mirrors `loadingMore` (computed below, after
+  // the rail) so the hook reads it at settle time without re-subscribing.
   const loadingMoreRef = useRef(false)
-  // The first row of the current visible window — the reveal anchor's landmark,
-  // read at gesture time. A ref so `revealPage`'s identity doesn't churn per render
-  // (the auto-reveal hook subscribes on it).
-  const firstDisplayedIdRef = useRef<string | undefined>(undefined)
   const { beginReveal, closeReveal } = useBoardCardRevealAnchor({
     cardRef,
     scrollerRef,
     listRef,
     shouldHoldOpen: useCallback(() => loadingMoreRef.current, []),
   })
-  // Rows scrolled out from under the gap so far, one page per upward gesture.
-  // Recycling this card instance onto another conversation resets the count —
-  // the conversation id lives IN the state (not a ref) so a discarded render
-  // can't strand the guard past the reset it was meant to trigger.
-  const seamRef = useRef<HTMLButtonElement>(null)
-  const [revealed, setRevealed] = useState({ conversationId: conversation.id, rows: 0 })
-  if (revealed.conversationId !== conversation.id) setRevealed({ conversationId: conversation.id, rows: 0 })
-  const revealedRows = revealed.conversationId === conversation.id ? revealed.rows : 0
+  // Which ledger rows the reader has opened into full messages. Recycling this
+  // card instance onto another conversation resets the set — the conversation id
+  // lives IN the state (not a ref) so a discarded render can't strand the reset.
+  const [ledgerExpansion, setLedgerExpansion] = useState<{ conversationId: string; expanded: Set<string> }>({
+    conversationId: conversation.id,
+    expanded: EMPTY_EXPANDED,
+  })
+  if (ledgerExpansion.conversationId !== conversation.id)
+    setLedgerExpansion({ conversationId: conversation.id, expanded: EMPTY_EXPANDED })
+  const expandedRowIds = ledgerExpansion.conversationId === conversation.id ? ledgerExpansion.expanded : EMPTY_EXPANDED
+  // The full tail is MONOTONE for the card's life on one conversation: the row
+  // that opened it stays its first row, so a message rendered full never demotes
+  // to a lead (which would unmount its MessageItem — losing an open edit buffer,
+  // menu or selection) and a newer arrival simply extends the tail. Only the
+  // FIRST full row is remembered; everything at or after it is full, so an older
+  // row inserted above (backfill) lands in the ledger where it belongs.
+  // `boardFullTailCount` therefore sizes the INITIAL tail, not a rolling window.
+  const [fullTailAnchor, setFullTailAnchor] = useState<{ conversationId: string; messageId: string | null }>({
+    conversationId: conversation.id,
+    messageId: null,
+  })
+  if (fullTailAnchor.conversationId !== conversation.id)
+    setFullTailAnchor({ conversationId: conversation.id, messageId: null })
+  const toggleLedgerRow = useCallback(
+    (messageId: string) =>
+      setLedgerExpansion((current) => {
+        const base = current.conversationId === conversation.id ? current.expanded : EMPTY_EXPANDED
+        const expanded = new Set(base)
+        if (!expanded.delete(messageId)) expanded.add(messageId)
+        return { conversationId: conversation.id, expanded }
+      }),
+    [conversation.id]
+  )
 
   // Shared graph + structural index, needed BEFORE the rail hook: the inline
   // branch composer derives the branch thread streams (and any pending
@@ -212,6 +236,11 @@ export function BoardCard({
     preferences?.boardCardCollapseToHeight ?? DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT,
     collapseAtHeight
   )
+  // Ledger density: how many newest replies stay full rows, how many ledger lines
+  // sit above them, and how long a collapsed lead runs.
+  const fullTailCount = Math.max(0, preferences?.boardFullTailCount ?? DEFAULT_BOARD_FULL_TAIL_COUNT)
+  const ledgerRowLimit = Math.max(0, preferences?.boardLedgerRows ?? DEFAULT_BOARD_LEDGER_ROWS)
+  const leadLineLength = preferences?.boardLeadLineLength ?? DEFAULT_BOARD_LEAD_LINE_LENGTH
   const messageCount = totalReplies + (openingMessage ? 1 : 0)
   const bodyRef = useRef<HTMLDivElement>(null)
   const [tall, setTall] = useState(false)
@@ -315,13 +344,13 @@ export function BoardCard({
         if (!seen.has(tagged.id)) rows.push(tagged)
       }
       rows.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-      const shown = expanded ? rows : rows.slice(-BRANCH_PREVIEW_CAP)
+      const shown = rows.slice(-BRANCH_PREVIEW_CAP)
       // Server-known members not shown (locally missing, or under the collapsed
       // window) count toward the "N more replies" link into the child's panel.
       const knownTotal = Math.max(branchMemberIds.length, rows.length)
       return { messages: shown, hiddenCount: Math.max(0, knownTotal - shown.length) }
     },
-    [messagesById, taggedByConversation, expanded]
+    [messagesById, taggedByConversation]
   )
   const branchesByForkMessageId = useMemo(() => {
     const branches = deriveBranchConversations({
@@ -400,126 +429,18 @@ export function BoardCard({
     splitThread.mutate({ conversationId: conversation.id, threadStreamId })
 
   // The rail carries every locally-synced reply; older ones (or a wholly unsynced
-  // stream — `source === "projection"`) may be missing, so on expand we backfill
-  // the full hydrated set from the server. Never blocks the first render: the
-  // local replies show immediately, this only fills the gap when online.
+  // stream — `source === "projection"`) may be missing. The ledger shows up to
+  // `ledgerRowLimit` older rows, so the card wants the whole hydrated set, not
+  // just a trailing preview — the backfill arms whenever the rail is short (the
+  // hook self-gates on rail coverage, so a complete rail fetches nothing). Never
+  // blocks the first render: the local replies show immediately.
   const incompleteLocally = source === "projection" || railReplies.length < totalReplies
-  const {
-    data: allMessages,
-    isError: expandFailed,
-    refetch: refetchMessages,
-  } = useConversationBackfill(workspaceId, conversation.id, {
-    enabled: expanded || revealedRows > 0,
-    railCoversMembership,
-    memberIds: conversation.messageIds,
-    knownMessageIds,
-  })
-
-  // Collapsed cards preview an append-only window over the local rail: trailing
-  // replies at first reveal, growing (never sliding) as new ones land, so a
-  // visible reply is never evicted back under the "N more" gap. Tombstones ride
-  // the rail like any other row, so a deleted reply spends a preview slot and is
-  // counted in `totalReplies` — the collapsed card reads "deleted", not "gone".
-  const collapsedReplies = useStableReplyWindow(conversation.id, railReplies)
-
-  // Expanded: the hook's merged view (rail > backfill store > projection).
-  // Collapsed: the stable window over it.
-  const revealedReplies = useRevealedReplyWindow(conversation.id, railReplies, collapsedReplies, revealedRows)
-  const replies: RenderableMessage[] = expanded ? railReplies : revealedReplies
-  // Merge this card's own just-sent replies with the confirmed set, skipping any
-  // the rail or a backfill already carries, then sort by time: a pending reply
-  // can be OLDER than a confirmed one (someone else's reply lands while yours is
-  // still in flight), so appending blindly would render it out of order.
-  const seenReplyIds = new Set(replies.map((m) => m.id))
-  // The hook stamps settling on its own rows; the server backfill above bypasses
-  // it, so the merged list runs through the same helper (rows already marked come
-  // back by identity).
-  const displayedReplies = applySettlingAll(
-    [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))].sort(
-      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-    ),
-    settlingIds
-  )
-  firstDisplayedIdRef.current = displayedReplies[0]?.id
-  // `totalReplies` counts tombstones as zero, so the visible rows must be counted
-  // the same way or a drawn tombstone would subtract from the gap it isn't in.
-  const hiddenCount = expanded ? 0 : Math.max(0, totalReplies - replies.filter((m) => !m.deletedAt).length)
-  // Any reveal — a page or the full expand — can outrun the local rail; the same
-  // server backfill fills both, so the wait and its retry show for both.
-  const revealing = expanded || revealedRows > 0
-  const loadingMore = revealing && incompleteLocally && !allMessages && !expandFailed
-  loadingMoreRef.current = loadingMore
-  // No middle is hidden, so opening + replies form one uninterrupted run that
-  // groups across the boundary. Otherwise a gap row sits between them.
-  const contiguous = (expanded && (!incompleteLocally || !!allMessages)) || (!expanded && hiddenCount === 0)
-  // The wait and the failure both swap the seam row's own label rather than adding
-  // a line below it, so nothing under the seam shifts through either (INV-21).
-  let seamLabel = `${hiddenCount} older ${hiddenCount === 1 ? "message" : "messages"}`
-  if (loadingMore) seamLabel = "Loading older messages…"
-  if (expandFailed) seamLabel = "Couldn't load older messages. Retry."
-
-  // Scrolling up onto the seam pulls the next page out from under it, the way
-  // reading up past the timeline's unread divider keeps going. Measure the anchor
-  // BEFORE the rows land, exactly as the tap path does.
-  // Demand is clamped to what the rail can actually satisfy plus one outstanding
-  // page: while the backfill is in flight the card doesn't grow, so the seam stays
-  // under the reader's cursor and every further wheel tick would otherwise add
-  // another page — a short flick banks twenty of them and the whole hidden middle
-  // dumps at once the moment the rows land.
-  const revealPage = useCallback(() => {
-    // The row directly below the seam as it stands NOW: the revealed page pushes
-    // exactly this row (and everything under it) down, so holding it still holds
-    // the reader's eye-line while a live tail reply below it still pushes normally.
-    const firstVisibleId = firstDisplayedIdRef.current
-    const landmark = firstVisibleId
-      ? cardRef.current?.querySelector<HTMLElement>(`[data-message-row][data-message-id="${firstVisibleId}"]`)
-      : null
-    beginReveal({ mode: "scroll", landmark })
-    setRevealed((current) => {
-      const rows = current.conversationId === conversation.id ? current.rows : 0
-      return {
-        conversationId: conversation.id,
-        rows: Math.min(rows, Math.max(0, railReplies.length - collapsedReplies.length)) + BOARD_GAP_REVEAL_PAGE_ROWS,
-      }
-    })
-  }, [beginReveal, conversation.id, railReplies.length, collapsedReplies.length])
-  useBoardGapAutoReveal({
-    seamRef,
-    cardRef,
-    scrollerRef,
-    enabled: !expanded && hiddenCount > 0 && !removed,
-    onReveal: revealPage,
-  })
-
-  // Viewport auto-read: rows that dwell on screen mark themselves read (the menu
-  // actions are the override). Every rendered row is eligible — on a collapsed
-  // card the cutoff through a trailing-preview row also covers the hidden "N
-  // more" middle, deliberately: the card IS the conversation surface, so reading
-  // its visible tail reads the conversation up to there, exactly like invoking
-  // "Mark as read up to here" on that row (Kris's dogfood ruling on PR #1174 —
-  // having the conversation open is enough to mark it).
-  // A tombstone counts as zero for unread, so it must not carry read state either
-  // way — keep it out of the auto-read set entirely.
-  const autoReadRows = (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).filter(
-    (m) => !m.deletedAt
-  )
-  useConversationAutoRead({
-    containerRef: cardRef,
-    messages: autoReadRows,
-    rootStreamId: streamId,
-    rowState: conversationReadValue.state,
-    markRead: markReadSilently,
-    registerExplicitUnread: setExplicitUnreadListener,
-    getReadTruth,
-    disabled: removed,
-  })
-
   // The card is a first-class reading surface (live message bodies, viewport
-  // auto-read above), so while any part of it is on screen its streams count
+  // auto-read below), so while any part of it is on screen its streams count
   // as visible for push suppression — otherwise a push banners the exact
   // message the user is reading on the board. Viewport-gated (not mount-gated)
   // so off-screen cards on a long board don't suppress streams the user can't
-  // see.
+  // see. The same signal gates the backfill below.
   const [cardInViewport, setCardInViewport] = useState(false)
   // Same observer answers "has the viewer seen this card" (`onSeen`, first
   // intersection only) — seen-ness is latched in a ref so a later re-intersection
@@ -541,6 +462,147 @@ export function BoardCard({
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+  // Without an IntersectionObserver (jsdom, ancient engines) there is no viewport
+  // truth to gate on — fail open rather than never fetching at all.
+  const viewportUnknown = typeof IntersectionObserver === "undefined"
+  // Two gates beyond "the rail is short": the card's rail has actually READ (a
+  // projection-sourced card is still resolving, and its incompleteness is an
+  // artifact of that, not a real gap — every mounted card fetching on mount was
+  // the #1640 cost class), and the card is on screen.
+  const backfillEnabled =
+    !removed && source !== "projection" && incompleteLocally && (cardInViewport || viewportUnknown)
+  const {
+    data: allMessages,
+    isError: expandFailed,
+    refetch: refetchMessages,
+  } = useConversationBackfill(workspaceId, conversation.id, {
+    enabled: backfillEnabled,
+    railCoversMembership,
+    memberIds: conversation.messageIds,
+    knownMessageIds,
+  })
+
+  const replies: RenderableMessage[] = railReplies
+  // Merge this card's own just-sent replies with the confirmed set, skipping any
+  // the rail or a backfill already carries, then sort by time: a pending reply
+  // can be OLDER than a confirmed one (someone else's reply lands while yours is
+  // still in flight), so appending blindly would render it out of order.
+  const seenReplyIds = new Set(replies.map((m) => m.id))
+  // The hook stamps settling on its own rows; the server backfill above bypasses
+  // it, so the merged list runs through the same helper (rows already marked come
+  // back by identity).
+  const displayedReplies = applySettlingAll(
+    [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))].sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    ),
+    settlingIds
+  )
+  // The reply region IS the ledger: the newest `fullTailCount` replies keep the
+  // full message row (reactions, actions, settling affordances); everything older
+  // that fits in `ledgerRowLimit` renders as a collapsed ledger line, and the mass
+  // above that collapses into one head row into the panel.
+  // Monotone: once a row opened the tail it stays its first row, so the partition
+  // only ever grows downward. A remembered anchor that has left the window (moved
+  // away, re-filed) falls back to a fresh newest-N partition, which the effect
+  // below re-remembers.
+  const anchorId = fullTailAnchor.conversationId === conversation.id ? fullTailAnchor.messageId : null
+  const anchorIndex = anchorId === null ? -1 : displayedReplies.findIndex((m) => m.id === anchorId)
+  const tailStart = anchorIndex >= 0 ? anchorIndex : Math.max(0, displayedReplies.length - fullTailCount)
+  const ledgerCandidates = displayedReplies.slice(0, tailStart)
+  const fullTailReplies = displayedReplies.slice(tailStart)
+  const ledgerReplies =
+    ledgerCandidates.length > ledgerRowLimit ? ledgerCandidates.slice(-ledgerRowLimit) : ledgerCandidates
+  const hiddenOlder = ledgerCandidates.slice(0, ledgerCandidates.length - ledgerReplies.length)
+  const ledgerIds = new Set(ledgerReplies.map((m) => m.id))
+  const visibleReplies = [...ledgerReplies, ...fullTailReplies]
+  const firstFullTailId = fullTailReplies[0]?.id ?? null
+  // Commit the partition's first row after render, never during it.
+  useEffect(() => {
+    if (firstFullTailId === null) return
+    setFullTailAnchor((current) =>
+      current.conversationId === conversation.id && current.messageId === firstFullTailId
+        ? current
+        : { conversationId: conversation.id, messageId: firstFullTailId }
+    )
+  }, [conversation.id, firstFullTailId])
+  // `totalReplies` counts tombstones as zero, so the rendered rows are counted the
+  // same way — replies the rail hasn't synced at all are earlier mass too.
+  const unsyncedOlder = Math.max(0, totalReplies - displayedReplies.filter((m) => !m.deletedAt).length)
+  const earlierCount = hiddenOlder.length + unsyncedOlder
+  // The backfill can outrun the local rail while the head row stands for rows only
+  // the server has; the wait and its retry take that same single row, so nothing
+  // below them shifts through either state (INV-21). Both are gated on there being
+  // unsynced older replies at all — a card whose whole conversation is on screen
+  // must never flip through a "Loading older messages…" row it has no use for
+  // (the flip would also swap the rows between the two render shapes below).
+  // Gated on the backfill actually being ARMED, not merely on the rail being
+  // short: an unarmed card (off-screen, rail unresolved) would otherwise sit under
+  // a "Loading older messages…" label with no request behind it, forever.
+  const loadingMore = unsyncedOlder > 0 && backfillEnabled && !allMessages && !expandFailed
+  loadingMoreRef.current = loadingMore
+  // The rows that backfill brings land ABOVE the full tail, inside this one virtua
+  // item. Arm the reveal window on the flight's rising edge, landmarked on the
+  // tail's first row — monotone above, so the element stays put for the whole
+  // window — and let `shouldHoldOpen` (loadingMoreRef) keep it open until the rows
+  // land. Idle card: never armed, so a live tail reply still pushes normally.
+  const revealArmedRef = useRef(false)
+  useEffect(() => {
+    if (!loadingMore) {
+      revealArmedRef.current = false
+      return
+    }
+    if (revealArmedRef.current) return
+    revealArmedRef.current = true
+    const landmark =
+      firstFullTailId === null
+        ? null
+        : (cardRef.current?.querySelector<HTMLElement>(`[data-message-row][data-message-id="${firstFullTailId}"]`) ??
+          null)
+    beginReveal({ mode: "scroll", landmark })
+  }, [loadingMore, firstFullTailId, beginReveal])
+  const failedOlder = unsyncedOlder > 0 && expandFailed
+  // Nothing sits above the ledger, so opening + replies form one uninterrupted run
+  // that groups across the boundary. Otherwise a head row sits between them.
+  const contiguous = earlierCount === 0 && !loadingMore && !failedOlder
+  // Device-local (INV-42). A range inside one day reads as times; across days the
+  // date carries it, since two clock times would say nothing about the span.
+  const { formatTime, formatDate } = useFormattedDate()
+  let earlierLabel = `${earlierCount} earlier`
+  if (hiddenOlder.length > 0) {
+    const first = new Date(hiddenOlder[0].createdAt)
+    const last = new Date(hiddenOlder[hiddenOlder.length - 1].createdAt)
+    const sameDay = localStartOfDayMs(first) === localStartOfDayMs(last)
+    const render = (date: Date) => (sameDay ? formatTime(date) : formatDate(date))
+    earlierLabel = `${earlierCount} earlier · ${render(first)} → ${render(last)}`
+  }
+
+  // Viewport auto-read: rows that dwell on screen mark themselves read (the menu
+  // actions are the override). Every rendered row is eligible — on a collapsed
+  // card the cutoff through a trailing-preview row also covers the hidden "N
+  // more" middle, deliberately: the card IS the conversation surface, so reading
+  // its visible tail reads the conversation up to there, exactly like invoking
+  // "Mark as read up to here" on that row (Kris's dogfood ruling on PR #1174 —
+  // having the conversation open is enough to mark it).
+  // A tombstone counts as zero for unread, so it must not carry read state either
+  // way — keep it out of the auto-read set entirely.
+  // The ledger does NOT change this: a lead mounts no `data-message-row`, so it
+  // never dwells as an observed row, but the cutoff through a read tail row still
+  // covers the older leads beneath it — whole-card read, exactly as before the
+  // ledger. Lead-granular read waits for sparse-read.
+  const autoReadRows = (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).filter(
+    (m) => !m.deletedAt
+  )
+  useConversationAutoRead({
+    containerRef: cardRef,
+    messages: autoReadRows,
+    rootStreamId: streamId,
+    rowState: conversationReadValue.state,
+    markRead: markReadSilently,
+    registerExplicitUnread: setExplicitUnreadListener,
+    getReadTruth,
+    disabled: removed,
+  })
+
   // A programmatic jump (the "N new" pill sets scrollTop to 0) doesn't fire the
   // gesture listeners that disarm the hold, so an armed window on a card that just
   // left the viewport would scroll the feed back toward it when its growth lands.
@@ -577,7 +639,58 @@ export function BoardCard({
     return () => observer.disconnect()
   }, [])
 
+  // One row above the ledger, whatever it says: the earlier mass, the wait for it,
+  // or its failure — so nothing below shifts as the state changes (INV-21). The
+  // head row is a link into the panel, where the whole conversation reads
+  // coherently.
+  let ledgerHeadRow = (
+    <Link
+      to={continueThreadTo()}
+      className="mt-3 block w-fit text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      {earlierLabel}
+    </Link>
+  )
+  if (loadingMore)
+    ledgerHeadRow = <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>
+  if (failedOlder)
+    ledgerHeadRow = (
+      <button
+        type="button"
+        onClick={() => void refetchMessages()}
+        className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+      >
+        Couldn't load older messages. Retry.
+      </button>
+    )
+
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
+    // A ledger line, not a full row: collapsed it carries `data-ledger-row` and no
+    // `data-message-row`, so viewport auto-read (which matches the latter) never
+    // counts a lead as a read row. Expanding mounts the real MessageItem, which
+    // brings the attribute — and the read participation — back with it.
+    if (ledgerIds.has(message.id))
+      return (
+        <LedgerRow
+          key={message.id}
+          workspaceId={workspaceId}
+          streamId={message.streamId ?? streamId}
+          message={message}
+          authorName={getActorName(message.authorId, message.authorType)}
+          currentUserId={currentUserId}
+          expanded={expandedRowIds.has(message.id)}
+          onToggle={() => toggleLedgerRow(message.id)}
+          leadLineLength={leadLineLength}
+          conversationId={conversation.id}
+          conversationRootStreamId={conversation.streamId}
+          onNewSubtopic={
+            structuralIndex.threadsByAnchorId.has(message.id)
+              ? undefined
+              : () => inlineComposer.openNewSubtopic(message.streamId ?? streamId, message.id)
+          }
+          onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
+        />
+      )
     // Mirrors the panel: a deleted row is a tombstone, never a blank MessageItem
     // carrying an author, a timestamp and an action menu. It still carries the
     // row attributes so the reveal anchor can landmark it when it is the first
@@ -596,6 +709,11 @@ export function BoardCard({
     // already exists under the message (a populated thread would mix membership —
     // "Split this thread" is the gesture there, adjustment D).
     const canBranch = !structuralIndex.threadsByAnchorId.has(message.id)
+    // Adjacency is computed over the raw run, so a full row whose predecessor
+    // collapsed to a lead would inherit `continuation` from a row that shows no
+    // author — the tail would open headerless. The first full row after any
+    // ledger line always carries its own header.
+    const isTailHead = message.id === firstFullTailId && ledgerReplies.length > 0
     return (
       <MessageItem
         key={message.id}
@@ -604,7 +722,7 @@ export function BoardCard({
         message={message}
         authorName={getActorName(message.authorId, message.authorType)}
         currentUserId={currentUserId}
-        continuation={continuation}
+        continuation={continuation && !isTailHead}
         conversationId={conversation.id}
         conversationRootStreamId={conversation.streamId}
         // Break the row out of the card's p-3/p-4 padding and pad the content back in,
@@ -864,7 +982,7 @@ export function BoardCard({
               )}
               {contiguous ? (
                 <BranchedBoardRows
-                  rows={branchRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies)}
+                  rows={branchRows(openingMessage ? [openingMessage, ...visibleReplies] : visibleReplies)}
                   workspaceId={workspaceId}
                   renderMessage={renderMessage}
                   continueThreadTo={continueThreadTo}
@@ -880,51 +998,9 @@ export function BoardCard({
                   {/* The opening renders outside the row builder here, so its inline
                     "new sub-topic" composer slot must be placed explicitly. */}
                   {openingMessage && inlineComposer.renderAfterMessage(openingMessage.id)}
-                  {!expanded && hiddenCount > 0 ? (
-                    <button
-                      ref={seamRef}
-                      type="button"
-                      onClick={() => {
-                        if (expandFailed) {
-                          void refetchMessages()
-                          return
-                        }
-                        beginReveal()
-                        setExpanded(true)
-                      }}
-                      className={cn(
-                        "mt-3 flex w-full items-center gap-3 text-xs transition-colors",
-                        expandFailed ? "text-destructive" : "text-muted-foreground hover:text-foreground"
-                      )}
-                    >
-                      <span className="flex-1 border-t border-current" />
-                      <span className="flex items-center gap-1 whitespace-nowrap">
-                        <ChevronDown className="h-3.5 w-3.5" />
-                        {seamLabel}
-                      </span>
-                      <span className="flex-1 border-t border-current" />
-                    </button>
-                  ) : (
-                    loadingMore && (
-                      <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>
-                    )
-                  )}
-                  {/* The backfill loads the older/full window; the recent replies the
-                rail carried are already shown above, so the error names "older"
-                rather than contradicting visible content. */}
-                  {/* Collapsed, the failure lives in the seam's own row; a standalone
-                      button there would add a row and shove the trailing replies. */}
-                  {expanded && expandFailed && (
-                    <button
-                      type="button"
-                      onClick={() => void refetchMessages()}
-                      className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
-                    >
-                      Couldn't load older messages. Retry.
-                    </button>
-                  )}
+                  {ledgerHeadRow}
                   <BranchedBoardRows
-                    rows={branchRows(displayedReplies)}
+                    rows={branchRows(visibleReplies)}
                     workspaceId={workspaceId}
                     renderMessage={renderMessage}
                     continueThreadTo={continueThreadTo}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { Fragment, createElement } from "react"
 import * as boardFeedListModule from "@/components/board/board-feed-list"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, BoardView, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import * as boardStoreModule from "@/stores/board-store"
-import { ServicesProvider, SidebarProvider, PanelProvider } from "@/contexts"
+import { ServicesProvider, SidebarProvider, PanelProvider, MediaGalleryProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
@@ -19,6 +19,8 @@ import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as pointerModule from "@/hooks/use-pointer"
 import * as panelHostModule from "@/components/layout/panel-host"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
+import { db } from "@/db"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -172,10 +174,12 @@ function mountBoard(
           <SidebarProvider>
             <MemoryRouter initialEntries={[entry]}>
               <PanelProvider>
-                <LocationProbe />
-                <Routes>
-                  <Route path="/w/:workspaceId/board" element={<BoardPage />} />
-                </Routes>
+                <MediaGalleryProvider>
+                  <LocationProbe />
+                  <Routes>
+                    <Route path="/w/:workspaceId/board" element={<BoardPage />} />
+                  </Routes>
+                </MediaGalleryProvider>
               </PanelProvider>
             </MemoryRouter>
           </SidebarProvider>
@@ -193,7 +197,9 @@ function mountBoard(
   return { listByWorkspace, tree: buildTree(), rerender, rerenderWith }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  // The rail reads real IDB — a seeded event must not leak into the next test.
+  await db.events.clear()
   // `virtua` renders zero items under jsdom's zero-height, no-op-ResizeObserver
   // layout, so swap the board's virtualization seam for a passthrough that renders
   // every child — these integration tests exercise the real cards; the windowing
@@ -359,36 +365,55 @@ describe("BoardPage", () => {
     expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
   })
 
-  it("collapses the middle as an 'N older messages' expander, pluralizing the count", async () => {
-    // 5 messages: opening + 3 recent shown + 1 hidden in the middle.
+  it("renders the older replies as ledger lead rows, the newest one full", async () => {
+    // 5 messages: opening + 3 shown replies; the ledger keeps the newest full and
+    // leads the two before it. The one member nothing local can render is earlier
+    // mass, so it rides the head row rather than a lead of its own.
     const recent = [
       makeOpeningMessage({ id: "m3" }),
       makeOpeningMessage({ id: "m4" }),
       makeOpeningMessage({ id: "m5" }),
     ]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)])
-    expect(await screen.findByText("1 older message")).toBeTruthy()
-    expect(screen.queryByText("1 older messages")).toBeNull()
+    await screen.findAllByText("Opening message body.")
+    await vi.waitFor(() => expect(document.querySelectorAll("[data-ledger-row]").length).toBe(2))
+    expect(await screen.findByText(/^1 earlier/)).toBeTruthy()
   })
 
-  it("offers a retry when expanding the middle fails", async () => {
+  it("offers a retry when the earlier mass can't be fetched", async () => {
     const recent = [
       makeOpeningMessage({ id: "m3" }),
       makeOpeningMessage({ id: "m4" }),
       makeOpeningMessage({ id: "m5" }),
     ]
+    // The backfill only arms on a card whose rail has READ (a projection-sourced
+    // card is still resolving), so seed the opening onto the rail — the older
+    // members stay server-only, which is what the failing fetch is for.
+    await db.events.put({
+      id: "evt_m1",
+      workspaceId: WORKSPACE_ID,
+      streamId: "stream_1",
+      sequence: "10",
+      _sequenceNum: 10,
+      eventType: "message_created",
+      payload: { messageId: "m1", contentMarkdown: "Opening message body.", reactions: {} },
+      actorId: "usr_me",
+      actorType: "user",
+      createdAt: "2026-06-22T12:00:00.000Z",
+      _cachedAt: 10,
+    })
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)], { failMessages: true })
-    fireEvent.click(await screen.findByText("1 older message"))
-    // The backfill retries once (retry: 1, ~1s backoff) before surfacing the
-    // error label, so the wait must span the retry cycle.
+    // The ledger wants the whole window, so the backfill arms without a gesture.
+    // It retries once (retry: 1, ~1s backoff) before surfacing the error label, so
+    // the wait must span the retry cycle.
     expect(await screen.findByText("Couldn't load older messages. Retry.", undefined, { timeout: 4000 })).toBeTruthy()
   })
 
-  it("shows no expander when the whole conversation already fits", async () => {
+  it("shows no head row when the whole conversation already fits the ledger", async () => {
     const recent = [makeOpeningMessage({ id: "m2" }), makeOpeningMessage({ id: "m3" })]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3"] }, { id: "m1" }, recent)])
     await screen.findAllByText("Opening message body.")
-    expect(screen.queryByText(/older messages?$/)).toBeNull()
+    expect(screen.queryByText(/earlier/)).toBeNull()
   })
 
   it("renders reactions on the opening message", async () => {


### PR DESCRIPTION
## Problem

Chunk 4 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): the card itself. Agent pads are one conversation of 100–220 messages; the tail-as-runs card rendered up to 5 full bodies (p90 ≈ 2,000 chars each) — pages of scroll per card, no overview.

## Solution

- Reply region partitions: newest `boardFullTailCount` render full; older visible replies render as `LedgerRow` leads; everything past `boardLedgerRows` collapses into one "N earlier · t1 → t2" head row linking into the conversation panel.
- **Monotone full tail**: once full, never a lead — a new arrival extends the tail instead of demoting the previous newest (demotion unmounted `MessageItem` mid-edit and ate the buffer; the #1702 monotonicity lesson applied again). Reset on conversation switch.
- **Backfill growth is compensated**: the reveal anchor arms on the backfill's in-flight rising edge, landmarked on the first full row, so older rows landing above the eye-line no longer jump the card (the seam/paged-reveal path is no longer rendered; its machinery partially survives for exactly this use — chunk 10's deletion scope shrinks accordingly).
- **No fetch storm**: backfill arms only when the rail has resolved (`source !== "projection"`), the card lacks members locally, AND the card is in/near viewport — previously every mounted card fired a full-conversation fetch on board load. Accepted residual: a genuinely cold conversation previews + links to the panel rather than board-backfilling; the stream subscription syncs its rail and self-heals.
- First full row after leads always carries its header (adjacency-continuation broke attribution under a same-author lead).
- Read mechanics UNCHANGED per ruling: leads render without the observed-row attribute but remain inside the whole-card read cutoff — the test states both facts; lead-granular read waits for sparse-read.

## Test plan

- [x] 360 tests green across board/conversations suites (7 new ledger tests + monotone/arming/gate/header regressions, each falsification-checked); tsc + lint clean. Adversarial verify (Opus high): 5 findings, 5 accepted+fixed with rulings, 0 refuted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788286503&installation_model_id=20758&pr_number=1727&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1727&signature=761595d356cc86eb3dc809b35743360f4b46d9c5457f4716aebd1716b63bbb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->