### PR TITLE
perf: per-key stream rows replace per-row stream live queries

### DIFF
--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -1,16 +1,32 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest"
 import { spyOnExport } from "@/test/spy"
-import { render, screen, act } from "@testing-library/react"
+import { render, screen, act, waitFor } from "@testing-library/react"
+import * as e2eSessionModule from "@/stores/e2e-session-store"
+import * as decryptCacheModule from "@/lib/crypto/decrypt-cache"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { ServicesProvider, type SavedService } from "@/contexts"
 import { MessageEvent } from "./message-event"
 import { TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
-import { clearWorkspaceActorTables, seedWorkspaceUser, workspaceUsersTable } from "@/test/workspace-rows"
+import {
+  clearStreams,
+  clearWorkspaceActorTables,
+  seedStream,
+  seedWorkspaceUser,
+  streamsTable,
+  workspaceUsersTable,
+} from "@/test/workspace-rows"
+import { useStreamFromStore } from "@/stores/stream-store"
 import { resetActorLookups } from "@/stores/actor-lookup"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
-import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "@/stores/workspace-table-registry"
+import {
+  allocateWorkspaceTableToken,
+  getWorkspaceTableSnapshot,
+  resetWorkspaceTableRegistry,
+  setWorkspaceReadMode,
+  subscribeWorkspaceTable,
+} from "@/stores/workspace-table-registry"
 import { EditLastMessageContext } from "./edit-last-message-context"
 import * as editorModule from "@/components/editor"
 import * as hooksModule from "@/hooks"
@@ -725,5 +741,111 @@ describe("row-tree read fan-out", () => {
 
     const rerendered = [...renders.entries()].filter(([id, count]) => count !== (before.get(id) ?? 0))
     expect(rerendered.map(([id]) => id)).toEqual([incoming.id])
+  })
+})
+
+describe("MessageEvent stream-row reads", () => {
+  const workspaceId = "ws_123"
+  const streamId = "stream_123"
+
+  function StreamRowProbe() {
+    return <span data-testid="stream-row-probe">{useStreamFromStore(streamId)?.displayName ?? "unresolved"}</span>
+  }
+
+  const rootStreamId = "stream_root"
+
+  async function primeStreamRegistry(): Promise<() => void> {
+    const token = allocateWorkspaceTableToken()
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    return unsubscribe
+  }
+
+  function sealedEvent(): StreamEvent {
+    return {
+      id: "event_sealed",
+      streamId,
+      sequence: "1",
+      eventType: "message_created",
+      actorType: "user",
+      actorId: "member_123",
+      createdAt: new Date().toISOString(),
+      payload: {
+        messageId: "msg_sealed",
+        ciphertext: "abc",
+        envelope: { v: 2, keyGeneration: 1, iv: "x", aad: "y" },
+        contentMarkdown: "",
+      },
+    }
+  }
+
+  let release: (() => void) | null = null
+
+  beforeEach(async () => {
+    resetWorkspaceTableRegistry()
+    resetWorkspaceStoreCache()
+    resetActorLookups()
+    await clearWorkspaceActorTables()
+    await seedWorkspaceUser(workspaceId, "member_123")
+    await clearStreams()
+    setWorkspaceReadMode("shared")
+  })
+
+  afterEach(() => {
+    release?.()
+    release = null
+    resetWorkspaceTableRegistry()
+    resetActorLookups()
+  })
+
+  it("a fifty-row window opens no per-row db.streams.get", async () => {
+    await seedStream(workspaceId, streamId, { displayName: "Seeded Channel" })
+    release = await primeStreamRegistry()
+    const get = vi.spyOn(streamsTable(), "get")
+
+    const events = Array.from({ length: 50 }, (_, i) => createMessageEvent(`msg_${i}`, `row ${i}`))
+    render(
+      <>
+        <StreamRowProbe />
+        {events.map((event) => (
+          <MessageEvent key={event.id} event={event} workspaceId={workspaceId} streamId={streamId} />
+        ))}
+      </>,
+      { wrapper: Wrapper }
+    )
+    await screen.findAllByText("row 0")
+
+    // Stream-derived output, so a hook that resolved nothing fails this test on
+    // correctness rather than passing it on a vacuous zero read count.
+    expect(await screen.findByTestId("stream-row-probe")).toHaveTextContent("Seeded Channel")
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it("an E2E row still holds at pending until its stream row hydrates", async () => {
+    release = await primeStreamRegistry()
+    vi.spyOn(e2eSessionModule, "useE2eSession").mockReturnValue({
+      status: "unlocked",
+      privateKey: {} as CryptoKey,
+      keyId: "key_1",
+    } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue(undefined)
+    const requestDecryption = vi
+      .spyOn(decryptCacheModule, "requestDecryption")
+      .mockResolvedValue(undefined as unknown as never)
+
+    const { container } = render(<MessageEvent event={sealedEvent()} workspaceId={workspaceId} streamId={streamId} />, {
+      wrapper: Wrapper,
+    })
+
+    // Row absent from the registry AND from IDB: the only correct answer is
+    // "hold" — a decrypt against the bare stream id caches its failure forever.
+    await waitFor(() => expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument())
+    expect(container.querySelector(".message-item")).not.toBeInTheDocument()
+    expect(requestDecryption).not.toHaveBeenCalled()
+
+    await seedStream(workspaceId, streamId, { rootStreamId })
+
+    await waitFor(() => expect(requestDecryption).toHaveBeenCalled())
+    expect(requestDecryption.mock.calls[0][2]).toMatchObject({ streamId, rootStreamId })
   })
 })

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest"
-import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { loadStreamEvents, orderStreamEvents, shareEventIdentities } from "./stream-store"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
+import { loadStreamEvents, orderStreamEvents, shareEventIdentities, useStreamFromStore } from "./stream-store"
+import {
+  allocateWorkspaceTableToken,
+  getWorkspaceTableSnapshot,
+  resetWorkspaceTableRegistry,
+  setWorkspaceReadMode,
+  subscribeWorkspaceTable,
+} from "./workspace-table-registry"
+import { makeCachedStream } from "@/test/workspace-rows"
 import { bumpLaterOptimisticAnchors } from "@/sync/stream-sync"
 
 const WORKSPACE_ID = "ws_1"
@@ -416,5 +425,177 @@ describe("shareEventIdentities", () => {
   it("passes the array through when there is no previous emission", () => {
     const next = [makeRealEvent("stream_1", "100")]
     expect(shareEventIdentities(null, next)).toBe(next)
+  })
+})
+
+describe("useStreamFromStore", () => {
+  const REGISTRY_WORKSPACE = "ws_registry"
+  const OTHER_WORKSPACE = "ws_other"
+
+  function makeStream(id: string, workspaceId: string, overrides: Partial<CachedStream> = {}): CachedStream {
+    return makeCachedStream(workspaceId, id, overrides)
+  }
+
+  /** Bring up the shared registry entry the fast path reads, and wait for its first emission. */
+  async function primeRegistry(workspaceId: string): Promise<() => void> {
+    const token = allocateWorkspaceTableToken()
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    return unsubscribe
+  }
+
+  /**
+   * Wait until a render counter stops moving. The fallback live query emits its
+   * "registry owns this" marker asynchronously after mount, so a count sampled
+   * right after the first resolve can still take one more render that has
+   * nothing to do with the write under test.
+   */
+  async function settle(count: () => number): Promise<void> {
+    let last = -1
+    await waitFor(() => {
+      const current = count()
+      const stable = current === last
+      last = current
+      expect(stable).toBe(true)
+    })
+  }
+
+  let releaseRegistry: (() => void) | null = null
+
+  beforeEach(async () => {
+    resetWorkspaceTableRegistry()
+    await db.streams.clear()
+    setWorkspaceReadMode("shared")
+  })
+
+  afterEach(() => {
+    releaseRegistry?.()
+    releaseRegistry = null
+    resetWorkspaceTableRegistry()
+    vi.restoreAllMocks()
+  })
+
+  it("a stream row present in the workspace registry resolves without a per-key live query", async () => {
+    await db.streams.bulkPut([makeStream("stream_a", REGISTRY_WORKSPACE), makeStream("stream_b", REGISTRY_WORKSPACE)])
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+    const get = vi.spyOn(db.streams, "get")
+
+    const { result } = renderHook(() => useStreamFromStore("stream_a"))
+
+    await waitFor(() => expect(result.current?.id).toBe("stream_a"))
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it("a stream row absent from the registry falls back to the per-key read", async () => {
+    await db.streams.put(makeStream("stream_registry", REGISTRY_WORKSPACE))
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+    // A socket write that landed before its workspace bootstrapped: in IDB, in no
+    // registry entry.
+    await db.streams.put(makeStream("stream_socket", OTHER_WORKSPACE))
+    const get = vi.spyOn(db.streams, "get")
+
+    const { result } = renderHook(() => useStreamFromStore("stream_socket"))
+
+    await waitFor(() => expect(result.current?.id).toBe("stream_socket"))
+    expect(get).toHaveBeenCalledWith("stream_socket")
+  })
+
+  it("a change to one stream re-renders only its readers", async () => {
+    await db.streams.bulkPut([makeStream("stream_a", REGISTRY_WORKSPACE), makeStream("stream_b", REGISTRY_WORKSPACE)])
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+
+    let rendersA = 0
+    let rendersB = 0
+    const readerA = renderHook(() => {
+      rendersA += 1
+      return useStreamFromStore("stream_a")
+    })
+    const readerB = renderHook(() => {
+      rendersB += 1
+      return useStreamFromStore("stream_b")
+    })
+    await waitFor(() => expect(readerA.result.current?.id).toBe("stream_a"))
+    await waitFor(() => expect(readerB.result.current?.id).toBe("stream_b"))
+    await settle(() => rendersB)
+    const rendersBBefore = rendersB
+
+    await db.streams.put(makeStream("stream_a", REGISTRY_WORKSPACE, { displayName: "renamed" }))
+
+    await waitFor(() => expect(readerA.result.current?.displayName).toBe("renamed"))
+    expect(rendersB).toBe(rendersBBefore)
+    expect(rendersA).toBeGreaterThan(0)
+  })
+
+  it("the row reference is stable across an unrelated streams write", async () => {
+    await db.streams.bulkPut([makeStream("stream_a", REGISTRY_WORKSPACE), makeStream("stream_b", REGISTRY_WORKSPACE)])
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+
+    const readerA = renderHook(() => useStreamFromStore("stream_a"))
+    const readerB = renderHook(() => useStreamFromStore("stream_b"))
+    await waitFor(() => expect(readerA.result.current?.id).toBe("stream_a"))
+    await waitFor(() => expect(readerB.result.current?.id).toBe("stream_b"))
+    const rowA = readerA.result.current
+
+    await db.streams.put(makeStream("stream_b", REGISTRY_WORKSPACE, { displayName: "renamed" }))
+
+    await waitFor(() => expect(readerB.result.current?.displayName).toBe("renamed"))
+    expect(readerA.result.current).toBe(rowA)
+  })
+
+  it("a row removed from the registry resolves to undefined, never a stale or sentinel value", async () => {
+    await db.streams.bulkPut([makeStream("stream_a", REGISTRY_WORKSPACE), makeStream("stream_b", REGISTRY_WORKSPACE)])
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+
+    const observed: unknown[] = []
+    const { result } = renderHook(() => {
+      const row = useStreamFromStore("stream_a")
+      observed.push(row)
+      return row
+    })
+    await waitFor(() => expect(result.current?.id).toBe("stream_a"))
+
+    // Pin the fallback read open: the removal must resolve to `undefined` off the
+    // registry emission alone, not by waiting for a per-key re-read.
+    vi.spyOn(db.streams, "get").mockReturnValue(new Promise(() => {}) as never)
+    await db.streams.delete("stream_a")
+
+    await waitFor(() => expect(result.current).toBeUndefined())
+    for (const value of observed) {
+      if (value === undefined) continue
+      expect(typeof value).toBe("object")
+      expect((value as CachedStream).id).toBe("stream_a")
+    }
+  })
+
+  it("an on→off flip holds the resolved row and opens no whole-table read per reader", async () => {
+    await db.streams.put(makeStream("stream_a", REGISTRY_WORKSPACE, { displayName: "Held Channel" }))
+    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
+
+    const observed: (CachedStream | undefined)[] = []
+    const readers = [0, 1, 2].map(() =>
+      renderHook(() => {
+        const row = useStreamFromStore("stream_a")
+        observed.push(row)
+        return row
+      })
+    )
+    for (const reader of readers) await waitFor(() => expect(reader.result.current?.id).toBe("stream_a"))
+    const held = readers.map((reader) => reader.result.current)
+
+    const where = vi.spyOn(db.streams, "where")
+    await act(async () => {
+      setWorkspaceReadMode("off")
+    })
+
+    readers.forEach((reader, index) => expect(reader.result.current).toBe(held[index]))
+    for (const reader of readers) {
+      await waitFor(() => expect(reader.result.current?.displayName).toBe("Held Channel"))
+    }
+    expect(observed).not.toContain(undefined)
+    // The flip must not migrate the readers' row registrations into private
+    // entries: that opens one whole-table streams query PER READER — the cost the
+    // kill switch exists to remove. The one expected call is the table
+    // subscriber's own re-key.
+    expect(where.mock.calls.length).toBe(1)
   })
 })

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -1,8 +1,15 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
-import { useRef } from "react"
+import { useCallback, useRef, useSyncExternalStore } from "react"
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
+import {
+  allocateWorkspaceTableToken,
+  findSharedRowWorkspace,
+  getWorkspaceTableRow,
+  hasResolvedSharedEntry,
+  subscribeWorkspaceTableRow,
+} from "./workspace-table-registry"
 
 /**
  * Cap the number of events loaded from IDB per stream when no sequence floor
@@ -224,8 +231,95 @@ export function shareEventIdentities(prev: CachedEvent[] | null, next: CachedEve
 }
 
 /**
+ * The fallback query's answer when the registry owns the id and no read was made.
+ * A module constant, so it never re-renders a consumer by identity; every other
+ * answer is exactly what `db.streams.get` returned, `undefined` for absent
+ * included — the fallback path's observable behaviour is byte-for-byte today's.
+ */
+const REGISTRY_OWNED_ROW = Symbol("registry-owned-stream-row")
+type StreamRowFallback = CachedStream | typeof REGISTRY_OWNED_ROW | undefined
+
+/**
  * Reactively read a single stream from IndexedDB.
+ *
+ * Fast path: when the shared workspace-streams registry already holds the id,
+ * the read is a Map hit woken by a per-key subscription. The fallback
+ * `useLiveQuery` below still mounts on this path (conditional hooks are banned),
+ * so its observable and global `storagemutated` listener are still per instance;
+ * what the fast path removes is the per-key IDB `get` and its re-run on every
+ * streams write. This hook is mounted four times per message row, so that read
+ * ran ~4× the rendered window on every write before.
+ *
+ * Fallback (D7, fail-open): an id no shared entry holds — a socket write that
+ * landed before bootstrap, or the `sharedWorkspaceReads=off` arm, where entries
+ * are private to a token this hook does not have and the fast path therefore
+ * misses by design — resolves through today's per-key `db.streams.get`. Both
+ * paths mount the same hooks unconditionally; only the work inside them differs.
+ *
+ * `undefined` means "genuinely not resolved anywhere". `resolveDecryptContext`
+ * reads that as "hold, never attempt", and a decrypt attempted against an
+ * unhydrated row caches its failure forever — so a value already resolved on
+ * either path is held across a registry flip rather than flickering to
+ * `undefined`.
  */
 export function useStreamFromStore(streamId: string | undefined): CachedStream | undefined {
-  return useLiveQuery(() => (streamId ? db.streams.get(streamId) : undefined), [streamId], undefined)
+  const tokenRef = useRef<number | null>(null)
+  tokenRef.current ??= allocateWorkspaceTableToken()
+  const token = tokenRef.current
+
+  const registryWorkspaceId = streamId ? findSharedRowWorkspace("streams", streamId) : undefined
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!streamId || !registryWorkspaceId) return () => {}
+      return subscribeWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token, onStoreChange)
+    },
+    [streamId, registryWorkspaceId, token]
+  )
+  const readRegistryRow = useCallback(
+    () =>
+      streamId && registryWorkspaceId
+        ? getWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token)
+        : undefined,
+    [streamId, registryWorkspaceId, token]
+  )
+  const registryRow = useSyncExternalStore(subscribe, readRegistryRow, readRegistryRow)
+
+  const fallback = useLiveQuery<StreamRowFallback>(async () => {
+    if (!streamId) return undefined
+    // Re-checked inside the query (not read off the render) so a registry that
+    // resolved between render and run still spares the read.
+    if (findSharedRowWorkspace("streams", streamId)) return REGISTRY_OWNED_ROW
+    return await db.streams.get(streamId)
+  }, [streamId, registryWorkspaceId])
+
+  const lastResolvedRef = useRef<{ streamId: string; row: CachedStream } | null>(null)
+  const lastOwnerRef = useRef<{ streamId: string; workspaceId: string } | null>(null)
+  if (!streamId) return undefined
+  if (lastResolvedRef.current?.streamId !== streamId) lastResolvedRef.current = null
+  if (lastOwnerRef.current?.streamId !== streamId) lastOwnerRef.current = null
+  if (registryRow && registryWorkspaceId) {
+    lastResolvedRef.current = { streamId, row: registryRow }
+    lastOwnerRef.current = { streamId, workspaceId: registryWorkspaceId }
+    return registryRow
+  }
+  const owner = lastOwnerRef.current
+  if (owner && !registryWorkspaceId && hasResolvedSharedEntry(owner.workspaceId, "streams")) {
+    // That entry is still live and resolved and no longer holds the id: a real
+    // removal, not the ownership drop the hold-over below exists for. Drop the
+    // held row so the sentinel yields `undefined` on this render instead of
+    // serving a deleted stream until the fallback query re-emits.
+    lastResolvedRef.current = null
+    lastOwnerRef.current = null
+  }
+  if (fallback === REGISTRY_OWNED_ROW) {
+    // The registry has dropped the id (teardown, workspace switch) and the query
+    // has not re-emitted yet — `useLiveQuery` keeps the previous result across a
+    // deps change, so this marker is exactly that window. Hold the last resolved
+    // row rather than flicker to `undefined`, which `resolveDecryptContext` would
+    // read as "unhydrated" and whose failed decrypt is cached forever.
+    return lastResolvedRef.current?.row
+  }
+  lastResolvedRef.current = fallback ? { streamId, row: fallback } : null
+  return fallback
 }

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -73,6 +73,11 @@ export type WorkspaceReadMode = "shared" | "off"
 interface WorkspaceTableEntry {
   workspaceId: string
   tableKey: WorkspaceTableKey
+  // Set from the key form at creation, not re-derived from the current mode: a
+  // token-keyed entry can outlive an off→shared flip inside the teardown grace,
+  // and `findSharedRowWorkspace` must not report ownership under a key a
+  // tokenless reader cannot resolve.
+  shared: boolean
   rows: IdentifiedRow[] | undefined
   byId: Map<string, IdentifiedRow>
   resolved: boolean
@@ -132,8 +137,12 @@ export function allocateWorkspaceTableToken(): number {
 
 let emissionCounter = 0
 
+function sharedEntryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey): string {
+  return `${workspaceId}|${tableKey}`
+}
+
 function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey, token: number): string {
-  return mode === "shared" ? `${workspaceId}|${tableKey}` : `${workspaceId}|${tableKey}|${token}`
+  return mode === "shared" ? sharedEntryKeyFor(workspaceId, tableKey) : `${workspaceId}|${tableKey}|${token}`
 }
 
 function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
@@ -238,6 +247,7 @@ function ensureEntry(
   const created: WorkspaceTableEntry = {
     workspaceId,
     tableKey,
+    shared: entryKey === sharedEntryKeyFor(workspaceId, tableKey),
     rows: undefined,
     byId: new Map(),
     resolved: false,
@@ -390,6 +400,38 @@ export function getWorkspaceTableRow<K extends WorkspaceTableKey>(
   return entry?.byId.get(rowId) as WorkspaceTableRowTypes[K] | undefined
 }
 
+/**
+ * The workspace whose **shared** entry currently holds `rowId`, or `undefined`.
+ *
+ * For consumers that know a row id but not its workspace (`useStreamFromStore`).
+ * Only shared entries qualify: with the mode `off` an entry is keyed by its
+ * subscriber's token, so a tokenless consumer would open a private live query of
+ * its own — the very cost the fast path removes — and the caller must fall back
+ * to a per-key read instead (D5, D7).
+ */
+export function findSharedRowWorkspace(tableKey: WorkspaceTableKey, rowId: string): string | undefined {
+  if (mode !== "shared") return undefined
+  for (const entry of entries.values()) {
+    if (!entry.shared) continue
+    if (entry.tableKey !== tableKey) continue
+    if (entry.byId.has(rowId)) return entry.workspaceId
+  }
+  return undefined
+}
+
+/**
+ * True when the shared (workspace, table) entry is live and has resolved.
+ *
+ * Lets a reader tell a row's genuine removal — that entry still answering, just
+ * without the id — from an ownership drop (mode flip, teardown), where the row
+ * is unchanged and only the reader's route to it went away.
+ */
+export function hasResolvedSharedEntry(workspaceId: string, tableKey: WorkspaceTableKey): boolean {
+  if (mode !== "shared") return false
+  const entry = entries.get(sharedEntryKeyFor(workspaceId, tableKey))
+  return Boolean(entry?.shared && entry.resolved && !entry.teardown)
+}
+
 function detach(entry: WorkspaceTableEntry, registration: Registration): void {
   if (registration.kind === "table") {
     entry.listeners.delete(registration.listener)
@@ -423,30 +465,43 @@ function visibleSnapshot(entry: WorkspaceTableEntry | undefined, registration: R
 }
 
 /**
- * Flip sharing on or off. Every live registration — array and row alike — is
- * moved to its new entry key synchronously, so the flag can arrive or change
- * mid-session without a single hook count changing (D5).
+ * Flip sharing on or off. Every live **table** registration is moved to its new
+ * entry key synchronously, so the flag can arrive or change mid-session without
+ * a single hook count changing (D5).
+ *
+ * Row registrations are DROPPED instead of moved. They belong to readers that
+ * found the entry by id rather than by token (`useStreamFromStore`), and there
+ * are several per rendered message row — migrating them would open one private
+ * whole-table live query per registration on the very flip that exists to kill
+ * whole-table reads, and the seeded rows being identity-equal means no listener
+ * would ever fire to unwind it. Each dropped listener is fired unconditionally
+ * so its reader re-renders, finds no shared owner, and falls back to its own
+ * per-key read; the registration is deleted, so its `unsubscribe` closure is a
+ * no-op and a fresh subscribe from the same reader starts clean.
  *
  * The new entry is seeded from the most recently emitted resolved predecessor
  * for the same (workspace, table): the query is identical, but private entries
  * emit independently, so an older resolved snapshot can still be sitting in the
- * map and would republish rolled-back rows. Publishing an unresolved entry instead would regress every consumer
- * to its bootstrap-era cache fallback for a frame — and the flag itself is read
+ * map and would republish rolled-back rows. Publishing an unresolved entry
+ * instead would regress every consumer to its bootstrap-era cache fallback for a frame — and the flag itself is read
  * through this registry, so an unresolved metadata entry would flip the mode back
  * and loop.
  */
 export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
   if (next === mode) return
-  const active = [...registrations.entries()]
+  const all = [...registrations.entries()]
+  const active = all.filter(([, registration]) => registration.kind === "table")
+  const dropped = all.filter(([, registration]) => registration.kind === "row")
   const before = new Map<number, unknown>()
   const seeds = new Map<string, WorkspaceTableEntry>()
 
-  for (const [id, registration] of active) {
+  for (const [id, registration] of all) {
     const entry = entries.get(registration.entryKey)
     before.set(id, visibleSnapshot(entry, registration))
     if (!entry) continue
     detach(entry, registration)
   }
+  for (const [id] of dropped) registrations.delete(id)
   for (const entry of entries.values()) {
     const seedKey = `${entry.workspaceId}|${entry.tableKey}`
     if (!entry.resolved) continue
@@ -467,13 +522,14 @@ export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
     attach(entry, registration)
     registrations.set(id, { ...registration, entryKey })
   }
-  for (const [, registration] of active) releaseEntry(registration.entryKey, true)
+  for (const [, registration] of all) releaseEntry(registration.entryKey, true)
 
   for (const [id] of active) {
     const current = registrations.get(id)
     if (!current) continue
     if (visibleSnapshot(entries.get(current.entryKey), current) !== before.get(id)) current.listener()
   }
+  for (const [, registration] of dropped) registration.listener()
 }
 
 /** Live Dexie subscriptions on workspace tables, teardown-grace ones included. */

--- a/apps/frontend/src/test/workspace-rows.ts
+++ b/apps/frontend/src/test/workspace-rows.ts
@@ -1,4 +1,4 @@
-import { db, type CachedWorkspaceUser } from "@/db"
+import { db, type CachedStream, type CachedWorkspaceUser } from "@/db"
 
 /**
  * Shared workspace-row seeding for component tests. `workspaceUsersTable()`
@@ -44,4 +44,43 @@ export async function seedWorkspaceUser(workspaceId: string, id: string, name = 
     _cachedAt: 1,
   }
   await db.workspaceUsers.put(user)
+}
+
+/** Resolved at call time for the same reason as `workspaceUsersTable`. */
+export function streamsTable(): typeof db.streams {
+  return db.streams
+}
+
+export async function clearStreams(): Promise<void> {
+  await db.streams.clear()
+}
+
+export function makeCachedStream(workspaceId: string, id: string, overrides: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId,
+    type: "channel",
+    displayName: id,
+    slug: id,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_1",
+    createdAt: "2026-03-01T10:00:00Z",
+    updatedAt: "2026-03-01T10:00:00Z",
+    archivedAt: null,
+    _cachedAt: 1,
+    ...overrides,
+  }
+}
+
+export async function seedStream(
+  workspaceId: string,
+  id: string,
+  overrides: Partial<CachedStream> = {}
+): Promise<void> {
+  await db.streams.put(makeCachedStream(workspaceId, id, overrides))
 }


### PR DESCRIPTION
## Problem

`useStreamFromStore(streamId)` mounts a private per-row `useLiveQuery` — ×4 per message row (`message-event.tsx` current/parent/root + `use-decrypted-message-content`) — each re-running `db.streams.get` on every matching write. Chunk 2's registry already holds every workspace stream row with per-key listeners. Chunk 4 of the PR 6/10 plan; base #1747.

## Solution

`useStreamFromStore` keeps its signature and gains a registry fast path (plan D7): when a shared entry owns the id, the row resolves per-key from the registry — no per-row IDB `get`, no per-write re-query. Otherwise the original `useLiveQuery` fallback runs verbatim (fail-open: socket-write-before-bootstrap, off arm, unknown ids). Both paths always mount (rules of hooks); the fallback's queryFn returns a module sentinel while the registry owns the id, and dexie-react-hooks' result retention makes the sentinel window a hold-over of the last resolved row rather than an `undefined` flicker — load-bearing for E2E: `resolveDecryptContext` caches a decrypt failure **forever** on a wrongly-absent stream row.

The adversarial round drove the surviving design:
- **Kill-switch flip drops row registrations** and refires their listeners so readers re-render and fall back; the original migrate-into-private-entries behavior would have opened ~100 whole-table liveQueries on an on→off flip and never self-corrected (identity-equal seeds meant no notify). Regression test asserts one whole-table read total across a flip with mounted readers.
- **Genuine removals clear the hold-over** (`hasResolvedSharedEntry`: the shared entry still answers, just without the id) so a deleted stream goes `undefined` in one hop as before; flips/teardowns keep the hold-over.
- `findSharedRowWorkspace` matches only shared-keyed entries — a token-keyed entry in teardown grace can't report ownership no reader can resolve.
- **Honest scope**: the fallback observable (and its global storagemutated listener) still mounts per instance — what this removes is the per-row IDB read and its re-run per write, not the subscription object count.

Verified clean by the adversarial pass with source evidence: sentinel cannot escape as a return value, decrypt hazard in both directions, hook-count constancy, account-switch flush ordering, and the dexie-react-hooks retention the design rests on.

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr6-10-plan-4119f5/ (chunk 4, D6/D7).

## Test plan

- [x] Targeted vitest (stream-store, workspace-table-registry, message-event; `--maxWorkers=2`): 70/0; typecheck clean; Opus-high adversarial verify (6 findings, all fixed) — every guard's neutralisation recorded, incl. pinning the fallback open so the removal test can't be masked
- [ ] Broad suites deliberately left to CI (local full runs disabled by request)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788347932&installation_model_id=20758&pr_number=1748&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1748&signature=7b07715c0f55a29a49c50981bb59253950a96e2a26a204c4ff8a7f1d97cf04f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->