### PR TITLE
feat(board): remove the Decisions lens

### DIFF
--- a/apps/backend/src/features/board-views/handlers.test.ts
+++ b/apps/backend/src/features/board-views/handlers.test.ts
@@ -115,10 +115,18 @@ describe("Board view handlers", () => {
     expect(mockCreate).not.toHaveBeenCalled()
   })
 
-  test("create rejects an unknown lens with a 400", async () => {
-    await expect(handlers.create(mockReq({ body: { name: "x", baseLens: "bogus" } }), mockRes())).rejects.toMatchObject(
-      { status: 400 }
+  test("create degrades a retired lens to `all` instead of rejecting", async () => {
+    // An SW-cached bundle still saves `decisions`; a saved view, not a 400.
+    await handlers.create(mockReq({ body: { name: "x", baseLens: "decisions" } }), mockRes())
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ baseLens: "all" }))
+  })
+
+  test("update degrades a retired lens to `all` instead of rejecting", async () => {
+    await handlers.update(
+      mockReq({ params: { boardViewId: "boardview_1" }, body: { baseLens: "decisions" } }),
+      mockRes()
     )
+    expect(mockUpdate).toHaveBeenCalledWith("ws_1", "usr_1", "boardview_1", { baseLens: "all" })
   })
 
   test("update renames a view", async () => {

--- a/apps/backend/src/features/board-views/handlers.ts
+++ b/apps/backend/src/features/board-views/handlers.ts
@@ -8,7 +8,6 @@ import {
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   MAX_BOARD_VIEW_NAME_LENGTH,
-  type BoardLens,
 } from "@threa/types"
 
 const boardViewParamsSchema = z.object({ boardViewId: z.string().min(1) })

--- a/apps/backend/src/features/board-views/handlers.ts
+++ b/apps/backend/src/features/board-views/handlers.ts
@@ -3,14 +3,21 @@ import type { Request, Response } from "express"
 import type { BoardViewService } from "./service"
 import { validateRequest } from "../../lib/validation"
 import {
-  BOARD_LENSES,
+  degradeBoardLens,
   BOARD_SCOPE_STREAM_TYPES,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   MAX_BOARD_VIEW_NAME_LENGTH,
+  type BoardLens,
 } from "@threa/types"
 
 const boardViewParamsSchema = z.object({ boardViewId: z.string().min(1) })
+
+/** A retired lens (`decisions`) degrades to the widest live lens instead of a
+ *  400: the frontend deploys before the backend and SW-cached bundles linger, so
+ *  an old bundle saving a view must get a saved view, not an error. Mirrors the
+ *  read-side `normalizeLens` and the conversations handler's degrade. */
+const baseLensSchema = z.string().transform(degradeBoardLens)
 
 const scopeStreamIdsSchema = z.array(z.string().min(1)).max(MAX_BOARD_SCOPE_STREAMS)
 const scopeStreamTypesSchema = z.array(z.enum(BOARD_SCOPE_STREAM_TYPES))
@@ -18,7 +25,7 @@ const scopeLabelIdsSchema = z.array(z.string().min(1)).max(MAX_BOARD_SCOPE_LABEL
 
 const createBoardViewSchema = z.object({
   name: z.string().trim().min(1).max(MAX_BOARD_VIEW_NAME_LENGTH),
-  baseLens: z.enum(BOARD_LENSES),
+  baseLens: baseLensSchema,
   scopeStreamIds: scopeStreamIdsSchema.optional().default([]),
   scopeStreamTypes: scopeStreamTypesSchema.optional().default([]),
   scopeLabelIds: scopeLabelIdsSchema.optional().default([]),
@@ -30,7 +37,7 @@ const createBoardViewSchema = z.object({
 const updateBoardViewSchema = z
   .object({
     name: z.string().trim().min(1).max(MAX_BOARD_VIEW_NAME_LENGTH).optional(),
-    baseLens: z.enum(BOARD_LENSES).optional(),
+    baseLens: baseLensSchema.optional(),
     scopeStreamIds: scopeStreamIdsSchema.optional(),
     scopeStreamTypes: scopeStreamTypesSchema.optional(),
     scopeLabelIds: scopeLabelIdsSchema.optional(),

--- a/apps/backend/src/features/board-views/repository.ts
+++ b/apps/backend/src/features/board-views/repository.ts
@@ -1,6 +1,6 @@
 import { sql, type Querier } from "../../db"
 import { boardViewId } from "../../lib/id"
-import { BOARD_LENSES, type BoardView, type BoardLens, type BoardScopeStreamType } from "@threa/types"
+import { degradeBoardLens, type BoardView, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 
 interface BoardViewRow {
   id: string
@@ -22,7 +22,7 @@ const SELECT =
  *  the single read boundary, so every consumer of a saved view (href,
  *  active-match, summary) sees a live lens. Mirrors `parseLensParam`. */
 function normalizeLens(value: string): BoardLens {
-  return (BOARD_LENSES as readonly string[]).includes(value) ? (value as BoardLens) : "all"
+  return degradeBoardLens(value)
 }
 
 function mapRow(row: BoardViewRow): BoardView {

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -156,8 +156,8 @@ describe("Conversation Handlers", () => {
     })
 
     test("threads the validated lens through to the service", async () => {
-      await handlers.listByWorkspace(mockReq({ query: { lens: "decisions" } }), mockRes())
-      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: "decisions" }))
+      await handlers.listByWorkspace(mockReq({ query: { lens: "mine" } }), mockRes())
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: "mine" }))
     })
 
     test("accepts the all lens as an explicit no-op filter", async () => {
@@ -166,7 +166,7 @@ describe("Conversation Handlers", () => {
     })
 
     test("degrades a retired lens to no lens condition instead of a 400", async () => {
-      await handlers.listByWorkspace(mockReq({ query: { lens: "needs-resolution" } }), mockRes())
+      await handlers.listByWorkspace(mockReq({ query: { lens: "decisions" } }), mockRes())
       expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", expect.objectContaining({ lens: undefined }))
     })
 

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -34,18 +34,6 @@ function boardLensCondSql(lens: BoardLens | undefined, userId: string) {
       )
     )`
   }
-  if (lens === "decisions") {
-    // Workspace-scoped (INV-8) and active-only, matching
-    // `MemoRepository.findConversationIdsWithMemos` and the file's
-    // `findActiveBySourceConversation` — an archived/superseded memo is no longer
-    // captured knowledge, so it must drop the conversation from the lens.
-    return composeSql`AND EXISTS (
-      SELECT 1 FROM memos
-      WHERE memos.source_conversation_id = conversations.id
-        AND memos.workspace_id = conversations.workspace_id
-        AND memos.status = 'active'
-    )`
-  }
   return sql``
 }
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -384,9 +384,10 @@ export class ConversationService {
       [...hydrateIds].map((id) => messageById.get(id)).filter((m): m is Message => Boolean(m))
     )
 
-    // The Decisions/Knowledge lens signal: which of these conversations produced a
-    // captured memo. One batch presence read (INV-56); a board-level field, not on
-    // the conversation aggregate the `conversation:*` events carry.
+    // `hasCapturedMemo` is kept for clients still running the retired Decisions
+    // lens from an SW-cached bundle — they filter on it client-side, so dropping
+    // it during the deploy window would blank their board. Removable next release.
+    // One batch presence read (INV-56).
     const conversationIdsWithMemos = await MemoRepository.findConversationIdsWithMemos(
       this.pool,
       workspaceId,

--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -53,8 +53,9 @@ describe("updatePreferencesSchema boardDefaultLens", () => {
     expect(updatePreferencesSchema.parse({ boardDefaultLens: "mine" }).boardDefaultLens).toBe("mine")
   })
 
-  it("rejects an unknown lens", () => {
-    expect(updatePreferencesSchema.safeParse({ boardDefaultLens: "everything" }).success).toBe(false)
+  it("degrades a retired or unknown lens to the default instead of rejecting the PATCH", () => {
+    expect(updatePreferencesSchema.parse({ boardDefaultLens: "decisions" }).boardDefaultLens).toBe("all")
+    expect(updatePreferencesSchema.parse({ boardDefaultLens: "everything" }).boardDefaultLens).toBe("all")
   })
 
   it("treats the field as optional", () => {

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -40,7 +40,7 @@ import {
   BOARD_LEAD_LINE_LENGTH_MIN,
   BOARD_LEAD_LINE_LENGTH_MAX,
   BOARD_MASS_BADGE_MODES,
-  BOARD_LENSES,
+  degradeBoardLens,
 } from "@threa/types"
 import { workScheduleSchema, statusPresetsSchema } from "../../lib/schemas"
 import { validateRequest } from "../../lib/validation"
@@ -113,7 +113,10 @@ const updatePreferencesSchema = z.object({
   boardLedgerRows: z.number().int().min(BOARD_LEDGER_ROWS_MIN).max(BOARD_LEDGER_ROWS_MAX).optional(),
   boardLeadLineLength: z.number().int().min(BOARD_LEAD_LINE_LENGTH_MIN).max(BOARD_LEAD_LINE_LENGTH_MAX).optional(),
   boardMassBadge: z.enum(BOARD_MASS_BADGE_MODES).optional(),
-  boardDefaultLens: z.enum(BOARD_LENSES).optional(),
+  // Degrades retired lens values (`decisions`) instead of 400ing: an SW-cached
+  // old bundle pinning a retired lens must not have its whole preferences PATCH
+  // rejected and rolled back. Same authority as board-views' baseLens.
+  boardDefaultLens: z.string().transform(degradeBoardLens).optional(),
   // A saved board view id (`boardview_…`) or null to clear. Non-empty, matching
   // the board-view endpoints' own id validation (board-views/handlers.ts); a
   // well-formed but stale id is accepted and degrades to the default lens

--- a/apps/backend/tests/integration/board-view-repository.test.ts
+++ b/apps/backend/tests/integration/board-view-repository.test.ts
@@ -37,7 +37,7 @@ describe("BoardViewRepository", () => {
       INSERT INTO board_views
         (id, workspace_id, user_id, name, base_lens, scope_stream_ids, scope_stream_types,
          scope_label_ids, exclude_stream_ids, exclude_stream_types, exclude_label_ids, sort_order)
-      VALUES (${id}, ${testWorkspaceId}, ${testUserId}, 'Legacy view', 'needs-resolution',
+      VALUES (${id}, ${testWorkspaceId}, ${testUserId}, 'Legacy view', 'decisions',
         '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], '{}'::text[], 0)
     `)
 

--- a/apps/backend/tests/integration/conversation-repository.test.ts
+++ b/apps/backend/tests/integration/conversation-repository.test.ts
@@ -470,15 +470,15 @@ describe("ConversationRepository", () => {
       }
     })
 
-    // A saved board view created before the status lenses were retired still holds
-    // `base_lens = 'active'` / `'needs-resolution'`. Those must degrade to `all`
+    // A saved board view created before the status/decisions lenses were retired
+    // still holds `base_lens = 'active'` / `'decisions'`. Those must degrade to `all`
     // (same rows, no filter, no throw), never to an empty board.
     test("a retired lens value still stored on a saved view returns exactly the `all` rows", async () => {
       const all = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
         lens: "all",
         limit: 100,
       })
-      for (const retired of ["active", "needs-resolution"] as unknown as BoardLens[]) {
+      for (const retired of ["active", "needs-resolution", "decisions"] as unknown as BoardLens[]) {
         const rows = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
           lens: retired,
           limit: 100,
@@ -518,19 +518,6 @@ describe("ConversationRepository", () => {
         { lens: "all", limit: 100 }
       )
       expect(strangerAll.map((r) => r.id)).toEqual(all.map((r) => r.id))
-    })
-
-    test("decisions lens keeps only conversations with an active captured memo", async () => {
-      const rows = await ConversationRepository.findByWorkspaceForViewer(pool, testWorkspaceId, testUserId, {
-        lens: "decisions",
-        limit: 100,
-      })
-      const ids = new Set(rows.map((r) => r.id))
-      expect(ids.has(decisionConv)).toBe(true)
-      expect(ids.has(activeConv)).toBe(false)
-      expect(ids.has(stalledConv)).toBe(false)
-      // An archived memo doesn't count — its conversation drops off.
-      expect(ids.has(archivedMemoConv)).toBe(false)
     })
   })
 

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -1,5 +1,5 @@
 import {
-  BOARD_LENSES,
+  degradeBoardLens,
   BOARD_SCOPE_STREAM_TYPES,
   DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
@@ -82,7 +82,7 @@ export const BOARD_FILTER_PARAMS = [
  *  preference renders the widest view rather than erroring or landing nowhere.
  *  The single degrade authority; `matchesBoardLens` mirrors it read-side. */
 export function parseLensParam(value: string | null): BoardLens {
-  return value && (BOARD_LENSES as readonly string[]).includes(value) ? (value as BoardLens) : DEFAULT_BOARD_LENS
+  return degradeBoardLens(value)
 }
 
 /**

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -121,7 +121,7 @@ describe("BoardModeBlock", () => {
     mountAt(`/w/${WS}/board`)
 
     expect(screen.getByText("Lenses")).toBeInTheDocument()
-    for (const label of ["All", "Decisions", "Mine"]) {
+    for (const label of ["All", "Mine"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument()
     }
   })
@@ -142,10 +142,10 @@ describe("BoardModeBlock", () => {
     expect(all.searchParams.get("in")).toBe("stream_1")
     expect(all.searchParams.get("label")).toBe("label_a")
 
-    const decisions = new URL(hrefOf("Decisions"), "http://x")
-    expect(decisions.pathname).toBe(`/w/${WS}/board`)
-    expect(decisions.searchParams.get("lens")).toBe("decisions")
-    expect(decisions.searchParams.get("in")).toBe("stream_1")
+    const mine = new URL(hrefOf("Mine"), "http://x")
+    expect(mine.pathname).toBe(`/w/${WS}/board`)
+    expect(mine.searchParams.get("lens")).toBe("mine")
+    expect(mine.searchParams.get("in")).toBe("stream_1")
   })
 
   it("every lens link carries an explicit ?lens=, never the bare entry alias", () => {
@@ -203,7 +203,7 @@ describe("BoardModeBlock", () => {
   it("renders per-lens counts from lensTotals, right-aligned inside each lens row", () => {
     stub()
     mountAt(`/w/${WS}/board`, {
-      lensTotals: { all: 14, decisions: 3, mine: 0 },
+      lensTotals: { all: 14, mine: 0 },
     })
 
     const all = screen.getByRole("link", { name: "All" })
@@ -216,7 +216,7 @@ describe("BoardModeBlock", () => {
     stub()
     mountAt(`/w/${WS}/board`, { lensTotals: null })
 
-    expect(screen.getByRole("link", { name: "Decisions" })).toHaveTextContent(/^Decisions$/)
+    expect(screen.getByRole("link", { name: "Mine" })).toHaveTextContent(/^Mine$/)
   })
 
   it("renders the Filters group with the stream and type pickers", () => {

--- a/apps/frontend/src/components/settings/appearance-settings.board-home.test.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.board-home.test.tsx
@@ -32,20 +32,16 @@ describe("AppearanceSettings — board home", () => {
   beforeEach(() => vi.restoreAllMocks())
   afterEach(() => vi.restoreAllMocks())
 
-  it("offers exactly the three board lenses", () => {
+  it("offers exactly the two board lenses", () => {
     mount("all")
     const options = screen.getAllByRole("radio").filter((el) => el.id.startsWith("board-home-lens-"))
-    expect(options.map((el) => el.id)).toEqual([
-      "board-home-lens-all",
-      "board-home-lens-decisions",
-      "board-home-lens-mine",
-    ])
+    expect(options.map((el) => el.id)).toEqual(["board-home-lens-all", "board-home-lens-mine"])
   })
 
   it("degrades a retired stored home lens to the default rather than selecting nothing", () => {
-    // A preference blob written before the status lenses were dropped still says
-    // `needs-resolution`. It must land on All, not blank the section or throw.
-    mount("needs-resolution")
+    // A preference blob written before the Decisions lens was dropped still says
+    // `decisions`. It must land on All, not blank the section or throw.
+    mount("decisions")
     expect(screen.getByText("Board home")).toBeInTheDocument()
     expect(document.getElementById("board-home-lens-all")).toHaveAttribute("data-state", "checked")
   })

--- a/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
+++ b/apps/frontend/src/hooks/use-board-sidebar-stats.test.ts
@@ -100,19 +100,19 @@ describe("aggregateBoardSidebarStats", () => {
     expect(lensTotals.all).toBe(1)
   })
 
-  it("computes per-lens totals via matchesBoardLens, keyed by exactly the three lenses", () => {
+  it("computes per-lens totals via matchesBoardLens, keyed by exactly the live lenses", () => {
     const { lensTotals } = aggregateBoardSidebarStats([
       post("c1", { streamId: "chan_a", status: "active", isMine: true }),
       post("c2", { streamId: "chan_a", status: "stalled", completenessScore: 1, idleHours: 0 }),
       post("c3", { streamId: "chan_a", status: "resolved", hasCapturedMemo: true }),
       post("c4", { streamId: "chan_b", status: "active", idleHours: 100, completenessScore: 1 }),
     ])
-    expect(lensTotals).toEqual({ all: 4, decisions: 1, mine: 1 })
+    expect(lensTotals).toEqual({ all: 4, mine: 1 })
   })
 
   it("returns empty tallies for an empty feed", () => {
     const { byStream, lensTotals } = aggregateBoardSidebarStats([])
     expect(byStream.size).toBe(0)
-    expect(lensTotals).toEqual({ all: 0, decisions: 0, mine: 0 })
+    expect(lensTotals).toEqual({ all: 0, mine: 0 })
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -74,14 +74,12 @@ function lensPost(
   opts: {
     status?: "active" | "stalled" | "resolved"
     completenessScore?: number
-    hasCapturedMemo?: boolean
     isMine?: boolean
   }
 ): CachedBoardPost {
   const base = post(id, activityMs)
   return {
     ...base,
-    hasCapturedMemo: opts.hasCapturedMemo ?? false,
     isMine: opts.isMine ?? false,
     conversation: {
       ...base.conversation,
@@ -284,15 +282,15 @@ describe("useStableBoardView", () => {
   })
 
   it("does not mark a committed card that is merely filtered out of the live subset", () => {
-    const withMemo = { ...post("m", 300), hasCapturedMemo: true } as CachedBoardPost
-    const plain = { ...post("a", 200), hasCapturedMemo: true } as CachedBoardPost
-    mockLive(feed(withMemo, plain))
+    const mine = { ...post("m", 300), isMine: true } as CachedBoardPost
+    const plain = { ...post("a", 200), isMine: true } as CachedBoardPost
+    mockLive(feed(mine, plain))
     const { result, rerender } = renderHook(() =>
-      useStableBoardView("ws_1", lensFilter("decisions"), undefined, undefined, undefined)
+      useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
     // "a" stops matching the lens but its row is still in the raw feed.
-    act(() => mockLive(feed(withMemo, { ...plain, hasCapturedMemo: false } as CachedBoardPost)))
+    act(() => mockLive(feed(mine, { ...plain, isMine: false } as CachedBoardPost)))
     rerender()
     expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
     expect([...result.current.removedIds]).toEqual([])
@@ -310,20 +308,18 @@ describe("useStableBoardView", () => {
     expect(result.current.posts.map((p) => p.id)).toEqual(["z"])
   })
 
-  it("shows only the lens's matching cards — decisions keeps captured-memo posts", () => {
-    const withMemo = { ...post("m", 300), hasCapturedMemo: true } as CachedBoardPost
-    const without = { ...post("n", 200), hasCapturedMemo: false } as CachedBoardPost
-    mockLive(feed(withMemo, without))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", lensFilter("decisions"), undefined, undefined, undefined)
-    )
+  it("shows only the lens's matching cards — mine keeps the viewer's own posts", () => {
+    const mine = { ...post("m", 300), isMine: true } as CachedBoardPost
+    const other = { ...post("n", 200), isMine: false } as CachedBoardPost
+    mockLive(feed(mine, other))
+    const { result } = renderHook(() => useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["m"])
   })
 
   it("resets the committed view when the lens changes", () => {
-    const withMemo = { ...post("m", 300), hasCapturedMemo: true } as CachedBoardPost
-    const plain = { ...post("a", 250), hasCapturedMemo: false } as CachedBoardPost
-    mockLive(feed(withMemo, plain))
+    const mine = { ...post("m", 300), isMine: true } as CachedBoardPost
+    const plain = { ...post("a", 250), isMine: false } as CachedBoardPost
+    mockLive(feed(mine, plain))
     const { result, rerender } = renderHook(
       ({ lens }) => useStableBoardView("ws_1", lensFilter(lens), undefined, undefined, undefined),
       {
@@ -331,60 +327,61 @@ describe("useStableBoardView", () => {
       }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
-    rerender({ lens: "decisions" })
-    // Fresh frozen view for the new lens — only the captured-memo card, not the
+    rerender({ lens: "mine" })
+    // Fresh frozen view for the new lens — only the viewer's own card, not the
     // previous lens's committed order.
     expect(result.current.posts.map((p) => p.id)).toEqual(["m"])
   })
 
-  it("commits the new lens's feed wholesale across disjoint subsets — no stranding behind the pill", () => {
-    // The bug this guards: switching between two lenses with disjoint subsets where
-    // a fresh card of the new lens sits ABOVE the old lens's committed floor. `s`
-    // is the only Mine card (floor 300); `d` is a Decisions card above it (400)
-    // that isn't a Mine card. Reconciling `d` against the stale `{s}` committed
-    // strands it behind an empty "N new" pill; folding the reset into the
-    // reconcile input commits `d` immediately instead.
-    const mine = lensPost("s", 300, { isMine: true })
-    const decision = lensPost("d", 400, { hasCapturedMemo: true })
-    mockLive(feed(mine, decision))
+  it("commits the new view's feed wholesale across disjoint subsets — no stranding behind the pill", () => {
+    // The bug this guards: switching between two views with disjoint subsets where
+    // a fresh card of the new view sits ABOVE the old view's committed floor. `s`
+    // is the only Mine card (floor 300, in chan_a); `d` sits above it (400) in
+    // chan_b and isn't a Mine card. Reconciling `d` against the stale `{s}`
+    // committed strands it behind an empty "N new" pill; folding the reset into
+    // the reconcile input commits `d` immediately instead.
+    const mine = { ...lensPost("s", 300, { isMine: true }), rootStreamId: "chan_a" } as CachedBoardPost
+    const other = { ...lensPost("d", 400, {}), rootStreamId: "chan_b" } as CachedBoardPost
+    mockLive(feed(mine, other))
     const { result, rerender } = renderHook(
-      ({ lens }) => useStableBoardView("ws_1", lensFilter(lens), undefined, undefined, undefined),
+      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
       {
-        initialProps: { lens: "mine" as BoardLens },
+        initialProps: { filter: lensFilter("mine") },
       }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
-    rerender({ lens: "decisions" })
+    rerender({ filter: scopeFilter(["chan_b"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["d"])
     expect(result.current.newCount).toBe(0)
   })
 
-  it("buffers a fresh new-lens arrival after a mixing-prone switch — no phantom absorption", () => {
-    // Guards the "mixing ids" path the fix names: on the switch a new-lens card
-    // sits BELOW the old lens's floor, so reconciling against the STALE committed
+  it("buffers a fresh new-view arrival after a mixing-prone switch — no phantom absorption", () => {
+    // Guards the "mixing ids" path the fix names: on the switch a new-view card
+    // sits BELOW the old view's floor, so reconciling against the STALE committed
     // (the pre-fix bug) mixes the old id into `committed.order`. That phantom id
     // then silently absorbs the SAME conversation when it later qualifies for the
-    // new lens (classified "already committed"), so its fresh arrival never shows
+    // new view (classified "already committed"), so its fresh arrival never shows
     // behind the "N new" pill. Feeding the reset (EMPTY_VIEW) into the reconcile
     // leaves no phantom, so the later arrival buffers. Fails on the pre-fix code.
-    const mine = lensPost("s", 300, { isMine: true }) // mine only
-    const decisionLow = lensPost("x", 200, { hasCapturedMemo: true }) // decisions, below s's floor
-    mockLive(feed(mine, decisionLow))
+    const scoped = { ...lensPost("s", 300, {}), rootStreamId: "chan_a" } as CachedBoardPost // chan_a only
+    const mineLow = { ...lensPost("x", 200, { isMine: true }), rootStreamId: "chan_b" } as CachedBoardPost // mine, below s's floor
+    mockLive(feed(scoped, mineLow))
     const { result, rerender } = renderHook(
-      ({ lens }) => useStableBoardView("ws_1", lensFilter(lens), undefined, undefined, undefined),
+      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
       {
-        initialProps: { lens: "mine" as BoardLens },
+        initialProps: { filter: scopeFilter(["chan_a"]) },
       }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
-    rerender({ lens: "decisions" })
+    rerender({ filter: lensFilter("mine") })
     expect(result.current.posts.map((p) => p.id)).toEqual(["x"])
 
-    // `s` gains a memo with fresh activity — a genuine new arrival on decisions.
-    const mineWithMemo = lensPost("s", 500, { isMine: true, hasCapturedMemo: true })
-    act(() => mockLive(feed(mineWithMemo, decisionLow)))
-    rerender({ lens: "decisions" })
+    // The viewer is `@`-mentioned on `s` with fresh activity — a genuine new
+    // arrival on Mine.
+    const nowMine = { ...lensPost("s", 500, { isMine: true }), rootStreamId: "chan_a" } as CachedBoardPost
+    act(() => mockLive(feed(nowMine, mineLow)))
+    rerender({ filter: lensFilter("mine") })
     // The fresh `s` waits behind the pill; it is not absorbed in-place.
     expect(result.current.newCount).toBe(1)
     expect(result.current.posts.map((p) => p.id)).toEqual(["x"])
@@ -392,19 +389,19 @@ describe("useStableBoardView", () => {
 
   it("keeps an acted-on card in place when it stops matching the lens (never yanked)", () => {
     // The steer this encodes: a card can stop MATCHING the lens after an update
-    // (here its memo is archived, so it leaves Decisions) — but a filter must
-    // never yank what's on screen. The committed card keeps rendering (retained)
-    // until the viewer commits a fresh view themselves.
-    const decision = lensPost("s", 300, { hasCapturedMemo: true })
-    const idle = lensPost("i", 200, { hasCapturedMemo: true })
-    mockLive(feed(decision, idle))
+    // (here the mention that made it the viewer's is deleted, so it leaves Mine)
+    // — but a filter must never yank what's on screen. The committed card keeps
+    // rendering (retained) until the viewer commits a fresh view themselves.
+    const mine = lensPost("s", 300, { isMine: true })
+    const idle = lensPost("i", 200, { isMine: true })
+    mockLive(feed(mine, idle))
     const { result, rerender } = renderHook(() =>
-      useStableBoardView("ws_1", lensFilter("decisions"), undefined, undefined, undefined)
+      useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["s", "i"])
 
-    // `s`'s memo is archived with fresh activity — it no longer matches the lens.
-    act(() => mockLive(feed(lensPost("s", 900, { hasCapturedMemo: false }), idle)))
+    // The mention on `s` is deleted with fresh activity — it no longer matches.
+    act(() => mockLive(feed(lensPost("s", 900, { isMine: false }), idle)))
     rerender()
     // Still rendered in place, and not counted as "new".
     expect(result.current.posts.map((p) => p.id)).toEqual(["s", "i"])
@@ -419,21 +416,21 @@ describe("useStableBoardView", () => {
     // Posting from a filtered board navigates back to the All home (the new post
     // might not match the filter); the pending optimistic card reveals itself at
     // top there via reconcile, no arm to carry across the reset.
-    const decision = lensPost("s", 300, { hasCapturedMemo: true })
-    mockLive(feed(decision))
+    const mine = lensPost("s", 300, { isMine: true })
+    mockLive(feed(mine))
     const { result, rerender } = renderHook(
       ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
       {
-        initialProps: { filter: lensFilter("decisions") },
+        initialProps: { filter: lensFilter("mine") },
       }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
     // Navigate to All, then the authored card lands after the fresh view's commit.
     rerender({ filter: ALL })
-    act(() => mockLive(feed(pendingPost("mine", 900), decision)))
+    act(() => mockLive(feed(pendingPost("own", 900), mine)))
     rerender({ filter: ALL })
-    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "s"])
+    expect(result.current.posts.map((p) => p.id)).toEqual(["own", "s"])
     expect(result.current.newCount).toBe(0)
   })
 
@@ -1089,7 +1086,7 @@ describe("useStableBoardView seed gate", () => {
   it("commits a filter switch instantly once this workspace has committed (the gate is per-workspace)", () => {
     mockLive(
       feed(
-        lensPost("decided", 300, { hasCapturedMemo: true }),
+        lensPost("decided", 300, { isMine: true }),
         lensPost("plain", 200, { status: "active", completenessScore: 5 })
       )
     )
@@ -1100,7 +1097,7 @@ describe("useStableBoardView seed gate", () => {
     expect(result.current.posts.map((p) => p.id)).toEqual(["decided", "plain"])
 
     // The new lens's query is still fetching — the lens must still switch now.
-    rerender({ lens: "decisions" as BoardLens, seed: { settled: false, newest: { id: "x", activityMs: 1 } } })
+    rerender({ lens: "mine" as BoardLens, seed: { settled: false, newest: { id: "x", activityMs: 1 } } })
     expect(result.current.posts.map((p) => p.id)).toEqual(["decided"])
     expect(result.current.isLoading).toBe(false)
   })

--- a/apps/frontend/src/lib/board/lens-defs.ts
+++ b/apps/frontend/src/lib/board/lens-defs.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react"
-import { BookMarked, LayoutGrid, User } from "lucide-react"
+import { LayoutGrid, User } from "lucide-react"
 import { type BoardLens } from "@threa/types"
 
 export interface BoardLensDef {
@@ -17,12 +17,6 @@ export interface BoardLensDef {
  */
 export const BOARD_LENS_DEFS: Record<BoardLens, BoardLensDef> = {
   all: { value: "all", label: "All", description: "Everything, newest activity first", icon: LayoutGrid },
-  decisions: {
-    value: "decisions",
-    label: "Decisions",
-    description: "Settled — captured as a memo",
-    icon: BookMarked,
-  },
   mine: {
     value: "mine",
     label: "Mine",

--- a/apps/frontend/src/lib/last-location.test.ts
+++ b/apps/frontend/src/lib/last-location.test.ts
@@ -43,6 +43,7 @@ describe("sanitizeBoardSearch", () => {
 
   it("degrades a retired lens value in a persisted last-location to `all`", () => {
     expect(sanitizeBoardSearch("?lens=needs-resolution&in=stream_a")).toBe("?lens=all&in=stream_a")
+    expect(sanitizeBoardSearch("?lens=decisions&in=stream_a")).toBe("?lens=all&in=stream_a")
   })
 
   it("strips panel, m, and unrelated params", () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -70,12 +70,6 @@ import {
   type ConversationWithStaleness,
 } from "@threa/types"
 
-/** Lenses that always contain the viewer's own fresh post: `all` (everything)
- *  and `mine` (a self-authored conversation is `isMine`). `decisions` gates on a
- *  memo a brand-new post doesn't have yet, so posting from it routes back to All
- *  so the author's card always surfaces. */
-const SELF_POST_VISIBLE_LENSES = new Set<BoardLens>(["all", "mine"])
-
 /** Stable empty set so a fresh unread session never re-renders on identity alone. */
 const EMPTY_CLEARED_UNREAD: ReadonlySet<string> = new Set()
 
@@ -92,15 +86,11 @@ const REVEAL_PREWARM_CARDS = 12
  *  one skeleton-length beat beyond the skeleton's own appearance. */
 const SEED_COMMIT_TIMEOUT_MS = SKELETON_DELAY_MS * 2
 
-/** Empty-state copy per lens — an empty Decisions view isn't "nothing on the board". */
+/** Empty-state copy per lens — an empty Mine view isn't "nothing on the board". */
 const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {
   all: {
     title: "Nothing on the board yet",
     body: "As your conversations build up, the topics worth returning to surface here, newest activity first.",
-  },
-  decisions: {
-    title: "No decisions captured yet",
-    body: "When a conversation produces a memo — a decision, a fact worth keeping — it surfaces here as settled knowledge.",
   },
   mine: {
     title: "Nothing here for you yet",
@@ -161,7 +151,7 @@ function groupByRecency(posts: BoardViewPost[], activityById: Map<string, number
  * message-led post) ordered by recent activity, grouped into recency sections.
  *
  * Route is `/w/:workspaceId/board`; the whole view is query state (INV-59). The
- * lens rides `?lens=` (`all`, `decisions`, `mine`
+ * lens rides `?lens=` (`all`, `mine`
  * — board-view-design.md § "Lenses"; absent or unknown degrades to `all`), the
  * stream scope rides `?in=`, and every rendered board URL carries an explicit
  * `?lens=`. The bare query-less `/board` is only an entry alias: it redirects
@@ -575,7 +565,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
 
   // Changing lens OR scope replaces the feed with a different (often much
   // shorter) subset, so jump to the top pre-paint — otherwise a viewer scrolled
-  // down the All wall who taps Decisions lands past the end of a one-card list.
+  // down the All wall who narrows the view lands past the end of a short list.
   const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}|${unreadOnly ? "unread" : ""}`
   useLayoutEffect(() => {
     closeAllRevealWindows()
@@ -595,10 +585,10 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
 
   const navigate = useNavigate()
   // "Show everything" / the own-post-must-surface baseline is **All**, not the
-  // viewer's home: a fresh post is no Decision (and needn't be Active), so only
-  // the widest lens guarantees the author's own card appears (design § "your own
-  // action always surfaces"). Explicit `?lens=all` — never the bare entry alias —
-  // with the non-filter query state (an open `?panel=`) riding along.
+  // viewer's home: only the widest lens guarantees the author's own card appears
+  // (design § "your own action always surfaces"). Explicit `?lens=all` — never
+  // the bare entry alias — with the non-filter query state (an open `?panel=`)
+  // riding along.
   const boardEverything = {
     pathname: `/w/${workspaceId}/board`,
     search: clearFiltersSearch(searchParams.toString()),
@@ -630,12 +620,15 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     // current view can contain it — an unfiltered `all`/`mine` lens — so stay
     // put there (a `mine` home shouldn't bounce the author off their own home),
     // but jump to the top so the prepended card and its flash are on-screen even
-    // if the viewer had scrolled down. Any other view (a status/memo lens, or an
-    // active scope filter) might not match the fresh post, so return to the All
+    // if the viewer had scrolled down. A filtered view might not match the fresh
+    // post, so return to the All
     // baseline; the optimistic card (written `_status: "pending"`) reveals itself
     // at top there via `reconcileStableView`, and `navigate` scrolls to top via
     // the `resetKey` layout effect.
-    const currentViewSurfacesOwnPost = SELF_POST_VISIBLE_LENSES.has(lens) && !hasFilterParams
+    // Every live lens contains the viewer's own fresh post (`all` shows
+    // everything, `mine` matches its author), so only an active scope filter can
+    // hide it.
+    const currentViewSurfacesOwnPost = !hasFilterParams
     if (currentViewSurfacesOwnPost) {
       closeAllRevealWindows()
       if (scrollerRef.current) scrollerRef.current.scrollTop = 0

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -194,8 +194,9 @@ right, so split the dials in two:
 - **Active** — `status = active`: still in motion, not stalled or resolved.
 - **Needs resolution** — `status = stalled`, or high `temporalStaleness` with
   low `completenessScore`. Loose ends, things hanging.
-- **Decisions / Knowledge** — conversations with a captured memo
-  (`source_conversation_id`, `knowledgeType` decision/fact). What got settled.
+- ~~**Decisions / Knowledge**~~ — retired 2026-08-03 (unused in practice; memo
+  discovery lives in the memory explorer). Stored `decisions` values degrade to
+  All via `degradeBoardLens`.
 
 **Personal lenses (per-viewer — "matters to _you_"):**
 

--- a/packages/types/src/board-lens.test.ts
+++ b/packages/types/src/board-lens.test.ts
@@ -32,11 +32,6 @@ describe("matchesBoardLens", () => {
     expect(matchesBoardLens(post({ hoursIdle: 0 }), "all")).toBe(true)
   })
 
-  it("decisions accepts only captured-memo posts", () => {
-    expect(matchesBoardLens(post({ hasCapturedMemo: true }), "decisions")).toBe(true)
-    expect(matchesBoardLens(post({ hasCapturedMemo: false }), "decisions")).toBe(false)
-  })
-
   it("mine accepts only the viewer's own posts (server-precomputed isMine)", () => {
     expect(matchesBoardLens(post({ isMine: true }), "mine")).toBe(true)
     expect(matchesBoardLens(post({ isMine: false }), "mine")).toBe(false)
@@ -46,8 +41,9 @@ describe("matchesBoardLens", () => {
   })
 
   it("a retired lens value still stored on a saved view degrades to `all`, never hides or throws", () => {
-    for (const retired of ["active", "needs-resolution", "nonsense"] as unknown as BoardLens[]) {
+    for (const retired of ["active", "needs-resolution", "decisions", "nonsense"] as unknown as BoardLens[]) {
       expect(matchesBoardLens(post({ status: "resolved", hasCapturedMemo: false, isMine: false }), retired)).toBe(true)
+      expect(matchesBoardLens(post({ hasCapturedMemo: true, isMine: false }), retired)).toBe(true)
       expect(matchesBoardLens(post({ status: "stalled", hoursIdle: 99, completenessScore: 7 }), retired)).toBe(true)
     }
   })

--- a/packages/types/src/board-lens.ts
+++ b/packages/types/src/board-lens.ts
@@ -1,5 +1,17 @@
-import type { BoardLens } from "./constants"
+import { BOARD_LENSES, DEFAULT_BOARD_LENS, type BoardLens } from "./constants"
 import type { BoardPost } from "./domain"
+
+/**
+ * The single degrade authority for lens values arriving from outside the live
+ * set — retired values (`decisions`), stale prefs, saved rows, old bundles.
+ * Every write path (board-views, user-preferences) and read boundary maps
+ * through this so a retired lens always means "widest live lens", never a 400.
+ */
+export function degradeBoardLens(value: unknown): BoardLens {
+  return typeof value === "string" && (BOARD_LENSES as readonly string[]).includes(value)
+    ? (value as BoardLens)
+    : DEFAULT_BOARD_LENS
+}
 
 /**
  * Whether a board post belongs on a lens — the read-side authority the board
@@ -8,19 +20,16 @@ import type { BoardPost } from "./domain"
  * lens the client then hides, or vice versa.
  *
  *  - `all` — everything, by recency. The default home; never hides anything.
- *  - `decisions` — produced a captured memo (`hasCapturedMemo`). What got settled.
  *  - `mine` — the viewer authored/participates in it or was `@`-mentioned
- *    (`isMine`, precomputed server-side like `hasCapturedMemo`). For you.
+ *    (`isMine`, precomputed server-side). For you.
  *
  * A lens value outside the list behaves as `all`: saved `board_views.base_lens`
- * rows and persisted last-locations still hold retired lens values, and a stale
- * filter must degrade to showing everything, never hide rows or throw. Mirrors
- * `parseLensParam`'s degrade.
+ * rows and persisted last-locations still hold retired lens values (`decisions`),
+ * and a stale filter must degrade to showing everything, never hide rows or
+ * throw. Mirrors `parseLensParam`'s degrade.
  */
 export function matchesBoardLens(post: BoardPost, lens: BoardLens): boolean {
   switch (lens) {
-    case "decisions":
-      return post.hasCapturedMemo === true
     case "mine":
       return post.isMine === true
     default:

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -483,10 +483,11 @@ export const MAX_BOARD_VIEW_NAME_LENGTH = 60
  * the dials, it doesn't decide what matters. `all` is the default and always
  * available: the board's job is to SURFACE, so the home view shows everything
  * and a lens is an optional narrowing the viewer opts into, never a mode they
- * must opt out of. Same signal for every viewer (personal lenses like Mine
- * come later). Ordered as they render in the lens picker.
+ * must opt out of. Ordered as they render in the lens picker. Retired values
+ * (`decisions`) may still sit in saved views and persisted URLs — every read
+ * boundary degrades them to `all` rather than throwing.
  */
-export const BOARD_LENSES = ["all", "decisions", "mine"] as const
+export const BOARD_LENSES = ["all", "mine"] as const
 export type BoardLens = (typeof BOARD_LENSES)[number]
 
 /** The board's home view: everything, newest activity first, nothing hidden. */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -832,16 +832,10 @@ export interface BoardPost {
    */
   streamIds: string[]
   /**
-   * Whether this conversation has at least one active captured memo — the
-   * Decisions/Knowledge lens signal (board-view-design.md § "Lenses"). A
-   * board-level field, not part of the conversation aggregate, because it comes
-   * from a memos join the pure `conversation:*` event payload never carries, so
-   * the board card preserves it across live merges. It's therefore only as fresh
-   * as the last fetch: a newly-captured memo surfaces on Decisions after a refetch
-   * (board refetches on mount/reconnect), and — the reverse — a memo leaving
-   * `active` (archive/supersede, not currently user-reachable) leaves a stale
-   * `true` until a lens fetch that still returns the row reseeds it. Both are the
-   * accepted staleness window until a live memo→board signal lands.
+   * Whether this conversation has at least one active captured memo. Was the
+   * retired Decisions lens's signal; kept one release so SW-cached bundles that
+   * still filter that lens client-side keep working — removable next release
+   * (see the memo batch read in conversations/service.ts).
    */
   hasCapturedMemo: boolean
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -335,7 +335,7 @@ export {
 } from "./markdown-strip"
 
 // Board lens predicate (shared FE filter / BE seed, board-view-design.md § "Lenses")
-export { matchesBoardLens } from "./board-lens"
+export { matchesBoardLens, degradeBoardLens } from "./board-lens"
 
 // Domain entities (wire format)
 export { getAvatarUrl, getBotAvatarUrl, getPersonaAvatarUrl } from "./domain"


### PR DESCRIPTION
## Problem

Kris: "Let's remove the decisions lens, it doesn't quite work and I'm not sure how to use it so I wouldn't use it." The lens gated on `hasCapturedMemo` (a memos join) and had its own SQL branch, empty-state copy, icon, and pin surface — all carrying a concept nobody uses.

## Solution

- `BOARD_LENSES = ["all", "mine"]`; the `matchesBoardLens` decisions case, the backend memo-`EXISTS` branch (`boardLensCondSql`), the `BOARD_LENS_DEFS`/`LENS_EMPTY_COPY` entries, and `SELF_POST_VISIBLE_LENSES` (vacuous with two self-visible lenses; the post-routing gate is now `!hasFilterParams`, provably the identical predicate) are deleted. The `Record<BoardLens,…>` types enumerated every site.
- **Retired values never 400.** One shared `degradeBoardLens` (packages/types, beside `matchesBoardLens`) is now the write-side authority for all three lens write paths — board-views `baseLens` create/update and user-preferences `boardDefaultLens` (adversarial verify caught that third path: a stale bundle pinning Decisions would have had its whole optimistic preferences PATCH rejected and rolled back, `boardDefaultViewId` included). Read boundaries (`parseLensParam`, `normalizeLens`, `sanitizeBoardSearch`) already degraded.
- **Deploy window held open deliberately:** `hasCapturedMemo` and its per-page memo query stay one release — SW-cached old bundles still filter the Decisions lens client-side over that flag; removing it would blank their board. Documented at both sites; removable next release.
- Product note: a saved "Decisions + filters" view silently broadens to "All + filters" (name and scope preserved); persisted `?lens=decisions` URLs and prefs degrade the same way.

## Test plan

- [x] Adversarial verify (Opus high): 1 finding (the prefs write path), fixed; deploy-window matrix, gate equivalence, and test-retarget coverage all re-derived clean
- [x] Targeted: types 154, backend board-views/conversations/user-preferences + integration 123, frontend 120 over 5 files; both tscs clean
- [x] Falsified: both write-path degrades reverted to `z.enum` → exactly their tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788354129&installation_model_id=20758&pr_number=1752&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1752&signature=b49935c4c8120d4f3eb5338214f5b085678573f03ea4a9bda847b9a07558972b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->