### PR TITLE
feat(board): sub-conversations collapse to ledger rows with outcome leads

### DIFF
--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { StreamTypes } from "@threa/types"
@@ -204,7 +205,7 @@ beforeEach(async () => {
 afterEach(() => vi.restoreAllMocks())
 
 describe("BoardCard branches", () => {
-  it("renders the child conversation nested under a branch header inside the parent card", async () => {
+  it("collapses the child conversation to one ledger row, expanding it in place", async () => {
     await db.streams.bulkPut([
       cachedStream("stream_1", StreamTypes.CHANNEL),
       cachedStream("thread_child", StreamTypes.THREAD, {
@@ -238,16 +239,115 @@ describe("BoardCard branches", () => {
     await db.conversations.bulkPut([parent, child])
 
     mount(parent)
-    // Branch header carries the child topic and links to the child's panel.
-    const header = await screen.findByText("GPU budget")
-    expect(header.closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
-    // The child's own messages render nested INSIDE the parent card (one card,
-    // Reddit-style), indented under the header's left rail.
+    // Default collapsed: one row naming the branch, with its outcome lead — the
+    // branch's own bodies are not in the document.
+    const row = await screen.findByRole("button", { name: "GPU budget, 2 messages" })
+    expect(screen.queryByText("Child branch first message.")).toBeNull()
+    await userEvent.click(row)
+
+    // Expanded: the child's messages render nested INSIDE the parent card (one
+    // card, Reddit-style), indented under the header's left rail, and the header
+    // links to the child's panel.
     const nested = await screen.findByText("Child branch first message.")
     expect(await screen.findByText("Child branch second message.")).toBeTruthy()
     expect(nested.closest(".border-l-2")).not.toBeNull()
+    expect(screen.getByText("GPU budget").closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
     // The branch tail offers the inline Reply affordance (no navigation).
     expect(screen.getByRole("button", { name: "Reply…" })).toBeTruthy()
+
+    // Minimize returns to the collapsed row.
+    await userEvent.click(screen.getByRole("button", { name: "Collapse GPU budget" }))
+    expect(await screen.findByRole("button", { name: "GPU budget, 2 messages" })).toBeTruthy()
+    expect(screen.queryByText("Child branch first message.")).toBeNull()
+  })
+
+  it("shows the branch's message count and its LAST message as the outcome lead", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    const branchIds = ["c1", "c2", "c3", "c4", "c5", "c6"]
+    await db.events.bulkPut(
+      branchIds.map((id, i) =>
+        messageEvent(id, "thread_child", 10 + i, i === branchIds.length - 1 ? "We went with the 5090s." : `Body ${id}.`)
+      )
+    )
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: branchIds,
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+
+    mount(parent)
+    const row = await screen.findByRole("button", { name: "GPU budget, 6 messages" })
+    expect(row.textContent).toContain("6")
+    await waitFor(() => expect(row.textContent).toContain("We went with the 5090s."))
+    // No branch body is in the document while collapsed.
+    for (const id of branchIds) expect(screen.queryByText(`Body ${id}.`)).toBeNull()
+
+    // Expanding keeps the overflow link into the child's panel intact.
+    await userEvent.click(row)
+    const overflow = await screen.findByText("4 more replies")
+    expect(overflow.closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
+  })
+
+  it("carries the settling texture on a collapsed branch row", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    await db.events.bulkPut([messageEvent("c1", "thread_child", 10, "Still provisional here.")])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: ["c1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    // The child's provisional (still-settling) member — the branch row wears the
+    // same texture the settling message rows do.
+    ;(child as unknown as { settlingMessageIds: string[] }).settlingMessageIds = ["c1"]
+    await db.conversations.bulkPut([parent, child])
+
+    const { container } = mount(parent)
+    // The settling state is IN the accessible name: an aria-label overrides the
+    // button's content, so an sr-only span inside it would never be announced.
+    const row = await screen.findByRole("button", { name: "GPU budget, 1 message, still settling" })
+    expect(container.querySelector("[data-ledger-branch-row][data-settling]")).not.toBeNull()
+    expect(row.contains(screen.getByText(/Still settling/))).toBe(false)
   })
 
   it("shows a 'branched from' provenance row on the child card", async () => {

--- a/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
@@ -167,12 +167,16 @@ beforeEach(async () => {
     placeholder: string
     contextChip?: string
     onSubmit: (input: { contentJson: unknown }) => Promise<void>
+    onClose: () => void
   }) => (
     <div>
       {props.contextChip && <span>{props.contextChip}</span>}
       <span>{props.placeholder}</span>
       <button type="button" onClick={() => void props.onSubmit({ contentJson: SENT_DOC })}>
         Send inline
+      </button>
+      <button type="button" onClick={props.onClose}>
+        Close inline
       </button>
     </div>
   )) as never)
@@ -320,7 +324,8 @@ describe("BoardCard — inline sub-topic + branch reply", () => {
     const user = userEvent.setup()
     mount(parent)
     await screen.findByText("Child branch message.")
-
+    // The branch is a collapsed ledger row on the card — expand it to reach its tail.
+    await user.click(screen.getByRole("button", { name: "GPU budget, 1 message" }))
     await user.click(screen.getByRole("button", { name: "Reply…" }))
     // The chip names the reply target — the inline forms all look alike.
     expect(await screen.findByText("Replying in GPU budget")).toBeTruthy()
@@ -404,13 +409,138 @@ describe("BoardCard — inline sub-topic + branch reply", () => {
     expect(await screen.findByText("Pending sub-topic body.")).toBeTruthy()
   })
 
+  it("pins a branch open while its composer is armed, withholding the minimize control", async () => {
+    const { parent } = await seedParentWithBranch()
+
+    const user = userEvent.setup()
+    mount(parent)
+    await screen.findByText("Child branch message.")
+    await user.click(screen.getByRole("button", { name: "GPU budget, 1 message" }))
+    await user.click(screen.getByRole("button", { name: "Reply…" }))
+    expect(await screen.findByText("Replying in GPU budget")).toBeTruthy()
+
+    // Collapsing the branch would unmount the composer the user is typing into,
+    // so the control is withheld entirely while it's armed.
+    expect(screen.queryByRole("button", { name: "Collapse GPU budget" })).toBeNull()
+    expect(screen.getByText("Child branch message.")).toBeTruthy()
+  })
+
+  it("keeps the new sub-topic expanded when the graph takes over from the pending branch", async () => {
+    await db.streams.bulkPut([cachedStream("stream_1", StreamTypes.CHANNEL)])
+    const post = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      topicSummary: "Hardware refresh",
+      streamIds: ["stream_1"],
+    })
+    await db.conversations.bulkPut([post])
+
+    const user = userEvent.setup()
+    mount(post)
+    await screen.findByText("Hardware refresh opening.")
+    await user.click(screen.getByRole("button", { name: "Message actions" }))
+    await user.click(screen.getByText("New sub-topic"))
+    await user.click(await screen.findByRole("button", { name: "Send inline" }))
+    await db.events.put(messageEvent("pend_1", createDraftPanelId("stream_1", "m_open"), 30, "Sub-topic body."))
+    await screen.findByText("Sub-topic body.")
+
+    // The echo lands: the thread stream and the child conversation materialize,
+    // so the graph branch (under a conversation id the card has never seen)
+    // replaces the pending one.
+    await db.streams.put(
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      })
+    )
+    await db.events.put(messageEvent("c1", "thread_child", 31, "Sub-topic body."))
+    await db.conversations.put(
+      makePost({
+        id: "conv_child",
+        streamId: "thread_child",
+        messageIds: ["c1"],
+        topicSummary: "GPU budget",
+        streamIds: ["thread_child"],
+      })
+    )
+
+    // The branch stays open across the hand-off — the message just sent is still
+    // a rendered body, not a folded ledger row.
+    expect(await screen.findByRole("button", { name: "Collapse GPU budget" })).toBeTruthy()
+    expect(await screen.findByText("Sub-topic body.")).toBeTruthy()
+    expect(document.body.querySelector("[data-ledger-branch-row]")).toBeNull()
+  })
+
+  it("pins an ancestor branch open while a nested branch's composer is armed", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_a", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+      cachedStream("thread_c", StreamTypes.THREAD, {
+        parentStreamId: "thread_a",
+        rootStreamId: "stream_1",
+        parentMessageId: "a1",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("a1", "thread_a", 10, "Branch A message."),
+      messageEvent("c1", "thread_c", 11, "Branch C message."),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      topicSummary: "Hardware refresh",
+      streamIds: ["stream_1"],
+    })
+    await db.conversations.bulkPut([
+      parent,
+      makePost({
+        id: "conv_a",
+        streamId: "thread_a",
+        messageIds: ["a1"],
+        topicSummary: "Topic A",
+        streamIds: ["thread_a"],
+      }),
+      makePost({
+        id: "conv_c",
+        streamId: "thread_c",
+        messageIds: ["c1"],
+        topicSummary: "Topic C",
+        streamIds: ["thread_c"],
+      }),
+    ])
+
+    const user = userEvent.setup()
+    mount(parent)
+    await user.click(await screen.findByRole("button", { name: "Topic A, 1 message" }))
+    await user.click(await screen.findByRole("button", { name: "Topic C, 1 message" }))
+    // The nested branch's tail comes before its ancestor's in the DOM.
+    await user.click(screen.getAllByRole("button", { name: "Reply…" })[0])
+    expect(await screen.findByText("Replying in Topic C")).toBeTruthy()
+
+    // Collapsing A would unmount C's live composer (and strand the open-composer
+    // state with no mounted UI), so A's control is withheld too.
+    expect(screen.queryByRole("button", { name: "Collapse Topic A" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Collapse Topic C" })).toBeNull()
+
+    await user.click(screen.getByRole("button", { name: "Close inline" }))
+    expect(await screen.findByRole("button", { name: "Collapse Topic A" })).toBeTruthy()
+  })
+
   it("keeps one inline composer open per card — opening another closes the first", async () => {
     const { parent } = await seedParentWithBranch()
 
     const user = userEvent.setup()
     mount(parent)
     await screen.findByText("Child branch message.")
-
+    // The branch is a collapsed ledger row on the card — expand it to reach its tail.
+    await user.click(screen.getByRole("button", { name: "GPU budget, 1 message" }))
     // Open the branch-tail reply…
     await user.click(screen.getByRole("button", { name: "Reply…" }))
     // The composer stub renders the reply chip once it's mounted in the tail.

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1115,6 +1115,14 @@ describe("BoardCard ledger", () => {
     expect(screen.getByText("Reply 5.")).toBeTruthy()
   })
 
+  it("does not count a tombstone hidden above the window in the head row", async () => {
+    // 20 replies, the second deleted: it falls in the hidden-older range, and
+    // `totalReplies` counts tombstones as zero — so must the head row.
+    mountCard(await seedLedgerRail(20, { deletedIndex: 1 }))
+
+    expect(await screen.findByText(/^3 earlier · /)).toBeTruthy()
+  })
+
   it("opens a ledger row into the full message in place, and minimizes it back to a lead", async () => {
     mountCard(await seedLedgerRail(8))
 

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -22,6 +22,7 @@ import {
   BranchProvenanceRow,
   BRANCH_SETTLING_RAIL_CLASS,
   BRANCH_ACCENTED_SETTLING_RAIL_CLASS,
+  type BranchExpansion,
 } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
@@ -386,6 +387,45 @@ export function BoardCard({
     derivePendingBranches,
     messagesById,
   ])
+  // Pending→graph hand-off: a branch the user just created is pinned open only
+  // while it is pending, and the real conversation id it lands under was never in
+  // the expansion set — so without this the new sub-topic folds the moment its
+  // echo arrives, hiding the message just sent. Fork ids whose pending branch this
+  // card rendered are remembered, and the graph branch that replaces one is adopted
+  // into the expansion set. Post-render (a discarded render must not consume it).
+  const handoffForkIdsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const handoff = handoffForkIdsRef.current
+    // A sub-topic started on a branch message materializes as a nested child, not
+    // a top-level group, so the whole rendered tree is scanned by fork id.
+    const byFork = new Map<string, BranchConversationView[]>()
+    const walk = (branches: BranchConversationView[]) => {
+      for (const branch of branches) {
+        const list = byFork.get(branch.forkMessageId)
+        if (list) list.push(branch)
+        else byFork.set(branch.forkMessageId, [branch])
+        walk(branch.children)
+      }
+    }
+    for (const branches of branchesByForkMessageId.values()) walk(branches)
+    const adopt: string[] = []
+    for (const [forkMessageId, branches] of byFork) {
+      if (branches.some((b) => b.pending)) {
+        handoff.add(forkMessageId)
+        continue
+      }
+      if (!handoff.delete(forkMessageId)) continue
+      for (const branch of branches) adopt.push(branch.conversationId)
+    }
+    if (adopt.length === 0) return
+    setLedgerExpansion((current) => {
+      const base = current.conversationId === conversation.id ? current.expanded : EMPTY_EXPANDED
+      if (adopt.every((id) => base.has(id))) return current
+      const expanded = new Set(base)
+      for (const id of adopt) expanded.add(id)
+      return { conversationId: conversation.id, expanded }
+    })
+  }, [branchesByForkMessageId, conversation.id])
   // Direct sub-topics under this conversation — the "↳" branch groups, counted
   // for the locator line and collapse pill. Top-level only (grandchildren nest
   // visually but don't inflate the card's headline count).
@@ -525,10 +565,10 @@ export function BoardCard({
         : { conversationId: conversation.id, messageId: firstFullTailId }
     )
   }, [conversation.id, firstFullTailId])
-  // `totalReplies` counts tombstones as zero, so the rendered rows are counted the
-  // same way — replies the rail hasn't synced at all are earlier mass too.
+  // `totalReplies` counts tombstones as zero, so BOTH sides count non-deleted
+  // only — replies the rail hasn't synced at all are earlier mass too.
   const unsyncedOlder = Math.max(0, totalReplies - displayedReplies.filter((m) => !m.deletedAt).length)
-  const earlierCount = hiddenOlder.length + unsyncedOlder
+  const earlierCount = hiddenOlder.filter((m) => !m.deletedAt).length + unsyncedOlder
   // The backfill can outrun the local rail while the head row stands for rows only
   // the server has; the wait and its retry take that same single row, so nothing
   // below them shifts through either state (INV-21). Both are gated on there being
@@ -779,6 +819,33 @@ export function BoardCard({
     )
   }
 
+  // A nested branch is a ledger line on the card: collapsed by default, expanding
+  // in place into the group above. It shares the card's ledger expansion set,
+  // keyed by the branch's conversation id (prefixed ULIDs, so it can't collide
+  // with the message ids in the same set) and reset on conversation switch with it.
+  // Two branches are never collapsible: a pending one (its sub-topic send is still
+  // in flight) and one whose inline composer is open — folding either would eat the
+  // affordance the user is composing into.
+  const openComposer = inlineComposer.openComposer
+  const branchSelfPinned = (branch: BranchConversationView) => {
+    if (branch.pending) return true
+    if (openComposer?.kind === "branch-reply") return openComposer.conversationId === branch.conversationId
+    if (openComposer?.kind === "new-subtopic") return branch.messages.some((m) => m.id === openComposer.messageId)
+    return false
+  }
+  // A descendant's pin pins its ancestors too: a nested branch is reachable only
+  // through them, so collapsing an ancestor would unmount the live composer AND
+  // strand `openComposer` non-null with no mounted UI.
+  const branchPinnedOpen = (branch: BranchConversationView): boolean =>
+    branchSelfPinned(branch) || branch.children.some(branchPinnedOpen)
+  const branchExpansion: BranchExpansion = {
+    workspaceId,
+    leadLineLength,
+    isExpanded: (branch) => branchPinnedOpen(branch) || expandedRowIds.has(branch.conversationId),
+    canCollapse: (branch) => !branchPinnedOpen(branch),
+    toggle: (branch) => toggleLedgerRow(branch.conversationId),
+  }
+
   // Header chrome shared by both header shapes (title-led and message-led), so
   // the chevron/dot/actions don't get duplicated across the two branches.
   const chevronToggle = (
@@ -989,6 +1056,7 @@ export function BoardCard({
                   onSplitThread={onSplitThread}
                   renderBranchMessage={renderBranchMessage}
                   renderBranchTail={inlineComposer.renderBranchTail}
+                  branchExpansion={branchExpansion}
                   renderAfterMessage={inlineComposer.renderAfterMessage}
                   onRedirectSession={openReplyComposer}
                 />
@@ -1007,6 +1075,7 @@ export function BoardCard({
                     onSplitThread={onSplitThread}
                     renderBranchMessage={renderBranchMessage}
                     renderBranchTail={inlineComposer.renderBranchTail}
+                    branchExpansion={branchExpansion}
                     renderAfterMessage={inlineComposer.renderAfterMessage}
                     onRedirectSession={openReplyComposer}
                   />

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useState, type ReactNode } from "react"
 import { Link } from "react-router-dom"
-import { CornerDownRight, GitBranch, ArrowRight, MoveRight, ChevronDown, Scissors } from "lucide-react"
+import { CornerDownRight, GitBranch, ArrowRight, MoveRight, ChevronDown, ChevronUp, Scissors } from "lucide-react"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { usePanel, createConversationPanelId } from "@/contexts"
 import {
@@ -15,6 +15,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
+import { LedgerBranchRow } from "@/components/board/ledger-row"
 import { DayDivider } from "@/components/timeline/day-divider"
 import { UnreadDivider } from "@/components/timeline/unread-divider"
 import { isContinuation } from "@/lib/message-grouping"
@@ -94,8 +95,25 @@ function SplitThreadAction({ label, onConfirm }: { label: string; onConfirm: () 
   )
 }
 
+/**
+ * Ledger collapse for nested branches, owned by the surface (the board card joins
+ * it to the card's ledger expansion set). Absent ⇒ every branch renders expanded,
+ * which is what the conversation panel wants.
+ */
+export interface BranchExpansion {
+  workspaceId: string
+  /** Lead-line budget for a collapsed branch row's outcome lead. */
+  leadLineLength: number
+  isExpanded: (branch: BranchConversationView) => boolean
+  /** False while the branch is pinned open (pending send, armed composer) — the
+   *  minimize control is withheld rather than rendered inert. */
+  canCollapse: (branch: BranchConversationView) => boolean
+  toggle: (branch: BranchConversationView) => void
+}
+
 interface BranchGroupProps {
   branch: BranchConversationView
+  expansion?: BranchExpansion
   /** Render one of the branch's own messages — render-only (its read state belongs
    *  to the child conversation, not the parent card). Omitted ⇒ header only. */
   renderBranchMessage?: (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => ReactNode
@@ -125,9 +143,30 @@ interface BranchGroupProps {
 export const BRANCH_SETTLING_RAIL_CLASS = "-left-2.5 sm:-left-3.5"
 export const BRANCH_ACCENTED_SETTLING_RAIL_CLASS = "left-0"
 
-export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, renderAfterMessage }: BranchGroupProps) {
+export function BranchGroup({
+  branch,
+  expansion,
+  renderBranchMessage,
+  renderBranchTail,
+  renderAfterMessage,
+}: BranchGroupProps) {
   const { getPanelUrl } = usePanel()
   const panelUrl = getPanelUrl(createConversationPanelId(branch.conversationId))
+  if (expansion && !expansion.isExpanded(branch)) {
+    return (
+      <LedgerBranchRow
+        workspaceId={expansion.workspaceId}
+        title={branch.title}
+        conversationId={branch.conversationId}
+        messageIds={branch.messages.map((m) => m.id)}
+        messageCount={branch.messages.length + branch.hiddenCount}
+        lastMessage={branch.messages.at(-1) ?? null}
+        leadLineLength={expansion.leadLineLength}
+        settling={branch.messages.some((m) => m.settling) || (branch.settlingMessageIds?.length ?? 0) > 0}
+        onToggle={() => expansion.toggle(branch)}
+      />
+    )
+  }
   // A pending branch (sub-topic sent, conversation echo not landed) has no real
   // conversation to open yet — its header is inert until the graph takes over.
   const header = (
@@ -138,16 +177,31 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
   )
   return (
     <div className="mt-3">
-      {branch.pending ? (
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">{header}</div>
-      ) : (
-        <Link
-          to={panelUrl}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          {header}
-        </Link>
-      )}
+      {/* Minimize strip: the header row carries the collapse control, so the
+          branch folds back to the exact line it expanded from (INV-21). */}
+      <div className="flex items-center gap-1.5">
+        {branch.pending ? (
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">{header}</div>
+        ) : (
+          <Link
+            to={panelUrl}
+            className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {header}
+          </Link>
+        )}
+        {expansion?.canCollapse(branch) && (
+          <button
+            type="button"
+            onClick={() => expansion.toggle(branch)}
+            aria-expanded
+            aria-label={`Collapse ${branch.title}`}
+            className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronUp className="size-3.5" />
+          </button>
+        )}
+      </div>
       <div className="mt-1 border-l-2 border-muted-foreground/25 pl-2 sm:pl-3 [&>*:first-child]:mt-0">
         {renderBranchMessage &&
           branch.messages.map((message, index) => {
@@ -173,6 +227,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
           <BranchGroup
             key={child.conversationId}
             branch={child}
+            expansion={expansion}
             renderBranchMessage={renderBranchMessage}
             renderBranchTail={renderBranchTail}
             renderAfterMessage={renderAfterMessage}
@@ -248,6 +303,8 @@ interface BranchedBoardRowsProps {
   renderBranchTail?: (branch: BranchConversationView) => ReactNode
   /** The inline "new sub-topic" composer slot rendered under a message row. */
   renderAfterMessage?: (messageId: string) => ReactNode
+  /** Collapse nested branches to one ledger row each. Absent ⇒ always expanded. */
+  branchExpansion?: BranchExpansion
   /** Open + focus the surface's reply composer for a running session's Redirect. */
   onRedirectSession?: () => void
 }
@@ -260,6 +317,7 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
     renderBranchMessage,
     renderBranchTail,
     renderAfterMessage,
+    branchExpansion,
     onSplitThread,
     onRedirectSession,
   } = props
@@ -295,6 +353,7 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
         <BranchGroup
           key={row.key}
           branch={row.branch}
+          expansion={branchExpansion}
           renderBranchMessage={renderBranchMessage}
           renderBranchTail={renderBranchTail}
           renderAfterMessage={renderAfterMessage}

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -18,7 +18,11 @@ import * as useMobileModule from "@/hooks/use-mobile"
 import * as messageHistoryDialogModule from "@/components/timeline/message-history-dialog"
 import * as conversationsModule from "@/hooks/use-conversations"
 import { spyOnExport } from "@/test/spy"
-import { LedgerEventGroup, LedgerRow } from "./ledger-row"
+import { LedgerBranchRow, LedgerEventGroup, LedgerRow } from "./ledger-row"
+import { boardBranchReplyDraftKey, boardSubtopicDraftKey } from "@/lib/board/draft-keys"
+import { __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
+// eslint-disable-next-line no-restricted-imports -- seeds IDB directly to drive the real board-drafts snapshot
+import { db } from "@/db"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -413,6 +417,83 @@ describe("LedgerRow settling", () => {
     await user.pointer({ keys: "[MouseRight]", target: rowButton })
     expect(await screen.findByRole("menuitem", { name: /Move to sub-topic/i })).toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Keep here" })).not.toBeInTheDocument()
+  })
+})
+
+describe("LedgerBranchRow", () => {
+  function renderBranchRow(overrides: Partial<Parameters<typeof LedgerBranchRow>[0]> = {}) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <LedgerBranchRow
+              workspaceId={WS}
+              title="GPU budget"
+              conversationId="conv_child"
+              messageIds={["msg_1"]}
+              messageCount={2}
+              lastMessage={message({ contentMarkdown: "We went with the 5090s." })}
+              leadLineLength={80}
+              settling={false}
+              onToggle={vi.fn()}
+              {...overrides}
+            />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+  }
+
+  beforeEach(async () => {
+    __clearBoardDraftsRegistry()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+  })
+
+  it("announces settling in the button's accessible name, never as content it overrides", () => {
+    renderBranchRow({ settling: true })
+    const button = screen.getByRole("button", { name: /GPU budget, 2 messages, still settling/ })
+    // The sr-only copy is a SIBLING: an aria-label overrides descendant content,
+    // so a span inside the button would never be announced.
+    const announcement = screen.getByText(/Still settling/)
+    expect(button.contains(announcement)).toBe(false)
+  })
+
+  it("shows a draft chip when the branch's tail reply holds an unsent draft", async () => {
+    await db.drafts.add({
+      id: "draft_1",
+      workspaceId: WS,
+      scope: boardBranchReplyDraftKey("conv_child"),
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "half a reply" }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+
+    const { container } = renderBranchRow()
+    await waitFor(() => expect(container.querySelector("[data-branch-draft-chip]")).not.toBeNull())
+    expect(screen.getByRole("button", { name: /GPU budget, 2 messages, unsent draft/ })).toBeInTheDocument()
+  })
+
+  it("shows a draft chip for an unsent sub-topic draft on one of the branch's messages", async () => {
+    await db.drafts.add({
+      id: "draft_2",
+      workspaceId: WS,
+      scope: boardSubtopicDraftKey(STREAM, "msg_1"),
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "a sub-topic" }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+
+    const { container } = renderBranchRow()
+    await waitFor(() => expect(container.querySelector("[data-branch-draft-chip]")).not.toBeNull())
+  })
+
+  it("shows no draft chip when the branch holds nothing unsent", async () => {
+    const { container } = renderBranchRow()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(container.querySelector("[data-branch-draft-chip]")).toBeNull()
+    expect(screen.getByRole("button", { name: "GPU budget, 2 messages" })).toBeInTheDocument()
   })
 })
 

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react"
 import { useNavigate } from "react-router-dom"
 import { toast } from "sonner"
-import { ChevronUp, ChevronRight, Paperclip, Link2 } from "lucide-react"
+import { ChevronUp, ChevronRight, CornerDownRight, Paperclip, Link2, Pencil } from "lucide-react"
 import { LabelableResourceTypes, LinkPreviewContentTypes } from "@threa/types"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
@@ -22,6 +22,8 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { useSettleConversationMessage } from "@/hooks/use-conversations"
+import { useScopeDraftPreview, useBoardSubtopicDraftIndex } from "@/hooks"
+import { boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { leadLine, rowArtifacts } from "@/lib/board/ledger"
 import { resolveInternalAppPath } from "@/lib/internal-url"
 import { getInitials } from "@/lib/initials"
@@ -424,6 +426,94 @@ export function LedgerRow({
         </div>
       )}
       {overlays}
+    </div>
+  )
+}
+
+/**
+ * A whole sub-conversation compressed to one ledger line: the branch's name, how
+ * many messages it holds, and the OUTCOME lead — the lead line of its LAST
+ * message, which is what the reader wants from a branch they aren't in. Expands
+ * in place into the branch's full rendering (rows, rails, overflow link, reply
+ * affordance), same a11y contract as {@link LedgerRow}.
+ */
+export function LedgerBranchRow({
+  workspaceId,
+  title,
+  conversationId,
+  messageIds,
+  messageCount,
+  lastMessage,
+  leadLineLength,
+  settling,
+  onToggle,
+}: {
+  workspaceId: string
+  title: string
+  /** The branch's own conversation id — its tail reply draft scope. */
+  conversationId: string
+  /** The branch's rendered message ids — their sub-topic draft scopes. */
+  messageIds: string[]
+  messageCount: number
+  /** The branch's newest locally-known message — the outcome lead. */
+  lastMessage: RenderableMessage | null
+  leadLineLength: number
+  settling: boolean
+  onToggle: () => void
+}) {
+  const { toEmoji } = useWorkspaceEmoji(workspaceId)
+  // An unsent draft inside the branch (its tail reply, or a sub-topic gesture on
+  // one of its messages) is invisible once the branch folds, so the collapsed row
+  // carries the same Pencil marker `CollapsedComposerBar` uses. Presence only —
+  // it never pins the branch open; tapping the row expands as normal.
+  const tailDraft = useScopeDraftPreview(workspaceId, boardBranchReplyDraftKey(conversationId))
+  const subtopicDrafts = useBoardSubtopicDraftIndex(workspaceId)
+  const hasDraft = tailDraft !== null || messageIds.some((id) => subtopicDrafts.has(id))
+  let lead: string | null = null
+  if (lastMessage) {
+    lead = lastMessage.deletedAt
+      ? TOMBSTONE_LEAD
+      : ledgerLead(lastMessage.contentMarkdown, leadLineLength, rowArtifacts(lastMessage), toEmoji)
+  }
+  return (
+    <div className="mt-3 ml-3" data-ledger-branch-row="" data-settling={settling ? "" : undefined}>
+      {/* Outside the button: an `aria-label` overrides the element's content, so
+          an sr-only span INSIDE it is never announced (as the message row does). */}
+      {settling && <span className="sr-only">Still settling — messages here may move to another topic</span>}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={false}
+        aria-label={`${title}, ${messageCount} ${messageCount === 1 ? "message" : "messages"}${
+          settling ? ", still settling" : ""
+        }${hasDraft ? ", unsent draft" : ""}`}
+        className={cn(
+          "relative flex w-full items-center gap-2 rounded border-l-2 border-muted-foreground/20 py-0.5 pl-2 text-left transition-opacity duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          settling && "opacity-70"
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-y-0 left-0 w-0 border-l-[2px] border-dashed transition-colors duration-300",
+            settling ? "border-muted-foreground/40" : "border-transparent"
+          )}
+        />
+        <CornerDownRight aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="max-w-[45%] shrink truncate text-xs font-medium text-foreground/75">{title}</span>
+        <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/70">{messageCount}</span>
+        {lead && <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{lead}</span>}
+        {hasDraft && (
+          <span
+            aria-hidden
+            data-branch-draft-chip=""
+            className="flex shrink-0 items-center gap-0.5 text-[10px] text-muted-foreground"
+          >
+            <Pencil className="size-3 shrink-0" />
+            Draft
+          </span>
+        )}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Chunk 5 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): nested sub-conversations rendered as full message walls inside the card — the ledger needed its "neat sub-conversation representation" (Kris's words) without hiding live composition.

## Solution

- `LedgerBranchRow`: one indented row per branch — shared-resolver stream name, message count, OUTCOME lead (its last message's lead line), settling texture with a real accessible-name announcement (the sr-only span sits OUTSIDE the aria-labeled button; inside it was screen-reader-dead), and a compact Draft chip when the branch holds an unsent reply/sub-topic draft (presence signal only, no pin).
- Expanded = today's full branch rendering, composer affordances intact. Expansion joins the card's existing set, keyed by branch conversation id.
- **Pinned open** (collapse withheld, not inert): pending branches, any branch whose OWN or DESCENDANT composer is armed (ancestor-collapse would unmount a nested live composer and wedge `openComposer`), and — the subtle one — across the pending→graph hand-off: the just-created sub-topic's real conversation id is seeded into the expansion set when its echo lands, so your new branch doesn't fold to one line a second after you sent into it.
- Conversation panel untouched: no expansion prop → always expanded, as today.
- Rides along: #1727's review fix — the head row no longer counts tombstones hidden above the window ("4 earlier" for 3 real messages).

## Test plan

- [x] 239 board tests green (collapsed/expanded round-trip, hand-off, ancestor pin, a11y relationship, draft chips, tombstone count — every verifier fix falsification-checked in a joint neutralisation run); tsc + lint clean. Adversarial verify (Opus high): 4 findings, 4 accepted+fixed, 0 refuted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788287991&installation_model_id=20758&pr_number=1728&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1728&signature=52e0c18890e8529335c471ae1deb03b591d5fd631387fefc9140aed97a34c2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->