### PR TITLE
feat(board): All clears filters; lens pin joins the row actions menu

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -137,15 +137,24 @@ describe("BoardModeBlock", () => {
     stub()
     mountAt(`/w/${WS}/board?lens=mine&in=stream_1&label=label_a`)
 
-    const all = new URL(hrefOf("All"), "http://x")
-    expect(all.searchParams.get("lens")).toBe("all")
-    expect(all.searchParams.get("in")).toBe("stream_1")
-    expect(all.searchParams.get("label")).toBe("label_a")
-
     const mine = new URL(hrefOf("Mine"), "http://x")
     expect(mine.pathname).toBe(`/w/${WS}/board`)
     expect(mine.searchParams.get("lens")).toBe("mine")
     expect(mine.searchParams.get("in")).toBe("stream_1")
+  })
+
+  it("the All lens clears every filter while keeping unrelated URL state", () => {
+    stub()
+    mountAt(`/w/${WS}/board?lens=mine&in=stream_1&label=label_a&unread=true&archived=true&panel=p_1`)
+
+    const all = new URL(hrefOf("All"), "http://x")
+    expect(all.pathname).toBe(`/w/${WS}/board`)
+    expect(all.searchParams.get("lens")).toBe("all")
+    expect(all.searchParams.get("in")).toBeNull()
+    expect(all.searchParams.get("label")).toBeNull()
+    expect(all.searchParams.get("unread")).toBeNull()
+    expect(all.searchParams.get("archived")).toBeNull()
+    expect(all.searchParams.get("panel")).toBe("p_1")
   })
 
   it("every lens link carries an explicit ?lens=, never the bare entry alias", () => {
@@ -264,8 +273,21 @@ describe("BoardModeBlock", () => {
     const { updatePreferences } = stub({ boardDefaultLens: "all" })
     mountAt(`/w/${WS}/board?lens=all`)
 
-    await user.click(screen.getByRole("button", { name: "Set Mine as board home" }))
+    await user.click(screen.getByRole("button", { name: "Actions for Mine" }))
+    await user.click(await screen.findByRole("menuitem", { name: /Set as board home/ }))
     expect(updatePreferences).toHaveBeenCalledWith({ boardDefaultLens: "mine", boardDefaultViewId: null })
+  })
+
+  it("shows the filled pin glyph on the lens that is the board home", () => {
+    stub({ boardDefaultLens: "mine" })
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    expect(screen.getByRole("link", { name: "Mine" }).querySelector("svg.fill-current")).not.toBeNull()
+    expect(screen.getByRole("link", { name: "All" }).querySelector("svg.fill-current")).toBeNull()
+    // Home state must live in the accessibility tree, not only the glyph: the
+    // actions trigger's label carries it for focus/AT users.
+    expect(screen.getByRole("button", { name: "Actions for Mine (board home)" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Actions for All" })).toBeInTheDocument()
   })
 
   it("pinning a saved view writes the home-view preference", async () => {

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { Link, useLocation, useSearchParams } from "react-router-dom"
 import { Archive, Bookmark, Check, MoreHorizontal, Pencil, Pin, Trash2 } from "lucide-react"
-import { BOARD_LENSES, type BoardLens, type BoardScopeStreamType } from "@threa/types"
+import { BOARD_LENSES, DEFAULT_BOARD_LENS, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useSidebar, usePreferencesOptional } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { useBoardHome, useBoardViews, useDeleteBoardView, useUpdateBoardView } from "@/hooks/use-board-views"
@@ -31,6 +31,7 @@ import {
   BOARD_LABEL_PARAM,
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
+  clearFiltersSearch,
   parseLensParam,
 } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
@@ -190,7 +191,11 @@ export function BoardModeBlock({ workspaceId, lensTotals, unreadStreamCount }: B
               )}
             >
               <Link
-                to={lensHref(workspaceId, value, location.search)}
+                to={
+                  value === DEFAULT_BOARD_LENS
+                    ? `/w/${workspaceId}/board${clearFiltersSearch(location.search)}`
+                    : lensHref(workspaceId, value, location.search)
+                }
                 onClick={collapseOnMobile}
                 aria-current={active ? "true" : undefined}
                 className={cn(
@@ -198,7 +203,13 @@ export function BoardModeBlock({ workspaceId, lensTotals, unreadStreamCount }: B
                   !active && "text-muted-foreground"
                 )}
               >
-                <Icon className="h-4 w-4 shrink-0" />
+                {/* aria-hidden: the row's accessible name stays the lens label —
+                    home state is announced by the actions trigger's label. */}
+                {isHome ? (
+                  <Pin aria-hidden className="h-4 w-4 shrink-0 fill-current" />
+                ) : (
+                  <Icon className="h-4 w-4 shrink-0" />
+                )}
                 <span className="min-w-0 flex-1 truncate">{def.label}</span>
                 {count !== null && (
                   <span aria-hidden className="shrink-0 text-xs tabular-nums text-muted-foreground">
@@ -206,21 +217,25 @@ export function BoardModeBlock({ workspaceId, lensTotals, unreadStreamCount }: B
                   </span>
                 )}
               </Link>
-              {/* Always laid out, faint until home — pinning a lens as the board
-                  home mirrors the appearance-settings radio; silent per INV-63
-                  (the fill is the signal), fixed footprint per INV-21. */}
-              <button
-                type="button"
-                onClick={() => void prefs?.updatePreferences({ boardDefaultLens: value, boardDefaultViewId: null })}
-                aria-pressed={isHome}
-                aria-label={isHome ? `${def.label} is your board home` : `Set ${def.label} as board home`}
-                className={cn(
-                  "ml-1 shrink-0 rounded p-1 transition-colors",
-                  isHome ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
-                )}
-              >
-                <Pin className={cn("h-3.5 w-3.5", isHome && "fill-current")} />
-              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={isHome ? `Actions for ${def.label} (board home)` : `Actions for ${def.label}`}
+                    className="shrink-0 rounded p-1.5 text-muted-foreground/40 transition-colors hover:text-foreground focus-visible:text-foreground group-hover:text-muted-foreground data-[state=open]:text-foreground"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={() => void prefs?.updatePreferences({ boardDefaultLens: value, boardDefaultViewId: null })}
+                  >
+                    <Pin className={cn("mr-2 h-4 w-4", isHome && "fill-current")} />
+                    {isHome ? "Board home" : "Set as board home"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           )
         })}


### PR DESCRIPTION
## Problem

Two lens-row nits from dogfood: clicking **All** with a saved view's filters active kept the filters (only the lens flipped — "if I press the lens All, it should clear the filters"), and the board-home pin was a bare always-visible button on lens rows while saved-view rows put the same action in an actions dropdown.

## Solution

- The All row links through `clearFiltersSearch` — every filter axis plus archived/unread cleared, the open `?panel=` kept. Other lenses keep carrying the current filters (deliberate: narrowing lenses compose with filters; All is the reset).
- The pin moved into the identical `⋯` dropdown the view rows use (same trigger classes, single Pin item). The home lens keeps a filled pin as its row glyph, and — adversarial-verify finding — the trigger's label carries the state ("Actions for Mine (board home)") so home state stays in the accessibility tree; the removed button had `aria-pressed` and the glyph alone is `aria-hidden`.

## Test plan

- [x] Adversarial verify (Opus high): 1 finding (a11y state loss), fixed; cleared the unread-floor interaction on All-clear, view-active deactivation, touch reachability, and test scoping
- [x] Targeted: board-mode-block 20/20 (incl. clear-keeps-panel, filled-pin + state-bearing-label assertions), tsc clean
- [x] Falsified: component reverted to HEAD copy → 3 tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788354742&installation_model_id=20758&pr_number=1753&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1753&signature=d84d983f53fc375d8e028223a1d0e3133eda1ee239b94313aea9c4a0c19714ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->