### PR TITLE
fix(board): veto stale archived-root cards with the local stream index

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.test.tsx
@@ -53,10 +53,19 @@ describe("BoardLinkRow", () => {
   it("falls back to the bare board route when no board state was retained", () => {
     render(
       <MemoryRouter>
-        <BoardLinkRow workspaceId={WS} userId={USER} unreadStreamCount={0} />
+        <BoardLinkRow workspaceId={WS} userId={USER} />
       </MemoryRouter>
     )
     expect(hrefOf("Board")).toBe(`/w/${WS}/board`)
+  })
+
+  it("carries no unread toggle — that's a board-mode filter, not a chats-mode row", () => {
+    render(
+      <MemoryRouter>
+        <BoardLinkRow workspaceId={WS} userId={USER} />
+      </MemoryRouter>
+    )
+    expect(screen.queryByText("Unread")).toBeNull()
   })
 })
 

--- a/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-link-row.tsx
@@ -89,11 +89,7 @@ export function BoardUnreadRow({
  * with `ChatsLinkRow`: both sit at the same spot (above the quick links) so the
  * cross-surface entry point doesn't move between modes.
  */
-export function BoardLinkRow({
-  workspaceId,
-  userId,
-  unreadStreamCount,
-}: ModeLinkRowProps & { unreadStreamCount: number }) {
+export function BoardLinkRow({ workspaceId, userId }: ModeLinkRowProps) {
   const { collapseOnMobile } = useSidebar()
   const streams = useWorkspaceStreams(workspaceId)
 
@@ -106,6 +102,8 @@ export function BoardLinkRow({
       )
     : `/w/${workspaceId}/board`
 
+  // No BoardUnreadRow here: the unread toggle is a board-mode filter
+  // (BoardModeFilters) — in chats mode this row is just the way over.
   return (
     <div className="mb-2 space-y-1">
       <Link to={boardHref} onClick={collapseOnMobile} className={ROW_CLASS}>
@@ -113,7 +111,6 @@ export function BoardLinkRow({
         Board
         <ArrowRight className="ml-auto h-4 w-4" />
       </Link>
-      <BoardUnreadRow workspaceId={workspaceId} unreadStreamCount={unreadStreamCount} />
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -340,7 +340,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // The single reactive topic-stats pass — one subscription for the whole board
   // sidebar (rows + Lenses counts), gated on board mode so chats mode subscribes
   // to nothing (perf contract in the exploration doc).
-  const boardSidebarStats = useBoardSidebarStats(workspaceId, isBoardPage)
+  const boardSidebarStats = useBoardSidebarStats(workspaceId, isBoardPage, archivedStreamIds)
   const boardMode = useMemo<SidebarBoardMode | null>(() => {
     if (!isBoardPage) return null
     return {

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -159,11 +159,18 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // and would otherwise still surface in the sidebar. A thread inherits its root
   // via `rootStreamId`, so one lookup hides every nested thread under an archived
   // root (scratchpad, channel, or any top-level stream).
-  const archivedStreamIds = useMemo(() => {
-    const ids = new Set<string>()
-    for (const stream of idbStreams) if (stream.archivedAt) ids.add(stream.id)
-    return ids
+  // Signature-memoized: `idbStreams` re-emits on every db.streams write, and
+  // this set now also feeds useBoardSidebarStats, whose aggregation must not
+  // re-run unless archived membership actually changed.
+  const archivedStreamIdSignature = useMemo(() => {
+    const ids: string[] = []
+    for (const stream of idbStreams) if (stream.archivedAt) ids.push(stream.id)
+    return ids.sort().join(",")
   }, [idbStreams])
+  const archivedStreamIds = useMemo(
+    () => new Set<string>(archivedStreamIdSignature ? archivedStreamIdSignature.split(",") : []),
+    [archivedStreamIdSignature]
+  )
 
   // Streams the user stepped away from with an unsent (loaded, non-stashed)
   // draft, surfaced as a per-row hint. `loadedDraftStreamIdSignature` (from the

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -423,7 +423,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   } else if (hasQuickLinksSection) {
     quickLinksSlot = (
       <>
-        <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} unreadStreamCount={unreadStreamCount} />
+        <BoardLinkRow workspaceId={workspaceId} userId={user?.id ?? null} />
         {quickLinks}
       </>
     )

--- a/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
+++ b/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
@@ -87,6 +87,19 @@ describe("aggregateBoardSidebarStats", () => {
     expect(byStream.get("chan_a")?.topics).toBe(1)
   })
 
+  it("excludes a stale card whose root is archived in the local stream index", () => {
+    const { byStream, lensTotals } = aggregateBoardSidebarStats(
+      [
+        post("c1", { streamId: "chan_a", rootArchived: false }),
+        post("c2", { streamId: "chan_b", rootArchived: false }),
+      ],
+      new Set(["chan_a"])
+    )
+    expect(byStream.get("chan_a")).toBeUndefined()
+    expect(byStream.get("chan_b")?.topics).toBe(1)
+    expect(lensTotals.all).toBe(1)
+  })
+
   it("computes per-lens totals via matchesBoardLens, keyed by exactly the three lenses", () => {
     const { lensTotals } = aggregateBoardSidebarStats([
       post("c1", { streamId: "chan_a", status: "active", isMine: true }),

--- a/apps/frontend/src/hooks/use-board-sidebar-stats.ts
+++ b/apps/frontend/src/hooks/use-board-sidebar-stats.ts
@@ -38,17 +38,23 @@ export const ZERO_BOARD_STREAM_STATS: BoardStreamStats = { topics: 0 }
  * (`rootStreamId ?? conversation.streamId` — the same COALESCE the board's scope
  * filter uses), unless it's an emptied shell (no messages — mirrors the server's
  * `cardinality(message_ids) > 0` board filter and `mergeBoardConversation`'s
- * delete-on-empty) or its root is archived (hidden on the board by default). Lens
+ * delete-on-empty) or its root is archived (hidden on the board by default) —
+ * per the post's own `rootArchived` flag or, for a card cached before its root
+ * was archived, the fresher `archivedRootIds` index the board vetoes with. Lens
  * totals reuse `matchesBoardLens`, the same read-side lens authority the board
  * card filters with, so the two surfaces can't drift.
  */
-export function aggregateBoardSidebarStats(posts: CachedBoardPost[]): BoardSidebarStats {
+export function aggregateBoardSidebarStats(
+  posts: CachedBoardPost[],
+  archivedRootIds: ReadonlySet<string> = new Set()
+): BoardSidebarStats {
   const byStream = new Map<string, BoardStreamStats>()
   const lensTotals = Object.fromEntries(BOARD_LENSES.map((lens) => [lens, 0])) as Record<BoardLens, number>
   for (const post of posts) {
     if (post.conversation.messageIds.length === 0) continue
     if (post.rootArchived === true) continue
     const rootId = post.rootStreamId ?? post.conversation.streamId
+    if (archivedRootIds.has(rootId)) continue
     let entry = byStream.get(rootId)
     if (!entry) {
       entry = { topics: 0 }
@@ -73,7 +79,11 @@ export function aggregateBoardSidebarStats(posts: CachedBoardPost[]): BoardSideb
  * is the ONLY subscription — call it once at the sidebar level and thread the
  * result to the rows via the board-mode descriptor, never a `liveQuery` per row.
  */
-export function useBoardSidebarStats(workspaceId: string, enabled: boolean): BoardSidebarStats | null {
+export function useBoardSidebarStats(
+  workspaceId: string,
+  enabled: boolean,
+  archivedRootIds: ReadonlySet<string>
+): BoardSidebarStats | null {
   const posts = useLiveQuery(async () => {
     // Off board mode, return before any table read so `useLiveQuery` subscribes
     // to nothing — chats mode pays zero cost.
@@ -83,5 +93,5 @@ export function useBoardSidebarStats(workspaceId: string, enabled: boolean): Boa
       .between([workspaceId, Dexie.minKey], [workspaceId, Dexie.maxKey])
       .toArray()
   }, [enabled, workspaceId])
-  return useMemo(() => (posts ? aggregateBoardSidebarStats(posts) : null), [posts])
+  return useMemo(() => (posts ? aggregateBoardSidebarStats(posts, archivedRootIds) : null), [posts, archivedRootIds])
 }

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -25,6 +25,7 @@ function filterOf(over: Partial<BoardViewFilter> = {}): BoardViewFilter {
     excludeLabels: null,
     unread: null,
     showArchived: false,
+    archivedRootIds: new Set<string>(),
     ...over,
   }
 }
@@ -766,6 +767,11 @@ describe("useStableBoardView — hide & mute exclusions", () => {
     return { ...streamPost(id, activityMs, rootStreamId), rootArchived: true } as unknown as CachedBoardPost
   }
 
+  /** A card cached while its root was still active — the stale-flag shape. */
+  function staleActivePost(id: string, activityMs: number, rootStreamId: string): CachedBoardPost {
+    return { ...streamPost(id, activityMs, rootStreamId), rootArchived: false } as unknown as CachedBoardPost
+  }
+
   const NO_EXCL = exclOf()
 
   it("drops a hidden card immediately — even after it was committed and retained (the crux)", () => {
@@ -840,6 +846,78 @@ describe("useStableBoardView — hide & mute exclusions", () => {
 
     rerender({ filter: ALL })
     expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+  })
+
+  it("vetoes a stale card whose root is archived in the local stream index", () => {
+    // `rootArchived: undefined` (cached before the flag existed) and
+    // `rootArchived: false` (cached before the root was archived) both fail open
+    // on the per-card flag alone — the server never re-seeds an archived
+    // conversation, so the veto has to come from the fresher stream index.
+    mockLive(
+      feed(streamPost("a", 300, "stream_x"), staleActivePost("b", 200, "stream_y"), streamPost("c", 100, "stream_z"))
+    )
+    const { result } = renderHook(() =>
+      useStableBoardView(
+        "ws_1",
+        filterOf({ archivedRootIds: new Set(["stream_x", "stream_y"]) }),
+        undefined,
+        undefined,
+        undefined
+      )
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["c"])
+  })
+
+  it("keeps stale-flag cards whose root is archived once showArchived opts in", () => {
+    mockLive(feed(streamPost("a", 300, "stream_x"), staleActivePost("b", 200, "stream_y")))
+    const { result } = renderHook(() =>
+      useStableBoardView(
+        "ws_1",
+        filterOf({ showArchived: true, archivedRootIds: new Set(["stream_x", "stream_y"]) }),
+        undefined,
+        undefined,
+        undefined
+      )
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+  })
+
+  it("keeps a `rootArchived: false` card whose root is not in the archived index", () => {
+    mockLive(feed(staleActivePost("a", 300, "stream_x")))
+    const { result } = renderHook(() =>
+      useStableBoardView(
+        "ws_1",
+        filterOf({ archivedRootIds: new Set(["stream_other"]) }),
+        undefined,
+        undefined,
+        undefined
+      )
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+
+  it("drops a committed card the instant its root joins the archived index", () => {
+    mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
+    const { result, rerender } = renderHook(
+      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
+      { initialProps: { filter: filterOf() } }
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    // A fresh arrival waits behind the "N new" pill — the reader's view is frozen.
+    act(() =>
+      mockLive(
+        feed(streamPost("new", 500, "stream_y"), streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y"))
+      )
+    )
+    rerender({ filter: filterOf() })
+    expect(result.current.newCount).toBe(1)
+
+    rerender({ filter: filterOf({ archivedRootIds: new Set(["stream_x"]) }) })
+    // Dropped instantly, and the frozen view is NOT reset: the buffered card is
+    // still behind the pill (a view-key reset would have committed it).
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+    expect(result.current.newCount).toBe(1)
   })
 
   it("reports hasRawPosts when the feed is seeded but every card is excluded (empty view, not loading)", () => {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -533,7 +533,9 @@ export function useStableBoardView(
   // `archivedRootIds` is deliberately NOT in this key: the veto drops at render
   // (`isExcluded` runs over committed cards too), so a root archived mid-view
   // loses its card immediately without resetting the reader's frozen view. On
-  // unarchive (with archived shown) the cards return behind the "N new" pill
+  // unarchive, a card archived DURING this view keeps its committed slot and
+  // restores in place (it vanished there; no reorder under the reader), while
+  // cards archived before the view committed arrive behind the "N new" pill
   // like any other new content.
   const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${unread?.key ?? ""}|${showArchived ? "arch" : ""}`
   const viewKeyRef = useRef(viewKey)

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -113,10 +113,18 @@ export interface BoardViewFilter {
    * lens/scope — it rides the view-reset key, so toggling it re-commits the feed
    * (archived cards interleave by activity, and toggling back off re-hides them)
    * instead of silently appending them below the fold. Gates against each post's
-   * own `rootArchived` verdict (the server's per-card archived flag), so it needs
-   * no workspace-streams lookup — the bootstrap seeds active streams only.
+   * own `rootArchived` verdict AND against `archivedRootIds`.
    */
   showArchived: boolean
+  /**
+   * Roots archived per the local stream index (the bootstrap ships archived rows
+   * since #1420). The per-card `rootArchived` flag stays primary — it survives
+   * per-row in IDB with no root-row resolution — but the server excludes archived
+   * conversations from every fetch, so a card cached with `rootArchived: false`
+   * before its root was archived is never reseeded and would render forever.
+   * This set is the fresher veto over that stale flag.
+   */
+  archivedRootIds: ReadonlySet<string>
 }
 
 /**
@@ -424,7 +432,18 @@ export function useStableBoardView(
   // dropping the argument silently was how the wiring went missing.
   seenRef: { readonly current: ReadonlySet<string> } | undefined
 ): StableBoardView {
-  const { lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, unread, showArchived } = filter
+  const {
+    lens,
+    scope,
+    types,
+    excludeStreams,
+    excludeTypes,
+    labels,
+    excludeLabels,
+    unread,
+    showArchived,
+    archivedRootIds,
+  } = filter
   const { hidden, muted, muteActive } = exclusions
   const rawLive = useBoardPosts(workspaceId)
 
@@ -440,10 +459,13 @@ export function useStableBoardView(
       const hiddenAt = hidden.get(post.conversation.id)
       if (hiddenAt !== undefined && postMs(post) <= hiddenAt) return true
       if (muteActive && muted.has(post.rootStreamId ?? post.conversation.streamId)) return true
-      if (!showArchived && post.rootArchived === true) return true
+      if (!showArchived) {
+        if (post.rootArchived === true) return true
+        if (archivedRootIds.has(post.rootStreamId ?? post.conversation.streamId)) return true
+      }
       return false
     },
-    [hidden, muted, muteActive, showArchived]
+    [hidden, muted, muteActive, showArchived, archivedRootIds]
   )
 
   // The branch relationship for one-card-per-root suppression (below) derives
@@ -508,6 +530,11 @@ export function useStableBoardView(
   // from EMPTY_VIEW and commit its own feed wholesale.
   // Label keys are the SELECTED ids, not the resolved streams — a live
   // re-resolution (an assignment changing) must not reset the frozen view.
+  // `archivedRootIds` is deliberately NOT in this key: the veto drops at render
+  // (`isExcluded` runs over committed cards too), so a root archived mid-view
+  // loses its card immediately without resetting the reader's frozen view. On
+  // unarchive (with archived shown) the cards return behind the "N new" pill
+  // like any other new content.
   const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${unread?.key ?? ""}|${showArchived ? "arch" : ""}`
   const viewKeyRef = useRef(viewKey)
   let committedInput = committed

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -313,11 +313,18 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // per-card `rootArchived` flag can be stale forever — the server excludes
   // archived conversations from every fetch, so a row cached before its root was
   // archived is never reseeded — and this set is the fresher veto.
-  const archivedRootIds = useMemo(() => {
-    const ids = new Set<string>()
-    for (const stream of streams) if (stream.archivedAt) ids.add(stream.id)
-    return ids
+  // Memoized on a content signature: `streams` re-emits on every db.streams
+  // write (previews, read state), and this set feeds the filter → the full
+  // board view pipeline, which must not re-run unless membership changed.
+  const archivedRootSignature = useMemo(() => {
+    const ids: string[] = []
+    for (const stream of streams) if (stream.archivedAt) ids.push(stream.id)
+    return ids.sort().join(",")
   }, [streams])
+  const archivedRootIds = useMemo(
+    () => new Set<string>(archivedRootSignature ? archivedRootSignature.split(",") : []),
+    [archivedRootSignature]
+  )
 
   const filter = useMemo<BoardViewFilter>(
     () => ({

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -307,6 +307,18 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     [labelAssignments, excludeLabelIds]
   )
 
+  const streams = useWorkspaceStreams(workspaceId)
+  // Archived roots straight from the local stream index (the bootstrap ships
+  // archived rows since #1420), mirroring the sidebar's index. The board's
+  // per-card `rootArchived` flag can be stale forever — the server excludes
+  // archived conversations from every fetch, so a row cached before its root was
+  // archived is never reseeded — and this set is the fresher veto.
+  const archivedRootIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const stream of streams) if (stream.archivedAt) ids.add(stream.id)
+    return ids
+  }, [streams])
+
   const filter = useMemo<BoardViewFilter>(
     () => ({
       lens,
@@ -320,6 +332,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         ? { key: BOARD_UNREAD_ON, streamIds: unreadStreamIds, clearedConversationIds: clearedUnreadIds }
         : null,
       showArchived,
+      archivedRootIds,
     }),
     [
       lens,
@@ -338,6 +351,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       unreadStreamIds,
       clearedUnreadIds,
       showArchived,
+      archivedRootIds,
     ]
   )
   const {
@@ -511,7 +525,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // genuinely slow. The board's readiness is derived rather than latched, so a
   // later filter change earns its own skeleton.
   const skeletonVisible = useCoordinatedPhase({ isLoading: loading, isReady: !loading }) === "skeleton"
-  const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -889,7 +889,8 @@ export interface BoardPost {
    * them when the viewer opts in (`?archived=true`), so this pins exactly the
    * cards the client must drop again when the viewer toggles archived back off —
    * a per-card signal that survives in IDB, unlike a workspace-streams lookup
-   * (the bootstrap seeds active streams only). Optional because cached rows
+   * (which needs the root row resolved; the client vetoes with that index too,
+   * as the fresher signal when this flag is stale). Optional because cached rows
    * predate the field; the client fails OPEN (surfaces the post) until reseed.
    */
   rootArchived?: boolean


### PR DESCRIPTION
## Problem

The board's archived exclusion (#1226) checks only the per-card `rootArchived` flag. A conversation row cached in `db.conversations` before its root stream was archived keeps `rootArchived: false` forever: the server excludes archived-root conversations from every board fetch, so the row is never reseeded, and the `stream:archived` socket patch (`setBoardRootArchived`) only covers clients online at archive time. Result: archived streams' conversations linger on the board indefinitely, with the "Archived" filter off.

## Solution

Veto with the local stream index, which is always fresh: since #1420 the workspace bootstrap ships archived root rows into `db.streams`.

- `board.tsx` builds `archivedRootIds` from `useWorkspaceStreams` (mirrors the sidebar's index at `sidebar.tsx:161`); new `BoardViewFilter.archivedRootIds`.
- `isExcluded` in `use-stable-board-view.ts`: with the filter off, exclude on `rootArchived === true` OR the effective root in the set — the set wins over a stale `false`. Drops at render (isExcluded runs over committed cards), so no `viewKey` coupling: adversarial review proved keying the view on the set would reset the reader's frozen order (and eat the "N new" pill) on any archive/unarchive workspace-wide. On unarchive, cards return behind the pill like other new content.
- Same veto threaded into `useBoardSidebarStats` (from the sidebar's existing `archivedStreamIds`) so board list and sidebar lens counts cannot disagree on stale rows.
- Stale "bootstrap seeds active streams only" comments corrected (`use-stable-board-view.ts`, `domain.ts`).

## Test plan

- [x] `use-stable-board-view` + `use-board-sidebar-stats` + `board` + sidebar suites — 337 pass; types 155 pass; tsc clean
- [x] Falsified: neutralizing the set check turns exactly the two veto tests red (instant-drop test also pins that the buffered pill survives, i.e. no view reset)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788335226&installation_model_id=20758&pr_number=1739&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1739&signature=1a38e599a1a4f73771853467554c968aa5cf2d755ba7a76847f33b1dc17e086a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->