### PR TITLE
feat(board): one-click Unread toggle in the sidebar

### DIFF
--- a/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
+++ b/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
@@ -398,6 +398,34 @@ describe("BoardCard unread divider", () => {
     expect(isBefore(after!, rowFor("r6"))).toBe(true)
   })
 
+  it("re-decides when the settled anchor row was deleted, instead of wedging on it", async () => {
+    unreadIds = new Set(["r3", "r4", "r5"])
+    const first = mount()
+    await screen.findByText("Reply 5.")
+
+    // Settle, then the anchor row (r3) is deleted — it leaves `readableRows`
+    // entirely, so the strictly-after check alone could never re-decide.
+    first.unmount()
+    unreadIds = new Set()
+    const settled = mount()
+    await screen.findByText("Reply 5.")
+    expect(dividerLabel()!.parentElement!.className).toContain("text-muted-foreground")
+
+    settled.unmount()
+    const r3 = messageEvent("r3", 3, "Reply 3.")
+    r3.payload = { ...(r3.payload as object), deletedAt: at(90) } as CachedEvent["payload"]
+    await db.events.put(r3)
+    const withNew = await arriveNewReply("r6", 20)
+    unreadIds = new Set(["r6"])
+    mount(withNew)
+    await screen.findByText("Reply r6.")
+
+    const after = dividerLabel()
+    expect(after, "a deleted anchor re-decides the latch").toBeTruthy()
+    expect(after!.parentElement!.className).toContain("text-destructive")
+    expect(isBefore(after!, rowFor("r6"))).toBe(true)
+  })
+
   it("does not move a live red divider when more unread arrives below it", async () => {
     unreadIds = new Set(["r4", "r5"])
     const { rerender } = mount()

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -259,6 +259,14 @@ export function unreadFocusSearch(search: string): string {
   return toSearch(params)
 }
 
+/** The mirror of {@link unreadFocusSearch}: drop the unread narrowing, leaving
+ *  every other axis untouched. */
+export function clearUnreadSearch(search: string): string {
+  const params = new URLSearchParams(search)
+  params.delete(BOARD_UNREAD_PARAM)
+  return toSearch(params)
+}
+
 /** Remove one value from any single filter axis (a chip's X). Works for every
  *  id/type list param — the value is dropped, order and the other params kept. */
 export function removeAxisValueSearch(search: string, param: string, value: string): string {

--- a/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
+++ b/apps/frontend/src/components/conversations/use-conversation-unread-marker.ts
@@ -141,7 +141,12 @@ export function useConversationUnreadMarker({
   if (latchStorage && latch.dimmed && latch.messageId !== null && firstUnreadId !== null) {
     const latchedIndex = rows.findIndex((row) => row.id === latch.messageId)
     const firstUnreadIndex = rows.findIndex((row) => row.id === firstUnreadId)
-    if (latchedIndex >= 0 && firstUnreadIndex > latchedIndex) {
+    // A settled anchor that left `rows` entirely (deleted, or re-filed out of
+    // the conversation) can never satisfy the strictly-after check — without
+    // the `< 0` arm the wedged entry pins "no divider" for the whole visit
+    // while the badge counts the arrivals. Hidden-older anchors are NOT this
+    // case: they stay in `rows`, so the deliberate draw-nothing hold survives.
+    if (latchedIndex < 0 || firstUnreadIndex > latchedIndex) {
       latch = { messageId: null, dimmed: false }
       latchStorage.set(conversationId, latch)
     }

--- a/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
@@ -4,7 +4,8 @@ import { render, screen } from "@/test"
 import * as Contexts from "@/contexts"
 import * as WorkspaceStore from "@/stores/workspace-store"
 import { setLastLocation } from "@/lib/last-location"
-import { BoardLinkRow, ChatsLinkRow } from "./board-link-row"
+import * as BoardViewHooks from "@/hooks/use-board-views"
+import { BoardLinkRow, BoardUnreadRow, ChatsLinkRow } from "./board-link-row"
 
 const WS = "workspace_1"
 const USER = "user_1"
@@ -14,6 +15,7 @@ function stub() {
     collapseOnMobile: vi.fn(),
   } as unknown as ReturnType<typeof Contexts.useSidebar>)
   vi.spyOn(WorkspaceStore, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(BoardViewHooks, "useBoardViews").mockReturnValue({ data: [] } as never)
 }
 
 function hrefOf(name: string): string {
@@ -51,9 +53,54 @@ describe("BoardLinkRow", () => {
   it("falls back to the bare board route when no board state was retained", () => {
     render(
       <MemoryRouter>
-        <BoardLinkRow workspaceId={WS} userId={USER} />
+        <BoardLinkRow workspaceId={WS} userId={USER} unreadStreamCount={0} />
       </MemoryRouter>
     )
     expect(hrefOf("Board")).toBe(`/w/${WS}/board`)
+  })
+})
+
+describe("BoardUnreadRow", () => {
+  function renderAt(path: string, unreadStreamCount = 0) {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <BoardUnreadRow workspaceId={WS} unreadStreamCount={unreadStreamCount} />
+      </MemoryRouter>
+    )
+  }
+
+  it("adds unread=true to the live board URL, preserving the other axes", () => {
+    renderAt(`/w/${WS}/board?lens=mine&in=stream_1&panel=x`)
+    expect(hrefOf("Unread")).toBe(`/w/${WS}/board?lens=mine&in=stream_1&panel=x&unread=true`)
+  })
+
+  it("drops exactly the unread param when it is already on", () => {
+    renderAt(`/w/${WS}/board?lens=mine&unread=true&in=stream_1`)
+    expect(hrefOf("Unread")).toBe(`/w/${WS}/board?lens=mine&in=stream_1`)
+  })
+
+  it("lands on the board home with unread=true from a non-board page", () => {
+    renderAt(`/w/${WS}/s/stream_9`)
+    expect(hrefOf("Unread")).toBe(`/w/${WS}/board?lens=all&unread=true`)
+  })
+
+  it("tracks the URL for its active state", () => {
+    renderAt(`/w/${WS}/board?lens=all&unread=true`)
+    expect(screen.getByRole("link", { name: "Unread" })).toHaveAttribute("aria-current", "true")
+  })
+
+  it("is not active off the board", () => {
+    renderAt(`/w/${WS}/s/stream_9`)
+    expect(screen.getByRole("link", { name: "Unread" })).not.toHaveAttribute("aria-current")
+  })
+
+  it("badges the unread stream count, and hides the badge at zero", () => {
+    renderAt(`/w/${WS}/board?lens=all`, 4)
+    expect(screen.getByRole("link", { name: /Unread/ })).toHaveTextContent("4")
+  })
+
+  it("renders no count at zero", () => {
+    renderAt(`/w/${WS}/board?lens=all`, 0)
+    expect(screen.getByRole("link", { name: "Unread" })).toHaveTextContent(/^Unread$/)
   })
 })

--- a/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
@@ -1,11 +1,23 @@
-import { Link } from "react-router-dom"
-import { ArrowLeft, ArrowRight, LayoutGrid } from "lucide-react"
-import { useSidebar } from "@/contexts"
+import { Link, useLocation } from "react-router-dom"
+import { ArrowLeft, ArrowRight, CircleDot, LayoutGrid } from "lucide-react"
+import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useBoardViews } from "@/hooks/use-board-views"
+import { boardHomeHref } from "@/components/board/board-saved-views"
+import {
+  BOARD_UNREAD_ON,
+  BOARD_UNREAD_PARAM,
+  clearUnreadSearch,
+  parseLensParam,
+  unreadFocusSearch,
+} from "@/components/board/board-filter-params"
+import { UnreadBadge } from "@/components/unread-badge"
+import { cn } from "@/lib/utils"
 import { buildBoardHref, getLastLocation } from "@/lib/last-location"
+import { isBoardPath } from "./board-sidebar-mode"
 
-const ROW_CLASS =
-  "flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors text-muted-foreground hover:bg-muted/50"
+const ROW_BASE_CLASS = "flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+const ROW_CLASS = `${ROW_BASE_CLASS} text-muted-foreground hover:bg-muted/50`
 
 interface ModeLinkRowProps {
   workspaceId: string
@@ -14,11 +26,69 @@ interface ModeLinkRowProps {
 }
 
 /**
+ * One-click unreads: navigates to the board narrowed to unread conversations
+ * (`?unread=true`), and off again when it's already on. Rendered in both modes —
+ * from the board it edits the live URL surgically (every other axis, the lens and
+ * an open `?panel=` survive); from anywhere else it lands on the viewer's board
+ * home with the narrowing applied. A navigation, so a `<Link>` (INV-40), and the
+ * active state is read from the URL, never held (INV-59).
+ */
+export function BoardUnreadRow({
+  workspaceId,
+  unreadStreamCount,
+}: {
+  workspaceId: string
+  /** Streams the viewer has unread (muted excluded) — the same membership the
+   *  board's `?unread=true` narrowing resolves against, derived once by the
+   *  sidebar for its Unread section. */
+  unreadStreamCount: number
+}) {
+  const { collapseOnMobile } = useSidebar()
+  const location = useLocation()
+  const prefs = usePreferencesOptional()
+  const { data: views } = useBoardViews(workspaceId)
+
+  const onBoard = isBoardPath(location.pathname)
+  const active = onBoard && new URLSearchParams(location.search).get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
+
+  let to: string
+  if (onBoard) {
+    to = `${location.pathname}${active ? clearUnreadSearch(location.search) : unreadFocusSearch(location.search)}`
+  } else {
+    const home = boardHomeHref(
+      workspaceId,
+      prefs?.preferences?.boardDefaultViewId ?? null,
+      views,
+      parseLensParam(prefs?.preferences?.boardDefaultLens ?? null)
+    )
+    const [path, search] = home.split("?")
+    to = `${path}${unreadFocusSearch(search ?? "")}`
+  }
+
+  return (
+    <Link
+      to={to}
+      onClick={collapseOnMobile}
+      aria-current={active ? "true" : undefined}
+      className={cn(ROW_BASE_CLASS, active ? "bg-primary/10" : "text-muted-foreground hover:bg-muted/50")}
+    >
+      <CircleDot className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">Unread</span>
+      {unreadStreamCount > 0 && <UnreadBadge count={unreadStreamCount} className="ml-auto" />}
+    </Link>
+  )
+}
+
+/**
  * Chats-mode link to the board, restoring the viewer's last board state. Pairs
  * with `ChatsLinkRow`: both sit at the same spot (above the quick links) so the
  * cross-surface entry point doesn't move between modes.
  */
-export function BoardLinkRow({ workspaceId, userId }: ModeLinkRowProps) {
+export function BoardLinkRow({
+  workspaceId,
+  userId,
+  unreadStreamCount,
+}: ModeLinkRowProps & { unreadStreamCount: number }) {
   const { collapseOnMobile } = useSidebar()
   const streams = useWorkspaceStreams(workspaceId)
 
@@ -38,6 +108,7 @@ export function BoardLinkRow({ workspaceId, userId }: ModeLinkRowProps) {
         Board
         <ArrowRight className="ml-auto h-4 w-4" />
       </Link>
+      <BoardUnreadRow workspaceId={workspaceId} unreadStreamCount={unreadStreamCount} />
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -96,7 +96,7 @@ function mountAt(path: string, props: Partial<Parameters<typeof BoardModeBlock>[
   return render(
     <MemoryRouter initialEntries={[path]}>
       <LocationProbe />
-      <BoardModeBlock workspaceId={WS} {...props} />
+      <BoardModeBlock workspaceId={WS} unreadStreamCount={0} {...props} />
     </MemoryRouter>
   )
 }
@@ -237,15 +237,16 @@ describe("BoardModeBlock", () => {
     expect(await screen.findByPlaceholderText("Find a stream")).toBeInTheDocument()
   })
 
-  it("the Unread only toggle flips ?unread=true and back", async () => {
+  it("the Unread row navigates ?unread=true on and back off", async () => {
     const user = userEvent.setup()
     stub()
-    mountAt(`/w/${WS}/board?lens=all`)
+    mountAt(`/w/${WS}/board?lens=all`, { unreadStreamCount: 3 })
 
-    await user.click(screen.getByRole("button", { name: "Unread only" }))
+    expect(hrefOf(/Unread/)).toBe(`/w/${WS}/board?lens=all&unread=true`)
+    await user.click(screen.getByRole("link", { name: /Unread/ }))
     expect(new URL(currentLoc(), "http://x").searchParams.get("unread")).toBe("true")
 
-    await user.click(screen.getByRole("button", { name: "Unread only" }))
+    await user.click(screen.getByRole("link", { name: /Unread/ }))
     expect(new URL(currentLoc(), "http://x").searchParams.get("unread")).toBeNull()
   })
 

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { Link, useLocation, useSearchParams } from "react-router-dom"
-import { Archive, Bookmark, Check, CircleDot, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
+import { Archive, Bookmark, Check, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
 import { BOARD_LENSES, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { cn } from "@/lib/utils"
@@ -31,16 +31,17 @@ import {
   BOARD_LABEL_PARAM,
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
-  BOARD_UNREAD_ON,
-  BOARD_UNREAD_PARAM,
   parseLensParam,
 } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { BoardFilterChips } from "./board-filter-chips"
+import { BoardUnreadRow } from "./board-link-row"
 
 interface BoardModeBlockProps {
   workspaceId: string
+  /** Streams the viewer has unread (muted excluded) — badges the Unread row. */
+  unreadStreamCount: number
   /** Per-lens workspace topic totals for the Lenses row counts, from the sidebar's
    *  single stats pass; `null`/absent while it resolves (render no count). */
   lensTotals?: Record<BoardLens, number> | null
@@ -60,7 +61,7 @@ const SECTION_LABEL_CLASS =
  * (INV-40/INV-59) — built with the same helpers the pickers use
  * (`lensHref`, `savedViewHref`) so the surfaces can't drift (INV-35).
  */
-export function BoardModeBlock({ workspaceId, lensTotals }: BoardModeBlockProps) {
+export function BoardModeBlock({ workspaceId, lensTotals, unreadStreamCount }: BoardModeBlockProps) {
   const { collapseOnMobile } = useSidebar()
   const location = useLocation()
   const prefs = usePreferencesOptional()
@@ -96,7 +97,7 @@ export function BoardModeBlock({ workspaceId, lensTotals }: BoardModeBlockProps)
 
   return (
     <div className="mb-2 space-y-1">
-      <BoardModeFilters workspaceId={workspaceId} />
+      <BoardModeFilters workspaceId={workspaceId} unreadStreamCount={unreadStreamCount} />
 
       {hasActiveFilters && <BoardFilterChips workspaceId={workspaceId} />}
 
@@ -247,7 +248,7 @@ export function BoardModeBlock({ workspaceId, lensTotals }: BoardModeBlockProps)
  * state, it just navigates. Filter rewrites `replace`, so toggling doesn't spam
  * history. Shares the URL vocabulary SSOT (`board-filter-params`) with the page.
  */
-function BoardModeFilters({ workspaceId }: { workspaceId: string }) {
+function BoardModeFilters({ workspaceId, unreadStreamCount }: { workspaceId: string; unreadStreamCount: number }) {
   const [searchParams, setSearchParams] = useSearchParams()
   const { selection } = useBoardSelection()
 
@@ -265,7 +266,6 @@ function BoardModeFilters({ workspaceId }: { workspaceId: string }) {
   const unmuteStream = useUnmuteStream(workspaceId)
 
   const showArchived = searchParams.get(BOARD_ARCHIVED_PARAM) === BOARD_ARCHIVED_ON
-  const unreadOnly = searchParams.get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
 
   const labelFor = (streamId: string) =>
     resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
@@ -333,12 +333,7 @@ function BoardModeFilters({ workspaceId }: { workspaceId: string }) {
           />
         )}
       </div>
-      <FilterToggleRow
-        icon={CircleDot}
-        label="Unread only"
-        active={unreadOnly}
-        onToggle={() => setParamLists([[BOARD_UNREAD_PARAM, unreadOnly ? [] : [BOARD_UNREAD_ON]]])}
-      />
+      <BoardUnreadRow workspaceId={workspaceId} unreadStreamCount={unreadStreamCount} />
       <FilterToggleRow
         icon={Archive}
         label="Archived"

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -283,6 +283,14 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     return ids
   }, [hasUnreadSection, processedStreams, getUnreadCount])
 
+  // The Unread affordance's badge: unread (unmuted) streams workspace-wide — the
+  // same predicate the Unread section's membership uses, ungated by the layout
+  // since the board row exists regardless of whether that section is configured.
+  const unreadStreamCount = useMemo(
+    () => processedStreams.filter((stream) => isUnreadStream(stream, getUnreadCount(stream.id))).length,
+    [processedStreams, getUnreadCount]
+  )
+
   // For Unread rows (drawn out of their home), a "· home" hint naming the custom
   // section or pinned label the stream lives in. Custom filing trumps a label,
   // matching the resolver's precedence.
@@ -394,13 +402,17 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       <>
         <ChatsLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
         {quickLinks}
-        <BoardModeBlock workspaceId={workspaceId} lensTotals={boardMode?.lensTotals ?? null} />
+        <BoardModeBlock
+          workspaceId={workspaceId}
+          lensTotals={boardMode?.lensTotals ?? null}
+          unreadStreamCount={unreadStreamCount}
+        />
       </>
     )
   } else if (hasQuickLinksSection) {
     quickLinksSlot = (
       <>
-        <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
+        <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} unreadStreamCount={unreadStreamCount} />
         {quickLinks}
       </>
     )


### PR DESCRIPTION
## Problem

Chunk 9 of the ledger board (plan: https://seer.build/ws_vbyzjvdg6g/b/ledger-build-plan-eeb96a/ ): the one inbox piece shipping now — Kris's one-click sidebar unread toggle. Everything else inbox-shaped (queue, triage, departure) is deferred by ruling.

## Solution

- `BoardUnreadRow` in both sidebar modes (under the Board link in chats mode; last filter row in board mode), REPLACING the board block's old "Unread only" FilterToggleRow — same `?unread=true` param, one control instead of two. A `<Link>` with URL-derived active state (INV-40/59): on-board it toggles the param surgically (new `clearUnreadSearch` mirror of `unreadFocusSearch`, no string splicing), preserving lens/scope/panel; off-board it targets the viewer's board home + `unread=true` via `boardHomeHref`.
- Badge: unread-stream count from the existing `isUnreadStream` pass, rendered with the shared `UnreadBadge` (Activity quick-link idiom), hidden at zero. No new derivations or fetches.
- Rides along (#1731 review fix): the settled-marker re-latch gains the `latchedIndex < 0` arm — a DELETED anchor row re-decides instead of wedging "no divider while the badge counts arrivals" for the rest of the visit; hidden-older anchors stay in `rows`, so their deliberate silence is untouched.
- Known residual: the Unread row's vertical position differs between sidebar modes (each mode's block is the only one mounted — deliberate).

## Test plan

- [x] 575 green across sidebar/board/conversations (7 toggle tests: param round-trips preserving state, home-href, active tracking, badge; deleted-anchor re-latch falsification-checked); tsc + lint clean.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788293084&installation_model_id=20758&pr_number=1732&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1732&signature=39ac4f3d9b65b244635f9da7f31df2d401a2d4b269264856737f8747d84a9cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->