### PR TITLE
feat(sync): diff workspace bootstrap before writing, behind bootstrapDiff

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -23,6 +23,7 @@ import { clearCallLifecycleLog } from "@/calls/lifecycle-log"
 import { resetIncomingCallStoreCache } from "@/stores/incoming-call-store"
 import { resetFloatingSurfaceGeometryStoreCache } from "@/stores/floating-surface-geometry-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
+import { resetRowConfirmations } from "@/sync/bootstrap-diff"
 import { useAuth } from "./hooks"
 
 const NO_ACCOUNT_KEY = "__no_account__"
@@ -75,6 +76,7 @@ export function useAccountScopeOptional(): AccountScopeValue | null {
 // them or account A's cached workspaces/drafts/shares bleed into account B.
 function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
+  resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()
   resetShareHandoffStoreCache()

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1642,17 +1642,24 @@ export async function clearAllCachedData(): Promise<void> {
       // must survive the re-login to heal the send.
     ])
   } finally {
-    const [{ resetWorkspaceStoreCache }, { resetStreamStoreCache }, { resetDraftStoreCache }, { resetUploadManager }] =
-      await Promise.all([
-        import("@/stores/workspace-store"),
-        import("@/stores/stream-store"),
-        import("@/stores/draft-store"),
-        import("@/lib/uploads/upload-manager"),
-      ])
+    const [
+      { resetWorkspaceStoreCache },
+      { resetStreamStoreCache },
+      { resetDraftStoreCache },
+      { resetUploadManager },
+      { resetRowConfirmations },
+    ] = await Promise.all([
+      import("@/stores/workspace-store"),
+      import("@/stores/stream-store"),
+      import("@/stores/draft-store"),
+      import("@/lib/uploads/upload-manager"),
+      import("@/sync/bootstrap-diff"),
+    ])
     resetWorkspaceStoreCache()
     resetStreamStoreCache()
     resetDraftStoreCache()
     resetUploadManager()
+    resetRowConfirmations()
   }
 }
 

--- a/apps/frontend/src/sync/bootstrap-diff.test.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { diffRows, diffSingleton, semanticEqual } from "./bootstrap-diff"
+
+describe("bootstrap diff", () => {
+  it("equal rows differing only in _cachedAt are unchanged", () => {
+    const existing = { id: "stream_1", name: "General", _cachedAt: 1 }
+    const candidate = { id: "stream_1", name: "General", _cachedAt: 999 }
+    const result = diffRows(new Map([[existing.id, existing]]), [candidate])
+    expect(result.toWrite).toEqual([])
+    expect(result.skipped).toBe(1)
+    expect(result.merged[0]).toBe(existing)
+  })
+
+  it("key order does not make a row look changed", () => {
+    const existing = { id: "stream_1", a: 1, b: { x: 1, y: 2 }, _cachedAt: 1 }
+    const candidate = { id: "stream_1", b: { y: 2, x: 1 }, a: 1, _cachedAt: 2 }
+    expect(JSON.stringify(existing)).not.toBe(JSON.stringify(candidate))
+    expect(diffRows(new Map([["stream_1", existing]]), [candidate]).toWrite).toEqual([])
+  })
+
+  it("a missing key equals an explicit undefined", () => {
+    const existing = { id: "stream_1", a: 1 }
+    const candidate = { id: "stream_1", a: 1, contextBag: undefined }
+    expect(semanticEqual(existing, candidate)).toBe(true)
+    expect(diffRows(new Map([["stream_1", existing]]), [candidate]).toWrite).toEqual([])
+  })
+
+  it("a nested payload change is detected", () => {
+    const existing = { id: "stream_1", lastMessagePreview: { content: "hi", authorId: "usr_1" }, _cachedAt: 1 }
+    const candidate = { id: "stream_1", lastMessagePreview: { content: "hey", authorId: "usr_1" }, _cachedAt: 1 }
+    const result = diffRows(new Map([["stream_1", existing]]), [candidate])
+    expect(result.toWrite).toEqual([candidate])
+    expect(result.merged[0]).toBe(candidate)
+    expect(result.skipped).toBe(0)
+  })
+
+  it("a nested array reorder is a change", () => {
+    const existing = { id: "stream_1", members: ["usr_1", "usr_2"] }
+    const candidate = { id: "stream_1", members: ["usr_2", "usr_1"] }
+    expect(semanticEqual(existing, candidate)).toBe(false)
+    expect(diffRows(new Map([["stream_1", existing]]), [candidate]).toWrite).toEqual([candidate])
+  })
+
+  it("a row absent from existing is always written", () => {
+    const candidate = { id: "stream_new", name: "New" }
+    const result = diffRows(new Map(), [candidate])
+    expect(result).toEqual({ toWrite: [candidate], merged: [candidate], skipped: 0 })
+  })
+
+  it("a row absent from candidates is neither written nor merged", () => {
+    const orphan = { id: "stream_gone", name: "Gone" }
+    const candidate = { id: "stream_1", name: "Here" }
+    const result = diffRows(
+      new Map([
+        [orphan.id, orphan],
+        [candidate.id, candidate],
+      ]),
+      [candidate]
+    )
+    expect(result.toWrite).toEqual([])
+    expect(result.merged).toEqual([candidate])
+    expect(result.merged).not.toContain(orphan)
+  })
+
+  it("diffSingleton reports write:false and returns the existing object", () => {
+    const existing = { id: "ws_1", config: { preset: "default" }, _cachedAt: 1 }
+    const candidate = { id: "ws_1", config: { preset: "default" }, _cachedAt: 42 }
+    const result = diffSingleton(existing, candidate)
+    expect(result.write).toBe(false)
+    expect(result.merged).toBe(existing)
+    expect(diffSingleton(undefined, candidate)).toEqual({ write: true, merged: candidate })
+  })
+})

--- a/apps/frontend/src/sync/bootstrap-diff.test.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.test.ts
@@ -34,6 +34,13 @@ describe("bootstrap diff", () => {
     expect(result.skipped).toBe(0)
   })
 
+  it("exotic instances always write — the diff never silently skips them", () => {
+    expect(semanticEqual(new Date(0), new Date(9e9))).toBe(false)
+    expect(semanticEqual(new Map([["a", 1]]), new Map([["a", 1]]))).toBe(false)
+    const same = new Date(0)
+    expect(semanticEqual(same, same)).toBe(true)
+  })
+
   it("a nested array reorder is a change", () => {
     const existing = { id: "stream_1", members: ["usr_1", "usr_2"] }
     const candidate = { id: "stream_1", members: ["usr_2", "usr_1"] }

--- a/apps/frontend/src/sync/bootstrap-diff.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.ts
@@ -1,0 +1,125 @@
+export const BOOTSTRAP_DIFF_IGNORED_KEYS: ReadonlySet<string> = new Set(["_cachedAt"])
+
+export interface RowDiff<T> {
+  toWrite: T[]
+  merged: T[]
+  skipped: number
+}
+
+export interface SingletonDiff<T> {
+  write: boolean
+  merged: T
+}
+
+export function semanticEqual(
+  a: unknown,
+  b: unknown,
+  ignoreKeys: ReadonlySet<string> = BOOTSTRAP_DIFF_IGNORED_KEYS
+): boolean {
+  if (Object.is(a, b)) return true
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false
+
+  const aIsArray = Array.isArray(a)
+  if (aIsArray !== Array.isArray(b)) return false
+  if (aIsArray) {
+    const left = a as unknown[]
+    const right = b as unknown[]
+    if (left.length !== right.length) return false
+    for (let i = 0; i < left.length; i++) {
+      if (!semanticEqual(left[i], right[i], ignoreKeys)) return false
+    }
+    return true
+  }
+
+  const left = a as Record<string, unknown>
+  const right = b as Record<string, unknown>
+  const keys = new Set<string>()
+  for (const key of Object.keys(left)) if (!ignoreKeys.has(key)) keys.add(key)
+  for (const key of Object.keys(right)) if (!ignoreKeys.has(key)) keys.add(key)
+  for (const key of keys) {
+    if (!semanticEqual(left[key], right[key], ignoreKeys)) return false
+  }
+  return true
+}
+
+export function diffRows<T extends { id: string }>(
+  existing: ReadonlyMap<string, T>,
+  candidates: T[],
+  ignoreKeys: ReadonlySet<string> = BOOTSTRAP_DIFF_IGNORED_KEYS
+): RowDiff<T> {
+  const toWrite: T[] = []
+  const merged: T[] = []
+  let skipped = 0
+  for (const candidate of candidates) {
+    const previous = existing.get(candidate.id)
+    if (previous !== undefined && semanticEqual(previous, candidate, ignoreKeys)) {
+      merged.push(previous)
+      skipped += 1
+      continue
+    }
+    toWrite.push(candidate)
+    merged.push(candidate)
+  }
+  return { toWrite, merged, skipped }
+}
+
+export function writeAllRows<T extends { id: string }>(candidates: T[]): RowDiff<T> {
+  return { toWrite: candidates, merged: candidates, skipped: 0 }
+}
+
+export function diffSingleton<T>(
+  existing: T | undefined,
+  candidate: T,
+  ignoreKeys: ReadonlySet<string> = BOOTSTRAP_DIFF_IGNORED_KEYS
+): SingletonDiff<T> {
+  if (existing !== undefined && semanticEqual(existing, candidate, ignoreKeys)) {
+    return { write: false, merged: existing }
+  }
+  return { write: true, merged: candidate }
+}
+
+export type ConfirmableTable = "streams" | "streamMemberships" | "streamReadState"
+
+// A skipped row keeps its old `_cachedAt` (no IDB write), but the local-wins
+// gates read that stamp as "when did we last know this row matched the server".
+// Confirmations restore that meaning without a write; per-JS-context is the
+// correct scope, since the gates compare against this context's fetch windows.
+const rowConfirmations = new Map<string, number>()
+
+function confirmationKey(workspaceId: string, table: ConfirmableTable, id: string): string {
+  return `${workspaceId}/${table}/${id}`
+}
+
+export function recordRowConfirmation(workspaceId: string, table: ConfirmableTable, id: string, at: number): void {
+  const key = confirmationKey(workspaceId, table, id)
+  const previous = rowConfirmations.get(key)
+  if (previous !== undefined && previous >= at) return
+  rowConfirmations.set(key, at)
+}
+
+export function rowConfirmedAt(workspaceId: string, table: ConfirmableTable, id: string): number | undefined {
+  return rowConfirmations.get(confirmationKey(workspaceId, table, id))
+}
+
+export function effectiveFreshness(workspaceId: string, table: ConfirmableTable, id: string, cachedAt: number): number {
+  const confirmed = rowConfirmations.get(confirmationKey(workspaceId, table, id))
+  return confirmed !== undefined && confirmed > cachedAt ? confirmed : cachedAt
+}
+
+export function resetRowConfirmations(): void {
+  rowConfirmations.clear()
+}
+
+export function recordSkippedRowConfirmations<T extends { id: string }>(
+  workspaceId: string,
+  table: ConfirmableTable,
+  diff: RowDiff<T>,
+  at: number
+): void {
+  if (diff.skipped === 0) return
+  const written = new Set(diff.toWrite.map((row) => row.id))
+  for (const row of diff.merged) {
+    if (written.has(row.id)) continue
+    recordRowConfirmation(workspaceId, table, row.id, at)
+  }
+}

--- a/apps/frontend/src/sync/bootstrap-diff.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.ts
@@ -115,6 +115,12 @@ export function effectiveFreshness(workspaceId: string, table: ConfirmableTable,
   return confirmed !== undefined && confirmed > cachedAt ? confirmed : cachedAt
 }
 
+export function removeRowConfirmations(workspaceId: string, table: ConfirmableTable, ids: Iterable<string>): void {
+  for (const id of ids) {
+    rowConfirmations.delete(confirmationKey(workspaceId, table, id))
+  }
+}
+
 export function resetRowConfirmations(): void {
   rowConfirmations.clear()
 }

--- a/apps/frontend/src/sync/bootstrap-diff.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.ts
@@ -11,6 +11,11 @@ export interface SingletonDiff<T> {
   merged: T
 }
 
+function isPlainObjectOrArray(value: object): boolean {
+  const tag = Object.prototype.toString.call(value)
+  return tag === "[object Object]" || tag === "[object Array]"
+}
+
 export function semanticEqual(
   a: unknown,
   b: unknown,
@@ -21,6 +26,10 @@ export function semanticEqual(
 
   const aIsArray = Array.isArray(a)
   if (aIsArray !== Array.isArray(b)) return false
+  // Exotic instances (Date/Map/Set/RegExp) carry no own enumerable keys, so a
+  // plain key walk would call every pair equal and silently skip the write.
+  // Reference identity is the only equality we can prove here: they always write.
+  if (!isPlainObjectOrArray(a) || !isPlainObjectOrArray(b)) return Object.is(a, b)
   if (aIsArray) {
     const left = a as unknown[]
     const right = b as unknown[]

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -12,6 +12,7 @@ import {
   resolveReadAllFrontiers,
   type ReadStateSnapshot,
 } from "./read-state"
+import { recordRowConfirmation, resetRowConfirmations } from "./bootstrap-diff"
 
 function snapshot(overrides: Partial<ReadStateSnapshot> = {}): ReadStateSnapshot {
   return {
@@ -71,6 +72,7 @@ async function seedMembership() {
 
 describe("applyReadStateSnapshotsIdb", () => {
   beforeEach(async () => {
+    resetRowConfirmations()
     await Promise.all([
       db.unreadState.clear(),
       db.streamMemberships.clear(),
@@ -146,6 +148,7 @@ describe("applyReadStateSnapshotsIdb — startedAt freshness guard", () => {
   // unread — operation order (touched-at), not sequence max, decides.
 
   beforeEach(async () => {
+    resetRowConfirmations()
     await Promise.all([
       db.unreadState.clear(),
       db.streamMemberships.clear(),
@@ -218,6 +221,30 @@ describe("applyReadStateSnapshotsIdb — startedAt freshness guard", () => {
     })
     const state = await db.unreadState.get("ws_1")
     expect(state?.readMessageIds?.stream_1).toEqual(["msg_5", "msg_7"])
+  })
+
+  it("counts a diff-confirmed row as touched even though its _cachedAt was never rewritten", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    const startedAt = Date.now()
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_10",
+      lastReadSequence: "100",
+      lastReadAt: "2026-01-01T00:00:10.000Z",
+      _cachedAt: startedAt - 5000,
+    })
+    recordRowConfirmation("ws_1", "streamReadState", "ws_1:stream_1", startedAt + 1000)
+
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()], startedAt)
+
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_10",
+      lastReadSequence: "100",
+    })
   })
 
   it("applies normally when no frontier row exists yet", async () => {

--- a/apps/frontend/src/sync/read-state.ts
+++ b/apps/frontend/src/sync/read-state.ts
@@ -5,6 +5,7 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import { applyStreamReadMessages, applyStreamsReadAllOrdinals, dropMessageActivities } from "./unread-counters"
 import { applyCountersToCache, putCountersIdb, type CounterMutator } from "./catch-up-batch"
+import { effectiveFreshness } from "./bootstrap-diff"
 
 /**
  * Upsert the read-frontier row in IDB — the sole read watermark. Runs inside the
@@ -49,7 +50,8 @@ export function toStreamReadFrontier(row: CachedStreamReadState): StreamReadFron
  */
 export async function readStateTouchedSince(workspaceId: string, streamId: string, since: number): Promise<boolean> {
   const row = await db.streamReadState.get(`${workspaceId}:${streamId}`)
-  return row !== undefined && row._cachedAt >= since
+  if (row === undefined) return false
+  return effectiveFreshness(workspaceId, "streamReadState", row.id, row._cachedAt) >= since
 }
 
 /** Merge one stream's standalone frontier into the workspace bootstrap query cache. */

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -28,6 +28,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import type { QueryClient } from "@tanstack/react-query"
 import { commitCounterMutation } from "./catch-up-batch"
+import { effectiveFreshness } from "./bootstrap-diff"
 import { mergeReadStateIntoBootstrapCache, putReadStateIdb, toStreamReadFrontier } from "./read-state"
 import {
   applyMovedSourceOrdinal,
@@ -570,7 +571,11 @@ async function persistBootstrapReadState(
 ): Promise<StreamReadFrontier | undefined> {
   if (bootstrap.readState === undefined) return undefined
   const existingRow = await db.streamReadState.get(`${workspaceId}:${streamId}`)
-  if (fetchStartedAt !== undefined && existingRow && existingRow._cachedAt >= fetchStartedAt) {
+  if (
+    fetchStartedAt !== undefined &&
+    existingRow &&
+    effectiveFreshness(workspaceId, "streamReadState", existingRow.id, existingRow._cachedAt) >= fetchStartedAt
+  ) {
     return toStreamReadFrontier(existingRow)
   }
   if (bootstrap.readState === null) {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -859,7 +859,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
             avatarEmoji: null,
             avatarUrl: null,
             systemPrompt: null,
-            model: "anthropic/claude-sonnet-4.5",
+            model: "openrouter:anthropic/claude-sonnet-5",
             temperature: null,
             maxTokens: null,
             enabledTools: null,
@@ -1135,6 +1135,21 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       })
 
       expect((await db.streams.get("stream_d1"))?.displayName).toBe("Stream stream_d1")
+    })
+
+    it("a reconnect carrying an older notificationLevel cannot clobber a membership row the diff just confirmed", async () => {
+      await warmThenOlderReconnect(true, {
+        streamMemberships: [
+          {
+            streamId: "stream_d1",
+            memberId: "member_1",
+            notificationLevel: "mentions",
+            joinedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      })
+
+      expect((await db.streamMemberships.get("ws_1:stream_d1"))?.notificationLevel).toBeNull()
     })
 
     it("with bootstrapDiff off, every row is rewritten", async () => {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -10,7 +10,7 @@ import {
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import { SocketEventGate } from "./socket-event-gate"
-import { resetRowConfirmations } from "./bootstrap-diff"
+import { resetRowConfirmations, rowConfirmedAt } from "./bootstrap-diff"
 import { PerfCapture, armPerfCapture, NO_CAPTURE } from "@/lib/perf/capture"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
@@ -955,6 +955,24 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       const samples = capture.snapshot()
       expect(samples.filter((s) => s.name === "bootstrap.rowsWritten").map((s) => s.value)).toEqual([0])
       expect(samples.filter((s) => s.name === "bootstrap.rowsSkipped").map((s) => s.value)).toEqual([rowCount])
+    })
+
+    it("the stale sweep drops a deleted row's confirmation", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+      expect(rowConfirmedAt("ws_1", "streams", "stream_d2")).toBeDefined()
+
+      await applyWorkspaceBootstrap(
+        "ws_1",
+        diffBootstrap({
+          streams: [{ ...makeStream("stream_d1"), lastMessagePreview: null }] as WorkspaceBootstrap["streams"],
+        }),
+        Date.now()
+      )
+
+      expect(await db.streams.get("stream_d2")).toBeUndefined()
+      expect(rowConfirmedAt("ws_1", "streams", "stream_d2")).toBeUndefined()
     })
 
     it("a changed row is written and its neighbours are not", async () => {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1091,6 +1091,23 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       )
     }
 
+    it("a warm apply carrying an older frontier cannot regress a row the diff just confirmed", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      const fetchStartedAt = Date.now() - 1000
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      const stale = diffBootstrap({
+        streamReadState: {
+          stream_d1: { lastReadEventId: "evt_old", lastReadSequence: "2", lastReadAt: "2025-01-01T00:00:00Z" },
+        },
+      })
+      await applyWorkspaceBootstrap("ws_1", stale, fetchStartedAt)
+
+      expect((await db.streamReadState.get("ws_1:stream_d1"))?.lastReadSequence).toBe("3")
+    })
+
     it("a reconnect carrying an older frontier cannot regress a row the diff just confirmed", async () => {
       await warmThenOlderReconnect(true, {
         streamReadState: {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { db } from "@/db"
 import { QueryClient } from "@tanstack/react-query"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -10,6 +10,8 @@ import {
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import { SocketEventGate } from "./socket-event-gate"
+import { resetRowConfirmations } from "./bootstrap-diff"
+import { PerfCapture, armPerfCapture, NO_CAPTURE } from "@/lib/perf/capture"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
 import { memoKeys } from "@/hooks/use-memos"
@@ -786,6 +788,348 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     expect(await db.streamReadState.get("ws_1:stream_live")).toMatchObject({
       lastReadEventId: "evt_live",
       lastReadSequence: "99",
+    })
+  })
+
+  describe("bootstrapDiff", () => {
+    interface DiffTable {
+      name: string
+      toArray: () => Promise<Array<{ id: string; _cachedAt: number }>>
+      bulkPut: (rows: Array<{ id: string; _cachedAt: number }>) => Promise<unknown>
+    }
+
+    function diffTables(): DiffTable[] {
+      return [
+        db.workspaces,
+        db.workspaceUsers,
+        db.streams,
+        db.streamMemberships,
+        db.streamReadState,
+        db.dmPeers,
+        db.personas,
+        db.bots,
+        db.labels,
+        db.labelAssignments,
+        db.unreadState,
+        db.userPreferences,
+        db.sidebarConfigs,
+        db.workspaceMetadata,
+      ] as unknown as DiffTable[]
+    }
+
+    async function stampCachedAt(value: number): Promise<void> {
+      for (const table of diffTables()) {
+        const rows = await table.toArray()
+        if (rows.length > 0) await table.bulkPut(rows.map((row) => ({ ...row, _cachedAt: value })))
+      }
+    }
+
+    async function cachedAtSnapshot(): Promise<Record<string, number>> {
+      const snapshot: Record<string, number> = {}
+      for (const table of diffTables()) {
+        for (const row of await table.toArray()) snapshot[`${table.name}:${row.id}`] = row._cachedAt
+      }
+      return snapshot
+    }
+
+    let diffBase: WorkspaceBootstrap | undefined
+
+    function diffBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
+      diffBase ??= makeBootstrap({
+        featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
+        users: [makeWorkspaceUser()],
+        streams: [
+          { ...makeStream("stream_d1"), lastMessagePreview: null },
+          { ...makeStream("stream_d2"), lastMessagePreview: null },
+        ] as WorkspaceBootstrap["streams"],
+        streamMemberships: [
+          { streamId: "stream_d1", memberId: "member_1", notificationLevel: null, joinedAt: "2026-01-01T00:00:00Z" },
+        ],
+        streamReadState: {
+          stream_d1: { lastReadEventId: "evt_1", lastReadSequence: "3", lastReadAt: "2026-01-01T00:00:00Z" },
+        },
+        dmPeers: [{ userId: "member_1", streamId: "stream_d2" }],
+        personas: [
+          {
+            id: "persona_d1",
+            workspaceId: "ws_1",
+            slug: "ariadne",
+            name: "Ariadne",
+            description: null,
+            avatarEmoji: null,
+            avatarUrl: null,
+            systemPrompt: null,
+            model: "anthropic/claude-sonnet-4.5",
+            temperature: null,
+            maxTokens: null,
+            enabledTools: null,
+            managedBy: "workspace",
+            ownerUserId: null,
+            status: "active",
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        bots: [
+          {
+            id: "bot_d1",
+            workspaceId: "ws_1",
+            type: "shared",
+            ownerUserId: null,
+            traits: [],
+            slug: "helper",
+            name: "Helper",
+            description: null,
+            avatarEmoji: null,
+            avatarUrl: null,
+            archivedAt: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        labels: [
+          {
+            id: "label_d1",
+            workspaceId: "ws_1",
+            creatorActorType: "user",
+            creatorUserId: "member_1",
+            name: "Focus",
+            slug: "focus",
+            color: "blue",
+            emoji: null,
+            description: null,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+            archivedAt: null,
+          },
+        ],
+        labelAssignments: [
+          {
+            labelId: "label_d1",
+            resourceType: "stream",
+            resourceId: "stream_d1",
+            actorType: "user",
+            userId: "member_1",
+            workspaceId: "ws_1",
+            assignedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        unreadCounts: { stream_d1: 2 },
+        mentionCounts: { stream_d1: 1 },
+        activityCounts: { stream_d1: 2 },
+        unreadActivityCount: 2,
+      })
+      return { ...structuredClone(diffBase), ...overrides }
+    }
+
+    beforeEach(async () => {
+      resetRowConfirmations()
+      await Promise.all([db.labels.clear(), db.labelAssignments.clear()])
+    })
+
+    afterEach(() => {
+      armPerfCapture(NO_CAPTURE)
+    })
+
+    it("a second identical bootstrap writes no rows", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+      const before = await cachedAtSnapshot()
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      expect(await cachedAtSnapshot()).toEqual(before)
+      expect(Object.values(before).every((value) => value === 1)).toBe(true)
+      expect(await db.streams.get("stream_d1")).toBeDefined()
+      expect(await db.streams.get("stream_d2")).toBeDefined()
+    })
+
+    it("a second identical bootstrap reports rowsWritten 0", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      const rowCount = Object.keys(await cachedAtSnapshot()).length
+
+      const capture = new PerfCapture()
+      armPerfCapture(capture)
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      const samples = capture.snapshot()
+      expect(samples.filter((s) => s.name === "bootstrap.rowsWritten").map((s) => s.value)).toEqual([0])
+      expect(samples.filter((s) => s.name === "bootstrap.rowsSkipped").map((s) => s.value)).toEqual([rowCount])
+    })
+
+    it("a changed row is written and its neighbours are not", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      const base = diffBootstrap()
+      const changed = diffBootstrap({
+        streams: base.streams.map((s) => (s.id === "stream_d1" ? { ...s, displayName: "Renamed" } : s)),
+      })
+      await applyWorkspaceBootstrap("ws_1", changed, Date.now())
+
+      expect((await db.streams.get("stream_d1"))?.displayName).toBe("Renamed")
+      expect((await db.streams.get("stream_d1"))?._cachedAt).toBeGreaterThan(1)
+      expect((await db.streams.get("stream_d2"))?._cachedAt).toBe(1)
+      expect((await db.workspaceUsers.get("member_1"))?._cachedAt).toBe(1)
+    })
+
+    it("a row present in the bootstrap but skipped by the diff is never swept", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      const fetchStartedAt = Date.now()
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), fetchStartedAt)
+
+      expect(await db.streams.get("stream_d1")).toBeDefined()
+      expect(await db.streams.get("stream_d2")).toBeDefined()
+      expect(await db.workspaceUsers.get("member_1")).toBeDefined()
+      expect(await db.streamMemberships.get("ws_1:stream_d1")).toBeDefined()
+      expect((await db.streams.get("stream_d1"))?._cachedAt).toBe(1)
+    })
+
+    it("a stream written by a socket handler during the fetch window and absent from the snapshot still survives", async () => {
+      const fetchStartedAt = Date.now() - 500
+      await db.streams.put({ ...makeStream("stream_socket_diff"), _cachedAt: fetchStartedAt + 100 })
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), fetchStartedAt)
+
+      expect(await db.streams.get("stream_socket_diff")).toBeDefined()
+    })
+
+    it("a socket write during the fetch window that the snapshot contradicts is still healed by the snapshot", async () => {
+      const fetchStartedAt = Date.now() - 500
+      await db.streams.put({
+        ...makeStream("stream_d1"),
+        displayName: "Local socket name",
+        _cachedAt: fetchStartedAt + 100,
+      })
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), fetchStartedAt)
+
+      expect((await db.streams.get("stream_d1"))?.displayName).toBe("Stream stream_d1")
+    })
+
+    it("userPreferences does not false-diff on the seed-only sendMode field", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      expect((await db.userPreferences.get("ws_1"))?._cachedAt).toBe(1)
+      expect((await db.userPreferences.get("ws_1")) as unknown as { sendMode?: string }).not.toHaveProperty("sendMode")
+    })
+
+    it("archived roots ride the single diffed streams write", async () => {
+      const archivedRoot = makeStream("stream_arch_diff", { archivedAt: "2026-01-01T00:00:00Z" })
+      await db.streams.put({
+        ...archivedRoot,
+        lastMessagePreview: {
+          authorId: "user_1",
+          authorType: "user",
+          content: "kept",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+        _cachedAt: Date.now() - 90000,
+      })
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap({ archivedStreams: [archivedRoot] }), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap({ archivedStreams: [archivedRoot] }), Date.now())
+
+      const row = await db.streams.get("stream_arch_diff")
+      expect(row?._cachedAt).toBe(1)
+      expect(row?.lastMessagePreview?.content).toBe("kept")
+    })
+
+    it("unreadState is not rewritten when counters and touch maps are unchanged", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      expect((await db.unreadState.get("ws_1"))?._cachedAt).toBe(1)
+    })
+
+    it("reconnect apply writes no rows for an unchanged workspace snapshot", async () => {
+      await applyReconnectBootstrapBatch("ws_1", diffBootstrap(), new Map(), new Set(), new Set(), Date.now() - 5000)
+      await stampCachedAt(1)
+      const before = await cachedAtSnapshot()
+
+      await applyReconnectBootstrapBatch("ws_1", diffBootstrap(), new Map(), new Set(), new Set(), Date.now())
+
+      expect(await cachedAtSnapshot()).toEqual(before)
+    })
+
+    async function warmThenOlderReconnect(
+      flagOn: boolean,
+      reconnectOverrides: Partial<WorkspaceBootstrap>
+    ): Promise<void> {
+      const flags: WorkspaceBootstrap["featureFlags"] = flagOn
+        ? { workspace: { bootstrapDiff: "on" }, user: {} }
+        : { workspace: {}, user: {} }
+      const warm = (): WorkspaceBootstrap =>
+        diffBootstrap({
+          featureFlags: flags,
+          streamReadState: {
+            stream_d1: { lastReadEventId: "evt_9", lastReadSequence: "9", lastReadAt: "2026-01-02T00:00:00Z" },
+          },
+        })
+
+      await applyWorkspaceBootstrap("ws_1", warm(), Date.now() - 5000)
+      await stampCachedAt(1)
+      const warmAppliedAt = Date.now()
+      await applyWorkspaceBootstrap("ws_1", warm(), warmAppliedAt)
+
+      await applyReconnectBootstrapBatch(
+        "ws_1",
+        diffBootstrap({ featureFlags: flags, ...reconnectOverrides }),
+        new Map(),
+        new Set(),
+        new Set(),
+        warmAppliedAt - 1000
+      )
+    }
+
+    it("a reconnect carrying an older frontier cannot regress a row the diff just confirmed", async () => {
+      await warmThenOlderReconnect(true, {
+        streamReadState: {
+          stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
+        },
+      })
+
+      expect((await db.streamReadState.get("ws_1:stream_d1"))?.lastReadSequence).toBe("9")
+    })
+
+    it("with bootstrapDiff off, an older reconnect frontier still loses to the freshly written row", async () => {
+      await warmThenOlderReconnect(false, {
+        streamReadState: {
+          stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
+        },
+      })
+
+      expect((await db.streamReadState.get("ws_1:stream_d1"))?.lastReadSequence).toBe("9")
+    })
+
+    it("a reconnect carrying an older displayName cannot clobber a stream row the diff just confirmed", async () => {
+      const base = diffBootstrap()
+      await warmThenOlderReconnect(true, {
+        streams: base.streams.map((s) => (s.id === "stream_d1" ? { ...s, displayName: "Older Name" } : s)),
+      })
+
+      expect((await db.streams.get("stream_d1"))?.displayName).toBe("Stream stream_d1")
+    })
+
+    it("with bootstrapDiff off, every row is rewritten", async () => {
+      const off = (): WorkspaceBootstrap => diffBootstrap({ featureFlags: { workspace: {}, user: {} } })
+      await applyWorkspaceBootstrap("ws_1", off(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      await applyWorkspaceBootstrap("ws_1", off(), Date.now())
+
+      const snapshot = await cachedAtSnapshot()
+      expect(Object.keys(snapshot).length).toBeGreaterThan(0)
+      expect(Object.entries(snapshot).filter(([, value]) => value === 1)).toEqual([])
     })
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -19,6 +19,7 @@ import {
   diffSingleton,
   effectiveFreshness,
   recordSkippedRowConfirmations,
+  removeRowConfirmations,
   semanticEqual,
   writeAllRows,
 } from "./bootstrap-diff"
@@ -3156,6 +3157,9 @@ export async function applyReconnectBootstrapBatch(
           db.streamReadState.bulkDelete(terminalRowIds),
           deleteSlotsForStreams(db, terminalIds),
         ])
+        removeRowConfirmations(workspaceId, "streams", terminalIds)
+        removeRowConfirmations(workspaceId, "streamMemberships", terminalRowIds)
+        removeRowConfirmations(workspaceId, "streamReadState", terminalRowIds)
       }
     }
   )
@@ -3273,7 +3277,7 @@ async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBoo
   // can't ride the generic deleteStale (Amendment A4).
   const staleStreamIds = await staleEntityIds(db.streams, "workspaceId", workspaceId, bootstrapStreamIds, now)
 
-  await Promise.all([
+  const [, , , staleMembershipIds] = await Promise.all([
     staleStreamIds.length > 0 ? db.streams.bulkDelete(staleStreamIds) : Promise.resolve(),
     deleteSlotsForStreams(db, staleStreamIds),
     deleteStale(db.workspaceUsers, "workspaceId", workspaceId, bootstrapUserIds, now),
@@ -3291,6 +3295,9 @@ async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBoo
     deleteStale(db.labels, "workspaceId", workspaceId, bootstrapLabelIds, now),
     deleteStale(db.labelAssignments, "workspaceId", workspaceId, bootstrapLabelAssignmentIds, now),
   ])
+
+  removeRowConfirmations(workspaceId, "streams", staleStreamIds)
+  removeRowConfirmations(workspaceId, "streamMemberships", staleMembershipIds)
 }
 
 async function staleEntityIds(
@@ -3319,9 +3326,10 @@ async function deleteStale(
   scopeValue: string,
   keepIds: Set<string>,
   now: number
-): Promise<void> {
+): Promise<string[]> {
   const toDelete = await staleEntityIds(table, scopeField, scopeValue, keepIds, now)
   if (toDelete.length > 0) {
     await table.bulkDelete(toDelete)
   }
+  return toDelete
 }

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2904,10 +2904,11 @@ export async function applyReconnectBootstrapBatch(
 
   const workspaceRow = { ...finalBootstrap.workspace, _cachedAt: now }
   const userRows = finalBootstrap.users.map((user) => ({ ...user, _cachedAt: now }))
+  const localStreamById = byId(localStreams)
   const streamRows = dedupeById<CachedStream>([
     ...finalBootstrap.streams.map((stream) => {
       const membership = membershipByStream.get(stream.id)
-      const local = localStreams.find((s) => s.id === stream.id)
+      const local = localStreamById.get(stream.id)
       return {
         ...stream,
         notificationLevel: membership?.notificationLevel,
@@ -2919,7 +2920,7 @@ export async function applyReconnectBootstrapBatch(
       }
     }),
     // Persist archived roots on reconnect too (mirrors applyWorkspaceBootstrap).
-    ...mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], byId(localStreams), now),
+    ...mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], localStreamById, now),
   ])
   const membershipRows = finalBootstrap.streamMemberships.map((membership) => ({
     ...membership,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2695,7 +2695,11 @@ export async function applyWorkspaceBootstrap(
         effectiveReadStateMap = { ...bootstrap.streamReadState }
         for (const [streamId, frontier] of Object.entries(bootstrap.streamReadState)) {
           const local = existingByStreamId.get(streamId)
-          if (fetchStartedAt !== undefined && local && local._cachedAt >= fetchStartedAt) {
+          if (
+            fetchStartedAt !== undefined &&
+            local &&
+            effectiveFreshness(workspaceId, "streamReadState", local.id, local._cachedAt) >= fetchStartedAt
+          ) {
             // Touched during the fetch window: preserve the local cache+IDB row
             // exactly, and carry its frontier into the returned map so the
             // query cache the caller writes doesn't regress either.

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1,11 +1,27 @@
 import {
   db,
+  type CachedBot,
+  type CachedDmPeer,
+  type CachedLabel,
+  type CachedLabelAssignment,
+  type CachedPersona,
   type CachedStream,
   type CachedStreamMembership,
   type CachedStreamReadState,
   type CachedUnreadState,
+  type CachedWorkspace,
+  type CachedWorkspaceUser,
 } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
+import { resolveFeatureFlags } from "@threa/types"
+import {
+  diffRows,
+  diffSingleton,
+  effectiveFreshness,
+  recordSkippedRowConfirmations,
+  semanticEqual,
+  writeAllRows,
+} from "./bootstrap-diff"
 import { seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import {
   seedAgentActivity,
@@ -511,8 +527,9 @@ export function mergeReconnectWorkspaceBootstrap({
   }
 
   if (fetchStartedAt !== undefined) {
+    const mergeWorkspaceId = workspaceBootstrap.workspace.id
     for (const stream of localStreams) {
-      if (stream._cachedAt < fetchStartedAt) continue
+      if (effectiveFreshness(mergeWorkspaceId, "streams", stream.id, stream._cachedAt) < fetchStartedAt) continue
       if (successfulStreamIds.has(stream.id)) continue
       // Archived rows persist in db.streams (they ride bootstrap.archivedStreams),
       // so a fresh _cachedAt no longer implies active — promoting one here would
@@ -522,13 +539,16 @@ export function mergeReconnectWorkspaceBootstrap({
     }
 
     for (const membership of localMemberships) {
-      if (membership._cachedAt < fetchStartedAt) continue
+      if (
+        effectiveFreshness(mergeWorkspaceId, "streamMemberships", membership.id, membership._cachedAt) < fetchStartedAt
+      )
+        continue
       if (successfulStreamIds.has(membership.streamId)) continue
       membershipsByStreamId.set(membership.streamId, toWorkspaceBootstrapMembership(membership))
     }
 
     for (const row of localReadStates) {
-      if (row._cachedAt < fetchStartedAt) continue
+      if (effectiveFreshness(mergeWorkspaceId, "streamReadState", row.id, row._cachedAt) < fetchStartedAt) continue
       if (successfulStreamIds.has(row.streamId)) continue
       readStateByStreamId.set(row.streamId, toStreamReadFrontier(row))
     }
@@ -2397,6 +2417,16 @@ async function upsertStreamRow(stream: Stream): Promise<void> {
   }
 }
 
+const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
+
+function byId<T extends { id: string }>(rows: T[]): Map<string, T> {
+  return new Map(rows.map((row) => [row.id, row]))
+}
+
+function dedupeById<T extends { id: string }>(rows: T[]): T[] {
+  return Array.from(byId(rows).values())
+}
+
 /**
  * Map slim archived-root `Stream` rows (bootstrap.archivedStreams — no preview
  * or membership joins) to `CachedStream` rows, merging onto any existing row so
@@ -2419,20 +2449,10 @@ export async function applyWorkspaceBootstrap(
 ): Promise<WorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
+  const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
-
-  // Workspace bootstrap doesn't carry stream-level fields that the per-stream
-  // bootstrap writes (e.g. `contextBag`), but `bulkPut` is a full overwrite.
-  // Read existing local records once so we can preserve those fields across
-  // a refresh — without this merge, opening any bag-attached scratchpad
-  // after a fresh load shows the message badge briefly, then loses it when
-  // workspace bootstrap clobbers the field.
-  const stopPreRead = capture.time("bootstrap.preRead")
-  const existingStreams = await db.streams.where("workspaceId").equals(workspaceId).toArray()
-  const existingByStreamId = new Map(existingStreams.map((s) => [s.id, s]))
-  stopPreRead()
 
   // Effective sidebar config for the in-memory seed below. If a newer
   // `sidebar_config:updated` landed during the fetch window we keep the local
@@ -2453,9 +2473,47 @@ export async function applyWorkspaceBootstrap(
   let effectiveReadStateMap = bootstrap.streamReadState
   let seedReadStates: CachedStreamReadState[] | undefined
 
-  // Counts only the conditional writes; the unconditional ones are summed at
-  // the mark below.
-  let conditionalRowsWritten = 0
+  let rowsWritten = 0
+  let rowsSkipped = 0
+
+  const workspaceRow = { ...bootstrap.workspace, _cachedAt: now }
+  const userRows = bootstrap.users.map((u) => ({ ...u, _cachedAt: now }))
+  const membershipRows = bootstrap.streamMemberships.map((sm) => ({
+    ...sm,
+    id: `${workspaceId}:${sm.streamId}`,
+    workspaceId,
+    _cachedAt: now,
+  }))
+  const dmPeerRows = bootstrap.dmPeers.map((dp) => ({
+    ...dp,
+    id: `${workspaceId}:${dp.streamId}`,
+    workspaceId,
+    _cachedAt: now,
+  }))
+  const personaRows = bootstrap.personas.map((p) => ({ ...p, workspaceId, _cachedAt: now }))
+  const botRows = bootstrap.bots.map((b) => ({ ...b, workspaceId, _cachedAt: now }))
+  const labelRows = bootstrap.labels.map((l) => ({ ...l, _cachedAt: now }))
+  const labelAssignmentRows = bootstrap.labelAssignments.map(assignmentToCached)
+  const metadataRow = {
+    id: workspaceId,
+    workspaceId,
+    emojis: bootstrap.emojis,
+    emojiWeights: bootstrap.emojiWeights,
+    commands: bootstrap.commands,
+    configuredToolCategories: bootstrap.configuredToolCategories,
+    featureFlags: bootstrap.featureFlags,
+    _cachedAt: now,
+  }
+
+  let mergedWorkspace: CachedWorkspace = workspaceRow
+  let mergedUsers: CachedWorkspaceUser[] = userRows
+  let mergedStreams: CachedStream[] = []
+  let mergedMemberships: CachedStreamMembership[] = membershipRows
+  let mergedDmPeers: CachedDmPeer[] = dmPeerRows
+  let mergedPersonas: CachedPersona[] = personaRows
+  let mergedBots: CachedBot[] = botRows
+  let mergedLabels: CachedLabel[] = labelRows
+  let mergedLabelAssignments: CachedLabelAssignment[] = labelAssignmentRows
 
   // One transaction over every table so they commit together and each table's
   // `useLiveQuery` fires once — one settle, not a per-table trickle. Parallel
@@ -2485,58 +2543,122 @@ export async function applyWorkspaceBootstrap(
       db.workspaceMetadata,
     ],
     async () => {
-      await Promise.all([
-        db.workspaces.put({ ...bootstrap.workspace, _cachedAt: now }),
-        db.workspaceUsers.bulkPut(bootstrap.users.map((u) => ({ ...u, _cachedAt: now }))),
-        db.streams.bulkPut(
-          bootstrap.streams.map((s) => {
-            const membership = membershipByStream.get(s.id)
-            const existing = existingByStreamId.get(s.id)
-            return {
-              ...s,
-              notificationLevel: membership?.notificationLevel,
-              // Preserve fields workspace-bootstrap doesn't carry but stream-
-              // bootstrap does (bag mirroring lives in `applyStreamBootstrap`).
-              contextBag: existing?.contextBag,
-              _cachedAt: now,
-            }
-          })
-        ),
+      const stopPreRead = capture.time("bootstrap.preRead")
+      const existingStreams = await db.streams.where("workspaceId").equals(workspaceId).toArray()
+      const existingByStreamId = new Map(existingStreams.map((s) => [s.id, s]))
+      const [
+        existingWorkspace,
+        existingUsers,
+        existingMemberships,
+        existingDmPeers,
+        existingPersonas,
+        existingBots,
+        existingLabels,
+        existingLabelAssignments,
+        existingMetadata,
+      ] = diffEnabled
+        ? await Promise.all([
+            db.workspaces.get(workspaceId),
+            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+            db.personas.where("workspaceId").equals(workspaceId).toArray(),
+            db.bots.where("workspaceId").equals(workspaceId).toArray(),
+            db.labels.where("workspaceId").equals(workspaceId).toArray(),
+            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+            db.workspaceMetadata.get(workspaceId),
+          ])
+        : [undefined, [], [], [], [], [], [], [], undefined]
+      stopPreRead()
+
+      const stopDiff = capture.time("bootstrap.diff")
+      const streamCandidates = dedupeById([
+        ...bootstrap.streams.map((s) => {
+          const membership = membershipByStream.get(s.id)
+          const existing = existingByStreamId.get(s.id)
+          return {
+            ...s,
+            notificationLevel: membership?.notificationLevel,
+            // Preserve fields workspace-bootstrap doesn't carry but stream-
+            // bootstrap does (bag mirroring lives in `applyStreamBootstrap`).
+            contextBag: existing?.contextBag,
+            _cachedAt: now,
+          }
+        }),
         // Archived roots ship slim (no preview/membership) but must persist so
         // every `useWorkspaceStreams` consumer (drafts, name resolution) keeps
         // seeing them across a reload. Not added to the TanStack bootstrap
         // `streams` cache — that list stays active-only.
-        db.streams.bulkPut(mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now)),
-        db.streamMemberships.bulkPut(
-          bootstrap.streamMemberships.map((sm) => ({
-            ...sm,
-            id: `${workspaceId}:${sm.streamId}`,
-            workspaceId,
-            _cachedAt: now,
-          }))
-        ),
-        db.dmPeers.bulkPut(
-          bootstrap.dmPeers.map((dp) => ({
-            ...dp,
-            id: `${workspaceId}:${dp.streamId}`,
-            workspaceId,
-            _cachedAt: now,
-          }))
-        ),
-        db.personas.bulkPut(bootstrap.personas.map((p) => ({ ...p, workspaceId: workspaceId, _cachedAt: now }))),
-        db.bots.bulkPut(bootstrap.bots.map((b) => ({ ...b, workspaceId: workspaceId, _cachedAt: now }))),
-        db.labels.bulkPut(bootstrap.labels.map((l) => ({ ...l, _cachedAt: now }))),
-        db.labelAssignments.bulkPut(bootstrap.labelAssignments.map(assignmentToCached)),
-        db.workspaceMetadata.put({
-          id: workspaceId,
-          workspaceId,
-          emojis: bootstrap.emojis,
-          emojiWeights: bootstrap.emojiWeights,
-          commands: bootstrap.commands,
-          configuredToolCategories: bootstrap.configuredToolCategories,
-          featureFlags: bootstrap.featureFlags,
-          _cachedAt: now,
-        }),
+        ...mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now),
+      ])
+
+      const workspaceDiff = diffEnabled
+        ? diffSingleton(existingWorkspace, workspaceRow)
+        : { write: true, merged: workspaceRow }
+      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
+      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, streamCandidates) : writeAllRows(streamCandidates)
+      const membershipsDiff = diffEnabled
+        ? diffRows(byId(existingMemberships), membershipRows)
+        : writeAllRows(membershipRows)
+      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
+      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
+      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
+      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
+      const labelAssignmentsDiff = diffEnabled
+        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+        : writeAllRows(labelAssignmentRows)
+      const metadataDiff = diffEnabled
+        ? diffSingleton(existingMetadata, metadataRow)
+        : { write: true, merged: metadataRow }
+      stopDiff()
+
+      mergedWorkspace = workspaceDiff.merged
+      mergedUsers = usersDiff.merged
+      mergedStreams = streamsDiff.merged
+      mergedMemberships = membershipsDiff.merged
+      mergedDmPeers = dmPeersDiff.merged
+      mergedPersonas = personasDiff.merged
+      mergedBots = botsDiff.merged
+      mergedLabels = labelsDiff.merged
+      mergedLabelAssignments = labelAssignmentsDiff.merged
+      recordSkippedRowConfirmations(workspaceId, "streams", streamsDiff, now)
+      recordSkippedRowConfirmations(workspaceId, "streamMemberships", membershipsDiff, now)
+      rowsSkipped +=
+        usersDiff.skipped +
+        streamsDiff.skipped +
+        membershipsDiff.skipped +
+        dmPeersDiff.skipped +
+        personasDiff.skipped +
+        botsDiff.skipped +
+        labelsDiff.skipped +
+        labelAssignmentsDiff.skipped +
+        (workspaceDiff.write ? 0 : 1) +
+        (metadataDiff.write ? 0 : 1)
+      rowsWritten +=
+        usersDiff.toWrite.length +
+        streamsDiff.toWrite.length +
+        membershipsDiff.toWrite.length +
+        dmPeersDiff.toWrite.length +
+        personasDiff.toWrite.length +
+        botsDiff.toWrite.length +
+        labelsDiff.toWrite.length +
+        labelAssignmentsDiff.toWrite.length +
+        (workspaceDiff.write ? 1 : 0) +
+        (metadataDiff.write ? 1 : 0)
+
+      await Promise.all([
+        workspaceDiff.write ? db.workspaces.put(workspaceRow) : Promise.resolve(),
+        usersDiff.toWrite.length > 0 ? db.workspaceUsers.bulkPut(usersDiff.toWrite) : Promise.resolve(),
+        streamsDiff.toWrite.length > 0 ? db.streams.bulkPut(streamsDiff.toWrite) : Promise.resolve(),
+        membershipsDiff.toWrite.length > 0 ? db.streamMemberships.bulkPut(membershipsDiff.toWrite) : Promise.resolve(),
+        dmPeersDiff.toWrite.length > 0 ? db.dmPeers.bulkPut(dmPeersDiff.toWrite) : Promise.resolve(),
+        personasDiff.toWrite.length > 0 ? db.personas.bulkPut(personasDiff.toWrite) : Promise.resolve(),
+        botsDiff.toWrite.length > 0 ? db.bots.bulkPut(botsDiff.toWrite) : Promise.resolve(),
+        labelsDiff.toWrite.length > 0 ? db.labels.bulkPut(labelsDiff.toWrite) : Promise.resolve(),
+        labelAssignmentsDiff.toWrite.length > 0
+          ? db.labelAssignments.bulkPut(labelAssignmentsDiff.toWrite)
+          : Promise.resolve(),
+        metadataDiff.write ? db.workspaceMetadata.put(metadataRow) : Promise.resolve(),
       ])
 
       // Per-stream merge with concurrent socket writes (INV-20): the server
@@ -2546,7 +2668,14 @@ export async function applyWorkspaceBootstrap(
       // count never healed.
       const existingUnread = await db.unreadState.get(workspaceId)
       effectiveUnread = mergeBootstrapUnreadFields(bootstrap, existingUnread, fetchStartedAt)
-      await db.unreadState.put({ id: workspaceId, workspaceId, ...effectiveUnread, _cachedAt: now })
+      const unreadRow = { id: workspaceId, workspaceId, ...effectiveUnread, _cachedAt: now }
+      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
+      if (unreadDiff.write) {
+        rowsWritten += 1
+        await db.unreadState.put(unreadRow)
+      } else {
+        rowsSkipped += 1
+      }
 
       // Standalone read frontier (read cutover), same per-stream freshness rule
       // as the counter triple above: the server snapshot wins except for
@@ -2583,33 +2712,48 @@ export async function applyWorkspaceBootstrap(
             _cachedAt: now,
           })
         }
-        if (serverRows.length > 0) {
-          await db.streamReadState.bulkPut(serverRows)
-          conditionalRowsWritten += serverRows.length
+        const readStateDiff = diffEnabled
+          ? diffRows(new Map(existingRows.map((row) => [row.id, row])), serverRows)
+          : writeAllRows(serverRows)
+        if (readStateDiff.toWrite.length > 0) {
+          await db.streamReadState.bulkPut(readStateDiff.toWrite)
         }
-        seedReadStates = mergeLocalAndServerReadStates(existingRows, serverRows)
+        rowsWritten += readStateDiff.toWrite.length
+        rowsSkipped += readStateDiff.skipped
+        recordSkippedRowConfirmations(workspaceId, "streamReadState", readStateDiff, now)
+        seedReadStates = mergeLocalAndServerReadStates(existingRows, readStateDiff.merged)
       }
 
       const existingPrefs = await db.userPreferences.get(workspaceId)
       if (!existingPrefs || !fetchStartedAt || existingPrefs._cachedAt < fetchStartedAt) {
-        conditionalRowsWritten += 1
-        await db.userPreferences.put({
+        const prefsRow = {
           ...bootstrap.userPreferences,
           id: workspaceId,
           workspaceId,
           _cachedAt: now,
-        })
+        }
+        if (diffEnabled && existingPrefs && semanticEqual(existingPrefs, prefsRow)) {
+          rowsSkipped += 1
+        } else {
+          rowsWritten += 1
+          await db.userPreferences.put(prefsRow)
+        }
       }
 
       const existingSidebar = await db.sidebarConfigs.get(workspaceId)
       if (!existingSidebar || !fetchStartedAt || existingSidebar._cachedAt < fetchStartedAt) {
-        conditionalRowsWritten += 1
-        await db.sidebarConfigs.put({
+        const sidebarRow = {
           id: workspaceId,
           workspaceId,
           config: bootstrap.sidebarConfig,
           _cachedAt: now,
-        })
+        }
+        if (diffEnabled && existingSidebar && semanticEqual(existingSidebar, sidebarRow)) {
+          rowsSkipped += 1
+        } else {
+          rowsWritten += 1
+          await db.sidebarConfigs.put(sidebarRow)
+        }
       } else {
         effectiveSidebarConfig = existingSidebar.config
       }
@@ -2617,21 +2761,8 @@ export async function applyWorkspaceBootstrap(
   )
 
   stopTx()
-  capture.mark(
-    "bootstrap.rowsWritten",
-    bootstrap.users.length +
-      bootstrap.streams.length +
-      (bootstrap.archivedStreams?.length ?? 0) +
-      bootstrap.streamMemberships.length +
-      bootstrap.dmPeers.length +
-      bootstrap.personas.length +
-      bootstrap.bots.length +
-      bootstrap.labels.length +
-      bootstrap.labelAssignments.length +
-      // workspace + workspaceMetadata + unreadState
-      3 +
-      conditionalRowsWritten
-  )
+  capture.mark("bootstrap.rowsWritten", rowsWritten)
+  capture.mark("bootstrap.rowsSkipped", rowsSkipped)
 
   // Clean up stale entities: anything in IDB for this workspace that
   // wasn't in the bootstrap AND was written before this bootstrap.
@@ -2652,40 +2783,23 @@ export async function applyWorkspaceBootstrap(
   // empty arrays for one render cycle until the async IDB read resolves.
   const stopSeed = capture.time("bootstrap.seed")
   seedWorkspaceCache(workspaceId, {
-    workspace: { ...bootstrap.workspace, _cachedAt: now },
-    users: bootstrap.users.map((u) => ({ ...u, _cachedAt: now })),
-    streams: [
-      ...bootstrap.streams.map((s) => ({
-        ...s,
-        notificationLevel: membershipByStream.get(s.id)?.notificationLevel,
-        _cachedAt: now,
-      })),
-      // Archived roots must be in the synchronous seed too, or the first paint
-      // can't tell a stream is archived until the IDB read resolves — a
-      // one-frame flash of archived-root drafts (INV-21-adjacent).
-      ...mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now),
-    ],
-    memberships: bootstrap.streamMemberships.map((sm) => ({
-      ...sm,
-      id: `${workspaceId}:${sm.streamId}`,
-      workspaceId,
-      _cachedAt: now,
-    })),
+    workspace: mergedWorkspace,
+    users: mergedUsers,
+    // Archived roots must be in the synchronous seed too, or the first paint
+    // can't tell a stream is archived until the IDB read resolves — a
+    // one-frame flash of archived-root drafts (INV-21-adjacent).
+    streams: mergedStreams,
+    memberships: mergedMemberships,
     // An omitted map leaves the in-memory rows in place (nothing was written);
     // a present map seeds IDB's effective contents — server rows plus every
     // local row the member-only map omits (nonmember thread lazy state) and
     // every frontier preserved as touched during the fetch window.
     readStates: seedReadStates,
-    dmPeers: bootstrap.dmPeers.map((dp) => ({
-      ...dp,
-      id: `${workspaceId}:${dp.streamId}`,
-      workspaceId,
-      _cachedAt: now,
-    })),
-    personas: bootstrap.personas.map((p) => ({ ...p, workspaceId, _cachedAt: now })),
-    bots: bootstrap.bots.map((b) => ({ ...b, workspaceId, _cachedAt: now })),
-    labels: bootstrap.labels.map((l) => ({ ...l, _cachedAt: now })),
-    labelAssignments: bootstrap.labelAssignments.map(assignmentToCached),
+    dmPeers: mergedDmPeers,
+    personas: mergedPersonas,
+    bots: mergedBots,
+    labels: mergedLabels,
+    labelAssignments: mergedLabelAssignments,
     unreadState: {
       id: workspaceId,
       workspaceId,
@@ -2752,6 +2866,9 @@ export async function applyReconnectBootstrapBatch(
   streamBootstraps: Map<string, StreamBootstrap>
 }> {
   const now = Date.now()
+  const capture = getPerfCapture()
+  let rowsWritten = 0
+  let rowsSkipped = 0
 
   const [localStreams, localMemberships, localReadStates, localUnreadState] = await Promise.all([
     db.streams.where("workspaceId").equals(workspaceId).toArray(),
@@ -2772,12 +2889,83 @@ export async function applyReconnectBootstrapBatch(
     fetchStartedAt,
   })
 
+  const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
+
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 
   // See applyWorkspaceBootstrap: preserve a sidebar config written by a
   // `sidebar_config:updated` event during the fetch window rather than seeding
   // (and returning) the older snapshot.
   let effectiveSidebarConfig = finalBootstrap.sidebarConfig
+
+  const workspaceRow = { ...finalBootstrap.workspace, _cachedAt: now }
+  const userRows = finalBootstrap.users.map((user) => ({ ...user, _cachedAt: now }))
+  const streamRows = dedupeById<CachedStream>([
+    ...finalBootstrap.streams.map((stream) => {
+      const membership = membershipByStream.get(stream.id)
+      const local = localStreams.find((s) => s.id === stream.id)
+      return {
+        ...stream,
+        notificationLevel: membership?.notificationLevel,
+        // Preserve fields workspace-bootstrap doesn't carry but
+        // stream-bootstrap mirrors locally (`contextBag` is the
+        // canonical example — see `applyStreamBootstrap`).
+        contextBag: local?.contextBag,
+        _cachedAt: now,
+      }
+    }),
+    // Persist archived roots on reconnect too (mirrors applyWorkspaceBootstrap).
+    ...mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], byId(localStreams), now),
+  ])
+  const membershipRows = finalBootstrap.streamMemberships.map((membership) => ({
+    ...membership,
+    id: `${workspaceId}:${membership.streamId}`,
+    workspaceId,
+    _cachedAt: now,
+  }))
+  const readStateRows = toCachedReadStates(workspaceId, finalBootstrap.streamReadState, now)
+  const dmPeerRows = finalBootstrap.dmPeers.map((dmPeer) => ({
+    ...dmPeer,
+    id: `${workspaceId}:${dmPeer.streamId}`,
+    workspaceId,
+    _cachedAt: now,
+  }))
+  const personaRows = finalBootstrap.personas.map((persona) => ({ ...persona, workspaceId, _cachedAt: now }))
+  const botRows = finalBootstrap.bots.map((bot) => ({ ...bot, workspaceId, _cachedAt: now }))
+  const labelRows = finalBootstrap.labels.map((label) => ({ ...label, _cachedAt: now }))
+  const labelAssignmentRows = finalBootstrap.labelAssignments.map(assignmentToCached)
+  const unreadRow = {
+    id: workspaceId,
+    workspaceId,
+    unreadCounts: finalBootstrap.unreadCounts,
+    ...bootstrapActivityCacheFields(finalBootstrap),
+    latestOrdinals: finalBootstrap.messageCounts,
+    readMessageIds: finalBootstrap.readMessageIds,
+    mutedStreamIds: finalBootstrap.mutedStreamIds,
+    counterTouchedAt: pruneCounterTouches(localUnreadState?.counterTouchedAt, fetchStartedAt),
+    mutedTouchedAt: pruneCounterTouches(localUnreadState?.mutedTouchedAt, fetchStartedAt),
+    _cachedAt: now,
+  }
+  const metadataRow = {
+    id: workspaceId,
+    workspaceId,
+    emojis: finalBootstrap.emojis,
+    emojiWeights: finalBootstrap.emojiWeights,
+    commands: finalBootstrap.commands,
+    configuredToolCategories: finalBootstrap.configuredToolCategories,
+    featureFlags: finalBootstrap.featureFlags,
+    _cachedAt: now,
+  }
+
+  let mergedWorkspace: CachedWorkspace = workspaceRow
+  let mergedUsers: CachedWorkspaceUser[] = userRows
+  let mergedStreams: CachedStream[] = streamRows
+  let mergedMemberships: CachedStreamMembership[] = membershipRows
+  let mergedDmPeers: CachedDmPeer[] = dmPeerRows
+  let mergedPersonas: CachedPersona[] = personaRows
+  let mergedBots: CachedBot[] = botRows
+  let mergedLabels: CachedLabel[] = labelRows
+  let mergedLabelAssignments: CachedLabelAssignment[] = labelAssignmentRows
 
   await db.transaction(
     "rw",
@@ -2802,91 +2990,147 @@ export async function applyReconnectBootstrapBatch(
       db.slots,
     ],
     async () => {
+      const [
+        existingWorkspace,
+        existingUsers,
+        existingStreams,
+        existingMemberships,
+        existingReadStates,
+        existingDmPeers,
+        existingPersonas,
+        existingBots,
+        existingLabels,
+        existingLabelAssignments,
+        existingUnread,
+        existingMetadata,
+      ] = diffEnabled
+        ? await Promise.all([
+            db.workspaces.get(workspaceId),
+            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+            db.streams.where("workspaceId").equals(workspaceId).toArray(),
+            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+            db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
+            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+            db.personas.where("workspaceId").equals(workspaceId).toArray(),
+            db.bots.where("workspaceId").equals(workspaceId).toArray(),
+            db.labels.where("workspaceId").equals(workspaceId).toArray(),
+            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+            db.unreadState.get(workspaceId),
+            db.workspaceMetadata.get(workspaceId),
+          ])
+        : [undefined, [], [], [], [], [], [], [], [], [], undefined, undefined]
+
+      const stopDiff = capture.time("bootstrap.diff")
+      const workspaceDiff = diffEnabled
+        ? diffSingleton(existingWorkspace, workspaceRow)
+        : { write: true, merged: workspaceRow }
+      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
+      const streamsDiff = diffEnabled ? diffRows(byId(existingStreams), streamRows) : writeAllRows(streamRows)
+      const membershipsDiff = diffEnabled
+        ? diffRows(byId(existingMemberships), membershipRows)
+        : writeAllRows(membershipRows)
+      const readStatesDiff = diffEnabled
+        ? diffRows(byId(existingReadStates), readStateRows)
+        : writeAllRows(readStateRows)
+      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
+      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
+      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
+      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
+      const labelAssignmentsDiff = diffEnabled
+        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+        : writeAllRows(labelAssignmentRows)
+      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
+      const metadataDiff = diffEnabled
+        ? diffSingleton(existingMetadata, metadataRow)
+        : { write: true, merged: metadataRow }
+      stopDiff()
+
+      mergedWorkspace = workspaceDiff.merged
+      mergedUsers = usersDiff.merged
+      mergedStreams = streamsDiff.merged
+      mergedMemberships = membershipsDiff.merged
+      mergedDmPeers = dmPeersDiff.merged
+      mergedPersonas = personasDiff.merged
+      mergedBots = botsDiff.merged
+      mergedLabels = labelsDiff.merged
+      mergedLabelAssignments = labelAssignmentsDiff.merged
+      recordSkippedRowConfirmations(workspaceId, "streams", streamsDiff, now)
+      recordSkippedRowConfirmations(workspaceId, "streamMemberships", membershipsDiff, now)
+      recordSkippedRowConfirmations(workspaceId, "streamReadState", readStatesDiff, now)
+      rowsSkipped +=
+        usersDiff.skipped +
+        streamsDiff.skipped +
+        membershipsDiff.skipped +
+        readStatesDiff.skipped +
+        dmPeersDiff.skipped +
+        personasDiff.skipped +
+        botsDiff.skipped +
+        labelsDiff.skipped +
+        labelAssignmentsDiff.skipped +
+        (workspaceDiff.write ? 0 : 1) +
+        (unreadDiff.write ? 0 : 1) +
+        (metadataDiff.write ? 0 : 1)
+      rowsWritten +=
+        usersDiff.toWrite.length +
+        streamsDiff.toWrite.length +
+        membershipsDiff.toWrite.length +
+        readStatesDiff.toWrite.length +
+        dmPeersDiff.toWrite.length +
+        personasDiff.toWrite.length +
+        botsDiff.toWrite.length +
+        labelsDiff.toWrite.length +
+        labelAssignmentsDiff.toWrite.length +
+        (workspaceDiff.write ? 1 : 0) +
+        (unreadDiff.write ? 1 : 0) +
+        (metadataDiff.write ? 1 : 0)
+
       await Promise.all([
-        db.workspaces.put({ ...finalBootstrap.workspace, _cachedAt: now }),
-        db.workspaceUsers.bulkPut(finalBootstrap.users.map((user) => ({ ...user, _cachedAt: now }))),
-        db.streams.bulkPut(
-          finalBootstrap.streams.map((stream) => {
-            const membership = membershipByStream.get(stream.id)
-            const local = localStreams.find((s) => s.id === stream.id)
-            return {
-              ...stream,
-              notificationLevel: membership?.notificationLevel,
-              // Preserve fields workspace-bootstrap doesn't carry but
-              // stream-bootstrap mirrors locally (`contextBag` is the
-              // canonical example — see `applyStreamBootstrap`).
-              contextBag: local?.contextBag,
-              _cachedAt: now,
-            }
-          })
-        ),
-        // Persist archived roots on reconnect too (mirrors applyWorkspaceBootstrap).
-        db.streams.bulkPut(
-          mapArchivedStreamRows(finalBootstrap.archivedStreams ?? [], new Map(localStreams.map((s) => [s.id, s])), now)
-        ),
-        db.streamMemberships.bulkPut(
-          finalBootstrap.streamMemberships.map((membership) => ({
-            ...membership,
-            id: `${workspaceId}:${membership.streamId}`,
-            workspaceId,
-            _cachedAt: now,
-          }))
-        ),
-        db.streamReadState.bulkPut(toCachedReadStates(workspaceId, finalBootstrap.streamReadState, now)),
-        db.dmPeers.bulkPut(
-          finalBootstrap.dmPeers.map((dmPeer) => ({
-            ...dmPeer,
-            id: `${workspaceId}:${dmPeer.streamId}`,
-            workspaceId,
-            _cachedAt: now,
-          }))
-        ),
-        db.personas.bulkPut(finalBootstrap.personas.map((persona) => ({ ...persona, workspaceId, _cachedAt: now }))),
-        db.bots.bulkPut(finalBootstrap.bots.map((bot) => ({ ...bot, workspaceId, _cachedAt: now }))),
-        db.labels.bulkPut(finalBootstrap.labels.map((label) => ({ ...label, _cachedAt: now }))),
-        db.labelAssignments.bulkPut(finalBootstrap.labelAssignments.map(assignmentToCached)),
-        db.unreadState.put({
-          id: workspaceId,
-          workspaceId,
-          unreadCounts: finalBootstrap.unreadCounts,
-          ...bootstrapActivityCacheFields(finalBootstrap),
-          latestOrdinals: finalBootstrap.messageCounts,
-          readMessageIds: finalBootstrap.readMessageIds,
-          mutedStreamIds: finalBootstrap.mutedStreamIds,
-          counterTouchedAt: pruneCounterTouches(localUnreadState?.counterTouchedAt, fetchStartedAt),
-          mutedTouchedAt: pruneCounterTouches(localUnreadState?.mutedTouchedAt, fetchStartedAt),
-          _cachedAt: now,
-        }),
-        db.workspaceMetadata.put({
-          id: workspaceId,
-          workspaceId,
-          emojis: finalBootstrap.emojis,
-          emojiWeights: finalBootstrap.emojiWeights,
-          commands: finalBootstrap.commands,
-          configuredToolCategories: finalBootstrap.configuredToolCategories,
-          featureFlags: finalBootstrap.featureFlags,
-          _cachedAt: now,
-        }),
+        workspaceDiff.write ? db.workspaces.put(workspaceRow) : Promise.resolve(),
+        usersDiff.toWrite.length > 0 ? db.workspaceUsers.bulkPut(usersDiff.toWrite) : Promise.resolve(),
+        streamsDiff.toWrite.length > 0 ? db.streams.bulkPut(streamsDiff.toWrite) : Promise.resolve(),
+        membershipsDiff.toWrite.length > 0 ? db.streamMemberships.bulkPut(membershipsDiff.toWrite) : Promise.resolve(),
+        readStatesDiff.toWrite.length > 0 ? db.streamReadState.bulkPut(readStatesDiff.toWrite) : Promise.resolve(),
+        dmPeersDiff.toWrite.length > 0 ? db.dmPeers.bulkPut(dmPeersDiff.toWrite) : Promise.resolve(),
+        personasDiff.toWrite.length > 0 ? db.personas.bulkPut(personasDiff.toWrite) : Promise.resolve(),
+        botsDiff.toWrite.length > 0 ? db.bots.bulkPut(botsDiff.toWrite) : Promise.resolve(),
+        labelsDiff.toWrite.length > 0 ? db.labels.bulkPut(labelsDiff.toWrite) : Promise.resolve(),
+        labelAssignmentsDiff.toWrite.length > 0
+          ? db.labelAssignments.bulkPut(labelAssignmentsDiff.toWrite)
+          : Promise.resolve(),
+        unreadDiff.write ? db.unreadState.put(unreadRow) : Promise.resolve(),
+        metadataDiff.write ? db.workspaceMetadata.put(metadataRow) : Promise.resolve(),
       ])
 
       const existingUserPreferences = await db.userPreferences.get(workspaceId)
       if (!existingUserPreferences || !fetchStartedAt || existingUserPreferences._cachedAt < fetchStartedAt) {
-        await db.userPreferences.put({
+        const prefsRow = {
           ...finalBootstrap.userPreferences,
           id: workspaceId,
           workspaceId,
           _cachedAt: now,
-        })
+        }
+        if (!diffEnabled || !existingUserPreferences || !semanticEqual(existingUserPreferences, prefsRow)) {
+          rowsWritten += 1
+          await db.userPreferences.put(prefsRow)
+        } else {
+          rowsSkipped += 1
+        }
       }
 
       const existingSidebarConfig = await db.sidebarConfigs.get(workspaceId)
       if (!existingSidebarConfig || !fetchStartedAt || existingSidebarConfig._cachedAt < fetchStartedAt) {
-        await db.sidebarConfigs.put({
+        const sidebarRow = {
           id: workspaceId,
           workspaceId,
           config: finalBootstrap.sidebarConfig,
           _cachedAt: now,
-        })
+        }
+        if (!diffEnabled || !existingSidebarConfig || !semanticEqual(existingSidebarConfig, sidebarRow)) {
+          rowsWritten += 1
+          await db.sidebarConfigs.put(sidebarRow)
+        } else {
+          rowsSkipped += 1
+        }
       } else {
         effectiveSidebarConfig = existingSidebarConfig.config
       }
@@ -2911,36 +3155,21 @@ export async function applyReconnectBootstrapBatch(
     }
   )
 
+  capture.mark("bootstrap.rowsWritten", rowsWritten)
+  capture.mark("bootstrap.rowsSkipped", rowsSkipped)
+
   if (fetchStartedAt !== undefined) {
     await cleanupStaleEntities(workspaceId, finalBootstrap, fetchStartedAt)
   }
 
   seedWorkspaceCache(workspaceId, {
-    workspace: { ...finalBootstrap.workspace, _cachedAt: now },
-    users: finalBootstrap.users.map((user) => ({ ...user, _cachedAt: now })),
-    streams: [
-      ...finalBootstrap.streams.map((stream) => ({
-        ...stream,
-        notificationLevel: membershipByStream.get(stream.id)?.notificationLevel,
-        _cachedAt: now,
-      })),
-      // Mirrors applyWorkspaceBootstrap: archived roots ride the seed so the
-      // first paint after reconnect knows they're archived (no draft flash).
-      // An archived stream open during reconnect can also land in the merged
-      // streams list via its per-stream bootstrap — skip those ids so the seed
-      // never carries duplicates.
-      ...mapArchivedStreamRows(
-        (finalBootstrap.archivedStreams ?? []).filter((s) => !finalBootstrap.streams.some((a) => a.id === s.id)),
-        new Map(localStreams.map((s) => [s.id, s])),
-        now
-      ),
-    ],
-    memberships: finalBootstrap.streamMemberships.map((membership) => ({
-      ...membership,
-      id: `${workspaceId}:${membership.streamId}`,
-      workspaceId,
-      _cachedAt: now,
-    })),
+    workspace: mergedWorkspace,
+    users: mergedUsers,
+    // Archived roots ride the seed (mirrors applyWorkspaceBootstrap) so the
+    // first paint after reconnect knows they're archived (no draft flash) —
+    // they are already deduped into the merged streams list.
+    streams: mergedStreams,
+    memberships: mergedMemberships,
     // A present map seeds IDB's effective contents: the merged map's rows win
     // per stream, but local rows the member-only map omits (nonmember thread
     // lazy state) stay seeded — the apply upserts, it never sweeps. Terminal
@@ -2952,16 +3181,11 @@ export async function applyReconnectBootstrapBatch(
           toCachedReadStates(workspaceId, finalBootstrap.streamReadState, now)
         )
       : undefined,
-    dmPeers: finalBootstrap.dmPeers.map((dmPeer) => ({
-      ...dmPeer,
-      id: `${workspaceId}:${dmPeer.streamId}`,
-      workspaceId,
-      _cachedAt: now,
-    })),
-    personas: finalBootstrap.personas.map((persona) => ({ ...persona, workspaceId, _cachedAt: now })),
-    bots: finalBootstrap.bots.map((bot) => ({ ...bot, workspaceId, _cachedAt: now })),
-    labels: finalBootstrap.labels.map((label) => ({ ...label, _cachedAt: now })),
-    labelAssignments: finalBootstrap.labelAssignments.map(assignmentToCached),
+    dmPeers: mergedDmPeers,
+    personas: mergedPersonas,
+    bots: mergedBots,
+    labels: mergedLabels,
+    labelAssignments: mergedLabelAssignments,
     unreadState: {
       id: workspaceId,
       workspaceId,
@@ -3012,6 +3236,12 @@ export async function applyReconnectBootstrapBatch(
   return { workspaceBootstrap: finalBootstrap, streamBootstraps }
 }
 
+// Every keep-set below derives from the BOOTSTRAP PAYLOAD, never from the set of
+// rows the apply actually wrote. Under `bootstrapDiff` a row present in the
+// payload can be skipped and keep an old `_cachedAt` — narrowing these sets to
+// "the ids we wrote" would sweep exactly those rows. Presence in the payload is
+// the protection; `_cachedAt >= now` only shields rows the payload never
+// enumerated (concurrent socket writes during the fetch window).
 async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBootstrap, now: number): Promise<void> {
   // Archived roots ride in bootstrap.archivedStreams (absent from .streams);
   // keep them so the absence-sweep doesn't delete rows every consumer still

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,6 +54,7 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
+  bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -19,6 +19,8 @@ export const PERF_MARK_NAMES = [
   "bootstrap.seed",
   "bootstrap.publish",
   "bootstrap.rowsWritten",
+  "bootstrap.rowsSkipped",
+  "bootstrap.diff",
   "catchup.entryApply",
   "catchup.replay",
   "catchup.collapse",


### PR DESCRIPTION
## Problem

`applyWorkspaceBootstrap` writes every row of a 14-table snapshot unconditionally, stamped `_cachedAt: now`, on every warm refresh and reconnect. Production captures from the affected phone put numbers on it: `bootstrap.rowsWritten` **1,009 on a semantically-warm refresh**, `bootstrap.tx` 322–725ms, and (with cleanup + catch-up) a ~3s main-thread apply wave on every PWA relaunch — the reported "PowerPoint" moment. Three amplifiers ride the writes: Dexie 4.4.2 full-range-invalidates a table on any ≥50-row `bulkPut`, one coarse cache signal wakes 10 workspace hooks wrapping the whole app, and the TanStack bootstrap object is replaced wholesale. Plan-PR 7, chunk 1/3 ([plan](https://seer.build/ws_vbyzjvdg6g/b/pr7-plan-55fcba/)).

## Solution

Diff before writing, behind a `bootstrapDiff` flag (default off — the off path short-circuits into the previous unconditional writes).

- **`bootstrap-diff.ts`** (pure): `semanticEqual` — key-order-insensitive, `undefined`-tolerant, `_cachedAt`-blind (`JSON.stringify` equality is the trap: IDB preserves insertion order, and socket-written rows carry a different key order than bootstrap spreads). `diffRows`/`diffSingleton` return identity-preserving merges: unchanged rows keep the *existing object*, so downstream memos keep row identity (#834/#835 preserved).
- **Atomicity (INV-20):** all 14 pre-reads moved inside the `rw` transaction — read→compare→write cannot interleave with a socket write. Consequence: `bootstrap.preRead` now nests inside `bootstrap.tx`; before/after captures must compare the sum.
- **The sweep is untouched and safe by construction:** `cleanupStaleEntities`' keep-sets derive from the bootstrap *payload*, never from written rows — a skipped row is protected by set membership, not freshness. Pinned by test + the one comment this PR adds; the adversarial pass also probe-verified the shrinking-payload case.
- **The reproduced regression and its fix:** six gate sites (`mergeReconnectWorkspaceBootstrap` streams/memberships/readState, `persistBootstrapReadState`, `applyWorkspaceBootstrap`'s own frontier merge, and `readStateTouchedSince`) use `_cachedAt >= fetchStartedAt` as local-wins authority; frozen stamps let an older reconnect snapshot regress a skipped row (the verifier reproduced a read frontier going "9"→"2"). Fixed with an in-memory row-confirmation registry: skipped rows in those three tables record their confirmation with **no IDB write**, and the gates consult `max(stamp, confirmation)`. The reproduced scenario is now a permanent test.
- Both apply paths (warm + reconnect) are diffed and measured (`bootstrap.rowsWritten` true count, `bootstrap.rowsSkipped`, `bootstrap.diff`).
- Off-path deltas, stated for capture-reading honesty: active+archived streams merge into one deduped write (same winner as the old sequential pair), the seed carries `contextBag` on active rows (removes a one-frame empty-bag flash), and `rowsWritten` is now a true count (previously payload arithmetic). Known cost, deferred to on-device measurement per the plan's gate: the `workspaceMetadata` compare walks the 1,914-entry emoji catalog (~55% of `bootstrap.diff`, ~1ms desktop) — if the phone capture shows `bootstrap.diff` material, the catalog gets a cheaper compare before the flag turns on.

## Test plan

- [x] frontend 5714/0 (18 new chunk tests incl. the acceptance "second identical bootstrap writes no rows", the D5 sweep pin, the reconnect-regression pair, kill-switch proof; every new test neutralize→red→restore verified — the D5 neutralization and the confirmation-registry neutralization both observed red)
- [x] packages/types 151/0 · root typecheck 0 errors · lint + 251 migrations clean
- [x] adversarial verify (Opus high, self-score 85): 7 findings — 1 reproduced major + 6 minor, all fixed or dispositioned in-body
- [ ] on-device A/B capture (flag off/on, same fixture) — chunk 3 ships the wide fixture that makes it measurable

<details>
<summary>📋 Full implementation plan</summary>

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr7-plan-55fcba/ — 17 design decisions; D6 amended after the chunk-1 adversarial verify (the frozen-`_cachedAt` reader audit was incomplete — the confirmation registry is the amendment). Chunks: (1) this diff, (2) publication gating, (3) the `workspace-wide` fixture + browser proof.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788296861&installation_model_id=20758&pr_number=1735&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1735&signature=b94d5f38b486e2b71fed07b8ab8878c8e49c44ad070b9baae4f52b991e9a0f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
