### PR TITLE
feat(conversations): archived conversations read read-only — root-inherited notice + gated affordances

### DIFF
--- a/apps/backend/src/features/conversations/service.reassign-messages.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign-messages.test.ts
@@ -338,3 +338,32 @@ describe("ConversationService.reassignMessagesToConversation", () => {
     })
   })
 })
+
+describe("ConversationService.reassignMessagesToConversation archived streams", () => {
+  afterEach(() => mock.restore())
+
+  test("rejects the batch when the stream's effective root is archived (INV-62)", async () => {
+    const convA = makeConversation({ id: "conv_a" })
+    const spies = setup({ conversations: { conv_a: convA }, primaries: { m1: "conv_a", m2: "conv_a" } })
+    spyOn(StreamRepository, "findById").mockImplementation(
+      async (_c: unknown, id: string) =>
+        (id === "chan_1"
+          ? { id: "chan_1", type: "thread", rootStreamId: "chan_root" }
+          : { id: "chan_root", type: "channel", rootStreamId: null, archivedAt: new Date() }) as never
+    )
+
+    await expect(reassign(["m1", "m2"], { kind: "new" })).rejects.toMatchObject({ status: 403 })
+    expect(spies.insert).not.toHaveBeenCalled()
+    expect(spies.addPrimaryMessages).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+
+  test("an unarchived stream still moves the batch", async () => {
+    const convA = makeConversation({ id: "conv_a" })
+    const spies = setup({ conversations: { conv_a: convA }, primaries: { m1: "conv_a", m2: "conv_a" } })
+
+    await reassign(["m1", "m2"], { kind: "new" })
+
+    expect(spies.addPrimaryMessages).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/features/conversations/service.reassign.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign.test.ts
@@ -14,15 +14,19 @@ const ACTOR_ID = "usr_1"
 
 // One root channel with a thread under it, plus a foreign root: the three
 // stream shapes the one-root rule must distinguish.
-const STREAMS: Record<string, { id: string; type: string; rootStreamId: string | null }> = {
+const STREAMS: Record<string, { id: string; type: string; rootStreamId: string | null; archivedAt?: Date }> = {
   chan_1: { id: "chan_1", type: "channel", rootStreamId: null },
   thread_1: { id: "thread_1", type: "thread", rootStreamId: "chan_1" },
   chan_2: { id: "chan_2", type: "channel", rootStreamId: null },
+  chan_arch: { id: "chan_arch", type: "channel", rootStreamId: null, archivedAt: new Date() },
+  thread_arch: { id: "thread_arch", type: "thread", rootStreamId: "chan_arch" },
 }
 
 const MESSAGES: Record<string, { streamId: string; authorId: string }> = {
   m1: { streamId: "chan_1", authorId: "usr_1" },
   m_thread: { streamId: "thread_1", authorId: "usr_2" },
+  m_arch: { streamId: "chan_arch", authorId: "usr_1" },
+  m_arch_thread: { streamId: "thread_arch", authorId: "usr_1" },
 }
 
 function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
@@ -207,5 +211,48 @@ describe("ConversationService.reassignMessage", () => {
     expect(result.previousConversation).toBeNull()
     expect(spies.feedbackInsert).not.toHaveBeenCalled()
     expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+})
+
+describe("ConversationService.reassignMessage archived streams", () => {
+  test("rejects a move inside an archived stream", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_arch", messageIds: ["m_arch"] })
+    const convOther = makeConversation({ id: "conv_other", streamId: "chan_arch", messageIds: [] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_other: convOther },
+      primaries: { m_arch: "conv_main" },
+    })
+
+    await expect(reassign("m_arch", "conv_other")).rejects.toMatchObject({ status: 403 })
+    expect(spies.removePrimaryMessage).not.toHaveBeenCalled()
+    expect(spies.addPrimaryMessage).not.toHaveBeenCalled()
+    expect(spies.feedbackInsert).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+
+  test("rejects a move in a thread whose root is archived (INV-62)", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "thread_arch", messageIds: ["m_arch_thread"] })
+    const convOther = makeConversation({ id: "conv_other", streamId: "thread_arch", messageIds: [] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_other: convOther },
+      primaries: { m_arch_thread: "conv_main" },
+    })
+
+    await expect(reassign("m_arch_thread", "conv_other")).rejects.toMatchObject({ status: 403 })
+    expect(spies.addPrimaryMessage).not.toHaveBeenCalled()
+  })
+
+  test("an unarchived root still moves", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "thread_1", messageIds: ["m_thread"] })
+    const convOther = makeConversation({ id: "conv_other", streamId: "thread_1", messageIds: [] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_other: convOther },
+      primaries: { m_thread: "conv_main" },
+    })
+
+    const result = await reassign("m_thread", "conv_other")
+
+    expect(result.conversation.id).toBe("conv_other")
+    expect(spies.addPrimaryMessage).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -215,6 +215,25 @@ export interface ApplySplitResult {
 }
 
 /**
+ * Re-filing a message is a write to its stream, so it obeys the same archived
+ * rule as sending one (`StreamService.resolveWritableMessageStream`): the
+ * effective root's `archivedAt` seals every thread under it (INV-62), and the
+ * anchor's own row seals it directly.
+ */
+async function assertStreamNotArchived(client: Querier, streamId: string): Promise<void> {
+  const stream = await StreamRepository.findById(client, streamId)
+  if (stream?.archivedAt) {
+    throw new HttpError("Cannot move messages in an archived stream", { status: 403 })
+  }
+  if (stream?.rootStreamId) {
+    const root = await StreamRepository.findById(client, stream.rootStreamId)
+    if (root?.archivedAt) {
+      throw new HttpError("Cannot move messages in a thread under an archived stream", { status: 403 })
+    }
+  }
+}
+
+/**
  * Public interface for querying conversations.
  * Computes temporal staleness on read.
  */
@@ -557,6 +576,9 @@ export class ConversationService {
           })
         }
       }
+
+      await assertStreamNotArchived(client, message.streamId)
+      if (target.streamId !== message.streamId) await assertStreamNotArchived(client, target.streamId)
 
       const previous = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
       if (previous?.id === target.id) {
@@ -974,6 +996,10 @@ export class ConversationService {
     const { workspaceId, streamId, messageIds, target, actorUserId } = params
 
     return withTransaction(this.pool, async (client) => {
+      // Every moving message and an existing destination are pinned to this
+      // stream below, so one archived check covers the whole batch.
+      await assertStreamNotArchived(client, streamId)
+
       const uniqueIds = [...new Set(messageIds)]
 
       // Unlocked peek: chooses the conversation lock set only. The authoritative

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1409,6 +1409,7 @@ describe("BoardCard — archived gating with no anchor stream row", () => {
     await userEvent.click(screen.getAllByLabelText("Message actions")[0])
     const entries = (await screen.findAllByRole("menuitem")).map((el) => el.textContent)
     expect(entries.filter((t) => t?.includes("sub-topic"))).toEqual([])
+    expect(entries.filter((t) => t?.includes("Quote reply"))).toEqual([])
     expect(screen.queryByTestId("reply-composer-open")).toBeNull()
   })
 
@@ -1419,5 +1420,6 @@ describe("BoardCard — archived gating with no anchor stream row", () => {
     await userEvent.click(screen.getAllByLabelText("Message actions")[0])
     const entries = (await screen.findAllByRole("menuitem")).map((el) => el.textContent)
     expect(entries.filter((t) => t?.includes("sub-topic")).length).toBeGreaterThan(0)
+    expect(entries.filter((t) => t?.includes("Quote reply")).length).toBeGreaterThan(0)
   })
 })

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -27,6 +27,7 @@ import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as inlineComposerModule from "@/components/board/board-inline-composer"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import * as boardStoreModule from "@/stores/board-store"
+import * as streamStoreModule from "@/stores/stream-store"
 import * as revealAnchorModule from "@/hooks/use-board-card-reveal-anchor"
 import { setBoardFlash, resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { spyOnExport } from "@/test/spy"
@@ -1369,5 +1370,54 @@ describe("BoardCard backfill arming", () => {
     const [options] = beginReveal.mock.calls.at(-1) as [{ mode: string; landmark: HTMLElement | null }]
     expect(options.mode).toBe("scroll")
     expect(options.landmark).toBe(container.querySelector('[data-message-row][data-message-id="m_r2"]'))
+  })
+})
+
+describe("BoardCard — archived is read-only (INV-62)", () => {
+  it("replaces the reply affordance with the archived notice", async () => {
+    spyOnExport(streamStoreModule, "useStreamFromStore").mockReturnValue(((id: string | undefined) =>
+      id === STREAM ? { id: STREAM, type: "channel", archivedAt: "2026-06-23T12:00:00.000Z" } : undefined) as never)
+    mountCard()
+    expect(
+      await screen.findByText("This conversation has been archived. It can be read but not extended.")
+    ).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Write a reply…" })).toBeNull()
+  })
+
+  it("keeps the reply affordance on an unarchived card", async () => {
+    mountCard()
+    expect(await screen.findByRole("button", { name: "Write a reply…" })).toBeTruthy()
+    expect(screen.queryByText("This conversation has been archived. It can be read but not extended.")).toBeNull()
+  })
+})
+
+describe("BoardCard — archived gating with no anchor stream row", () => {
+  it("seals the card from the post's rootArchived verdict when the anchor row is absent", async () => {
+    mountCard({ ...makePost(), rootArchived: true } as BoardViewPost)
+    expect(
+      await screen.findByText(
+        "The stream this conversation belongs to has been archived. It can be read but not extended."
+      )
+    ).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Write a reply…" })).toBeNull()
+  })
+
+  it("offers no branch affordances on an archived card", async () => {
+    mountCard({ ...makePost(), rootArchived: true } as BoardViewPost)
+    await screen.findByText("Opening body.")
+
+    await userEvent.click(screen.getAllByLabelText("Message actions")[0])
+    const entries = (await screen.findAllByRole("menuitem")).map((el) => el.textContent)
+    expect(entries.filter((t) => t?.includes("sub-topic"))).toEqual([])
+    expect(screen.queryByTestId("reply-composer-open")).toBeNull()
+  })
+
+  it("keeps the branch affordances on an unarchived card", async () => {
+    mountCard()
+    await screen.findByText("Opening body.")
+
+    await userEvent.click(screen.getAllByLabelText("Message actions")[0])
+    const entries = (await screen.findAllByRole("menuitem")).map((el) => el.textContent)
+    expect(entries.filter((t) => t?.includes("sub-topic")).length).toBeGreaterThan(0)
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1079,9 +1079,9 @@ export function BoardCard({
     // Scope quote reply to this card: a message row's "Quote reply" routes into
     // this card's own reply composer, not another card's.
     <ConversationReadProvider value={conversationReadValue}>
-      <QuoteReplyProvider>
+      <QuoteReplyProvider disabled={!!archivedReason}>
         {/* Desktop text-selection → floating "Quote" button, scoped to this card. */}
-        <TextSelectionQuote streamId={streamId} containerRef={cardRef} />
+        {!archivedReason && <TextSelectionQuote streamId={streamId} containerRef={cardRef} />}
         {moveToSubtopic.moveDialog}
         {/* Rest shadow lifts the card off the page — the light-mode card/bg
             lightness delta is ~1%, so the border alone left cards reading flat.

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -206,12 +206,22 @@ export function BoardCard({
   // sub-topic draft rails) the card must subscribe to as extra rails.
   const conversationGraph = useConversationGraph(workspaceId)
   const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const streamId = conversation.streamId
+  // Archived cards are reachable under `?archived=true` — read-only (INV-62).
+  const cardStream = useStreamFromStore(streamId)
+  const archived = useEffectiveArchived({
+    stream: cardStream,
+    rootStreamId: cardStream?.rootStreamId ?? null,
+    fallbackRootArchived: post.rootArchived === true,
+  })
+  const archivedReason = conversationArchivedReason(archived)
   const inlineComposer = useInlineBranchComposer({
     workspaceId,
     conversationId: conversation.id,
     memberMessageIds: conversation.messageIds,
     index: structuralIndex,
     graph: conversationGraph,
+    archived: !!archivedReason,
   })
   const { derivePendingBranches } = inlineComposer
 
@@ -237,15 +247,6 @@ export function BoardCard({
     extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
   })
 
-  const streamId = conversation.streamId
-  // Archived cards are reachable under `?archived=true` — read-only (INV-62).
-  const cardStream = useStreamFromStore(streamId)
-  const archived = useEffectiveArchived({
-    stream: cardStream,
-    rootStreamId: cardStream?.rootStreamId ?? null,
-    fallbackRootArchived: post.rootArchived === true,
-  })
-  const archivedReason = conversationArchivedReason(archived)
   // Leading visual matches the sidebar's stream row: a per-type glyph on a tinted
   // tile, except a DM shows the peer avatar over it (icon as the fallback). Shared
   // `streamTypeVisual` keeps board and sidebar in lockstep.

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -47,7 +47,9 @@ import {
 import { DeletedMessageEvent } from "@/components/timeline/deleted-message-event"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
-import { useActors, useVisibleStreams } from "@/hooks"
+import { useActors, useVisibleStreams, useEffectiveArchived } from "@/hooks"
+import { useStreamFromStore } from "@/stores/stream-store"
+import { conversationArchivedReason } from "@/components/composer/composer-disabled-notice"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useBoardFlash } from "@/stores/board-flash-store"
 import { boardUnreadLatchStorage } from "@/stores/board-unread-latch-store"
@@ -236,6 +238,14 @@ export function BoardCard({
   })
 
   const streamId = conversation.streamId
+  // Archived cards are reachable under `?archived=true` — read-only (INV-62).
+  const cardStream = useStreamFromStore(streamId)
+  const archived = useEffectiveArchived({
+    stream: cardStream,
+    rootStreamId: cardStream?.rootStreamId ?? null,
+    fallbackRootArchived: post.rootArchived === true,
+  })
+  const archivedReason = conversationArchivedReason(archived)
   // Leading visual matches the sidebar's stream row: a per-type glyph on a tinted
   // tile, except a DM shows the peer avatar over it (icon as the fallback). Shared
   // `streamTypeVisual` keeps board and sidebar in lockstep.
@@ -806,11 +816,13 @@ export function BoardCard({
           conversationId={conversation.id}
           conversationRootStreamId={conversation.streamId}
           onNewSubtopic={
-            structuralIndex.threadsByAnchorId.has(message.id)
+            structuralIndex.threadsByAnchorId.has(message.id) || archivedReason
               ? undefined
               : () => inlineComposer.openNewSubtopic(message.streamId ?? streamId, message.id)
           }
-          onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
+          onMoveToSubtopic={
+            archivedReason ? undefined : moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)
+          }
         />
       )
     // Mirrors the panel: a deleted row is a tombstone, never a blank MessageItem
@@ -851,8 +863,12 @@ export function BoardCard({
         // so an actor accent fills to the card edges (stream-view look) with rows aligned.
         surfaceClassName="bg-card px-3 sm:px-4"
         rowInsetClassName="-mx-3 sm:-mx-4"
-        onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
-        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
+        onNewSubtopic={
+          canBranch && !archivedReason ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined
+        }
+        onMoveToSubtopic={
+          archivedReason ? undefined : moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)
+        }
       />
     )
   }
@@ -887,12 +903,12 @@ export function BoardCard({
           settlingRailClassName={rail ? BRANCH_ACCENTED_SETTLING_RAIL_CLASS : BRANCH_SETTLING_RAIL_CLASS}
           suppressRowAccent
           onNewSubtopic={
-            canBranch
+            canBranch && !archivedReason
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
               : undefined
           }
           onMoveToSubtopic={
-            branch.pending
+            branch.pending || archivedReason
               ? undefined
               : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId, message.settling)
           }
@@ -1177,9 +1193,9 @@ export function BoardCard({
                   continueThreadTo={continueThreadTo}
                   onSplitThread={onSplitThread}
                   renderBranchMessage={renderBranchMessage}
-                  renderBranchTail={inlineComposer.renderBranchTail}
+                  renderBranchTail={archivedReason ? undefined : inlineComposer.renderBranchTail}
                   branchExpansion={branchExpansion}
-                  renderAfterMessage={inlineComposer.renderAfterMessage}
+                  renderAfterMessage={archivedReason ? undefined : inlineComposer.renderAfterMessage}
                   onRedirectSession={openReplyComposer}
                   ledgerEventExpansion={ledgerEventExpansion}
                 />
@@ -1192,16 +1208,16 @@ export function BoardCard({
                     continueThreadTo={continueThreadTo}
                     onSplitThread={onSplitThread}
                     renderBranchMessage={renderBranchMessage}
-                    renderBranchTail={inlineComposer.renderBranchTail}
+                    renderBranchTail={archivedReason ? undefined : inlineComposer.renderBranchTail}
                     branchExpansion={branchExpansion}
-                    renderAfterMessage={inlineComposer.renderAfterMessage}
+                    renderAfterMessage={archivedReason ? undefined : inlineComposer.renderAfterMessage}
                     onRedirectSession={openReplyComposer}
                     ledgerEventExpansion={ledgerEventExpansion}
                   />
                   {openingMessage && renderMessage(openingMessage, false)}
                   {/* The opening renders outside the row builder here, so its inline
                     "new sub-topic" composer slot must be placed explicitly. */}
-                  {openingMessage && inlineComposer.renderAfterMessage(openingMessage.id)}
+                  {openingMessage && !archivedReason && inlineComposer.renderAfterMessage(openingMessage.id)}
                   {ledgerHeadRow}
                   <BranchedBoardRows
                     rows={ledgerBranchRows(visibleReplies)}
@@ -1210,9 +1226,9 @@ export function BoardCard({
                     continueThreadTo={continueThreadTo}
                     onSplitThread={onSplitThread}
                     renderBranchMessage={renderBranchMessage}
-                    renderBranchTail={inlineComposer.renderBranchTail}
+                    renderBranchTail={archivedReason ? undefined : inlineComposer.renderBranchTail}
                     branchExpansion={branchExpansion}
-                    renderAfterMessage={inlineComposer.renderAfterMessage}
+                    renderAfterMessage={archivedReason ? undefined : inlineComposer.renderAfterMessage}
                     onRedirectSession={openReplyComposer}
                     ledgerEventExpansion={ledgerEventExpansion}
                   />
@@ -1238,6 +1254,8 @@ export function BoardCard({
                 // freshest activity. Falls back to the conversation's own stream — NOT the
                 // opening message's, which for a thread post is the parent-stream message.
                 lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? streamId}
+                disabled={!!archivedReason}
+                disabledReason={archivedReason}
               />
             )}
           </div>

--- a/apps/frontend/src/components/board/board-reply-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.test.tsx
@@ -144,3 +144,31 @@ describe("BoardReplyComposer alwaysDocked (docked-composer semantics)", () => {
     expect(screen.getByTestId("form-stub")).toHaveAttribute("data-restore", "draft_adv")
   })
 })
+
+describe("BoardReplyComposer archived (read-only conversation)", () => {
+  it("replaces the docked form with the notice", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    mount({
+      alwaysDocked: true,
+      disabled: true,
+      disabledReason: "This conversation has been archived. It can be read but not extended.",
+    })
+    expect(
+      screen.getByText("This conversation has been archived. It can be read but not extended.")
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("form-stub")).toBeNull()
+  })
+
+  it("replaces the resting affordance with the notice", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    mount({
+      disabled: true,
+      disabledReason: "The stream this conversation belongs to has been archived. It can be read but not extended.",
+    })
+    expect(
+      screen.getByText("The stream this conversation belongs to has been archived. It can be read but not extended.")
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Write a reply…" })).toBeNull()
+    expect(screen.queryByTestId("form-stub")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -4,6 +4,7 @@ import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useScopeDraftPreview } from "@/hooks"
 import { CollapsedComposerBar } from "@/components/composer/collapsed-composer-bar"
+import { ComposerDisabledNotice } from "@/components/composer/composer-disabled-notice"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
 import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import { cn } from "@/lib/utils"
@@ -52,6 +53,14 @@ interface BoardReplyComposerProps {
    * disarms. Ignored unless `alwaysDocked`.
    */
   armedReply?: ArmedReply
+  /**
+   * Writing is closed for this conversation (its stream, or the root it
+   * inherits from, is archived — INV-62). The notice replaces the composer
+   * entirely; the backend rejects the write regardless.
+   */
+  disabled?: boolean
+  /** Notice copy shown in place of the composer while `disabled`. */
+  disabledReason?: string
 }
 
 /** A sub-conversation the docked panel composer is armed to reply into. */
@@ -82,6 +91,7 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const alwaysDocked = props.alwaysDocked ?? false
+  const { disabled, disabledReason } = props
 
   // The scope's unsent draft, advertised on the resting button and — when it
   // isn't checked out on this device (stashed / roamed) — checked out by the
@@ -147,6 +157,11 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   // restore is consumed by the mounted form's own URL effect (no mount to hang
   // it on).
   const noopClose = useCallback(() => {}, [])
+
+  if (disabled && disabledReason) {
+    return <ComposerDisabledNotice reason={disabledReason} />
+  }
+
   if (alwaysDocked) {
     return (
       <BoardReplyComposerForm

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -140,6 +140,59 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
     expect(result.current.renderAfterMessage("msg_fork_b")).toBeNull()
   })
 
+  it("neither opens nor consumes a stash deep-link while the surface is archived", async () => {
+    const draftId = await seedDraft("board:branch-reply:conv_branch")
+    const { result, rerender } = renderHook(
+      ({ archived }: { archived: boolean }) =>
+        useInlineBranchComposer({
+          workspaceId,
+          conversationId: PARENT_ID,
+          memberMessageIds: ["msg_fork", "msg_fork_b"],
+          index,
+          graph: makeGraph(),
+          archived,
+        }),
+      { wrapper: wrapperWithStash(draftId), initialProps: { archived: true } }
+    )
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(result.current.openComposer).toBeNull()
+
+    // The param was never consumed, so unarchiving still honours the deep link.
+    rerender({ archived: false })
+    await waitFor(() =>
+      expect(result.current.openComposer).toEqual({
+        kind: "branch-reply",
+        conversationId: "conv_branch",
+        threadStreamId: "stream_thread_1",
+      })
+    )
+  })
+
+  it("drops an open inline composer when the surface becomes archived mid-session", async () => {
+    const { result, rerender } = renderHook(
+      ({ archived }: { archived: boolean }) =>
+        useInlineBranchComposer({
+          workspaceId,
+          conversationId: PARENT_ID,
+          memberMessageIds: ["msg_fork", "msg_fork_b"],
+          index,
+          graph: makeGraph(),
+          archived,
+        }),
+      { wrapper: wrapperWithStash("draft_none"), initialProps: { archived: false } }
+    )
+    act(() => result.current.openNewSubtopic("stream_9", "msg_fork"))
+    expect(result.current.extraDraftPanelIds).toEqual([createDraftPanelId("stream_9", "msg_fork")])
+
+    rerender({ archived: true })
+    // No stranded state: no open composer, and no dead draft-panel rail left
+    // subscribed — so nothing stays force-pinned after an unarchive either.
+    await waitFor(() => expect(result.current.openComposer).toBeNull())
+    expect(result.current.extraDraftPanelIds).toEqual([])
+    rerender({ archived: false })
+    expect(result.current.openComposer).toBeNull()
+  })
+
   it("ignores stash rows belonging to the panel's own reply scope", async () => {
     // A reply-scope stash is the conversation panel's to consume, not this
     // surface's branch/sub-topic composers.

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -129,6 +129,15 @@ export function useInlineBranchComposer(params: {
    * model. Pending branches always stay inline (no real conversation id to arm).
    */
   onArmBranchReply?: (target: ArmBranchTarget, restoreStashedId: string | null) => void
+  /**
+   * The surface is read-only (archived conversation/root — INV-62): it renders no
+   * inline composers, so an open one is dropped here rather than stranded — the
+   * form that would have called `onClose` is already unmounted, and a stranded
+   * `openComposer` keeps a dead draft-panel rail subscribed, force-pins its
+   * branch, and blocks the sub-topic-draft rescope effect. A `?stash=` deep link
+   * is likewise neither opened nor consumed, so it stays retryable elsewhere.
+   */
+  archived?: boolean
 }): {
   branchStreamIds: string[]
   extraDraftPanelIds: string[]
@@ -148,7 +157,7 @@ export function useInlineBranchComposer(params: {
    *  before the `conversation:created` echo hands rendering to the graph. */
   derivePendingBranches: (messagesById: Map<string, RenderableMessage>) => BranchConversationView[]
 } {
-  const { workspaceId, conversationId, memberMessageIds, index, graph, onArmBranchReply } = params
+  const { workspaceId, conversationId, memberMessageIds, index, graph, onArmBranchReply, archived = false } = params
   const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
   const [openComposer, setOpenComposer] = useState<OpenInlineComposer | null>(null)
   // Draft panels of "new sub-topic" sends still in flight — kept subscribed until
@@ -157,6 +166,11 @@ export function useInlineBranchComposer(params: {
   const [pendingSubtopics, setPendingSubtopics] = useState<Array<{ streamId: string; messageId: string }>>([])
 
   const closeComposer = useCallback(() => setOpenComposer(null), [])
+
+  useEffect(() => {
+    if (archived) setOpenComposer(null)
+  }, [archived])
+
   const openNewSubtopic = useCallback(
     (streamId: string, messageId: string, restoreStashedId: string | null = null) =>
       setOpenComposer({ kind: "new-subtopic", streamId, messageId, restoreStashedId }),
@@ -216,6 +230,7 @@ export function useInlineBranchComposer(params: {
   const stashTarget = useStashParamDraftRow(workspaceId)
   const consumedStashRef = useRef<string | null>(null)
   useEffect(() => {
+    if (archived) return
     if (!stashTarget || consumedStashRef.current === stashTarget.draftId) return
     const parsed = parseBoardDraftKey(stashTarget.scope)
     if (!parsed || parsed.kind === "reply") return
@@ -243,7 +258,7 @@ export function useInlineBranchComposer(params: {
     if (graph.conversationIdByMemberMessageId.get(parsed.messageId) !== conversationId) return
     consumedStashRef.current = stashTarget.draftId
     setOpenComposer({ kind: "new-subtopic", streamId: parsed.streamId, messageId: parsed.messageId })
-  }, [stashTarget, graph, branchStreamIds, conversationId, onArmBranchReply])
+  }, [stashTarget, graph, branchStreamIds, conversationId, onArmBranchReply, archived])
 
   // The composer's own pending→graph hand-off: a pending branch is keyed by the
   // synthetic draft-panel id, so once the graph replaces it with the real child

--- a/apps/frontend/src/components/composer/composer-disabled-notice.tsx
+++ b/apps/frontend/src/components/composer/composer-disabled-notice.tsx
@@ -1,0 +1,27 @@
+/**
+ * The banner a composer surface renders in place of its editor when writing is
+ * closed (archived stream/root, system stream). Shared so the timeline and the
+ * conversation surfaces can't drift in copy or shape; each caller keeps its own
+ * shell (floating, docked, in-card).
+ */
+export const CONVERSATION_ARCHIVED_REASON = "This conversation has been archived. It can be read but not extended."
+export const CONVERSATION_ROOT_ARCHIVED_REASON =
+  "The stream this conversation belongs to has been archived. It can be read but not extended."
+
+/** Read-only copy for a conversation surface, by where the archive lives. */
+export function conversationArchivedReason(archived: {
+  ownArchived: boolean
+  rootArchived: boolean
+}): string | undefined {
+  if (archived.ownArchived) return CONVERSATION_ARCHIVED_REASON
+  if (archived.rootArchived) return CONVERSATION_ROOT_ARCHIVED_REASON
+  return undefined
+}
+
+export function ComposerDisabledNotice({ reason }: { reason: string }) {
+  return (
+    <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
+      <p className="text-sm text-muted-foreground text-center">{reason}</p>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/composer/index.ts
+++ b/apps/frontend/src/components/composer/index.ts
@@ -14,3 +14,9 @@ export { StreamTargetPicker, type StreamTargetPickerProps } from "./stream-targe
 export { StreamSortToggle } from "./stream-sort-toggle"
 export { OverlayComposerShell, type OverlayComposerShellProps } from "./overlay-composer-shell"
 export { ConversationReplyStrip } from "./conversation-reply-strip"
+export {
+  ComposerDisabledNotice,
+  CONVERSATION_ARCHIVED_REASON,
+  CONVERSATION_ROOT_ARCHIVED_REASON,
+  conversationArchivedReason,
+} from "./composer-disabled-notice"

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -1668,3 +1668,98 @@ describe("hasUnknownMembers — backfill invalidation gate", () => {
     expect(hasUnknownMembers(["m1", "r1", "r2"], new Set(["m1", "r1"]))).toBe(true)
   })
 })
+
+describe("ConversationPanel — archived is read-only (INV-62)", () => {
+  /** Per-id stream rows, so the anchor and its root can differ. */
+  function seedStreams(rows: Record<string, Record<string, unknown>>) {
+    vi.spyOn(streamStoreModule, "useStreamFromStore").mockImplementation(((id: string | undefined) =>
+      id ? (rows[id] ?? undefined) : undefined) as never)
+  }
+
+  /** Captures the docked composer's gating props without mounting the editor. */
+  function captureComposer() {
+    const captured: { disabled?: boolean; disabledReason?: string } = {}
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      captured.disabled = props.disabled
+      captured.disabledReason = props.disabledReason
+      return props.disabled && props.disabledReason ? (
+        <div data-testid="composer-notice">{props.disabledReason}</div>
+      ) : (
+        <div data-testid="composer-form" />
+      )
+    })
+    return captured
+  }
+
+  it("gates the composer and the sub-topic affordance when the anchor stream is archived", async () => {
+    seedStreams({ stream_1: { id: "stream_1", type: "channel", archivedAt: "2026-01-01T00:00:00.000Z" } })
+    const captured = captureComposer()
+    const user = userEvent.setup()
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    expect(captured.disabled).toBe(true)
+    expect(captured.disabledReason).toBe("This conversation has been archived. It can be read but not extended.")
+    expect(screen.getByTestId("composer-notice")).toBeTruthy()
+    expect(screen.queryByTestId("composer-form")).toBeNull()
+
+    await user.click(screen.getAllByRole("button", { name: "Message actions" })[0]!)
+    expect(screen.queryByText("New sub-topic")).toBeNull()
+  })
+
+  it("inherits the root's archived state for a conversation anchored in a thread", async () => {
+    seedStreams({
+      stream_1: { id: "stream_1", type: "thread", rootStreamId: "stream_root", archivedAt: null },
+      stream_root: { id: "stream_root", type: "channel", archivedAt: "2026-01-01T00:00:00.000Z" },
+    })
+    const captured = captureComposer()
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    expect(captured.disabled).toBe(true)
+    expect(captured.disabledReason).toBe(
+      "The stream this conversation belongs to has been archived. It can be read but not extended."
+    )
+  })
+
+  it("falls back to the post's rootArchived verdict on a cold load with no root row", async () => {
+    seedStreams({ stream_1: { id: "stream_1", type: "thread", rootStreamId: "stream_root", archivedAt: null } })
+    const captured = captureComposer()
+    mountPanel({ cached: asCached({ ...makePost(), rootArchived: true }) })
+    await screen.findByText("Opening message body.")
+
+    expect(captured.disabled).toBe(true)
+    expect(captured.disabledReason).toBe(
+      "The stream this conversation belongs to has been archived. It can be read but not extended."
+    )
+  })
+
+  it("seals from the post's verdict when the anchor stream row is absent entirely", async () => {
+    // Cold load with no resolvable chain: an absent anchor means "unknown", so
+    // the post's effective-root verdict still applies.
+    seedStreams({})
+    const captured = captureComposer()
+    mountPanel({ cached: asCached({ ...makePost(), rootArchived: true }) })
+    await screen.findByText("Opening message body.")
+
+    expect(captured.disabled).toBe(true)
+    expect(captured.disabledReason).toBe(
+      "The stream this conversation belongs to has been archived. It can be read but not extended."
+    )
+  })
+
+  it("leaves an unarchived conversation writable", async () => {
+    seedStreams({ stream_1: { id: "stream_1", type: "channel", archivedAt: null } })
+    const captured = captureComposer()
+    const user = userEvent.setup()
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    expect(captured.disabled).toBe(false)
+    expect(captured.disabledReason).toBeUndefined()
+    expect(screen.getByTestId("composer-form")).toBeTruthy()
+
+    await user.click(screen.getAllByRole("button", { name: "Message actions" })[0]!)
+    expect(screen.getByText("New sub-topic")).toBeTruthy()
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -63,11 +63,12 @@ import {
   useFloatingComposerAnchor,
   useFloatingComposerHeight,
   FLOATING_COMPOSER_HEIGHT_VAR,
+  conversationArchivedReason,
 } from "@/components/composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
-import { useActors, useVisibleStreams } from "@/hooks"
+import { useActors, useVisibleStreams, useEffectiveArchived } from "@/hooks"
 import { useStashedDrafts } from "@/hooks/use-stashed-drafts"
 import { boardReplyDraftKey, boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -377,6 +378,15 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   const hostStream = useStreamFromStore(anchorStreamId)
   const hostStreamType = hostStream?.type
   const locator = useStreamName(workspaceId, anchorStreamId ?? "", "generic") ?? "Conversation"
+  // Archived conversations are read-only (INV-62): the anchor stream's own
+  // state, else the root it inherits from, else the board post's cold-load
+  // verdict (kept live by `setBoardRootArchived`).
+  const archived = useEffectiveArchived({
+    stream: hostStream,
+    rootStreamId: hostStream?.rootStreamId ?? null,
+    fallbackRootArchived: post?.rootArchived === true,
+  })
+  const archivedReason = conversationArchivedReason(archived)
 
   // The pre-`post` half of the same machine: blank while the fetch is young, the
   // panel's own skeleton once it is genuinely slow. The latch is what lets the
@@ -412,6 +422,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
             workspaceId={workspaceId}
             post={post}
             hostStreamType={hostStreamType}
+            archivedReason={archivedReason}
             openReplySignal={openReplySignal}
             contentRef={setFloatingAnchorEl}
             skeletonAlreadyVisible={skeletonShownRef.current.shown}
@@ -463,6 +474,9 @@ interface ConversationPanelBodyProps {
   workspaceId: string
   post: BoardViewPost
   hostStreamType: string | undefined
+  /** Set when the conversation is archived: the composer and the branch affordances
+   *  are replaced by this notice (read-only, INV-62). */
+  archivedReason: string | undefined
   /** Bumped each time the panel is opened via "Reply in conversation" — opens the composer. */
   openReplySignal: number
   /** Rendered here, not by the parent, so it flips on the same `phase` the rows do. */
@@ -484,6 +498,7 @@ function ConversationPanelBody({
   workspaceId,
   post,
   hostStreamType,
+  archivedReason,
   openReplySignal,
   header,
   contentRef,
@@ -827,8 +842,12 @@ function ConversationPanelBody({
         // aligned — matching the board card and timeline.
         surfaceClassName="bg-background px-3 sm:px-6"
         rowInsetClassName="-mx-3 sm:-mx-6"
-        onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
-        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)}
+        onNewSubtopic={
+          canBranch && !archivedReason ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined
+        }
+        onMoveToSubtopic={
+          archivedReason ? undefined : moveToSubtopic.moveHandlerFor(message.id, conversation.id, message.settling)
+        }
       />
     )
   }
@@ -857,12 +876,12 @@ function ConversationPanelBody({
           settlingRailClassName={rail ? BRANCH_ACCENTED_SETTLING_RAIL_CLASS : BRANCH_SETTLING_RAIL_CLASS}
           suppressRowAccent
           onNewSubtopic={
-            canBranch
+            canBranch && !archivedReason
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
               : undefined
           }
           onMoveToSubtopic={
-            branch.pending
+            branch.pending || archivedReason
               ? undefined
               : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId, message.settling)
           }
@@ -1051,8 +1070,8 @@ function ConversationPanelBody({
                     splitThread.mutate({ conversationId: conversation.id, threadStreamId })
                   }
                   renderBranchMessage={renderBranchMessage}
-                  renderBranchTail={inlineComposer.renderBranchTail}
-                  renderAfterMessage={inlineComposer.renderAfterMessage}
+                  renderBranchTail={archivedReason ? undefined : inlineComposer.renderBranchTail}
+                  renderAfterMessage={archivedReason ? undefined : inlineComposer.renderAfterMessage}
                   onRedirectSession={() => setFocusSeq((n) => n + 1)}
                 />
               )}
@@ -1136,6 +1155,8 @@ function ConversationPanelBody({
               // a sub-conversation when a branch reply is armed.
               alwaysDocked
               armedReply={armedReply}
+              disabled={!!archivedReason}
+              disabledReason={archivedReason}
             />
           </FloatingComposerShell>
         </QuoteReplyProvider>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -559,6 +559,7 @@ function ConversationPanelBody({
     index: structuralIndex,
     graph: conversationGraph,
     onArmBranchReply: armBranch,
+    archived: !!archivedReason,
   })
   const { derivePendingBranches, queueExistingBranchReply } = inlineComposer
 

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1039,9 +1039,9 @@ function ConversationPanelBody({
           to this container's bottom as the shared floating pill (same as the
           stream page) instead of sitting in the scrolled flow. */}
       <SidePanelContent ref={contentRef} className="relative flex flex-col">
-        <QuoteReplyProvider>
+        <QuoteReplyProvider disabled={!!archivedReason}>
           {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
-          <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
+          {!archivedReason && <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />}
           {moveToSubtopic.moveDialog}
           <div
             ref={attachListRef}

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -18,6 +18,7 @@ import { useConnectionState } from "@/components/layout/connection-status"
 import {
   ConversationReplyStrip,
   FloatingComposerShell,
+  ComposerDisabledNotice,
   MessageComposer,
   OverlayComposerShell,
   ScheduledMessagesPicker,
@@ -784,9 +785,7 @@ function MessageInputComponent({
     // area and overlaps the first messages instead.
     return (
       <FloatingComposerShell ref={composerHeightRef} data-message-composer-root>
-        <div className="flex items-center justify-center py-3 px-4 rounded-md bg-muted/50">
-          <p className="text-sm text-muted-foreground text-center">{disabledReason}</p>
-        </div>
+        <ComposerDisabledNotice reason={disabledReason} />
       </FloatingComposerShell>
     )
   }

--- a/apps/frontend/src/components/timeline/quote-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/quote-reply-context.tsx
@@ -21,7 +21,7 @@ interface QuoteReplyContextValue {
 
 const QuoteReplyCtx = createContext<QuoteReplyContextValue | null>(null)
 
-export function QuoteReplyProvider({ children }: { children: ReactNode }) {
+export function QuoteReplyProvider({ children, disabled }: { children: ReactNode; disabled?: boolean }) {
   const handlerRef = useRef<((data: QuoteReplyData) => void) | null>(null)
 
   const registerHandler = useCallback((handler: (data: QuoteReplyData) => void) => {
@@ -36,6 +36,11 @@ export function QuoteReplyProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const value = useMemo(() => ({ triggerQuoteReply, registerHandler }), [triggerQuoteReply, registerHandler])
+
+  // Disabled (e.g. archived conversations): render without the context so every
+  // quote affordance — row menu, long-press, selection button — disappears
+  // instead of routing into a composer that can't open.
+  if (disabled) return <>{children}</>
 
   return <QuoteReplyCtx.Provider value={value}>{children}</QuoteReplyCtx.Provider>
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -27,6 +27,7 @@ import {
   useStopAgentSession,
   useEditLastMessageTrigger,
   useKeyboardShortcuts,
+  useEffectiveArchived,
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
@@ -666,32 +667,24 @@ export function StreamContent({
   const stream = streamFromProps ?? idbStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
   const isSystem = stream?.type === StreamTypes.SYSTEM
-  // A thread inherits its lifecycle from its root (INV-62): archiving marks
-  // only the root row, so the thread's own `archivedAt` can't tell the client
-  // it is sealed. The root's archived state is resolved from two sources,
-  // chosen by whether the root is resident in the workspace stream cache:
-  //
-  //   - root in `idbStreams` → use its `archivedAt` directly. This is live:
-  //     `stream:archived`/`stream:unarchived` are routed to the thread's room
-  //     too, so `handleStreamArchived`/`handleStreamUnarchived` update the
-  //     root's IDB row and this value re-renders without a refresh. Covers
-  //     live archive/unarchive and rapid toggling.
-  //   - root not in `idbStreams` → the cold-load deep-link case (the workspace
-  //     bootstrap excludes archived roots, so a thread under an already-
-  //     archived root has no root row to read). Fall back to the per-stream
-  //     bootstrap's `rootArchivedAt`, which the backend populates for threads.
-  //
-  // The two null meanings ("root active" vs "root unknown") must NOT be
-  // merged with `??` — that collapses them and lets a stale bootstrap value
-  // win after unarchive, which was the flicker/rapid-toggle bug.
+  // Archived state is root-inherited (INV-62); the shared hook owns the
+  // two-source resolution (root row in the stream cache, else the per-stream
+  // bootstrap's cold-load verdict).
   const rootStreamId = isThread ? (stream?.rootStreamId ?? null) : null
+  // The root row is resolved here, from the warm workspace-stream cache this
+  // component already reads, rather than left to the hook: a self-resolving
+  // read reports the root absent on the mount's first render, so a stale
+  // bootstrap verdict would flash the archived notice over the composer.
   const rootFromCache = useMemo(
     () => (rootStreamId ? (idbStreams.find((candidate) => candidate.id === rootStreamId) ?? null) : null),
     [idbStreams, rootStreamId]
   )
-  const rootArchivedAt =
-    rootFromCache !== null ? (rootFromCache.archivedAt ?? null) : (bootstrap?.rootArchivedAt ?? null)
-  const isArchived = stream?.archivedAt != null || rootArchivedAt != null
+  const { rootArchived, isArchived } = useEffectiveArchived({
+    stream,
+    rootStreamId,
+    rootStream: rootFromCache,
+    fallbackRootArchived: bootstrap?.rootArchivedAt,
+  })
 
   // Conversation overlay (channels/DMs): URL-derived so a refresh or shared
   // link restores the same view (INV-59). The stream header owns the toggle;
@@ -2242,7 +2235,7 @@ export function StreamContent({
     disabledReason = "System notifications are read-only."
   } else if (stream?.archivedAt) {
     disabledReason = "This thread has been sealed in the labyrinth. It can be read but not extended."
-  } else if (rootArchivedAt) {
+  } else if (rootArchived) {
     disabledReason = "The stream this thread belongs to has been archived. It can be read but not extended."
   }
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -268,3 +268,4 @@ export {
 } from "./use-labels"
 
 export { useComposerActionSide, composerPopoverAlign } from "./use-composer-action-side"
+export { useEffectiveArchived, type EffectiveArchived } from "./use-effective-archived"

--- a/apps/frontend/src/hooks/use-effective-archived.test.ts
+++ b/apps/frontend/src/hooks/use-effective-archived.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { CachedStream } from "@/db"
+import * as streamStore from "@/stores/stream-store"
+import { useEffectiveArchived } from "./use-effective-archived"
+
+function seedRoot(root: Partial<CachedStream> | undefined) {
+  vi.spyOn(streamStore, "useStreamFromStore").mockReturnValue(root as CachedStream | undefined)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useEffectiveArchived", () => {
+  it("seals on the anchor stream's own archivedAt", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: "2026-01-01T00:00:00.000Z" },
+        rootStreamId: null,
+        fallbackRootArchived: false,
+      })
+    )
+    expect(result.current).toEqual({ ownArchived: true, rootArchived: false, isArchived: true })
+  })
+
+  it("inherits from the root row in the stream cache", () => {
+    seedRoot({ id: "stream_root", archivedAt: "2026-01-01T00:00:00.000Z" })
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        fallbackRootArchived: false,
+      })
+    )
+    expect(result.current).toEqual({ ownArchived: false, rootArchived: true, isArchived: true })
+  })
+
+  it("a present, unarchived root row wins over a stale fallback", () => {
+    seedRoot({ id: "stream_root", archivedAt: null })
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        fallbackRootArchived: true,
+      })
+    )
+    expect(result.current).toEqual({ ownArchived: false, rootArchived: false, isArchived: false })
+  })
+
+  it("falls back to the cold-load verdict when the root row is absent", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        fallbackRootArchived: "2026-01-01T00:00:00.000Z",
+      })
+    )
+    expect(result.current).toEqual({ ownArchived: false, rootArchived: true, isArchived: true })
+  })
+
+  it("is unarchived with no own state, no root row and no fallback", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        fallbackRootArchived: undefined,
+      })
+    )
+    expect(result.current).toEqual({ ownArchived: false, rootArchived: false, isArchived: false })
+  })
+
+  it("ignores a root fallback when the surface has no root to inherit from", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({ stream: { archivedAt: null }, rootStreamId: null, fallbackRootArchived: true })
+    )
+    expect(result.current.isArchived).toBe(false)
+  })
+  it("applies the fallback when the anchor row itself is absent (chain unresolvable)", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({ stream: undefined, rootStreamId: null, fallbackRootArchived: true })
+    )
+    expect(result.current).toEqual({ ownArchived: false, rootArchived: true, isArchived: true })
+  })
+
+  it("stays unarchived with an absent anchor and no fallback verdict", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({ stream: undefined, rootStreamId: null, fallbackRootArchived: false })
+    )
+    expect(result.current.isArchived).toBe(false)
+  })
+
+  it("uses a caller-supplied root row instead of self-resolving", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        rootStream: { archivedAt: null },
+        fallbackRootArchived: "2026-01-01T00:00:00.000Z",
+      })
+    )
+    expect(result.current.isArchived).toBe(false)
+    expect(streamStore.useStreamFromStore).toHaveBeenCalledWith(undefined)
+  })
+
+  it("a caller-supplied null root row means known-absent and takes the fallback", () => {
+    seedRoot(undefined)
+    const { result } = renderHook(() =>
+      useEffectiveArchived({
+        stream: { archivedAt: null },
+        rootStreamId: "stream_root",
+        rootStream: null,
+        fallbackRootArchived: "2026-01-01T00:00:00.000Z",
+      })
+    )
+    expect(result.current.rootArchived).toBe(true)
+  })
+})

--- a/apps/frontend/src/hooks/use-effective-archived.ts
+++ b/apps/frontend/src/hooks/use-effective-archived.ts
@@ -1,0 +1,72 @@
+import { useStreamFromStore } from "@/stores/stream-store"
+
+export interface EffectiveArchivedInput {
+  /** The anchor stream row (its own `archivedAt` seals the surface directly). */
+  stream: { archivedAt?: string | null } | null | undefined
+  /** The root to inherit from (INV-62), or null when the anchor IS the root. */
+  rootStreamId: string | null | undefined
+  /**
+   * A root row the caller already resolved (`null` = resolved as absent). When
+   * omitted the hook resolves it itself from the stream store; callers holding
+   * a warm-cached row pass it so the first render doesn't report the root
+   * absent and flash the cold-load verdict.
+   */
+  rootStream?: { archivedAt?: string | null } | null
+  /**
+   * Cold-load verdict for the root, used only when the root row is absent from
+   * the local stream cache: the per-stream bootstrap's `rootArchivedAt` for the
+   * timeline, the board post's `rootArchived` for the conversation surfaces.
+   */
+  fallbackRootArchived: string | boolean | null | undefined
+}
+
+export interface EffectiveArchived {
+  /** The anchor stream itself is archived. */
+  ownArchived: boolean
+  /** The root this surface inherits from is archived. */
+  rootArchived: boolean
+  isArchived: boolean
+}
+
+/**
+ * Effective archived state for a stream-anchored surface. A thread (or a
+ * conversation anchored in one) inherits its lifecycle from its root (INV-62):
+ * archiving marks only the root row, so the anchor's own `archivedAt` can't
+ * tell the client it is sealed. The root's state comes from two sources,
+ * chosen by whether the root is resident in the local stream cache:
+ *
+ *   - root in `db.streams` → use its `archivedAt`. This is live:
+ *     `stream:archived`/`stream:unarchived` are routed to the thread's room
+ *     too, so the row updates and this value re-renders without a refresh.
+ *     Covers live archive/unarchive and rapid toggling.
+ *   - root absent → the cold-load deep-link case (a thread whose root the local
+ *     cache hasn't got — an already-archived root reached by deep link has no
+ *     row to read). Fall back to the caller's cold-load verdict.
+ *
+ * The same applies when the ANCHOR row itself is absent: the caller derives
+ * `rootStreamId` from that row, so an absent anchor leaves the chain
+ * unresolvable — the fallback is a verdict about the effective root and still
+ * applies.
+ *
+ * The two absences ("root active" vs "root unknown") must NOT be merged — that
+ * collapses them and lets a stale fallback win after unarchive, which was the
+ * flicker/rapid-toggle bug.
+ */
+export function useEffectiveArchived({
+  stream,
+  rootStreamId,
+  rootStream,
+  fallbackRootArchived,
+}: EffectiveArchivedInput): EffectiveArchived {
+  const selfResolvedRoot = useStreamFromStore(rootStream === undefined ? (rootStreamId ?? undefined) : undefined)
+  const rootRow = rootStream === undefined ? selfResolvedRoot : rootStream
+  const fallbackArchived = fallbackRootArchived != null && fallbackRootArchived !== false
+  let rootArchived = false
+  if (rootStreamId) {
+    rootArchived = rootRow ? rootRow.archivedAt != null : fallbackArchived
+  } else if (!stream) {
+    rootArchived = fallbackArchived
+  }
+  const ownArchived = stream?.archivedAt != null
+  return { ownArchived, rootArchived, isArchived: ownArchived || rootArchived }
+}


### PR DESCRIPTION
## Problem

An archived stream's conversation is fully writable-looking in the conversation panel and on the board card: live composer, "New sub-topic", "Move to sub-topic…". The backend 403s the send (`resolveWritableMessageStream`, INV-62) so the user only learns at failure. Threads already do this right (`stream-content.tsx` archived notice + composer gating, root-inherited); conversations never got it. Worse, message **reassignment** never checked archived at all — the one write path that skipped the gate, so an "archived" conversation could still have its messages re-filed.

## Solution

- `useEffectiveArchived` (new, lifted from stream-content): own `archivedAt` → root row in `db.streams` (present row wins) → caller fallback. An **absent** anchor row means unknown → fallback applies — critical because archived-root threads are exactly the rows `cleanupStaleEntities` sweeps from `db.streams`. `stream-content.tsx` adopts it, passing its warm `useWorkspaceStreams` row so first-render behavior is unchanged (no notice flash).
- `ComposerDisabledNotice` extracted from `MessageInput`; `BoardReplyComposer` gains `disabled`/`disabledReason` and renders the notice in both docked and resting modes. Panel + board card gate the footer composer, all `onNewSubtopic`/`onMoveToSubtopic` sites, and `renderBranchTail`/`renderAfterMessage`. Copy: "The stream this conversation belongs to has been archived. It can be read but not extended." (root case; own-archived variant likewise). Cold-load fallback is `post.rootArchived`, kept live by `setBoardRootArchived`.
- Backend: `assertStreamNotArchived` in the conversations service, called from `reassignMessage` (message + differing target stream) and `reassignMessagesToConversation` — mirrors `resolveWritableMessageStream`'s effective-root rule.
- Known gap (deliberate): the conversation actions menu still offers status change/split on archived conversations — awaiting a product ruling; `StreamContent` has no mount-test scaffolding, so the warm-row wiring is covered at the hook seam only.

## Test plan

- [x] Adversarial verify (Opus high): 4 findings, all fixed (absent-row fail-open, card branch affordances, ungated reassign incl. backend, warm-cache first render)
- [x] Targeted suites: use-effective-archived 10, backend reassign 19, plus fixer's run of the touched panel/card/composer suites — all green; frontend+backend tsc clean
- [x] Falsified: absent-row branch and backend guard each neutralized → exactly their tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788339208&installation_model_id=20758&pr_number=1740&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1740&signature=02ce925cfa04e5e0680ea7b33fa70a61ab1eefc8a20f7b86ae0b7895ba72ee4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->