### PR TITLE
feat(board): surrounding events as hair-thin ledger rows

### DIFF
--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -10,6 +10,8 @@ import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } 
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+import { __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
+import { boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
 import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
@@ -164,6 +166,9 @@ const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), 
 beforeEach(async () => {
   __clearBoardRailRegistry()
   __clearConversationGraphRegistry()
+  __clearBoardDraftsRegistry()
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
   await db.events.clear()
   await db.streams.clear()
   await db.conversations.clear()
@@ -348,6 +353,86 @@ describe("BoardCard branches", () => {
     const row = await screen.findByRole("button", { name: "GPU budget, 1 message, still settling" })
     expect(container.querySelector("[data-ledger-branch-row][data-settling]")).not.toBeNull()
     expect(row.contains(screen.getByText(/Still settling/))).toBe(false)
+  })
+
+  async function seedNestedBranches() {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_a", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+      cachedStream("thread_c", StreamTypes.THREAD, {
+        parentStreamId: "thread_a",
+        rootStreamId: "stream_1",
+        parentMessageId: "a1",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("a1", "thread_a", 10, "Branch A message."),
+      messageEvent("c1", "thread_c", 11, "Grandchild C message."),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const branchA = makePost({
+      id: "conv_a",
+      streamId: "thread_a",
+      messageIds: ["a1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_a"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    const branchC = makePost({
+      id: "conv_c",
+      streamId: "thread_c",
+      messageIds: ["c1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_c"],
+      rootStreamId: "stream_1",
+      topicSummary: "Cooling",
+    })
+    return { parent, branchA, branchC }
+  }
+
+  it("rolls a grandchild branch's unsent draft up onto the collapsed ancestor row", async () => {
+    const { parent, branchA, branchC } = await seedNestedBranches()
+    await db.conversations.bulkPut([parent, branchA, branchC])
+    await db.drafts.add({
+      id: "draft_c",
+      workspaceId: WS,
+      scope: boardBranchReplyDraftKey("conv_c"),
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "half a reply" }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+
+    const { container } = mount(parent)
+    // A is collapsed, so C is not in the document at all — its draft is invisible
+    // unless A's one remaining row speaks for the whole subtree.
+    await screen.findByRole("button", { name: /^GPU budget, 1 message/ })
+    expect(screen.queryByText("Grandchild C message.")).toBeNull()
+    await waitFor(() => expect(container.querySelector("[data-branch-draft-chip]")).not.toBeNull())
+    expect(screen.getByRole("button", { name: "GPU budget, 1 message, unsent draft" })).toBeInTheDocument()
+  })
+
+  it("rolls a grandchild branch's settling state up onto the collapsed ancestor row", async () => {
+    const { parent, branchA, branchC } = await seedNestedBranches()
+    ;(branchC as unknown as { settlingMessageIds: string[] }).settlingMessageIds = ["c1"]
+    await db.conversations.bulkPut([parent, branchA, branchC])
+
+    const { container } = mount(parent)
+    const row = await screen.findByRole("button", { name: "GPU budget, 1 message, still settling" })
+    expect(row).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector("[data-ledger-branch-row][data-settling]")).not.toBeNull())
   })
 
   it("shows a 'branched from' provenance row on the child card", async () => {

--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -11,7 +11,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 import { __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
-import { boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
+import { boardBranchReplyDraftKey, boardSubtopicDraftKey } from "@/lib/board/draft-keys"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
 import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
@@ -248,6 +248,7 @@ describe("BoardCard branches", () => {
     // branch's own bodies are not in the document.
     const row = await screen.findByRole("button", { name: "GPU budget, 2 messages" })
     expect(screen.queryByText("Child branch first message.")).toBeNull()
+    const collapsedWrapperClass = row.closest("[data-ledger-branch-row]")!.className
     await userEvent.click(row)
 
     // Expanded: the child's messages render nested INSIDE the parent card (one
@@ -256,7 +257,11 @@ describe("BoardCard branches", () => {
     const nested = await screen.findByText("Child branch first message.")
     expect(await screen.findByText("Child branch second message.")).toBeTruthy()
     expect(nested.closest(".border-l-2")).not.toBeNull()
-    expect(screen.getByText("GPU budget").closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
+    const header = screen.getByText("GPU budget").closest("a")
+    expect(header?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
+    // The two states share one wrapper box, so toggling never shifts the branch's
+    // leading edge (INV-21) — a stray `ml-3` on either side moves the ↳ 0.75rem.
+    expect(header!.parentElement!.parentElement!.className).toBe(collapsedWrapperClass)
     // The branch tail offers the inline Reply affordance (no navigation).
     expect(screen.getByRole("button", { name: "Reply…" })).toBeTruthy()
 
@@ -422,6 +427,53 @@ describe("BoardCard branches", () => {
     expect(screen.queryByText("Grandchild C message.")).toBeNull()
     await waitFor(() => expect(container.querySelector("[data-branch-draft-chip]")).not.toBeNull())
     expect(screen.getByRole("button", { name: "GPU budget, 1 message, unsent draft" })).toBeInTheDocument()
+  })
+
+  it("shows the draft chip for a sub-topic draft on a branch message outside the preview window", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    const branchIds = ["c1", "c2", "c3", "c4"]
+    await db.events.bulkPut(branchIds.map((id, i) => messageEvent(id, "thread_child", 10 + i, `Body ${id}.`)))
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: branchIds,
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+    // `c1` is the OLDEST member — outside the 2-message preview window the
+    // collapsed row's lead is built from.
+    await db.drafts.add({
+      id: "draft_old",
+      workspaceId: WS,
+      scope: boardSubtopicDraftKey("thread_child", "c1"),
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "a sub-topic" }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+
+    const { container } = mount(parent)
+    await screen.findByRole("button", { name: /^GPU budget, 4 messages/ })
+    await waitFor(() => expect(container.querySelector("[data-branch-draft-chip]")).not.toBeNull())
+    expect(screen.getByRole("button", { name: "GPU budget, 4 messages, unsent draft" })).toBeInTheDocument()
   })
 
   it("rolls a grandchild branch's settling state up onto the collapsed ancestor row", async () => {

--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+const CONV = "conv_1"
+const STREAM = "stream_1"
+
+function at(seconds: number): string {
+  return `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`
+}
+
+function cachedStream(id: string, type: string): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: type as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: at(0),
+    updatedAt: at(0),
+    archivedAt: null,
+    _cachedAt: 0,
+  }
+}
+
+let seq = 0
+function event(eventType: string, seconds: number, payload: unknown, id?: string): CachedEvent {
+  seq += 1
+  return {
+    id: id ?? `evt_${seq}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType: eventType as CachedEvent["eventType"],
+    payload: payload as CachedEvent["payload"],
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: at(seconds),
+    _cachedAt: seq,
+  }
+}
+
+function messageEvent(id: string, seconds: number, content: string): CachedEvent {
+  return event("message_created", seconds, { messageId: id, contentMarkdown: content, reactions: {} }, `evt_${id}`)
+}
+
+function memoEvent(id: string, seconds: number, memoId: string, title: string): CachedEvent {
+  return event(
+    "memos:captured",
+    seconds,
+    { conversationId: CONV, memos: [{ memoId, title, knowledgeType: "fact", sourceMessageIds: ["r1"] }] },
+    id
+  )
+}
+
+function post(): CachedBoardPost {
+  return {
+    id: CONV,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    rootStreamId: STREAM,
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: CONV,
+      streamId: STREAM,
+      workspaceId: WS,
+      messageIds: ["m_open", "r1", "r2", "r3"],
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: "Index migration",
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: at(0),
+      createdAt: at(0),
+      updatedAt: at(0),
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: {
+      id: "m_open",
+      streamId: STREAM,
+      authorId: "usr_other",
+      authorType: "user",
+      contentMarkdown: "Opening the index migration.",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: at(0),
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: 3,
+  } as unknown as CachedBoardPost
+}
+
+function mount() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <MediaGalleryProvider>
+                  <BoardCard
+                    workspaceId={WS}
+                    post={post() as BoardViewPost}
+                    contextLabel="#general"
+                    streamType="channel"
+                  />
+                </MediaGalleryProvider>
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+beforeEach(async () => {
+  seq = 0
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  await db.streams.put(cachedStream(STREAM, StreamTypes.CHANNEL))
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+/** Rendered order of the card's text, so a row's placement is assertable. */
+function textOrder(...needles: string[]): number[] {
+  const body = document.body.textContent ?? ""
+  return needles.map((needle) => body.indexOf(needle))
+}
+
+describe("BoardCard ledger events", () => {
+  it("renders a capture between the ledger messages as a thin title-only line linking to the memo", async () => {
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      memoEvent("evt_memo", 11, "memo_9", "Postgres upserts need the index"),
+      messageEvent("r2", 12, "Second reply."),
+      messageEvent("r3", 13, "Third reply."),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    const link = await screen.findByRole("link", { name: /Memo: Postgres upserts need the index/ })
+    expect(link).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_9")
+    // The full capture row's phrasing (and its memo-opening buttons) is not what
+    // a ledger line renders — title only, never the memo body.
+    expect(screen.queryByText(/Saved to memory/)).toBeNull()
+
+    const [first, memo, second] = textOrder("First reply.", "Memo: Postgres upserts need the index", "Second reply.")
+    expect(first).toBeGreaterThan(-1)
+    expect(memo).toBeGreaterThan(first)
+    expect(second).toBeGreaterThan(memo)
+  })
+
+  it("coalesces a run of three ledger events into one row that expands and re-coalesces", async () => {
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      memoEvent("evt_a", 11, "memo_1", "Alpha"),
+      memoEvent("evt_b", 12, "memo_2", "Beta"),
+      memoEvent("evt_c", 13, "memo_3", "Gamma"),
+      messageEvent("r2", 14, "Second reply."),
+      messageEvent("r3", 15, "Third reply."),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    const summary = await screen.findByRole("button", { name: /3 events —/ })
+    expect(summary).toHaveTextContent("3 events — Memo: Alpha · Memo: Beta · Memo: Gamma")
+    await userEvent.click(summary)
+
+    const group = screen.getByRole("button", { name: "3 events" }).parentElement as HTMLElement
+    expect(within(group).getAllByRole("link")).toHaveLength(3)
+    expect(within(group).getByRole("link", { name: /Memo: Beta/ })).toHaveAttribute(
+      "href",
+      "/w/ws_1/memory?memo=memo_2"
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "3 events" }))
+    expect(screen.getByRole("button", { name: /3 events —/ })).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /Memo: Beta/ })).toBeNull()
+  })
+
+  it("keeps an event in the full-tail region fully rendered", async () => {
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      messageEvent("r2", 11, "Second reply."),
+      messageEvent("r3", 12, "Third reply."),
+      memoEvent("evt_tail", 13, "memo_9", "Postgres upserts need the index"),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    // The full capture row (title as a preview-opening button), not a thin line.
+    expect(await screen.findByText(/Saved to memory/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Postgres upserts need the index" })).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /Memo: Postgres upserts need the index/ })).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
-import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows, foldLedgerEventRows } from "@/components/board/board-row-item"
 import {
   BranchedBoardRows,
   BranchProvenanceRow,
@@ -556,6 +556,13 @@ export function BoardCard({
   const ledgerIds = new Set(ledgerReplies.map((m) => m.id))
   const visibleReplies = [...ledgerReplies, ...fullTailReplies]
   const firstFullTailId = fullTailReplies[0]?.id ?? null
+  // Events interleave at their own timeline positions; those landing among the
+  // ledger rows compress to the same hair-thin line the messages do, coalescing
+  // adjacent runs. A card with no ledger rows is all full detail, so nothing folds.
+  const ledgerBranchRows = (messages: RenderableMessage[]) => {
+    const rows = branchRows(messages)
+    return ledgerReplies.length > 0 ? foldLedgerEventRows(rows, firstFullTailId) : rows
+  }
   // Commit the partition's first row after render, never during it.
   useEffect(() => {
     if (firstFullTailId === null) return
@@ -838,6 +845,12 @@ export function BoardCard({
   // strand `openComposer` non-null with no mounted UI.
   const branchPinnedOpen = (branch: BranchConversationView): boolean =>
     branchSelfPinned(branch) || branch.children.some(branchPinnedOpen)
+  // A coalesced event group shares the same expansion set, keyed by its row key
+  // (`ledger-events:<first event key>`) — reset on conversation switch with it.
+  const ledgerEventExpansion = {
+    isExpanded: (key: string) => expandedRowIds.has(key),
+    toggle: toggleLedgerRow,
+  }
   const branchExpansion: BranchExpansion = {
     workspaceId,
     leadLineLength,
@@ -1049,7 +1062,7 @@ export function BoardCard({
               )}
               {contiguous ? (
                 <BranchedBoardRows
-                  rows={branchRows(openingMessage ? [openingMessage, ...visibleReplies] : visibleReplies)}
+                  rows={ledgerBranchRows(openingMessage ? [openingMessage, ...visibleReplies] : visibleReplies)}
                   workspaceId={workspaceId}
                   renderMessage={renderMessage}
                   continueThreadTo={continueThreadTo}
@@ -1059,6 +1072,7 @@ export function BoardCard({
                   branchExpansion={branchExpansion}
                   renderAfterMessage={inlineComposer.renderAfterMessage}
                   onRedirectSession={openReplyComposer}
+                  ledgerEventExpansion={ledgerEventExpansion}
                 />
               ) : (
                 <>
@@ -1068,7 +1082,7 @@ export function BoardCard({
                   {openingMessage && inlineComposer.renderAfterMessage(openingMessage.id)}
                   {ledgerHeadRow}
                   <BranchedBoardRows
-                    rows={branchRows(visibleReplies)}
+                    rows={ledgerBranchRows(visibleReplies)}
                     workspaceId={workspaceId}
                     renderMessage={renderMessage}
                     continueThreadTo={continueThreadTo}
@@ -1078,6 +1092,7 @@ export function BoardCard({
                     branchExpansion={branchExpansion}
                     renderAfterMessage={inlineComposer.renderAfterMessage}
                     onRedirectSession={openReplyComposer}
+                    ledgerEventExpansion={ledgerEventExpansion}
                   />
                 </>
               )}

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -205,6 +205,7 @@ describe("buildBranchedBoardRows continuation", () => {
       displayDepth: 1,
       overflow: false,
       messages: [msg("c1", "u2", 2, "thread_x")],
+      memberMessageIds: ["c1"],
       hiddenCount: 0,
       children: [],
     }
@@ -228,6 +229,7 @@ describe("buildBranchedBoardRows continuation", () => {
       displayDepth: 1,
       overflow: false,
       messages: [msg("c1", "u2", 2, "thread_x")],
+      memberMessageIds: ["c1"],
       hiddenCount: 0,
       children: [],
     }

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -4,6 +4,7 @@ import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import {
   buildBoardRows,
   buildBranchedBoardRows,
+  foldLedgerEventRows,
   injectBoardDayDividers,
   injectUnreadDivider,
   type BoardRow,
@@ -385,5 +386,44 @@ describe("injectUnreadDivider", () => {
     const input = [messageRow("a", day1Morning), messageRow("b", day1Evening)]
     expect(injectUnreadDivider(input, "missing")).toEqual(input)
     expect(injectUnreadDivider(input, null)).toEqual(input)
+  })
+})
+
+describe("foldLedgerEventRows", () => {
+  const rows = () =>
+    buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [memoEventRow("e1", 1), memoEventRow("e2", 2)])
+
+  it("coalesces a run in the ledger region into one group row", () => {
+    const folded = foldLedgerEventRows(rows(), "b")
+    expect(folded.map((r) => r.kind)).toEqual(["message", "ledger-event-group", "message"])
+    const group = folded[1]
+    expect(group.kind === "ledger-event-group" && group.key).toBe("ledger-events:e1")
+    expect(group.kind === "ledger-event-group" && group.rows.map((r) => r.key)).toEqual(["e1", "e2"])
+  })
+
+  it("thins a lone ledger-region event without grouping it", () => {
+    const folded = foldLedgerEventRows(
+      buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [memoEventRow("e1", 1)]),
+      "b"
+    )
+    expect(folded.map((r) => r.kind)).toEqual(["message", "ledger-event", "message"])
+  })
+
+  it("leaves events at or below the full-tail boundary fully rendered", () => {
+    const folded = foldLedgerEventRows(
+      buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 1)], [memoEventRow("e1", 2), memoEventRow("e2", 3)]),
+      "b"
+    )
+    expect(folded.map((r) => r.kind)).toEqual(["message", "message", "event", "event"])
+  })
+
+  it("is a no-op when the whole card is the full tail", () => {
+    const input = rows()
+    expect(foldLedgerEventRows(input, "a")).toBe(input)
+  })
+
+  it("folds every event when there is no full tail row at all", () => {
+    const folded = foldLedgerEventRows(rows(), null)
+    expect(folded.map((r) => r.kind)).toEqual(["message", "ledger-event-group", "message"])
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react"
+import { Bot, Clock, Sparkles, TerminalSquare } from "lucide-react"
 import type { StreamEvent } from "@threa/types"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { isContinuation } from "@/lib/message-grouping"
@@ -7,10 +9,12 @@ import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import { DelegationEvent } from "@/components/timeline/delegation-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
-import { useSocket } from "@/contexts"
+import { useSocket, useTrace } from "@/contexts"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useAgentActivity, type MessageAgentActivity } from "@/hooks/use-agent-activity"
+import { LedgerEventGroup, LedgerEventRow, type LedgerEventDescriptor } from "@/components/board/ledger-row"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
+import { coalesceLedgerItems, ledgerEventContent, type LedgerItemKind } from "@/lib/board/ledger"
 import type { BranchGrouping, BranchNode, BranchConversationView } from "@/lib/board/branch-grouping"
 import { localStartOfDayMs } from "@/lib/dates"
 
@@ -29,6 +33,8 @@ import { localStartOfDayMs } from "@/lib/dates"
 export type BoardRow =
   | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean; displayDepth?: number }
   | { kind: "event"; key: string; row: BoardEventRow; displayDepth?: number }
+  | { kind: "ledger-event"; key: string; row: BoardEventRow; displayDepth?: number }
+  | { kind: "ledger-event-group"; key: string; rows: BoardEventRow[]; displayDepth?: number }
   | { kind: "seam"; key: string; streamId: string; direction: "down" | "up"; displayDepth?: number }
   | { kind: "branch-group"; key: string; branch: BranchConversationView; displayDepth?: number }
   | { kind: "continue-thread"; key: string; streamId: string; hiddenCount: number; displayDepth?: number }
@@ -139,6 +145,66 @@ export function buildBoardRows(messages: RenderableMessage[], eventRows: BoardEv
     }
   }
   return rows
+}
+
+/**
+ * Fold the event rows of the card's LEDGER region into hair-thin ledger lines,
+ * coalescing adjacent runs of two or more into one expandable group
+ * (`coalesceLedgerItems`). The region ends at the first full-tail message row —
+ * below it the reader is in full-detail mode, so those events keep their full
+ * rendering (session cards, delegation cards).
+ *
+ * Runs are cut at every indent change, so a spanning thread's event never
+ * coalesces with a base-level one. Events above the card's window are not
+ * represented at all: they are render-only (`bumps: false`) and the head row
+ * counts messages, so folding them into it would inflate a message count.
+ */
+export function foldLedgerEventRows(rows: BoardRow[], fullTailStartMessageId: string | null): BoardRow[] {
+  const boundary = rows.findIndex((row) => row.kind === "message" && row.message.id === fullTailStartMessageId)
+  const end = boundary < 0 ? rows.length : boundary
+  if (end === 0) return rows
+
+  const out: BoardRow[] = []
+  let segment: BoardRow[] = []
+  let segmentDepth: number | null = null
+
+  const flush = () => {
+    if (segment.length === 0) return
+    const depth = segmentDepth ?? 0
+    for (const item of coalesceLedgerItems(segment.map(ledgerItem))) {
+      if (item.kind === "event-group") {
+        out.push({
+          kind: "ledger-event-group",
+          key: `ledger-events:${item.events[0].source.key}`,
+          rows: item.events.flatMap((event) => (event.row ? [event.row] : [])),
+          displayDepth: depth,
+        })
+        continue
+      }
+      const { source } = item
+      if (source.kind === "event")
+        out.push({ kind: "ledger-event", key: source.key, row: source.row, displayDepth: depth })
+      else out.push(source)
+    }
+    segment = []
+  }
+
+  for (let index = 0; index < end; index++) {
+    const row = rows[index]
+    const depth = row.displayDepth ?? 0
+    if (segmentDepth !== null && depth !== segmentDepth) flush()
+    segmentDepth = depth
+    segment.push(row)
+  }
+  flush()
+  out.push(...rows.slice(end))
+  return out
+}
+
+/** A board row as a coalescing item: only event rows can join a run. */
+function ledgerItem(row: BoardRow): { kind: LedgerItemKind; source: BoardRow; row?: BoardEventRow } {
+  if (row.kind === "event") return { kind: "event", source: row, row: row.row }
+  return { kind: "message", source: row }
 }
 
 function messageMs(message: RenderableMessage): number {
@@ -417,6 +483,60 @@ export function BoardEventRowItem({
       return exhaustive
     }
   }
+}
+
+const LEDGER_EVENT_ICONS: Record<BoardEventRow["kind"], ReactNode> = {
+  session: <Bot className="size-3" />,
+  memo: <Sparkles className="size-3 text-amber-500" />,
+  followUp: <Clock className="size-3" />,
+  delegation: <TerminalSquare className="size-3" />,
+}
+
+function ledgerDescriptor(row: BoardEventRow, workspaceId: string, traceUrl: (sessionId: string) => string) {
+  const content = ledgerEventContent(row, { workspaceId, traceUrl })
+  return {
+    key: content.key,
+    icon: LEDGER_EVENT_ICONS[content.kind],
+    label: content.label,
+    meta: content.meta,
+    href: content.href,
+  } satisfies LedgerEventDescriptor
+}
+
+/**
+ * One event compressed to a ledger line. Its tap affordance is the kind's own:
+ * a session opens the trace view its full card links to, a single capture deep-
+ * links to the memo in the memory explorer. Follow-ups and delegations act only
+ * through buttons on their full cards, so their lines are non-interactive.
+ */
+export function LedgerBoardEventRow({ row, workspaceId }: { row: BoardEventRow; workspaceId: string }) {
+  const { getTraceUrl } = useTrace()
+  const descriptor = ledgerDescriptor(row, workspaceId, getTraceUrl)
+  return (
+    <LedgerEventRow icon={descriptor.icon} label={descriptor.label} meta={descriptor.meta} href={descriptor.href} />
+  )
+}
+
+/** A coalesced run of ledger event lines, expanding in place. */
+export function LedgerBoardEventGroup({
+  rows,
+  workspaceId,
+  expanded,
+  onToggle,
+}: {
+  rows: BoardEventRow[]
+  workspaceId: string
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const { getTraceUrl } = useTrace()
+  return (
+    <LedgerEventGroup
+      events={rows.map((row) => ledgerDescriptor(row, workspaceId, getTraceUrl))}
+      expanded={expanded}
+      onToggle={onToggle}
+    />
+  )
 }
 
 const SESSION_TERMINAL_EVENT_TYPES = new Set<string>([

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -160,7 +160,9 @@ function collectBranchSubtree(branch: BranchConversationView): {
   settling: boolean
 } {
   const conversationIds = [branch.conversationId]
-  const messageIds = branch.messages.map((m) => m.id)
+  // Full members, not the preview slice: a sub-topic draft anchored on a branch
+  // message outside the collapsed window still has to surface on this row.
+  const messageIds = [...branch.memberMessageIds]
   let settling = branch.messages.some((m) => m.settling) || (branch.settlingMessageIds?.length ?? 0) > 0
   for (const child of branch.children) {
     const sub = collectBranchSubtree(child)

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -14,7 +14,12 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
-import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
+import {
+  BoardEventRowItem,
+  LedgerBoardEventGroup,
+  LedgerBoardEventRow,
+  type BoardRow,
+} from "@/components/board/board-row-item"
 import { LedgerBranchRow } from "@/components/board/ledger-row"
 import { DayDivider } from "@/components/timeline/day-divider"
 import { UnreadDivider } from "@/components/timeline/unread-divider"
@@ -143,6 +148,29 @@ interface BranchGroupProps {
 export const BRANCH_SETTLING_RAIL_CLASS = "-left-2.5 sm:-left-3.5"
 export const BRANCH_ACCENTED_SETTLING_RAIL_CLASS = "left-0"
 
+/**
+ * Roll a branch's draft/settling inputs up over its whole subtree — collapsing
+ * hides descendants too, so a grandchild's unsent draft or provisional message
+ * must surface on the ancestor's one remaining row. Mirrors the pin walk
+ * (`branchPinnedOpen`); pure, so no hook runs per descendant.
+ */
+function collectBranchSubtree(branch: BranchConversationView): {
+  conversationIds: string[]
+  messageIds: string[]
+  settling: boolean
+} {
+  const conversationIds = [branch.conversationId]
+  const messageIds = branch.messages.map((m) => m.id)
+  let settling = branch.messages.some((m) => m.settling) || (branch.settlingMessageIds?.length ?? 0) > 0
+  for (const child of branch.children) {
+    const sub = collectBranchSubtree(child)
+    conversationIds.push(...sub.conversationIds)
+    messageIds.push(...sub.messageIds)
+    settling = settling || sub.settling
+  }
+  return { conversationIds, messageIds, settling }
+}
+
 export function BranchGroup({
   branch,
   expansion,
@@ -153,16 +181,17 @@ export function BranchGroup({
   const { getPanelUrl } = usePanel()
   const panelUrl = getPanelUrl(createConversationPanelId(branch.conversationId))
   if (expansion && !expansion.isExpanded(branch)) {
+    const subtree = collectBranchSubtree(branch)
     return (
       <LedgerBranchRow
         workspaceId={expansion.workspaceId}
         title={branch.title}
-        conversationId={branch.conversationId}
-        messageIds={branch.messages.map((m) => m.id)}
+        conversationIds={subtree.conversationIds}
+        messageIds={subtree.messageIds}
         messageCount={branch.messages.length + branch.hiddenCount}
         lastMessage={branch.messages.at(-1) ?? null}
         leadLineLength={expansion.leadLineLength}
-        settling={branch.messages.some((m) => m.settling) || (branch.settlingMessageIds?.length ?? 0) > 0}
+        settling={subtree.settling}
         onToggle={() => expansion.toggle(branch)}
       />
     )
@@ -307,6 +336,9 @@ interface BranchedBoardRowsProps {
   branchExpansion?: BranchExpansion
   /** Open + focus the surface's reply composer for a running session's Redirect. */
   onRedirectSession?: () => void
+  /** Expansion state for coalesced ledger event groups, keyed by the group's row
+   *  key — the surface's own ledger expansion set. Absent ⇒ always coalesced. */
+  ledgerEventExpansion?: { isExpanded: (key: string) => boolean; toggle: (key: string) => void }
 }
 
 function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNode {
@@ -336,6 +368,18 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
           row={row.row}
           workspaceId={workspaceId}
           onRedirectSession={onRedirectSession}
+        />
+      )
+    case "ledger-event":
+      return <LedgerBoardEventRow key={row.key} row={row.row} workspaceId={workspaceId} />
+    case "ledger-event-group":
+      return (
+        <LedgerBoardEventGroup
+          key={row.key}
+          rows={row.rows}
+          workspaceId={workspaceId}
+          expanded={props.ledgerEventExpansion?.isExpanded(row.key) ?? false}
+          onToggle={() => props.ledgerEventExpansion?.toggle(row.key)}
         />
       )
     case "seam":

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -422,29 +422,35 @@ describe("LedgerRow settling", () => {
 })
 
 describe("LedgerBranchRow", () => {
-  function renderBranchRow(overrides: Partial<Parameters<typeof LedgerBranchRow>[0]> = {}) {
+  function renderBranchRows(...rows: Array<Partial<Parameters<typeof LedgerBranchRow>[0]>>) {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     return render(
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
-            <LedgerBranchRow
-              workspaceId={WS}
-              title="GPU budget"
-              conversationIds={["conv_child"]}
-              messageIds={["msg_1"]}
-              messageCount={2}
-              lastMessage={message({ contentMarkdown: "We went with the 5090s." })}
-              leadLineLength={80}
-              settling={false}
-              onToggle={vi.fn()}
-              {...overrides}
-            />
+            {(rows.length ? rows : [{}]).map((overrides, i) => (
+              <div key={i} data-row-index={i}>
+                <LedgerBranchRow
+                  workspaceId={WS}
+                  title="GPU budget"
+                  conversationIds={["conv_child"]}
+                  messageIds={["msg_1"]}
+                  messageCount={2}
+                  lastMessage={message({ contentMarkdown: "We went with the 5090s." })}
+                  leadLineLength={80}
+                  settling={false}
+                  onToggle={vi.fn()}
+                  {...overrides}
+                />
+              </div>
+            ))}
           </MemoryRouter>
         </TooltipProvider>
       </QueryClientProvider>
     )
   }
+  const renderBranchRow = (overrides: Partial<Parameters<typeof LedgerBranchRow>[0]> = {}) =>
+    renderBranchRows(overrides)
 
   beforeEach(async () => {
     __clearBoardDraftsRegistry()
@@ -491,9 +497,22 @@ describe("LedgerBranchRow", () => {
   })
 
   it("shows no draft chip when the branch holds nothing unsent", async () => {
-    const { container } = renderBranchRow()
-    await new Promise((resolve) => setTimeout(resolve, 50))
-    expect(container.querySelector("[data-branch-draft-chip]")).toBeNull()
+    // The absence claim needs the drafts index SETTLED, not a timer: a sibling row
+    // whose branch does hold a draft is the marker — its chip can only appear once
+    // the shared snapshot has loaded, so the empty row's absence is then real.
+    await db.drafts.add({
+      id: "draft_other",
+      workspaceId: WS,
+      scope: boardBranchReplyDraftKey("conv_other"),
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "elsewhere" }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+
+    const { container } = renderBranchRows({}, { title: "Cooling", conversationIds: ["conv_other"], messageIds: [] })
+    const marker = container.querySelector('[data-row-index="1"]')!
+    await waitFor(() => expect(marker.querySelector("[data-branch-draft-chip]")).not.toBeNull())
+    expect(container.querySelector('[data-row-index="0"] [data-branch-draft-chip]')).toBeNull()
     expect(screen.getByRole("button", { name: "GPU budget, 2 messages" })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -430,7 +431,7 @@ describe("LedgerBranchRow", () => {
             <LedgerBranchRow
               workspaceId={WS}
               title="GPU budget"
-              conversationId="conv_child"
+              conversationIds={["conv_child"]}
               messageIds={["msg_1"]}
               messageCount={2}
               lastMessage={message({ contentMarkdown: "We went with the 5090s." })}
@@ -504,15 +505,25 @@ describe("LedgerEventGroup", () => {
     { key: "e3", icon: null, label: "call" },
   ]
 
+  // Expansion is the surface's state (the card's ledger expansion set), so the
+  // group is controlled — the harness stands in for that owner.
+  function ControlledGroup() {
+    const [expanded, setExpanded] = useState(false)
+    return <LedgerEventGroup events={events} expanded={expanded} onToggle={() => setExpanded((e) => !e)} />
+  }
+
   it("coalesces to one composite row, expands to the individual rows, and re-coalesces", async () => {
     const user = userEvent.setup()
-    render(<LedgerEventGroup events={events} />)
+    render(<ControlledGroup />)
     const summary = screen.getByRole("button", { name: /3 events/ })
     expect(summary).toHaveTextContent("3 events — memo captured · thread split · call")
     await user.click(summary)
-    expect(screen.getAllByRole("button")).toHaveLength(3)
+    // Expanded: the three rows, plus the summary row that folds them back — the
+    // individual rows keep their own tap affordance, so collapsing has its own.
     expect(screen.getByText("memo captured")).toBeInTheDocument()
-    await user.click(screen.getByText("thread split"))
-    expect(screen.getByRole("button", { name: /3 events/ })).toBeInTheDocument()
+    expect(screen.getByText("thread split")).toBeInTheDocument()
+    expect(screen.getByText("call")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "3 events" }))
+    expect(screen.getByRole("button", { name: /3 events —/ })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react"
-import { useNavigate } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { toast } from "sonner"
-import { ChevronUp, ChevronRight, CornerDownRight, Paperclip, Link2, Pencil } from "lucide-react"
+import { ChevronUp, ChevronDown, ChevronRight, CornerDownRight, Paperclip, Link2, Pencil } from "lucide-react"
 import { LabelableResourceTypes, LinkPreviewContentTypes } from "@threa/types"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
@@ -22,7 +22,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { useSettleConversationMessage } from "@/hooks/use-conversations"
-import { useScopeDraftPreview, useBoardSubtopicDraftIndex } from "@/hooks"
+import { useBoardScopeDraftIndex, useBoardSubtopicDraftIndex } from "@/hooks"
 import { boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { leadLine, rowArtifacts } from "@/lib/board/ledger"
 import { resolveInternalAppPath } from "@/lib/internal-url"
@@ -440,7 +440,7 @@ export function LedgerRow({
 export function LedgerBranchRow({
   workspaceId,
   title,
-  conversationId,
+  conversationIds,
   messageIds,
   messageCount,
   lastMessage,
@@ -450,9 +450,11 @@ export function LedgerBranchRow({
 }: {
   workspaceId: string
   title: string
-  /** The branch's own conversation id — its tail reply draft scope. */
-  conversationId: string
-  /** The branch's rendered message ids — their sub-topic draft scopes. */
+  /** The branch's conversation id AND every descendant's — their tail reply draft
+   *  scopes. Collapse hides the whole subtree, so the row speaks for all of it. */
+  conversationIds: string[]
+  /** The rendered message ids of the branch and its descendants — their sub-topic
+   *  draft scopes. */
   messageIds: string[]
   messageCount: number
   /** The branch's newest locally-known message — the outcome lead. */
@@ -466,9 +468,11 @@ export function LedgerBranchRow({
   // one of its messages) is invisible once the branch folds, so the collapsed row
   // carries the same Pencil marker `CollapsedComposerBar` uses. Presence only —
   // it never pins the branch open; tapping the row expands as normal.
-  const tailDraft = useScopeDraftPreview(workspaceId, boardBranchReplyDraftKey(conversationId))
+  const scopeDrafts = useBoardScopeDraftIndex(workspaceId)
   const subtopicDrafts = useBoardSubtopicDraftIndex(workspaceId)
-  const hasDraft = tailDraft !== null || messageIds.some((id) => subtopicDrafts.has(id))
+  const hasDraft =
+    conversationIds.some((id) => scopeDrafts.has(boardBranchReplyDraftKey(id))) ||
+    messageIds.some((id) => subtopicDrafts.has(id))
   let lead: string | null = null
   if (lastMessage) {
     lead = lastMessage.deletedAt
@@ -568,12 +572,15 @@ export function LedgerEventRow({
   icon,
   label,
   meta,
+  href,
   onToggle,
   expanded,
 }: {
   icon: ReactNode
   label: string
   meta?: string
+  /** The kind's own detail target — the row navigates instead of toggling (INV-40). */
+  href?: string
   onToggle?: () => void
   expanded?: boolean
 }) {
@@ -587,6 +594,12 @@ export function LedgerEventRow({
     </>
   )
   const className = "flex w-full items-center gap-1.5 py-px text-left text-xs text-muted-foreground"
+  if (href)
+    return (
+      <Link to={href} className={cn(className, "no-underline transition-colors hover:text-foreground")}>
+        {content}
+      </Link>
+    )
   if (!onToggle) return <div className={className}>{content}</div>
   return (
     <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={className}>
@@ -600,30 +613,42 @@ export interface LedgerEventDescriptor {
   icon: ReactNode
   label: string
   meta?: string
+  href?: string
 }
 
 /**
  * A coalesced run of events (the `coalesceLedgerItems` grouping): one thin
  * summary row that expands in place into the individual rows and re-coalesces
  * on a second tap.
+ *
+ * Expansion is the surface's state, not the group's: the card holds one ledger
+ * expansion set for message leads, branches and event groups alike, so it
+ * resets on conversation switch with them.
  */
-export function LedgerEventGroup({ events }: { events: LedgerEventDescriptor[] }) {
-  const [expanded, setExpanded] = useState(false)
-  const toggle = useCallback(() => setExpanded((e) => !e), [])
+export function LedgerEventGroup({
+  events,
+  expanded,
+  onToggle,
+}: {
+  events: LedgerEventDescriptor[]
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const toggle = onToggle
   if (expanded) {
+    // The summary row stays: an expanded row carries its OWN tap affordance (a
+    // capture's memo link, a session's trace), so the way back has to be a
+    // control of its own rather than "tap any row".
     return (
       <div>
+        <LedgerEventRow
+          icon={<ChevronDown className="size-3" />}
+          label={`${events.length} events`}
+          onToggle={toggle}
+          expanded
+        />
         {events.map((event) => (
-          <LedgerEventRow
-            key={event.key}
-            icon={event.icon}
-            label={event.label}
-            meta={event.meta}
-            // Any of the rows re-coalesces the group — the reader's way back is
-            // wherever their eye landed.
-            onToggle={toggle}
-            expanded
-          />
+          <LedgerEventRow key={event.key} icon={event.icon} label={event.label} meta={event.meta} href={event.href} />
         ))}
       </div>
     )

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -480,7 +480,9 @@ export function LedgerBranchRow({
       : ledgerLead(lastMessage.contentMarkdown, leadLineLength, rowArtifacts(lastMessage), toEmoji)
   }
   return (
-    <div className="mt-3 ml-3" data-ledger-branch-row="" data-settling={settling ? "" : undefined}>
+    // `mt-3` and nothing else: the expanded BranchGroup's wrapper is the same, so
+    // the branch's leading edge holds still across a collapse/expand toggle.
+    <div className="mt-3" data-ledger-branch-row="" data-settling={settling ? "" : undefined}>
       {/* Outside the button: an `aria-label` overrides the element's content, so
           an sr-only span INSIDE it is never announced (as the message row does). */}
       {settling && <span className="sr-only">Still settling — messages here may move to another topic</span>}

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
-import { createElement, type ReactNode } from "react"
+import { createElement, type ReactElement, type ReactNode } from "react"
+import { createDraftPanelId } from "@/contexts"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import { upsertLoadedDraft, purgeScopeDrafts, stashLoadedDraft } from "@/hooks/use-draft-message"
@@ -145,6 +147,88 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
     const { result } = mountHook(draftId)
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(result.current.openComposer).toBeNull()
+  })
+})
+
+describe("useInlineBranchComposer pending→real hand-off", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    await purgeScopeDrafts(workspaceId, "board:subtopic:stream_9:msg_new")
+    vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+      queueDraftMessage: vi.fn().mockResolvedValue(undefined),
+      currentUserId: "usr_me",
+    } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  })
+
+  const emptyIndex = { threadsByAnchorId: new Map() } as unknown as StreamStructuralIndex
+  const emptyGraph = {
+    conversationByAnchorStreamId: new Map(),
+    conversationIdByMemberMessageId: new Map([["msg_new", PARENT_ID]]),
+    conversationById: new Map(),
+  } as unknown as ConversationGraph
+  const materializedIndex = {
+    threadsByAnchorId: new Map([["msg_new", { id: "stream_thread_new" }]]),
+  } as unknown as StreamStructuralIndex
+  const materializedGraph = {
+    conversationByAnchorStreamId: new Map([
+      [
+        "stream_thread_new",
+        { id: "conv_new", conversation: { id: "conv_new", streamId: "stream_thread_new", messageIds: ["m_real"] } },
+      ],
+    ]),
+    conversationIdByMemberMessageId: new Map([["msg_new", PARENT_ID]]),
+    conversationById: new Map(),
+  } as unknown as ConversationGraph
+
+  it("re-keys an open branch-tail composer onto the real conversation when the graph replaces the pending branch", async () => {
+    const draftPanelId = createDraftPanelId("stream_9", "msg_new")
+    const { result, rerender } = renderHook(
+      ({ index: i, graph: g }: { index: StreamStructuralIndex; graph: ConversationGraph }) =>
+        useInlineBranchComposer({
+          workspaceId,
+          conversationId: PARENT_ID,
+          memberMessageIds: ["msg_new"],
+          index: i,
+          graph: g,
+        }),
+      { wrapper: wrapperWithStash("draft_none"), initialProps: { index: emptyIndex, graph: emptyGraph } }
+    )
+
+    // Send the sub-topic through the gesture's own form (its `onSubmit` is the
+    // only path that registers the pending entry).
+    act(() => result.current.openNewSubtopic("stream_9", "msg_new"))
+    const form = result.current.renderAfterMessage("msg_new") as ReactElement<{
+      onSubmit: (input: unknown) => Promise<void>
+    }>
+    await act(() => form.props.onSubmit({ contentJson: { type: "doc", content: [] } }))
+
+    const optimistic = { id: "m_opt", streamId: draftPanelId, createdAt: "2026-07-28T10:00:00.000Z" }
+    const pendingBranch = result.current.derivePendingBranches(
+      new Map([["m_opt", optimistic as never]])
+    )[0] as BranchConversationView
+    expect(pendingBranch.pending).toBe(true)
+    act(() => result.current.openBranchReply(pendingBranch))
+    expect(result.current.openComposer).toMatchObject({ kind: "branch-reply", conversationId: draftPanelId })
+
+    // The echo lands: the graph's real branch replaces the synthetic one.
+    rerender({ index: materializedIndex, graph: materializedGraph })
+    await waitFor(() =>
+      expect(result.current.openComposer).toMatchObject({
+        kind: "branch-reply",
+        conversationId: "conv_new",
+        threadStreamId: "stream_thread_new",
+      })
+    )
+    // …and the real branch's tail still renders the mounted composer (the
+    // affordance has no `onSubmit`), so the editor never unmounted.
+    const tail = result.current.renderBranchTail({
+      ...pendingBranch,
+      conversationId: "conv_new",
+      threadStreamId: "stream_thread_new",
+      pending: false,
+    }) as ReactElement<Record<string, unknown>>
+    expect(tail.props).toHaveProperty("onSubmit")
   })
 })
 

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -245,6 +245,28 @@ export function useInlineBranchComposer(params: {
     setOpenComposer({ kind: "new-subtopic", streamId: parsed.streamId, messageId: parsed.messageId })
   }, [stashTarget, graph, branchStreamIds, conversationId, onArmBranchReply])
 
+  // The composer's own pending→graph hand-off: a pending branch is keyed by the
+  // synthetic draft-panel id, so once the graph replaces it with the real child
+  // an untouched `openComposer` matches no rendered branch — `renderBranchTail`
+  // unmounts the live editor and the branch's pin drops. Re-key it onto the real
+  // conversation/thread. Declared BEFORE the drop effect below so the pending
+  // entry it reads is still registered on the commit that materializes.
+  useEffect(() => {
+    if (openComposer?.kind !== "branch-reply") return
+    const openConversationId = openComposer.conversationId
+    const pending = pendingSubtopics.find((p) => createDraftPanelId(p.streamId, p.messageId) === openConversationId)
+    if (!pending) return
+    const threadId = index.threadsByAnchorId.get(pending.messageId)?.id
+    if (!threadId) return
+    const childPost = graph.conversationByAnchorStreamId.get(threadId)
+    if (!childPost) return
+    setOpenComposer((current) =>
+      current?.kind === "branch-reply" && current.conversationId === openConversationId
+        ? { ...current, conversationId: childPost.id, threadStreamId: threadId }
+        : current
+    )
+  }, [openComposer, pendingSubtopics, index, graph])
+
   // A pending sub-topic is handed to the graph path only once BOTH its thread
   // stream exists (promotion) AND the child conversation is cached — dropping it
   // at thread creation alone would blank the message for the beat until the
@@ -297,6 +319,7 @@ export function useInlineBranchComposer(params: {
           displayDepth: 1,
           overflow: false,
           messages: rows,
+          memberMessageIds: rows.map((m) => m.id),
           hiddenCount: 0,
           children: [],
           pending: true,

--- a/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
@@ -18,6 +18,7 @@ function branch(overrides: Partial<BranchConversationView>): BranchConversationV
     displayDepth: 1,
     overflow: false,
     messages: [],
+    memberMessageIds: [],
     hiddenCount: 0,
     children: [],
     ...overrides,

--- a/apps/frontend/src/components/timeline/follow-up-event.tsx
+++ b/apps/frontend/src/components/timeline/follow-up-event.tsx
@@ -4,7 +4,7 @@ import { Clock, Check, Loader2 } from "lucide-react"
 import type { AgentFollowUpScheduledEventPayload, StreamEvent } from "@threa/types"
 import { agentFollowUpsApi } from "@/api"
 import { useActors } from "@/hooks"
-import { formatTime, formatFullDateTime } from "@/lib/dates"
+import { formatFireTime, formatFullDateTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 
 interface FollowUpScheduledEventProps {
@@ -16,12 +16,6 @@ interface FollowUpScheduledEventProps {
    * one who clicked) sees the card as cancelled, and it survives a reload.
    */
   cancelledByEvent?: boolean
-}
-
-/** Compact fire time in the viewer's local zone (INV-42): "Wed, Jul 8 at 2:30 PM". */
-function formatFireTime(date: Date): string {
-  const day = date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })
-  return `${day} at ${formatTime(date)}`
 }
 
 /**

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -62,6 +62,7 @@ export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } 
 export {
   useScopeDraftPreview,
   useBoardSubtopicDraftIndex,
+  useBoardScopeDraftIndex,
   useBoardDraftsReady,
   type ScopeDraftPreview,
   type SubtopicDraftEntry,

--- a/apps/frontend/src/hooks/use-conversation-graph.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.ts
@@ -300,6 +300,7 @@ export function deriveBranchConversations(params: {
         displayDepth: depth,
         overflow,
         messages: markedMessages,
+        memberMessageIds: [...new Set([...childMemberIds, ...markedMessages.map((m) => m.id)])],
         settlingMessageIds,
         hiddenCount,
         children,

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -183,6 +183,20 @@ export function useScopeDraftPreview(workspaceId: string, scope: string): ScopeD
 }
 
 /**
+ * Every board draft in the workspace keyed by scope — for a surface that must
+ * test MANY scopes at once (a collapsed branch rolling its whole subtree up),
+ * where one {@link useScopeDraftPreview} per scope would be a hook in a loop.
+ */
+export function useBoardScopeDraftIndex(workspaceId: string): Map<string, ScopeDraftPreview> {
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(
+    () => boardDraftsRegistry.get(workspaceId)?.snapshot.previewByScope ?? EMPTY_SNAPSHOT.previewByScope,
+    [workspaceId]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
  * Every new-sub-topic draft in the workspace, keyed by its fork message id —
  * so a conversation surface can mark the message rows that carry an unsent
  * sub-topic draft while the gesture's composer is unmounted. Same shared

--- a/apps/frontend/src/lib/board/branch-grouping.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.ts
@@ -249,6 +249,10 @@ export interface BranchConversationView {
   /** The child conversation's own messages, resolved through the parent card's rail
    *  (already sliced to the collapsed window when the card is collapsed). */
   messages: RenderableMessage[]
+  /** Every member message id of the child conversation — the full set, not the
+   *  collapsed-window slice {@link messages} carries. Draft/collapse rollups scope
+   *  by message id, so they must see members outside the preview window too. */
+  memberMessageIds: string[]
   /** The child conversation's own provisional (still-settling) member ids —
    *  already stamped onto {@link messages}; kept so a surface re-deriving rows
    *  from this view marks them the same way. */

--- a/apps/frontend/src/lib/board/ledger.test.ts
+++ b/apps/frontend/src/lib/board/ledger.test.ts
@@ -2,7 +2,17 @@ import { describe, expect, it } from "vitest"
 
 import type { AttachmentSummary, LinkPreviewSummary } from "@threa/types"
 
-import { coalesceLedgerItems, estimateReadingMinutes, leadLine, linkLabel, rowArtifacts } from "./ledger"
+import type { CachedEvent } from "@/db"
+import { formatFireTime } from "@/lib/dates"
+import type { BoardEventRow } from "./board-event-rows"
+import {
+  coalesceLedgerItems,
+  estimateReadingMinutes,
+  leadLine,
+  ledgerEventContent,
+  linkLabel,
+  rowArtifacts,
+} from "./ledger"
 
 describe("leadLine", () => {
   it("returns plain text unchanged", () => {
@@ -191,5 +201,187 @@ describe("coalesceLedgerItems", () => {
 
   it("returns an empty list unchanged", () => {
     expect(coalesceLedgerItems([])).toEqual([])
+  })
+})
+
+describe("ledgerEventContent", () => {
+  const ctx = { workspaceId: "ws_1", traceUrl: (sessionId: string) => `/w/ws_1/trace/${sessionId}` }
+
+  function event(eventType: string, payload: unknown): CachedEvent {
+    return {
+      id: "evt_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1",
+      _sequenceNum: 1,
+      eventType: eventType as CachedEvent["eventType"],
+      payload: payload as CachedEvent["payload"],
+      actorId: null,
+      actorType: null,
+      createdAt: "2026-07-28T10:00:00.000Z",
+      _cachedAt: 1,
+    }
+  }
+
+  it("names the persona, its steps and duration, and links the trace", () => {
+    const row: BoardEventRow = {
+      kind: "session",
+      key: "slot_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      events: [
+        event("agent_session:started", { sessionId: "sess_1", personaName: "Ariadne" }),
+        event("agent_session:completed", { sessionId: "sess_1", stepCount: 41, messageCount: 2, duration: 720_000 }),
+      ],
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "slot_1",
+      kind: "session",
+      label: "Ariadne",
+      meta: "41 steps · 12m 0s",
+      href: "/w/ws_1/trace/sess_1",
+    })
+  })
+
+  it("reads a still-running session as running", () => {
+    const row: BoardEventRow = {
+      kind: "session",
+      key: "slot_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      events: [event("agent_session:started", { sessionId: "sess_1", personaName: "Ariadne" })],
+    }
+    expect(ledgerEventContent(row, ctx).meta).toBe("running")
+  })
+
+  it("carries a capture's TITLE and its memo deep link, never the memo content", () => {
+    const row: BoardEventRow = {
+      kind: "memo",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("memos:captured", {
+        conversationId: "conv_1",
+        memos: [
+          {
+            memoId: "memo_9",
+            title: "Postgres upserts need the index",
+            knowledgeType: "fact",
+            sourceMessageIds: ["msg_1"],
+          },
+        ],
+      }),
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "evt_1",
+      kind: "memo",
+      label: "Memo: Postgres upserts need the index",
+      href: "/w/ws_1/memory?memo=memo_9",
+    })
+  })
+
+  it("leaves a multi-memo capture without a link (no single target to open)", () => {
+    const row: BoardEventRow = {
+      kind: "memo",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("memos:captured", {
+        conversationId: "conv_1",
+        memos: [
+          { memoId: "memo_1", title: "One", knowledgeType: "fact", sourceMessageIds: [] },
+          { memoId: "memo_2", title: "Two", knowledgeType: "fact", sourceMessageIds: [] },
+        ],
+      }),
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "evt_1",
+      kind: "memo",
+      label: "Memo: One, Two",
+      href: undefined,
+    })
+  })
+
+  it("marks a cancelled follow-up cancelled and never links it", () => {
+    const row: BoardEventRow = {
+      kind: "followUp",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      cancelled: true,
+      event: event("agent:follow_up_scheduled", {
+        followUpId: "fu_1",
+        note: "Chase the vendor quote",
+        scheduledFor: "2026-08-01T09:00:00.000Z",
+      }),
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "evt_1",
+      kind: "followUp",
+      label: "Follow-up: Chase the vendor quote",
+      meta: "cancelled",
+    })
+  })
+
+  it("renders a fired follow-up's schedule as an absolute time, never a clamped countdown", () => {
+    const scheduledFor = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+    const row: BoardEventRow = {
+      kind: "followUp",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      cancelled: false,
+      event: event("agent:follow_up_scheduled", {
+        followUpId: "fu_1",
+        note: "Chase the vendor quote",
+        scheduledFor: scheduledFor.toISOString(),
+      }),
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "evt_1",
+      kind: "followUp",
+      label: "Follow-up: Chase the vendor quote",
+      meta: `fires ${formatFireTime(scheduledFor)}`,
+    })
+  })
+
+  it("labels an unclaimed delegation with the shared Open label", () => {
+    const row: BoardEventRow = {
+      kind: "delegation",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("delegation:created", {
+        delegationId: "dlg_1",
+        title: "Migrate the index",
+        brief: "…",
+        contextRefs: [],
+        sourceConversationId: "conv_1",
+      }),
+    }
+    expect(ledgerEventContent(row, ctx)?.meta).toBe("Open")
+  })
+
+  it("carries a delegation's title and its latest status", () => {
+    const row: BoardEventRow = {
+      kind: "delegation",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("delegation:created", {
+        delegationId: "dlg_1",
+        title: "Migrate the index",
+        brief: "…",
+        contextRefs: [],
+        sourceConversationId: "conv_1",
+      }),
+      statusPatch: { delegationId: "dlg_1", status: "claimed" },
+    }
+    expect(ledgerEventContent(row, ctx)).toEqual({
+      key: "evt_1",
+      kind: "delegation",
+      label: "Delegation: Migrate the index",
+      meta: "Claimed",
+    })
   })
 })

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -1,12 +1,23 @@
 import {
+  DelegationStatuses,
   isInAppLinkContentType,
   LinkPreviewContentTypes,
+  type AgentFollowUpScheduledEventPayload,
+  type AgentSessionCompletedPayload,
+  type AgentSessionFailedPayload,
+  type AgentSessionStartedPayload,
   type AttachmentSummary,
+  type DelegationCreatedEventPayload,
   type LinkPreviewContentType,
   type LinkPreviewSummary,
+  type MemosCapturedEventPayload,
 } from "@threa/types"
 
+import type { BoardEventRow } from "@/lib/board/board-event-rows"
+import { DELEGATION_STATUS_LABEL } from "@/lib/delegation-display"
+import { formatDuration, formatFireTime } from "@/lib/dates"
 import { resolveEmojiShortcodes, stripMarkdownKeepingCode, truncateInline } from "@/lib/markdown/strip"
+import { memoDeepLink } from "@/lib/memo-url"
 
 /** Characters of prose one reading-minute covers. */
 const CHARS_PER_MINUTE = 1100
@@ -86,6 +97,120 @@ function hostname(url: string): string {
     return new URL(url).hostname.replace(/^www\./, "")
   } catch {
     return url
+  }
+}
+
+/**
+ * The renderable content of one ledger event line — everything the thin row
+ * shows, plus the in-app detail target when the kind has one. Data only: the
+ * surface picks the icon and turns `href` into a `<Link>` (INV-40).
+ */
+export interface LedgerEventContent {
+  key: string
+  kind: BoardEventRow["kind"]
+  label: string
+  meta?: string
+  href?: string
+}
+
+export interface LedgerEventContentCtx {
+  workspaceId: string
+  /** The session's trace-view URL, from the surface's `useTrace`. */
+  traceUrl: (sessionId: string) => string
+}
+
+function stepsLabel(count: number): string {
+  return `${count} ${count === 1 ? "step" : "steps"}`
+}
+
+/**
+ * A board event row compressed to its ledger line. Titles and counts only —
+ * a capture line carries its memos' TITLES, never their content (INV-62): the
+ * memo body is the memory explorer's, one deep link away.
+ */
+export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCtx): LedgerEventContent {
+  switch (row.kind) {
+    case "session": {
+      let sessionId = ""
+      let personaName: string | null = null
+      let completed: AgentSessionCompletedPayload | null = null
+      let failed: AgentSessionFailedPayload | null = null
+      let interrupted = false
+      let deleted = false
+      for (const event of row.events) {
+        const id = (event.payload as { sessionId?: string } | undefined)?.sessionId
+        if (id) sessionId = id
+        switch (event.eventType) {
+          case "agent_session:started":
+            personaName = (event.payload as AgentSessionStartedPayload | undefined)?.personaName ?? null
+            break
+          case "agent_session:completed":
+            completed = event.payload as AgentSessionCompletedPayload
+            break
+          case "agent_session:failed":
+            failed = event.payload as AgentSessionFailedPayload
+            break
+          case "agent_session:interrupted":
+            interrupted = true
+            break
+          case "agent_session:deleted":
+            deleted = true
+            break
+        }
+      }
+      // Same precedence the full card derives: deleted › completed › failed ›
+      // interrupted, so a retried session never reads as finished.
+      let meta: string
+      if (deleted) meta = "deleted"
+      else if (completed) meta = `${stepsLabel(completed.stepCount)} · ${formatDuration(completed.duration)}`
+      else if (failed) meta = `${stepsLabel(failed.stepCount)} · failed`
+      else if (interrupted) meta = "retrying"
+      else meta = "running"
+      return {
+        key: row.key,
+        kind: "session",
+        label: personaName ?? "Agent",
+        meta,
+        href: sessionId ? ctx.traceUrl(sessionId) : undefined,
+      }
+    }
+    case "memo": {
+      const memos = (row.event.payload as MemosCapturedEventPayload | undefined)?.memos ?? []
+      const titles = memos.map((memo) => memo.title)
+      return {
+        key: row.key,
+        kind: "memo",
+        label: titles.length === 0 ? "Memo captured" : `Memo: ${titles.join(", ")}`,
+        // One memo has an unambiguous target; a batch would have to pick one, so
+        // it stays a plain line and the reader opens what they want in the panel.
+        href: memos.length === 1 ? memoDeepLink(ctx.workspaceId, memos[0].memoId) : undefined,
+      }
+    }
+    case "followUp": {
+      const payload = row.event.payload as AgentFollowUpScheduledEventPayload | undefined
+      let meta: string | undefined
+      if (row.cancelled) meta = "cancelled"
+      else if (payload) meta = `fires ${formatFireTime(new Date(payload.scheduledFor))}`
+      return {
+        key: row.key,
+        kind: "followUp",
+        label: payload?.note ? `Follow-up: ${payload.note}` : "Follow-up scheduled",
+        meta,
+      }
+    }
+    case "delegation": {
+      const payload = row.event.payload as DelegationCreatedEventPayload | undefined
+      return {
+        key: row.key,
+        kind: "delegation",
+        label: payload?.title ? `Delegation: ${payload.title}` : "Delegation",
+        meta: DELEGATION_STATUS_LABEL[row.statusPatch?.status ?? DelegationStatuses.OPEN],
+      }
+    }
+    default: {
+      const exhaustive: never = row
+      return exhaustive
+    }
   }
 }
 

--- a/apps/frontend/src/lib/dates.ts
+++ b/apps/frontend/src/lib/dates.ts
@@ -359,6 +359,12 @@ export function getFutureDatePresets(now: Date = new Date()): DatePreset[] {
   ]
 }
 
+/** Compact fire time in the viewer's local zone (INV-42): "Wed, Jul 8 at 2:30 PM". */
+export function formatFireTime(date: Date): string {
+  const day = date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })
+  return `${day} at ${formatTime(date)}`
+}
+
 /**
  * Format a duration in milliseconds to a human-readable string.
  * Examples: "150ms", "2.3s", "1m 30s"

--- a/tests/browser/ledger-shots.spec.ts
+++ b/tests/browser/ledger-shots.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace } from "./helpers"
+
+// Throwaway visual pass for the ledger board stack — deleted after the run.
+
+const LONG_BODIES = [
+  "Verify pass came back: 4 accepted, 0 refuted. The two that mattered were the re-arming anchor adopting a page of uncompensated growth, and the phantom-page stacking under an unsynced rail.\n\nFix batch is running now; the falsification checks neutralise each guard in turn and re-run the suite, so a fix that does nothing shows up as a green test that should have been red.\n\nGates: 5584 frontend tests, typecheck clean, lint clean across the monorepo.",
+  "Third explorer back — the data model. This is the one that changes what I think the work is.\n\nThe conversation projection and the event rail can disagree under latency: the projection says a message exists while the rail has no body for it. Slow Wi-Fi stretches that window from milliseconds to minutes, which is exactly the state you hit yesterday.\n\nProposal: the card renders rail-truth and represents the gap honestly instead of pretending the projection is renderable.",
+  "Sol's back, and it corrected three things I told you an hour ago. Those first, since I asserted them.\n\nThe extractor does NOT force status over a user lock — the guard is in the SQL CASE. The reassignment event does reach the board store. And saved items already open the panel.\n\nWhat stands: the write-divergence finding, the ghost card, and the calls exclusion being four layers deep.",
+  "Chunk 4 landed. The card renders the ledger: newest replies stay full rows, older ones collapse to lead lines that expand in place, and the mass above the window folds into one head row into the panel.\n\nThe monotone rule from the scroll-reveal work applies again: once a row renders full it never demotes, so an open edit buffer can't be unmounted by a new arrival.",
+]
+
+function workspaceIdFrom(page: Page): string {
+  const match = page.url().match(/\/w\/(ws_[a-z0-9]+)/i)
+  if (!match) throw new Error(`No workspace id in url ${page.url()}`)
+  return match[1]
+}
+
+test("ledger board shots", async ({ page }) => {
+  test.setTimeout(240_000)
+  await loginAndCreateWorkspace(page, "ledger-shots")
+  const workspaceId = workspaceIdFrom(page)
+  // Brand-new workspace: the empty state's big button, not the section menu.
+  await page.getByRole("button", { name: "+ New Scratchpad" }).click()
+  await expect(page.locator("[data-editor-zone='main'] [contenteditable='true']").last()).toBeVisible({
+    timeout: 15_000,
+  })
+
+  const composer = page.locator("[data-editor-zone='main'] [contenteditable='true']").last()
+  const send = async (text: string) => {
+    await composer.click()
+    const paragraphs = text.split("\n\n")
+    for (let i = 0; i < paragraphs.length; i++) {
+      if (i > 0) {
+        await page.keyboard.press("Shift+Enter")
+        await page.keyboard.press("Shift+Enter")
+      }
+      await composer.pressSequentially(paragraphs[i].replace(/\n/g, " "), { delay: 1 })
+    }
+    await page.keyboard.press("Enter")
+    await page.waitForTimeout(400)
+  }
+
+  await send("Kicking off the ledger visual pass — this scratchpad stands in for a CC coding session.")
+  for (let i = 0; i < 8; i++) {
+    await send(LONG_BODIES[i % LONG_BODIES.length])
+    if (i % 3 === 1) await send("Short steer from me: keep going, but bound the retries first.")
+  }
+  await send("Latest state: stack is green end to end, ten PRs linked, whole-stack review running.")
+
+  // Board, desktop.
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto(`/w/${workspaceId}/board?lens=all`)
+  await expect(page.locator("[data-ledger-row]").first()).toBeVisible({ timeout: 20_000 })
+  await page.waitForTimeout(1200)
+  await page.screenshot({ path: ".tmp/shots-ledger/01-board-desktop.png" })
+
+  // Expand one ledger row in place.
+  await page.locator("[data-ledger-row]").nth(1).click()
+  await page.waitForTimeout(600)
+  await page.screenshot({ path: ".tmp/shots-ledger/02-board-desktop-expanded.png" })
+
+  // Mobile.
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.waitForTimeout(800)
+  await page.screenshot({ path: ".tmp/shots-ledger/03-board-mobile.png" })
+
+  // Mobile scrolled to the card top (header + head row).
+  const scroller = page.locator("[data-board-scroll-viewport]")
+  await scroller.evaluate((el) => el.scrollTo(0, 0))
+  await page.waitForTimeout(500)
+  await page.screenshot({ path: ".tmp/shots-ledger/04-board-mobile-top.png" })
+})


### PR DESCRIPTION
## Problem

Chunk 6 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): Kris's ruling — "I don't want to leave stuff out": agent traces, memo captures, follow-ups and delegations must be REPRESENTED in the ledger, hair-thin, coalescing when adjacent, never showcasing memo content.

## Solution

- `ledgerEventContent` (lib mapper, data-only): sessions → persona + steps + duration linking to the trace; captures → memo TITLE only, deep-linking via canonical `memoDeepLink()` (multi-memo rows carry no link — no single target); follow-ups → note + `formatFireTime` (moved to `lib/dates.ts` and shared with the timeline card — `formatFutureTime` clamped past dates to "fires 0m", and a fired follow-up aging into the ledger is the COMMON case); delegations → `DELEGATION_STATUS_LABEL` SSOT (the hand-rolled default was "created", not even a `DelegationStatus`).
- `foldLedgerEventRows`: events fold thin ONLY in the ledger region (cut at depth changes + the full-tail boundary); full-tail events keep today's full rendering with their mutating actions. Runs of ≥2 coalesce to one "3 events — …" row; expanded groups keep the summary row as the collapse control (all-links groups would otherwise trap re-coalescing).
- Rides along (#1728 review fix): collapsed branch rows roll up Draft-chip + settling from the WHOLE subtree (`collectBranchSubtree`, mirroring the pin walk) via a map-shaped `useBoardScopeDraftIndex`.
- Known sub-threshold notes, recorded so nobody rediscovers them: a depth-3 overflow can make the full-tail boundary unfindable (folds tail events thin, ~3-level nesting required); the coalesced-group expansion key can shift if a session row materializes ahead of the group's first event (state re-collapses, id leaks until conversation switch); session status derivation duplicates unexported `deriveStatus` (precedence verified identical today); follow-up/delegation THIN rows drop the full rows' mutating actions — the panel carries them.

## Test plan

- [x] 889 tests green across board/lib/timeline (mapper per-kind, fold boundary, coalescing round-trip, past-fire-time, SSOT labels, subtree roll-up — all falsification-checked); tsc + lint clean. Adversarial verify (Opus high): 2 findings accepted+fixed, 1 refuted (the "dead alias" was live), 4 sub-threshold recorded.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788289633&installation_model_id=20758&pr_number=1729&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1729&signature=391816d5eb8a0aed9865e954b17bfe0744419d79fdc6a163e2b80927c8610a47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->