### PR TITLE
perf: one live query per workspace table behind sharedWorkspaceReads

### DIFF
--- a/apps/backend/src/features/perf-diagnostics/handlers.test.ts
+++ b/apps/backend/src/features/perf-diagnostics/handlers.test.ts
@@ -5,8 +5,12 @@ import { PERF_CAPTURE_MAX_SAMPLES } from "@threa/types"
 import { createPerfDiagnosticsHandlers, PERF_CAPTURE_MAX_BYTES } from "./handlers"
 import type { PerfDiagnosticsService } from "./service"
 
+const captured: unknown[] = []
 const service = {
-  createCapture: async () => ({ id: "perfcap_x" }),
+  createCapture: async (args: { capture: unknown }) => {
+    captured.push(args.capture)
+    return { id: "perfcap_x" }
+  },
 } as unknown as PerfDiagnosticsService
 
 const handlers = createPerfDiagnosticsHandlers({ perfDiagnosticsService: service })
@@ -55,9 +59,33 @@ describe("perf-capture create handler", () => {
     expect({ statusCode: res.statusCode, body: res.body }).toEqual({ statusCode: 201, body: { id: "perfcap_x" } })
   })
 
-  it("rejects an unknown mark name with a 400 VALIDATION_ERROR", async () => {
-    const err = await failure({ ...validCapture, samples: [{ name: "stream.secretPayload", at: 1 }] })
-    expect({ status: err.status, code: err.code }).toEqual({ status: 400, code: "VALIDATION_ERROR" })
+  it("drops samples with unknown mark names and stores the rest", async () => {
+    // A Pages deploy runs ahead of Railway, so a client one release ahead may
+    // send names this build's closed set doesn't know — the capture survives,
+    // the unknown samples never enter storage.
+    const res = response()
+    await handlers.create(
+      request({
+        ...validCapture,
+        samples: [
+          { name: "bootstrap.fetch", at: 1, value: 12 },
+          { name: "future.unknownMark", at: 2, value: 3 },
+        ],
+      }),
+      res
+    )
+    expect({
+      statusCode: res.statusCode,
+      samples: (captured.at(-1) as { samples: { name: string }[] }).samples.map((s) => s.name),
+    }).toEqual({ statusCode: 201, samples: ["bootstrap.fetch"] })
+  })
+
+  it("rejects a capture whose samples are all unknown as empty-invalid only if the schema requires samples", async () => {
+    // All-unknown samples degrade to an empty samples array; the schema decides
+    // whether that is acceptable — this pins the handler never 400s on names.
+    const res = response()
+    await handlers.create(request({ ...validCapture, samples: [{ name: "future.unknownMark", at: 2, value: 3 }] }), res)
+    expect(res.statusCode).toBe(201)
   })
 
   it("rejects a capture over the sample cap", async () => {

--- a/apps/backend/src/features/perf-diagnostics/handlers.ts
+++ b/apps/backend/src/features/perf-diagnostics/handlers.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express"
 import { HttpError } from "@threa/backend-common"
-import { performanceCaptureSchema } from "@threa/types"
+import { PERF_MARK_NAMES, performanceCaptureSchema } from "@threa/types"
 import { validateRequest } from "../../lib/validation"
 import type { PerfDiagnosticsService } from "./service"
 
@@ -17,6 +17,19 @@ interface Dependencies {
 export function createPerfDiagnosticsHandlers({ perfDiagnosticsService }: Dependencies) {
   return {
     async create(req: Request, res: Response) {
+      // The frontend (Pages) deploys ahead of this backend (Railway), so a
+      // client one release ahead may send mark names this build's closed set
+      // doesn't know. Drop those samples instead of 400ing the whole capture —
+      // unknown names never enter storage, and the session's other diagnostics
+      // survive the deploy window.
+      const body = req.body as { samples?: unknown }
+      if (Array.isArray(body?.samples)) {
+        const known = new Set<string>(PERF_MARK_NAMES)
+        body.samples = body.samples.filter(
+          (sample) =>
+            typeof (sample as { name?: unknown })?.name === "string" && known.has((sample as { name: string }).name)
+        )
+      }
       const capture = validateRequest(performanceCaptureSchema, req.body)
 
       const byteSize = Buffer.byteLength(JSON.stringify(capture), "utf8")

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -8,6 +8,7 @@ import { ThreaDatabase, accountDbName } from "@/db"
 import { setActiveDb } from "@/db/database"
 import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -76,6 +77,7 @@ export function useAccountScopeOptional(): AccountScopeValue | null {
 // them or account A's cached workspaces/drafts/shares bleed into account B.
 function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()

--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -879,6 +879,21 @@ describe("CoordinatedLoadingProvider store publication", () => {
     )
   }
 
+  /**
+   * The provider's ten table reads resolve in separate IndexedDB tasks, so one
+   * microtask tick leaves stragglers that would land inside the measured window
+   * and be counted as apply-driven renders. Drain until the count holds still.
+   */
+  async function settleStoreReads(renderCount: () => number): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const before = renderCount()
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      if (renderCount() === before) return
+    }
+  }
+
   function diffBootstrap(): WorkspaceBootstrap {
     return structuredClone(bootstrapBase)
   }
@@ -967,9 +982,7 @@ describe("CoordinatedLoadingProvider store publication", () => {
         <TestConsumer />
       </CoordinatedLoadingProvider>
     )
-    await act(async () => {
-      await Promise.resolve()
-    })
+    await settleStoreReads(() => providerRenders)
     const before = providerRenders
 
     await act(async () => {
@@ -994,9 +1007,7 @@ describe("CoordinatedLoadingProvider store publication", () => {
         <TestConsumer />
       </CoordinatedLoadingProvider>
     )
-    await act(async () => {
-      await Promise.resolve()
-    })
+    await settleStoreReads(() => providerRenders)
     const before = providerRenders
 
     const changed = diffBootstrap()

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -65,6 +65,20 @@ function createWrapper(
   }
 }
 
+/**
+ * The store hooks read IndexedDB and fall back to the in-memory cache only until
+ * the live query resolves — seeding the cache alone means the first emission
+ * clears the seeded identity again. Mirror the rows those hooks re-read.
+ */
+async function seedWorkspaceCacheAndIdb(
+  workspaceId: string,
+  seed: Parameters<typeof seedWorkspaceCache>[1]
+): Promise<void> {
+  seedWorkspaceCache(workspaceId, seed)
+  await db.workspaceUsers.bulkPut(seed.users)
+  if (seed.dmPeers.length > 0) await db.dmPeers.bulkPut(seed.dmPeers)
+}
+
 describe("useStreamOrDraft real stream send", () => {
   beforeEach(async () => {
     await clearAllCachedData()
@@ -93,7 +107,7 @@ describe("useStreamOrDraft real stream send", () => {
       lastMessagePreview: null,
     }
 
-    seedWorkspaceCache("ws_1", {
+    await seedWorkspaceCacheAndIdb("ws_1", {
       workspace: {
         id: "ws_1",
         name: "Workspace",
@@ -328,7 +342,7 @@ describe("useStreamOrDraft draft DM send", () => {
       createdAt,
     })
 
-    seedWorkspaceCache("ws_1", {
+    await seedWorkspaceCacheAndIdb("ws_1", {
       workspace: {
         id: "ws_1",
         name: "Workspace",
@@ -539,7 +553,7 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
       _cachedAt: Date.now(),
       ...streamOverrides,
     }
-    seedWorkspaceCache("ws_1", {
+    await seedWorkspaceCacheAndIdb("ws_1", {
       workspace: {
         id: "ws_1",
         name: "Workspace",

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -62,6 +62,8 @@ import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { isServerStreamId } from "@/lib/stream-ids"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { setWorkspaceReadMode } from "@/stores/workspace-table-registry"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { SyncEngine, SyncEngineContext, isSyncEngineCurrent } from "@/sync/sync-engine"
 import { draftsApi, messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
@@ -335,6 +337,21 @@ function MessageQueueHandler() {
   return null
 }
 
+/**
+ * Pushes the `sharedWorkspaceReads` flag into the workspace-table registry. The
+ * flag flips sharing only — the hook shape is identical in both arms — so it can
+ * arrive late or change mid-session without changing a single hook count (D5).
+ */
+function WorkspaceReadModeSync({ workspaceId }: { workspaceId: string }) {
+  const shared = useFeatureFlag(workspaceId, "sharedWorkspaceReads") === "on"
+
+  useEffect(() => {
+    setWorkspaceReadMode(shared ? "shared" : "off")
+  }, [shared])
+
+  return null
+}
+
 function StreamNameDecryptor({ workspaceId }: { workspaceId: string }) {
   useDecryptStreamNames(workspaceId)
   return null
@@ -474,6 +491,7 @@ export function WorkspaceLayout() {
             <AppUpdateChecker />
             <FreshnessWatchers />
             <MessageQueueHandler />
+            <WorkspaceReadModeSync workspaceId={workspaceId} />
             <StreamNameDecryptor workspaceId={workspaceId} />
             <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={coordinatedStreamIds}>
               <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>

--- a/apps/frontend/src/stores/workspace-store.test.tsx
+++ b/apps/frontend/src/stores/workspace-store.test.tsx
@@ -1,13 +1,16 @@
-import { describe, it, expect, beforeEach } from "vitest"
-import { renderHook, act, waitFor } from "@testing-library/react"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { renderHook, act, render, waitFor } from "@testing-library/react"
 import { LabelableResourceTypes } from "@threa/types"
-import { db, type CachedLabelAssignment, type CachedWorkspaceUser } from "@/db"
+import { db, type CachedLabelAssignment, type CachedStream, type CachedWorkspaceUser } from "@/db"
+import * as streamNameCache from "@/lib/crypto/stream-name-cache"
+import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
 import {
   resetWorkspaceStoreCache,
   seedWorkspaceCache,
   upsertWorkspaceUserInCache,
   useWorkspaceLabelAssignments,
   useWorkspaceMetadata,
+  useWorkspaceStreams,
   useWorkspaceUsers,
 } from "./workspace-store"
 
@@ -62,6 +65,12 @@ function seedWithUsers(users: CachedWorkspaceUser[]): void {
 describe("workspace store cache subscriptions", () => {
   beforeEach(() => {
     resetWorkspaceStoreCache()
+    resetWorkspaceTableRegistry()
+  })
+
+  afterEach(() => {
+    resetWorkspaceTableRegistry()
+    vi.restoreAllMocks()
   })
 
   it("rerenders existing array readers when the workspace cache is seeded", () => {
@@ -225,5 +234,87 @@ describe("workspace store cache subscriptions", () => {
     })
 
     await waitFor(() => expect(result.current).toEqual([]))
+  })
+
+  it("an incremental socket delete still empties the hook", async () => {
+    // Same contract as the case above, re-asserted through the shared registry:
+    // an emptied IDB must win over the bootstrap cache, or a socket unassign is
+    // masked until the next bootstrap.
+    setWorkspaceReadMode("shared")
+    await db.labelAssignments.clear()
+    const assignment: CachedLabelAssignment = {
+      id: "workspace_1:stream:stream_9:label_9:user_1",
+      workspaceId: "workspace_1",
+      labelId: "label_9",
+      resourceType: LabelableResourceTypes.STREAM,
+      resourceId: "stream_9",
+      userId: "user_1",
+      assignedAt: "2026-03-01T10:00:00Z",
+      _cachedAt: Date.now(),
+    }
+    await db.labelAssignments.put(assignment)
+    act(() => {
+      seedWorkspaceCache("workspace_1", {
+        workspace: {
+          id: "workspace_1",
+          name: "Workspace",
+          slug: "workspace",
+          createdAt: "2026-03-01T10:00:00Z",
+          updatedAt: "2026-03-01T10:00:00Z",
+          _cachedAt: Date.now(),
+        },
+        users: [],
+        streams: [],
+        memberships: [],
+        dmPeers: [],
+        personas: [],
+        bots: [],
+        labelAssignments: [assignment],
+      })
+    })
+
+    const { result } = renderHook(() => useWorkspaceLabelAssignments("workspace_1"))
+    await waitFor(() => expect(result.current.map((a) => a.id)).toEqual([assignment.id]))
+
+    await act(async () => {
+      await db.labelAssignments.delete(assignment.id)
+    })
+
+    await waitFor(() => expect(result.current).toEqual([]))
+  })
+
+  it("the decrypted-name overlay is applied once per workspace, not once per consumer", async () => {
+    setWorkspaceReadMode("shared")
+    await db.streams.clear()
+    const stream: CachedStream = {
+      id: "stream_overlay",
+      workspaceId: "workspace_1",
+      type: "channel",
+      slug: "general",
+      displayName: "General",
+      _cachedAt: 1,
+    } as CachedStream
+    await db.streams.put(stream)
+
+    const overlay = vi.spyOn(streamNameCache, "applyDecryptedNameOverlay")
+
+    function TenConsumers() {
+      const rows: CachedStream[][] = []
+      for (let i = 0; i < 10; i++) {
+        rows.push(useWorkspaceStreams("workspace_1"))
+      }
+      return <div>{rows[0].length}</div>
+    }
+
+    const { findByText } = render(<TenConsumers />)
+    await findByText("1")
+    const afterMount = overlay.mock.calls.length
+
+    await act(async () => {
+      await db.streams.put({ ...stream, displayName: "Renamed", _cachedAt: 2 })
+    })
+    await waitFor(() => expect(overlay.mock.calls.length).toBeGreaterThan(afterMount))
+
+    expect(overlay.mock.calls.length - afterMount).toBe(1)
   })
 })

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -1,11 +1,16 @@
-import { useMemo, useSyncExternalStore } from "react"
-import { useLiveQuery } from "dexie-react-hooks"
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
 import { useBatchedValue } from "./apply-window"
 import {
-  applyDecryptedNameOverlay,
-  getStreamNameCacheVersion,
-  subscribeStreamNameCache,
-} from "@/lib/crypto/stream-name-cache"
+  allocateWorkspaceTableToken,
+  getWorkspaceTableSnapshot,
+  subscribeWorkspaceTable,
+  type WorkspaceTableKey,
+  type WorkspaceTableRowTypes,
+} from "./workspace-table-registry"
+// Namespace import so the shared overlay memo below is spy-able against the
+// module (INV-48) — the "once per workspace, not once per consumer" property is
+// only assertable through the real call.
+import * as streamNameCache from "@/lib/crypto/stream-name-cache"
 import {
   db,
   type CachedWorkspace,
@@ -140,6 +145,7 @@ export function resetWorkspaceStoreCache(): void {
   cache.sidebarConfig.clear()
   cache.metadata.clear()
   cacheVersion.clear()
+  nameOverlayMemo.clear()
   // cacheSignal is bumped, never cleared: resetting it to 0 and publishing 1
   // reproduces a value a mounted subscriber may already hold, and
   // useSyncExternalStore compares values — the reset would then not re-render.
@@ -329,17 +335,50 @@ export function upsertWorkspaceUserInCache(workspaceId: string, user: CachedWork
 // assignment removed via a socket event, which updates IDB but not the cache)
 // would otherwise be masked until the next bootstrap.
 
-function useArrayStoreHook<T>(queryFn: () => Promise<T[]> | T[], deps: unknown[], cached: T[]): T[] {
-  const live = useLiveQuery(queryFn, deps)
+// One shared empty array: a fresh `[]` per render would defeat every identity
+// check downstream (the shared name overlay's memo, and any consumer memoising
+// on the returned reference) for the whole pre-resolution window.
+const EMPTY_ROWS: never[] = []
+
+function useWorkspaceTableToken(): number {
+  const token = useRef<number | null>(null)
+  if (token.current === null) token.current = allocateWorkspaceTableToken()
+  return token.current
+}
+
+function useWorkspaceTable<K extends WorkspaceTableKey>(
+  workspaceId: string | undefined,
+  tableKey: K
+): WorkspaceTableRowTypes[K][] | undefined {
+  const token = useWorkspaceTableToken()
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      workspaceId ? subscribeWorkspaceTable(workspaceId, tableKey, token, listener) : () => {},
+    [workspaceId, tableKey, token]
+  )
+  const getSnapshot = useCallback(
+    () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey, token) : undefined),
+    [workspaceId, tableKey, token]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+function useArrayStoreHook<K extends WorkspaceTableKey>(
+  workspaceId: string | undefined,
+  tableKey: K,
+  cached: WorkspaceTableRowTypes[K][]
+): WorkspaceTableRowTypes[K][] {
+  const live = useWorkspaceTable(workspaceId, tableKey)
   return useBatchedValue(live ?? cached)
 }
 
-function useSingletonStoreHook<T>(
-  queryFn: () => Promise<T | undefined> | T | undefined,
-  deps: unknown[],
-  cached: T | undefined
-): T | undefined {
-  const live = useLiveQuery(queryFn, deps, cached)
+function useSingletonStoreHook<K extends WorkspaceTableKey>(
+  workspaceId: string | undefined,
+  tableKey: K,
+  cached: WorkspaceTableRowTypes[K] | undefined
+): WorkspaceTableRowTypes[K] | undefined {
+  const rows = useWorkspaceTable(workspaceId, tableKey)
+  const live = rows ? rows[0] : cached
   const resolved = live === undefined && cached !== undefined ? cached : live
   return useBatchedValue(resolved)
 }
@@ -347,17 +386,13 @@ function useSingletonStoreHook<T>(
 export function useWorkspaceFromStore(workspaceId: string | undefined): CachedWorkspace | undefined {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.workspaces.get(workspaceId) : undefined
-  return useSingletonStoreHook(() => (workspaceId ? db.workspaces.get(workspaceId) : undefined), [workspaceId], cached)
+  return useSingletonStoreHook(workspaceId, "workspace", cached)
 }
 
 export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorkspaceUser[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.users.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.users.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "users", cached)
 }
 
 /**
@@ -368,12 +403,23 @@ export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorksp
  */
 export function useWorkspaceStreamsRaw(workspaceId: string | undefined): CachedStream[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.streams.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.streams.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.streams.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "streams", cached)
+}
+
+/**
+ * One overlay per workspace per change, not one per consumer per render: the
+ * inputs are shared (the registry's rows reference and the name cache's version),
+ * so 40 readers of `useWorkspaceStreams` would otherwise each walk every stream.
+ */
+const nameOverlayMemo = new Map<string, { rows: CachedStream[]; version: number; result: CachedStream[] }>()
+
+function sharedNameOverlay(workspaceId: string, streams: CachedStream[], version: number): CachedStream[] {
+  const memo = nameOverlayMemo.get(workspaceId)
+  if (memo && memo.rows === streams && memo.version === version) return memo.result
+  const result = streamNameCache.applyDecryptedNameOverlay(workspaceId, streams)
+  nameOverlayMemo.set(workspaceId, { rows: streams, version, result })
+  return result
 }
 
 export function useWorkspaceStreams(workspaceId: string | undefined): CachedStream[] {
@@ -382,41 +428,33 @@ export function useWorkspaceStreams(workspaceId: string | undefined): CachedStre
   // `displayName` so every label resolver reflects it without per-surface changes.
   // The plaintext lives only in the memory-only `stream-name-cache`; IDB keeps
   // ciphertext. `version` re-overlays when a decrypt lands (see `stream-name-cache`).
-  const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
+  const version = useSyncExternalStore(
+    streamNameCache.subscribeStreamNameCache,
+    streamNameCache.getStreamNameCacheVersion,
+    streamNameCache.getStreamNameCacheVersion
+  )
   return useMemo(
-    () => (workspaceId ? applyDecryptedNameOverlay(workspaceId, streams) : streams),
+    () => (workspaceId ? sharedNameOverlay(workspaceId, streams, version) : streams),
     [streams, workspaceId, version]
   )
 }
 
 export function useWorkspaceStreamMemberships(workspaceId: string | undefined): CachedStreamMembership[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.memberships.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.streamMemberships.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.memberships.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "memberships", cached)
 }
 
 export function useWorkspaceStreamReadStates(workspaceId: string | undefined): CachedStreamReadState[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.readStates.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.streamReadState.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.readStates.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "readStates", cached)
 }
 
 export function useWorkspaceDmPeers(workspaceId: string | undefined): CachedDmPeer[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.dmPeers.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.dmPeers.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.dmPeers.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "dmPeers", cached)
 }
 
 /**
@@ -438,76 +476,48 @@ export function upsertWorkspacePersonaCache(workspaceId: string, persona: Cached
 
 export function useWorkspacePersonas(workspaceId: string | undefined): CachedPersona[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.personas.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.personas.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.personas.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "personas", cached)
 }
 
 export function useWorkspaceBots(workspaceId: string | undefined): CachedBot[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.bots.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.bots.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.bots.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "bots", cached)
 }
 
 export function useWorkspaceLabels(workspaceId: string | undefined): CachedLabel[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.labels.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.labels.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.labels.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "labels", cached)
 }
 
 export function useWorkspaceLabelAssignments(workspaceId: string | undefined): CachedLabelAssignment[] {
   useWorkspaceCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.labelAssignments.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
-    () => (workspaceId ? db.labelAssignments.where("workspaceId").equals(workspaceId).toArray() : []),
-    [workspaceId],
-    cached
-  )
+  const cached = workspaceId ? (cache.labelAssignments.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
+  return useArrayStoreHook(workspaceId, "labelAssignments", cached)
 }
 
 export function useWorkspaceUnreadState(workspaceId: string | undefined): CachedUnreadState | undefined {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.unreadState.get(workspaceId) : undefined
-  return useSingletonStoreHook(() => (workspaceId ? db.unreadState.get(workspaceId) : undefined), [workspaceId], cached)
+  return useSingletonStoreHook(workspaceId, "unreadState", cached)
 }
 
 export function useWorkspaceUserPreferences(workspaceId: string | undefined): CachedUserPreferences | undefined {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.userPreferences.get(workspaceId) : undefined
-  return useSingletonStoreHook(
-    () => (workspaceId ? db.userPreferences.get(workspaceId) : undefined),
-    [workspaceId],
-    cached
-  )
+  return useSingletonStoreHook(workspaceId, "userPreferences", cached)
 }
 
 export function useWorkspaceSidebarConfig(workspaceId: string | undefined): CachedSidebarConfig | undefined {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.sidebarConfig.get(workspaceId) : undefined
-  return useSingletonStoreHook(
-    () => (workspaceId ? db.sidebarConfigs.get(workspaceId) : undefined),
-    [workspaceId],
-    cached
-  )
+  return useSingletonStoreHook(workspaceId, "sidebarConfig", cached)
 }
 
 export function useWorkspaceMetadata(workspaceId: string | undefined): CachedWorkspaceMetadata | undefined {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.metadata.get(workspaceId) : undefined
-  return useSingletonStoreHook(
-    () => (workspaceId ? db.workspaceMetadata.get(workspaceId) : undefined),
-    [workspaceId],
-    cached
-  )
+  return useSingletonStoreHook(workspaceId, "metadata", cached)
 }

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -106,12 +106,19 @@ function publishWorkspaceCache(workspaceId: string): void {
   emitWorkspaceCacheChange(workspaceId)
 }
 
-function useWorkspaceCacheSignal(workspaceId: string | undefined): number {
-  return useSyncExternalStore(
-    (listener) => subscribeWorkspaceCache(workspaceId, listener),
-    () => getWorkspaceCacheSnapshot(workspaceId),
-    () => getWorkspaceCacheSnapshot(workspaceId)
+/**
+ * Wake the caller on in-memory cache publications, but only while it still reads
+ * the cache — once the table's live query has resolved, the cache no longer
+ * contributes to the returned value, and waking for it re-renders every reader a
+ * second time for one change (the emission already woke them).
+ */
+function useWorkspaceCacheSignal(workspaceId: string | undefined, active: boolean): number {
+  const subscribe = useCallback(
+    (listener: () => void) => (active ? subscribeWorkspaceCache(workspaceId, listener) : () => {}),
+    [workspaceId, active]
   )
+  const getSnapshot = useCallback(() => (active ? getWorkspaceCacheSnapshot(workspaceId) : 0), [workspaceId, active])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }
 
 export function hasSeededWorkspaceCache(workspaceId: string): boolean {
@@ -360,7 +367,9 @@ function useWorkspaceTable<K extends WorkspaceTableKey>(
     () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey, token) : undefined),
     [workspaceId, tableKey, token]
   )
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const live = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  useWorkspaceCacheSignal(workspaceId, live === undefined)
+  return live
 }
 
 function useArrayStoreHook<K extends WorkspaceTableKey>(
@@ -384,13 +393,11 @@ function useSingletonStoreHook<K extends WorkspaceTableKey>(
 }
 
 export function useWorkspaceFromStore(workspaceId: string | undefined): CachedWorkspace | undefined {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.workspaces.get(workspaceId) : undefined
   return useSingletonStoreHook(workspaceId, "workspace", cached)
 }
 
 export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorkspaceUser[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.users.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "users", cached)
 }
@@ -402,7 +409,6 @@ export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorksp
  * to the post-overlay hook would re-run it on every name that lands.
  */
 export function useWorkspaceStreamsRaw(workspaceId: string | undefined): CachedStream[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.streams.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "streams", cached)
 }
@@ -440,19 +446,16 @@ export function useWorkspaceStreams(workspaceId: string | undefined): CachedStre
 }
 
 export function useWorkspaceStreamMemberships(workspaceId: string | undefined): CachedStreamMembership[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.memberships.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "memberships", cached)
 }
 
 export function useWorkspaceStreamReadStates(workspaceId: string | undefined): CachedStreamReadState[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.readStates.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "readStates", cached)
 }
 
 export function useWorkspaceDmPeers(workspaceId: string | undefined): CachedDmPeer[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.dmPeers.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "dmPeers", cached)
 }
@@ -475,49 +478,41 @@ export function upsertWorkspacePersonaCache(workspaceId: string, persona: Cached
 }
 
 export function useWorkspacePersonas(workspaceId: string | undefined): CachedPersona[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.personas.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "personas", cached)
 }
 
 export function useWorkspaceBots(workspaceId: string | undefined): CachedBot[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.bots.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "bots", cached)
 }
 
 export function useWorkspaceLabels(workspaceId: string | undefined): CachedLabel[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.labels.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "labels", cached)
 }
 
 export function useWorkspaceLabelAssignments(workspaceId: string | undefined): CachedLabelAssignment[] {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.labelAssignments.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "labelAssignments", cached)
 }
 
 export function useWorkspaceUnreadState(workspaceId: string | undefined): CachedUnreadState | undefined {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.unreadState.get(workspaceId) : undefined
   return useSingletonStoreHook(workspaceId, "unreadState", cached)
 }
 
 export function useWorkspaceUserPreferences(workspaceId: string | undefined): CachedUserPreferences | undefined {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.userPreferences.get(workspaceId) : undefined
   return useSingletonStoreHook(workspaceId, "userPreferences", cached)
 }
 
 export function useWorkspaceSidebarConfig(workspaceId: string | undefined): CachedSidebarConfig | undefined {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.sidebarConfig.get(workspaceId) : undefined
   return useSingletonStoreHook(workspaceId, "sidebarConfig", cached)
 }
 
 export function useWorkspaceMetadata(workspaceId: string | undefined): CachedWorkspaceMetadata | undefined {
-  useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? cache.metadata.get(workspaceId) : undefined
   return useSingletonStoreHook(workspaceId, "metadata", cached)
 }

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -151,6 +151,28 @@ describe("workspace table registry", () => {
     }).toEqual({ user_1: 0, user_2: true })
   })
 
+  it("a private entry tears down at zero grace after its consumer unmounts", async () => {
+    // The 5s grace exists so a SHARED entry survives a remount; a token-keyed
+    // entry has exactly one consumer, so retaining its whole-table liveQuery
+    // for 5s per unmount doubled the off-arm's subscriptions on navigation
+    // (whole-stack finding). Zero delay still absorbs a same-task remount.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      setWorkspaceReadMode("off")
+      await db.workspaceUsers.put(makeUser("user_1"))
+      const { findByText, unmount } = render(<ManyConsumers count={2} />)
+      await findByText("1")
+      const mounted = activeWorkspaceSubscriptionCount()
+      unmount()
+      await act(async () => {
+        vi.advanceTimersByTime(0)
+      })
+      expect({ mounted, afterUnmount: activeWorkspaceSubscriptionCount() }).toEqual({ mounted: 2, afterUnmount: 0 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("the last unsubscribe tears the query down after the grace window, and a re-subscribe inside it reuses the entry", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
@@ -301,6 +323,9 @@ describe("workspace table registry", () => {
         flush: async () => {},
       } as unknown as ReturnType<typeof perfCapture.getPerfCapture>)
 
+      // The mark measures the shared-arm economy only: in `off` mode the count
+      // tracks consumer mounts and would flood the capture ring, so nothing is
+      // emitted there (whole-stack finding).
       setWorkspaceReadMode("off")
       await db.workspaceUsers.put(makeUser("user_1"))
 
@@ -320,7 +345,7 @@ describe("workspace table registry", () => {
       const afterUnmount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
 
       expect({ afterMount: afterMount?.[1], afterFlip: afterFlip?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
-        afterMount: 3,
+        afterMount: undefined,
         afterFlip: 1,
         afterUnmount: 0,
       })

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -353,4 +353,31 @@ describe("workspace table registry", () => {
       vi.useRealTimers()
     }
   })
+
+  it("an off to shared flip seeds the shared entry from the freshest private snapshot", async () => {
+    let dataset: CachedWorkspaceUser[] = [makeUser("user_1")]
+    vi.spyOn(db.workspaceUsers, "where").mockReturnValue({
+      equals: () => ({ toArray: async () => [...dataset] }),
+    } as unknown as ReturnType<typeof db.workspaceUsers.where>)
+
+    setWorkspaceReadMode("off")
+    const noop = () => {}
+    const staleToken = allocateWorkspaceTableToken()
+    subscribeWorkspaceTable(WORKSPACE, "users", staleToken, noop)
+    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)).toHaveLength(1))
+
+    dataset = [makeUser("user_1"), makeUser("user_2")]
+    const freshToken = allocateWorkspaceTableToken()
+    subscribeWorkspaceTable(WORKSPACE, "users", freshToken, noop)
+    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", freshToken)).toHaveLength(2))
+
+    setWorkspaceReadMode("shared")
+
+    // Synchronously after the flip: the shared entry's own query has not emitted
+    // yet, so this reads exactly what the migration seeded.
+    expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)?.map((row) => row.id)).toEqual([
+      "user_1",
+      "user_2",
+    ])
+  })
 })

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -299,9 +299,6 @@ describe("workspace table registry", () => {
     act(() => {
       setWorkspaceReadMode("off")
     })
-    // The flip's drop+refire machinery still carries a registration that existed
-    // at flip time.
-    expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)).toBeDefined()
 
     // The reader's effect re-runs after the flip: the new subscribe must be a
     // no-op, and the consumer reads undefined and falls back to its own query.

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, renderHook, waitFor } from "@testing-library/react"
+import { useState, useSyncExternalStore } from "react"
+import { db, type CachedWorkspaceUser } from "@/db"
+import * as perfCapture from "@/lib/perf/capture"
+import { resetWorkspaceStoreCache, useWorkspaceUsers } from "./workspace-store"
+import {
+  activeWorkspaceSubscriptionCount,
+  allocateWorkspaceTableToken,
+  getWorkspaceTableRow,
+  getWorkspaceTableSnapshot,
+  resetWorkspaceTableRegistry,
+  setWorkspaceReadMode,
+  subscribeWorkspaceTable,
+  subscribeWorkspaceTableRow,
+} from "./workspace-table-registry"
+
+const WORKSPACE = "workspace_1"
+const OTHER_WORKSPACE = "workspace_2"
+
+function makeUser(id: string, overrides: Partial<CachedWorkspaceUser> = {}): CachedWorkspaceUser {
+  return {
+    id,
+    workspaceId: WORKSPACE,
+    workosUserId: `workos_${id}`,
+    email: `${id}@example.com`,
+    role: "member",
+    slug: id,
+    name: id,
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: 1,
+    ...overrides,
+  }
+}
+
+function ManyConsumers({ count }: { count: number }) {
+  const rows: CachedWorkspaceUser[][] = []
+  for (let i = 0; i < count; i++) {
+    rows.push(useWorkspaceUsers(WORKSPACE))
+  }
+  return <div data-testid="rows">{rows[0].length}</div>
+}
+
+function useRegistryRows(workspaceId: string, token: number): CachedWorkspaceUser[] | undefined {
+  return useSyncExternalStore(
+    (listener) => subscribeWorkspaceTable(workspaceId, "users", token, listener),
+    () => getWorkspaceTableSnapshot(workspaceId, "users", token),
+    () => getWorkspaceTableSnapshot(workspaceId, "users", token)
+  )
+}
+
+describe("workspace table registry", () => {
+  beforeEach(async () => {
+    resetWorkspaceTableRegistry()
+    resetWorkspaceStoreCache()
+    await db.workspaceUsers.clear()
+  })
+
+  afterEach(() => {
+    resetWorkspaceTableRegistry()
+    vi.restoreAllMocks()
+  })
+
+  it("twenty consumers of useWorkspaceUsers open one IDB read", async () => {
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+    setWorkspaceReadMode("shared")
+    const where = vi.spyOn(db.workspaceUsers, "where")
+
+    const { findByText } = render(<ManyConsumers count={20} />)
+    await findByText("2")
+
+    expect(where).toHaveBeenCalledTimes(1)
+    expect(activeWorkspaceSubscriptionCount()).toBe(1)
+  })
+
+  it("mode off creates one subscription per consumer", async () => {
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+    setWorkspaceReadMode("off")
+    const where = vi.spyOn(db.workspaceUsers, "where")
+
+    const { findByText } = render(<ManyConsumers count={20} />)
+    await findByText("2")
+
+    expect(where).toHaveBeenCalledTimes(20)
+    expect(activeWorkspaceSubscriptionCount()).toBe(20)
+  })
+
+  it("an unchanged row keeps its object identity across emissions", async () => {
+    setWorkspaceReadMode("shared")
+    await db.workspaceUsers.put(makeUser("user_1"))
+    const token = allocateWorkspaceTableToken()
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    await waitFor(() => expect(result.current).toHaveLength(1))
+    const first = result.current![0]
+
+    await act(async () => {
+      await db.workspaceUsers.put(makeUser("user_2"))
+    })
+    await waitFor(() => expect(result.current).toHaveLength(2))
+
+    expect(result.current!.find((row) => row.id === "user_1")).toBe(first)
+  })
+
+  it("a change to one row does not re-render a consumer reading another row", async () => {
+    setWorkspaceReadMode("shared")
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+    const renders = { user_1: 0, user_2: 0 }
+
+    function RowProbe({ rowId }: { rowId: "user_1" | "user_2" }) {
+      const [token] = useState(allocateWorkspaceTableToken)
+      const row = useSyncExternalStore(
+        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", rowId, token, listener),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token)
+      )
+      renders[rowId] += 1
+      return <span data-testid={rowId}>{row?.name ?? "-"}</span>
+    }
+
+    const { findByText } = render(
+      <>
+        <RowProbe rowId="user_1" />
+        <RowProbe rowId="user_2" />
+      </>
+    )
+    await findByText("user_1")
+    const before = { ...renders }
+
+    await act(async () => {
+      await db.workspaceUsers.put(makeUser("user_2", { name: "Renamed" }))
+    })
+    await findByText("Renamed")
+
+    expect({
+      user_1: renders.user_1 - before.user_1,
+      user_2: renders.user_2 - before.user_2 > 0,
+    }).toEqual({ user_1: 0, user_2: true })
+  })
+
+  it("the last unsubscribe tears the query down after the grace window, and a re-subscribe inside it reuses the entry", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      setWorkspaceReadMode("shared")
+      await db.workspaceUsers.put(makeUser("user_1"))
+      const token = allocateWorkspaceTableToken()
+      const noop = () => {}
+      const unsubscribe = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
+      await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1))
+
+      unsubscribe()
+      expect(activeWorkspaceSubscriptionCount()).toBe(1)
+
+      const again = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
+      expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1)
+      expect(activeWorkspaceSubscriptionCount()).toBe(1)
+
+      again()
+      await act(async () => {
+        vi.advanceTimersByTime(6_000)
+      })
+      expect(activeWorkspaceSubscriptionCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("a subscriber that mounts after the first emission gets the current snapshot synchronously", async () => {
+    setWorkspaceReadMode("shared")
+    await db.workspaceUsers.put(makeUser("user_1"))
+    const token = allocateWorkspaceTableToken()
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    const seen: (number | undefined)[] = []
+    function LateConsumer() {
+      const rows = useWorkspaceUsers(WORKSPACE)
+      seen.push(rows.length)
+      return null
+    }
+    render(<LateConsumer />)
+
+    expect(seen[0]).toBe(1)
+  })
+
+  it("switching workspaces does not leak the previous workspace's rows", async () => {
+    setWorkspaceReadMode("shared")
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_other", { workspaceId: OTHER_WORKSPACE })])
+
+    const { result, rerender } = renderHook(({ workspaceId }) => useWorkspaceUsers(workspaceId), {
+      initialProps: { workspaceId: WORKSPACE },
+    })
+    await waitFor(() => expect(result.current.map((row) => row.id)).toEqual(["user_1"]))
+
+    rerender({ workspaceId: OTHER_WORKSPACE })
+    await waitFor(() => expect(result.current.map((row) => row.id)).toEqual(["user_other"]))
+  })
+
+  it("a flip after mount leaks no listener and tears down cleanly", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      setWorkspaceReadMode("off")
+      await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+
+      const { findByText, unmount } = render(<ManyConsumers count={5} />)
+      await findByText("2")
+
+      act(() => {
+        setWorkspaceReadMode("shared")
+      })
+      expect(activeWorkspaceSubscriptionCount()).toBe(1)
+
+      unmount()
+      await act(async () => {
+        vi.advanceTimersByTime(6_000)
+      })
+
+      expect(activeWorkspaceSubscriptionCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("a flip preserves the resolved snapshot and does not notify unchanged consumers", async () => {
+    setWorkspaceReadMode("off")
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+    let renders = 0
+    const seen: (CachedWorkspaceUser[] | undefined)[] = []
+
+    function Consumer() {
+      const [token] = useState(allocateWorkspaceTableToken)
+      const rows = useRegistryRows(WORKSPACE, token)
+      renders += 1
+      seen.push(rows)
+      return <span data-testid="count">{rows?.length ?? "-"}</span>
+    }
+
+    const { findByText } = render(<Consumer />)
+    await findByText("2")
+    const before = seen[seen.length - 1]!
+    const rendersBefore = renders
+
+    act(() => {
+      setWorkspaceReadMode("shared")
+    })
+
+    expect({
+      rows: seen[seen.length - 1],
+      extraRenders: renders - rendersBefore,
+      ids: seen[seen.length - 1]!.map((row) => row.id),
+    }).toEqual({ rows: before, extraRenders: 0, ids: ["user_1", "user_2"] })
+  })
+
+  it("a row subscriber keeps working across a flip", async () => {
+    setWorkspaceReadMode("off")
+    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+
+    function RowProbe() {
+      const [token] = useState(allocateWorkspaceTableToken)
+      const row = useSyncExternalStore(
+        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, listener),
+        () => getWorkspaceTableRow(WORKSPACE, "users", "user_1", token),
+        () => getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)
+      )
+      return <span data-testid="row">{row?.name ?? "-"}</span>
+    }
+
+    const { findByText } = render(<RowProbe />)
+    await findByText("user_1")
+
+    act(() => {
+      setWorkspaceReadMode("shared")
+    })
+
+    await act(async () => {
+      await db.workspaceUsers.put(makeUser("user_1", { name: "Renamed" }))
+    })
+    await findByText("Renamed")
+  })
+
+  it("the subscription-count mark tracks entry lifecycle", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const mark = vi.fn()
+      vi.spyOn(perfCapture, "getPerfCapture").mockReturnValue({
+        mark,
+        measure: () => {},
+        flush: async () => {},
+      } as unknown as ReturnType<typeof perfCapture.getPerfCapture>)
+
+      setWorkspaceReadMode("off")
+      await db.workspaceUsers.put(makeUser("user_1"))
+
+      const { findByText, unmount } = render(<ManyConsumers count={3} />)
+      await findByText("1")
+      const afterMount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
+
+      act(() => {
+        setWorkspaceReadMode("shared")
+      })
+      const afterFlip = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
+
+      unmount()
+      await act(async () => {
+        vi.advanceTimersByTime(6_000)
+      })
+      const afterUnmount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
+
+      expect({ afterMount: afterMount?.[1], afterFlip: afterFlip?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
+        afterMount: 3,
+        afterFlip: 1,
+        afterUnmount: 0,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -286,31 +286,50 @@ describe("workspace table registry", () => {
     }).toEqual({ rows: before, extraRenders: 0, ids: ["user_1", "user_2"] })
   })
 
-  it("a row subscriber keeps working across a flip", async () => {
-    setWorkspaceReadMode("off")
+  it("a row registration survives a flip, but a re-subscribe in off mode mints nothing", async () => {
+    setWorkspaceReadMode("shared")
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
+    const token = allocateWorkspaceTableToken()
+    const notify = vi.fn()
 
-    function RowProbe() {
-      const [token] = useState(allocateWorkspaceTableToken)
-      const row = useSyncExternalStore(
-        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, listener),
-        () => getWorkspaceTableRow(WORKSPACE, "users", "user_1", token),
-        () => getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)
-      )
-      return <span data-testid="row">{row?.name ?? "-"}</span>
-    }
+    let unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
+    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
+    const sharedEntries = activeWorkspaceSubscriptionCount()
 
-    const { findByText } = render(<RowProbe />)
-    await findByText("user_1")
+    act(() => {
+      setWorkspaceReadMode("off")
+    })
+    // The flip's drop+refire machinery still carries a registration that existed
+    // at flip time.
+    expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)).toBeDefined()
+
+    // The reader's effect re-runs after the flip: the new subscribe must be a
+    // no-op, and the consumer reads undefined and falls back to its own query.
+    unsubscribe()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    const afterDrop = activeWorkspaceSubscriptionCount()
+    const noop = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
+    noop()
+
+    expect({
+      minted: activeWorkspaceSubscriptionCount() - afterDrop,
+      row: getWorkspaceTableRow(WORKSPACE, "users", "user_1", token),
+    }).toEqual({ minted: 0, row: undefined })
 
     act(() => {
       setWorkspaceReadMode("shared")
     })
+    unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
+    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
+    expect(activeWorkspaceSubscriptionCount()).toBe(sharedEntries)
 
     await act(async () => {
       await db.workspaceUsers.put(makeUser("user_1", { name: "Renamed" }))
     })
-    await findByText("Renamed")
+    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("Renamed"))
+    unsubscribe()
   })
 
   it("the subscription-count mark tracks entry lifecycle", async () => {

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -76,6 +76,7 @@ interface WorkspaceTableEntry {
   rows: IdentifiedRow[] | undefined
   byId: Map<string, IdentifiedRow>
   resolved: boolean
+  emissionSeq: number
   listeners: Set<() => void>
   keyListeners: Map<string, Set<() => void>>
   refCount: number
@@ -129,6 +130,8 @@ export function allocateWorkspaceTableToken(): number {
   return nextToken++
 }
 
+let emissionCounter = 0
+
 function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey, token: number): string {
   return mode === "shared" ? `${workspaceId}|${tableKey}` : `${workspaceId}|${tableKey}|${token}`
 }
@@ -146,6 +149,7 @@ function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
     entry.byId = new Map(incoming.map((row) => [row.id, row]))
     entry.rows = incoming
     entry.resolved = true
+    entry.emissionSeq = ++emissionCounter
     for (const notify of entry.listeners) notify()
     for (const keyed of entry.keyListeners.values()) {
       for (const notify of keyed) notify()
@@ -179,6 +183,7 @@ function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
   const wasResolved = entry.resolved
   entry.byId = byId
   entry.resolved = true
+  entry.emissionSeq = ++emissionCounter
   // A snapshot reference that survives an emission is what keeps array
   // consumers from re-rendering when nothing they read changed.
   if (changed) entry.rows = next
@@ -236,6 +241,7 @@ function ensureEntry(
     rows: undefined,
     byId: new Map(),
     resolved: false,
+    emissionSeq: 0,
     listeners: new Set(),
     keyListeners: new Map(),
     refCount: 0,
@@ -249,6 +255,7 @@ function ensureEntry(
     created.rows = seed.rows
     created.byId = new Map(seed.byId)
     created.resolved = true
+    created.emissionSeq = seed.emissionSeq
   }
   entries.set(entryKey, created)
   created.subscription = liveQuery(() => WORKSPACE_TABLE_QUERIES[tableKey](workspaceId)).subscribe((rows) =>
@@ -415,9 +422,10 @@ function visibleSnapshot(entry: WorkspaceTableEntry | undefined, registration: R
  * moved to its new entry key synchronously, so the flag can arrive or change
  * mid-session without a single hook count changing (D5).
  *
- * The new entry is seeded from a resolved predecessor for the same
- * (workspace, table): the query is identical, so any resolved entry is a correct
- * snapshot. Publishing an unresolved entry instead would regress every consumer
+ * The new entry is seeded from the most recently emitted resolved predecessor
+ * for the same (workspace, table): the query is identical, but private entries
+ * emit independently, so an older resolved snapshot can still be sitting in the
+ * map and would republish rolled-back rows. Publishing an unresolved entry instead would regress every consumer
  * to its bootstrap-era cache fallback for a frame — and the flag itself is read
  * through this registry, so an unresolved metadata entry would flip the mode back
  * and loop.
@@ -436,7 +444,9 @@ export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
   }
   for (const entry of entries.values()) {
     const seedKey = `${entry.workspaceId}|${entry.tableKey}`
-    if (entry.resolved && !seeds.has(seedKey)) seeds.set(seedKey, entry)
+    if (!entry.resolved) continue
+    const held = seeds.get(seedKey)
+    if (!held || entry.emissionSeq > held.emissionSeq) seeds.set(seedKey, entry)
   }
 
   mode = next

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -137,6 +137,22 @@ function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
   const entry = entries.get(entryKey)
   if (!entry) return
 
+  // Private (token-keyed) entries have exactly one consumer and match the
+  // pre-registry useLiveQuery behaviour: fresh rows, notify on every emission.
+  // The per-row semantic compare would be pure added cost there — for the
+  // metadata singleton it deep-walks the ~356KB emoji row once per consumer
+  // per reaction, and the rows genuinely changed so everyone re-renders anyway.
+  if (entryKey.split("|").length === 3) {
+    entry.byId = new Map(incoming.map((row) => [row.id, row]))
+    entry.rows = incoming
+    entry.resolved = true
+    for (const notify of entry.listeners) notify()
+    for (const keyed of entry.keyListeners.values()) {
+      for (const notify of keyed) notify()
+    }
+    return
+  }
+
   const previous = entry.rows
   const byId = new Map<string, IdentifiedRow>()
   const changedIds: string[] = []
@@ -187,6 +203,11 @@ function liveEntryCount(): number {
 }
 
 function markLiveEntries(): void {
+  // The mark measures the shared-arm subscription economy. In `off` mode the
+  // count tracks consumer mounts (~700 per window) — emitting it would flood
+  // the 2000-sample capture ring and evict the marks the A/B compares, and
+  // liveEntryCount() itself is O(entries) on a hot path.
+  if (mode !== "shared") return
   const count = liveEntryCount()
   if (count === lastMarkedLiveEntries) return
   lastMarkedLiveEntries = count
@@ -241,6 +262,11 @@ function releaseEntry(entryKey: string, immediate: boolean): void {
   const entry = entries.get(entryKey)
   if (!entry) return
   if (entry.refCount > 0 || entry.listeners.size > 0 || entry.keyListeners.size > 0) return
+  // Private (token-keyed) entries tear down immediately: their one consumer is
+  // gone, nobody else can adopt them, and the grace window would keep a
+  // whole-table liveQuery re-reading for 5s per unmounted consumer — a
+  // behaviour change vs the pre-registry useLiveQuery cleanup in the arm every
+  // user ships with. A StrictMode remount just re-creates the private query.
   if (immediate) {
     if (entry.teardown) clearTimeout(entry.teardown)
     entry.subscription.unsubscribe()
@@ -249,13 +275,20 @@ function releaseEntry(entryKey: string, immediate: boolean): void {
     return
   }
   if (entry.teardown) return
+  // Private (token-keyed) entries get a zero-delay grace: their one consumer is
+  // gone and nobody else can adopt them, so the 5s window would keep a
+  // whole-table liveQuery re-reading per unmounted consumer — a behaviour
+  // change vs the pre-registry useLiveQuery cleanup in the default arm. Zero
+  // delay still absorbs a same-task unsubscribe/resubscribe (StrictMode
+  // remount): the callback re-checks liveness and aborts.
+  const graceMs = entryKey.split("|").length === 3 ? 0 : TABLE_TEARDOWN_GRACE_MS
   entry.teardown = setTimeout(() => {
     const live = entries.get(entryKey)
     if (!live || live.refCount > 0 || live.listeners.size > 0 || live.keyListeners.size > 0) return
     live.subscription.unsubscribe()
     entries.delete(entryKey)
     markLiveEntries()
-  }, TABLE_TEARDOWN_GRACE_MS)
+  }, graceMs)
   markLiveEntries()
 }
 

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -337,6 +337,11 @@ export function subscribeWorkspaceTableRow(
   token: number,
   listener: () => void
 ): () => void {
+  // Row reads are a shared-mode feature: a shared→off flip landing between a
+  // reader's render and this subscribe effect would otherwise mint one private
+  // whole-table query per reader that no drop machinery unwinds. The off arm's
+  // consumer falls back to its own live query.
+  if (mode !== "shared") return () => {}
   const entryKey = entryKeyFor(workspaceId, tableKey, token)
   const entry = ensureEntry(entryKey, workspaceId, tableKey)
   let keyed = entry.keyListeners.get(rowId)

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -1,0 +1,445 @@
+import { liveQuery, type Subscription } from "dexie"
+import { semanticEqual } from "@/sync/bootstrap-diff"
+// Namespace import so a test can spy the facade against the module (INV-48).
+import * as perfCapture from "@/lib/perf/capture"
+import {
+  db,
+  type CachedBot,
+  type CachedDmPeer,
+  type CachedLabel,
+  type CachedLabelAssignment,
+  type CachedPersona,
+  type CachedSidebarConfig,
+  type CachedStream,
+  type CachedStreamMembership,
+  type CachedStreamReadState,
+  type CachedUnreadState,
+  type CachedUserPreferences,
+  type CachedWorkspace,
+  type CachedWorkspaceMetadata,
+  type CachedWorkspaceUser,
+} from "@/db"
+
+/** The row type each table key resolves to (INV-31: the key union is derived from it). */
+export interface WorkspaceTableRowTypes {
+  users: CachedWorkspaceUser
+  streams: CachedStream
+  memberships: CachedStreamMembership
+  readStates: CachedStreamReadState
+  dmPeers: CachedDmPeer
+  personas: CachedPersona
+  bots: CachedBot
+  labels: CachedLabel
+  labelAssignments: CachedLabelAssignment
+  workspace: CachedWorkspace
+  unreadState: CachedUnreadState
+  userPreferences: CachedUserPreferences
+  sidebarConfig: CachedSidebarConfig
+  metadata: CachedWorkspaceMetadata
+}
+
+export type WorkspaceTableKey = keyof WorkspaceTableRowTypes
+
+interface IdentifiedRow {
+  id: string
+}
+
+type TableQuery = (workspaceId: string) => Promise<IdentifiedRow[]>
+
+function oneRow<T extends IdentifiedRow>(row: T | undefined): T[] {
+  return row ? [row] : []
+}
+
+const WORKSPACE_TABLE_QUERIES: Record<WorkspaceTableKey, TableQuery> = {
+  users: (workspaceId) => db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+  streams: (workspaceId) => db.streams.where("workspaceId").equals(workspaceId).toArray(),
+  memberships: (workspaceId) => db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+  readStates: (workspaceId) => db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
+  dmPeers: (workspaceId) => db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+  personas: (workspaceId) => db.personas.where("workspaceId").equals(workspaceId).toArray(),
+  bots: (workspaceId) => db.bots.where("workspaceId").equals(workspaceId).toArray(),
+  labels: (workspaceId) => db.labels.where("workspaceId").equals(workspaceId).toArray(),
+  labelAssignments: (workspaceId) => db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+  workspace: async (workspaceId) => oneRow(await db.workspaces.get(workspaceId)),
+  unreadState: async (workspaceId) => oneRow(await db.unreadState.get(workspaceId)),
+  userPreferences: async (workspaceId) => oneRow(await db.userPreferences.get(workspaceId)),
+  sidebarConfig: async (workspaceId) => oneRow(await db.sidebarConfigs.get(workspaceId)),
+  metadata: async (workspaceId) => oneRow(await db.workspaceMetadata.get(workspaceId)),
+}
+
+/** `shared` = one live query per (workspace, table); `off` = one per subscriber, as before the registry. */
+export type WorkspaceReadMode = "shared" | "off"
+
+interface WorkspaceTableEntry {
+  workspaceId: string
+  tableKey: WorkspaceTableKey
+  rows: IdentifiedRow[] | undefined
+  byId: Map<string, IdentifiedRow>
+  resolved: boolean
+  listeners: Set<() => void>
+  keyListeners: Map<string, Set<() => void>>
+  refCount: number
+  subscription: Subscription
+  teardown: ReturnType<typeof setTimeout> | null
+}
+
+interface RegistrationBase {
+  workspaceId: string
+  tableKey: WorkspaceTableKey
+  token: number
+  listener: () => void
+  entryKey: string
+}
+
+type Registration = (RegistrationBase & { kind: "table" }) | (RegistrationBase & { kind: "row"; rowId: string })
+
+// INV-9 exception, the same one `railRegistry`/`threadIndexRegistry` carry
+// (`hooks/use-board-card-messages.ts`): one module-level `liveQuery` per
+// (workspace, table), ref-counted across every consumer. `useWorkspaceUsers`
+// alone has 40 call sites and each used to open its own whole-table
+// subscription, so a rendered timeline opened ~50 identical reads of the same
+// rows. A context provider would re-render its whole subtree on every table
+// change — which is the cost this exists to remove.
+const entries = new Map<string, WorkspaceTableEntry>()
+// Keyed by an internal registration id, not by the consumer token: one token can
+// hold several registrations, and `unsubscribe` must resolve ITS entry key here
+// at call time — a captured key goes stale the moment a mode flip re-keys it,
+// which leaks the listener and pins `refCount` for the session.
+const registrations = new Map<number, Registration>()
+
+// Matches `RAIL_TEARDOWN_GRACE_MS`: a remount unsubscribes before it
+// re-subscribes, and tearing the query down in between would re-read the table.
+const TABLE_TEARDOWN_GRACE_MS = 5_000
+
+let mode: WorkspaceReadMode = "off"
+let nextToken = 1
+let nextRegistrationId = 1
+let lastMarkedLiveEntries = -1
+
+/**
+ * Rows compare on every own key, `_cachedAt` included: a caller reading
+ * freshness off a row must not be handed an object whose stamp is older than
+ * IDB's. Unchanged rows keep their stamp (the bootstrap diff skips them), so
+ * identity still survives the writes that matter.
+ */
+const COMPARE_ALL_KEYS: ReadonlySet<string> = new Set()
+
+/** A stable token for one consumer, so the `off` mode can key a private entry per subscriber. */
+export function allocateWorkspaceTableToken(): number {
+  return nextToken++
+}
+
+function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey, token: number): string {
+  return mode === "shared" ? `${workspaceId}|${tableKey}` : `${workspaceId}|${tableKey}|${token}`
+}
+
+function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
+  const entry = entries.get(entryKey)
+  if (!entry) return
+
+  const previous = entry.rows
+  const byId = new Map<string, IdentifiedRow>()
+  const changedIds: string[] = []
+  let changed = previous === undefined || previous.length !== incoming.length
+  const next = incoming.map((row, index) => {
+    const prior = entry.byId.get(row.id)
+    if (prior && semanticEqual(prior, row, COMPARE_ALL_KEYS)) {
+      byId.set(row.id, prior)
+      if (previous?.[index] !== prior) changed = true
+      return prior
+    }
+    byId.set(row.id, row)
+    changedIds.push(row.id)
+    changed = true
+    return row
+  })
+  for (const id of entry.byId.keys()) {
+    if (!byId.has(id)) {
+      changedIds.push(id)
+      changed = true
+    }
+  }
+
+  const wasResolved = entry.resolved
+  entry.byId = byId
+  entry.resolved = true
+  // A snapshot reference that survives an emission is what keeps array
+  // consumers from re-rendering when nothing they read changed.
+  if (changed) entry.rows = next
+
+  if (changed || !wasResolved) {
+    for (const notify of entry.listeners) notify()
+  }
+  for (const id of changedIds) {
+    const keyed = entry.keyListeners.get(id)
+    if (!keyed) continue
+    for (const notify of keyed) notify()
+  }
+}
+
+/** Entries holding a Dexie subscription that is not already scheduled for teardown. */
+function liveEntryCount(): number {
+  let count = 0
+  for (const entry of entries.values()) {
+    if (!entry.teardown) count += 1
+  }
+  return count
+}
+
+function markLiveEntries(): void {
+  const count = liveEntryCount()
+  if (count === lastMarkedLiveEntries) return
+  lastMarkedLiveEntries = count
+  perfCapture.getPerfCapture().mark("store.tableSubscriptions", count)
+}
+
+function ensureEntry(
+  entryKey: string,
+  workspaceId: string,
+  tableKey: WorkspaceTableKey,
+  seed?: WorkspaceTableEntry
+): WorkspaceTableEntry {
+  const existing = entries.get(entryKey)
+  if (existing) {
+    if (existing.teardown) {
+      clearTimeout(existing.teardown)
+      existing.teardown = null
+      markLiveEntries()
+    }
+    return existing
+  }
+
+  const created: WorkspaceTableEntry = {
+    workspaceId,
+    tableKey,
+    rows: undefined,
+    byId: new Map(),
+    resolved: false,
+    listeners: new Set(),
+    keyListeners: new Map(),
+    refCount: 0,
+    subscription: { unsubscribe() {} } as Subscription,
+    teardown: null,
+  }
+  // Register BEFORE subscribing so a synchronous first emission finds the entry;
+  // the callback re-reads it from the map, so a late emission after teardown is
+  // a no-op.
+  if (seed?.resolved) {
+    created.rows = seed.rows
+    created.byId = new Map(seed.byId)
+    created.resolved = true
+  }
+  entries.set(entryKey, created)
+  created.subscription = liveQuery(() => WORKSPACE_TABLE_QUERIES[tableKey](workspaceId)).subscribe((rows) =>
+    applyEmission(entryKey, rows)
+  )
+  markLiveEntries()
+  return created
+}
+
+function releaseEntry(entryKey: string, immediate: boolean): void {
+  const entry = entries.get(entryKey)
+  if (!entry) return
+  if (entry.refCount > 0 || entry.listeners.size > 0 || entry.keyListeners.size > 0) return
+  if (immediate) {
+    if (entry.teardown) clearTimeout(entry.teardown)
+    entry.subscription.unsubscribe()
+    entries.delete(entryKey)
+    markLiveEntries()
+    return
+  }
+  if (entry.teardown) return
+  entry.teardown = setTimeout(() => {
+    const live = entries.get(entryKey)
+    if (!live || live.refCount > 0 || live.listeners.size > 0 || live.keyListeners.size > 0) return
+    live.subscription.unsubscribe()
+    entries.delete(entryKey)
+    markLiveEntries()
+  }, TABLE_TEARDOWN_GRACE_MS)
+  markLiveEntries()
+}
+
+/**
+ * Subscribe one consumer to a workspace table. `token` comes from
+ * {@link allocateWorkspaceTableToken} and must be stable for the consumer's
+ * lifetime — in `off` mode it is what keeps the subscription private.
+ */
+export function subscribeWorkspaceTable(
+  workspaceId: string,
+  tableKey: WorkspaceTableKey,
+  token: number,
+  listener: () => void
+): () => void {
+  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entry = ensureEntry(entryKey, workspaceId, tableKey)
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  const registrationId = nextRegistrationId++
+  registrations.set(registrationId, { kind: "table", workspaceId, tableKey, token, listener, entryKey })
+
+  return () => {
+    const registration = registrations.get(registrationId)
+    if (!registration) return
+    registrations.delete(registrationId)
+    const current = entries.get(registration.entryKey)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+  }
+}
+
+/** Subscribe to one row of a shared table, so a change to row X wakes only X's readers (D6). */
+export function subscribeWorkspaceTableRow(
+  workspaceId: string,
+  tableKey: WorkspaceTableKey,
+  rowId: string,
+  token: number,
+  listener: () => void
+): () => void {
+  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entry = ensureEntry(entryKey, workspaceId, tableKey)
+  let keyed = entry.keyListeners.get(rowId)
+  if (!keyed) {
+    keyed = new Set()
+    entry.keyListeners.set(rowId, keyed)
+  }
+  keyed.add(listener)
+  entry.refCount += 1
+  const registrationId = nextRegistrationId++
+  registrations.set(registrationId, { kind: "row", workspaceId, tableKey, rowId, token, listener, entryKey })
+
+  return () => {
+    const registration = registrations.get(registrationId)
+    if (!registration) return
+    registrations.delete(registrationId)
+    const current = entries.get(registration.entryKey)
+    if (!current) return
+    const set = current.keyListeners.get(rowId)
+    if (set) {
+      set.delete(listener)
+      if (set.size === 0) current.keyListeners.delete(rowId)
+    }
+    current.refCount -= 1
+    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+  }
+}
+
+/** The table's rows, or `undefined` while the first read is in flight (`useLiveQuery`'s contract). */
+export function getWorkspaceTableSnapshot<K extends WorkspaceTableKey>(
+  workspaceId: string,
+  tableKey: K,
+  token: number
+): WorkspaceTableRowTypes[K][] | undefined {
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  return entry?.rows as WorkspaceTableRowTypes[K][] | undefined
+}
+
+export function getWorkspaceTableRow<K extends WorkspaceTableKey>(
+  workspaceId: string,
+  tableKey: K,
+  rowId: string,
+  token: number
+): WorkspaceTableRowTypes[K] | undefined {
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  return entry?.byId.get(rowId) as WorkspaceTableRowTypes[K] | undefined
+}
+
+function detach(entry: WorkspaceTableEntry, registration: Registration): void {
+  if (registration.kind === "table") {
+    entry.listeners.delete(registration.listener)
+  } else {
+    const set = entry.keyListeners.get(registration.rowId)
+    if (set) {
+      set.delete(registration.listener)
+      if (set.size === 0) entry.keyListeners.delete(registration.rowId)
+    }
+  }
+  entry.refCount -= 1
+}
+
+function attach(entry: WorkspaceTableEntry, registration: Registration): void {
+  if (registration.kind === "table") {
+    entry.listeners.add(registration.listener)
+  } else {
+    let keyed = entry.keyListeners.get(registration.rowId)
+    if (!keyed) {
+      keyed = new Set()
+      entry.keyListeners.set(registration.rowId, keyed)
+    }
+    keyed.add(registration.listener)
+  }
+  entry.refCount += 1
+}
+
+function visibleSnapshot(entry: WorkspaceTableEntry | undefined, registration: Registration): unknown {
+  if (!entry) return undefined
+  return registration.kind === "table" ? entry.rows : entry.byId.get(registration.rowId)
+}
+
+/**
+ * Flip sharing on or off. Every live registration — array and row alike — is
+ * moved to its new entry key synchronously, so the flag can arrive or change
+ * mid-session without a single hook count changing (D5).
+ *
+ * The new entry is seeded from a resolved predecessor for the same
+ * (workspace, table): the query is identical, so any resolved entry is a correct
+ * snapshot. Publishing an unresolved entry instead would regress every consumer
+ * to its bootstrap-era cache fallback for a frame — and the flag itself is read
+ * through this registry, so an unresolved metadata entry would flip the mode back
+ * and loop.
+ */
+export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
+  if (next === mode) return
+  const active = [...registrations.entries()]
+  const before = new Map<number, unknown>()
+  const seeds = new Map<string, WorkspaceTableEntry>()
+
+  for (const [id, registration] of active) {
+    const entry = entries.get(registration.entryKey)
+    before.set(id, visibleSnapshot(entry, registration))
+    if (!entry) continue
+    detach(entry, registration)
+  }
+  for (const entry of entries.values()) {
+    const seedKey = `${entry.workspaceId}|${entry.tableKey}`
+    if (entry.resolved && !seeds.has(seedKey)) seeds.set(seedKey, entry)
+  }
+
+  mode = next
+
+  for (const [id, registration] of active) {
+    const entryKey = entryKeyFor(registration.workspaceId, registration.tableKey, registration.token)
+    const entry = ensureEntry(
+      entryKey,
+      registration.workspaceId,
+      registration.tableKey,
+      seeds.get(`${registration.workspaceId}|${registration.tableKey}`)
+    )
+    attach(entry, registration)
+    registrations.set(id, { ...registration, entryKey })
+  }
+  for (const [, registration] of active) releaseEntry(registration.entryKey, true)
+
+  for (const [id] of active) {
+    const current = registrations.get(id)
+    if (!current) continue
+    if (visibleSnapshot(entries.get(current.entryKey), current) !== before.get(id)) current.listener()
+  }
+}
+
+/** Live Dexie subscriptions on workspace tables, teardown-grace ones included. */
+export function activeWorkspaceSubscriptionCount(): number {
+  return entries.size
+}
+
+export function resetWorkspaceTableRegistry(): void {
+  for (const entry of entries.values()) {
+    if (entry.teardown) clearTimeout(entry.teardown)
+    entry.subscription.unsubscribe()
+  }
+  entries.clear()
+  registrations.clear()
+  mode = "off"
+  lastMarkedLiveEntries = -1
+}

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -62,6 +62,7 @@ export const FEATURE_FLAGS = {
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
+  sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -28,6 +28,7 @@ export const PERF_MARK_NAMES = [
   "catchup.collapse",
   "catchup.serialReplay",
   "stream.subscriptions",
+  "store.tableSubscriptions",
   "stream.eventApply",
   "stream.idbTransaction",
   "liveQuery.rerun",


### PR DESCRIPTION
## Problem

`useWorkspaceUsers` (40 call sites), `useWorkspaceStreams` (42), `useWorkspaceUserId` (27) each mount a private `useLiveQuery` over the whole workspace table via `useArrayStoreHook`/`useSingletonStoreHook` — a 50-row timeline window opens ~50 identical whole-table subscriptions, each re-running its own IDB read and rebuilding rows on every table write. Chunk 2 of the PR 6/10 plan; base #1742.

## Solution

One ref-counted `liveQuery` per `(workspace, table)`, behind `sharedWorkspaceReads` (default off).

- **New `workspace-table-registry.ts`** — module-level registry (the `railRegistry` INV-9 precedent): per-entry `rows`/`byId`, per-key row listener sets, grace-window teardown, row identity preserved via `semanticEqual`. The two internal store hooks read it through `useSyncExternalStore`; all 14 exported hooks and every call site are unchanged.
- **Flag flips sharing, never hook shape** (plan D5): `off` runs one private registry entry per subscriber, so hook counts are identical in both arms and a mid-session flip is safe. The flip is the *normal* path (the flag resolves after first paint), and the adversarial round found the whole defect cluster there: a stale-key unsubscribe closure that leaked listeners and pinned whole-table liveQueries across workspace switches (blocker), a painted frame of bootstrap-era cache on flip, row subscribers never migrated, and a feedback loop when the flag itself is read through the registry it re-keys. Fixed by making the registrations map the single key authority: flips detach/re-attach every registration (rows included), seed new entries from resolved predecessors, and notify only on real snapshot change. Each fix carries a regression test that fails with the fix reverted.
- `store.tableSubscriptions` capture mark emits from the registry on entry lifecycle (grace-excluded, deduped) — the original effect-based sample ran before the subtree subscribed and measured ~0 in both arms.
- The decrypted-name overlay (`useWorkspaceStreams`) memoises once per workspace per change instead of once per consumer per render.
- **Honest dependency**: row-identity stability across bootstraps only materialises with `bootstrapDiff=on` — a plain bootstrap restamps `_cachedAt` on every row, failing the equality deliberately (serving an older-stamped object would be new behavior). Not a regression (the old per-hook `useLiveQuery` preserved nothing); the measured win for the off-diff cell is subscription count, not identity.

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr6-10-plan-4119f5/ (chunk 2, D3-D6).

## Test plan

- [x] Targeted vitest (`workspace-table-registry` ×11, `workspace-store` ×7, `workspace-store.publication` ×3, `--maxWorkers=2`): 21/0; typecheck clean; Opus-high adversarial verify (7 findings, all fixed or documented) with neutralisation checks both directions
- [ ] Broad suites deliberately left to CI (local full runs disabled by request)

## Post-review updates (whole-stack pass)
- Off-arm parity restored: private (token-keyed) entries tear down at zero grace and skip the per-row semantic compare — the default arm now matches pre-registry `useLiveQuery` behavior instead of paying 5s retained whole-table queries per unmount and a ~356KB metadata deep-compare per consumer per reaction.
- `store.tableSubscriptions` emits only in shared mode (the off-arm count tracks consumer mounts and floods the 2000-sample capture ring, making the A/B populations incomparable).
- The capture upload endpoint drops samples with unknown mark names instead of rejecting the whole capture — Pages deploys ahead of Railway, and a client one release ahead must not lose its session's diagnostics.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788342055&installation_model_id=20758&pr_number=1744&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1744&signature=c4061e02ed70c8296c7cf356159f5a50b8bb6b0eb3153541517a530378e7a1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
