### PR TITLE
perf: indexed message-patch lookup on IDB v47 payload.messageId

### DIFF
--- a/apps/backend/src/features/perf-diagnostics/handlers.test.ts
+++ b/apps/backend/src/features/perf-diagnostics/handlers.test.ts
@@ -88,6 +88,16 @@ describe("perf-capture create handler", () => {
     expect(res.statusCode).toBe(201)
   })
 
+  it("a malformed non-string sample name still 400s", async () => {
+    const err = await failure({ ...validCapture, samples: [{ name: 42, at: 1, value: 12 }] })
+    expect({ status: err.status, code: err.code }).toEqual({ status: 400, code: "VALIDATION_ERROR" })
+  })
+
+  it("a missing sample name still 400s", async () => {
+    const err = await failure({ ...validCapture, samples: [{ at: 1, value: 12 }] })
+    expect({ status: err.status, code: err.code }).toEqual({ status: 400, code: "VALIDATION_ERROR" })
+  })
+
   it("rejects a capture over the sample cap", async () => {
     const samples = Array.from({ length: PERF_CAPTURE_MAX_SAMPLES + 1 }, (_, i) => ({ name: "liveQuery.rerun", at: i }))
     const err = await failure({ ...validCapture, samples })

--- a/apps/backend/src/features/perf-diagnostics/handlers.ts
+++ b/apps/backend/src/features/perf-diagnostics/handlers.ts
@@ -25,10 +25,13 @@ export function createPerfDiagnosticsHandlers({ perfDiagnosticsService }: Depend
       const body = req.body as { samples?: unknown }
       if (Array.isArray(body?.samples)) {
         const known = new Set<string>(PERF_MARK_NAMES)
-        body.samples = body.samples.filter(
-          (sample) =>
-            typeof (sample as { name?: unknown })?.name === "string" && known.has((sample as { name: string }).name)
-        )
+        // Only a *string* name the set doesn't know is a deploy-window sample;
+        // a non-string name is malformed and stays loud — it flows to the
+        // schema and 400s as before.
+        body.samples = body.samples.filter((sample) => {
+          const name = (sample as { name?: unknown })?.name
+          return typeof name !== "string" || known.has(name)
+        })
       }
       const capture = validateRequest(performanceCaptureSchema, req.body)
 

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -10,6 +10,7 @@ import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { resetActorLookups } from "@/stores/actor-lookup"
+import { resetEventWriteFlags } from "@/db/event-writes"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -80,6 +81,7 @@ function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
   resetWorkspaceTableRegistry()
   resetActorLookups()
+  resetEventWriteFlags()
   resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()

--- a/apps/frontend/src/db/database.schema.test.ts
+++ b/apps/frontend/src/db/database.schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import Dexie from "dexie"
+import { ThreaDatabase } from "./database"
+
+describe("v47 payload.messageId index", () => {
+  it("opening at v47 indexes payload.messageId over pre-existing rows", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+
+    // Seed at the v46 events shape — the last version before the dotted-key-path
+    // index — so the row exists before the index does.
+    const legacy = new Dexie(name)
+    legacy.version(46).stores({
+      events:
+        "id, workspaceId, streamId, sequence, [streamId+sequence], [streamId+_sequenceNum], eventType, [streamId+eventType], _clientId, _cachedAt, _status",
+    })
+    await legacy.open()
+    await legacy.table("events").bulkPut([
+      {
+        id: "event_1",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        sequence: "1",
+        _sequenceNum: 1,
+        eventType: "message_created",
+        payload: { messageId: "msg_1", contentMarkdown: "hello" },
+        _cachedAt: 1000,
+      },
+      {
+        id: "event_2",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        sequence: "2",
+        _sequenceNum: 2,
+        eventType: "call_started",
+        payload: { callId: "call_1" },
+        _cachedAt: 1000,
+      },
+    ])
+    legacy.close()
+
+    const db = new ThreaDatabase(name)
+    await db.open()
+
+    // The engine built the index over the pre-existing row: the query finds it
+    // without any row having been rewritten, and the payload is intact.
+    const matched = await db.events.where("payload.messageId").equals("msg_1").toArray()
+    expect(matched.map((row) => ({ id: row.id, payload: row.payload }))).toEqual([
+      { id: "event_1", payload: { messageId: "msg_1", contentMarkdown: "hello" } },
+    ])
+
+    // Sparse: the row carrying no payload.messageId is not in the index.
+    const all = await db.events.where("payload.messageId").notEqual("").count()
+    expect(all).toBe(1)
+
+    // The upgrade ADDS an index; it must not drop the ones the v46 store
+    // declared. Querying them on the upgraded handle is what makes a silently
+    // dropped index red instead of invisible.
+    const byStreamAndType = await db.events
+      .where("[streamId+eventType]")
+      .equals(["stream_1", "message_created"])
+      .count()
+    const byStatus = await db.events.where("_status").equals("pending").count()
+    expect({ byStreamAndType, byStatus }).toEqual({ byStreamAndType: 1, byStatus: 0 })
+
+    db.close()
+    await Dexie.delete(name)
+  })
+})

--- a/apps/frontend/src/db/database.schema.test.ts
+++ b/apps/frontend/src/db/database.schema.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest"
+import { afterEach, describe, it, expect, vi } from "vitest"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 import Dexie from "dexie"
 import { ThreaDatabase } from "./database"
 
@@ -64,5 +68,53 @@ describe("v47 payload.messageId index", () => {
 
     db.close()
     await Dexie.delete(name)
+  })
+})
+
+describe("one-way-door recovery", () => {
+  it("a versionchange from another tab closes the connection and reloads", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+    const db = new ThreaDatabase(name)
+    await db.open()
+    const reload = vi.fn()
+    vi.spyOn(window, "location", "get").mockReturnValue({ reload } as unknown as Location)
+
+    db.on("versionchange").fire({ newVersion: 480 } as IDBVersionChangeEvent)
+
+    expect({ open: db.isOpen(), reloaded: reload.mock.calls.length }).toEqual({ open: false, reloaded: 1 })
+    await Dexie.delete(name)
+  })
+
+  it("a quota-aborted upgrade deletes the cache and reopens once, then rethrows", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+    const db = new ThreaDatabase(name)
+    const quota = Object.assign(new Error("upgrade aborted"), { name: "AbortError" })
+    const wrapped = Object.assign(new Error("wrapped"), { name: "OpenFailedError", inner: quota })
+    const open = vi
+      .spyOn(Dexie.prototype, "open")
+      .mockImplementation(() => Promise.reject(wrapped) as unknown as ReturnType<Dexie["open"]>)
+    const del = vi.spyOn(Dexie, "delete").mockResolvedValue(undefined)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    await expect(db.open()).rejects.toBe(wrapped)
+
+    expect({ deleted: del.mock.calls.map(([n]) => n), superOpens: open.mock.calls.length }).toEqual({
+      deleted: [name],
+      superOpens: 2,
+    })
+  })
+
+  it("an unrelated open failure rethrows without deleting the cache", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+    const db = new ThreaDatabase(name)
+    const other = Object.assign(new Error("nope"), { name: "InvalidStateError" })
+    vi.spyOn(Dexie.prototype, "open").mockImplementation(
+      () => Promise.reject(other) as unknown as ReturnType<Dexie["open"]>
+    )
+    const del = vi.spyOn(Dexie, "delete").mockResolvedValue(undefined)
+
+    await expect(db.open()).rejects.toBe(other)
+
+    expect(del).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1,4 +1,4 @@
-import Dexie, { type EntityTable, type Table } from "dexie"
+import Dexie, { type EntityTable, type PromiseExtended, type Table } from "dexie"
 import type {
   Activity,
   AuthorType,
@@ -1083,6 +1083,8 @@ export class ThreaDatabase extends Dexie {
   slots!: Table<CachedSlot, [string, string]>
   streamContextItems!: EntityTable<CachedStreamContextItem, "key">
 
+  private upgradeRecoveryAvailable = true
+
   constructor(name: string) {
     super(name)
 
@@ -1568,7 +1570,52 @@ export class ThreaDatabase extends Dexie {
     })
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
+
+    // Another tab upgraded the shared per-account database. Dexie closes this
+    // connection but leaves auto-open on, so the next operation would reopen
+    // with the older schema against the newer physical DB and throw
+    // VersionError for the rest of the tab's life.
+    this.on("versionchange", () => {
+      this.close()
+      if (typeof window !== "undefined" && typeof window.location?.reload === "function") window.location.reload()
+      return false
+    })
   }
+
+  // Auto-open routes through here too (Dexie calls `db.open()` on first use),
+  // so this is the one seam every open failure crosses.
+  override open(): PromiseExtended<Dexie> {
+    return super.open().catch((error: unknown) => {
+      if (!this.upgradeRecoveryAvailable || !isRecoverableOpenFailure(error)) throw error
+      this.upgradeRecoveryAvailable = false
+      console.error(`[db] upgrade failed for ${this.name}; deleting the cache and reopening cold`, error)
+      this.close()
+      return Dexie.delete(this.name).then(() => this.open()) as PromiseExtended<Dexie>
+    })
+  }
+}
+
+const RECOVERABLE_OPEN_FAILURE_NAMES: ReadonlySet<string> = new Set([
+  "QuotaExceededError",
+  "AbortError",
+  "UpgradeError",
+])
+
+/**
+ * A failed version upgrade (quota abort mid index build) is retried on every
+ * open, so the app never reaches a working state. Everything in this database
+ * is a server-derived cache, so deleting it recovers to a cold start; the loud
+ * console.error plus the one-shot guard keep this a reported failure with a
+ * recovery, not a silent fallback (INV-11).
+ */
+function isRecoverableOpenFailure(error: unknown): boolean {
+  let current = error
+  for (let depth = 0; current && depth < 5; depth++) {
+    const name = (current as { name?: unknown }).name
+    if (typeof name === "string" && RECOVERABLE_OPEN_FAILURE_NAMES.has(name)) return true
+    current = (current as { inner?: unknown }).inner
+  }
+  return false
 }
 
 // The active account's database. AccountScope owns this pointer and is its

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1552,6 +1552,21 @@ export class ThreaDatabase extends Dexie {
       conversationMessages: "messageId, conversationId, workspaceId",
     })
 
+    // v47: `payload.messageId` becomes a sparse dotted-key-path index so a
+    // message patch (reaction, edit, delete, move, link-preview resolve, thread
+    // heal) is a direct lookup instead of a cursor over the whole
+    // [streamId+"message_created"] range. No `.upgrade()` — the engine builds
+    // the index over existing rows; no row is rewritten.
+    // One-way door: once a client has opened at v47, code declaring only v46
+    // cannot open the database (IndexedDB refuses a version downgrade), so a
+    // revert of this bump is not available — reverting means a v48. The
+    // *lookup* that uses the index is flag-gated (`indexedMessagePatch`)
+    // instead, and that is what a rollback turns off.
+    this.version(47).stores({
+      events:
+        "id, workspaceId, streamId, sequence, [streamId+sequence], [streamId+_sequenceNum], eventType, [streamId+eventType], _clientId, _cachedAt, _status, payload.messageId",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -4,9 +4,9 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   EVENT_BULK_PUT_LIMIT,
   isEventWriteChunkingEnabled,
-  primeEventWriteChunking,
+  primeEventWriteFlags,
   putEventsBounded,
-  resetEventWriteChunking,
+  resetEventWriteFlags,
   skipNoOpEventRewrites,
 } from "./event-writes"
 
@@ -33,7 +33,7 @@ function makePage(streamId: string, count: number): CachedEvent[] {
 }
 
 beforeEach(async () => {
-  resetEventWriteChunking()
+  resetEventWriteFlags()
   await db.events.clear()
   await db.workspaceMetadata.clear()
 })
@@ -209,15 +209,15 @@ describe("isEventWriteChunkingEnabled", () => {
   it("a primed value wins without reading the row", async () => {
     await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
     const get = vi.spyOn(db.workspaceMetadata, "get")
-    primeEventWriteChunking("ws_1", { workspace: {}, user: { eventWriteChunking: "on" } })
+    primeEventWriteFlags("ws_1", { workspace: {}, user: { eventWriteChunking: "on" } })
 
     expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
     expect(get).not.toHaveBeenCalled()
   })
 
-  it("resetEventWriteChunking clears the primed value", async () => {
-    primeEventWriteChunking("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
-    resetEventWriteChunking()
+  it("resetEventWriteFlags clears the primed value", async () => {
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    resetEventWriteFlags()
 
     expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
   })

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -221,4 +221,22 @@ describe("isEventWriteChunkingEnabled", () => {
 
     expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
   })
+
+  it("a prime landing mid-read wins over the older persisted row", async () => {
+    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const real = db.workspaceMetadata.get.bind(db.workspaceMetadata)
+    vi.spyOn(db.workspaceMetadata, "get").mockImplementation(((key: string) =>
+      gate.then(() => real(key))) as unknown as typeof db.workspaceMetadata.get)
+
+    const inFlight = isEventWriteChunkingEnabled(db, "ws_1")
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    release()
+
+    expect(await inFlight).toBe(true)
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+  })
 })

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -4,6 +4,7 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   EVENT_BULK_PUT_LIMIT,
   isEventWriteChunkingEnabled,
+  readEventWriteFlagsFresh,
   primeEventWriteFlags,
   putEventsBounded,
   resetEventWriteFlags,
@@ -238,5 +239,19 @@ describe("isEventWriteChunkingEnabled", () => {
 
     expect(await inFlight).toBe(true)
     expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+  })
+
+  it("readEventWriteFlagsFresh ignores the cache and re-reads the row every call", async () => {
+    await putMetadata({ workspace: { eventWriteChunking: "on", indexedMessagePatch: "on" }, user: {} })
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off", indexedMessagePatch: "off" }, user: {} })
+
+    const first = await readEventWriteFlagsFresh(db, "ws_1")
+    await putMetadata({ workspace: { eventWriteChunking: "off", indexedMessagePatch: "on" }, user: {} })
+    const second = await readEventWriteFlagsFresh(db, "ws_1")
+
+    expect({ first, second }).toEqual({
+      first: { chunking: true, indexedMessagePatch: true },
+      second: { chunking: false, indexedMessagePatch: true },
+    })
   })
 })

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -75,6 +75,7 @@ export function skipNoOpEventRewrites(
 type EventWriteFlags = { chunking: boolean; indexedMessagePatch: boolean }
 
 const flagsByWorkspace = new Map<string, EventWriteFlags>()
+let primeGeneration = 0
 
 function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
@@ -86,19 +87,25 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
 
 /** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
 export function primeEventWriteFlags(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
+  primeGeneration += 1
   flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
 }
 
 /** Test-only: drop the cache so each case resolves from its own prime/IDB row. */
 export function resetEventWriteFlags(): void {
+  primeGeneration += 1
   flagsByWorkspace.clear()
 }
 
 async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
   const cached = flagsByWorkspace.get(workspaceId)
   if (cached !== undefined) return cached
+  // The persisted row is the warm-start fallback, so a prime that lands while
+  // this read is in flight is strictly newer and must win (INV-20).
+  const generation = primeGeneration
   const metadata = await database.workspaceMetadata.get(workspaceId)
   const flags = resolveEventWriteFlags(metadata?.featureFlags)
+  if (primeGeneration !== generation) return flagsByWorkspace.get(workspaceId) ?? flags
   flagsByWorkspace.set(workspaceId, flags)
   return flags
 }

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -119,6 +119,18 @@ export async function isEventWriteChunkingEnabled(database: ThreaDatabase, works
   return (await getEventWriteFlags(database, workspaceId)).chunking
 }
 
+/**
+ * The chunking flag read straight from the persisted row, bypassing the module
+ * cache. The service worker runs its own module instance that nothing primes
+ * and nothing resets, so a cached value there would outlive an account switch
+ * and hide a backoffice flip until the worker restarts; the per-account
+ * `database` handle makes a fresh read account-correct by construction.
+ */
+export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
+  const metadata = await database.workspaceMetadata.get(workspaceId)
+  return resolveEventWriteFlags(metadata?.featureFlags)
+}
+
 /** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
 export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
   return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -72,20 +72,35 @@ export function skipNoOpEventRewrites(
 // that Dexie must deserialize per read — so resolving the flag from it on every
 // event write costs more than the write. Resolve once per workspace per module
 // instance instead, primed from the network bootstrap and socket flag flips.
-const chunkingByWorkspace = new Map<string, boolean>()
+type EventWriteFlags = { chunking: boolean; indexedMessagePatch: boolean }
 
-function resolveChunking(layers: FeatureFlagLayers | null | undefined): boolean {
-  return resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS).eventWriteChunking === "on"
+const flagsByWorkspace = new Map<string, EventWriteFlags>()
+
+function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
+  const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
+  return {
+    chunking: resolved.eventWriteChunking === "on",
+    indexedMessagePatch: resolved.indexedMessagePatch === "on",
+  }
 }
 
 /** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
-export function primeEventWriteChunking(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
-  chunkingByWorkspace.set(workspaceId, resolveChunking(layers))
+export function primeEventWriteFlags(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
+  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
 }
 
 /** Test-only: drop the cache so each case resolves from its own prime/IDB row. */
-export function resetEventWriteChunking(): void {
-  chunkingByWorkspace.clear()
+export function resetEventWriteFlags(): void {
+  flagsByWorkspace.clear()
+}
+
+async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
+  const cached = flagsByWorkspace.get(workspaceId)
+  if (cached !== undefined) return cached
+  const metadata = await database.workspaceMetadata.get(workspaceId)
+  const flags = resolveEventWriteFlags(metadata?.featureFlags)
+  flagsByWorkspace.set(workspaceId, flags)
+  return flags
 }
 
 /**
@@ -94,10 +109,10 @@ export function resetEventWriteChunking(): void {
  * the pre-#1455 flat `featureFlags` shape rather than throwing on it.
  */
 export async function isEventWriteChunkingEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  const cached = chunkingByWorkspace.get(workspaceId)
-  if (cached !== undefined) return cached
-  const metadata = await database.workspaceMetadata.get(workspaceId)
-  const chunked = resolveChunking(metadata?.featureFlags)
-  chunkingByWorkspace.set(workspaceId, chunked)
-  return chunked
+  return (await getEventWriteFlags(database, workspaceId)).chunking
+}
+
+/** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
+export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
+  return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch
 }

--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import type { StreamEvent } from "@threa/types"
 import { db } from "@/db"
-import { resetEventWriteChunking } from "@/db/event-writes"
+import { resetEventWriteFlags } from "@/db/event-writes"
 import {
   computeTimelineLoadState,
   filterEventsForDisplay,
@@ -231,7 +231,7 @@ describe("getEffectiveEvents", () => {
 
 describe("cacheToIndexedDB with eventWriteChunking on", () => {
   beforeEach(async () => {
-    resetEventWriteChunking()
+    resetEventWriteFlags()
     await db.events.clear()
     await db.workspaceMetadata.clear()
     await db.workspaceMetadata.put({

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -126,7 +126,7 @@ async function promoteDraft(
   // re-increment here.
   const anchorId = creation.parentAnchorId ?? creation.parentMessageId
   if (creation.type === StreamTypes.THREAD && creation.parentStreamId && anchorId) {
-    setParentThreadId(creation.parentStreamId, anchorId, realStreamId).catch(() => {})
+    setParentThreadId(next.workspaceId, creation.parentStreamId, anchorId, realStreamId).catch(() => {})
   }
 
   // Clean up draft data (no-ops gracefully for non-scratchpad drafts).

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -264,7 +264,12 @@ export function useQueueDraftMessage(workspaceId: string) {
       const anchorId = params.streamCreation?.parentAnchorId ?? params.streamCreation?.parentMessageId
       if (params.streamCreation?.type === StreamTypes.THREAD && params.streamCreation.parentStreamId && anchorId) {
         const draftPanelId = createDraftPanelId(params.streamCreation.parentStreamId, anchorId)
-        await optimisticReplyCountUpdate(params.streamCreation.parentStreamId, anchorId, draftPanelId).catch(() => {})
+        await optimisticReplyCountUpdate(
+          params.workspaceId,
+          params.streamCreation.parentStreamId,
+          anchorId,
+          draftPanelId
+        ).catch(() => {})
       }
 
       notifyQueue()

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -1,6 +1,6 @@
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import type { CachedEvent, ThreaDatabase } from "../db/database"
-import { isEventWriteChunkingEnabled, putEventsBounded } from "../db/event-writes"
+import { putEventsBounded, readEventWriteFlagsFresh } from "../db/event-writes"
 import { writeSlotCarrier } from "../stores/slot-store"
 
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
@@ -143,7 +143,7 @@ async function prefetchEventsAround(
     if (data?.events?.length > 0) {
       const now = Date.now()
       const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
-      const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
+      const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
       await db.transaction("rw", [db.events, db.slots], async () => {
         await putEventsBounded(
           db.events,
@@ -193,7 +193,7 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
     // sink the stream into "Other". Merge via update() so lastMessagePreview
     // and membership-derived fields (notificationLevel) from
     // applyWorkspaceBootstrap survive.
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
+    const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       await putEventsBounded(
         db.events,

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -10,6 +10,7 @@ import {
   preserveBakedInAppData,
   registerStreamSocketHandlers,
   toCachedStreamBootstrap,
+  updateEventByAnchor,
   updateMessageEvent,
   updateMemoEmbedSummary,
   type CachedStreamBootstrap,
@@ -1207,7 +1208,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: Date.now(),
     })
 
-    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
+    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
 
     const event = await db.events.get("evt_1")
     expect((event?.payload as Record<string, unknown>).replyCount).toBe(5)
@@ -1224,7 +1225,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: before - 10000,
     })
 
-    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
+    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
 
     const event = await db.events.get("evt_patched")
     expect(event?._patchedAt).toBeDefined()
@@ -1246,12 +1247,12 @@ describe("updateMessageEvent", () => {
     // concurrently. With the old read-then-update implementation the last
     // write would overwrite earlier ones and lose fields.
     await Promise.all([
-      updateMessageEvent(streamId, messageId, (p) => ({
+      updateMessageEvent(false, streamId, messageId, (p) => ({
         ...p,
         replyCount: 3,
         threadSummary: { lastReplyContentMarkdown: "hi", participantIds: ["u1"] },
       })),
-      updateMessageEvent(streamId, messageId, (p) => ({
+      updateMessageEvent(false, streamId, messageId, (p) => ({
         ...p,
         threadId: "thread_123",
       })),
@@ -1262,6 +1263,278 @@ describe("updateMessageEvent", () => {
     expect(payload.threadId).toBe("thread_123")
     expect(payload.replyCount).toBe(3)
     expect(payload.threadSummary).toEqual({ lastReplyContentMarkdown: "hi", participantIds: ["u1"] })
+  })
+})
+
+describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessagePatch)", () => {
+  function seedRow(overrides: {
+    id: string
+    streamId: string
+    sequence: string
+    payload: Record<string, unknown>
+    eventType?: StreamEvent["eventType"]
+  }): CachedEvent {
+    return {
+      ...makeEvent({
+        id: overrides.id,
+        streamId: overrides.streamId,
+        sequence: overrides.sequence,
+        payload: overrides.payload,
+        eventType: overrides.eventType ?? "message_created",
+      }),
+      workspaceId: "ws_1",
+      _sequenceNum: Number(overrides.sequence),
+      _cachedAt: Date.now(),
+    } as CachedEvent
+  }
+
+  /**
+   * Counts what each arm's cursor actually visits: `filter` predicate calls are
+   * the scan's per-row cost, `modify` callback calls are the rows the cursor
+   * yielded, and `written` is Dexie's own count of rows it re-put (the callback
+   * returning `false` is what keeps a guard-skipped row out of that count — so
+   * the wrapper must PROPAGATE the callback's return value, never swallow it).
+   * The indexed arm runs no `filter` at all.
+   */
+  const unsubscribes: Array<() => void> = []
+
+  function trackCursor() {
+    const counts = { indexes: [] as string[], filtered: 0, visited: 0, written: 0 }
+    // Dexie's `modify()` resolves to the number of rows the cursor MATCHED, not
+    // the number it wrote — the `updating` hook is what fires per actual put.
+    const onUpdating = () => {
+      counts.written += 1
+    }
+    db.events.hook("updating", onUpdating)
+    unsubscribes.push(() => db.events.hook("updating").unsubscribe(onUpdating))
+    const originalWhere = db.events.where.bind(db.events)
+    vi.spyOn(db.events, "where").mockImplementation(((key: string) => {
+      counts.indexes.push(String(key))
+      const clause = originalWhere(key as never) as unknown as {
+        equals: (value: unknown) => Record<string, unknown>
+      }
+      const originalEquals = clause.equals.bind(clause)
+      clause.equals = (value: unknown) => {
+        const collection = originalEquals(value) as unknown as {
+          filter: (fn: (row: CachedEvent) => boolean) => unknown
+          modify: (fn: (row: CachedEvent) => void | boolean) => PromiseLike<number>
+        }
+        const originalFilter = collection.filter.bind(collection)
+        const originalModify = collection.modify.bind(collection)
+        collection.filter = (fn) =>
+          originalFilter((row) => {
+            counts.filtered += 1
+            return fn(row)
+          })
+        collection.modify = (fn) =>
+          originalModify((row) => {
+            counts.visited += 1
+            return fn(row)
+          })
+        return collection as never
+      }
+      return clause as never
+    }) as never)
+    return counts
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    while (unsubscribes.length > 0) unsubscribes.pop()?.()
+  })
+
+  async function seedLargeStream(streamId: string, count: number, targetMessageId: string): Promise<void> {
+    const rows: CachedEvent[] = []
+    for (let i = 0; i < count; i += 1) {
+      const messageId = i === count - 2 ? targetMessageId : `msg_bulk_${i}`
+      rows.push(
+        seedRow({
+          id: `evt_bulk_${i}`,
+          streamId,
+          sequence: String(i + 1),
+          payload: { messageId, contentMarkdown: "x" },
+        })
+      )
+    }
+    await db.events.bulkPut(rows)
+  }
+
+  it("a reaction patch touches one row in a thousand-event stream", async () => {
+    const streamId = "stream_big"
+    const messageId = "msg_target"
+    await seedLargeStream(streamId, 1000, messageId)
+
+    const indexed = trackCursor()
+    await updateMessageEvent(true, streamId, messageId, (p) => ({ ...p, reactions: ["👍"] }))
+    expect(indexed.indexes).toEqual(["payload.messageId"])
+    expect({ filtered: indexed.filtered, visited: indexed.visited }).toEqual({ filtered: 0, visited: 1 })
+    vi.restoreAllMocks()
+
+    const scanned = trackCursor()
+    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, reactions: ["👍", "🎉"] }))
+    expect(scanned.indexes).toEqual(["[streamId+eventType]"])
+    expect({ filtered: scanned.filtered, visited: scanned.visited }).toEqual({ filtered: 1000, visited: 1 })
+
+    const patched = await db.events.get("evt_bulk_998")
+    expect((patched?.payload as Record<string, unknown>).reactions).toEqual(["👍", "🎉"])
+  }, 20000)
+
+  it("a patch for a message in another stream is not applied", async () => {
+    const messageId = "msg_shared"
+    await db.events.bulkPut([
+      seedRow({ id: "evt_here", streamId: "stream_here", sequence: "1", payload: { messageId, replyCount: 0 } }),
+      seedRow({ id: "evt_there", streamId: "stream_there", sequence: "1", payload: { messageId, replyCount: 0 } }),
+    ])
+
+    const counts = trackCursor()
+    await updateMessageEvent(true, "stream_here", messageId, (p) => ({ ...p, replyCount: 7 }))
+
+    const here = await db.events.get("evt_here")
+    const there = await db.events.get("evt_there")
+    expect({
+      here: (here?.payload as Record<string, unknown>).replyCount,
+      there: (there?.payload as Record<string, unknown>).replyCount,
+      therePatchedAt: there?._patchedAt,
+      visited: counts.visited,
+      written: counts.written,
+    }).toEqual({ here: 7, there: 0, therePatchedAt: undefined, visited: 2, written: 1 })
+  })
+
+  it("a same-id row of another event type is visited but not re-put", async () => {
+    const messageId = "msg_typed"
+    await db.events.bulkPut([
+      seedRow({ id: "evt_created", streamId: "stream_typed", sequence: "1", payload: { messageId, replyCount: 0 } }),
+      seedRow({
+        id: "evt_edited",
+        streamId: "stream_typed",
+        sequence: "2",
+        eventType: "message_edited",
+        payload: { messageId, replyCount: 0 },
+      }),
+    ])
+
+    const counts = trackCursor()
+    await updateMessageEvent(true, "stream_typed", messageId, (p) => ({ ...p, replyCount: 9 }))
+
+    const created = await db.events.get("evt_created")
+    const edited = await db.events.get("evt_edited")
+    expect({
+      created: (created?.payload as Record<string, unknown>).replyCount,
+      edited: (edited?.payload as Record<string, unknown>).replyCount,
+      editedPatchedAt: edited?._patchedAt,
+      visited: counts.visited,
+      written: counts.written,
+    }).toEqual({ created: 9, edited: 0, editedPatchedAt: undefined, visited: 2, written: 1 })
+  })
+
+  it("concurrent patches to the same message do not lose an update", async () => {
+    const messageId = "msg_race_indexed"
+    await db.events.put(
+      seedRow({ id: "evt_race_indexed", streamId: "stream_race", sequence: "1", payload: { messageId } })
+    )
+
+    await Promise.all([
+      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, replyCount: 3 })),
+      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, threadId: "thread_1" })),
+    ])
+
+    const event = await db.events.get("evt_race_indexed")
+    expect(event?.payload).toEqual({ messageId, replyCount: 3, threadId: "thread_1" })
+  })
+
+  it("an event whose payload carries no messageId is never matched", async () => {
+    await db.events.bulkPut([
+      seedRow({
+        id: "evt_no_message_id",
+        streamId: "stream_sparse",
+        sequence: "1",
+        eventType: "call_started",
+        payload: { callId: "call_1" },
+      }),
+      seedRow({
+        id: "evt_with_message_id",
+        streamId: "stream_sparse",
+        sequence: "2",
+        payload: { messageId: "msg_sparse" },
+      }),
+    ])
+
+    await updateMessageEvent(true, "stream_sparse", "msg_sparse", (p) => ({ ...p, replyCount: 1 }))
+
+    const untouched = await db.events.get("evt_no_message_id")
+    const patched = await db.events.get("evt_with_message_id")
+    expect({
+      untouched: untouched?.payload,
+      untouchedPatchedAt: untouched?._patchedAt,
+      patched: patched?.payload,
+    }).toEqual({
+      untouched: { callId: "call_1" },
+      untouchedPatchedAt: undefined,
+      patched: { messageId: "msg_sparse", replyCount: 1 },
+    })
+  })
+
+  it("the same message id in two streams patches only the caller's stream", async () => {
+    const messageId = "msg_moved"
+    await db.events.bulkPut([
+      seedRow({ id: "evt_old_stream", streamId: "stream_old", sequence: "1", payload: { messageId, tag: "old" } }),
+      seedRow({ id: "evt_new_stream", streamId: "stream_new", sequence: "1", payload: { messageId, tag: "new" } }),
+    ])
+
+    await updateMessageEvent(true, "stream_new", messageId, (p) => ({ ...p, tag: "patched" }))
+
+    const rows = await db.events.bulkGet(["evt_old_stream", "evt_new_stream"])
+    expect(rows.map((row) => (row?.payload as Record<string, unknown>).tag)).toEqual(["old", "patched"])
+  })
+
+  it("six payload shapes round-trip through the updater on the indexed path", async () => {
+    const streamId = "stream_callers"
+    await db.events.bulkPut([
+      seedRow({ id: "evt_edit", streamId, sequence: "1", payload: { messageId: "msg_edit" } }),
+      seedRow({ id: "evt_delete", streamId, sequence: "2", payload: { messageId: "msg_delete" } }),
+      seedRow({ id: "evt_move", streamId, sequence: "3", payload: { messageId: "msg_move" } }),
+      seedRow({ id: "evt_reaction", streamId, sequence: "4", payload: { messageId: "msg_reaction" } }),
+      seedRow({ id: "evt_preview", streamId, sequence: "5", payload: { messageId: "msg_preview" } }),
+      seedRow({ id: "evt_heal", streamId, sequence: "6", payload: { messageId: "msg_heal" } }),
+      seedRow({
+        id: "evt_card",
+        streamId,
+        sequence: "7",
+        eventType: "memos:captured",
+        payload: { memoId: "memo_1" },
+      }),
+    ])
+
+    await updateMessageEvent(true, streamId, "msg_edit", (p) => ({ ...p, contentMarkdown: "edited", editedAt: "t" }))
+    await updateMessageEvent(true, streamId, "msg_delete", (p) => ({ ...p, deletedAt: "t" }))
+    await updateMessageEvent(true, streamId, "msg_move", (p) => ({ ...p, movedToStreamId: "stream_other" }))
+    await updateMessageEvent(true, streamId, "msg_reaction", (p) => ({ ...p, reactions: ["👍"] }))
+    await updateMessageEvent(true, streamId, "msg_preview", (p) => ({ ...p, linkPreviews: [{ url: "u" }] }))
+    await updateEventByAnchor(true, streamId, "msg_heal", (p) => ({ ...p, threadId: "thread_healed" }))
+    await updateEventByAnchor(true, streamId, "evt_card", (p) => ({ ...p, threadId: "thread_card" }))
+
+    const rows = await db.events.bulkGet([
+      "evt_edit",
+      "evt_delete",
+      "evt_move",
+      "evt_reaction",
+      "evt_preview",
+      "evt_heal",
+      "evt_card",
+    ])
+    expect(rows.map((row) => row?.payload)).toEqual([
+      { messageId: "msg_edit", contentMarkdown: "edited", editedAt: "t" },
+      { messageId: "msg_delete", deletedAt: "t" },
+      { messageId: "msg_move", movedToStreamId: "stream_other" },
+      { messageId: "msg_reaction", reactions: ["👍"] },
+      { messageId: "msg_preview", linkPreviews: [{ url: "u" }] },
+      { messageId: "msg_heal", threadId: "thread_healed" },
+      { memoId: "memo_1", threadId: "thread_card" },
+    ])
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,5 +1,10 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import { isEventWriteChunkingEnabled, isNoOpRewrite, putEventsBounded } from "@/db/event-writes"
+import {
+  isEventWriteChunkingEnabled,
+  isIndexedMessagePatchEnabled,
+  isNoOpRewrite,
+  putEventsBounded,
+} from "@/db/event-writes"
 import {
   StreamTypes,
   THREAD_ANCHORABLE_EVENT_TYPES,
@@ -922,31 +927,51 @@ export async function updateMemoEmbedSummary(streamId: string, summary: MemoEmbe
 }
 
 export async function updateMessageEvent(
+  indexed: boolean,
   streamId: string,
   messageId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
 ): Promise<void> {
-  // Use compound index to narrow to message_created events for this stream,
-  // then filter by messageId in the payload (not indexed but over a small set).
   // modify() runs the callback inside a readwrite cursor so the read and write
   // are atomic. This prevents lost updates when multiple socket handlers
   // (messages:moved, stream:created, thread:updated) update the same parent
   // message concurrently — the second transaction sees the first's writes.
+  const patch = (event: CachedEvent) => {
+    const updatedPayload = updater(event.payload as Record<string, unknown>)
+    const now = Date.now()
+    event.payload = updatedPayload
+    event._cachedAt = now
+    // Freshness watermark — see `_patchedAt` doc on CachedEvent. Only
+    // bumped by socket-handler patches (and the optimistic helpers below
+    // that mirror them); bootstrap apply leaves it alone so a later
+    // bootstrap response can decide whether its enrichment is stale.
+    event._patchedAt = now
+  }
+
+  if (indexed) {
+    // The `payload.messageId` sparse index (v47) makes this a direct lookup.
+    // The stream/type guard stays inside the cursor so a message that moved
+    // streams is still not patched in its old stream — today's semantics.
+    // `false` (not a bare return) is what tells Dexie to SKIP the row: any
+    // other return value re-puts it, which would fire observability for every
+    // same-id row in another stream.
+    await db.events
+      .where("payload.messageId")
+      .equals(messageId)
+      .modify((event) => {
+        if (event.streamId !== streamId || event.eventType !== "message_created") return false
+        patch(event)
+      })
+    return
+  }
+
+  // Use compound index to narrow to message_created events for this stream,
+  // then filter by messageId in the payload (not indexed but over a small set).
   await db.events
     .where("[streamId+eventType]")
     .equals([streamId, "message_created"])
     .filter((e) => (e.payload as { messageId?: string })?.messageId === messageId)
-    .modify((event) => {
-      const updatedPayload = updater(event.payload as Record<string, unknown>)
-      const now = Date.now()
-      event.payload = updatedPayload
-      event._cachedAt = now
-      // Freshness watermark — see `_patchedAt` doc on CachedEvent. Only
-      // bumped by socket-handler patches (and the optimistic helpers below
-      // that mirror them); bootstrap apply leaves it alone so a later
-      // bootstrap response can decide whether its enrichment is stale.
-      event._patchedAt = now
-    })
+    .modify(patch)
 }
 
 /**
@@ -957,12 +982,13 @@ export async function updateMessageEvent(
  * for messages, event id for cards).
  */
 export async function updateEventByAnchor(
+  indexed: boolean,
   streamId: string,
   anchorId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
 ): Promise<void> {
   if (anchorId.startsWith("msg_")) {
-    await updateMessageEvent(streamId, anchorId, updater)
+    await updateMessageEvent(indexed, streamId, anchorId, updater)
     return
   }
   await db.events
@@ -987,11 +1013,13 @@ export async function updateEventByAnchor(
  * anchor's canonical id so event-anchored (card) threads bump too.
  */
 export async function optimisticReplyCountUpdate(
+  workspaceId: string,
   parentStreamId: string,
   anchorId: string,
   threadId: string
 ): Promise<void> {
-  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
+  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
     replyCount: ((p.replyCount as number) ?? 0) + 1,
@@ -1007,8 +1035,14 @@ export async function optimisticReplyCountUpdate(
  * created, we swap the threadId to the server-assigned one so navigation
  * targets the real thread.
  */
-export async function setParentThreadId(parentStreamId: string, anchorId: string, threadId: string): Promise<void> {
-  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
+export async function setParentThreadId(
+  workspaceId: string,
+  parentStreamId: string,
+  anchorId: string,
+  threadId: string
+): Promise<void> {
+  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
   }))
@@ -1343,8 +1377,9 @@ export function registerStreamSocketHandlers(
     }
 
     const now = Date.now()
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.slots], async () => {
-      await updateMessageEvent(streamId, editPayload.messageId, (p) => ({
+      await updateMessageEvent(indexed, streamId, editPayload.messageId, (p) => ({
         ...p,
         contentJson: editPayload.contentJson,
         contentMarkdown: editPayload.contentMarkdown,
@@ -1400,7 +1435,8 @@ export function registerStreamSocketHandlers(
 
   const handleMessageDeleted = async (payload: MessageDeletedPayload) => {
     if (payload.streamId !== streamId) return
-    await updateMessageEvent(streamId, payload.messageId, (p) => ({
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
       ...p,
       deletedAt: payload.deletedAt,
     }))
@@ -1419,7 +1455,10 @@ export function registerStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
+    const [chunked, indexed] = await Promise.all([
+      isEventWriteChunkingEnabled(db, workspaceId),
+      isIndexedMessagePatchEnabled(db, workspaceId),
+    ])
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1441,7 +1480,7 @@ export function registerStreamSocketHandlers(
         // identical result. This makes `messages:moved` self-sufficient:
         // the thread card surfaces with the right count even if
         // `thread:updated` is delayed or lost.
-        await updateMessageEvent(streamId, payload.targetMessageId, (p) => ({
+        await updateMessageEvent(indexed, streamId, payload.targetMessageId, (p) => ({
           ...p,
           threadId: payload.thread.id,
           replyCount: payload.parentReplyCount,
@@ -1524,7 +1563,8 @@ export function registerStreamSocketHandlers(
 
   const handleReactionAdded = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    await updateMessageEvent(streamId, payload.messageId, (p) => {
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       const existing = reactions[payload.emoji] || []
       if (!existing.includes(payload.userId)) {
@@ -1543,7 +1583,8 @@ export function registerStreamSocketHandlers(
 
   const handleReactionRemoved = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    await updateMessageEvent(streamId, payload.messageId, (p) => {
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       if (reactions[payload.emoji]) {
         reactions[payload.emoji] = reactions[payload.emoji].filter((id) => id !== payload.userId)
@@ -1575,7 +1616,8 @@ export function registerStreamSocketHandlers(
     const anchorId = stream.parentAnchorId
     if (!anchorId) return
 
-    await updateEventByAnchor(streamId, anchorId, (p) => ({
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateEventByAnchor(indexed, streamId, anchorId, (p) => ({
       ...p,
       threadId: stream.id,
     }))
@@ -1606,7 +1648,8 @@ export function registerStreamSocketHandlers(
     // Heal only the fields the patch carries: the edit path omits replyCount
     // (summary-only refresh) so it can't overwrite a concurrent create/delete's
     // authoritative count.
-    await updateEventByAnchor(streamId, payload.anchorId, (p) => ({
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateEventByAnchor(indexed, streamId, payload.anchorId, (p) => ({
       ...p,
       ...(payload.replyCount !== undefined ? { replyCount: payload.replyCount } : {}),
       ...(payload.threadSummary !== undefined ? { threadSummary: payload.threadSummary } : {}),
@@ -1730,7 +1773,8 @@ export function registerStreamSocketHandlers(
 
   const handleLinkPreviewReady = async (payload: LinkPreviewReadyPayload) => {
     if (payload.streamId !== streamId) return
-    await updateMessageEvent(streamId, payload.messageId, (p) => ({
+    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
+    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
       ...p,
       linkPreviews: preserveBakedInAppData(payload.previews, p.linkPreviews as LinkPreviewSummary[] | undefined),
     }))

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -107,7 +107,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isEventWriteChunkingEnabled, primeEventWriteChunking } from "@/db/event-writes"
+import { isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -1673,7 +1673,7 @@ export function registerWorkspaceSocketHandlers(
     if (!patched) return
     const layers = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.featureFlags
     if (layers) {
-      primeEventWriteChunking(workspaceId, layers)
+      primeEventWriteFlags(workspaceId, layers)
       void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
     }
   }
@@ -2569,7 +2569,7 @@ export async function applyWorkspaceBootstrap(
 ): Promise<AppliedWorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
-  primeEventWriteChunking(workspaceId, bootstrap.featureFlags)
+  primeEventWriteFlags(workspaceId, bootstrap.featureFlags)
   const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   // Build membership lookup for O(1) access when merging onto streams
@@ -3060,7 +3060,7 @@ export async function applyReconnectBootstrapBatch(
     fetchStartedAt,
   })
 
-  primeEventWriteChunking(workspaceId, finalBootstrap.featureFlags)
+  primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
   const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -58,6 +58,7 @@ export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
+  indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.


### PR DESCRIPTION
## Problem

`updateMessageEvent` cursors the entire `[streamId+"message_created"]` range and filters on unindexed `payload.messageId` — on every reaction, edit, delete, move, link-preview resolve and thread heal. In a 1,000-event stream that's 1,000 filter calls per patch. Chunk 5 of the PR 6/10 plan; base #1748.

## Solution

Two deliberately separate commits (plan D8):

**Commit 1 — the schema, alone.** IDB v47 appends a sparse `payload.messageId` index to `events` (Dexie dotted keyPath; engine-built over existing rows, no `.upgrade()`, no row rewrites). This is the one-way door: a v47 install cannot reopen at v46; revert = bump to v48. The events schema string is a verified byte-exact superset of v46's — a dropped index would be silently *deleted* on upgrade for every install — and the upgrade test queries the new index **and** two pre-existing ones (`[streamId+eventType]`, `_status`) on a DB seeded at the v46 shape, so both the addition and the survivals are pinned.

**Commit 2 — the lookup, flag-gated (`indexedMessagePatch`, default off).** Flag-on: `where("payload.messageId").equals(id)` with the stream/eventType guard inside the `modify` callback, `return false` on skip — Dexie re-puts any row whose callback doesn't return `false`, so a bare `return` would have rewritten same-id rows in other streams and woken their observers (adversarial finding, fixed with a visited-vs-written counter test). Flag-off: today's scan verbatim. The flag resolves **above every transaction** as an `indexed: boolean` parameter — the adversarial round caught it being awaited inside two patch transactions, where an un-primed workspace (socket edit before any bootstrap) would have thrown `NotFound` and aborted the patch, flag-off included; that was chunk 1's lesson re-violated, now structurally prevented.

Behavior preserved exactly: a moved message is not patched in its old stream; `message_edited` rows carrying the same messageId are visited but never written (the guard half the index makes newly load-bearing has its own test); `updateEventByAnchor`'s `event_` branch untouched. Deferred by plan decision, not oversight: retention/eviction (D11), board-rail bounding (D12), `updateMemoEmbedSummary` (D13).

Plan: https://seer.build/ws_vbyzjvdg6g/b/pr6-10-plan-4119f5/ (chunk 5, D8).

## Test plan

- [x] Targeted vitest (stream-sync ×127, database.schema ×1; `--maxWorkers=2`): 128/0; typecheck clean; Opus-high adversarial verify (6 findings, all fixed) — every guard's neutralisation recorded (flag-off forced, guard drops, return-false revert)
- [ ] Broad suites deliberately left to CI; manual dev:test upgrade check deferred to the whole-stack pass

## Post-review updates (whole-stack pass)
- `resetEventWriteFlags` registered in `flushModuleStoreCaches`: the per-workspace flag cache is keyed by workspaceId only, so two accounts sharing a workspace would otherwise carry the first account's resolved values across a switch until the next bootstrap re-prime.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788350906&installation_model_id=20758&pr_number=1750&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1750&signature=0af5959d289970e5f22eca23556061bb624a3c58647d0ea65f9edd52cccff06b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
