### PR TITLE
fix: make mobile settings drawers usable

### DIFF
--- a/apps/frontend/src/components/settings/settings-dialog.test.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.test.tsx
@@ -89,7 +89,7 @@ describe("SettingsDialog", () => {
     expect(tabs).toHaveClass("flex", "flex-1", "min-h-0", "flex-col")
     expect(panels).toHaveClass("flex", "flex-1", "min-h-0", "overflow-hidden")
     expect(nav).toHaveClass("min-h-0", "overflow-y-auto")
-    expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto")
+    expect(content).toHaveClass("flex-1", "min-h-0", "overflow-y-auto", "pt-6")
   })
 
   it("does not close on Escape while shortcut capture is active", async () => {

--- a/apps/frontend/src/components/ui/responsive-dialog.tsx
+++ b/apps/frontend/src/components/ui/responsive-dialog.tsx
@@ -171,7 +171,7 @@ const ResponsiveDialogContent = React.forwardRef<HTMLDivElement, ResponsiveDialo
             <div
               data-slot="drawer-snap-spacer"
               aria-hidden
-              className="shrink-0 transition-[height] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
+              className="shrink-0 transition-[height] duration-500 [transition-timing-function:cubic-bezier(0.32,0.72,0,1)]"
               style={{ height: getSnapPointOffset(activeSnapPoint) }}
             />
           )}

--- a/apps/frontend/src/components/ui/responsive-dialog.tsx
+++ b/apps/frontend/src/components/ui/responsive-dialog.tsx
@@ -33,6 +33,14 @@ const DEFAULT_ACTIVE_SNAP = 0.8
 // content can drop the vaul `h-[100dvh]` requirement when there are no
 // snap points to anchor to.
 const DisableSnapPointsContext = React.createContext(false)
+const ActiveSnapPointContext = React.createContext<number | string | null>(null)
+
+function getSnapPointOffset(activeSnapPoint: number | string | null): string {
+  if (typeof activeSnapPoint === "number") {
+    return `${Math.max(0, Math.round((1 - activeSnapPoint) * 10_000) / 100)}dvh`
+  }
+  return activeSnapPoint ? `max(0px, calc(100dvh - ${activeSnapPoint}))` : "0px"
+}
 
 // ── Root ────────────────────────────────────────────────────────────────
 
@@ -62,7 +70,9 @@ interface ResponsiveDialogProps {
 function ResponsiveDialog({ children, snapPoints, disableSnapPoints, ...props }: ResponsiveDialogProps) {
   const isMobile = useIsMobile()
   const resolvedSnaps = React.useMemo(() => snapPoints ?? [...DEFAULT_SNAP_POINTS], [snapPoints])
-  const [activeSnap, setActiveSnap] = React.useState<number | string | null>(DEFAULT_ACTIVE_SNAP)
+  const [activeSnap, setActiveSnap] = React.useState<number | string | null>(
+    () => resolvedSnaps[0] ?? DEFAULT_ACTIVE_SNAP
+  )
 
   // Reset snap point when drawer opens
   const handleOpenChange = React.useCallback(
@@ -86,16 +96,18 @@ function ResponsiveDialog({ children, snapPoints, disableSnapPoints, ...props }:
     )
   } else if (isMobile) {
     root = (
-      <Drawer
-        open={props.open}
-        onOpenChange={handleOpenChange}
-        snapPoints={resolvedSnaps}
-        activeSnapPoint={activeSnap}
-        setActiveSnapPoint={setActiveSnap}
-        fadeFromIndex={resolvedSnaps.length - 1}
-      >
-        {children}
-      </Drawer>
+      <ActiveSnapPointContext.Provider value={activeSnap}>
+        <Drawer
+          open={props.open}
+          onOpenChange={handleOpenChange}
+          snapPoints={resolvedSnaps}
+          activeSnapPoint={activeSnap}
+          setActiveSnapPoint={setActiveSnap}
+          fadeFromIndex={resolvedSnaps.length - 1}
+        >
+          {children}
+        </Drawer>
+      </ActiveSnapPointContext.Provider>
     )
   } else {
     root = <Dialog {...props}>{children}</Dialog>
@@ -140,6 +152,7 @@ const ResponsiveDialogContent = React.forwardRef<HTMLDivElement, ResponsiveDialo
   ({ className, desktopClassName, drawerClassName, children, hideCloseButton, ...props }, ref) => {
     const isMobile = useResponsiveMode()
     const noSnapPoints = React.useContext(DisableSnapPointsContext)
+    const activeSnapPoint = React.useContext(ActiveSnapPointContext)
 
     if (isMobile) {
       // With snap points: vaul's transform-based positioning needs the drawer
@@ -154,6 +167,14 @@ const ResponsiveDialogContent = React.forwardRef<HTMLDivElement, ResponsiveDialo
           {...props}
         >
           {children}
+          {!noSnapPoints && (
+            <div
+              data-slot="drawer-snap-spacer"
+              aria-hidden
+              className="shrink-0 transition-[height] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
+              style={{ height: getSnapPointOffset(activeSnapPoint) }}
+            />
+          )}
         </DrawerContent>
       )
     }

--- a/apps/frontend/src/components/ui/responsive-mode.test.tsx
+++ b/apps/frontend/src/components/ui/responsive-mode.test.tsx
@@ -66,3 +66,37 @@ describe("ResponsiveDialog mode coupling", () => {
     expect(screen.getByText("Settings")).toBeInTheDocument()
   })
 })
+
+describe("ResponsiveDialog snap layout", () => {
+  beforeEach(() => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+  })
+
+  it("reserves the hidden part of a partially snapped drawer below its content", () => {
+    render(
+      <ResponsiveDialog open onOpenChange={() => {}}>
+        <ResponsiveDialogContent>
+          <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    )
+
+    const drawer = screen.getByRole("dialog")
+    const spacer = drawer.querySelector('[data-slot="drawer-snap-spacer"]')
+    expect(drawer.lastElementChild).toBe(spacer)
+    expect(spacer).toHaveClass("shrink-0", "transition-[height]")
+    expect(spacer).toHaveStyle({ height: "20dvh" })
+  })
+
+  it("uses a custom initial snap point for the reserved space", () => {
+    render(
+      <ResponsiveDialog open onOpenChange={() => {}} snapPoints={[0.5, 1]}>
+        <ResponsiveDialogContent>
+          <ResponsiveDialogTitle>Settings</ResponsiveDialogTitle>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    )
+
+    expect(document.querySelector('[data-slot="drawer-snap-spacer"]')).toHaveStyle({ height: "50dvh" })
+  })
+})

--- a/apps/frontend/src/components/ui/responsive-settings-nav.tsx
+++ b/apps/frontend/src/components/ui/responsive-settings-nav.tsx
@@ -17,7 +17,7 @@ interface ResponsiveSettingsNavProps<T extends string> {
 export const SETTINGS_DIALOG_LAYOUT_CLASSNAMES = {
   tabs: "flex min-h-0 flex-1 flex-col",
   panels: "flex min-h-0 flex-1 flex-col overflow-hidden sm:grid sm:grid-cols-[220px,minmax(0,1fr)]",
-  content: "flex-1 min-h-0 overflow-y-auto px-4 pb-4 pt-4 scrollbar-thin sm:px-6 sm:py-6",
+  content: "flex-1 min-h-0 overflow-y-auto px-4 pb-4 pt-6 scrollbar-thin sm:px-6 sm:py-6",
 } as const
 
 export function ResponsiveSettingsNav<T extends string>({

--- a/apps/frontend/src/components/workspace-settings/statuses-tab.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/statuses-tab.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  WORKSPACE_PERMISSION_SCOPES,
+  type StatusPreset,
+  type WorkspaceBootstrap,
+  type WorkspaceSettings,
+} from "@threa/types"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import * as emojiHooks from "@/hooks/use-workspace-emoji"
+import { StatusesTab } from "./statuses-tab"
+
+const PRESET: StatusPreset = {
+  id: "status_1",
+  emoji: ":wave:",
+  text: "Heads down",
+  defaultDuration: null,
+  pausesNotifications: false,
+}
+
+function renderTab() {
+  const queryClient = new QueryClient()
+  queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+    viewerPermissions: [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN],
+    workspaceSettings: { userStatusPresets: [PRESET] } as WorkspaceSettings,
+  } as unknown as WorkspaceBootstrap)
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StatusesTab workspaceId="ws_1" />
+    </QueryClientProvider>
+  )
+}
+
+describe("StatusesTab", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(emojiHooks, "useWorkspaceEmoji").mockReturnValue({
+      toEmoji: () => "👋",
+      toShortcode: () => "wave",
+    } as unknown as ReturnType<typeof emojiHooks.useWorkspaceEmoji>)
+  })
+
+  it("wraps each status preset into two usable rows on narrow screens", () => {
+    renderTab()
+
+    const textInput = screen.getByPlaceholderText("Status text")
+    const preset = textInput.closest('[data-slot="status-preset"]')
+
+    expect(preset).toHaveClass("grid", "grid-cols-[auto_minmax(0,1fr)_auto_auto]", "sm:flex")
+    expect(textInput).toHaveClass("col-span-3", "min-w-0", "sm:flex-1")
+    expect(screen.getByRole("combobox")).toHaveClass("col-span-2", "w-full", "sm:w-36")
+  })
+})

--- a/apps/frontend/src/components/workspace-settings/statuses-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/statuses-tab.tsx
@@ -19,6 +19,7 @@ import { hasPermission } from "@/lib/permissions"
 import { STATUS_DURATION_OPTIONS, durationsEqual } from "@/lib/status"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ReactionEmojiPicker } from "@/components/timeline/reaction-emoji-picker"
 
@@ -94,7 +95,11 @@ export function StatusesTab({ workspaceId }: StatusesTabProps) {
         {draft.map((preset, index) => {
           const glyph = preset.emoji ? toEmoji(preset.emoji) : null
           return (
-            <div key={preset.id} className="flex items-center gap-2">
+            <div
+              key={preset.id}
+              data-slot="status-preset"
+              className="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2 sm:flex"
+            >
               <ReactionEmojiPicker
                 workspaceId={workspaceId}
                 onSelect={(picked) => updatePreset(index, { emoji: toShortcode(picked) })}
@@ -115,7 +120,7 @@ export function StatusesTab({ workspaceId }: StatusesTabProps) {
                 maxLength={STATUS_TEXT_MAX_LENGTH}
                 placeholder="Status text"
                 disabled={!canManage}
-                className="flex-1"
+                className="col-span-3 min-w-0 sm:flex-1"
               />
               <Select
                 value={durationIdForPreset(preset)}
@@ -126,7 +131,7 @@ export function StatusesTab({ workspaceId }: StatusesTabProps) {
                 }
                 disabled={!canManage}
               >
-                <SelectTrigger className="w-36">
+                <SelectTrigger className={cn("w-full sm:w-36", canManage ? "col-span-2" : "col-span-3")}>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -179,7 +184,7 @@ export function StatusesTab({ workspaceId }: StatusesTabProps) {
       )}
 
       {canManage ? (
-        <div className="flex justify-end gap-2">
+        <div className="flex flex-wrap justify-end gap-2">
           <Button
             type="button"
             variant="ghost"


### PR DESCRIPTION
## Problem

At the default 80% mobile snap, `ResponsiveDialogContent` laid out children across `100dvh` even though Vaul translated the bottom 20% below the viewport. Trailing settings rows and footers such as Switch account’s Add account action appeared missing until the drawer was fully expanded. Workspace status presets also forced every control onto one narrow row, and settings content sat too close below the mobile tab picker.

## Solution

- Track the active Vaul snap point and reserve its hidden viewport offset with a final flex spacer. The spacer follows Vaul’s 500ms transition, collapses at full height, and supports numeric or pixel snap points.
- Render each status preset as two mobile grid rows while retaining the desktop flex row; allow footer actions to wrap.
- Increase the mobile gap below the settings picker from 16px to 24px.

## Files

| File | Change |
| ---- | ------ |
| `components/ui/responsive-dialog.tsx` | Reserve space hidden below partial mobile snaps. |
| `components/ui/responsive-mode.test.tsx` | Cover default and custom initial snap offsets. |
| `components/ui/responsive-settings-nav.tsx` | Add mobile picker-to-content spacing. |
| `components/settings/settings-dialog.test.tsx` | Assert the shared mobile spacing. |
| `components/workspace-settings/statuses-tab.tsx` | Wrap preset controls on narrow screens. |
| `components/workspace-settings/statuses-tab.test.tsx` | Cover the mobile preset grid. |

## Test plan

- [x] Targeted frontend tests: 7 passed
- [x] Monorepo typecheck: 15 workspaces passed
- [x] Full pre-commit lint, typecheck, OpenAPI, Dockerfile, and migration checks: 251 migrations clean
- [x] Frontend production build
- [x] Combined correctness, design, UX, and mobile review: no findings

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
