### PR TITLE
feat(board): unread mass badge on the card header

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -13,6 +13,7 @@ import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 import { resetComposeOverlayStoreCache } from "@/stores/compose-overlay-store"
 import { resetBoardFlashStoreCache } from "@/stores/board-flash-store"
+import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
 import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
 import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
@@ -81,6 +82,7 @@ function flushModuleStoreCaches(): void {
   resetE2eSessionStoreCache()
   resetComposeOverlayStoreCache()
   resetBoardFlashStoreCache()
+  resetBoardUnreadLatches()
   // Ordered hangup before state drop: the call-store reset emits leave, closes
   // the transport, and stops tracks (the CallManager's registered hangup) so an
   // account switch with a live call never leaves the prior account's mic hot.

--- a/apps/frontend/src/components/board/board-card.mass-badge.test.tsx
+++ b/apps/frontend/src/components/board/board-card.mass-badge.test.tsx
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes, type BoardMassBadge } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+const CONV = "conv_1"
+const STREAM = "stream_1"
+const REPLY_IDS = ["r1", "r2", "r3", "r4", "r5"]
+
+function at(seconds: number): string {
+  return `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`
+}
+
+function cachedStream(id: string): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: StreamTypes.CHANNEL as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: at(0),
+    updatedAt: at(0),
+    archivedAt: null,
+    _cachedAt: 0,
+  }
+}
+
+let seq = 0
+function messageEvent(id: string, seconds: number, content: string): CachedEvent {
+  seq += 1
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType: "message_created" as CachedEvent["eventType"],
+    payload: { messageId: id, contentMarkdown: content, reactions: {} } as CachedEvent["payload"],
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: at(seconds),
+    _cachedAt: seq,
+  }
+}
+
+/** Reply bodies by id; a test overrides them to drive the minutes estimate. */
+let replyBody = (index: number) => `Reply ${index + 1}.`
+
+function post(): CachedBoardPost {
+  return {
+    id: CONV,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    rootStreamId: STREAM,
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: CONV,
+      streamId: STREAM,
+      workspaceId: WS,
+      messageIds: ["m_open", ...REPLY_IDS],
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: "Index migration",
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: at(0),
+      createdAt: at(0),
+      updatedAt: at(0),
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: {
+      id: "m_open",
+      streamId: STREAM,
+      authorId: "usr_other",
+      authorType: "user",
+      contentMarkdown: "Opening the index migration.",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: at(0),
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: REPLY_IDS.length,
+  } as unknown as CachedBoardPost
+}
+
+function tree() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <MediaGalleryProvider>
+                  <BoardCard
+                    workspaceId={WS}
+                    post={post() as BoardViewPost}
+                    contextLabel="#general"
+                    streamType="channel"
+                  />
+                </MediaGalleryProvider>
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function mount() {
+  return render(tree())
+}
+
+/** The badge's reserved header slot — present whether or not it holds a pill. */
+function badgeSlot(): HTMLElement {
+  const el = document.querySelector<HTMLElement>("[data-mass-badge-slot]")
+  expect(el, "the header should always carry the badge slot").toBeTruthy()
+  return el!
+}
+
+function badgeText(): string | null {
+  return badgeSlot().textContent || null
+}
+
+function dividerLabel(): HTMLElement | undefined {
+  return screen.queryAllByText("New").find((el) => el.className.includes("bg-background"))
+}
+
+let unreadIds = new Set<string>()
+let ledgerRowsPref = 15
+let massBadgePref: BoardMassBadge = "count-minutes"
+const readValue = {
+  state: (_streamId: string, messageId: string): RowReadState => (unreadIds.has(messageId) ? "unread" : "read"),
+  markReadUpToHere: vi.fn(),
+  markUnread: vi.fn(),
+}
+
+beforeEach(async () => {
+  seq = 0
+  unreadIds = new Set()
+  ledgerRowsPref = 15
+  massBadgePref = "count-minutes"
+  replyBody = (index) => `Reply ${index + 1}.`
+  __clearBoardRailRegistry()
+  resetBoardUnreadLatches()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  await db.streams.put(cachedStream(STREAM))
+  await db.conversations.put(post())
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue({
+    workspaceId: WS,
+    unreadCounts: { [STREAM]: 3 },
+    mentionCounts: {},
+    messageCounts: { [STREAM]: 6 },
+    readMessageIds: {},
+  } as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreamReadStates").mockReturnValue([
+    {
+      id: `${WS}:${STREAM}`,
+      workspaceId: WS,
+      streamId: STREAM,
+      lastReadSequence: "1",
+      lastReadAt: at(10),
+      lastReadEventId: "evt_r1",
+    },
+  ] as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockImplementation(
+    () =>
+      ({
+        preferences: {
+          timezone: "UTC",
+          locale: "en-US",
+          boardLedgerRows: ledgerRowsPref,
+          boardMassBadge: massBadgePref,
+        },
+      }) as unknown as ReturnType<typeof contextsModule.usePreferences>
+  )
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: (messages) => messages.some((m) => unreadIds.has(m.id)),
+    markReadSilently: vi.fn().mockResolvedValue(undefined),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+/** Seed the rail after the per-test bodies are chosen. */
+async function seedRail() {
+  await db.events.bulkPut([
+    messageEvent("m_open", 0, "Opening the index migration."),
+    ...REPLY_IDS.map((id, i) => messageEvent(id, 10 + i, replyBody(i))),
+  ])
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard mass badge", () => {
+  it("reports the unread count and the reading minutes over those rows only", async () => {
+    // 1200 chars each: two unread rows = 2400 → 3 minutes. The read rows are far
+    // longer, so a badge that measured the whole card would say something else.
+    replyBody = (index) => (index >= 3 ? "u".repeat(1200) : "r".repeat(4000))
+    await seedRail()
+    unreadIds = new Set(["r4", "r5"])
+    mount()
+    await screen.findByText("u".repeat(1200))
+
+    expect(badgeText()).toBe("2 new · ~3 min")
+  })
+
+  it("drops the minutes in count mode", async () => {
+    replyBody = () => "x".repeat(1200)
+    massBadgePref = "count"
+    await seedRail()
+    unreadIds = new Set(["r3", "r4", "r5"])
+    mount()
+    await screen.findByText("x".repeat(1200))
+
+    expect(badgeText()).toBe("3 new")
+  })
+
+  it("hides the badge entirely when the preference is off", async () => {
+    massBadgePref = "off"
+    await seedRail()
+    unreadIds = new Set(["r3", "r4", "r5"])
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(badgeText()).toBeNull()
+  })
+
+  it("hides the badge when nothing is unread, keeping the slot", async () => {
+    await seedRail()
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(badgeText()).toBeNull()
+    expect(badgeSlot()).toBeTruthy()
+  })
+
+  it("counts unread hidden behind the head row, where the divider draws nothing", async () => {
+    // Two ledger lines + the full tail: r1/r2 collapse into the head row's mass,
+    // so the divider can't render — the badge is the only signal for that mass.
+    ledgerRowsPref = 2
+    await seedRail()
+    unreadIds = new Set(REPLY_IDS)
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(document.querySelector('[data-message-id="r1"]')).toBeNull()
+    expect(dividerLabel()).toBeUndefined()
+    expect(badgeText()).toBe("5 new · ~1 min")
+  })
+
+  it("decays live as rows are read, without latching", async () => {
+    await seedRail()
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const { rerender } = mount()
+    await screen.findByText("Reply 5.")
+    expect(badgeText()).toBe("3 new · ~1 min")
+
+    unreadIds = new Set(["r5"])
+    rerender(tree())
+    expect(badgeText()).toBe("1 new · ~1 min")
+
+    unreadIds = new Set()
+    rerender(tree())
+    expect(badgeText()).toBeNull()
+  })
+
+  it("keeps the header structure identical with and without the badge", async () => {
+    await seedRail()
+    unreadIds = new Set(["r5"])
+    const { rerender } = mount()
+    await screen.findByText("Reply 5.")
+    const shape = (): string[] =>
+      [...badgeSlot().parentElement!.children].map((el) => (el as HTMLElement).tagName + ":" + el.getAttribute("class"))
+    const withBadge = shape()
+    expect(badgeText()).toBe("1 new · ~1 min")
+
+    unreadIds = new Set()
+    rerender(tree())
+
+    expect(badgeText()).toBeNull()
+    expect(shape()).toEqual(withBadge)
+  })
+})

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_BOARD_FULL_TAIL_COUNT,
   DEFAULT_BOARD_LEDGER_ROWS,
   DEFAULT_BOARD_LEAD_LINE_LENGTH,
+  DEFAULT_USER_PREFERENCES,
 } from "@threa/types"
 import { RelativeTime } from "@/components/relative-time"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -49,6 +50,7 @@ import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useBoardFlash } from "@/stores/board-flash-store"
+import { boardUnreadLatchStorage } from "@/stores/board-unread-latch-store"
 import { usePanel, createConversationPanelId, usePreferences } from "@/contexts"
 import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { useSplitThread } from "@/hooks/use-conversations"
@@ -57,6 +59,7 @@ import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
 import { LedgerRow } from "@/components/board/ledger-row"
+import { isEffectivelyUnread, unreadMass, type EffectiveUnreadCtx } from "@/lib/board/ledger"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { localStartOfDayMs } from "@/lib/dates"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
@@ -550,6 +553,22 @@ export function BoardCard({
     (m) => !m.deletedAt
   )
   const readStateResolved = useConversationReadStateDecidable(workspaceId, readableRows, streamId)
+  // ONE effective-unread derivation for the whole card (INV-35): the ledger
+  // lead's tint and the header's mass badge both read it, so a row can never be
+  // tinted but uncounted. Live off the overlay + frontiers, never the latched
+  // divider position.
+  const unreadCtx: EffectiveUnreadCtx = {
+    currentUserId,
+    fallbackStreamId: streamId,
+    state: conversationReadValue.state,
+  }
+  // Counted over `readableRows`, which INCLUDES the mass hidden behind the head
+  // row — off-card unread is exactly what the badge signals, since the divider
+  // deliberately draws nothing there. Boundary: replies the rail has never
+  // synced are outside the count and contribute no minutes; only known rows are
+  // reported, so the number never outruns what the card can account for.
+  const unread = unreadMass(readableRows, unreadCtx)
+  const massBadgeMode = preferences?.boardMassBadge ?? DEFAULT_USER_PREFERENCES.boardMassBadge
   // The reply region IS the ledger: the newest `fullTailCount` replies keep the
   // full message row (reactions, actions, settling affordances); everything older
   // that fits in `ledgerRowLimit` renders as a collapsed ledger line, and the mass
@@ -597,6 +616,10 @@ export function BoardCard({
     currentUserId,
     readStateResolved,
     renderedMessageIds,
+    // virtua unmounts this card past its scroll buffer; a component-local latch
+    // would re-decide on remount against read state auto-read has cleared and
+    // drop the divider mid-visit. The registry makes the decision board-scoped.
+    latchStorage: boardUnreadLatchStorage,
   })
   const ledgerBranchRows = (messages: RenderableMessage[]) =>
     injectUnreadDivider(foldedBranchRows(messages), markerMessageId, isDimmed)
@@ -770,15 +793,7 @@ export function BoardCard({
           onToggle={() => toggleLedgerRow(message.id)}
           // Live effective read state, not the latched divider position: the tint
           // decays as auto-read clears rows, the way the header dot does.
-          unread={
-            message.authorId !== currentUserId &&
-            conversationReadValue.state(
-              message.streamId ?? streamId,
-              message.id,
-              message.sequence,
-              message.createdAt
-            ) === "unread"
-          }
+          unread={isEffectivelyUnread(message, unreadCtx)}
           leadLineLength={leadLineLength}
           conversationId={conversation.id}
           conversationRootStreamId={conversation.streamId}
@@ -939,6 +954,23 @@ export function BoardCard({
       {cardHasUnread && <span className="h-2 w-2 rounded-full bg-primary" />}
     </span>
   )
+  // How much new reading this card holds — an aggregate, never a "when": the
+  // count (and, per preference, the estimated minutes) of the same effectively
+  // unread rows the leads tint. Display-only. The slot is always in the header
+  // (INV-21) so the badge arriving or clearing never restructures it; the pill
+  // borrows the sidebar unread badge's visual language, destructive-tinted like
+  // the lead tint it summarizes.
+  const massBadgeLabel =
+    massBadgeMode === "count-minutes" ? `${unread.count} new · ~${unread.minutes} min` : `${unread.count} new`
+  const massBadge = (
+    <span data-mass-badge-slot className="flex shrink-0 items-center">
+      {massBadgeMode !== "off" && unread.count > 0 && (
+        <span className="inline-flex h-4 items-center rounded-full bg-destructive px-1.5 text-[10px] font-medium whitespace-nowrap text-destructive-foreground">
+          {massBadgeLabel}
+        </span>
+      )}
+    </span>
+  )
   const headerActions = (
     <>
       {/* Open the whole conversation in the side panel (Mechanism B) — reads it
@@ -1064,6 +1096,7 @@ export function BoardCard({
                   >
                     {conversation.topicSummary}
                   </span>
+                  {massBadge}
                   {unreadDot}
                   {headerActions}
                 </div>
@@ -1080,6 +1113,7 @@ export function BoardCard({
                 {locatorLink("sm")}
                 {subtopicLabel}
                 <div className="ml-auto flex items-center gap-1.5">
+                  {massBadge}
                   {unreadDot}
                   <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
                   {headerActions}

--- a/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
+++ b/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
@@ -8,6 +8,7 @@ import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
 import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
@@ -188,6 +189,7 @@ beforeEach(async () => {
   markUnread.mockClear()
   markReadSilently.mockClear()
   __clearBoardRailRegistry()
+  resetBoardUnreadLatches()
   __clearConversationGraphRegistry()
   await db.events.clear()
   await db.streams.clear()
@@ -330,6 +332,104 @@ describe("BoardCard unread divider", () => {
     expect(after!.parentElement!.className).not.toContain("text-destructive")
     expect(isBefore(rowFor("r2"), after!)).toBe(true)
     expect(isBefore(after!, rowFor("r3"))).toBe(true)
+  })
+
+  it("keeps the divider across an unmount/remount, dimmed once the rows are read", async () => {
+    // virtua unmounts a card scrolled past its buffer; the same board visit must
+    // still show the divider when it comes back, muted rather than re-reddened.
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const { unmount } = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()!.parentElement!.className).toContain("text-destructive")
+
+    unmount()
+    unreadIds = new Set()
+    mount()
+    await screen.findByText("Reply 5.")
+
+    const after = dividerLabel()
+    expect(after, "the latch survives the remount").toBeTruthy()
+    expect(after!.parentElement!.className).toContain("text-muted-foreground")
+    expect(after!.parentElement!.className).not.toContain("text-destructive")
+    expect(isBefore(rowFor("r2"), after!)).toBe(true)
+    expect(isBefore(after!, rowFor("r3"))).toBe(true)
+  })
+
+  /** Appends a genuinely new reply to IDB and returns the post that includes it. */
+  async function arriveNewReply(id: string, seconds: number, resetRegistries = true): Promise<CachedBoardPost> {
+    await db.events.put(messageEvent(id, seconds, `Reply ${id}.`))
+    const withReply = {
+      ...post(),
+      conversation: { ...post().conversation, messageIds: ["m_open", ...REPLY_IDS, id] },
+      totalReplies: REPLY_IDS.length + 1,
+    } as unknown as CachedBoardPost
+    await db.conversations.put(withReply)
+    if (resetRegistries) {
+      __clearBoardRailRegistry()
+      __clearConversationGraphRegistry()
+    }
+    return withReply
+  }
+
+  it("re-latches a red divider above an arrival that lands under a settled marker", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const first = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()!.parentElement!.className).toContain("text-destructive")
+
+    // Everything read: the latch settles to muted.
+    first.unmount()
+    unreadIds = new Set()
+    const settled = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()!.parentElement!.className).toContain("text-muted-foreground")
+
+    // A new reply arrives below the settled marker.
+    settled.unmount()
+    const withNew = await arriveNewReply("r6", 20)
+    unreadIds = new Set(["r6"])
+    mount(withNew)
+    await screen.findByText("Reply r6.")
+
+    const after = dividerLabel()
+    expect(after, "the settled latch is discarded and re-decided").toBeTruthy()
+    expect(after!.parentElement!.className).toContain("text-destructive")
+    expect(isBefore(rowFor("r5"), after!)).toBe(true)
+    expect(isBefore(after!, rowFor("r6"))).toBe(true)
+  })
+
+  it("does not move a live red divider when more unread arrives below it", async () => {
+    unreadIds = new Set(["r4", "r5"])
+    const { rerender } = mount()
+    await screen.findByText("Reply 5.")
+    expect(isBefore(dividerLabel()!, rowFor("r4"))).toBe(true)
+
+    // Never unmount: a live (non-dimmed) latch must survive more arrivals in place.
+    const withNew = await arriveNewReply("r6", 20, false)
+    unreadIds = new Set(["r4", "r5", "r6"])
+    rerender(tree(withNew))
+    await screen.findByText("Reply r6.")
+
+    const after = dividerLabel()
+    expect(after!.parentElement!.className).toContain("text-destructive")
+    expect(isBefore(rowFor("r3"), after!)).toBe(true)
+    expect(isBefore(after!, rowFor("r4"))).toBe(true)
+  })
+
+  it("drops the divider after a registry reset when everything is read", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const { unmount } = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()).toBeTruthy()
+
+    unmount()
+    // A fresh board visit resets the registry: nothing unread, nothing to latch.
+    resetBoardUnreadLatches()
+    unreadIds = new Set()
+    mount()
+    await screen.findByText("Reply 5.")
+
+    expect(dividerLabel()).toBeUndefined()
   })
 
   it("skips an unread swallowed by a depth-collapsed subtree and lands on the first rendered one", async () => {

--- a/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
+++ b/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
@@ -31,6 +31,21 @@ export function useConversationReadStateDecidable(
   }, [unreadState, streamReadStates, rows, rootStreamId])
 }
 
+/** One conversation's latched marker decision: where the divider sits, and
+ *  whether it has already settled from red to muted. */
+export interface UnreadMarkerLatch {
+  messageId: string | null
+  dimmed: boolean
+}
+
+/** Latch storage outliving the component, keyed by conversation id. Surfaces
+ *  whose rows unmount while still "open" (the board's virtualised cards) pass
+ *  one; the panel omits it and keeps its own per-open ref. */
+export interface UnreadMarkerLatchStorage {
+  get(conversationId: string): UnreadMarkerLatch | undefined
+  set(conversationId: string, latch: UnreadMarkerLatch): void
+}
+
 interface UseConversationUnreadMarkerOptions {
   /** Resets the latch — one marker decision per conversation, per open. */
   conversationId: string
@@ -46,6 +61,8 @@ interface UseConversationUnreadMarkerOptions {
   /** Ids that actually get a rendered row — a marker inside a collapsed subtree
    *  would draw no divider and have no scroll target. `null` = no filtering. */
   renderedMessageIds?: ReadonlySet<string> | null
+  /** External latch storage; omit to latch in a component-local ref. */
+  latchStorage?: UnreadMarkerLatchStorage
 }
 
 interface UseConversationUnreadMarkerResult {
@@ -72,6 +89,7 @@ export function useConversationUnreadMarker({
   currentUserId,
   readStateResolved,
   renderedMessageIds = null,
+  latchStorage,
 }: UseConversationUnreadMarkerOptions): UseConversationUnreadMarkerResult {
   const firstUnreadId = useMemo(() => {
     if (!readStateResolved) return null
@@ -89,6 +107,9 @@ export function useConversationUnreadMarker({
   // already-cleared value on the commit that matters — the divider would be
   // drawn at the tail, or not at all. The ref resets on conversation change and
   // then captures the first non-null first-unread; nothing after that moves it.
+  // With external storage the latch outlives the component (a board card is
+  // unmounted by virtualisation while its board visit is still one "open"), and
+  // the conversation key is what scopes it; the local ref is the panel's path.
   const latchRef = useRef<{ conversationId: string; messageId: string | null; dimmed: boolean }>({
     conversationId,
     messageId: null,
@@ -103,13 +124,35 @@ export function useConversationUnreadMarker({
     latchRef.current = { conversationId, messageId: null, dimmed: false }
     if (dismissed !== null) setDismissed(null)
   }
-  if (firstUnreadId && latchRef.current.messageId === null) {
-    latchRef.current.messageId = firstUnreadId
+  let latch: UnreadMarkerLatch = latchRef.current
+  if (latchStorage) {
+    const stored = latchStorage.get(conversationId)
+    if (stored) latch = stored
+    else {
+      latch = { messageId: null, dimmed: false }
+      latchStorage.set(conversationId, latch)
+    }
+  }
+  // Away-arrival re-latch, storage path only (the panel's per-open ref keeps the
+  // strict one-way rule). A settled entry points at rows the user has read; when
+  // new unread arrives strictly below it the muted divider marks nothing and the
+  // mass badge contradicts it, so that entry is discarded and re-decided. Only
+  // when dimmed: a live red divider must never move while unread is pending.
+  if (latchStorage && latch.dimmed && latch.messageId !== null && firstUnreadId !== null) {
+    const latchedIndex = rows.findIndex((row) => row.id === latch.messageId)
+    const firstUnreadIndex = rows.findIndex((row) => row.id === firstUnreadId)
+    if (latchedIndex >= 0 && firstUnreadIndex > latchedIndex) {
+      latch = { messageId: null, dimmed: false }
+      latchStorage.set(conversationId, latch)
+    }
+  }
+  if (firstUnreadId && latch.messageId === null) {
+    latch.messageId = firstUnreadId
   }
 
   const dismiss = useCallback(() => setDismissed(conversationId), [conversationId])
 
-  const latched = latchRef.current.messageId
+  const latched = latch.messageId
   const markerMessageId = dismissed === conversationId ? null : latched
 
   const unreadCount = useMemo(() => {
@@ -128,8 +171,8 @@ export function useConversationUnreadMarker({
   // Settling is one-way, like the timeline's: once the marker's rows have all
   // been read the divider stays muted for this open. A later arrival must not
   // re-redden a divider that now points at rows the user has already read.
-  if (markerMessageId != null && unreadCount === 0) latchRef.current.dimmed = true
-  const isDimmed = markerMessageId != null && latchRef.current.dimmed
+  if (markerMessageId != null && unreadCount === 0) latch.dimmed = true
+  const isDimmed = markerMessageId != null && latch.dimmed
 
   return { markerMessageId, unreadCount, isDimmed, dismiss }
 }

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -5,6 +5,7 @@ import { useWorkspaceStreamReadStates, useWorkspaceUnreadState } from "@/stores/
 import { applyReadStateSnapshots } from "@/hooks/use-unread-counts"
 import type { RowReadState } from "@/components/timeline/read-frontier-context"
 import type { RenderableMessage } from "@/components/message/message-item"
+import { isEffectivelyUnread } from "@/lib/board/ledger"
 
 /**
  * Per-row read state + the two read actions for a conversation surface (board
@@ -200,10 +201,7 @@ export function useConversationReadController(
 
   const hasUnread = useCallback(
     (messages: RenderableMessage[]): boolean =>
-      messages.some(
-        (m) =>
-          m.authorId !== currentUserId && state(m.streamId ?? rootStreamId, m.id, m.sequence, m.createdAt) === "unread"
-      ),
+      messages.some((m) => isEffectivelyUnread(m, { currentUserId, fallbackStreamId: rootStreamId, state })),
     [state, currentUserId, rootStreamId]
   )
 

--- a/apps/frontend/src/lib/board/ledger.test.ts
+++ b/apps/frontend/src/lib/board/ledger.test.ts
@@ -12,6 +12,9 @@ import {
   ledgerEventContent,
   linkLabel,
   rowArtifacts,
+  unreadMass,
+  type EffectiveUnreadCtx,
+  type UnreadCandidate,
 } from "./ledger"
 
 describe("leadLine", () => {
@@ -87,6 +90,47 @@ describe("estimateReadingMinutes", () => {
     expect(estimateReadingMinutes(1100)).toBe(1)
     expect(estimateReadingMinutes(1101)).toBe(2)
     expect(estimateReadingMinutes(12_000)).toBe(11)
+  })
+})
+
+describe("unreadMass", () => {
+  const row = (id: string, authorId: string, chars: number): UnreadCandidate => ({
+    id,
+    authorId,
+    createdAt: "2026-06-22T12:00:00.000Z",
+    contentMarkdown: "x".repeat(chars),
+  })
+  const ctx = (unread: string[]): EffectiveUnreadCtx => ({
+    currentUserId: "usr_me",
+    fallbackStreamId: "stream_1",
+    state: (_streamId, messageId) => (unread.includes(messageId) ? "unread" : "read"),
+  })
+
+  it("counts the unread rows and their reading minutes", () => {
+    const rows = [row("a", "usr_other", 600), row("b", "usr_other", 600), row("c", "usr_other", 5000)]
+    expect(unreadMass(rows, ctx(["a", "b"]))).toEqual({ count: 2, minutes: 2 })
+  })
+
+  it("excludes read rows and the viewer's own messages", () => {
+    const rows = [row("a", "usr_me", 5000), row("b", "usr_other", 100)]
+    expect(unreadMass(rows, ctx(["a", "b"]))).toEqual({ count: 1, minutes: 1 })
+  })
+
+  it("is zero when nothing is unread", () => {
+    expect(unreadMass([row("a", "usr_other", 900)], ctx([]))).toEqual({ count: 0, minutes: 0 })
+  })
+
+  it("resolves a row without its own stream against the fallback", () => {
+    const seen: string[] = []
+    unreadMass([{ ...row("a", "usr_other", 10), streamId: "thread_9" }, row("b", "usr_other", 10)], {
+      currentUserId: "usr_me",
+      fallbackStreamId: "stream_1",
+      state: (streamId) => {
+        seen.push(streamId)
+        return "read"
+      },
+    })
+    expect(seen).toEqual(["thread_9", "stream_1"])
   })
 })
 

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -53,6 +53,65 @@ export function estimateReadingMinutes(chars: number): number {
   return Math.max(1, Math.ceil(chars / CHARS_PER_MINUTE))
 }
 
+/** The row fields the effective-unread derivation reads, structurally. */
+export interface UnreadCandidate {
+  id: string
+  streamId?: string
+  sequence?: string
+  authorId: string
+  createdAt: string | Date
+  contentMarkdown: string
+}
+
+export interface EffectiveUnreadCtx {
+  currentUserId: string | null | undefined
+  /** Stream a row without one of its own belongs to (the card's anchor). */
+  fallbackStreamId: string
+  state: (
+    streamId: string,
+    messageId: string,
+    sequence: string | undefined,
+    createdAt: string | Date
+  ) => "read" | "unread" | "ungated"
+}
+
+/**
+ * The single "effectively unread for this viewer" decision every conversation
+ * surface reads (INV-35): the header dot, the ledger lead's tint and the mass
+ * badge's count all call this, so a row can never be tinted but uncounted. Live
+ * off the read overlay + per-stream frontiers — never the latched divider
+ * position, which is a one-way per-open decision.
+ */
+export function isEffectivelyUnread(message: UnreadCandidate, ctx: EffectiveUnreadCtx): boolean {
+  return (
+    message.authorId !== ctx.currentUserId &&
+    ctx.state(message.streamId ?? ctx.fallbackStreamId, message.id, message.sequence, message.createdAt) === "unread"
+  )
+}
+
+export interface UnreadMass {
+  count: number
+  minutes: number
+}
+
+/**
+ * How much unread mass the given rows carry. Callers pass the rows they KNOW
+ * (the card's readable rows, including the ones hidden behind the head row —
+ * off-card unread is exactly what the badge exists to signal). Replies the rail
+ * has never synced are deliberately outside: their count is knowable but their
+ * length is not, and a count that outran its minutes would read as a lie.
+ */
+export function unreadMass(messages: UnreadCandidate[], ctx: EffectiveUnreadCtx): UnreadMass {
+  let count = 0
+  let chars = 0
+  for (const message of messages) {
+    if (!isEffectivelyUnread(message, ctx)) continue
+    count += 1
+    chars += message.contentMarkdown.length
+  }
+  return { count, minutes: estimateReadingMinutes(chars) }
+}
+
 /** The `RenderableMessage` fields the artifact row reads, structurally. */
 export interface LedgerArtifactSource {
   attachments?: AttachmentSummary[]

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -40,6 +40,7 @@ import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardRemovedCard } from "@/components/board/board-removed-card"
 import { openCompose, registerComposeOnPosted } from "@/stores/compose-overlay-store"
 import { setBoardFlash } from "@/stores/board-flash-store"
+import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
 import { boardHomeHref } from "@/components/board/board-saved-views"
 import { useBoardViews } from "@/hooks/use-board-views"
 import { isBoardFiltered } from "@/lib/board/filter-state"
@@ -352,12 +353,20 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // Per-session and per-workspace, never persisted: a seen card stays frozen, an
   // unseen one that gains activity goes back behind the "N new" pill.
   const seenCardsRef = useRef<Set<string>>(new Set())
+  // A fresh board visit is a fresh "open": drop last visit's divider latches
+  // before any card renders (parents render first, so this beats an effect).
+  const visitRef = useRef(false)
+  if (!visitRef.current) {
+    visitRef.current = true
+    resetBoardUnreadLatches()
+  }
   // A render-phase `setState` doesn't update this render's binding, so the
   // switch render must read the local value, not `seedTimedOut`.
   let timedOut = seedTimedOut
   if (seedWorkspaceRef.current !== workspaceId) {
     seedWorkspaceRef.current = workspaceId
     seenCardsRef.current = new Set()
+    resetBoardUnreadLatches()
     timedOut = false
     if (seedTimedOut) setSeedTimedOut(false)
   }

--- a/apps/frontend/src/stores/board-unread-latch-store.ts
+++ b/apps/frontend/src/stores/board-unread-latch-store.ts
@@ -1,0 +1,26 @@
+import type {
+  UnreadMarkerLatch,
+  UnreadMarkerLatchStorage,
+} from "@/components/conversations/use-conversation-unread-marker"
+
+// Where a board card's "New" divider decision lives. virtua unmounts cards past
+// its scroll buffer, so a component-local latch re-decides on remount against
+// read state auto-read has since cleared — the divider vanishes mid-session.
+// Board-scoped and keyed by conversation id, it survives that remount; the
+// conversation panel keeps its own per-open ref and is unaffected.
+
+const latches = new Map<string, UnreadMarkerLatch>()
+
+export const boardUnreadLatchStorage: UnreadMarkerLatchStorage = {
+  get(conversationId) {
+    return latches.get(conversationId)
+  },
+  set(conversationId, latch) {
+    latches.set(conversationId, latch)
+  },
+}
+
+/** A fresh board visit (or workspace switch) is a fresh open: drop every latch. */
+export function resetBoardUnreadLatches(): void {
+  latches.clear()
+}


### PR DESCRIPTION
## Problem

Chunk 8 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): Kris's "how much is new" signal — importance by reading weight, not just position; aggregate only, never a "when".

## Solution

- `isEffectivelyUnread` + `unreadMass` in `lib/board/ledger.ts` — ONE unread authority. The row tint (chunk 7), the new badge, and `useConversationReadController.hasUnread` (the header dot, which held a literal copy of the predicate) all consume it now.
- Header badge per `boardMassBadge`: "14 new · ~11 min" (minutes = `estimateReadingMinutes` over unread rows' chars) / "14 new" / off; hidden at zero. Counts the hidden-older mass behind the head row — exactly where the divider deliberately draws nothing, so the two signals compose instead of overlapping. Never-synced rows excluded from both count and minutes (only what's known). Reserved slot in both header shapes (INV-21).
- Rides along (#1730 review fix, then hardened by this chunk's verify): the marker latch lives in a board-scoped store keyed by conversation id — survives virtua unmount/remount with dimming intact, resets per board visit/workspace/account — AND re-latches a fresh red divider when arrivals land strictly after a SETTLED (dimmed) marker, mirroring the timeline's away-arrival re-latch. A live red divider still never moves. Panel path byte-identical.

## Test plan

- [x] 342 green (badge math/modes/decay, hidden-mass badge-with-silent-divider pairing, header-shape parity, remount survival, settled-then-arrival re-latch — each falsification-checked); tsc + lint clean. Adversarial verify (Opus high): 1 finding accepted+fixed, 0 refuted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788292600&installation_model_id=20758&pr_number=1731&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1731&signature=b942b2d86bc0550a23654a2d9723b4ccad6313c19cb3717e2e8af528fb40e39a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->