### PR TITLE
perf: one actor lookup and emoji index per workspace

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -9,6 +9,7 @@ import { setActiveDb } from "@/db/database"
 import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
+import { resetActorLookups } from "@/stores/actor-lookup"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -78,6 +79,7 @@ export function useAccountScopeOptional(): AccountScopeValue | null {
 function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
   resetWorkspaceTableRegistry()
+  resetActorLookups()
   resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest"
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest"
 import { spyOnExport } from "@/test/spy"
 import { render, screen, act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
@@ -6,6 +6,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { ServicesProvider, type SavedService } from "@/contexts"
 import { MessageEvent } from "./message-event"
+import { TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
+import { clearWorkspaceActorTables, seedWorkspaceUser, workspaceUsersTable } from "@/test/workspace-rows"
+import { resetActorLookups } from "@/stores/actor-lookup"
+import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "@/stores/workspace-table-registry"
 import { EditLastMessageContext } from "./edit-last-message-context"
 import * as editorModule from "@/components/editor"
 import * as hooksModule from "@/hooks"
@@ -613,5 +618,112 @@ describe("MessageEvent", () => {
 
       expect(screen.getByText("Editing unsent message")).toBeInTheDocument()
     })
+  })
+})
+
+describe("row-tree read fan-out", () => {
+  const workspaceId = "ws_123"
+  const streamId = "stream_123"
+
+  function makeCtx(): TimelineItemRenderContext {
+    return {
+      workspaceId,
+      streamId,
+      sessionLiveCounts: new Map(),
+      sessionLiveSubsteps: new Map(),
+      cancelledFollowUpIds: new Set(),
+      delegationStatusPatches: new Map(),
+      botAccessStatusPatches: new Map(),
+      callEndedPatches: new Map(),
+    }
+  }
+
+  const rowEvents = Array.from({ length: 50 }, (_, i) => createMessageEvent(`msg_${i}`, `row ${i}`))
+
+  beforeEach(async () => {
+    resetWorkspaceTableRegistry()
+    resetWorkspaceStoreCache()
+    resetActorLookups()
+    await clearWorkspaceActorTables()
+    await seedWorkspaceUser(workspaceId, "member_123")
+  })
+
+  afterEach(() => {
+    resetWorkspaceTableRegistry()
+    resetActorLookups()
+  })
+
+  it("a fifty-row window opens one users read, not fifty", async () => {
+    // The real lookup, not the suite's stub: this test is about what the row
+    // tree reads from IDB.
+    vi.spyOn(hooksModule, "useActors").mockRestore()
+    setWorkspaceReadMode("shared")
+    const where = vi.spyOn(workspaceUsersTable(), "where")
+
+    render(
+      <>
+        {rowEvents.map((event) => (
+          <MessageEvent key={event.id} event={event} workspaceId={workspaceId} streamId={streamId} />
+        ))}
+      </>,
+      { wrapper: Wrapper }
+    )
+    await screen.findAllByText("row 0")
+
+    expect(where).toHaveBeenCalledTimes(1)
+  })
+
+  it("fifty rows open one users read per consumer when sharing is off", async () => {
+    vi.spyOn(hooksModule, "useActors").mockRestore()
+    setWorkspaceReadMode("off")
+    const where = vi.spyOn(workspaceUsersTable(), "where")
+
+    render(
+      <>
+        {rowEvents.map((event) => (
+          <MessageEvent key={event.id} event={event} workspaceId={workspaceId} streamId={streamId} />
+        ))}
+      </>,
+      { wrapper: Wrapper }
+    )
+    await screen.findAllByText("row 0")
+
+    expect(where.mock.calls.length).toBeGreaterThan(50)
+  })
+
+  // Runs under the suite's stubbed `useActors`, so it covers the pre-existing
+  // per-item row memo (#835), not the actor-lookup registry.
+  it("an incoming message re-renders the new row only", async () => {
+    const renders = new Map<string, number>()
+    mockGetStatus = (id: string) => {
+      renders.set(id, (renders.get(id) ?? 0) + 1)
+      return null
+    }
+
+    const rows = (events: StreamEvent[], ctx: TimelineItemRenderContext) => (
+      <>
+        {events.map((event) => (
+          <TimelineItemContent
+            key={event.id}
+            item={{ type: "event", event }}
+            ctx={ctx}
+            deferSecondaryHydration={false}
+          />
+        ))}
+      </>
+    )
+
+    const { rerender } = render(rows(rowEvents, makeCtx()), { wrapper: Wrapper })
+    await screen.findAllByText("row 0")
+    const before = new Map(renders)
+
+    const incoming = createMessageEvent("msg_new", "row new")
+    // A fresh ctx per data tick is what production does — the memo compares
+    // per-item content, not container identity.
+    rerender(rows([...rowEvents, incoming], makeCtx()))
+    await screen.findByText("row new")
+
+    const rerendered = [...renders.entries()].filter(([id, count]) => count !== (before.get(id) ?? 0))
+    expect(rerendered.map(([id]) => id)).toEqual([incoming.id])
   })
 })

--- a/apps/frontend/src/hooks/use-actors.ts
+++ b/apps/frontend/src/hooks/use-actors.ts
@@ -1,63 +1,21 @@
-import { useCallback, useMemo } from "react"
-import {
-  getAvatarUrl,
-  getBotAvatarUrl,
-  getPersonaAvatarUrl,
-  resolveActiveStatus,
-  resolveNotificationPause,
-  type ActiveNotificationPause,
-} from "@threa/types"
 import { useWorkspaceEmoji } from "./use-workspace-emoji"
 import { useWorkspaceUsers, useWorkspacePersonas, useWorkspaceBots } from "@/stores/workspace-store"
-import type { Persona, Bot, User, AuthorType } from "@threa/types"
+import { getActorLookup } from "@/stores/actor-lookup"
 
-/** Resolved, expiry-masked status for an actor (users only today). */
-export interface ActorStatus {
-  /** Emoji glyph for the avatar badge, or null when the status has only text. */
-  emoji: string | null
-  text: string | null
-  /** ISO instant the status auto-clears at, or null for indefinite. */
-  expiresAt: string | null
-}
+import type { ActorLookup } from "@/stores/actor-lookup"
 
-interface ActorAvatarInfo {
-  fallback: string
-  slug?: string
-  avatarUrl?: string
-  /** Present only when the actor is a user with an active status. */
-  status?: ActorStatus
-  /**
-   * The user's active notification pause (do-not-disturb), when present —
-   * carries the end instant so callers can show "paused until …".
-   */
-  dnd?: ActiveNotificationPause
-}
+export { actorTypeFromId } from "@/stores/actor-lookup"
+export type { ActorLookup, ActorStatus } from "@/stores/actor-lookup"
 
 /**
- * Infer an actor's type from its prefixed ULID. Used where only the id is
- * known — notably reactions, which store `Record<emoji, actorId[]>` with no
- * per-reactor type. Prefixes are stable by convention (`persona_…` for AI
- * agents, `bot_…` for bots, `usr_…` for workspace users).
- */
-export function actorTypeFromId(id: string): AuthorType {
-  if (id.startsWith("persona_")) return "persona"
-  if (id.startsWith("bot_")) return "bot"
-  return "user"
-}
-
-export interface ActorLookup {
-  getActorName: (actorId: string | null, actorType: AuthorType | null) => string
-  getActorInitials: (actorId: string | null, actorType: AuthorType | null) => string
-  /** Returns avatar info including fallback text and persona slug (for SVG icon support) */
-  getActorAvatar: (actorId: string | null, actorType: AuthorType | null) => ActorAvatarInfo
-  getUser: (userId: string) => User | undefined
-  getPersona: (personaId: string) => Persona | undefined
-  getBot: (botId: string) => Bot | undefined
-}
-
-/**
- * Hook to look up actor names from cached workspace data.
- * Reads from IndexedDB via useLiveQuery — reactive and offline-capable.
+ * Actor names, initials and avatars from cached workspace data — reactive and
+ * offline-capable.
+ *
+ * The maps and the emoji indexes are built once per workspace per change in
+ * `stores/actor-lookup`, not once per consumer: this hook is reached three times
+ * per rendered message row, and rebuilding three actor Maps plus the ~1,914-entry
+ * shortcode index per consumer was the row tree's largest per-render cost. The
+ * returned object's identity is stable while its inputs are.
  */
 export function useActors(workspaceId: string): ActorLookup {
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
@@ -66,162 +24,5 @@ export function useActors(workspaceId: string): ActorLookup {
   const personas = useWorkspacePersonas(workspaceId)
   const bots = useWorkspaceBots(workspaceId)
 
-  const userMap = useMemo(() => new Map(users.map((u) => [u.id, u])), [users])
-  const personaMap = useMemo(() => new Map(personas.map((p) => [p.id, p])), [personas])
-  const botMap = useMemo(() => new Map(bots.map((b) => [b.id, b])), [bots])
-
-  const getUser = useCallback((userId: string): User | undefined => userMap.get(userId) as User | undefined, [userMap])
-
-  const getPersona = useCallback(
-    (personaId: string): Persona | undefined => personaMap.get(personaId) as Persona | undefined,
-    [personaMap]
-  )
-
-  const getBot = useCallback((botId: string): Bot | undefined => botMap.get(botId) as Bot | undefined, [botMap])
-
-  const getActorName = useCallback(
-    (actorId: string | null, actorType: AuthorType | null): string => {
-      if (!actorId) return "Unknown"
-      if (actorType === "system") return "Threa"
-
-      if (actorType === "persona") {
-        return personaMap.get(actorId)?.name ?? "AI Companion"
-      }
-
-      if (actorType === "bot") {
-        return botMap.get(actorId)?.name ?? "Bot"
-      }
-
-      return userMap.get(actorId)?.name || actorId.substring(0, 8)
-    },
-    [userMap, personaMap, botMap]
-  )
-
-  const getActorInitials = useCallback(
-    (actorId: string | null, actorType: AuthorType | null): string => {
-      if (!actorId) return "?"
-      if (actorType === "system") return "T"
-
-      if (actorType === "persona") {
-        const persona = personaMap.get(actorId)
-        if (persona?.avatarEmoji) {
-          const emoji = toEmoji(persona.avatarEmoji)
-          if (emoji) return emoji
-        }
-        return initialsFrom(persona?.name) ?? "AI"
-      }
-
-      if (actorType === "bot") {
-        const bot = botMap.get(actorId)
-        if (bot?.avatarEmoji) {
-          const emoji = toEmoji(bot.avatarEmoji)
-          if (emoji) return emoji
-        }
-        return initialsFrom(bot?.name) ?? "B"
-      }
-
-      return initialsFrom(userMap.get(actorId)?.name) ?? actorId.substring(0, 2).toUpperCase()
-    },
-    [userMap, personaMap, botMap, toEmoji]
-  )
-
-  const getActorAvatar = useCallback(
-    (actorId: string | null, actorType: AuthorType | null): ActorAvatarInfo => {
-      const fallback = getActorInitials(actorId, actorType)
-
-      if (actorType === "system") return { fallback }
-
-      if (actorType === "persona" && actorId) {
-        const persona = personaMap.get(actorId)
-        const avatarUrl = getPersonaAvatarUrl(workspaceId, persona?.avatarUrl, 64)
-        if (avatarUrl) return { fallback, slug: persona?.slug, avatarUrl }
-        return { fallback, slug: persona?.slug }
-      }
-
-      if (actorType === "bot" && actorId) {
-        const bot = getBot(actorId)
-        const avatarUrl = getBotAvatarUrl(workspaceId, bot?.avatarUrl, 64)
-        if (avatarUrl) return { fallback, avatarUrl }
-        return { fallback }
-      }
-
-      if (actorId) {
-        const workspaceUser = userMap.get(actorId)
-        const status = resolveUserStatus(workspaceUser, toEmoji)
-        const dnd = resolveUserDnd(workspaceUser)
-        const avatarUrl = getAvatarUrl(workspaceId, workspaceUser?.avatarUrl, 64)
-        const info: ActorAvatarInfo = { fallback }
-        if (avatarUrl) info.avatarUrl = avatarUrl
-        if (status) info.status = status
-        if (dnd) info.dnd = dnd
-        return info
-      }
-
-      return { fallback }
-    },
-    [getActorInitials, getBot, userMap, workspaceId, toEmoji]
-  )
-
-  return useMemo(
-    () => ({
-      getActorName,
-      getActorInitials,
-      getActorAvatar,
-      getUser,
-      getPersona,
-      getBot,
-    }),
-    [getActorName, getActorInitials, getActorAvatar, getUser, getPersona, getBot]
-  )
-}
-
-/**
- * Resolve a workspace user's stored status fields into a display status,
- * masking expired/empty ones and converting the emoji shortcode to a glyph.
- * Returns undefined when there is nothing to show. `User` carries the status
- * fields on the wire; cached rows predating the feature simply lack them.
- */
-function resolveUserStatus(
-  user: User | undefined,
-  toEmoji: (shortcode: string) => string | null
-): ActorStatus | undefined {
-  if (!user) return undefined
-  const active = resolveActiveStatus({
-    statusEmoji: user.statusEmoji ?? null,
-    statusText: user.statusText ?? null,
-    statusExpiresAt: user.statusExpiresAt ?? null,
-  })
-  if (!active) return undefined
-  return {
-    emoji: active.emoji ? toEmoji(active.emoji) : null,
-    text: active.text,
-    expiresAt: active.expiresAt,
-  }
-}
-
-/**
- * The workspace user's active notification pause (do-not-disturb), from either a
- * do-not-disturb status or a manual pause, or null when notifications are
- * flowing. Tolerant of cached rows predating the feature, which lack the fields.
- */
-function resolveUserDnd(user: User | undefined): ActiveNotificationPause | null {
-  if (!user) return null
-  return resolveNotificationPause({
-    statusEmoji: user.statusEmoji ?? null,
-    statusText: user.statusText ?? null,
-    statusExpiresAt: user.statusExpiresAt ?? null,
-    statusPausesNotifications: user.statusPausesNotifications ?? false,
-    notificationsPausedUntil: user.notificationsPausedUntil ?? null,
-    notificationsPausedIndefinitely: user.notificationsPausedIndefinitely ?? false,
-  })
-}
-
-function initialsFrom(name: string | null | undefined): string | undefined {
-  if (!name) return undefined
-  const words = name.split(" ")
-  return words
-    .slice(0, 2)
-    .map((w) => w[0])
-    .join("")
-    .toUpperCase()
+  return getActorLookup(workspaceId, users, personas, bots, toEmoji)
 }

--- a/apps/frontend/src/hooks/use-workspace-emoji.ts
+++ b/apps/frontend/src/hooks/use-workspace-emoji.ts
@@ -1,7 +1,6 @@
-import { useCallback, useMemo } from "react"
 import { useWorkspaceMetadata } from "@/stores/workspace-store"
+import { getWorkspaceEmojiIndexes } from "@/stores/actor-lookup"
 import type { EmojiEntry } from "@threa/types"
-import { buildShortcodeIndex, stripShortcodeColons } from "@/lib/emoji-picker"
 
 interface WorkspaceEmojiData {
   /** All available emojis in the workspace */
@@ -16,49 +15,18 @@ interface WorkspaceEmojiData {
   toShortcode: (emoji: string) => string | null
 }
 
+const EMPTY_EMOJIS: EmojiEntry[] = []
+const EMPTY_WEIGHTS: Record<string, number> = {}
+
 /**
  * Hook to look up emojis from workspace data.
- * Reads from IndexedDB via useLiveQuery — reactive and offline-capable.
+ * Reads from IndexedDB via the shared workspace-table registry — reactive and
+ * offline-capable. The shortcode index and the reverse map are built once per
+ * emoji set (`stores/actor-lookup`), not once per consumer.
  */
 export function useWorkspaceEmoji(workspaceId: string): WorkspaceEmojiData {
   const metadata = useWorkspaceMetadata(workspaceId)
-
-  const emojis = useMemo(() => (metadata?.emojis ?? []) as EmojiEntry[], [metadata])
-  const emojiWeights = useMemo(() => metadata?.emojiWeights ?? {}, [metadata])
-
-  const emojiMap = useMemo(() => buildShortcodeIndex(emojis), [emojis])
-
-  const getEmoji = useCallback(
-    (shortcode: string): EmojiEntry | undefined => emojiMap.get(stripShortcodeColons(shortcode)),
-    [emojiMap]
-  )
-
-  const toEmoji = useCallback(
-    (shortcode: string): string | null => {
-      const entry = getEmoji(shortcode)
-      return entry?.emoji ?? null
-    },
-    [getEmoji]
-  )
-
-  const shortcodeMap = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const entry of emojis) {
-      map.set(entry.emoji, entry.shortcode)
-    }
-    return map
-  }, [emojis])
-
-  const toShortcode = useCallback((emoji: string): string | null => shortcodeMap.get(emoji) ?? null, [shortcodeMap])
-
-  return useMemo(
-    () => ({
-      emojis,
-      emojiWeights,
-      toEmoji,
-      getEmoji,
-      toShortcode,
-    }),
-    [emojis, emojiWeights, toEmoji, getEmoji, toShortcode]
-  )
+  const emojis = (metadata?.emojis ?? EMPTY_EMOJIS) as EmojiEntry[]
+  const emojiWeights = metadata?.emojiWeights ?? EMPTY_WEIGHTS
+  return getWorkspaceEmojiIndexes(emojis, emojiWeights)
 }

--- a/apps/frontend/src/hooks/use-workspace-emoji.ts
+++ b/apps/frontend/src/hooks/use-workspace-emoji.ts
@@ -28,5 +28,5 @@ export function useWorkspaceEmoji(workspaceId: string): WorkspaceEmojiData {
   const metadata = useWorkspaceMetadata(workspaceId)
   const emojis = (metadata?.emojis ?? EMPTY_EMOJIS) as EmojiEntry[]
   const emojiWeights = metadata?.emojiWeights ?? EMPTY_WEIGHTS
-  return getWorkspaceEmojiIndexes(emojis, emojiWeights)
+  return getWorkspaceEmojiIndexes(workspaceId, emojis, emojiWeights)
 }

--- a/apps/frontend/src/stores/actor-lookup.test.tsx
+++ b/apps/frontend/src/stores/actor-lookup.test.tsx
@@ -180,7 +180,6 @@ describe("actor lookup", () => {
     await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
     await db.workspaceMetadata.put(makeMetadata())
     const seen: Array<[unknown, unknown]> = []
-    ;(globalThis as never as { __dbg: string[] }).__dbg = []
 
     const { findByText, rerender } = render(<TwoConsumers tick={0} seen={seen} />)
     await findByText("Ada-Ada-0")

--- a/apps/frontend/src/stores/actor-lookup.test.tsx
+++ b/apps/frontend/src/stores/actor-lookup.test.tsx
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, renderHook, waitFor } from "@testing-library/react"
+import { db, type CachedPersona, type CachedWorkspaceMetadata, type CachedWorkspaceUser } from "@/db"
+import * as emojiPicker from "@/lib/emoji-picker"
+import * as perfCapture from "@/lib/perf/capture"
+import { useActors } from "@/hooks/use-actors"
+import { useWorkspaceStreams, resetWorkspaceStoreCache, upsertWorkspacePersonaCache } from "./workspace-store"
+import { resetActorLookups } from "./actor-lookup"
+import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
+
+const WORKSPACE = "ws_1"
+
+function makeUser(id: string, name: string): CachedWorkspaceUser {
+  return {
+    id,
+    workspaceId: WORKSPACE,
+    workosUserId: `workos_${id}`,
+    email: `${id}@example.com`,
+    role: "member",
+    slug: id,
+    name,
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: 1,
+  }
+}
+
+function makePersona(id: string, name: string): CachedPersona {
+  return {
+    id,
+    workspaceId: WORKSPACE,
+    slug: name.toLowerCase(),
+    name,
+    description: null,
+    avatarEmoji: null,
+    avatarUrl: null,
+    systemPrompt: null,
+    model: "claude-sonnet-4-20250514",
+    temperature: null,
+    maxTokens: null,
+    enabledTools: null,
+    managedBy: "system",
+    ownerUserId: null,
+    status: "active",
+    createdAt: "2026-03-01T10:00:00Z",
+    updatedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: 1,
+  }
+}
+
+function makeMetadata(): CachedWorkspaceMetadata {
+  return {
+    id: WORKSPACE,
+    workspaceId: WORKSPACE,
+    emojis: [
+      { shortcode: "smile", emoji: "😄", type: "unicode", group: "people", order: 1, aliases: ["grin"] },
+      { shortcode: "thread", emoji: "🧵", type: "unicode", group: "objects", order: 2, aliases: [] },
+    ],
+    emojiWeights: {},
+    _cachedAt: 1,
+  } as CachedWorkspaceMetadata
+}
+
+function ManyActorConsumers({ count }: { count: number }) {
+  const lookups = []
+  for (let i = 0; i < count; i++) {
+    lookups.push(useActors(WORKSPACE))
+  }
+  return <div data-testid="name">{lookups[0].getActorName("usr_1", "user")}</div>
+}
+
+function TwoConsumers({ tick, seen }: { tick: number; seen: Array<[unknown, unknown]> }) {
+  const first = useActors(WORKSPACE)
+  const second = useActors(WORKSPACE)
+  seen.push([first, second])
+  return (
+    <div data-testid="name">
+      {first.getActorName("usr_1", "user")}-{second.getActorName("usr_1", "user")}-{tick}
+    </div>
+  )
+}
+
+describe("actor lookup", () => {
+  beforeEach(async () => {
+    resetWorkspaceTableRegistry()
+    resetWorkspaceStoreCache()
+    resetActorLookups()
+    await db.workspaceUsers.clear()
+    await db.personas.clear()
+    await db.bots.clear()
+    await db.workspaceMetadata.clear()
+    await db.streams.clear()
+    setWorkspaceReadMode("shared")
+  })
+
+  afterEach(() => {
+    resetWorkspaceTableRegistry()
+    resetActorLookups()
+    vi.restoreAllMocks()
+  })
+
+  it("the emoji shortcode index is built once for twenty useActors consumers", async () => {
+    await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
+    await db.workspaceMetadata.put(makeMetadata())
+    const build = vi.spyOn(emojiPicker, "buildShortcodeIndex")
+
+    const { findByText } = render(<ManyActorConsumers count={20} />)
+    await findByText("Ada")
+
+    expect(build).toHaveBeenCalledTimes(1)
+  })
+
+  it("the ActorLookup identity is stable when unrelated workspace data changes", async () => {
+    await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
+    await db.workspaceMetadata.put(makeMetadata())
+    const { result } = renderHook(() => ({
+      lookup: useActors(WORKSPACE),
+      streams: useWorkspaceStreams(WORKSPACE),
+    }))
+    await waitFor(() => expect(result.current.lookup.getActorName("usr_1", "user")).toBe("Ada"))
+    const before = result.current.lookup
+
+    await act(async () => {
+      await db.streams.put({
+        id: "stream_1",
+        workspaceId: WORKSPACE,
+        type: "channel",
+        slug: "general",
+        displayName: null,
+        _cachedAt: 1,
+      } as never)
+    })
+    await waitFor(() => expect(result.current.streams).toHaveLength(1))
+
+    expect(result.current.lookup).toBe(before)
+  })
+
+  it("the identity changes when a user's name changes, and the new name resolves", async () => {
+    await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
+    await db.workspaceMetadata.put(makeMetadata())
+    const { result } = renderHook(() => useActors(WORKSPACE))
+    await waitFor(() => expect(result.current.getActorName("usr_1", "user")).toBe("Ada"))
+    const before = result.current
+
+    await act(async () => {
+      await db.workspaceUsers.put(makeUser("usr_1", "Ada Lovelace"))
+    })
+    await waitFor(() => expect(result.current.getActorName("usr_1", "user")).toBe("Ada Lovelace"))
+
+    expect(result.current).not.toBe(before)
+  })
+
+  it("a persona added by upsertWorkspacePersonaCache is visible without a bootstrap", async () => {
+    await db.workspaceMetadata.put(makeMetadata())
+    const { result } = renderHook(() => useActors(WORKSPACE))
+    await waitFor(() => expect(result.current.getActorName("persona_1", "persona")).toBe("AI Companion"))
+
+    await act(async () => {
+      upsertWorkspacePersonaCache(WORKSPACE, makePersona("persona_1", "Ariadne"))
+    })
+
+    await waitFor(() => expect(result.current.getActorName("persona_1", "persona")).toBe("Ariadne"))
+  })
+
+  it("each consumer keeps its own lookup identity across a re-render when sharing is off", async () => {
+    setWorkspaceReadMode("off")
+    await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
+    await db.workspaceMetadata.put(makeMetadata())
+    const seen: Array<[unknown, unknown]> = []
+    ;(globalThis as never as { __dbg: string[] }).__dbg = []
+
+    const { findByText, rerender } = render(<TwoConsumers tick={0} seen={seen} />)
+    await findByText("Ada-Ada-0")
+    rerender(<TwoConsumers tick={1} seen={seen} />)
+    await findByText("Ada-Ada-1")
+    const [firstBefore, secondBefore] = seen[seen.length - 1]
+
+    rerender(<TwoConsumers tick={2} seen={seen} />)
+    await findByText("Ada-Ada-2")
+    const [firstAfter, secondAfter] = seen[seen.length - 1]
+
+    expect({
+      firstStable: firstAfter === firstBefore,
+      secondStable: secondAfter === secondBefore,
+    }).toEqual({ firstStable: true, secondStable: true })
+  })
+
+  it("the lookup build count is bounded by the consumer count and does not grow on re-render", async () => {
+    setWorkspaceReadMode("off")
+    await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
+    await db.workspaceMetadata.put(makeMetadata())
+    const time = vi.fn((_name: string) => () => {})
+    vi.spyOn(perfCapture, "getPerfCapture").mockReturnValue({
+      time,
+      mark: () => {},
+      count: () => {},
+    } as unknown as ReturnType<typeof perfCapture.getPerfCapture>)
+    const builds = () => time.mock.calls.filter(([name]) => name === "actors.lookupBuild").length
+
+    const seen: Array<[unknown, unknown]> = []
+    const { findByText, rerender } = render(<TwoConsumers tick={0} seen={seen} />)
+    await findByText("Ada-Ada-0")
+    rerender(<TwoConsumers tick={1} seen={seen} />)
+    await findByText("Ada-Ada-1")
+    const settled = builds()
+
+    rerender(<TwoConsumers tick={2} seen={seen} />)
+    await findByText("Ada-Ada-2")
+
+    // Two consumers, each building its own actor maps and emoji indexes while
+    // the rows resolve — a per-consumer constant, not a per-render one.
+    expect({ settled, grew: builds() - settled }).toEqual({ settled, grew: 0 })
+    expect(settled).toBeLessThanOrEqual(12)
+  })
+
+  it("an unknown actor id falls back exactly as before", async () => {
+    await db.workspaceMetadata.put(makeMetadata())
+    const { result } = renderHook(() => useActors(WORKSPACE))
+    await waitFor(() => expect(result.current.getActorName(null, null)).toBe("Unknown"))
+
+    expect({
+      persona: result.current.getActorName("persona_missing", "persona"),
+      bot: result.current.getActorName("bot_missing", "bot"),
+      user: result.current.getActorName("usr_abcdefghij", "user"),
+      systemName: result.current.getActorName("usr_1", "system"),
+      personaInitials: result.current.getActorInitials("persona_missing", "persona"),
+      botInitials: result.current.getActorInitials("bot_missing", "bot"),
+      userInitials: result.current.getActorInitials("usr_abcdefghij", "user"),
+      nullInitials: result.current.getActorInitials(null, null),
+      avatar: result.current.getActorAvatar("usr_abcdefghij", "user"),
+    }).toEqual({
+      persona: "AI Companion",
+      bot: "Bot",
+      user: "usr_abcd",
+      systemName: "Threa",
+      personaInitials: "AI",
+      botInitials: "B",
+      userInitials: "US",
+      nullInitials: "?",
+      avatar: { fallback: "US" },
+    })
+  })
+})

--- a/apps/frontend/src/stores/actor-lookup.test.tsx
+++ b/apps/frontend/src/stores/actor-lookup.test.tsx
@@ -219,10 +219,12 @@ describe("actor lookup", () => {
     rerender(<TwoConsumers tick={2} seen={seen} />)
     await findByText("Ada-Ada-2")
 
-    // Two consumers, each building its own actor maps and emoji indexes while
-    // the rows resolve — a per-consumer constant, not a per-render one.
+    // One sample per emoji-index build (the only producer): two consumers each
+    // build their own while the rows resolve — a per-consumer constant, not a
+    // per-render one.
     expect({ settled, grew: builds() - settled }).toEqual({ settled, grew: 0 })
-    expect(settled).toBeLessThanOrEqual(12)
+    // One emoji-index build per consumer, and nothing else samples this timer.
+    expect(settled).toBe(2)
   })
 
   it("an unknown actor id falls back exactly as before", async () => {

--- a/apps/frontend/src/stores/actor-lookup.ts
+++ b/apps/frontend/src/stores/actor-lookup.ts
@@ -1,0 +1,296 @@
+import {
+  getAvatarUrl,
+  getBotAvatarUrl,
+  getPersonaAvatarUrl,
+  resolveActiveStatus,
+  resolveNotificationPause,
+  type ActiveNotificationPause,
+  type AuthorType,
+  type Bot,
+  type EmojiEntry,
+  type Persona,
+  type User,
+} from "@threa/types"
+// Namespace imports so a test can spy the shared builders against the module (INV-48).
+import * as emojiPicker from "@/lib/emoji-picker"
+import * as perfCapture from "@/lib/perf/capture"
+
+/** Resolved, expiry-masked status for an actor (users only today). */
+export interface ActorStatus {
+  /** Emoji glyph for the avatar badge, or null when the status has only text. */
+  emoji: string | null
+  text: string | null
+  /** ISO instant the status auto-clears at, or null for indefinite. */
+  expiresAt: string | null
+}
+
+interface ActorAvatarInfo {
+  fallback: string
+  slug?: string
+  avatarUrl?: string
+  /** Present only when the actor is a user with an active status. */
+  status?: ActorStatus
+  /**
+   * The user's active notification pause (do-not-disturb), when present —
+   * carries the end instant so callers can show "paused until …".
+   */
+  dnd?: ActiveNotificationPause
+}
+
+export interface ActorLookup {
+  getActorName: (actorId: string | null, actorType: AuthorType | null) => string
+  getActorInitials: (actorId: string | null, actorType: AuthorType | null) => string
+  /** Returns avatar info including fallback text and persona slug (for SVG icon support) */
+  getActorAvatar: (actorId: string | null, actorType: AuthorType | null) => ActorAvatarInfo
+  getUser: (userId: string) => User | undefined
+  getPersona: (personaId: string) => Persona | undefined
+  getBot: (botId: string) => Bot | undefined
+}
+
+export interface WorkspaceEmojiIndexes {
+  emojis: EmojiEntry[]
+  emojiWeights: Record<string, number>
+  toEmoji: (shortcode: string) => string | null
+  getEmoji: (shortcode: string) => EmojiEntry | undefined
+  toShortcode: (emoji: string) => string | null
+}
+
+/**
+ * Infer an actor's type from its prefixed ULID. Used where only the id is
+ * known — notably reactions, which store `Record<emoji, actorId[]>` with no
+ * per-reactor type. Prefixes are stable by convention (`persona_…` for AI
+ * agents, `bot_…` for bots, `usr_…` for workspace users).
+ */
+export function actorTypeFromId(id: string): AuthorType {
+  if (id.startsWith("persona_")) return "persona"
+  if (id.startsWith("bot_")) return "bot"
+  return "user"
+}
+
+// One derived index set per distinct `emojis` array identity, not one per
+// consumer: `buildShortcodeIndex` walks every emoji AND every alias over the
+// ~1,914-entry set, and `useWorkspaceEmoji` is reached three times per rendered
+// message row. Keyed by the array the shared workspace-table registry hands out,
+// so a new identity means the rows genuinely changed.
+const emojiIndexes = new WeakMap<EmojiEntry[], WorkspaceEmojiIndexes>()
+
+const EMPTY_EMOJI_INDEXES: WorkspaceEmojiIndexes = {
+  emojis: Object.freeze([]) as unknown as EmojiEntry[],
+  emojiWeights: Object.freeze({}) as Record<string, number>,
+  getEmoji: () => undefined,
+  toEmoji: () => null,
+  toShortcode: () => null,
+}
+
+/**
+ * The cached row shapes (`CachedWorkspaceUser`, `CachedPersona`, `CachedBot`) are
+ * declared independently of the wire types, so the maps are keyed on the one
+ * field they share and cast on the way out — exactly as the hook did before.
+ */
+interface ActorRow {
+  id: string
+}
+
+interface ActorLookupEntry {
+  personas: readonly ActorRow[]
+  bots: readonly ActorRow[]
+  toEmoji: (shortcode: string) => string | null
+  lookup: ActorLookup
+}
+
+// Keyed on the users array, not the workspace id: with sharing off every
+// consumer holds its own render-stable rows array, so a single slot per
+// workspace would be evicted by the next consumer and never hit. One entry per
+// distinct rows identity means the shared arm shares an entry and the off arm
+// keeps one per consumer.
+let actorLookups = new WeakMap<readonly ActorRow[], ActorLookupEntry>()
+
+/**
+ * The shortcode index, reverse emoji map and their accessors for one `emojis`
+ * array. Rebuilt only when the array or the weights reference changes; every
+ * consumer of the same rows gets the same object identity.
+ */
+export function getWorkspaceEmojiIndexes(
+  emojis: EmojiEntry[],
+  emojiWeights: Record<string, number>
+): WorkspaceEmojiIndexes {
+  const cached = emojiIndexes.get(emojis)
+  if (cached) return cached
+  // The pre-resolution empty set is every consumer's first read; indexing it
+  // would be a build per mount for a map that can only be empty.
+  if (emojis.length === 0 && Object.keys(emojiWeights).length === 0) return EMPTY_EMOJI_INDEXES
+
+  const stopTimer = perfCapture.getPerfCapture().time("actors.lookupBuild")
+  const shortcodeIndex = emojiPicker.buildShortcodeIndex(emojis)
+  const reverseIndex = new Map<string, string>()
+  for (const entry of emojis) reverseIndex.set(entry.emoji, entry.shortcode)
+  stopTimer()
+
+  const getEmoji = (shortcode: string): EmojiEntry | undefined =>
+    shortcodeIndex.get(emojiPicker.stripShortcodeColons(shortcode))
+  const indexes: WorkspaceEmojiIndexes = {
+    emojis,
+    emojiWeights,
+    getEmoji,
+    toEmoji: (shortcode: string) => getEmoji(shortcode)?.emoji ?? null,
+    toShortcode: (emoji: string) => reverseIndex.get(emoji) ?? null,
+  }
+  emojiIndexes.set(emojis, indexes)
+  return indexes
+}
+
+/**
+ * The actor maps and resolvers for one workspace. The returned object's identity
+ * changes only when the users/personas/bots rows or the emoji resolver changed —
+ * that stability is what keeps the memoised row tree from re-rendering when
+ * unrelated workspace data ticks.
+ */
+export function getActorLookup(
+  workspaceId: string,
+  users: readonly ActorRow[],
+  personas: readonly ActorRow[],
+  bots: readonly ActorRow[],
+  toEmoji: (shortcode: string) => string | null
+): ActorLookup {
+  const cached = actorLookups.get(users)
+  if (cached && cached.personas === personas && cached.bots === bots && cached.toEmoji === toEmoji) {
+    return cached.lookup
+  }
+
+  const stopTimer = perfCapture.getPerfCapture().time("actors.lookupBuild")
+  const userMap = new Map(users.map((u) => [u.id, u as User]))
+  const personaMap = new Map(personas.map((p) => [p.id, p as Persona]))
+  const botMap = new Map(bots.map((b) => [b.id, b as Bot]))
+  stopTimer()
+
+  const getUser = (userId: string): User | undefined => userMap.get(userId)
+  const getPersona = (personaId: string): Persona | undefined => personaMap.get(personaId)
+  const getBot = (botId: string): Bot | undefined => botMap.get(botId)
+
+  const getActorName = (actorId: string | null, actorType: AuthorType | null): string => {
+    if (!actorId) return "Unknown"
+    if (actorType === "system") return "Threa"
+    if (actorType === "persona") return personaMap.get(actorId)?.name ?? "AI Companion"
+    if (actorType === "bot") return botMap.get(actorId)?.name ?? "Bot"
+    return userMap.get(actorId)?.name || actorId.substring(0, 8)
+  }
+
+  const getActorInitials = (actorId: string | null, actorType: AuthorType | null): string => {
+    if (!actorId) return "?"
+    if (actorType === "system") return "T"
+
+    if (actorType === "persona") {
+      const persona = personaMap.get(actorId)
+      if (persona?.avatarEmoji) {
+        const emoji = toEmoji(persona.avatarEmoji)
+        if (emoji) return emoji
+      }
+      return initialsFrom(persona?.name) ?? "AI"
+    }
+
+    if (actorType === "bot") {
+      const bot = botMap.get(actorId)
+      if (bot?.avatarEmoji) {
+        const emoji = toEmoji(bot.avatarEmoji)
+        if (emoji) return emoji
+      }
+      return initialsFrom(bot?.name) ?? "B"
+    }
+
+    return initialsFrom(userMap.get(actorId)?.name) ?? actorId.substring(0, 2).toUpperCase()
+  }
+
+  const getActorAvatar = (actorId: string | null, actorType: AuthorType | null): ActorAvatarInfo => {
+    const fallback = getActorInitials(actorId, actorType)
+
+    if (actorType === "system") return { fallback }
+
+    if (actorType === "persona" && actorId) {
+      const persona = personaMap.get(actorId)
+      const avatarUrl = getPersonaAvatarUrl(workspaceId, persona?.avatarUrl, 64)
+      if (avatarUrl) return { fallback, slug: persona?.slug, avatarUrl }
+      return { fallback, slug: persona?.slug }
+    }
+
+    if (actorType === "bot" && actorId) {
+      const bot = getBot(actorId)
+      const avatarUrl = getBotAvatarUrl(workspaceId, bot?.avatarUrl, 64)
+      if (avatarUrl) return { fallback, avatarUrl }
+      return { fallback }
+    }
+
+    if (actorId) {
+      const workspaceUser = userMap.get(actorId)
+      const status = resolveUserStatus(workspaceUser, toEmoji)
+      const dnd = resolveUserDnd(workspaceUser)
+      const avatarUrl = getAvatarUrl(workspaceId, workspaceUser?.avatarUrl, 64)
+      const info: ActorAvatarInfo = { fallback }
+      if (avatarUrl) info.avatarUrl = avatarUrl
+      if (status) info.status = status
+      if (dnd) info.dnd = dnd
+      return info
+    }
+
+    return { fallback }
+  }
+
+  const lookup: ActorLookup = { getActorName, getActorInitials, getActorAvatar, getUser, getPersona, getBot }
+  actorLookups.set(users, { personas, bots, toEmoji, lookup })
+  return lookup
+}
+
+/**
+ * Resolve a workspace user's stored status fields into a display status,
+ * masking expired/empty ones and converting the emoji shortcode to a glyph.
+ * Returns undefined when there is nothing to show. `User` carries the status
+ * fields on the wire; cached rows predating the feature simply lack them.
+ */
+function resolveUserStatus(
+  user: User | undefined,
+  toEmoji: (shortcode: string) => string | null
+): ActorStatus | undefined {
+  if (!user) return undefined
+  const active = resolveActiveStatus({
+    statusEmoji: user.statusEmoji ?? null,
+    statusText: user.statusText ?? null,
+    statusExpiresAt: user.statusExpiresAt ?? null,
+  })
+  if (!active) return undefined
+  return {
+    emoji: active.emoji ? toEmoji(active.emoji) : null,
+    text: active.text,
+    expiresAt: active.expiresAt,
+  }
+}
+
+/**
+ * The workspace user's active notification pause (do-not-disturb), from either a
+ * do-not-disturb status or a manual pause, or null when notifications are
+ * flowing. Tolerant of cached rows predating the feature, which lack the fields.
+ */
+function resolveUserDnd(user: User | undefined): ActiveNotificationPause | null {
+  if (!user) return null
+  return resolveNotificationPause({
+    statusEmoji: user.statusEmoji ?? null,
+    statusText: user.statusText ?? null,
+    statusExpiresAt: user.statusExpiresAt ?? null,
+    statusPausesNotifications: user.statusPausesNotifications ?? false,
+    notificationsPausedUntil: user.notificationsPausedUntil ?? null,
+    notificationsPausedIndefinitely: user.notificationsPausedIndefinitely ?? false,
+  })
+}
+
+function initialsFrom(name: string | null | undefined): string | undefined {
+  if (!name) return undefined
+  const words = name.split(" ")
+  return words
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+}
+
+/** Drop every memoised lookup — tests and account switches only. */
+export function resetActorLookups(): void {
+  actorLookups = new WeakMap()
+}

--- a/apps/frontend/src/stores/actor-lookup.ts
+++ b/apps/frontend/src/stores/actor-lookup.ts
@@ -92,6 +92,7 @@ interface ActorRow {
 }
 
 interface ActorLookupEntry {
+  workspaceId: string
   personas: readonly ActorRow[]
   bots: readonly ActorRow[]
   toEmoji: (shortcode: string) => string | null
@@ -153,7 +154,16 @@ export function getActorLookup(
   toEmoji: (shortcode: string) => string | null
 ): ActorLookup {
   const cached = actorLookups.get(users)
-  if (cached && cached.personas === personas && cached.bots === bots && cached.toEmoji === toEmoji) {
+  // workspaceId must participate: pre-hydration every workspace passes the same
+  // EMPTY_ROWS singletons, and a rows-only hit would serve workspace A's lookup
+  // (A's id baked into getActorAvatar) to workspace B's first render.
+  if (
+    cached &&
+    cached.workspaceId === workspaceId &&
+    cached.personas === personas &&
+    cached.bots === bots &&
+    cached.toEmoji === toEmoji
+  ) {
     return cached.lookup
   }
 
@@ -235,7 +245,7 @@ export function getActorLookup(
   }
 
   const lookup: ActorLookup = { getActorName, getActorInitials, getActorAvatar, getUser, getPersona, getBot }
-  actorLookups.set(users, { personas, bots, toEmoji, lookup })
+  actorLookups.set(users, { workspaceId, personas, bots, toEmoji, lookup })
   return lookup
 }
 

--- a/apps/frontend/src/stores/actor-lookup.ts
+++ b/apps/frontend/src/stores/actor-lookup.ts
@@ -48,6 +48,7 @@ export interface ActorLookup {
 }
 
 export interface WorkspaceEmojiIndexes {
+  workspaceId: string | null
   emojis: EmojiEntry[]
   emojiWeights: Record<string, number>
   toEmoji: (shortcode: string) => string | null
@@ -75,6 +76,8 @@ export function actorTypeFromId(id: string): AuthorType {
 const emojiIndexes = new WeakMap<EmojiEntry[], WorkspaceEmojiIndexes>()
 
 const EMPTY_EMOJI_INDEXES: WorkspaceEmojiIndexes = {
+  // Safe to share across workspaces: every accessor returns undefined/null.
+  workspaceId: null,
   emojis: Object.freeze([]) as unknown as EmojiEntry[],
   emojiWeights: Object.freeze({}) as Record<string, number>,
   getEmoji: () => undefined,
@@ -112,11 +115,16 @@ let actorLookups = new WeakMap<readonly ActorRow[], ActorLookupEntry>()
  * consumer of the same rows gets the same object identity.
  */
 export function getWorkspaceEmojiIndexes(
+  workspaceId: string,
   emojis: EmojiEntry[],
   emojiWeights: Record<string, number>
 ): WorkspaceEmojiIndexes {
+  // workspaceId and weights participate in the hit: `EMPTY_EMOJIS` is a module
+  // singleton shared across workspaces, so an emojis-only key would serve one
+  // workspace's weights (quick-bar ranking) to another whose metadata row also
+  // lacks an emoji set — the same cross-workspace class getActorLookup guards.
   const cached = emojiIndexes.get(emojis)
-  if (cached) return cached
+  if (cached && cached.workspaceId === workspaceId && cached.emojiWeights === emojiWeights) return cached
   // The pre-resolution empty set is every consumer's first read; indexing it
   // would be a build per mount for a map that can only be empty.
   if (emojis.length === 0 && Object.keys(emojiWeights).length === 0) return EMPTY_EMOJI_INDEXES
@@ -130,6 +138,7 @@ export function getWorkspaceEmojiIndexes(
   const getEmoji = (shortcode: string): EmojiEntry | undefined =>
     shortcodeIndex.get(emojiPicker.stripShortcodeColons(shortcode))
   const indexes: WorkspaceEmojiIndexes = {
+    workspaceId,
     emojis,
     emojiWeights,
     getEmoji,

--- a/apps/frontend/src/stores/actor-lookup.ts
+++ b/apps/frontend/src/stores/actor-lookup.ts
@@ -98,7 +98,6 @@ interface ActorLookupEntry {
   workspaceId: string
   personas: readonly ActorRow[]
   bots: readonly ActorRow[]
-  toEmoji: (shortcode: string) => string | null
   lookup: ActorLookup
 }
 
@@ -106,8 +105,11 @@ interface ActorLookupEntry {
 // consumer holds its own render-stable rows array, so a single slot per
 // workspace would be evicted by the next consumer and never hit. One entry per
 // distinct rows identity means the shared arm shares an entry and the off arm
-// keeps one per consumer.
-let actorLookups = new WeakMap<readonly ActorRow[], ActorLookupEntry>()
+// keeps one per consumer. Nested by the emoji resolver because two consumers
+// can be handed the same rows array while holding their own emoji indexes (the
+// off arm's private live queries), and a single slot per array would then be
+// evicted by whichever consumer rendered last, on every render.
+let actorLookups = new WeakMap<readonly ActorRow[], WeakMap<(shortcode: string) => string | null, ActorLookupEntry>>()
 
 /**
  * The shortcode index, reverse emoji map and their accessors for one `emojis`
@@ -129,6 +131,8 @@ export function getWorkspaceEmojiIndexes(
   // would be a build per mount for a map that can only be empty.
   if (emojis.length === 0 && Object.keys(emojiWeights).length === 0) return EMPTY_EMOJI_INDEXES
 
+  // Times the emoji index build only — the sole producer of this sample, so one
+  // sample means one emoji-index rebuild.
   const stopTimer = perfCapture.getPerfCapture().time("actors.lookupBuild")
   const shortcodeIndex = emojiPicker.buildShortcodeIndex(emojis)
   const reverseIndex = new Map<string, string>()
@@ -162,25 +166,18 @@ export function getActorLookup(
   bots: readonly ActorRow[],
   toEmoji: (shortcode: string) => string | null
 ): ActorLookup {
-  const cached = actorLookups.get(users)
+  const byResolver = actorLookups.get(users)
+  const cached = byResolver?.get(toEmoji)
   // workspaceId must participate: pre-hydration every workspace passes the same
   // EMPTY_ROWS singletons, and a rows-only hit would serve workspace A's lookup
   // (A's id baked into getActorAvatar) to workspace B's first render.
-  if (
-    cached &&
-    cached.workspaceId === workspaceId &&
-    cached.personas === personas &&
-    cached.bots === bots &&
-    cached.toEmoji === toEmoji
-  ) {
+  if (cached && cached.workspaceId === workspaceId && cached.personas === personas && cached.bots === bots) {
     return cached.lookup
   }
 
-  const stopTimer = perfCapture.getPerfCapture().time("actors.lookupBuild")
   const userMap = new Map(users.map((u) => [u.id, u as User]))
   const personaMap = new Map(personas.map((p) => [p.id, p as Persona]))
   const botMap = new Map(bots.map((b) => [b.id, b as Bot]))
-  stopTimer()
 
   const getUser = (userId: string): User | undefined => userMap.get(userId)
   const getPersona = (personaId: string): Persona | undefined => personaMap.get(personaId)
@@ -254,7 +251,9 @@ export function getActorLookup(
   }
 
   const lookup: ActorLookup = { getActorName, getActorInitials, getActorAvatar, getUser, getPersona, getBot }
-  actorLookups.set(users, { workspaceId, personas, bots, toEmoji, lookup })
+  const resolvers = byResolver ?? new WeakMap<(shortcode: string) => string | null, ActorLookupEntry>()
+  resolvers.set(toEmoji, { workspaceId, personas, bots, lookup })
+  actorLookups.set(users, resolvers)
   return lookup
 }
 

--- a/apps/frontend/src/test/workspace-rows.ts
+++ b/apps/frontend/src/test/workspace-rows.ts
@@ -1,0 +1,47 @@
+import { db, type CachedWorkspaceUser } from "@/db"
+
+/**
+ * Shared workspace-row seeding for component tests. `workspaceUsersTable()`
+ * resolves the table at call time — `db` is an account-scoped proxy, so binding
+ * it at module load would pin whichever account was active then. A test spies
+ * its `where` to count reads ("one per workspace, not one per row").
+ */
+export function workspaceUsersTable(): typeof db.workspaceUsers {
+  return db.workspaceUsers
+}
+
+export async function clearWorkspaceActorTables(): Promise<void> {
+  await db.workspaceUsers.clear()
+  await db.personas.clear()
+  await db.bots.clear()
+  await db.workspaceMetadata.clear()
+}
+
+export async function seedWorkspaceUser(workspaceId: string, id: string, name = "Test User"): Promise<void> {
+  const user: CachedWorkspaceUser = {
+    id,
+    workspaceId,
+    workosUserId: `workos_${id}`,
+    email: `${id}@example.com`,
+    role: "member",
+    slug: id,
+    name,
+    description: null,
+    avatarUrl: null,
+    timezone: null,
+    locale: null,
+    pronouns: null,
+    phone: null,
+    githubUsername: null,
+    statusEmoji: null,
+    statusText: null,
+    statusExpiresAt: null,
+    statusPausesNotifications: false,
+    notificationsPausedUntil: null,
+    notificationsPausedIndefinitely: false,
+    setupCompleted: true,
+    joinedAt: "2026-03-01T10:00:00Z",
+    _cachedAt: 1,
+  }
+  await db.workspaceUsers.put(user)
+}

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -29,6 +29,7 @@ export const PERF_MARK_NAMES = [
   "catchup.serialReplay",
   "stream.subscriptions",
   "store.tableSubscriptions",
+  "actors.lookupBuild",
   "stream.eventApply",
   "stream.idbTransaction",
   "liveQuery.rerun",


### PR DESCRIPTION
## Problem

`useActors` mounts four whole-workspace reads and rebuilds three actor Maps plus the emoji shortcode index — `buildShortcodeIndex` walks all ~1,914 emoji **and every alias** — per consumer per change. It is called ~3× per message row (`MessageEvent`, `MessageAuthorStatus`, `ActorAvatar`), so a 50-row window performs ~5 Map/index builds per row on every emission. Chunk 3 of the PR 6/10 plan; base #1744.

## Solution

One shared `ActorLookup` and one emoji index per workspace, derived from chunk 2's table registry.

- **New `stores/actor-lookup.ts`** — `getActorLookup` memoised in a `WeakMap` keyed on the users rows array (personas/bots/emoji compared on hit), `getWorkspaceEmojiIndexes` likewise per emoji array; rebuilds timed by the new `actors.lookupBuild` capture mark. Rows-keyed over workspace-keyed is load-bearing: in the flag-**off** arm every consumer holds private row arrays, and the adversarial round showed a single workspace-keyed slot would thrash there — ~150 consumers evicting each other, ~9,750 Map insertions per render pass where today there are zero, and a fresh lookup identity every render defeating `use-in-app-link-chip`/`label-detail` memos. The WeakMap hits per consumer in the off arm and shares one entry in the on arm; two regression tests fail against the single-slot design.
- `useActors` is now a thin read (same three store hooks + `useWorkspaceEmoji` → `getActorLookup`); **every exported function moved verbatim** — `use-actors.test.ts` (27 cases) passes unmodified. `useWorkspaceEmoji` reads the shared indexes, signature unchanged.
- `resetActorLookups` registered in `flushModuleStoreCaches` (the chunk 2 account-switch precedent).
- Honest test note: the "incoming message re-renders the new row only" probe covers the pre-existing #835 row-memo property (stubbed hook) and is labelled as such; chunk 3's own coverage is the two-consumer off-mode identity test and the bounded-build-count producer test. The real-hook append fan-out observed while writing it is carried to the whole-stack review, not silently claimed fixed.

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr6-10-plan-4119f5/ (chunk 3, D15).

## Test plan

- [x] Targeted vitest (`actor-lookup` ×7, `use-actors` ×27 unmodified, `message-event` ×29, `--maxWorkers=2`): 63/0; typecheck clean; Opus-high adversarial verify (6 findings, all fixed) with neutralisation both ways
- [ ] Broad suites deliberately left to CI (local full runs disabled by request)

## Post-review updates (whole-stack pass)
- `workspaceId` and the weights reference now participate in the emoji-index cache hit: `EMPTY_EMOJIS` is a module singleton shared across workspaces, so an emojis-only key could serve one workspace's reaction-ranking weights to another (same cross-workspace class as the actor-lookup hit-check fix above).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788344767&installation_model_id=20758&pr_number=1747&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1747&signature=dedb4226b3bdb5f6a1bc87b8ca0e466bddd79b74f9e4975ae22c33c2574c3263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
