### PR TITLE
perf: sub-50 event writes + no-op rewrite skip behind eventWriteChunking

### DIFF
--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { liveQuery } from "dexie"
+import { db, sequenceToNum, type CachedEvent } from "@/db"
+import {
+  EVENT_BULK_PUT_LIMIT,
+  isEventWriteChunkingEnabled,
+  primeEventWriteChunking,
+  putEventsBounded,
+  resetEventWriteChunking,
+  skipNoOpEventRewrites,
+} from "./event-writes"
+
+function makeRow(streamId: string, index: number, overrides: Partial<CachedEvent> = {}): CachedEvent {
+  const sequence = String(1000 + index)
+  return {
+    id: `evt_${streamId}_${index}`,
+    workspaceId: "ws_1",
+    streamId,
+    sequence,
+    _sequenceNum: sequenceToNum(sequence),
+    eventType: "message_created",
+    payload: { messageId: `evt_${streamId}_${index}`, contentMarkdown: "hi" },
+    actorId: "usr_1",
+    actorType: "user",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    _cachedAt: 1,
+    ...overrides,
+  } as CachedEvent
+}
+
+function makePage(streamId: string, count: number): CachedEvent[] {
+  return Array.from({ length: count }, (_, i) => makeRow(streamId, i))
+}
+
+beforeEach(async () => {
+  resetEventWriteChunking()
+  await db.events.clear()
+  await db.workspaceMetadata.clear()
+})
+
+async function putMetadata(featureFlags: unknown): Promise<void> {
+  await db.workspaceMetadata.put({
+    id: "ws_1",
+    workspaceId: "ws_1",
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    featureFlags,
+    _cachedAt: 1,
+  } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("putEventsBounded", () => {
+  it("a 50-row page is written as two sub-50 batches", async () => {
+    const rows = makePage("stream_a", 50)
+    const bulkPut = vi.spyOn(db.events, "bulkPut")
+
+    await putEventsBounded(db.events, rows, true)
+
+    expect(bulkPut).toHaveBeenCalledTimes(2)
+    expect(bulkPut.mock.calls.map((call) => (call[0] as CachedEvent[]).length)).toEqual([EVENT_BULK_PUT_LIMIT, 1])
+    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
+  })
+
+  it("writes a single bulkPut when chunking is off", async () => {
+    const bulkPut = vi.spyOn(db.events, "bulkPut")
+
+    await putEventsBounded(db.events, makePage("stream_a", 50), false)
+
+    expect(bulkPut).toHaveBeenCalledTimes(1)
+    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
+  })
+})
+
+describe("skipNoOpEventRewrites", () => {
+  it("re-writing an identical page writes nothing", async () => {
+    const rows = makePage("stream_a", 50)
+    await putEventsBounded(db.events, rows, true)
+
+    const existingRows = await db.events.bulkGet(rows.map((row) => row.id))
+    const existingById = new Map(
+      existingRows.filter((row): row is CachedEvent => row != null).map((row) => [row.id, row] as const)
+    )
+    const candidates = rows.map((row) => ({ ...row, _cachedAt: 999 }))
+    const bulkPut = vi.spyOn(db.events, "bulkPut")
+
+    await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates), true)
+
+    expect(bulkPut).toHaveBeenCalledTimes(0)
+    const after = await db.events.where("streamId").equals("stream_a").toArray()
+    expect(after.every((row) => row._cachedAt === 1)).toBe(true)
+  })
+
+  it("a row carrying optimistic _status is never skipped", async () => {
+    const optimistic = makeRow("stream_a", 0, { _status: "pending" })
+    await db.events.put(optimistic)
+
+    const candidate = { ...optimistic, _status: undefined } as CachedEvent
+    const kept = skipNoOpEventRewrites(new Map([[optimistic.id, optimistic]]), [candidate])
+
+    expect(kept).toEqual([candidate])
+  })
+
+  it("keeps a row whose payload changed and drops the unchanged neighbour", () => {
+    const unchanged = makeRow("stream_a", 0)
+    const changedBefore = makeRow("stream_a", 1)
+    const changedAfter = {
+      ...changedBefore,
+      payload: { ...(changedBefore.payload as Record<string, unknown>), contentMarkdown: "edited" },
+    }
+
+    const kept = skipNoOpEventRewrites(
+      new Map([
+        [unchanged.id, unchanged],
+        [changedBefore.id, changedBefore],
+      ]),
+      [{ ...unchanged, _cachedAt: 999 }, changedAfter]
+    )
+
+    expect(kept).toEqual([changedAfter])
+  })
+})
+
+describe("live-query wake set (D1)", () => {
+  async function countEmissions(run: () => Promise<void>): Promise<number> {
+    let emissions = 0
+    let firstEmission: (() => void) | undefined
+    const firstEmitted = new Promise<void>((resolve) => {
+      firstEmission = resolve
+    })
+    const subscription = liveQuery(() =>
+      db.events
+        .where("[streamId+_sequenceNum]")
+        .between(["stream_a", 0], ["stream_a", Number.MAX_SAFE_INTEGER])
+        .toArray()
+    ).subscribe(() => {
+      emissions += 1
+      firstEmission?.()
+    })
+    await firstEmitted
+    const baseline = emissions
+
+    await run()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    subscription.unsubscribe()
+    return emissions - baseline
+  }
+
+  it("a 50-row page does not wake a live query ranged on another stream", async () => {
+    const chunkedEmissions = await countEmissions(async () => {
+      await putEventsBounded(db.events, makePage("stream_b", 50), true)
+    })
+    expect(chunkedEmissions).toBe(0)
+
+    await db.events.clear()
+
+    const unchunkedEmissions = await countEmissions(async () => {
+      await putEventsBounded(db.events, makePage("stream_b", 50), false)
+    })
+    expect(unchunkedEmissions).toBeGreaterThan(0)
+  })
+
+  it("a patch to a row the query returned still wakes it", async () => {
+    await db.events.put(makeRow("stream_a", 0))
+
+    const emissions = await countEmissions(async () => {
+      await putEventsBounded(
+        db.events,
+        [makeRow("stream_a", 0, { payload: { messageId: "evt_stream_a_0", contentMarkdown: "edited" } })],
+        true
+      )
+    })
+
+    expect(emissions).toBeGreaterThan(0)
+  })
+})
+
+describe("isEventWriteChunkingEnabled", () => {
+  it("resolves a persisted layered row and caches it", async () => {
+    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
+    const get = vi.spyOn(db.workspaceMetadata, "get")
+
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it("a pre-#1455 flat row neither throws nor enables", async () => {
+    await putMetadata({ eventWriteChunking: "on" })
+
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
+  })
+
+  it("a primed value wins without reading the row", async () => {
+    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    const get = vi.spyOn(db.workspaceMetadata, "get")
+    primeEventWriteChunking("ws_1", { workspace: {}, user: { eventWriteChunking: "on" } })
+
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it("resetEventWriteChunking clears the primed value", async () => {
+    primeEventWriteChunking("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    resetEventWriteChunking()
+
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
+  })
+})

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -164,6 +164,17 @@ describe("live-query wake set (D1)", () => {
     expect(unchunkedEmissions).toBeGreaterThan(0)
   })
 
+  it("a page written inside one wrapping transaction still does not wake another stream's query", async () => {
+    const emissions = await countEmissions(async () => {
+      await db.transaction("rw", [db.events], async () => {
+        await putEventsBounded(db.events, makePage("stream_b", 50), true)
+      })
+    })
+
+    expect(emissions).toBe(0)
+    expect(await db.events.where("streamId").equals("stream_b").count()).toBe(50)
+  })
+
   it("a patch to a row the query returned still wakes it", async () => {
     await db.events.put(makeRow("stream_a", 0))
 

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -1,0 +1,103 @@
+import { coerceLayers, resolveFeatureFlags, type FeatureFlagLayers } from "@threa/types"
+import type { EntityTable } from "dexie"
+import type { CachedEvent, ThreaDatabase } from "@/db/database"
+
+/**
+ * Dexie 4.4.2 registers precise changed keys for a `bulkPut` of fewer than 50
+ * values; at 50 or more it marks FULL_RANGE on the primary key AND on every
+ * index of the table (`dexie.js:5199-5226`), which wakes every live query
+ * mounted on `db.events` app-wide.
+ */
+export const EVENT_BULK_PUT_LIMIT = 49
+
+type EventTable = EntityTable<CachedEvent, "id">
+
+const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
+
+/**
+ * Writes events in slices below Dexie's FULL_RANGE threshold when `chunked`,
+ * and as today's single `bulkPut` when not. Opens no transaction of its own —
+ * the caller's transaction is what makes the slices atomic.
+ */
+export async function putEventsBounded(table: EventTable, rows: CachedEvent[], chunked: boolean): Promise<void> {
+  if (rows.length === 0) return
+  if (!chunked || rows.length <= EVENT_BULK_PUT_LIMIT) {
+    await table.bulkPut(rows)
+    return
+  }
+  for (let start = 0; start < rows.length; start += EVENT_BULK_PUT_LIMIT) {
+    await table.bulkPut(rows.slice(start, start + EVENT_BULK_PUT_LIMIT))
+  }
+}
+
+/**
+ * Whether putting `candidate` over `existing` would change nothing the app
+ * can observe. Skipping these puts matters for perceived performance: every
+ * write to `db.events` re-runs the timeline's `useLiveQuery`, and a bootstrap
+ * that rewrites byte-identical rows forces a full-window re-render for no
+ * user-visible change. `_cachedAt` is bookkeeping (nothing reads it for
+ * eviction or rendering), so a row that differs only by `_cachedAt` is a
+ * no-op. Rows carrying optimistic `_status` are never skipped — the put
+ * intentionally clears that flag on confirm.
+ */
+export function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
+  if (existing._status !== undefined) return false
+  return (
+    existing.streamId === candidate.streamId &&
+    existing.workspaceId === candidate.workspaceId &&
+    existing.sequence === candidate.sequence &&
+    existing.broadcastSequence === candidate.broadcastSequence &&
+    existing._clientId === candidate._clientId &&
+    existing._sequenceNum === candidate._sequenceNum &&
+    existing.eventType === candidate.eventType &&
+    existing.actorId === candidate.actorId &&
+    existing.actorType === candidate.actorType &&
+    existing.createdAt === candidate.createdAt &&
+    JSON.stringify(existing.payload) === JSON.stringify(candidate.payload)
+  )
+}
+
+/** `candidates` minus the rows whose put would change nothing (see {@link isNoOpRewrite}). */
+export function skipNoOpEventRewrites(
+  existingById: Map<string, CachedEvent>,
+  candidates: CachedEvent[]
+): CachedEvent[] {
+  return candidates.filter((candidate) => {
+    const existing = existingById.get(candidate.id)
+    return existing === undefined || !isNoOpRewrite(existing, candidate)
+  })
+}
+
+// The `workspaceMetadata` row carries the workspace emoji list — hundreds of KB
+// that Dexie must deserialize per read — so resolving the flag from it on every
+// event write costs more than the write. Resolve once per workspace per module
+// instance instead, primed from the network bootstrap and socket flag flips.
+const chunkingByWorkspace = new Map<string, boolean>()
+
+function resolveChunking(layers: FeatureFlagLayers | null | undefined): boolean {
+  return resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS).eventWriteChunking === "on"
+}
+
+/** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
+export function primeEventWriteChunking(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
+  chunkingByWorkspace.set(workspaceId, resolveChunking(layers))
+}
+
+/** Test-only: drop the cache so each case resolves from its own prime/IDB row. */
+export function resetEventWriteChunking(): void {
+  chunkingByWorkspace.clear()
+}
+
+/**
+ * The viewer's `eventWriteChunking` value — the primed value when one exists,
+ * otherwise resolved once from the layers persisted for a warm start. Tolerates
+ * the pre-#1455 flat `featureFlags` shape rather than throwing on it.
+ */
+export async function isEventWriteChunkingEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
+  const cached = chunkingByWorkspace.get(workspaceId)
+  if (cached !== undefined) return cached
+  const metadata = await database.workspaceMetadata.get(workspaceId)
+  const chunked = resolveChunking(metadata?.featureFlags)
+  chunkingByWorkspace.set(workspaceId, chunked)
+  return chunked
+}

--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
+import type { StreamEvent } from "@threa/types"
+import { db } from "@/db"
+import { resetEventWriteChunking } from "@/db/event-writes"
 import {
   computeTimelineLoadState,
   filterEventsForDisplay,
@@ -9,6 +12,7 @@ import {
   getNextBootstrapFloorState,
   getOldestSequence,
   getRenderableEvents,
+  cacheToIndexedDB,
 } from "./use-events"
 
 describe("useEvents helpers", () => {
@@ -222,5 +226,58 @@ describe("getEffectiveEvents", () => {
 
   it("returns empty when IDB resolved empty and bootstrap has no events", () => {
     expect(getEffectiveEvents(true, [], [])).toEqual([])
+  })
+})
+
+describe("cacheToIndexedDB with eventWriteChunking on", () => {
+  beforeEach(async () => {
+    resetEventWriteChunking()
+    await db.events.clear()
+    await db.workspaceMetadata.clear()
+    await db.workspaceMetadata.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      emojis: [],
+      emojiWeights: {},
+      commands: [],
+      featureFlags: { workspace: { eventWriteChunking: "on" }, user: {} },
+      _cachedAt: 1,
+    } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
+  })
+
+  function page(count: number, from: number): StreamEvent[] {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `evt_${from + i}`,
+      streamId: "stream_1",
+      sequence: String(from + i),
+      eventType: "message_created" as const,
+      payload: { messageId: `evt_${from + i}`, contentMarkdown: "hi" },
+      actorId: "usr_1",
+      actorType: "user" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    })) as StreamEvent[]
+  }
+
+  it("an older page still lands in the timeline window after chunked writing", async () => {
+    await cacheToIndexedDB("ws_1", "stream_1", page(50, 100))
+    await cacheToIndexedDB("ws_1", "stream_1", page(50, 50))
+
+    const cached = await db.events.where("streamId").equals("stream_1").toArray()
+    expect(cached).toHaveLength(100)
+
+    const displayFloor = getDisplayFloor(getMinimumSequence(page(50, 100)), getMinimumSequence(page(50, 50)))
+    expect(getRenderableEvents(cached, displayFloor)).toHaveLength(100)
+  })
+
+  it("a page that heals thread stats still heals them when chunked", async () => {
+    await cacheToIndexedDB("ws_1", "stream_1", page(50, 100))
+    await db.events.update("evt_120", {
+      payload: { messageId: "evt_120", contentMarkdown: "hi", threadId: "str_t", replyCount: 3 },
+    })
+
+    await cacheToIndexedDB("ws_1", "stream_1", page(50, 100))
+
+    const healed = await db.events.get("evt_120")
+    expect(healed?.payload).toMatchObject({ threadId: "str_t", replyCount: 3 })
   })
 })

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -3,6 +3,7 @@ import { useStreamBootstrap } from "./use-streams"
 import { useStreamService } from "@/contexts"
 import { useQueryClient, useInfiniteQuery } from "@tanstack/react-query"
 import { db, sequenceToNum } from "@/db"
+import { isEventWriteChunkingEnabled, putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
 import { isTerminalBootstrapError, shouldSuppressBootstrapError } from "@/lib/query-load-state"
@@ -272,32 +273,37 @@ function dedupeAndSort(eventArrays: StreamEvent[][]): StreamEvent[] {
  *  healed card/message (chip vanishes, Discuss reappears). Preserve them. */
 const HEALED_THREAD_STAT_KEYS = ["threadId", "replyCount", "threadSummary"] as const
 
-async function cacheToIndexedDB(workspaceId: string, streamId: string, events: StreamEvent[], carrier?: SlotCarrier) {
+export async function cacheToIndexedDB(
+  workspaceId: string,
+  streamId: string,
+  events: StreamEvent[],
+  carrier?: SlotCarrier
+) {
   const now = Date.now()
+  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   await db.transaction("rw", [db.events, db.slots], async () => {
     if (events.length > 0) {
       const existingRows = await db.events.bulkGet(events.map((e) => e.id))
       const existingById = new Map(
         existingRows.filter((row): row is NonNullable<typeof row> => row != null).map((row) => [row.id, row] as const)
       )
-      await db.events.bulkPut(
-        events.map((e) => {
-          const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
-          const existing = existingById.get(e.id)
-          if (!existing) return base
-          const existingPayload = existing.payload as Record<string, unknown>
-          const healed: Record<string, unknown> = {}
-          for (const key of HEALED_THREAD_STAT_KEYS) {
-            if (existingPayload[key] !== undefined) healed[key] = existingPayload[key]
-          }
-          if (Object.keys(healed).length === 0) return base
-          return {
-            ...base,
-            payload: { ...(base.payload as Record<string, unknown>), ...healed },
-            _patchedAt: existing._patchedAt,
-          }
-        })
-      )
+      const candidates = events.map((e) => {
+        const base = { ...e, workspaceId, _sequenceNum: sequenceToNum(e.sequence), _cachedAt: now }
+        const existing = existingById.get(e.id)
+        if (!existing) return base
+        const existingPayload = existing.payload as Record<string, unknown>
+        const healed: Record<string, unknown> = {}
+        for (const key of HEALED_THREAD_STAT_KEYS) {
+          if (existingPayload[key] !== undefined) healed[key] = existingPayload[key]
+        }
+        if (Object.keys(healed).length === 0) return base
+        return {
+          ...base,
+          payload: { ...(base.payload as Record<string, unknown>), ...healed },
+          _patchedAt: existing._patchedAt,
+        }
+      })
+      await putEventsBounded(db.events, chunked ? skipNoOpEventRewrites(existingById, candidates) : candidates, chunked)
     }
     // Persist the page's slot carrier alongside its events so pointers in pages
     // older than the bootstrap window hydrate from the store (Amendment A2).

--- a/apps/frontend/src/hooks/use-feature-flags.ts
+++ b/apps/frontend/src/hooks/use-feature-flags.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {
+  coerceLayers,
   defaultFeatureFlagValue,
   flagAllowsScope,
   isFeatureFlagValue,
@@ -42,26 +43,6 @@ function useFeatureFlagLayers(workspaceId: string): FeatureFlagLayers | null {
   // Fall back to the persisted row only when no bootstrap is cached at all.
   const layers = cached ? cached.layers : persistedLayers
   return useMemo(() => coerceLayers(layers), [layers])
-}
-
-// Pre-#1455 clients stored `featureFlags` as the flat resolved map (typically
-// `{}`); read as layers, `layers.workspace`/`layers.user` are undefined and the
-// resolver throws on Object.entries — killing the first render until the row is
-// rewritten. Coerce any value missing a layer record to well-formed layers
-// (dropping the unlayerable flat keys — the next bootstrap re-persists the real
-// shape); a well-formed value passes through by reference so downstream memos hold.
-function coerceLayers(layers: FeatureFlagLayers | null): FeatureFlagLayers | null {
-  if (!layers) return null
-  if (isLayerRecord(layers.workspace) && isLayerRecord(layers.user)) return layers
-  return {
-    workspace: isLayerRecord(layers.workspace) ? layers.workspace : {},
-    user: isLayerRecord(layers.user) ? layers.user : {},
-  }
-}
-
-function isLayerRecord(value: unknown): value is Record<string, string> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false
-  return Object.values(value).every((entry) => typeof entry === "string")
 }
 
 /**

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -1,5 +1,6 @@
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
-import type { ThreaDatabase } from "../db/database"
+import type { CachedEvent, ThreaDatabase } from "../db/database"
+import { isEventWriteChunkingEnabled, putEventsBounded } from "../db/event-writes"
 import { writeSlotCarrier } from "../stores/slot-store"
 
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
@@ -142,14 +143,17 @@ async function prefetchEventsAround(
     if (data?.events?.length > 0) {
       const now = Date.now()
       const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
+      const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
       await db.transaction("rw", [db.events, db.slots], async () => {
-        await db.events.bulkPut(
+        await putEventsBounded(
+          db.events,
           data.events.map((e: Record<string, unknown>) => ({
             ...e,
             workspaceId,
             _sequenceNum: sequenceToNum(e.sequence as string),
             _cachedAt: now,
-          }))
+          })) as CachedEvent[],
+          chunked
         )
         // Warm the pointer slots this prefetch exists to preserve; an
         // events-around window merges (it is not an authoritative snapshot).
@@ -189,14 +193,17 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
     // sink the stream into "Other". Merge via update() so lastMessagePreview
     // and membership-derived fields (notificationLevel) from
     // applyWorkspaceBootstrap survive.
+    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
-      await db.events.bulkPut(
+      await putEventsBounded(
+        db.events,
         events.map((e) => ({
           ...e,
           workspaceId,
           _sequenceNum: sequenceToNum(e.sequence),
           _cachedAt: now,
-        }))
+        })),
+        chunked
       )
 
       // Warm the bootstrap's pointer slots in the same transaction; a cold

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,4 +1,5 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
+import { isEventWriteChunkingEnabled, isNoOpRewrite, putEventsBounded } from "@/db/event-writes"
 import {
   StreamTypes,
   THREAD_ANCHORABLE_EVENT_TYPES,
@@ -109,7 +110,7 @@ export function toCachedStreamBootstrap(
   }
 }
 
-async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> {
+async function resolveUnknownOptimisticAnchors(streamId: string, chunked: boolean): Promise<void> {
   const unresolved = (await db.events.where("_status").anyOf(["pending", "failed", "editing"]).toArray()).filter(
     (event) => event.streamId === streamId && event._anchorSequenceNum == null
   )
@@ -133,7 +134,7 @@ async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> 
       anchor ?? Math.max(0, Math.min(...persistedEvents.map((persisted) => persisted._sequenceNum)) - 1)
     return [{ ...event, _anchorSequenceNum: resolvedAnchor, _cachedAt: now }]
   })
-  if (resolved.length > 0) await db.events.bulkPut(resolved)
+  await putEventsBounded(db.events, resolved, chunked)
 }
 
 export async function bumpLaterOptimisticAnchors(
@@ -269,33 +270,6 @@ async function pruneBootstrapReplaceWindow(streamId: string, bootstrap: StreamBo
 }
 
 /**
- * Whether putting `candidate` over `existing` would change nothing the app
- * can observe. Skipping these puts matters for perceived performance: every
- * write to `db.events` re-runs the timeline's `useLiveQuery`, and a bootstrap
- * that rewrites byte-identical rows forces a full-window re-render for no
- * user-visible change. `_cachedAt` is bookkeeping (nothing reads it for
- * eviction or rendering), so a row that differs only by `_cachedAt` is a
- * no-op. Rows carrying optimistic `_status` are never skipped — the put
- * intentionally clears that flag on confirm.
- */
-function isNoOpRewrite(existing: CachedEvent, candidate: CachedEvent): boolean {
-  if (existing._status !== undefined) return false
-  return (
-    existing.streamId === candidate.streamId &&
-    existing.workspaceId === candidate.workspaceId &&
-    existing.sequence === candidate.sequence &&
-    existing.broadcastSequence === candidate.broadcastSequence &&
-    existing._clientId === candidate._clientId &&
-    existing._sequenceNum === candidate._sequenceNum &&
-    existing.eventType === candidate.eventType &&
-    existing.actorId === candidate.actorId &&
-    existing.actorType === candidate.actorType &&
-    existing.createdAt === candidate.createdAt &&
-    JSON.stringify(existing.payload) === JSON.stringify(candidate.payload)
-  )
-}
-
-/**
  * Returns the standalone frontier preserved because the local row was touched
  * at/after `fetchStartedAt` (undefined when the response's readState applied
  * normally) — `applyStreamBootstrap` republishes it to the query caches.
@@ -305,6 +279,7 @@ async function writeBootstrapEventsAndStream(
   streamId: string,
   bootstrap: StreamBootstrap,
   now: number,
+  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<StreamReadFrontier | undefined> {
   await cleanupStaleOptimisticEvents(streamId)
@@ -464,10 +439,8 @@ async function writeBootstrapEventsAndStream(
       }
     }
 
-    if (toWrite.length > 0) {
-      await db.events.bulkPut(toWrite)
-    }
-    await resolveUnknownOptimisticAnchors(streamId)
+    await putEventsBounded(db.events, toWrite, chunked)
+    await resolveUnknownOptimisticAnchors(streamId, chunked)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
@@ -712,6 +685,7 @@ export async function applyStreamBootstrap(
   options?: StreamBootstrapApplyOptions
 ): Promise<void> {
   const now = Date.now()
+  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   let preservedReadState: StreamReadFrontier | undefined
   await db.transaction(
     "rw",
@@ -722,6 +696,7 @@ export async function applyStreamBootstrap(
         streamId,
         bootstrap,
         now,
+        chunked,
         options?.fetchStartedAt
       )
     }
@@ -763,9 +738,10 @@ export async function applyStreamBootstrapInCurrentTransaction(
   streamId: string,
   bootstrap: StreamBootstrap,
   now = Date.now(),
+  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<void> {
-  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, fetchStartedAt)
+  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 
@@ -1219,6 +1195,7 @@ export function registerStreamSocketHandlers(
       // after the transaction commits so the backfill never runs inside it.
       let gapAfterSequence: string | null = null
 
+      const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
       await db.transaction("rw", [db.events, db.pendingMessages, db.slots], async () => {
         // Merge the carrier's slots in the same transaction as the event. A
@@ -1267,7 +1244,7 @@ export function registerStreamSocketHandlers(
           _sequenceNum: sequenceToNum(newEvent.sequence),
           _cachedAt: now,
         })
-        await resolveUnknownOptimisticAnchors(streamId)
+        await resolveUnknownOptimisticAnchors(streamId, chunked)
 
         if (newPayload.clientMessageId) {
           if (optimistic) {
@@ -1442,6 +1419,7 @@ export function registerStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
+    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1472,13 +1450,15 @@ export function registerStreamSocketHandlers(
       }
 
       if (payload.destinationStreamId === streamId) {
-        await db.events.bulkPut(
+        await putEventsBounded(
+          db.events,
           payload.events.map((event) => ({
             ...event,
             workspaceId,
             _sequenceNum: sequenceToNum(event.sequence),
             _cachedAt: now,
-          }))
+          })),
+          chunked
         )
         // B3: the moved messages' pointer cards would skeleton in the
         // destination panel (cross-stream sources aren't in the local event
@@ -1656,6 +1636,7 @@ export function registerStreamSocketHandlers(
     // Set when this event's sequence reveals missed events behind it; reported
     // after the transaction commits so the backfill never runs inside it.
     let gapAfterSequence: string | null = null
+    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     // Same transactional shape as handleMessageCreated: dedupe, gap-read, and
     // put must be atomic, or a concurrent append can land between the gap read
     // and this write and make the cursor lie in either direction.
@@ -1678,7 +1659,7 @@ export function registerStreamSocketHandlers(
         _sequenceNum: sequenceToNum(payload.event.sequence),
         _cachedAt: now,
       })
-      await resolveUnknownOptimisticAnchors(streamId)
+      await resolveUnknownOptimisticAnchors(streamId, chunked)
       if (commandClientId && optimisticCommand) {
         await bumpLaterOptimisticAnchors(
           streamId,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -107,6 +107,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
+import { isEventWriteChunkingEnabled, primeEventWriteChunking } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -1671,7 +1672,10 @@ export function registerWorkspaceSocketHandlers(
     }))
     if (!patched) return
     const layers = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.featureFlags
-    if (layers) void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
+    if (layers) {
+      primeEventWriteChunking(workspaceId, layers)
+      void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
+    }
   }
 
   const handleFeatureFlagsUpdated = (payload: FeatureFlagsUpdatedPayload) => {
@@ -2565,6 +2569,7 @@ export async function applyWorkspaceBootstrap(
 ): Promise<AppliedWorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
+  primeEventWriteChunking(workspaceId, bootstrap.featureFlags)
   const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   // Build membership lookup for O(1) access when merging onto streams
@@ -3055,6 +3060,8 @@ export async function applyReconnectBootstrapBatch(
     fetchStartedAt,
   })
 
+  primeEventWriteChunking(workspaceId, finalBootstrap.featureFlags)
+  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -3331,7 +3338,7 @@ export async function applyReconnectBootstrapBatch(
         // Carry the fetch window so a per-stream envelope's stale `readState`
         // never clobbers a frontier touched during the reconnect (same rule
         // the workspace map merge above applies).
-        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, fetchStartedAt)
+        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
       }
 
       if (terminalStreamIds.size > 0) {
@@ -3500,7 +3507,17 @@ async function cleanupStaleEntities(
   // can't ride the generic deleteStale (Amendment A4).
   const staleStreamIds = await staleEntityIds(db.streams, "workspaceId", workspaceId, bootstrapStreamIds, now)
 
-  const [, , staleUserIds, staleMembershipIds, staleDmPeerIds, stalePersonaIds, staleBotIds, staleLabelIds, staleLabelAssignmentIds] = await Promise.all([
+  const [
+    ,
+    ,
+    staleUserIds,
+    staleMembershipIds,
+    staleDmPeerIds,
+    stalePersonaIds,
+    staleBotIds,
+    staleLabelIds,
+    staleLabelAssignmentIds,
+  ] = await Promise.all([
     staleStreamIds.length > 0 ? db.streams.bulkDelete(staleStreamIds) : Promise.resolve(),
     deleteSlotsForStreams(db, staleStreamIds),
     deleteStale(db.workspaceUsers, "workspaceId", workspaceId, bootstrapUserIds, now),

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -57,6 +57,7 @@ export const FEATURE_FLAGS = {
   bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
+  eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
@@ -125,6 +126,26 @@ export function resolveFeatureFlags(layers: FeatureFlagLayers): FeatureFlags {
 // The two functions below take the registry as a parameter so the scope and layering
 // rules stay testable: FEATURE_FLAGS is empty between rollouts, and an empty
 // registry resolves every input to {}.
+
+// Pre-#1455 clients stored `featureFlags` as the flat resolved map (typically
+// `{}`); read as layers, `layers.workspace`/`layers.user` are undefined and the
+// resolver throws on Object.entries — killing the first render until the row is
+// rewritten. Coerce any value missing a layer record to well-formed layers
+// (dropping the unlayerable flat keys — the next bootstrap re-persists the real
+// shape); a well-formed value passes through by reference so downstream memos hold.
+export function coerceLayers(layers: FeatureFlagLayers | null): FeatureFlagLayers | null {
+  if (!layers) return null
+  if (isLayerRecord(layers.workspace) && isLayerRecord(layers.user)) return layers
+  return {
+    workspace: isLayerRecord(layers.workspace) ? layers.workspace : {},
+    user: isLayerRecord(layers.user) ? layers.user : {},
+  }
+}
+
+function isLayerRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false
+  return Object.values(value).every((entry) => typeof entry === "string")
+}
 
 export function registryAllowsScope(registry: FeatureFlagRegistry, key: string, scope: FeatureFlagScope): boolean {
   return Object.hasOwn(registry, key) && registry[key].scopes.includes(scope)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -980,6 +980,7 @@ export {
   defaultFeatureFlagValue,
   defaultFeatureFlags,
   resolveFeatureFlags,
+  coerceLayers,
 } from "./feature-flags"
 
 // Client performance capture (closed mark registry + wire schema)


### PR DESCRIPTION
## Problem

Dexie 4.4.2 registers precise changed keys for a `bulkPut` of fewer than 50 values; at ≥50 it marks `FULL_RANGE` on the primary key **and every index** of the table (`dexie.js:5199-5226`). Threa's event page size is exactly 50 (`EVENT_PAGE_SIZE`), so one older-page fetch — or any bootstrap/moved-messages batch that size — wakes every live query mounted on `db.events` app-wide: the open timeline, the gallery, the panels, `use-all-drafts`, and all board rails. Production captures (build 5602209) show 51 `liveQuery.rerun` totalling 5.3s while browsing. First chunk of the PR 6/10 plan (bounded timeline reads).

## Solution

Write events in ≤49-row slices and skip rewrites that change nothing, behind `eventWriteChunking` (workspace/user scope, default off — off is byte-identical to today).

- **New `apps/frontend/src/db/event-writes.ts`**: `EVENT_BULK_PUT_LIMIT = 49` + `putEventsBounded` (no transaction of its own — callers own theirs, so a mid-slice quota failure aborts atomically); `isNoOpRewrite`/`skipNoOpEventRewrites` lifted verbatim from `stream-sync.ts` (INV-35; optimistic-`_status` rows are never skipped).
- **All five ≥50-capable write sites routed**: stream bootstrap, `messages:moved`, older-page `cacheToIndexedDB` (skip runs after the `HEALED_THREAD_STAT_KEYS` merge, so healing survives), SW prefetch ×2, and `resolveUnknownOptimisticAnchors` — the last one matters because Dexie unions observability **per transaction**, so one unrouted ≥50 put in the same tx would void every slice.
- **Flag plumbing follows the `bootstrapDiff` precedent**: resolved from the fresh bootstrap payload and primed into a per-workspace module cache (`primeEventWriteChunking` at both bootstrap-apply sites + the socket flag-flip handler); the IDB fallback read coerces the persisted layers through the shared `coerceLayers` (moved to `@threa/types`, INV-35) — the raw read would re-open the #1489 flat-shape crash, inside the bootstrap transaction. Deliberate limitation: a cold start with an empty cache resolves "off" for the first bootstrap, and a second tab lags a flip until its own prime.
- The wake-set claim is pinned by a test against fake-indexeddb, not by the source read: a 50-row page to stream B must not wake a query ranged on stream A, and raising the limit to 50 turns it red (verified).

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr6-10-plan-4119f5/ (chunk 1, decisions D1/D5/D10).

## Test plan

- [x] Targeted vitest (`event-writes`, `stream-sync`, `use-events`, `--maxWorkers=2`): 155 pass / 0 fail; typecheck clean; Opus-high adversarial verify (4 findings, all fixed — flat-flags crash, 356KB-row-per-write flag read, unrouted anchor bulkPut, stale flag reads) + neutralisation checks
- [ ] Broad suites deliberately left to CI (local full runs disabled by request)

## Post-review updates (whole-stack pass)
- The prime cache described above was later generalized in #1750: `primeEventWriteChunking`/`resetEventWriteChunking` are now `primeEventWriteFlags`/`resetEventWriteFlags`, holding both event-write flags on one prime path.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788339982&installation_model_id=20758&pr_number=1742&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1742&signature=6c81537496850905a2c73c32876f2f42784b676e9408f1b1dd5533a669b3c8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
