### PR TITLE
feat(sync): gate bootstrap publications — one signal, one object, only when something changed

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -17,6 +17,11 @@ import * as loadingComponentsModule from "@/components/loading"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import * as e2eSessionModule from "@/stores/e2e-session-store"
 import { clearStreamNameCache, primeStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
+import { db } from "@/db"
+import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
+import { resetRowConfirmations } from "@/sync/bootstrap-diff"
+import { makeStreamBootstrap, makeWorkspaceBootstrap } from "@/test/fixtures/sync-engine"
+import type { WorkspaceBootstrap } from "@threa/types"
 
 type MockQueryResult = {
   status: "pending" | "success" | "error"
@@ -833,5 +838,173 @@ describe("MainContentGate", () => {
 
     expect(screen.queryByTestId("stream-content-skeleton")).not.toBeInTheDocument()
     expect(screen.getByTestId("content")).toBeInTheDocument()
+  })
+})
+
+describe("CoordinatedLoadingProvider store publication", () => {
+  // The real workspace-store hooks, so the provider is woken (or not) by the
+  // real publication signal — the 10-hook fan-out this gating exists to stop.
+  const WS = "ws_clp"
+
+  function installNonStoreSpies(): void {
+    vi.spyOn(syncStatusModule, "useSyncStatus").mockReturnValue("synced")
+    vi.spyOn(syncStatusModule, "useSyncSnapshot").mockReturnValue({
+      statuses: new Map() as ReadonlyMap<string, syncStatusModule.SyncStatus>,
+      errors: new Map() as ReadonlyMap<string, syncStatusModule.SyncErrorRecord>,
+    })
+    vi.spyOn(useCoordinatedStreamQueriesModule, "useCoordinatedStreamQueries").mockImplementation(
+      () =>
+        ({
+          loadState: QUERY_LOAD_STATE.READY,
+          isLoading: false,
+          isError: false,
+          errors: [],
+          results: [],
+        }) as unknown as ReturnType<typeof useCoordinatedStreamQueriesModule.useCoordinatedStreamQueries>
+    )
+    vi.spyOn(usePreloadImagesModule, "usePreloadImages").mockReturnValue(true)
+    vi.spyOn(draftStoreModule, "seedDraftCacheFromIdb").mockImplementation(async () => undefined)
+    vi.spyOn(draftStoreModule, "hasSeededDraftCache").mockReturnValue(true)
+    vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("user_1")
+    vi.spyOn(e2eSessionModule, "useE2eSession").mockImplementation(
+      () =>
+        ({
+          status: "no-key",
+          keyId: null,
+          publicKey: null,
+          privateKey: null,
+          deviceTrusted: false,
+          error: null,
+        }) as e2eSessionModule.E2eSessionState
+    )
+  }
+
+  function diffBootstrap(): WorkspaceBootstrap {
+    return structuredClone(bootstrapBase)
+  }
+
+  let bootstrapBase: WorkspaceBootstrap
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    installNonStoreSpies()
+    workspaceStoreModule.resetWorkspaceStoreCache()
+    resetRowConfirmations()
+    await Promise.all([
+      db.workspaces.clear(),
+      db.workspaceUsers.clear(),
+      db.streams.clear(),
+      db.streamMemberships.clear(),
+      db.streamReadState.clear(),
+      db.dmPeers.clear(),
+      db.personas.clear(),
+      db.bots.clear(),
+      db.labels.clear(),
+      db.labelAssignments.clear(),
+      db.unreadState.clear(),
+      db.userPreferences.clear(),
+      db.sidebarConfigs.clear(),
+      db.workspaceMetadata.clear(),
+    ])
+    const now = new Date().toISOString()
+    bootstrapBase = {
+      ...makeWorkspaceBootstrap(),
+      workspace: { id: WS, name: "CLP", slug: "clp", createdBy: "user_1", createdAt: now, updatedAt: now },
+      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
+      users: [
+        {
+          id: "user_1",
+          workspaceId: WS,
+          workosUserId: "workos_1",
+          email: "kris@example.com",
+          role: "owner",
+          slug: "kris",
+          name: "Kris",
+          description: null,
+          avatarUrl: null,
+          timezone: null,
+          locale: null,
+          pronouns: null,
+          phone: null,
+          githubUsername: null,
+          statusEmoji: null,
+          statusText: null,
+          statusExpiresAt: null,
+          statusPausesNotifications: false,
+          notificationsPausedUntil: null,
+          notificationsPausedIndefinitely: false,
+          setupCompleted: true,
+          joinedAt: now,
+        },
+      ] as unknown as WorkspaceBootstrap["users"],
+      streams: [
+        { ...makeStreamBootstrap("stream_clp1").stream, workspaceId: WS, lastMessagePreview: null },
+      ] as unknown as WorkspaceBootstrap["streams"],
+      streamMemberships: [
+        { streamId: "stream_clp1", memberId: "user_1", notificationLevel: null, joinedAt: now },
+      ] as unknown as WorkspaceBootstrap["streamMemberships"],
+    }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("an unchanged bootstrap apply does not re-render the coordinated-loading provider", async () => {
+    // One of the provider's 10 store hooks, wrapped rather than replaced: each
+    // call is one provider render pass.
+    const realUseWorkspaceUsers = workspaceStoreModule.useWorkspaceUsers
+    let providerRenders = 0
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockImplementation((workspaceId) => {
+      providerRenders += 1
+      return realUseWorkspaceUsers(workspaceId)
+    })
+
+    await applyWorkspaceBootstrap(WS, diffBootstrap(), Date.now() - 5000)
+
+    render(
+      <CoordinatedLoadingProvider workspaceId={WS} streamIds={[]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const before = providerRenders
+
+    await act(async () => {
+      await applyWorkspaceBootstrap(WS, diffBootstrap(), Date.now())
+    })
+
+    expect(providerRenders).toBe(before)
+  })
+
+  it("a changed row re-renders the coordinated-loading provider exactly once", async () => {
+    const realUseWorkspaceUsers = workspaceStoreModule.useWorkspaceUsers
+    let providerRenders = 0
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockImplementation((workspaceId) => {
+      providerRenders += 1
+      return realUseWorkspaceUsers(workspaceId)
+    })
+
+    await applyWorkspaceBootstrap(WS, diffBootstrap(), Date.now() - 5000)
+
+    render(
+      <CoordinatedLoadingProvider workspaceId={WS} streamIds={[]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const before = providerRenders
+
+    const changed = diffBootstrap()
+    changed.users = changed.users.map((u) => ({ ...u, name: "Renamed" }))
+    await act(async () => {
+      await applyWorkspaceBootstrap(WS, changed, Date.now())
+    })
+
+    expect(providerRenders).toBe(before + 1)
   })
 })

--- a/apps/frontend/src/hooks/use-personas.ts
+++ b/apps/frontend/src/hooks/use-personas.ts
@@ -6,10 +6,33 @@ import type {
   PersonaCustomConfig,
   PersonaKind,
   PersonaListItem,
+  WorkspaceBootstrap,
 } from "@threa/types"
 import { personasApi } from "@/api"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import { cachedPersonaFromListItem } from "@/lib/personas"
 import { upsertWorkspacePersonaCache } from "@/stores/workspace-store"
+
+/**
+ * Mirror a store persona upsert into the bootstrap query cache. The publication
+ * gate diffs the store against the bootstrap snapshot, so a writer that patches
+ * only the store leaves the cache stale behind an `anyChanged=false` apply when
+ * the reconciling broadcast is lost. Same upsert-by-id rule as the
+ * `agent_config:updated` handler: merge the light display fields onto an
+ * existing row, else insert the synthesized row.
+ */
+function upsertBootstrapPersona(queryClient: QueryClient, workspaceId: string, item: PersonaListItem): void {
+  const { id, slug, name, description, avatarEmoji, avatarUrl, model, status } = item
+  const patch = { slug, name, description, avatarEmoji, avatarUrl, model, status }
+  queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (prev) => {
+    if (!prev) return prev
+    const personas = prev.personas ?? []
+    if (personas.some((persona) => persona.id === id)) {
+      return { ...prev, personas: personas.map((persona) => (persona.id === id ? { ...persona, ...patch } : persona)) }
+    }
+    return { ...prev, personas: [...personas, cachedPersonaFromListItem(item, workspaceId)] }
+  })
+}
 
 export const personaKeys = {
   all: ["personas"] as const,
@@ -297,6 +320,7 @@ export function useForkPersona(workspaceId: string) {
     onSuccess: (persona, input) => {
       if (input.scope === "personal") {
         upsertWorkspacePersonaCache(workspaceId, cachedPersonaFromListItem(persona, workspaceId))
+        upsertBootstrapPersona(queryClient, workspaceId, persona)
         return
       }
       upsertIntoList(queryClient, personaKeys.list(workspaceId), persona)
@@ -338,6 +362,7 @@ export function useArchivePersona(workspaceId: string) {
       // the owner-room broadcast (the durable reconcile) is in flight.
       if (persona.kind === "personal") {
         upsertWorkspacePersonaCache(workspaceId, cachedPersonaFromListItem(persona, workspaceId))
+        upsertBootstrapPersona(queryClient, workspaceId, persona)
       }
     },
   })
@@ -356,6 +381,7 @@ export function useUnarchivePersona(workspaceId: string) {
       removeFromList(queryClient, personaKeys.archived(workspaceId), persona.id)
       if (persona.kind === "personal") {
         upsertWorkspacePersonaCache(workspaceId, cachedPersonaFromListItem(persona, workspaceId))
+        upsertBootstrapPersona(queryClient, workspaceId, persona)
         return
       }
       upsertIntoList(queryClient, personaKeys.list(workspaceId), persona)

--- a/apps/frontend/src/hooks/use-workspace-member-management.test.tsx
+++ b/apps/frontend/src/hooks/use-workspace-member-management.test.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { WorkspaceBootstrap } from "@threa/types"
+import { workspaceMembersApi } from "@/api/workspace-members"
+import { db, type CachedWorkspaceUser } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { useChangeWorkspaceMemberRole } from "./use-workspace-member-management"
+
+const WS = "ws_members"
+const USER_ID = "usr_member"
+
+function makeUser(role: "owner" | "admin" | "member"): CachedWorkspaceUser {
+  return {
+    id: USER_ID,
+    workspaceId: WS,
+    workosUserId: "workos_1",
+    email: "kris@example.com",
+    role,
+    slug: "kris",
+    name: "Kris",
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-01-01T00:00:00Z",
+    _cachedAt: Date.now(),
+  }
+}
+
+describe("useChangeWorkspaceMemberRole", () => {
+  beforeEach(async () => {
+    await db.workspaceUsers.clear()
+  })
+
+  it("patches both the IDB row and the cached bootstrap's user entry", async () => {
+    await db.workspaceUsers.put(makeUser("member"))
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { _cachedAt, ...wireUser } = makeUser("member")
+    queryClient.setQueryData(workspaceKeys.bootstrap(WS), { users: [wireUser] } as unknown as WorkspaceBootstrap)
+
+    const changeRole = vi.spyOn(workspaceMembersApi, "changeRole").mockResolvedValue(undefined)
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => useChangeWorkspaceMemberRole(WS), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({ userId: USER_ID, roleSlug: "admin" })
+    })
+
+    await waitFor(async () => {
+      expect((await db.workspaceUsers.get(USER_ID))?.role).toBe("admin")
+    })
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(WS))?.users).toEqual([
+      { ...wireUser, role: "admin" },
+    ])
+    expect(changeRole).toHaveBeenCalledWith(WS, USER_ID, "admin")
+  })
+})

--- a/apps/frontend/src/hooks/use-workspace-member-management.ts
+++ b/apps/frontend/src/hooks/use-workspace-member-management.ts
@@ -1,12 +1,23 @@
-import { useMutation } from "@tanstack/react-query"
-import type { WorkspaceRoleSlug } from "@threa/types"
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query"
+import type { User, WorkspaceBootstrap, WorkspaceRoleSlug } from "@threa/types"
 import { workspaceMembersApi } from "@/api/workspace-members"
 import { db } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+
+// The bootstrap query cache mirrors the IDB tables the publication gate diffs;
+// an optimistic write that touches only IDB would leave the cache stale behind
+// an anyChanged=false apply if the reconciling broadcast is lost.
+function patchBootstrapUsers(queryClient: QueryClient, workspaceId: string, update: (users: User[]) => User[]): void {
+  queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (prev) =>
+    prev ? { ...prev, users: update(prev.users) } : prev
+  )
+}
 
 // Server is the source of truth; the regional event poller reconciles Dexie
 // within a few seconds, so optimistic writes only need to survive that
 // window.
 export function useChangeWorkspaceMemberRole(workspaceId: string) {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (params: { userId: string; roleSlug: WorkspaceRoleSlug }) => {
       await workspaceMembersApi.changeRole(workspaceId, params.userId, params.roleSlug)
@@ -18,19 +29,27 @@ export function useChangeWorkspaceMemberRole(workspaceId: string) {
         return { previousRole: current?.role ?? null }
       }
       await db.workspaceUsers.put({ ...current, role: roleSlug, _cachedAt: Date.now() })
+      patchBootstrapUsers(queryClient, workspaceId, (users) =>
+        users.map((user) => (user.id === userId ? { ...user, role: roleSlug } : user))
+      )
       return { previousRole: current.role }
     },
     onError: async (_err, { userId }, context) => {
       if (!context?.previousRole) return
+      const previousRole = context.previousRole
       const current = await db.workspaceUsers.get(userId)
       if (current) {
-        void db.workspaceUsers.put({ ...current, role: context.previousRole, _cachedAt: Date.now() })
+        void db.workspaceUsers.put({ ...current, role: previousRole, _cachedAt: Date.now() })
       }
+      patchBootstrapUsers(queryClient, workspaceId, (users) =>
+        users.map((user) => (user.id === userId ? { ...user, role: previousRole } : user))
+      )
     },
   })
 }
 
 export function useRemoveWorkspaceMember(workspaceId: string) {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (params: { userId: string }) => {
       await workspaceMembersApi.remove(workspaceId, params.userId)
@@ -41,11 +60,21 @@ export function useRemoveWorkspaceMember(workspaceId: string) {
       if (snapshot) {
         await db.workspaceUsers.delete(userId)
       }
-      return { snapshot }
+      const previousUser = queryClient
+        .getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
+        ?.users.find((user) => user.id === userId)
+      patchBootstrapUsers(queryClient, workspaceId, (users) => users.filter((user) => user.id !== userId))
+      return { snapshot, previousUser }
     },
     onError: (_err, _vars, context) => {
       if (context?.snapshot) {
         void db.workspaceUsers.put(context.snapshot)
+      }
+      const previousUser = context?.previousUser
+      if (previousUser) {
+        patchBootstrapUsers(queryClient, workspaceId, (users) =>
+          users.some((user) => user.id === previousUser.id) ? users : [...users, previousUser]
+        )
       }
     },
   })

--- a/apps/frontend/src/hooks/use-workspaces.ts
+++ b/apps/frontend/src/hooks/use-workspaces.ts
@@ -111,7 +111,7 @@ export function useWorkspaceBootstrap(workspaceId: string) {
       // Shred bootstrap into individual IDB tables (including unreadState +
       // userPreferences); cache the returned merged bootstrap so the query
       // cache carries the same counter values as IDB.
-      return await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)
+      return (await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)).bootstrap
     },
     // Keep terminal auth/not-found errors disabled to avoid loops.
     // Non-terminal errors can recover automatically on future attempts.

--- a/apps/frontend/src/stores/workspace-store.publication.test.ts
+++ b/apps/frontend/src/stores/workspace-store.publication.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { db, type CachedWorkspace, type CachedWorkspaceUser } from "@/db"
+import {
+  getCachedWorkspaceTables,
+  resetWorkspaceStoreCache,
+  seedCacheFromIdb,
+  seedWorkspaceCache,
+  subscribeWorkspaceCache,
+} from "./workspace-store"
+
+const WS = "ws_pub"
+
+function makeWorkspace(): CachedWorkspace {
+  return {
+    id: WS,
+    name: "Publication",
+    slug: "publication",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    _cachedAt: Date.now(),
+  }
+}
+
+function makeUser(name: string): CachedWorkspaceUser {
+  return {
+    id: "user_1",
+    workspaceId: WS,
+    workosUserId: "workos_1",
+    email: "kris@example.com",
+    role: "owner",
+    slug: "kris",
+    name,
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-01-01T00:00:00Z",
+    _cachedAt: Date.now(),
+  }
+}
+
+function seed(users: CachedWorkspaceUser[], options?: { publish?: boolean }): void {
+  seedWorkspaceCache(
+    WS,
+    {
+      workspace: makeWorkspace(),
+      users,
+      streams: [],
+      memberships: [],
+      dmPeers: [],
+      personas: [],
+      bots: [],
+    },
+    options
+  )
+}
+
+describe("seedWorkspaceCache publication gating", () => {
+  beforeEach(async () => {
+    resetWorkspaceStoreCache()
+    await Promise.all([db.workspaces.clear(), db.workspaceUsers.clear()])
+  })
+
+  it("seedWorkspaceCache with publish:false does not notify subscribers", () => {
+    let notifications = 0
+    const unsubscribe = subscribeWorkspaceCache(WS, () => {
+      notifications += 1
+    })
+
+    seed([makeUser("Kris")], { publish: false })
+
+    expect(notifications).toBe(0)
+    // ...and the data landed regardless: the gate is about waking readers.
+    expect(getCachedWorkspaceTables(WS).users).toHaveLength(1)
+    unsubscribe()
+  })
+
+  it("seedWorkspaceCache with publish:false still advances the write-ordering version", async () => {
+    // IDB holds the stale row; the cache is about to receive the fresh one from
+    // a non-publishing seed while seedCacheFromIdb is mid-flight.
+    await db.workspaces.put(makeWorkspace())
+    await db.workspaceUsers.put(makeUser("Stale"))
+
+    const idbSeed = seedCacheFromIdb(WS)
+    seed([makeUser("Fresh")], { publish: false })
+    await idbSeed
+
+    expect(getCachedWorkspaceTables(WS).users?.map((u) => u.name)).toEqual(["Fresh"])
+  })
+
+  it("a publishing seed notifies exactly once", () => {
+    let notifications = 0
+    const unsubscribe = subscribeWorkspaceCache(WS, () => {
+      notifications += 1
+    })
+
+    seed([makeUser("Kris")])
+
+    expect(notifications).toBe(1)
+    unsubscribe()
+  })
+})

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -57,7 +57,13 @@ const cache = {
 
 // Monotonic version per workspace so seedCacheFromIdb (async IDB read) never
 // overwrites a fresher seedWorkspaceCache call (synchronous bootstrap write).
+// ALWAYS bumped, including for a seed that publishes nothing: it orders writes,
+// it does not describe change.
 const cacheVersion = new Map<string, number>()
+
+// What `useSyncExternalStore` reads. Bumped only when a seed actually changed
+// something, so an unchanged bootstrap apply wakes no subscriber.
+const cacheSignal = new Map<string, number>()
 const cacheListeners = new Map<string, Set<() => void>>()
 
 function emitWorkspaceCacheChange(workspaceId: string): void {
@@ -66,7 +72,7 @@ function emitWorkspaceCacheChange(workspaceId: string): void {
   for (const listener of listeners) listener()
 }
 
-function subscribeWorkspaceCache(workspaceId: string | undefined, listener: () => void): () => void {
+export function subscribeWorkspaceCache(workspaceId: string | undefined, listener: () => void): () => void {
   if (!workspaceId) return () => {}
 
   let listeners = cacheListeners.get(workspaceId)
@@ -87,7 +93,12 @@ function subscribeWorkspaceCache(workspaceId: string | undefined, listener: () =
 }
 
 function getWorkspaceCacheSnapshot(workspaceId: string | undefined): number {
-  return workspaceId ? (cacheVersion.get(workspaceId) ?? 0) : 0
+  return workspaceId ? (cacheSignal.get(workspaceId) ?? 0) : 0
+}
+
+function publishWorkspaceCache(workspaceId: string): void {
+  cacheSignal.set(workspaceId, (cacheSignal.get(workspaceId) ?? 0) + 1)
+  emitWorkspaceCacheChange(workspaceId)
 }
 
 function useWorkspaceCacheSignal(workspaceId: string | undefined): number {
@@ -113,7 +124,7 @@ export function hasSeededWorkspaceCache(workspaceId: string): boolean {
 }
 
 export function resetWorkspaceStoreCache(): void {
-  const workspaceIds = new Set([...cacheVersion.keys(), ...cacheListeners.keys()])
+  const workspaceIds = new Set([...cacheVersion.keys(), ...cacheSignal.keys(), ...cacheListeners.keys()])
   cache.workspaces.clear()
   cache.users.clear()
   cache.streams.clear()
@@ -129,8 +140,11 @@ export function resetWorkspaceStoreCache(): void {
   cache.sidebarConfig.clear()
   cache.metadata.clear()
   cacheVersion.clear()
+  // cacheSignal is bumped, never cleared: resetting it to 0 and publishing 1
+  // reproduces a value a mounted subscriber may already hold, and
+  // useSyncExternalStore compares values — the reset would then not re-render.
   for (const workspaceId of workspaceIds) {
-    emitWorkspaceCacheChange(workspaceId)
+    publishWorkspaceCache(workspaceId)
   }
 }
 
@@ -226,9 +240,11 @@ export function seedWorkspaceCache(
     userPreferences?: CachedUserPreferences
     sidebarConfig?: CachedSidebarConfig
     metadata?: CachedWorkspaceMetadata
-  }
+  },
+  options?: { publish?: boolean }
 ): void {
-  // Bump version so concurrent seedCacheFromIdb calls know to skip.
+  // Bump version so concurrent seedCacheFromIdb calls know to skip. Always —
+  // the version orders writes; `publish` says whether anything changed.
   cacheVersion.set(workspaceId, (cacheVersion.get(workspaceId) ?? 0) + 1)
   cache.workspaces.set(workspaceId, data.workspace)
   cache.users.set(workspaceId, data.users)
@@ -244,7 +260,35 @@ export function seedWorkspaceCache(
   if (data.userPreferences) cache.userPreferences.set(workspaceId, data.userPreferences)
   if (data.sidebarConfig) cache.sidebarConfig.set(workspaceId, data.sidebarConfig)
   if (data.metadata) cache.metadata.set(workspaceId, data.metadata)
-  emitWorkspaceCacheChange(workspaceId)
+  if (options?.publish !== false) publishWorkspaceCache(workspaceId)
+}
+
+/**
+ * The arrays/singletons currently cached for a workspace, so an apply can hand
+ * back the very same reference for a table its diff found unchanged.
+ */
+export function getCachedWorkspaceTables(workspaceId: string): {
+  users?: CachedWorkspaceUser[]
+  streams?: CachedStream[]
+  memberships?: CachedStreamMembership[]
+  readStates?: CachedStreamReadState[]
+  dmPeers?: CachedDmPeer[]
+  personas?: CachedPersona[]
+  bots?: CachedBot[]
+  labels?: CachedLabel[]
+  labelAssignments?: CachedLabelAssignment[]
+} {
+  return {
+    users: cache.users.get(workspaceId),
+    streams: cache.streams.get(workspaceId),
+    memberships: cache.memberships.get(workspaceId),
+    readStates: cache.readStates.get(workspaceId),
+    dmPeers: cache.dmPeers.get(workspaceId),
+    personas: cache.personas.get(workspaceId),
+    bots: cache.bots.get(workspaceId),
+    labels: cache.labels.get(workspaceId),
+    labelAssignments: cache.labelAssignments.get(workspaceId),
+  }
 }
 
 /**
@@ -266,7 +310,7 @@ export function upsertWorkspaceUserInCache(workspaceId: string, user: CachedWork
   const exists = current.some((u) => u.id === user.id)
   cache.users.set(workspaceId, exists ? current.map((u) => (u.id === user.id ? user : u)) : [...current, user])
   cacheVersion.set(workspaceId, (cacheVersion.get(workspaceId) ?? 0) + 1)
-  emitWorkspaceCacheChange(workspaceId)
+  publishWorkspaceCache(workspaceId)
 }
 
 // Array-valued hooks read live from IDB but fall back to the in-memory
@@ -383,7 +427,7 @@ export function upsertWorkspacePersonaCache(workspaceId: string, persona: Cached
   const idx = rows.findIndex((p) => p.id === persona.id)
   cache.personas.set(workspaceId, idx >= 0 ? rows.map((p) => (p.id === persona.id ? persona : p)) : [...rows, persona])
   cacheVersion.set(workspaceId, (cacheVersion.get(workspaceId) ?? 0) + 1)
-  emitWorkspaceCacheChange(workspaceId)
+  publishWorkspaceCache(workspaceId)
   void db.personas.put(persona)
 }
 

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -196,8 +196,13 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
   if (!workspace) return false
 
   // If the version bumped during our async reads, a bootstrap completed
-  // and seeded fresher data — skip writing stale cache.
-  if ((cacheVersion.get(workspaceId) ?? 0) !== versionBefore) return true
+  // and seeded fresher data — skip writing stale cache. Still publish: that
+  // seed may have been publish:false (unchanged apply), and a subscriber that
+  // mounted cold before it would otherwise never learn the cache is populated.
+  if ((cacheVersion.get(workspaceId) ?? 0) !== versionBefore) {
+    publishWorkspaceCache(workspaceId)
+    return true
+  }
 
   seedWorkspaceCache(workspaceId, {
     workspace,

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -2145,3 +2145,135 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
     engine.destroy()
   })
 })
+
+describe("SyncEngine bootstrap query-cache identity (bootstrapDiff)", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    resetApplyWindow()
+    await Promise.all([
+      db.workspaces.clear(),
+      db.workspaceUsers.clear(),
+      db.streams.clear(),
+      db.streamMemberships.clear(),
+      db.streamReadState.clear(),
+      db.dmPeers.clear(),
+      db.personas.clear(),
+      db.bots.clear(),
+      db.labels.clear(),
+      db.labelAssignments.clear(),
+      db.unreadState.clear(),
+      db.userPreferences.clear(),
+      db.sidebarConfigs.clear(),
+      db.workspaceMetadata.clear(),
+    ])
+  })
+
+  // One frozen base, cloned per call: `makeWorkspaceBootstrap` stamps `new
+  // Date()` into createdAt/updatedAt, so two live calls are genuinely different
+  // payloads and nothing would compare unchanged.
+  let diffBase: WorkspaceBootstrap | undefined
+
+  function diffOnBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
+    diffBase ??= {
+      ...makeWorkspaceBootstrap(),
+      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
+      streams: [
+        {
+          ...makeStreamBootstrap("stream_id_1").stream,
+          lastMessagePreview: {
+            messageId: "msg_1",
+            content: "hello",
+            authorId: "user_1",
+            authorName: "Kris",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        },
+      ] as unknown as WorkspaceBootstrap["streams"],
+    }
+    return { ...structuredClone(diffBase), ...overrides }
+  }
+
+  /** Two warm applies of the same engine; `second` supplies the second payload. */
+  async function runTwoWarmBootstraps(second: () => WorkspaceBootstrap): Promise<{
+    deps: ReturnType<typeof makeDeps>
+    engine: SyncEngine
+    afterFirst: WorkspaceBootstrap | undefined
+  }> {
+    const deps = makeDeps()
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(diffOnBootstrap())
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    await engine.onConnect(asSocket(socket))
+    const afterFirst = deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(second())
+    await engine.onConnect(asSocket(socket))
+    return { deps, engine, afterFirst }
+  }
+
+  it("an unchanged warm bootstrap leaves the cached bootstrap object identity intact", async () => {
+    // The cached object carries a local patch (the shape `stream-content.tsx`
+    // and the settings tabs write), so it is NOT deep-equal to the incoming
+    // payload: TanStack's own replaceEqualDeep cannot preserve identity here,
+    // only the "nothing was written, so keep prev" gate can.
+    const deps = makeDeps()
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(diffOnBootstrap())
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    await engine.onConnect(asSocket(socket))
+    const cached = deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))!
+    deps.queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...cached,
+      streams: cached.streams.map((s) => ({ ...s, lastMessagePreview: null })),
+    })
+    // Read back: TanStack's structural sharing means the object now in the
+    // cache is not the one handed to setQueryData.
+    const patched = deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(patched).not.toBe(cached)
+
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(diffOnBootstrap())
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).toBe(patched)
+    engine.destroy()
+  })
+
+  it("a changed bootstrap replaces the cached object", async () => {
+    const { deps, engine, afterFirst } = await runTwoWarmBootstraps(() =>
+      diffOnBootstrap({ syncHead: "4242", workspace: { ...diffOnBootstrap().workspace, name: "Renamed" } })
+    )
+
+    expect(deps.queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))).not.toBe(afterFirst)
+    expect(deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.workspace.name).toBe(
+      "Renamed"
+    )
+    engine.destroy()
+  })
+
+  it("an optimistic preferences patch in the query cache survives an unchanged bootstrap", async () => {
+    const deps = makeDeps()
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(diffOnBootstrap())
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    socket.ackBehavior = "immediate"
+
+    await engine.onConnect(asSocket(socket))
+    const cached = deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))!
+    deps.queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...cached,
+      userPreferences: { ...cached.userPreferences, theme: "dark" },
+    })
+
+    deps.workspaceService.bootstrap.mockResolvedValueOnce(diffOnBootstrap())
+    await engine.onConnect(asSocket(socket))
+
+    expect(
+      deps.queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.userPreferences.theme
+    ).toBe("dark")
+    engine.destroy()
+  })
+})

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -8,6 +8,7 @@ import { ApiError } from "@/api/client"
 import {
   applyReconnectBootstrapBatch,
   applyWorkspaceBootstrap,
+  bootstrapNonRowFieldsEqual,
   registerWorkspaceSocketHandlers,
 } from "./workspace-sync"
 import {
@@ -826,12 +827,24 @@ export class SyncEngine {
 
         // Write to IDB (source of truth); the returned bootstrap carries the
         // per-stream-merged counter fields so the cache write below matches IDB.
-        bootstrap = await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)
+        const applied = await applyWorkspaceBootstrap(workspaceId, bootstrap, fetchStartedAt)
+        bootstrap = applied.bootstrap
 
-        // Write to TanStack cache (bridge for coordinated-loading, sidebar loading/error)
+        // Write to TanStack cache (bridge for coordinated-loading, sidebar loading/error).
+        // Functional updater: when the apply wrote no row and every field the row
+        // diff can't speak for is unchanged, keep the cached object. Returning
+        // `prev` makes TanStack's replaceEqualDeep an identity hit instead of a
+        // ~1,000-row walk, and leaves other writers' cache patches intact.
         const stopPublish = getPerfCapture().time("bootstrap.publish")
-        queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), bootstrap)
+        const next = bootstrap
+        let replaced = false
+        queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (prev?: WorkspaceBootstrap) => {
+          if (!applied.anyChanged && prev && bootstrapNonRowFieldsEqual(prev, next)) return prev
+          replaced = true
+          return next
+        })
         stopPublish()
+        if (replaced) getPerfCapture().mark("bootstrap.cachePublish", 1)
 
         // Cold-boot single bootstrap: this first-connect snapshot is the
         // authority for everything <= its sync head (read-before-stamp on the

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -33,6 +33,7 @@ import {
 } from "@threa/types"
 import { assignmentId } from "@/hooks/use-labels"
 import { getAgentActivityForStream, __resetAgentActivityStore } from "@/stores/agent-activity-store"
+import { getCachedWorkspaceTables, subscribeWorkspaceCache } from "@/stores/workspace-store"
 import type { Socket } from "socket.io-client"
 
 function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
@@ -408,7 +409,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       _cachedAt: fetchStartedAt + 100,
     })
 
-    const returned = await applyWorkspaceBootstrap(
+    const { bootstrap: returned } = await applyWorkspaceBootstrap(
       "ws_1",
       makeBootstrap({
         streamReadState: {
@@ -442,7 +443,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       _cachedAt: fetchStartedAt + 100,
     })
 
-    const returned = await applyWorkspaceBootstrap(
+    const { bootstrap: returned } = await applyWorkspaceBootstrap(
       "ws_1",
       makeBootstrap({
         streamReadState: {
@@ -472,7 +473,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       _cachedAt: fetchStartedAt - 1000,
     })
 
-    const returned = await applyWorkspaceBootstrap(
+    const { bootstrap: returned } = await applyWorkspaceBootstrap(
       "ws_1",
       makeBootstrap({
         streamReadState: {
@@ -1168,6 +1169,71 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       })
 
       expect((await db.streamMemberships.get("ws_1:stream_d1"))?.notificationLevel).toBeNull()
+    })
+
+    it("an identical re-apply emits no store publication", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+
+      let notifications = 0
+      const unsubscribe = subscribeWorkspaceCache("ws_1", () => {
+        notifications += 1
+      })
+      const capture = new PerfCapture()
+      armPerfCapture(capture)
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+      unsubscribe()
+
+      expect(notifications).toBe(0)
+      expect(capture.snapshot().filter((s) => s.name === "bootstrap.storePublish")).toEqual([])
+    })
+
+    it("a changed row still publishes exactly once", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+
+      const base = diffBootstrap()
+      const changed = diffBootstrap({
+        streams: base.streams.map((s) => (s.id === "stream_d1" ? { ...s, displayName: "Renamed" } : s)),
+      })
+      let notifications = 0
+      const unsubscribe = subscribeWorkspaceCache("ws_1", () => {
+        notifications += 1
+      })
+      await applyWorkspaceBootstrap("ws_1", changed, Date.now())
+      unsubscribe()
+
+      expect(notifications).toBe(1)
+    })
+
+    it("a bootstrap that drops a row publishes and replaces the cached bootstrap object", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      await stampCachedAt(1)
+
+      const base = diffBootstrap()
+      const dropped = diffBootstrap({
+        streams: base.streams.filter((s) => s.id !== "stream_d2") as WorkspaceBootstrap["streams"],
+      })
+      let notifications = 0
+      const unsubscribe = subscribeWorkspaceCache("ws_1", () => {
+        notifications += 1
+      })
+      const applied = await applyWorkspaceBootstrap("ws_1", dropped, Date.now())
+      unsubscribe()
+
+      expect(notifications).toBe(1)
+      expect(await db.streams.get("stream_d2")).toBeUndefined()
+      // The value sync-engine's setQueryData gate consults: false here would
+      // leave the swept stream in the cached bootstrap forever.
+      expect(applied.anyChanged).toBe(true)
+      expect(getCachedWorkspaceTables("ws_1").streams?.map((s) => s.id)).toEqual(["stream_d1"])
+    })
+
+    it("two unchanged applies keep the cached streams array reference", async () => {
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now() - 5000)
+      const first = getCachedWorkspaceTables("ws_1").streams
+
+      await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
+
+      expect(getCachedWorkspaceTables("ws_1").streams).toBe(first)
     })
 
     it("with bootstrapDiff off, every row is rewritten", async () => {
@@ -3773,7 +3839,7 @@ describe("latest ordinal seeding and reconnect merge (sync phase 2c)", () => {
       _cachedAt: fetchStartedAt + 200,
     })
 
-    const effective = await applyWorkspaceBootstrap(
+    const { bootstrap: effective } = await applyWorkspaceBootstrap(
       "ws_1",
       makeBootstrap({
         unreadCounts: { stream_drifted: 3, stream_busy: 9 },

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2443,7 +2443,10 @@ export interface AppliedWorkspaceBootstrap {
 
 // The top-level `WorkspaceBootstrap` fields the 14-table row diff DOES cover:
 // `anyChanged` already answers for them, and comparing them below would
-// re-introduce the deep walk this gate exists to avoid.
+// re-introduce the deep walk this gate exists to avoid. That delegation is
+// sound only while every writer that mutates these rows in IDB also patches
+// the bootstrap query cache — an IDB-only writer would leave the query cache
+// permanently stale behind an anyChanged=false apply.
 type BootstrapRowCoveredField =
   | "workspace"
   | "users"

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -23,7 +23,7 @@ import {
   semanticEqual,
   writeAllRows,
 } from "./bootstrap-diff"
-import { seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
+import { getCachedWorkspaceTables, seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import {
   seedAgentActivity,
   upsertAgentSession,
@@ -2435,6 +2435,109 @@ function dedupeById<T extends { id: string }>(rows: T[]): T[] {
  * reload's bootstrap apply. When no local row exists, the result is just the
  * plain stream fields stamped with `_cachedAt`.
  */
+export interface AppliedWorkspaceBootstrap {
+  bootstrap: WorkspaceBootstrap
+  /** True when the apply wrote at least one row (or singleton) to IDB. */
+  anyChanged: boolean
+}
+
+// The top-level `WorkspaceBootstrap` fields the 14-table row diff DOES cover:
+// `anyChanged` already answers for them, and comparing them below would
+// re-introduce the deep walk this gate exists to avoid.
+type BootstrapRowCoveredField =
+  | "workspace"
+  | "users"
+  | "streams"
+  | "streamMemberships"
+  | "dmPeers"
+  | "personas"
+  | "bots"
+  | "labels"
+  | "labelAssignments"
+  | "emojis"
+  | "userPreferences"
+
+type BootstrapNonRowField = Exclude<keyof WorkspaceBootstrap, BootstrapRowCoveredField>
+
+const BOOTSTRAP_NON_ROW_FIELDS = [
+  "syncHead",
+  "archivedStreams",
+  "activeAgentSessions",
+  "activeCalls",
+  "emojiWeights",
+  "commands",
+  "configuredToolCategories",
+  "featureFlags",
+  "sidebarConfig",
+  "streamReadState",
+  "unreadCounts",
+  "unreadActivities",
+  "unreadActivityCount",
+  "activityCounts",
+  "mentionCounts",
+  "messageCounts",
+  "readMessageIds",
+  "mutedStreamIds",
+  "boardViews",
+  "invitations",
+  "viewerPermissions",
+  "viewerIsPlatformAdmin",
+  "workspaceSettings",
+] as const satisfies readonly BootstrapNonRowField[]
+
+// A new `WorkspaceBootstrap` field must be classified: either add it to
+// BootstrapRowCoveredField or list it above, or this assignment fails to compile.
+type UnclassifiedBootstrapField = Exclude<BootstrapNonRowField, (typeof BOOTSTRAP_NON_ROW_FIELDS)[number]>
+const _bootstrapFieldsExhaustive: UnclassifiedBootstrapField extends never ? true : false = true
+void _bootstrapFieldsExhaustive
+
+/** Whether two bootstraps agree on every field the row diff cannot speak for. */
+export function bootstrapNonRowFieldsEqual(a: WorkspaceBootstrap, b: WorkspaceBootstrap): boolean {
+  return BOOTSTRAP_NON_ROW_FIELDS.every((field) => semanticEqual(a[field], b[field]))
+}
+
+/**
+ * The seed array for a table: the array the in-memory cache already holds when
+ * the diff wrote nothing for that table, so the store can skip the `set` and
+ * every downstream memo keeps its input identity (D11). The length guard covers
+ * the one zero-write shape that still changes the list: a row the payload
+ * dropped is merged away without any write, and the sweep's per-table deleted
+ * count covers the case where a socket add and a sweep delete balance lengths.
+ * A socket write landing between the merge and this seed still drifts the reused
+ * array; that window is bounded by the next liveQuery emission.
+ */
+function reuseIfUnchanged<T>(previous: T[] | undefined, merged: T[], writeCount: number, tableDeleted: number): T[] {
+  return writeCount === 0 && tableDeleted === 0 && previous !== undefined && previous.length === merged.length
+    ? previous
+    : merged
+}
+
+interface TableDeletions {
+  streams: number
+  users: number
+  memberships: number
+  readStates: number
+  dmPeers: number
+  personas: number
+  bots: number
+  labels: number
+  labelAssignments: number
+  total: number
+}
+
+const NO_TABLE_DELETIONS: TableDeletions = {
+  streams: 0,
+  users: 0,
+  memberships: 0,
+  readStates: 0,
+  dmPeers: 0,
+  personas: 0,
+  bots: 0,
+  labels: 0,
+  labelAssignments: 0,
+  total: 0,
+}
+
 function mapArchivedStreamRows(
   archivedStreams: Stream[],
   existingByStreamId: Map<string, CachedStream>,
@@ -2447,7 +2550,7 @@ export async function applyWorkspaceBootstrap(
   workspaceId: string,
   bootstrap: WorkspaceBootstrap,
   fetchStartedAt?: number
-): Promise<WorkspaceBootstrap> {
+): Promise<AppliedWorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
   const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
@@ -2515,6 +2618,20 @@ export async function applyWorkspaceBootstrap(
   let mergedBots: CachedBot[] = botRows
   let mergedLabels: CachedLabel[] = labelRows
   let mergedLabelAssignments: CachedLabelAssignment[] = labelAssignmentRows
+
+  // Per-table write counts, so the in-memory seed can hand back the array the
+  // cache already holds for every table that wrote nothing (D11).
+  const writeCounts = {
+    users: 0,
+    streams: 0,
+    memberships: 0,
+    readStates: 0,
+    dmPeers: 0,
+    personas: 0,
+    bots: 0,
+    labels: 0,
+    labelAssignments: 0,
+  }
 
   // One transaction over every table so they commit together and each table's
   // `useLiveQuery` fires once — one settle, not a per-table trickle. Parallel
@@ -2624,6 +2741,14 @@ export async function applyWorkspaceBootstrap(
       mergedLabelAssignments = labelAssignmentsDiff.merged
       recordSkippedRowConfirmations(workspaceId, "streams", streamsDiff, now)
       recordSkippedRowConfirmations(workspaceId, "streamMemberships", membershipsDiff, now)
+      writeCounts.users = usersDiff.toWrite.length
+      writeCounts.streams = streamsDiff.toWrite.length
+      writeCounts.memberships = membershipsDiff.toWrite.length
+      writeCounts.dmPeers = dmPeersDiff.toWrite.length
+      writeCounts.personas = personasDiff.toWrite.length
+      writeCounts.bots = botsDiff.toWrite.length
+      writeCounts.labels = labelsDiff.toWrite.length
+      writeCounts.labelAssignments = labelAssignmentsDiff.toWrite.length
       rowsSkipped +=
         usersDiff.skipped +
         streamsDiff.skipped +
@@ -2725,6 +2850,7 @@ export async function applyWorkspaceBootstrap(
         }
         rowsWritten += readStateDiff.toWrite.length
         rowsSkipped += readStateDiff.skipped
+        writeCounts.readStates = readStateDiff.toWrite.length
         recordSkippedRowConfirmations(workspaceId, "streamReadState", readStateDiff, now)
         seedReadStates = mergeLocalAndServerReadStates(existingRows, readStateDiff.merged)
       }
@@ -2777,9 +2903,10 @@ export async function applyWorkspaceBootstrap(
   // socket handlers DURING the fetch have _cachedAt > fetchStartedAt and
   // survive. Only truly stale entities (from before we started fetching)
   // are removed. If no fetchStartedAt provided, skip cleanup entirely.
+  let deletions = NO_TABLE_DELETIONS
   if (fetchStartedAt !== undefined) {
     const stopCleanup = capture.time("bootstrap.cleanup")
-    await cleanupStaleEntities(workspaceId, bootstrap, fetchStartedAt)
+    deletions = await cleanupStaleEntities(workspaceId, bootstrap, fetchStartedAt)
     stopCleanup()
   }
 
@@ -2787,54 +2914,73 @@ export async function applyWorkspaceBootstrap(
   // synchronous render (the default value). Without this, every component sees
   // empty arrays for one render cycle until the async IDB read resolves.
   const stopSeed = capture.time("bootstrap.seed")
-  seedWorkspaceCache(workspaceId, {
-    workspace: mergedWorkspace,
-    users: mergedUsers,
-    // Archived roots must be in the synchronous seed too, or the first paint
-    // can't tell a stream is archived until the IDB read resolves — a
-    // one-frame flash of archived-root drafts (INV-21-adjacent).
-    streams: mergedStreams,
-    memberships: mergedMemberships,
-    // An omitted map leaves the in-memory rows in place (nothing was written);
-    // a present map seeds IDB's effective contents — server rows plus every
-    // local row the member-only map omits (nonmember thread lazy state) and
-    // every frontier preserved as touched during the fetch window.
-    readStates: seedReadStates,
-    dmPeers: mergedDmPeers,
-    personas: mergedPersonas,
-    bots: mergedBots,
-    labels: mergedLabels,
-    labelAssignments: mergedLabelAssignments,
-    unreadState: {
-      id: workspaceId,
-      workspaceId,
-      ...effectiveUnread,
-      _cachedAt: now,
+  const anyChanged = rowsWritten > 0 || deletions.total > 0
+  const previousTables = getCachedWorkspaceTables(workspaceId)
+  seedWorkspaceCache(
+    workspaceId,
+    {
+      workspace: mergedWorkspace,
+      users: reuseIfUnchanged(previousTables.users, mergedUsers, writeCounts.users, deletions.users),
+      // Archived roots must be in the synchronous seed too, or the first paint
+      // can't tell a stream is archived until the IDB read resolves — a
+      // one-frame flash of archived-root drafts (INV-21-adjacent).
+      streams: reuseIfUnchanged(previousTables.streams, mergedStreams, writeCounts.streams, deletions.streams),
+      memberships: reuseIfUnchanged(
+        previousTables.memberships,
+        mergedMemberships,
+        writeCounts.memberships,
+        deletions.memberships
+      ),
+      // An omitted map leaves the in-memory rows in place (nothing was written);
+      // a present map seeds IDB's effective contents — server rows plus every
+      // local row the member-only map omits (nonmember thread lazy state) and
+      // every frontier preserved as touched during the fetch window.
+      readStates:
+        seedReadStates &&
+        reuseIfUnchanged(previousTables.readStates, seedReadStates, writeCounts.readStates, deletions.readStates),
+      dmPeers: reuseIfUnchanged(previousTables.dmPeers, mergedDmPeers, writeCounts.dmPeers, deletions.dmPeers),
+      personas: reuseIfUnchanged(previousTables.personas, mergedPersonas, writeCounts.personas, deletions.personas),
+      bots: reuseIfUnchanged(previousTables.bots, mergedBots, writeCounts.bots, deletions.bots),
+      labels: reuseIfUnchanged(previousTables.labels, mergedLabels, writeCounts.labels, deletions.labels),
+      labelAssignments: reuseIfUnchanged(
+        previousTables.labelAssignments,
+        mergedLabelAssignments,
+        writeCounts.labelAssignments,
+        deletions.labelAssignments
+      ),
+      unreadState: {
+        id: workspaceId,
+        workspaceId,
+        ...effectiveUnread,
+        _cachedAt: now,
+      },
+      userPreferences: {
+        ...bootstrap.userPreferences,
+        id: workspaceId,
+        workspaceId,
+        sendMode: bootstrap.userPreferences.messageSendMode,
+        _cachedAt: now,
+      },
+      sidebarConfig: {
+        id: workspaceId,
+        workspaceId,
+        config: effectiveSidebarConfig,
+        _cachedAt: now,
+      },
+      metadata: {
+        id: workspaceId,
+        workspaceId,
+        emojis: bootstrap.emojis,
+        emojiWeights: bootstrap.emojiWeights,
+        commands: bootstrap.commands,
+        configuredToolCategories: bootstrap.configuredToolCategories,
+        _cachedAt: now,
+      },
     },
-    userPreferences: {
-      ...bootstrap.userPreferences,
-      id: workspaceId,
-      workspaceId,
-      sendMode: bootstrap.userPreferences.messageSendMode,
-      _cachedAt: now,
-    },
-    sidebarConfig: {
-      id: workspaceId,
-      workspaceId,
-      config: effectiveSidebarConfig,
-      _cachedAt: now,
-    },
-    metadata: {
-      id: workspaceId,
-      workspaceId,
-      emojis: bootstrap.emojis,
-      emojiWeights: bootstrap.emojiWeights,
-      commands: bootstrap.commands,
-      configuredToolCategories: bootstrap.configuredToolCategories,
-      _cachedAt: now,
-    },
-  })
+    { publish: anyChanged }
+  )
   stopSeed()
+  if (anyChanged) capture.mark("bootstrap.storePublish", 1)
 
   // Seed the sidebar agent-activity store so a session already running on cold
   // load paints its stream row without waiting for a live event.
@@ -2846,16 +2992,19 @@ export async function applyWorkspaceBootstrap(
   // merged counter fields and the preserved frontiers so cache and IDB never
   // disagree on unread state.
   return {
-    ...bootstrap,
-    streamReadState: effectiveReadStateMap,
-    unreadCounts: effectiveUnread.unreadCounts,
-    unreadActivities: effectiveUnread.unreadActivities,
-    activityCounts: effectiveUnread.activityCounts,
-    mentionCounts: effectiveUnread.mentionCounts,
-    unreadActivityCount: effectiveUnread.unreadActivityCount,
-    messageCounts: effectiveUnread.latestOrdinals,
-    readMessageIds: effectiveUnread.readMessageIds,
-    mutedStreamIds: effectiveUnread.mutedStreamIds,
+    anyChanged,
+    bootstrap: {
+      ...bootstrap,
+      streamReadState: effectiveReadStateMap,
+      unreadCounts: effectiveUnread.unreadCounts,
+      unreadActivities: effectiveUnread.unreadActivities,
+      activityCounts: effectiveUnread.activityCounts,
+      mentionCounts: effectiveUnread.mentionCounts,
+      unreadActivityCount: effectiveUnread.unreadActivityCount,
+      messageCounts: effectiveUnread.latestOrdinals,
+      readMessageIds: effectiveUnread.readMessageIds,
+      mutedStreamIds: effectiveUnread.mutedStreamIds,
+    },
   }
 }
 
@@ -2973,6 +3122,18 @@ export async function applyReconnectBootstrapBatch(
   let mergedLabels: CachedLabel[] = labelRows
   let mergedLabelAssignments: CachedLabelAssignment[] = labelAssignmentRows
 
+  const writeCounts = {
+    users: 0,
+    streams: 0,
+    memberships: 0,
+    readStates: 0,
+    dmPeers: 0,
+    personas: 0,
+    bots: 0,
+    labels: 0,
+    labelAssignments: 0,
+  }
+
   await db.transaction(
     "rw",
     [
@@ -3063,6 +3224,15 @@ export async function applyReconnectBootstrapBatch(
       recordSkippedRowConfirmations(workspaceId, "streams", streamsDiff, now)
       recordSkippedRowConfirmations(workspaceId, "streamMemberships", membershipsDiff, now)
       recordSkippedRowConfirmations(workspaceId, "streamReadState", readStatesDiff, now)
+      writeCounts.users = usersDiff.toWrite.length
+      writeCounts.streams = streamsDiff.toWrite.length
+      writeCounts.memberships = membershipsDiff.toWrite.length
+      writeCounts.readStates = readStatesDiff.toWrite.length
+      writeCounts.dmPeers = dmPeersDiff.toWrite.length
+      writeCounts.personas = personasDiff.toWrite.length
+      writeCounts.bots = botsDiff.toWrite.length
+      writeCounts.labels = labelsDiff.toWrite.length
+      writeCounts.labelAssignments = labelAssignmentsDiff.toWrite.length
       rowsSkipped +=
         usersDiff.skipped +
         streamsDiff.skipped +
@@ -3167,69 +3337,102 @@ export async function applyReconnectBootstrapBatch(
   capture.mark("bootstrap.rowsWritten", rowsWritten)
   capture.mark("bootstrap.rowsSkipped", rowsSkipped)
 
-  if (fetchStartedAt !== undefined) {
-    await cleanupStaleEntities(workspaceId, finalBootstrap, fetchStartedAt)
+  const swept =
+    fetchStartedAt !== undefined
+      ? await cleanupStaleEntities(workspaceId, finalBootstrap, fetchStartedAt)
+      : NO_TABLE_DELETIONS
+  const terminalCount = terminalStreamIds.size
+  const deletions: TableDeletions = {
+    ...swept,
+    streams: swept.streams + terminalCount,
+    memberships: swept.memberships + terminalCount,
+    readStates: swept.readStates + terminalCount,
+    total: swept.total + terminalCount,
   }
 
-  seedWorkspaceCache(workspaceId, {
-    workspace: mergedWorkspace,
-    users: mergedUsers,
-    // Archived roots ride the seed (mirrors applyWorkspaceBootstrap) so the
-    // first paint after reconnect knows they're archived (no draft flash) —
-    // they are already deduped into the merged streams list.
-    streams: mergedStreams,
-    memberships: mergedMemberships,
-    // A present map seeds IDB's effective contents: the merged map's rows win
-    // per stream, but local rows the member-only map omits (nonmember thread
-    // lazy state) stay seeded — the apply upserts, it never sweeps. Terminal
-    // streams' rows are bulkDeleted in this same transaction, so they must not
-    // be re-seeded from the pre-transaction snapshot.
-    readStates: finalBootstrap.streamReadState
-      ? mergeLocalAndServerReadStates(
-          localReadStates.filter((row) => !terminalStreamIds.has(row.streamId)),
-          toCachedReadStates(workspaceId, finalBootstrap.streamReadState, now)
-        )
-      : undefined,
-    dmPeers: mergedDmPeers,
-    personas: mergedPersonas,
-    bots: mergedBots,
-    labels: mergedLabels,
-    labelAssignments: mergedLabelAssignments,
-    unreadState: {
-      id: workspaceId,
-      workspaceId,
-      unreadCounts: finalBootstrap.unreadCounts,
-      ...bootstrapActivityCacheFields(finalBootstrap),
-      latestOrdinals: finalBootstrap.messageCounts,
-      readMessageIds: finalBootstrap.readMessageIds,
-      mutedStreamIds: finalBootstrap.mutedStreamIds,
-      counterTouchedAt: pruneCounterTouches(localUnreadState?.counterTouchedAt, fetchStartedAt),
-      mutedTouchedAt: pruneCounterTouches(localUnreadState?.mutedTouchedAt, fetchStartedAt),
-      _cachedAt: now,
+  // Per-stream bootstraps and terminal deletes write `db.streams` inside the
+  // same transaction without going through the workspace diff, so either one
+  // means the cached arrays can no longer be assumed current.
+  const anyChanged = rowsWritten > 0 || streamBootstraps.size > 0 || deletions.total > 0
+  const previousTables = getCachedWorkspaceTables(workspaceId)
+  const seedReadStates = finalBootstrap.streamReadState
+    ? mergeLocalAndServerReadStates(
+        localReadStates.filter((row) => !terminalStreamIds.has(row.streamId)),
+        toCachedReadStates(workspaceId, finalBootstrap.streamReadState, now)
+      )
+    : undefined
+
+  seedWorkspaceCache(
+    workspaceId,
+    {
+      workspace: mergedWorkspace,
+      users: reuseIfUnchanged(previousTables.users, mergedUsers, writeCounts.users, deletions.users),
+      // Archived roots ride the seed (mirrors applyWorkspaceBootstrap) so the
+      // first paint after reconnect knows they're archived (no draft flash) —
+      // they are already deduped into the merged streams list.
+      streams: reuseIfUnchanged(previousTables.streams, mergedStreams, writeCounts.streams, deletions.streams),
+      memberships: reuseIfUnchanged(
+        previousTables.memberships,
+        mergedMemberships,
+        writeCounts.memberships,
+        deletions.memberships
+      ),
+      // A present map seeds IDB's effective contents: the merged map's rows win
+      // per stream, but local rows the member-only map omits (nonmember thread
+      // lazy state) stay seeded — the apply upserts, it never sweeps. Terminal
+      // streams' rows are bulkDeleted in this same transaction, so they must not
+      // be re-seeded from the pre-transaction snapshot.
+      readStates:
+        seedReadStates &&
+        reuseIfUnchanged(previousTables.readStates, seedReadStates, writeCounts.readStates, deletions.readStates),
+      dmPeers: reuseIfUnchanged(previousTables.dmPeers, mergedDmPeers, writeCounts.dmPeers, deletions.dmPeers),
+      personas: reuseIfUnchanged(previousTables.personas, mergedPersonas, writeCounts.personas, deletions.personas),
+      bots: reuseIfUnchanged(previousTables.bots, mergedBots, writeCounts.bots, deletions.bots),
+      labels: reuseIfUnchanged(previousTables.labels, mergedLabels, writeCounts.labels, deletions.labels),
+      labelAssignments: reuseIfUnchanged(
+        previousTables.labelAssignments,
+        mergedLabelAssignments,
+        writeCounts.labelAssignments,
+        deletions.labelAssignments
+      ),
+      unreadState: {
+        id: workspaceId,
+        workspaceId,
+        unreadCounts: finalBootstrap.unreadCounts,
+        ...bootstrapActivityCacheFields(finalBootstrap),
+        latestOrdinals: finalBootstrap.messageCounts,
+        readMessageIds: finalBootstrap.readMessageIds,
+        mutedStreamIds: finalBootstrap.mutedStreamIds,
+        counterTouchedAt: pruneCounterTouches(localUnreadState?.counterTouchedAt, fetchStartedAt),
+        mutedTouchedAt: pruneCounterTouches(localUnreadState?.mutedTouchedAt, fetchStartedAt),
+        _cachedAt: now,
+      },
+      userPreferences: {
+        ...finalBootstrap.userPreferences,
+        id: workspaceId,
+        workspaceId,
+        sendMode: finalBootstrap.userPreferences.messageSendMode,
+        _cachedAt: now,
+      },
+      sidebarConfig: {
+        id: workspaceId,
+        workspaceId,
+        config: effectiveSidebarConfig,
+        _cachedAt: now,
+      },
+      metadata: {
+        id: workspaceId,
+        workspaceId,
+        emojis: finalBootstrap.emojis,
+        emojiWeights: finalBootstrap.emojiWeights,
+        commands: finalBootstrap.commands,
+        configuredToolCategories: finalBootstrap.configuredToolCategories,
+        _cachedAt: now,
+      },
     },
-    userPreferences: {
-      ...finalBootstrap.userPreferences,
-      id: workspaceId,
-      workspaceId,
-      sendMode: finalBootstrap.userPreferences.messageSendMode,
-      _cachedAt: now,
-    },
-    sidebarConfig: {
-      id: workspaceId,
-      workspaceId,
-      config: effectiveSidebarConfig,
-      _cachedAt: now,
-    },
-    metadata: {
-      id: workspaceId,
-      workspaceId,
-      emojis: finalBootstrap.emojis,
-      emojiWeights: finalBootstrap.emojiWeights,
-      commands: finalBootstrap.commands,
-      configuredToolCategories: finalBootstrap.configuredToolCategories,
-      _cachedAt: now,
-    },
-  })
+    { publish: anyChanged }
+  )
+  if (anyChanged) capture.mark("bootstrap.storePublish", 1)
 
   // The returned bootstrap is written to the bootstrap query cache by the
   // caller; reflect the preserved local config so it doesn't carry the stale
@@ -3251,7 +3454,11 @@ export async function applyReconnectBootstrapBatch(
 // "the ids we wrote" would sweep exactly those rows. Presence in the payload is
 // the protection; `_cachedAt >= now` only shields rows the payload never
 // enumerated (concurrent socket writes during the fetch window).
-async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBootstrap, now: number): Promise<void> {
+async function cleanupStaleEntities(
+  workspaceId: string,
+  bootstrap: WorkspaceBootstrap,
+  now: number
+): Promise<TableDeletions> {
   // Archived roots ride in bootstrap.archivedStreams (absent from .streams);
   // keep them so the absence-sweep doesn't delete rows every consumer still
   // needs (drafts hiding, name resolution) across a reload.
@@ -3277,7 +3484,7 @@ async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBoo
   // can't ride the generic deleteStale (Amendment A4).
   const staleStreamIds = await staleEntityIds(db.streams, "workspaceId", workspaceId, bootstrapStreamIds, now)
 
-  const [, , , staleMembershipIds] = await Promise.all([
+  const [, , staleUserIds, staleMembershipIds, staleDmPeerIds, stalePersonaIds, staleBotIds, staleLabelIds, staleLabelAssignmentIds] = await Promise.all([
     staleStreamIds.length > 0 ? db.streams.bulkDelete(staleStreamIds) : Promise.resolve(),
     deleteSlotsForStreams(db, staleStreamIds),
     deleteStale(db.workspaceUsers, "workspaceId", workspaceId, bootstrapUserIds, now),
@@ -3298,6 +3505,27 @@ async function cleanupStaleEntities(workspaceId: string, bootstrap: WorkspaceBoo
 
   removeRowConfirmations(workspaceId, "streams", staleStreamIds)
   removeRowConfirmations(workspaceId, "streamMemberships", staleMembershipIds)
+
+  const streams = staleStreamIds.length
+  const users = staleUserIds.length
+  const memberships = staleMembershipIds.length
+  const dmPeers = staleDmPeerIds.length
+  const personas = stalePersonaIds.length
+  const bots = staleBotIds.length
+  const labels = staleLabelIds.length
+  const labelAssignments = staleLabelAssignmentIds.length
+  return {
+    streams,
+    users,
+    memberships,
+    readStates: 0,
+    dmPeers,
+    personas,
+    bots,
+    labels,
+    labelAssignments,
+    total: streams + users + memberships + dmPeers + personas + bots + labels + labelAssignments,
+  }
 }
 
 async function staleEntityIds(

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -21,6 +21,8 @@ export const PERF_MARK_NAMES = [
   "bootstrap.rowsWritten",
   "bootstrap.rowsSkipped",
   "bootstrap.diff",
+  "bootstrap.storePublish",
+  "bootstrap.cachePublish",
   "catchup.entryApply",
   "catchup.replay",
   "catchup.collapse",


### PR DESCRIPTION
## Problem

Chunk 1 stops the writes; this chunk stops the wake-ups. Even with zero rows written, `seedWorkspaceCache` bumps one coarse counter that notifies every `useWorkspaceCacheSignal` subscriber — including `CoordinatedLoadingProvider`, which reads 10 workspace hooks and wraps the whole app — and `sync-engine` replaces the TanStack bootstrap object wholesale, deep-walking ~1,000 rows via `replaceEqualDeep` on every warm refresh. Plan-PR 7, chunk 2/3 ([plan](https://seer.build/ws_vbyzjvdg6g/b/pr7-plan-55fcba/)).

## Solution

- **Signal split (D10):** `cacheVersion` stays monotonic and always bumps — `seedCacheFromIdb`'s stale-read guard depends on it (pinned by the test the split exists for) — while `cacheSignal`, the value `useSyncExternalStore` reads, bumps and emits only when the apply says something changed.
- **`anyChanged` counts deletions, not just writes.** The adversarial pass reproduced the trap: a payload whose only change is a *removed* row writes nothing, and a write-only gate would suppress the publication while the gated cache write kept the deleted stream alive in the bootstrap object forever (the pre-chunk unconditional write healed this). `cleanupStaleEntities` now returns per-table deleted counts; they feed `anyChanged` on both apply paths and the per-table reuse rule.
- **Array identity for unchanged tables (D11):** zero-write, zero-delete, length-stable tables pass the previous cached array back to the seed, so downstream memos keep identity. The residual socket-drift window is bounded by the next liveQuery emission (stated in-code).
- **TanStack gate (D12):** the warm `setQueryData` becomes `(prev) => shouldReuse ? prev : next`. Returning `prev` skips the ~1,000-row deep walk *and* stops an unchanged bootstrap from clobbering optimistic patches other writers put in the cache (preferences/settings tabs) — verified against the vendored query-core 5.99 source. `shouldReuse` = row-diff unchanged AND `semanticEqual` over `BOOTSTRAP_NON_ROW_FIELDS` — a list that is now **compile-time exhaustive** against `WorkspaceBootstrap` (`Exclude<keyof …>` + completeness assert), so the next optional field added to the interface fails the build until classified instead of silently never propagating on warm refreshes.
- Marks: `bootstrap.storePublish` / `bootstrap.cachePublish`, emitted only on the publishing branch — the acceptance capture's "absent on an unchanged refresh" numbers.

## Test plan

- [x] frontend 5727/0 — 10 new tests incl. the D10 stale-read regression pin, the drop-a-row publication test (both halves of the reproduced blocker), the two-applies array-reference pin (replacing a test the verifier proved vacuous), and the coordinated-loading render-count probe with real store hooks
- [x] packages/types 151/0 · typecheck clean (exhaustiveness assert verified to error on a removed entry) · lint + 251 migrations clean
- [x] adversarial verify (Opus high, self-score 88): 6 findings — 1 reproduced blocker, all fixed in-branch
- [ ] on-device A/B — chunk 3


## External-review acknowledgments

- **Delayed bootstrap vs a newer flag event** (Sol): a slow in-flight bootstrap payload can overwrite a fresher socket-delivered flag/metadata value for one apply cycle — a pre-existing overwrite class; the flag deliberately rides the payload being applied (plan D13), so a kill-switch flip takes effect on the next apply.
- **First-frame fallback staleness under array reuse** (Sol): a socket write between two unchanged applies leaves the in-memory fallback array pre-write until the next liveQuery emission; mounted readers are unaffected, a fresh mount can see one stale synchronous frame. Real fix belongs to plan-PR 6 (per-row subscriptions retire this fallback).
- **`useWorkspaceBootstrap`'s queryFn refetch path has no identity gate** (Fable): a query-driven refetch still replaces the object — byte-identical to pre-stack behavior; noted as a follow-up alongside PR 6.

<details>
<summary>📋 Full implementation plan</summary>

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr7-plan-55fcba/ — chunk 2 of 3 (D10/D11/D12/D14). Notable deviation from the plan's letter: the plan's test-7 fixture was provably vacuous (TanStack already preserves identity for deep-equal payloads); the shipped fixture patches the cache first so only the gate can preserve identity.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788300542&installation_model_id=20758&pr_number=1736&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1736&signature=30a4c67064b154b5ed8f641e4ba2fb54a7387acb9670015538641d28959e66f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
