### PR TITLE
feat(board): the "New" divider in the ledger

### DIFF
--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -82,6 +82,21 @@ function memoEvent(id: string, seconds: number, memoId: string, title: string): 
   )
 }
 
+function multiMemoEvent(id: string, seconds: number): CachedEvent {
+  return event(
+    "memos:captured",
+    seconds,
+    {
+      conversationId: CONV,
+      memos: [
+        { memoId: "memo_1", title: "One", knowledgeType: "fact", sourceMessageIds: ["r1"] },
+        { memoId: "memo_2", title: "Two", knowledgeType: "fact", sourceMessageIds: ["r1"] },
+      ],
+    },
+    id
+  )
+}
+
 function post(): CachedBoardPost {
   return {
     id: CONV,
@@ -205,7 +220,7 @@ function textOrder(...needles: string[]): number[] {
 }
 
 describe("BoardCard ledger events", () => {
-  it("renders a capture between the ledger messages as a thin title-only line linking to the memo", async () => {
+  it("renders a capture between the ledger messages as a thin title-only line that previews in place", async () => {
     await db.events.bulkPut([
       messageEvent("r1", 10, "First reply."),
       memoEvent("evt_memo", 11, "memo_9", "Postgres upserts need the index"),
@@ -215,16 +230,51 @@ describe("BoardCard ledger events", () => {
     await db.conversations.put(post())
     mount()
 
-    const link = await screen.findByRole("link", { name: /Memo: Postgres upserts need the index/ })
-    expect(link).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_9")
-    // The full capture row's phrasing (and its memo-opening buttons) is not what
-    // a ledger line renders — title only, never the memo body.
+    const row = await screen.findByRole("button", { name: /Memo: Postgres upserts need the index/ })
+    // Never a navigation off the board: the thin row opens the same in-place
+    // preview the full capture row does (INV-35).
+    expect(row).not.toHaveAttribute("href")
+    expect(screen.queryByRole("link", { name: /Memo: Postgres upserts need the index/ })).toBeNull()
+    expect(screen.queryByRole("dialog")).toBeNull()
+
+    await userEvent.click(row)
+    const dialog = await screen.findByRole("dialog")
+    expect(within(dialog).getByText("Postgres upserts need the index")).toBeInTheDocument()
+    expect(within(dialog).getByRole("link", { name: /Open in memory/ })).toHaveAttribute(
+      "href",
+      "/w/ws_1/memory?memo=memo_9"
+    )
+
+    // The full capture row's phrasing (and its memo body) is not what a ledger
+    // line renders — title only.
     expect(screen.queryByText(/Saved to memory/)).toBeNull()
 
     const [first, memo, second] = textOrder("First reply.", "Memo: Postgres upserts need the index", "Second reply.")
     expect(first).toBeGreaterThan(-1)
     expect(memo).toBeGreaterThan(first)
     expect(second).toBeGreaterThan(memo)
+  })
+
+  // jsdom can't measure pixels, so this holds the padding CLASS contract that
+  // produces the hit area; the rendered height is a browser-suite follow-up.
+  it("gives interactive ledger event rows a thumb-sized hit area and leaves inert ones hair-thin", async () => {
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      memoEvent("evt_memo", 11, "memo_9", "Single"),
+      messageEvent("r2", 12, "Second reply."),
+      multiMemoEvent("evt_multi", 13),
+      messageEvent("r3", 14, "Third reply."),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    const interactiveRow = await screen.findByRole("button", { name: /Memo: Single/ })
+    expect(interactiveRow.className).toContain("py-0.5")
+    expect(interactiveRow.className).toContain("text-xs")
+
+    const inertRow = screen.getByText("Memo: One, Two").parentElement as HTMLElement
+    expect(inertRow.className).toContain("py-px")
+    expect(inertRow.className).not.toContain("py-0.5")
   })
 
   it("coalesces a run of three ledger events into one row that expands and re-coalesces", async () => {
@@ -244,15 +294,19 @@ describe("BoardCard ledger events", () => {
     await userEvent.click(summary)
 
     const group = screen.getByRole("button", { name: "3 events" }).parentElement as HTMLElement
-    expect(within(group).getAllByRole("link")).toHaveLength(3)
-    expect(within(group).getByRole("link", { name: /Memo: Beta/ })).toHaveAttribute(
+    expect(within(group).queryAllByRole("link")).toHaveLength(0)
+    const beta = within(group).getByRole("button", { name: "Memo: Beta" })
+    await userEvent.click(beta)
+    const dialog = await screen.findByRole("dialog")
+    expect(within(dialog).getByRole("link", { name: /Open in memory/ })).toHaveAttribute(
       "href",
       "/w/ws_1/memory?memo=memo_2"
     )
+    await userEvent.keyboard("{Escape}")
 
     await userEvent.click(screen.getByRole("button", { name: "3 events" }))
     expect(screen.getByRole("button", { name: /3 events —/ })).toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: /Memo: Beta/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Memo: Beta" })).toBeNull()
   })
 
   it("keeps an event in the full-tail region fully rendered", async () => {
@@ -268,6 +322,6 @@ describe("BoardCard ledger events", () => {
     // The full capture row (title as a preview-opening button), not a thin line.
     expect(await screen.findByText(/Saved to memory/)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Postgres upserts need the index" })).toBeInTheDocument()
-    expect(screen.queryByRole("link", { name: /Memo: Postgres upserts need the index/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: /^Memo: Postgres upserts need the index/ })).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
-import { buildBranchedBoardRows, foldLedgerEventRows } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows, foldLedgerEventRows, injectUnreadDivider } from "@/components/board/board-row-item"
 import {
   BranchedBoardRows,
   BranchProvenanceRow,
@@ -39,6 +39,10 @@ import { ConversationReadProvider, useConversationReadController } from "@/compo
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
+import {
+  useConversationReadStateDecidable,
+  useConversationUnreadMarker,
+} from "@/components/conversations/use-conversation-unread-marker"
 import { DeletedMessageEvent } from "@/components/timeline/deleted-message-event"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
@@ -537,6 +541,15 @@ export function BoardCard({
     ),
     settlingIds
   )
+  // The rows that carry read state: the opening plus every locally displayed
+  // reply, tombstones excluded (a deleted row counts as zero unread, so it must
+  // neither anchor the marker nor be auto-read). Feeds both the unread marker
+  // below and the viewport auto-read further down — one set, so "what can hold
+  // the divider" and "what can clear it" stay the same rows.
+  const readableRows = (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).filter(
+    (m) => !m.deletedAt
+  )
+  const readStateResolved = useConversationReadStateDecidable(workspaceId, readableRows, streamId)
   // The reply region IS the ledger: the newest `fullTailCount` replies keep the
   // full message row (reactions, actions, settling affordances); everything older
   // that fits in `ledgerRowLimit` renders as a collapsed ledger line, and the mass
@@ -559,10 +572,41 @@ export function BoardCard({
   // Events interleave at their own timeline positions; those landing among the
   // ledger rows compress to the same hair-thin line the messages do, coalescing
   // adjacent runs. A card with no ledger rows is all full detail, so nothing folds.
-  const ledgerBranchRows = (messages: RenderableMessage[]) => {
+  const foldedBranchRows = (messages: RenderableMessage[]) => {
     const rows = branchRows(messages)
     return ledgerReplies.length > 0 ? foldLedgerEventRows(rows, firstFullTailId) : rows
   }
+  // The card's "New" divider: the SAME marker the conversation panel latches
+  // (per-stream frontiers + read overlay, one decision per open, one-way dim),
+  // rendered through the same `unread` row kind and `UnreadDivider`.
+  // Rows first, marker second (as in the panel): a message swallowed by a
+  // depth-collapsed "continue thread" row has no row, so a marker latched there
+  // would draw nothing and never correct itself. Unlike the panel, the set also
+  // unions the ledger's hidden older mass — that mass is deliberately off-card,
+  // and a marker landing in it must keep drawing NO divider rather than sliding
+  // down onto the first visible row and pointing at the wrong message.
+  const renderedMessageIds = new Set<string>(hiddenOlder.map((m) => m.id))
+  for (const row of foldedBranchRows(openingMessage ? [openingMessage, ...visibleReplies] : visibleReplies)) {
+    if (row.kind === "message") renderedMessageIds.add(row.message.id)
+  }
+  const { markerMessageId, isDimmed } = useConversationUnreadMarker({
+    conversationId: conversation.id,
+    rows: readableRows,
+    rootStreamId: streamId,
+    rowState: conversationReadValue.state,
+    currentUserId,
+    readStateResolved,
+    renderedMessageIds,
+  })
+  const ledgerBranchRows = (messages: RenderableMessage[]) =>
+    injectUnreadDivider(foldedBranchRows(messages), markerMessageId, isDimmed)
+  // The non-contiguous shape renders the opening outside the row builder, so the
+  // divider above it is lifted out of that same injection rather than drawn by a
+  // second authority — `injectUnreadDivider` stays the only thing that decides.
+  const openingLeadRows =
+    openingMessage && markerMessageId === openingMessage.id
+      ? ledgerBranchRows([openingMessage]).filter((row) => row.kind === "unread")
+      : []
   // Commit the partition's first row after render, never during it.
   useEffect(() => {
     if (firstFullTailId === null) return
@@ -636,12 +680,9 @@ export function BoardCard({
   // never dwells as an observed row, but the cutoff through a read tail row still
   // covers the older leads beneath it — whole-card read, exactly as before the
   // ledger. Lead-granular read waits for sparse-read.
-  const autoReadRows = (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).filter(
-    (m) => !m.deletedAt
-  )
   useConversationAutoRead({
     containerRef: cardRef,
-    messages: autoReadRows,
+    messages: readableRows,
     rootStreamId: streamId,
     rowState: conversationReadValue.state,
     markRead: markReadSilently,
@@ -727,6 +768,17 @@ export function BoardCard({
           currentUserId={currentUserId}
           expanded={expandedRowIds.has(message.id)}
           onToggle={() => toggleLedgerRow(message.id)}
+          // Live effective read state, not the latched divider position: the tint
+          // decays as auto-read clears rows, the way the header dot does.
+          unread={
+            message.authorId !== currentUserId &&
+            conversationReadValue.state(
+              message.streamId ?? streamId,
+              message.id,
+              message.sequence,
+              message.createdAt
+            ) === "unread"
+          }
           leadLineLength={leadLineLength}
           conversationId={conversation.id}
           conversationRootStreamId={conversation.streamId}
@@ -1076,6 +1128,19 @@ export function BoardCard({
                 />
               ) : (
                 <>
+                  <BranchedBoardRows
+                    rows={openingLeadRows}
+                    workspaceId={workspaceId}
+                    renderMessage={renderMessage}
+                    continueThreadTo={continueThreadTo}
+                    onSplitThread={onSplitThread}
+                    renderBranchMessage={renderBranchMessage}
+                    renderBranchTail={inlineComposer.renderBranchTail}
+                    branchExpansion={branchExpansion}
+                    renderAfterMessage={inlineComposer.renderAfterMessage}
+                    onRedirectSession={openReplyComposer}
+                    ledgerEventExpansion={ledgerEventExpansion}
+                  />
                   {openingMessage && renderMessage(openingMessage, false)}
                   {/* The opening renders outside the row builder here, so its inline
                     "new sub-topic" composer slot must be placed explicitly. */}

--- a/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
+++ b/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
@@ -1,0 +1,407 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+const CONV = "conv_1"
+const STREAM = "stream_1"
+const REPLY_IDS = ["r1", "r2", "r3", "r4", "r5"]
+
+function at(seconds: number): string {
+  return `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`
+}
+
+function cachedStream(id: string, extra: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: StreamTypes.CHANNEL as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: at(0),
+    updatedAt: at(0),
+    archivedAt: null,
+    _cachedAt: 0,
+    ...extra,
+  }
+}
+
+let seq = 0
+function messageEvent(id: string, seconds: number, content: string, streamId: string = STREAM): CachedEvent {
+  seq += 1
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId,
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType: "message_created" as CachedEvent["eventType"],
+    payload: { messageId: id, contentMarkdown: content, reactions: {} } as CachedEvent["payload"],
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: at(seconds),
+    _cachedAt: seq,
+  }
+}
+
+function post(): CachedBoardPost {
+  return {
+    id: CONV,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    rootStreamId: STREAM,
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: CONV,
+      streamId: STREAM,
+      workspaceId: WS,
+      messageIds: ["m_open", ...REPLY_IDS],
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: "Index migration",
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: at(0),
+      createdAt: at(0),
+      updatedAt: at(0),
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: {
+      id: "m_open",
+      streamId: STREAM,
+      authorId: "usr_other",
+      authorType: "user",
+      contentMarkdown: "Opening the index migration.",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: at(0),
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: REPLY_IDS.length,
+  } as unknown as CachedBoardPost
+}
+
+function tree(cardPost: CachedBoardPost = post()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <MediaGalleryProvider>
+                  <BoardCard
+                    workspaceId={WS}
+                    post={cardPost as BoardViewPost}
+                    contextLabel="#general"
+                    streamType="channel"
+                  />
+                </MediaGalleryProvider>
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function mount(cardPost?: CachedBoardPost) {
+  return render(tree(cardPost))
+}
+
+/** Message ids the fake read state reports as unread; mutated between renders. */
+let unreadIds = new Set<string>()
+const markReadUpToHere = vi.fn()
+const markUnread = vi.fn()
+const markReadSilently = vi.fn().mockResolvedValue(undefined)
+const readValue = {
+  state: (_streamId: string, messageId: string): RowReadState => (unreadIds.has(messageId) ? "unread" : "read"),
+  markReadUpToHere,
+  markUnread,
+}
+
+/** The divider's own label — `bg-background` distinguishes it from any other "New". */
+function dividerLabel(): HTMLElement | undefined {
+  return screen.queryAllByText("New").find((el) => el.className.includes("bg-background"))
+}
+
+function rowFor(messageId: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-message-id="${messageId}"]`)
+  expect(el, `a row should render for ${messageId}`).toBeTruthy()
+  return el!
+}
+
+function isBefore(a: Element, b: Element): boolean {
+  return (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+}
+
+function ledgerRow(messageId: string): HTMLElement {
+  const el = document.querySelector<HTMLElement>(`[data-ledger-row][data-message-id="${messageId}"]`)
+  expect(el, `${messageId} should render as a ledger lead`).toBeTruthy()
+  return el!
+}
+
+let ledgerRowsPref = 15
+
+beforeEach(async () => {
+  seq = 0
+  unreadIds = new Set()
+  ledgerRowsPref = 15
+  markReadUpToHere.mockClear()
+  markUnread.mockClear()
+  markReadSilently.mockClear()
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  await db.streams.put(cachedStream(STREAM))
+  await db.events.bulkPut([
+    messageEvent("m_open", 0, "Opening the index migration."),
+    ...REPLY_IDS.map((id, i) => messageEvent(id, 10 + i, `Reply ${i + 1}.`)),
+  ])
+  await db.conversations.put(post())
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  // The marker's gate: the card's only stream is decidable (it has a read-state row).
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue({
+    workspaceId: WS,
+    unreadCounts: { [STREAM]: 3 },
+    mentionCounts: {},
+    messageCounts: { [STREAM]: 6 },
+    readMessageIds: {},
+  } as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreamReadStates").mockReturnValue([
+    {
+      id: `${WS}:${STREAM}`,
+      workspaceId: WS,
+      streamId: STREAM,
+      lastReadSequence: "1",
+      lastReadAt: at(10),
+      lastReadEventId: "evt_r1",
+    },
+  ] as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockImplementation(
+    () =>
+      ({
+        preferences: { timezone: "UTC", locale: "en-US", boardLedgerRows: ledgerRowsPref },
+      }) as unknown as ReturnType<typeof contextsModule.usePreferences>
+  )
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: (messages) => messages.some((m) => unreadIds.has(m.id)),
+    markReadSilently,
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard unread divider", () => {
+  it("draws the New line above the first unread lead when the frontier sits mid-ledger", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    mount()
+    await screen.findByText("Reply 5.")
+
+    const divider = dividerLabel()
+    expect(divider, "the New divider should render").toBeTruthy()
+    expect(isBefore(rowFor("r2"), divider!)).toBe(true)
+    expect(isBefore(divider!, rowFor("r3"))).toBe(true)
+    // Chunk 3's lead tint, wired to the same effective read state.
+    expect(ledgerRow("r3").className).toContain("border-destructive/70")
+    expect(ledgerRow("r2").className).toContain("border-muted-foreground/20")
+  })
+
+  it("draws the New line above the full-tail row when that row is the first unread", async () => {
+    unreadIds = new Set(["r5"])
+    mount()
+    await screen.findByText("Reply 5.")
+
+    const divider = dividerLabel()
+    expect(divider).toBeTruthy()
+    expect(isBefore(ledgerRow("r4"), divider!)).toBe(true)
+    expect(isBefore(divider!, rowFor("r5"))).toBe(true)
+  })
+
+  it("draws nothing when every row is read", async () => {
+    mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()).toBeUndefined()
+  })
+
+  it("draws nothing when the first unread sits above the head row's range", async () => {
+    // Two ledger lines + one full tail: r1/r2 collapse into the head row's mass,
+    // so the marker anchors on a message this card renders no row for. The
+    // opening stays READ on purpose — an unread opening would latch there and
+    // draw a legitimate divider, hiding the hidden-lead case this asserts.
+    ledgerRowsPref = 2
+    unreadIds = new Set(REPLY_IDS)
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(document.querySelector('[data-message-id="r1"]')).toBeNull()
+    expect(dividerLabel()).toBeUndefined()
+  })
+
+  it("draws the New line above the opening on an entirely-unread non-contiguous card", async () => {
+    // Hidden older mass makes the card non-contiguous, where the opening renders
+    // outside the row builder — the divider must still land above it.
+    ledgerRowsPref = 2
+    unreadIds = new Set(["m_open", ...REPLY_IDS])
+    mount()
+    await screen.findByText("Reply 5.")
+
+    const divider = dividerLabel()
+    expect(divider, "the New divider should render above the opening").toBeTruthy()
+    expect(isBefore(divider!, rowFor("m_open"))).toBe(true)
+  })
+
+  it("dims in place once the marker's rows are read, without moving", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const { rerender } = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()!.parentElement!.className).toContain("text-destructive")
+    expect(isBefore(dividerLabel()!, rowFor("r3"))).toBe(true)
+
+    // Read past the marker. Re-render, never re-mount: the latch is per open.
+    unreadIds = new Set()
+    rerender(tree())
+
+    const after = dividerLabel()
+    expect(after, "the divider stays for this open").toBeTruthy()
+    expect(after!.parentElement!.className).toContain("text-muted-foreground")
+    expect(after!.parentElement!.className).not.toContain("text-destructive")
+    expect(isBefore(rowFor("r2"), after!)).toBe(true)
+    expect(isBefore(after!, rowFor("r3"))).toBe(true)
+  })
+
+  it("skips an unread swallowed by a depth-collapsed subtree and lands on the first rendered one", async () => {
+    // stream_1 › thread_1 › thread_2 › thread_3: the depth-3 subtree collapses to
+    // one "continue thread" row, so t3 gets no message row. A marker latched
+    // there would draw nothing and never correct itself.
+    await db.events.clear()
+    await db.conversations.clear()
+    await db.streams.bulkPut([
+      cachedStream(STREAM),
+      cachedStream("thread_1", {
+        type: StreamTypes.THREAD as CachedStream["type"],
+        parentStreamId: STREAM,
+        rootStreamId: STREAM,
+        parentMessageId: "m_open",
+      }),
+      cachedStream("thread_2", {
+        type: StreamTypes.THREAD as CachedStream["type"],
+        parentStreamId: "thread_1",
+        rootStreamId: STREAM,
+        parentMessageId: "t1",
+      }),
+      cachedStream("thread_3", {
+        type: StreamTypes.THREAD as CachedStream["type"],
+        parentStreamId: "thread_2",
+        rootStreamId: STREAM,
+        parentMessageId: "t2",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("m_open", 0, "Opening the index migration."),
+      messageEvent("t1", 10, "Depth one.", "thread_1"),
+      messageEvent("t2", 11, "Depth two.", "thread_2"),
+      messageEvent("t3", 12, "Depth three.", "thread_3"),
+      messageEvent("r_late", 13, "Back on the base level."),
+    ])
+    const deepPost = {
+      ...post(),
+      streamIds: [STREAM, "thread_1", "thread_2", "thread_3"],
+      conversation: { ...post().conversation, messageIds: ["m_open", "t1", "t2", "t3", "r_late"] },
+      totalReplies: 4,
+    } as unknown as CachedBoardPost
+    await db.conversations.put(deepPost)
+    // Every stream the rows sit on must be decidable, or the marker never latches.
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreamReadStates").mockReturnValue(
+      [STREAM, "thread_1", "thread_2", "thread_3"].map((streamId) => ({
+        id: `${WS}:${streamId}`,
+        workspaceId: WS,
+        streamId,
+        lastReadSequence: "1",
+        lastReadAt: at(10),
+        lastReadEventId: "evt_r1",
+      })) as never
+    )
+    unreadIds = new Set(["t3", "r_late"])
+
+    mount(deepPost)
+    await screen.findByText("Back on the base level.")
+
+    expect(document.querySelector('[data-message-id="t3"]')).toBeNull()
+    const divider = dividerLabel()
+    expect(divider, "the divider should land on the first row-rendered unread").toBeTruthy()
+    expect(isBefore(divider!, rowFor("r_late"))).toBe(true)
+  })
+
+  it("never marks anything read", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(markReadSilently).not.toHaveBeenCalled()
+    expect(markReadUpToHere).not.toHaveBeenCalled()
+    expect(markUnread).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 import { Bot, Clock, Sparkles, TerminalSquare } from "lucide-react"
 import type { StreamEvent } from "@threa/types"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
@@ -6,6 +6,7 @@ import { isContinuation } from "@/lib/message-grouping"
 import { type RenderableMessage } from "@/components/message/message-item"
 import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
+import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import { DelegationEvent } from "@/components/timeline/delegation-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
@@ -492,28 +493,47 @@ const LEDGER_EVENT_ICONS: Record<BoardEventRow["kind"], ReactNode> = {
   delegation: <TerminalSquare className="size-3" />,
 }
 
-function ledgerDescriptor(row: BoardEventRow, workspaceId: string, traceUrl: (sessionId: string) => string) {
-  const content = ledgerEventContent(row, { workspaceId, traceUrl })
+type OpenMemo = { memoId: string; title: string }
+
+function ledgerDescriptor(
+  row: BoardEventRow,
+  traceUrl: (sessionId: string) => string,
+  onOpenMemo: (memo: OpenMemo) => void
+) {
+  const content = ledgerEventContent(row, { traceUrl })
   return {
     key: content.key,
     icon: LEDGER_EVENT_ICONS[content.kind],
     label: content.label,
     meta: content.meta,
     href: content.href,
+    onOpen: content.memo ? () => onOpenMemo(content.memo as OpenMemo) : undefined,
   } satisfies LedgerEventDescriptor
 }
 
 /**
  * One event compressed to a ledger line. Its tap affordance is the kind's own:
- * a session opens the trace view its full card links to, a single capture deep-
- * links to the memo in the memory explorer. Follow-ups and delegations act only
- * through buttons on their full cards, so their lines are non-interactive.
+ * a session opens the trace view its full card links to, a single capture opens
+ * the SAME in-place `MemoPreviewDialog` the full capture row does (never a
+ * navigation off the board — the dialog's footer carries the deep link). Follow-
+ * ups and delegations act only through buttons on their full cards, so their
+ * lines are non-interactive.
  */
 export function LedgerBoardEventRow({ row, workspaceId }: { row: BoardEventRow; workspaceId: string }) {
   const { getTraceUrl } = useTrace()
-  const descriptor = ledgerDescriptor(row, workspaceId, getTraceUrl)
+  const [openMemo, setOpenMemo] = useState<OpenMemo | null>(null)
+  const descriptor = ledgerDescriptor(row, getTraceUrl, setOpenMemo)
   return (
-    <LedgerEventRow icon={descriptor.icon} label={descriptor.label} meta={descriptor.meta} href={descriptor.href} />
+    <>
+      <LedgerEventRow
+        icon={descriptor.icon}
+        label={descriptor.label}
+        meta={descriptor.meta}
+        href={descriptor.href}
+        onOpen={descriptor.onOpen}
+      />
+      <LedgerMemoPreview workspaceId={workspaceId} memo={openMemo} onClose={() => setOpenMemo(null)} />
+    </>
   )
 }
 
@@ -530,11 +550,37 @@ export function LedgerBoardEventGroup({
   onToggle: () => void
 }) {
   const { getTraceUrl } = useTrace()
+  const [openMemo, setOpenMemo] = useState<OpenMemo | null>(null)
   return (
-    <LedgerEventGroup
-      events={rows.map((row) => ledgerDescriptor(row, workspaceId, getTraceUrl))}
-      expanded={expanded}
-      onToggle={onToggle}
+    <>
+      <LedgerEventGroup
+        events={rows.map((row) => ledgerDescriptor(row, getTraceUrl, setOpenMemo))}
+        expanded={expanded}
+        onToggle={onToggle}
+      />
+      <LedgerMemoPreview workspaceId={workspaceId} memo={openMemo} onClose={() => setOpenMemo(null)} />
+    </>
+  )
+}
+
+function LedgerMemoPreview({
+  workspaceId,
+  memo,
+  onClose,
+}: {
+  workspaceId: string
+  memo: OpenMemo | null
+  onClose: () => void
+}) {
+  return (
+    <MemoPreviewDialog
+      open={memo !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      workspaceId={workspaceId}
+      memoId={memo?.memoId ?? ""}
+      fallbackTitle={memo?.title ?? ""}
     />
   )
 }

--- a/apps/frontend/src/components/board/ledger-row.tsx
+++ b/apps/frontend/src/components/board/ledger-row.tsx
@@ -575,6 +575,7 @@ export function LedgerEventRow({
   label,
   meta,
   href,
+  onOpen,
   onToggle,
   expanded,
 }: {
@@ -583,6 +584,8 @@ export function LedgerEventRow({
   meta?: string
   /** The kind's own detail target — the row navigates instead of toggling (INV-40). */
   href?: string
+  /** Opens the kind's in-place preview (a dialog) instead of navigating. */
+  onOpen?: () => void
   onToggle?: () => void
   expanded?: boolean
 }) {
@@ -595,16 +598,31 @@ export function LedgerEventRow({
       {meta && <span className="shrink-0 text-muted-foreground/70">· {meta}</span>}
     </>
   )
-  const className = "flex w-full items-center gap-1.5 py-px text-left text-xs text-muted-foreground"
+  // The text stays hair-thin (`text-xs`); an interactive row grows only its
+  // PADDING, so its hit area matches a message ledger row's instead of the ~18px
+  // a `py-px` line leaves for a thumb.
+  const className = "flex w-full items-center gap-1.5 text-left text-xs text-muted-foreground"
+  const interactive = cn(className, "py-0.5")
   if (href)
     return (
-      <Link to={href} className={cn(className, "no-underline transition-colors hover:text-foreground")}>
+      <Link to={href} className={cn(interactive, "no-underline transition-colors hover:text-foreground")}>
         {content}
       </Link>
     )
-  if (!onToggle) return <div className={className}>{content}</div>
+  if (onOpen)
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-haspopup="dialog"
+        className={cn(interactive, "transition-colors hover:text-foreground")}
+      >
+        {content}
+      </button>
+    )
+  if (!onToggle) return <div className={cn(className, "py-px")}>{content}</div>
   return (
-    <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={className}>
+    <button type="button" onClick={onToggle} aria-expanded={expanded ?? false} className={interactive}>
       {content}
     </button>
   )
@@ -616,6 +634,7 @@ export interface LedgerEventDescriptor {
   label: string
   meta?: string
   href?: string
+  onOpen?: () => void
 }
 
 /**
@@ -650,7 +669,14 @@ export function LedgerEventGroup({
           expanded
         />
         {events.map((event) => (
-          <LedgerEventRow key={event.key} icon={event.icon} label={event.label} meta={event.meta} href={event.href} />
+          <LedgerEventRow
+            key={event.key}
+            icon={event.icon}
+            label={event.label}
+            meta={event.meta}
+            href={event.href}
+            onOpen={event.onOpen}
+          />
         ))}
       </div>
     )

--- a/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
+++ b/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
@@ -1,6 +1,35 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 import type { ConversationRowRead } from "@/components/message/conversation-read-context"
 import type { RenderableMessage } from "@/components/message/message-item"
+import { useWorkspaceStreamReadStates, useWorkspaceUnreadState } from "@/stores/workspace-store"
+
+/**
+ * Whether every stream the given rows span can already be decided as read or
+ * unread — the gate {@link useConversationUnreadMarker}'s `readStateResolved`
+ * wants. A row whose leg has no frontier yet derives as `ungated`, so latching
+ * before that would anchor the marker below the true first unread, and the latch
+ * is one-way. A leg counts as decidable once it has a `stream_read_state` row or
+ * a zero unread count (mark-all-read advances counts without a frontier).
+ */
+export function useConversationReadStateDecidable(
+  workspaceId: string,
+  rows: RenderableMessage[],
+  rootStreamId: string
+): boolean {
+  const unreadState = useWorkspaceUnreadState(workspaceId)
+  const streamReadStates = useWorkspaceStreamReadStates(workspaceId)
+  return useMemo(() => {
+    if (unreadState === undefined) return false
+    const decidable = new Set(streamReadStates.map((row) => row.streamId))
+    for (const [streamId, count] of Object.entries(unreadState.unreadCounts ?? {})) {
+      if (count === 0) decidable.add(streamId)
+    }
+    for (const row of rows) {
+      if (!decidable.has(row.streamId ?? rootStreamId)) return false
+    }
+    return true
+  }, [unreadState, streamReadStates, rows, rootStreamId])
+}
 
 interface UseConversationUnreadMarkerOptions {
   /** Resets the latch — one marker decision per conversation, per open. */

--- a/apps/frontend/src/lib/board/ledger.test.ts
+++ b/apps/frontend/src/lib/board/ledger.test.ts
@@ -205,7 +205,7 @@ describe("coalesceLedgerItems", () => {
 })
 
 describe("ledgerEventContent", () => {
-  const ctx = { workspaceId: "ws_1", traceUrl: (sessionId: string) => `/w/ws_1/trace/${sessionId}` }
+  const ctx = { traceUrl: (sessionId: string) => `/w/ws_1/trace/${sessionId}` }
 
   function event(eventType: string, payload: unknown): CachedEvent {
     return {
@@ -254,7 +254,7 @@ describe("ledgerEventContent", () => {
     expect(ledgerEventContent(row, ctx).meta).toBe("running")
   })
 
-  it("carries a capture's TITLE and its memo deep link, never the memo content", () => {
+  it("carries a capture's TITLE and its memo descriptor (no href — the row previews in place)", () => {
     const row: BoardEventRow = {
       kind: "memo",
       key: "evt_1",
@@ -276,11 +276,11 @@ describe("ledgerEventContent", () => {
       key: "evt_1",
       kind: "memo",
       label: "Memo: Postgres upserts need the index",
-      href: "/w/ws_1/memory?memo=memo_9",
+      memo: { memoId: "memo_9", title: "Postgres upserts need the index" },
     })
   })
 
-  it("leaves a multi-memo capture without a link (no single target to open)", () => {
+  it("leaves a multi-memo capture without a preview target (no single memo to open)", () => {
     const row: BoardEventRow = {
       kind: "memo",
       key: "evt_1",
@@ -298,7 +298,7 @@ describe("ledgerEventContent", () => {
       key: "evt_1",
       kind: "memo",
       label: "Memo: One, Two",
-      href: undefined,
+      memo: undefined,
     })
   })
 

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -17,7 +17,6 @@ import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import { DELEGATION_STATUS_LABEL } from "@/lib/delegation-display"
 import { formatDuration, formatFireTime } from "@/lib/dates"
 import { resolveEmojiShortcodes, stripMarkdownKeepingCode, truncateInline } from "@/lib/markdown/strip"
-import { memoDeepLink } from "@/lib/memo-url"
 
 /** Characters of prose one reading-minute covers. */
 const CHARS_PER_MINUTE = 1100
@@ -103,7 +102,8 @@ function hostname(url: string): string {
 /**
  * The renderable content of one ledger event line — everything the thin row
  * shows, plus the in-app detail target when the kind has one. Data only: the
- * surface picks the icon and turns `href` into a `<Link>` (INV-40).
+ * surface picks the icon, turns `href` into a `<Link>` (INV-40), and maps
+ * `memo` onto the same in-place `MemoPreviewDialog` the full capture row opens.
  */
 export interface LedgerEventContent {
   key: string
@@ -111,10 +111,11 @@ export interface LedgerEventContent {
   label: string
   meta?: string
   href?: string
+  /** The single memo a capture line previews in place. */
+  memo?: { memoId: string; title: string }
 }
 
 export interface LedgerEventContentCtx {
-  workspaceId: string
   /** The session's trace-view URL, from the surface's `useTrace`. */
   traceUrl: (sessionId: string) => string
 }
@@ -126,7 +127,7 @@ function stepsLabel(count: number): string {
 /**
  * A board event row compressed to its ledger line. Titles and counts only —
  * a capture line carries its memos' TITLES, never their content (INV-62): the
- * memo body is the memory explorer's, one deep link away.
+ * memo body is the preview dialog's, one tap away.
  */
 export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCtx): LedgerEventContent {
   switch (row.kind) {
@@ -183,7 +184,7 @@ export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCt
         label: titles.length === 0 ? "Memo captured" : `Memo: ${titles.join(", ")}`,
         // One memo has an unambiguous target; a batch would have to pick one, so
         // it stays a plain line and the reader opens what they want in the panel.
-        href: memos.length === 1 ? memoDeepLink(ctx.workspaceId, memos[0].memoId) : undefined,
+        memo: memos.length === 1 ? { memoId: memos[0].memoId, title: memos[0].title } : undefined,
       }
     }
     case "followUp": {


### PR DESCRIPTION
## Problem

Chunk 7 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): the unread seam. Rulings: the timeline's divider VERBATIM (a "New" line, no timestamp, viewer-local), and read-state mechanics untouched — render existing state, write nothing.

## Solution

- Pure reuse: the card calls `useConversationUnreadMarker` with the panel's inputs (one-way latch + dimming come free), renders `UnreadDivider` through the `BranchedBoardRows` path that already existed, positioned by the single-authority `injectUnreadDivider`.
- The card's windowing needed two anchoring rules the panel doesn't: `renderedMessageIds` = rendered rows ∪ `hiddenOlder` — hidden-older mass still BLOCKS the divider (a "New" line pointing at off-card rows is a lie; chunk 8's badge carries that signal) while depth>2 overflow-swallowed messages cannot latch the marker into never drawing; and an entirely-unread non-contiguous card injects the divider above its opening (the opening renders outside the reply rows).
- Ledger leads at/past the frontier wear the red-rail unread tint from LIVE read state (decays with auto-read) while the divider latches — the timeline's exact split.
- No mark-read paths touched; a test asserts the chunk adds no read writes.
- Rides along (#1729 review fixes): thin memo rows open `MemoPreviewDialog` in place (no more navigating off-board where the full row deliberately doesn't), and interactive event rows share a `py-0.5` hit-area contract.

## Test plan

- [x] 331 green across board/conversations (divider mid-ledger/at-tail/absent/dimming-latch, hidden-lead guard now asserting the real case, deep-overflow anchoring, opening divider, no-write assertion — each falsification-checked); tsc + lint clean. Adversarial verify (Opus high): 2 findings accepted+fixed, 0 refuted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788291189&installation_model_id=20758&pr_number=1730&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1730&signature=424786decfb8719682ddba8fe177d6a45b9331150398c5ab1fd576eceaab4463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->