### PR TITLE
feat(board): type capture scoped to the last-clicked card

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1093,6 +1093,9 @@ export function BoardCard({
             a keyboard user could otherwise focus into the dead conversation. */}
         <div
           ref={cardRef}
+          // Type-to-focus routes a keystroke to THIS card's composer when the
+          // last click landed anywhere inside it (see use-type-to-focus).
+          data-type-capture-scope=""
           className={cn(
             "board-card-hover rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]",
             flash && "board-post-flash",

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -186,6 +186,7 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
         className={cn("mt-3", quietFocus && "focus-visible:ring-0 focus-visible:ring-offset-0")}
         draft={scopeDraft}
         placeholder="Write a reply…"
+        typeCaptureOpener
         onClick={() => setOpen(true)}
       />
     )

--- a/apps/frontend/src/components/composer/collapsed-composer-bar.tsx
+++ b/apps/frontend/src/components/composer/collapsed-composer-bar.tsx
@@ -42,15 +42,26 @@ export function CollapsedComposerBar({
   onClick,
   className,
   buttonRef,
+  typeCaptureOpener,
 }: {
   draft?: ScopeDraftPreview | null
   placeholder: string
   onClick: () => void
   className?: string
   buttonRef?: Ref<HTMLButtonElement>
+  /** Marks this bar as the card's reply target for type-to-focus. Only the
+   *  card-level reply bar sets it — a branch/sub-topic bar would win DOM order
+   *  and swallow the keystroke into a branch the user never chose. */
+  typeCaptureOpener?: boolean
 }) {
   return (
-    <button ref={buttonRef} type="button" onClick={onClick} className={cn(CARD_CLASS, className)}>
+    <button
+      ref={buttonRef}
+      type="button"
+      data-composer-opener={typeCaptureOpener ? "" : undefined}
+      onClick={onClick}
+      className={cn(CARD_CLASS, className)}
+    >
       <span className={ROW_CLASS}>
         {draft ? (
           <CollapsedDraftPreview draft={draft} />

--- a/apps/frontend/src/hooks/use-mobile.tsx
+++ b/apps/frontend/src/hooks/use-mobile.tsx
@@ -2,11 +2,11 @@ import { useSyncExternalStore } from "react"
 
 export const MOBILE_BREAKPOINT = 640
 
-const mobileQuery = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+export const MOBILE_VIEWPORT_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
 // Shared subscription — one matchMedia listener regardless of how many
 // components call useIsMobile (avoids N listeners in long message lists).
-const mql = typeof window !== "undefined" ? window.matchMedia(mobileQuery) : null
+const mql = typeof window !== "undefined" ? window.matchMedia(MOBILE_VIEWPORT_QUERY) : null
 
 function subscribe(onChange: () => void) {
   mql?.addEventListener("change", onChange)

--- a/apps/frontend/src/hooks/use-pointer.tsx
+++ b/apps/frontend/src/hooks/use-pointer.tsx
@@ -10,10 +10,10 @@ import { useIsMobile } from "./use-mobile"
 // device-class layout/mode decisions (e.g. the overlay-vs-pinned sidebar); use
 // `useTouchCapable` to additively enable touch gestures, and `useInputMode` for
 // affordances that follow whichever input the user is actively driving.
-const coarseQuery = "(pointer: coarse)"
+export const COARSE_POINTER_QUERY = "(pointer: coarse)"
 
 // Shared subscription — one matchMedia listener regardless of how many callers.
-const coarseMql = typeof window !== "undefined" ? window.matchMedia(coarseQuery) : null
+const coarseMql = typeof window !== "undefined" ? window.matchMedia(COARSE_POINTER_QUERY) : null
 
 function subscribe(onChange: () => void) {
   coarseMql?.addEventListener("change", onChange)

--- a/apps/frontend/src/hooks/use-type-to-focus.test.tsx
+++ b/apps/frontend/src/hooks/use-type-to-focus.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { render } from "@testing-library/react"
 import { findVisibleZoneEditor, useTypeToFocus } from "./use-type-to-focus"
 
@@ -247,7 +247,7 @@ describe("useTypeToFocus", () => {
 
   it("main→panel: the panel's docked editor takes the key when the last click was in main and no card composer is open", () => {
     buildDom(
-      '<main data-editor-zone="main"><div id="feed"></div></main>' +
+      '<main data-editor-zone="main"><div data-type-capture-scope id="feed"></div></main>' +
         '<aside data-editor-zone="panel"><div contenteditable="true" id="p"></div></aside>'
     )
     const panel = document.getElementById("p") as HTMLElement
@@ -257,6 +257,268 @@ describe("useTypeToFocus", () => {
     press("a")
 
     expect(document.activeElement).toBe(panel)
+  })
+})
+
+describe("useTypeToFocus card scopes", () => {
+  /** Runs the hook's bounded rAF poll to completion. */
+  function runFrames(count = 25) {
+    for (let i = 0; i < count; i += 1) vi.advanceTimersByTime(16)
+  }
+
+  function clickIn(id: string) {
+    document.getElementById(id)!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  }
+
+  let execCommand: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    execCommand = vi.fn(() => true)
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("routes the key to the last-clicked card's editor, not the last card in the feed", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><div contenteditable="true" id="a"></div></div>' +
+        '<div data-type-capture-scope id="cardB"><div contenteditable="true" id="b"></div></div>' +
+        "</main>"
+    )
+    const a = document.getElementById("a") as HTMLElement
+    const b = document.getElementById("b") as HTMLElement
+    setVisible(a, true)
+    setVisible(b, true)
+
+    clickIn("rowA")
+    press("x")
+
+    expect(document.activeElement).toBe(a)
+    expect(document.activeElement).not.toBe(b)
+  })
+
+  it("opens the clicked card's resting composer and types the swallowed character into it", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        '<div data-type-capture-scope id="cardB"><div contenteditable="true" id="b"></div></div>' +
+        "</main>"
+    )
+    setVisible(document.getElementById("b") as HTMLElement, true)
+    const cardA = document.getElementById("cardA") as HTMLElement
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    setVisible(opener, true)
+    // The real composer mounts on the opener's click, a frame or more later.
+    opener.addEventListener("click", () => {
+      opener.remove()
+      const editor = document.createElement("div")
+      editor.setAttribute("contenteditable", "true")
+      editor.id = "a"
+      cardA.appendChild(editor)
+      setVisible(editor, true)
+    })
+
+    clickIn("rowA")
+    const event = new KeyboardEvent("keydown", { key: "x", bubbles: true, cancelable: true })
+    document.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
+    runFrames()
+
+    expect(document.activeElement).toBe(document.getElementById("a"))
+    expect(execCommand).toHaveBeenCalledWith("insertText", false, "x")
+    expect(document.activeElement).not.toBe(document.getElementById("b"))
+  })
+
+  it("gives up silently when the opener never mounts an editor", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        "</main>"
+    )
+    setVisible(document.getElementById("opener") as HTMLElement, true)
+
+    clickIn("rowA")
+    expect(() => {
+      press("x")
+      runFrames()
+    }).not.toThrow()
+
+    expect(document.activeElement).toBe(document.body)
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it("an archived card (no editor, no opener) swallows the key instead of typing into another card", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><p>Replies are closed.</p></div>' +
+        '<div data-type-capture-scope id="cardB"><div contenteditable="true" id="b"></div></div>' +
+        "</main>"
+    )
+    const b = document.getElementById("b") as HTMLElement
+    setVisible(b, true)
+
+    clickIn("rowA")
+    press("x")
+
+    expect(document.activeElement).not.toBe(b)
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it("opens the card's OWN reply bar, not a branch bar that comes earlier in the card", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA">' +
+        '<div id="rowA"></div>' +
+        '<button id="branch"></button>' +
+        '<button data-composer-opener id="opener"></button>' +
+        "</div>" +
+        "</main>"
+    )
+    const branch = document.getElementById("branch") as HTMLButtonElement
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    setVisible(branch, true)
+    setVisible(opener, true)
+    const branchClick = vi.fn()
+    branch.addEventListener("click", branchClick)
+    const openerClick = vi.fn()
+    opener.addEventListener("click", openerClick)
+
+    clickIn("rowA")
+    press("x")
+
+    expect(openerClick).toHaveBeenCalled()
+    expect(branchClick).not.toHaveBeenCalled()
+  })
+
+  it("an open panel with a live editor outranks the card scope the conversation was opened from", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        "</main>" +
+        '<aside data-editor-zone="panel"><div contenteditable="true" id="p"></div></aside>'
+    )
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    const panel = document.getElementById("p") as HTMLElement
+    setVisible(opener, true)
+    setVisible(panel, true)
+    const openerClick = vi.fn()
+    opener.addEventListener("click", openerClick)
+
+    clickIn("rowA")
+    press("x")
+
+    expect(document.activeElement).toBe(panel)
+    expect(openerClick).not.toHaveBeenCalled()
+  })
+
+  it("swallows the key when the card's opener is scrolled off-screen, rather than yanking the feed to it", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        '<div data-type-capture-scope id="cardB"><div contenteditable="true" id="b"></div></div>' +
+        "</main>"
+    )
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    setScrolledOffScreen(opener)
+    setVisible(document.getElementById("b") as HTMLElement, true)
+    const openerClick = vi.fn()
+    opener.addEventListener("click", openerClick)
+
+    clickIn("rowA")
+    press("x")
+    runFrames()
+
+    expect(openerClick).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(document.body)
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it("accumulates keys pressed while the composer is still mounting and inserts them together", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        "</main>"
+    )
+    const cardA = document.getElementById("cardA") as HTMLElement
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    setVisible(opener, true)
+    // Mounts only after a couple of frames, leaving a real typing window.
+    let framesUntilMount = 3
+    opener.addEventListener("click", () => {
+      const mount = () => {
+        framesUntilMount -= 1
+        if (framesUntilMount > 0) {
+          requestAnimationFrame(mount)
+          return
+        }
+        opener.remove()
+        const editor = document.createElement("div")
+        editor.setAttribute("contenteditable", "true")
+        editor.id = "a"
+        cardA.appendChild(editor)
+        setVisible(editor, true)
+      }
+      requestAnimationFrame(mount)
+    })
+
+    clickIn("rowA")
+    press("x")
+    const second = new KeyboardEvent("keydown", { key: "y", bubbles: true, cancelable: true })
+    document.dispatchEvent(second)
+    expect(second.defaultPrevented).toBe(true)
+    runFrames()
+
+    expect(document.activeElement).toBe(document.getElementById("a"))
+    expect(execCommand).toHaveBeenCalledTimes(1)
+    expect(execCommand).toHaveBeenCalledWith("insertText", false, "xy")
+  })
+
+  it("on a coarse pointer it only clicks the opener — the floating composer autofocuses itself", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA"><div id="rowA"></div><button data-composer-opener id="opener"></button></div>' +
+        "</main>"
+    )
+    const opener = document.getElementById("opener") as HTMLButtonElement
+    setVisible(opener, true)
+    const openerClick = vi.fn()
+    opener.addEventListener("click", openerClick)
+    const originalMatchMedia = window.matchMedia
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({ ...originalMatchMedia(query), matches: query === "(pointer: coarse)" }),
+    })
+
+    const event = new KeyboardEvent("keydown", { key: "x", bubbles: true, cancelable: true })
+    clickIn("rowA")
+    document.dispatchEvent(event)
+    runFrames()
+    Object.defineProperty(window, "matchMedia", { configurable: true, writable: true, value: originalMatchMedia })
+
+    expect(openerClick).toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+    expect(execCommand).not.toHaveBeenCalled()
+  })
+
+  it("a click outside any card scope keeps the zone-wide behavior", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div id="header"></div>' +
+        '<div data-type-capture-scope id="cardB"><div contenteditable="true" id="b"></div></div>' +
+        "</main>"
+    )
+    const b = document.getElementById("b") as HTMLElement
+    setVisible(b, true)
+
+    clickIn("header")
+    press("x")
+
+    expect(document.activeElement).toBe(b)
   })
 })
 

--- a/apps/frontend/src/hooks/use-type-to-focus.test.tsx
+++ b/apps/frontend/src/hooks/use-type-to-focus.test.tsx
@@ -301,6 +301,28 @@ describe("useTypeToFocus card scopes", () => {
     expect(document.activeElement).not.toBe(b)
   })
 
+  it("within one card, the card-level reply editor (last in DOM) beats an earlier open branch editor", () => {
+    buildDom(
+      '<main data-editor-zone="main">' +
+        '<div data-type-capture-scope id="cardA">' +
+        '<div id="rowA"></div>' +
+        '<div contenteditable="true" id="branch"></div>' +
+        '<div contenteditable="true" id="reply"></div>' +
+        "</div>" +
+        "</main>"
+    )
+    const branch = document.getElementById("branch") as HTMLElement
+    const reply = document.getElementById("reply") as HTMLElement
+    setVisible(branch, true)
+    setVisible(reply, true)
+
+    clickIn("rowA")
+    press("x")
+
+    expect(document.activeElement).toBe(reply)
+    expect(document.activeElement).not.toBe(branch)
+  })
+
   it("opens the clicked card's resting composer and types the swallowed character into it", () => {
     buildDom(
       '<main data-editor-zone="main">' +

--- a/apps/frontend/src/hooks/use-type-to-focus.ts
+++ b/apps/frontend/src/hooks/use-type-to-focus.ts
@@ -48,13 +48,15 @@ export function findVisibleZoneEditor(zone: HTMLElement | null): HTMLElement | n
     }, null)
 }
 
-/** First on-screen editor inside one card scope, skipping inline-edit editors. */
+/**
+ * On-screen editor inside one card scope — LAST in document order, same rule as
+ * the zone-wide lookup: branch/sub-topic composers render above the card-level
+ * reply composer, and a click on the card body means the card's own composer,
+ * not a sub-conversation's (an open branch editor still wins by being focused —
+ * the already-typing guard runs before any lookup).
+ */
 function findScopeEditor(scope: HTMLElement): HTMLElement | null {
-  return (
-    Array.from(scope.querySelectorAll<HTMLElement>('[contenteditable="true"]')).find(
-      (element) => !element.closest("[data-inline-edit]") && isOnScreen(element)
-    ) ?? null
-  )
+  return findVisibleZoneEditor(scope)
 }
 
 const OPENER_POLL_FRAMES = 20
@@ -187,8 +189,8 @@ export function useTypeToFocus() {
           return
         }
         // Opening a conversation from inside a card records the scope, but the
-        // panel that just opened is where the typing belongs — an open panel
-        // with a live editor always outranks the card it was opened from.
+        // panel that just opened is where the typing belongs — with no visible
+        // editor in the card, an open panel's live editor outranks the opener.
         const panelEditor = findVisibleZoneEditor(zoneContainer("panel"))
         if (panelEditor) {
           focusAtEnd(panelEditor)

--- a/apps/frontend/src/hooks/use-type-to-focus.ts
+++ b/apps/frontend/src/hooks/use-type-to-focus.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from "react"
+import { MOBILE_VIEWPORT_QUERY } from "./use-mobile"
+import { COARSE_POINTER_QUERY } from "./use-pointer"
 
 /** Focus a contentEditable element with the cursor placed at the end of its content. */
 export function focusAtEnd(el: HTMLElement) {
@@ -46,6 +48,24 @@ export function findVisibleZoneEditor(zone: HTMLElement | null): HTMLElement | n
     }, null)
 }
 
+/** First on-screen editor inside one card scope, skipping inline-edit editors. */
+function findScopeEditor(scope: HTMLElement): HTMLElement | null {
+  return (
+    Array.from(scope.querySelectorAll<HTMLElement>('[contenteditable="true"]')).find(
+      (element) => !element.closest("[data-inline-edit]") && isOnScreen(element)
+    ) ?? null
+  )
+}
+
+const OPENER_POLL_FRAMES = 20
+
+/** Non-hook twin of `useIsMobileOrCoarse`, evaluated at keydown time. */
+function isMobileOrCoarse(): boolean {
+  return window.matchMedia(MOBILE_VIEWPORT_QUERY).matches || window.matchMedia(COARSE_POINTER_QUERY).matches
+}
+
+type PendingOpen = { scope: HTMLElement; chars: string }
+
 function zoneContainer(zone: "main" | "panel"): HTMLElement | null {
   return document.querySelector<HTMLElement>(`[data-editor-zone="${zone}"]`)
 }
@@ -59,15 +79,52 @@ function zoneContainer(zone: "main" | "panel"): HTMLElement | null {
  *
  * Priority:
  *  1. Active inline-edit editor (`[data-inline-edit] [contenteditable]`)
- *  2. Last-clicked zone's on-screen editor
- *  3. The other zone's on-screen editor
+ *  2. Last-clicked card scope (main zone): its editor → an open panel's editor
+ *     → its on-screen reply opener → swallow
+ *  3. Last-clicked zone's on-screen editor
+ *  4. The other zone's on-screen editor
  */
 export function useTypeToFocus() {
   const lastZoneRef = useRef<"main" | "panel">("main")
+  const lastScopeRef = useRef<HTMLElement | null>(null)
+  const pendingOpenRef = useRef<PendingOpen | null>(null)
 
   useEffect(() => {
+    /**
+     * Clicking a resting "Write a reply…" bar mounts the composer a frame or
+     * more later, so the keystrokes that triggered it are held in the latch and
+     * replayed once the editor exists. `insertText` (not a synthetic key event)
+     * is what ProseMirror observes as real typing.
+     */
+    function openAndCapture(scope: HTMLElement, opener: HTMLElement, char: string) {
+      opener.click()
+      // After the click: the click handler below clears any stale latch.
+      const pending: PendingOpen = { scope, chars: char }
+      pendingOpenRef.current = pending
+      let framesLeft = OPENER_POLL_FRAMES
+      const poll = () => {
+        if (pendingOpenRef.current !== pending) return
+        const editor = findScopeEditor(scope)
+        if (editor) {
+          pendingOpenRef.current = null
+          focusAtEnd(editor)
+          document.execCommand("insertText", false, pending.chars)
+          return
+        }
+        framesLeft -= 1
+        if (framesLeft > 0) {
+          requestAnimationFrame(poll)
+          return
+        }
+        pendingOpenRef.current = null
+      }
+      requestAnimationFrame(poll)
+    }
+
     function handleClick(e: MouseEvent) {
       const target = e.target as HTMLElement | null
+      pendingOpenRef.current = null
+      lastScopeRef.current = target?.closest<HTMLElement>("[data-type-capture-scope]") ?? null
       const zone = target?.closest<HTMLElement>("[data-editor-zone]")
       if (zone) {
         const value = zone.dataset.editorZone as "main" | "panel"
@@ -92,6 +149,16 @@ export function useTypeToFocus() {
         return
       }
 
+      // A composer is mid-mount for the scope the user is still typing into;
+      // keep accumulating rather than letting the key reach the zone-wide
+      // lookup and land in another card.
+      const pending = pendingOpenRef.current
+      if (pending && lastScopeRef.current === pending.scope) {
+        e.preventDefault()
+        pending.chars += e.key
+        return
+      }
+
       // If a dialog is open, focus its editor (full-screen editor) or bail out
       // (delete confirmation, command palette, etc.)
       const openDialog = document.querySelector<HTMLElement>('[role="dialog"][data-state="open"]')
@@ -106,6 +173,42 @@ export function useTypeToFocus() {
       const inlineEditor = document.querySelector<HTMLElement>("[data-inline-edit] [contenteditable='true']")
       if (inlineEditor) {
         focusAtEnd(inlineEditor)
+        return
+      }
+
+      // The board's main zone is a feed of independent cards; the keystroke
+      // belongs to the card the user last clicked, not to whichever card sits
+      // lowest in the DOM.
+      const scope = lastScopeRef.current
+      if (lastZoneRef.current === "main" && scope?.isConnected) {
+        const scopedEditor = findScopeEditor(scope)
+        if (scopedEditor) {
+          focusAtEnd(scopedEditor)
+          return
+        }
+        // Opening a conversation from inside a card records the scope, but the
+        // panel that just opened is where the typing belongs — an open panel
+        // with a live editor always outranks the card it was opened from.
+        const panelEditor = findVisibleZoneEditor(zoneContainer("panel"))
+        if (panelEditor) {
+          focusAtEnd(panelEditor)
+          return
+        }
+        const opener = scope.querySelector<HTMLElement>("[data-composer-opener]")
+        if (opener && isOnScreen(opener)) {
+          if (isMobileOrCoarse()) {
+            // The mobile composer is a floating pill portalled outside the
+            // scope that autofocuses itself, so there is nothing to poll for
+            // here and the triggering character is accepted as lost.
+            opener.click()
+          } else {
+            e.preventDefault()
+            openAndCapture(scope, opener, e.key)
+          }
+        }
+        // A scope that yields nothing (archived card, opener scrolled away)
+        // is a decision, not an absence: swallow rather than type into a
+        // different card.
         return
       }
 


### PR DESCRIPTION
## Problem

Kris on staging: with several card composers open, typing focused the wrong one — the main zone treated the whole feed as one capture area, so "last visible editor" picked whichever card sat lowest, not the card he clicked. And typing on a card showing only the resting "Write a reply…" button did nothing; it should open that card's composer with the keystroke landing in it.

## Solution

Card-scoped capture. The hook's capture-phase click listener records the last-clicked card (`data-type-capture-scope` on the card root); a printable key in the main zone then resolves in order:

1. A visible editor inside that card — focused, native key delivery.
2. An open conversation panel with a live editor — the panel wins (an "Open conversation" click records the card as the last click; the card must not steal the keystroke from the panel it just opened).
3. The card's own resting reply bar (`data-composer-opener` — only `BoardReplyComposer`'s bar carries it via `typeCaptureOpener`; branch/sub-topic bars deliberately don't, or DOM order would route text into a sub-conversation), required on-screen so a scrolled-away card can't yank the feed back. Desktop: the key is swallowed, the bar clicked, and a pending latch buffers this and any further keystrokes during the TipTap mount (nothing leaks to other cards), inserting the accumulated string once the editor appears. Coarse-pointer/narrow: the bar is clicked but nothing is swallowed — the floating pill portals outside the scope and autofocuses itself; the first character is accepted as lost there.
4. A card offering nothing (archived, or its opener off-screen) swallows the key — same "absence is a decision" rule the panel already has — instead of falling through into a neighbor's draft.

Clicks outside any card keep the previous zone-wide behavior. Timeline surfaces carry no scope attribute and are untouched. `MOBILE_VIEWPORT_QUERY`/`COARSE_POINTER_QUERY` exported from their owning hooks rather than duplicated.

## Test plan

- [x] Adversarial verify (Opus high): 6 findings against the first cut — sub-topic-bar mis-target, panel steal, floating-pill char loss, scroll yank, archived fall-through, mount-window leak — all fixed in the policy above
- [x] Targeted files: use-type-to-focus (12 scoped-capture cases), board-reply-composer, board-card, collapsed-composer-bar — 99 green; tsc clean
- [x] Falsified: branch-bar attribute restored → red; panel-wins check deleted → 3 red; scoped branch and swallow+insert neutralized → red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788348178&installation_model_id=20758&pr_number=1749&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1749&signature=db81aabcb3998c4ef31d357b0a435c2d6b5ec5dcd8f5e31f852ba034e1e6b67b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->