### PR TITLE
feat(board): section headers filter the board; With-drafts filter

### DIFF
--- a/apps/frontend/src/components/board/board-filter-params.test.ts
+++ b/apps/frontend/src/components/board/board-filter-params.test.ts
@@ -205,6 +205,12 @@ describe("drafts filter", () => {
 describe("clearAxisSearch", () => {
   it("drops one axis and keeps everything else", () => {
     expect(clearAxisSearch("?lens=all&label=l1&is=dm", "label")).toBe("?lens=all&is=dm")
-    expect(clearAxisSearch("?in=a", "in")).toBe("")
+  })
+
+  it("never yields a bare search — clearing the last axis pins an explicit lens", () => {
+    // An empty search is the board's home-redirect alias; a saved home would
+    // teleport the user instead of showing the unfiltered board.
+    expect(clearAxisSearch("?in=a", "in")).toBe("?lens=all")
+    expect(clearAxisSearch("?lens=mine&in=a", "in")).toBe("?lens=mine")
   })
 })

--- a/apps/frontend/src/components/board/board-filter-params.test.ts
+++ b/apps/frontend/src/components/board/board-filter-params.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { MAX_BOARD_SCOPE_STREAMS } from "@threa/types"
 import {
+  clearAxisSearch,
+  clearDraftsSearch,
   clearFiltersSearch,
+  draftsFocusSearch,
   focusScopeSearch,
   isSoleInclude,
   labelFocusSearch,
@@ -178,5 +181,30 @@ describe("removeAxisValueSearch", () => {
   it("drops one value from a list param and keeps the others and unrelated params", () => {
     expect(removeAxisValueSearch("?in=a,b,c&is=dm", "in", "b")).toBe("?in=a%2Cc&is=dm")
     expect(removeAxisValueSearch("?not-label=l1&panel=x", "not-label", "l1")).toBe("?panel=x")
+  })
+})
+
+describe("drafts filter", () => {
+  it("focuses the drafts axis without touching any other", () => {
+    expect(draftsFocusSearch("?lens=mine&in=a&panel=x")).toBe("?lens=mine&in=a&panel=x&drafts=true")
+  })
+
+  it("is idempotent — re-focusing an already-on drafts filter changes nothing", () => {
+    expect(draftsFocusSearch("?drafts=true&lens=all")).toBe("?drafts=true&lens=all")
+  })
+
+  it("clears only the drafts axis", () => {
+    expect(clearDraftsSearch("?lens=all&drafts=true&unread=true")).toBe("?lens=all&unread=true")
+  })
+
+  it("is swept by clearFiltersSearch", () => {
+    expect(clearFiltersSearch("?lens=mine&drafts=true&panel=x")).toBe("?lens=all&panel=x")
+  })
+})
+
+describe("clearAxisSearch", () => {
+  it("drops one axis and keeps everything else", () => {
+    expect(clearAxisSearch("?lens=all&label=l1&is=dm", "label")).toBe("?lens=all&is=dm")
+    expect(clearAxisSearch("?in=a", "in")).toBe("")
   })
 })

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -64,6 +64,15 @@ export const BOARD_UNREAD_PARAM = "unread"
 /** The `?unread=` value that opts into the unread-only narrowing. */
 export const BOARD_UNREAD_ON = "true"
 
+/** Drafts opt-in (`?drafts=true`) — narrows to conversations carrying an unsent
+ *  board draft (a card reply, a nested branch reply, or a sub-topic draft on one
+ *  of the conversation's messages). Client-resolved off the shared board-drafts
+ *  snapshot, so it stays live as drafts are written instead of snapshotting ids. */
+export const BOARD_DRAFTS_PARAM = "drafts"
+
+/** The `?drafts=` value that opts into the drafts-only narrowing. */
+export const BOARD_DRAFTS_ON = "true"
+
 /** Every board filter param, for clear-all sweeps. */
 export const BOARD_FILTER_PARAMS = [
   BOARD_SCOPE_PARAM,
@@ -74,6 +83,7 @@ export const BOARD_FILTER_PARAMS = [
   BOARD_EXCLUDE_LABEL_PARAM,
   BOARD_ARCHIVED_PARAM,
   BOARD_UNREAD_PARAM,
+  BOARD_DRAFTS_PARAM,
 ] as const
 
 /** Parse a stored or URL-supplied lens value: a valid lens, anything else
@@ -259,12 +269,35 @@ export function unreadFocusSearch(search: string): string {
   return toSearch(params)
 }
 
+/** Drop ONE filter axis entirely, leaving every other axis (and unrelated URL
+ *  state) untouched — the un-toggle behind an already-active filter affordance.
+ *  One builder for every axis so the affordances can't drift (INV-35). */
+export function clearAxisSearch(search: string, param: string): string {
+  const params = new URLSearchParams(search)
+  params.delete(param)
+  return toSearch(params)
+}
+
 /** The mirror of {@link unreadFocusSearch}: drop the unread narrowing, leaving
  *  every other axis untouched. */
 export function clearUnreadSearch(search: string): string {
+  return clearAxisSearch(search, BOARD_UNREAD_PARAM)
+}
+
+/**
+ * The board-mode Drafts verb: FOCUS the board on conversations carrying an
+ * unsent draft (`?drafts=true`), leaving every other axis untouched.
+ */
+export function draftsFocusSearch(search: string): string {
   const params = new URLSearchParams(search)
-  params.delete(BOARD_UNREAD_PARAM)
+  params.set(BOARD_DRAFTS_PARAM, BOARD_DRAFTS_ON)
   return toSearch(params)
+}
+
+/** The mirror of {@link draftsFocusSearch}: drop the drafts narrowing, leaving
+ *  every other axis untouched. */
+export function clearDraftsSearch(search: string): string {
+  return clearAxisSearch(search, BOARD_DRAFTS_PARAM)
 }
 
 /** Remove one value from any single filter axis (a chip's X). Works for every

--- a/apps/frontend/src/components/board/board-filter-params.ts
+++ b/apps/frontend/src/components/board/board-filter-params.ts
@@ -275,6 +275,9 @@ export function unreadFocusSearch(search: string): string {
 export function clearAxisSearch(search: string, param: string): string {
   const params = new URLSearchParams(search)
   params.delete(param)
+  // Clearing the LAST axis must never yield a bare `/board` — that's the home
+  // redirect (a saved home would teleport the user). Keep the lens explicit.
+  if (!params.has(BOARD_LENS_PARAM)) params.set(BOARD_LENS_PARAM, DEFAULT_BOARD_LENS)
   return toSearch(params)
 }
 

--- a/apps/frontend/src/components/board/board-removed-card.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.tsx
@@ -13,6 +13,8 @@ interface BoardRemovedCardProps {
   dmPeerUserId?: string | null
   /** The conversation that now holds the opening message, or null when none does. */
   successor: RemovedSuccessor | null
+  /** Overlay copy when there is no successor. Defaults to the left-the-board wording. */
+  emptyLabel?: string
 }
 
 /**
@@ -30,6 +32,7 @@ export function BoardRemovedCard({
   streamType,
   dmPeerUserId,
   successor,
+  emptyLabel = "No longer on your board.",
 }: BoardRemovedCardProps) {
   const { getPanelUrl } = usePanel()
 
@@ -58,7 +61,7 @@ export function BoardRemovedCard({
               </Link>
             </span>
           ) : (
-            <span>No longer on your board.</span>
+            <span>{emptyLabel}</span>
           )}
         </div>
       </div>

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.test.tsx
@@ -268,6 +268,18 @@ describe("BoardModeBlock", () => {
     expect(new URL(currentLoc(), "http://x").searchParams.get("archived")).toBe("true")
   })
 
+  it("the With drafts toggle flips ?drafts=true and back off", async () => {
+    const user = userEvent.setup()
+    stub()
+    mountAt(`/w/${WS}/board?lens=all`)
+
+    await user.click(screen.getByRole("button", { name: "With drafts" }))
+    expect(new URL(currentLoc(), "http://x").searchParams.get("drafts")).toBe("true")
+
+    await user.click(screen.getByRole("button", { name: "With drafts" }))
+    expect(new URL(currentLoc(), "http://x").searchParams.get("drafts")).toBeNull()
+  })
+
   it("pinning a lens writes the home-lens preference and clears any view home", async () => {
     const user = userEvent.setup()
     const { updatePreferences } = stub({ boardDefaultLens: "all" })

--- a/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
+++ b/apps/frontend/src/components/layout/sidebar/board-mode-block.tsx
@@ -25,6 +25,8 @@ import {
 import {
   BOARD_ARCHIVED_ON,
   BOARD_ARCHIVED_PARAM,
+  BOARD_DRAFTS_ON,
+  BOARD_DRAFTS_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
   BOARD_EXCLUDE_SCOPE_PARAM,
   BOARD_EXCLUDE_TYPE_PARAM,
@@ -281,6 +283,7 @@ function BoardModeFilters({ workspaceId, unreadStreamCount }: { workspaceId: str
   const unmuteStream = useUnmuteStream(workspaceId)
 
   const showArchived = searchParams.get(BOARD_ARCHIVED_PARAM) === BOARD_ARCHIVED_ON
+  const draftsOnly = searchParams.get(BOARD_DRAFTS_PARAM) === BOARD_DRAFTS_ON
 
   const labelFor = (streamId: string) =>
     resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
@@ -354,6 +357,12 @@ function BoardModeFilters({ workspaceId, unreadStreamCount }: { workspaceId: str
         label="Archived"
         active={showArchived}
         onToggle={() => setParamLists([[BOARD_ARCHIVED_PARAM, showArchived ? [] : [BOARD_ARCHIVED_ON]]])}
+      />
+      <FilterToggleRow
+        icon={Pencil}
+        label="With drafts"
+        active={draftsOnly}
+        onToggle={() => setParamLists([[BOARD_DRAFTS_PARAM, draftsOnly ? [] : [BOARD_DRAFTS_ON]]])}
       />
     </div>
   )

--- a/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
+++ b/apps/frontend/src/components/layout/sidebar/board-sidebar-mode.ts
@@ -61,6 +61,10 @@ export interface SidebarBoardMode {
    *  it keeps matching as things get read/unread instead of freezing the ids
    *  that were unread at click time. */
   unreadFocusHref: () => string
+  /** Board URL with ONE filter axis dropped — the un-toggle behind an already-
+   *  active section-header filter, so the same control turns it back off. Takes a
+   *  `board-filter-params` param name. */
+  clearAxisHref: (param: string) => string
   /** Mute / unmute a root stream on the board. */
   setMuted: (streamId: string, mute: boolean) => void
   /** Per-root-stream topic tally for the row's board-mode preview line. `null`

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -374,6 +374,7 @@ describe("ScratchpadItem", () => {
       labelFocusHref: (labelId) => `/w/workspace_1/board?label=${labelId}`,
       typeFocusHref: (type) => `/w/workspace_1/board?is=${type}`,
       unreadFocusHref: () => `/w/workspace_1/board?unread=true`,
+      clearAxisHref: (param: string) => `/w/workspace_1/board?cleared=${param}`,
       setMuted: vi.fn(),
       statsForStream: () => null,
       lensTotals: null,

--- a/apps/frontend/src/components/layout/sidebar/sections.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.test.tsx
@@ -99,6 +99,60 @@ describe("SectionHeader board-mode Scope all", () => {
   })
 })
 
+describe("SectionHeader board-mode filter affordance", () => {
+  it("keeps the affordance visible (not hover-revealed) and uses the filter icon in board mode", () => {
+    renderHeader({
+      label: "Channels",
+      titleHref: "/w/ws_1/board?is=channel",
+      titleActionLabel: "Filter board by Channels",
+      filterAffordance: true,
+    })
+
+    const link = screen.getByRole("link", { name: "Filter board by Channels" })
+    expect(link.className).not.toContain("reveal-actions")
+    expect(link.className).toContain("opacity-60")
+    // The affordance filters, so it must not read as "navigate away".
+    expect(link.querySelector("svg")).toHaveClass("lucide-list-filter")
+  })
+
+  it("keeps the chats-mode affordance hover-revealed with the navigate icon", () => {
+    renderHeader({ label: "Design", titleHref: "/w/ws_1/labels/label_1" })
+
+    const link = screen.getByRole("link", { name: "Open Design" })
+    expect(link.className).toContain("reveal-actions")
+    expect(link.querySelector("svg")).toHaveClass("lucide-arrow-up-right")
+  })
+
+  it("tints the active filter and points it at the clearing URL", () => {
+    renderHeader({
+      label: "Design",
+      titleHref: "/w/ws_1/board?lens=all",
+      titleActionLabel: "Clear board filter Design",
+      filterAffordance: true,
+      filterActive: true,
+    })
+
+    const link = screen.getByRole("link", { name: "Clear board filter Design" })
+    expect(link).toHaveAttribute("href", "/w/ws_1/board?lens=all")
+    expect(link).toHaveAttribute("aria-current", "true")
+    expect(link.className).toContain("bg-primary/10")
+  })
+
+  it("names the Scope-all cap when the section holds more streams than the scope carries", () => {
+    renderHeader({
+      label: "Reading list",
+      scopeAllHref: "/w/ws_1/board?in=a,b",
+      scopeAllTitle: "Scope board to the first 50 of 73 streams",
+      filterAffordance: true,
+    })
+
+    expect(screen.getByRole("link", { name: "Scope board to the first 50 of 73 streams" })).toHaveAttribute(
+      "href",
+      "/w/ws_1/board?in=a,b"
+    )
+  })
+})
+
 describe("SectionHeader label open target", () => {
   it("points the open link at the label page in chats mode", () => {
     renderHeader({ label: "Design", titleContent: "Design", titleHref: "/w/ws_1/labels/label_1" })

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -43,6 +43,24 @@ interface SectionHeaderProps {
    * don't scope (smart/type/label).
    */
   scopeAllHref?: string
+  /** Overrides the default "Scope board to …" name/tooltip — the cap signal when
+   *  a section holds more streams than the scope can carry. */
+  scopeAllTitle?: string
+  /**
+   * Board mode: make the filter affordance (`scopeAllHref`/`titleHref`) a
+   * PERSISTENT, always-visible control instead of the hover-revealed one. Touch
+   * has no hover, so the hover-only treatment made the board's per-section
+   * filters undiscoverable on the surface they matter most; and the icon becomes
+   * `ListFilter` for both, since the affordance filters the board rather than
+   * navigating anywhere. Chats mode leaves it unset and renders unchanged.
+   */
+  filterAffordance?: boolean
+  /**
+   * The section's filter is the board's CURRENT selection. Tints the affordance
+   * (the same `bg-primary/10` + `aria-current` an active board row uses); the
+   * caller points the href at the clearing URL, so the same control un-toggles.
+   */
+  filterActive?: boolean
   /** Current collapse state. If omitted, header renders as static (non-clickable). */
   state?: CollapseState
   /** Toggle callback. If omitted, header renders as static. */
@@ -82,6 +100,9 @@ export function SectionHeader({
   titleActionLabel,
   onTitleNavigate,
   scopeAllHref,
+  scopeAllTitle: scopeAllTitleOverride,
+  filterAffordance = false,
+  filterActive = false,
   state,
   onToggle,
   unreadAggregate = 0,
@@ -149,8 +170,17 @@ export function SectionHeader({
   // through the React tree — without this guard, clicking (or pressing
   // Enter/Space on) a menu item bubbles up to the header's `onToggle` and
   // collapses the section as a side effect.
-  const scopeAllTitle = label ? `Scope board to ${label} streams` : "Scope board to these streams"
+  const scopeAllTitle =
+    scopeAllTitleOverride ?? (label ? `Scope board to ${label} streams` : "Scope board to these streams")
   const titleLinkLabel = titleActionLabel ?? (label ? `Open ${label}` : "Open")
+  // Same footprint in every state (INV-21): only the icon's opacity/tint change.
+  const actionClass = filterAffordance
+    ? cn(
+        "h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded transition-opacity",
+        filterActive ? "bg-primary/10 text-primary opacity-100" : "opacity-60 hover:opacity-100 hover:bg-muted"
+      )
+    : "h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded reveal-actions hover:bg-muted"
+  const TitleIcon = filterAffordance ? ListFilter : ArrowUpRight
 
   const rightContent = (
     <div
@@ -163,7 +193,8 @@ export function SectionHeader({
         <Link
           to={scopeAllHref}
           onClick={onTitleNavigate}
-          className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded reveal-actions hover:bg-muted"
+          className={actionClass}
+          aria-current={filterActive ? "true" : undefined}
           title={scopeAllTitle}
           aria-label={scopeAllTitle}
         >
@@ -174,11 +205,12 @@ export function SectionHeader({
         <Link
           to={titleHref}
           onClick={onTitleNavigate}
-          className="h-5 w-5 max-sm:h-8 max-sm:w-8 flex items-center justify-center rounded reveal-actions hover:bg-muted"
+          className={actionClass}
+          aria-current={filterActive ? "true" : undefined}
           title={titleLinkLabel}
           aria-label={titleLinkLabel}
         >
-          <ArrowUpRight className="h-3.5 w-3.5" />
+          <TitleIcon className="h-3.5 w-3.5" />
         </Link>
       )}
       {hasAggregate && (
@@ -328,6 +360,12 @@ interface StreamSectionProps {
   /** Board mode only: "Scope all" header link scoping `?in=` to every stream in
    *  this section (Unread / custom sections). Forwarded to SectionHeader. */
   scopeAllHref?: string
+  /** Overrides the "Scope all" name/tooltip (the cap signal). Forwarded to SectionHeader. */
+  scopeAllTitle?: string
+  /** Board mode: persistent, always-visible filter affordance. Forwarded to SectionHeader. */
+  filterAffordance?: boolean
+  /** Board mode: this section's filter is the board's current selection. Forwarded to SectionHeader. */
+  filterActive?: boolean
   items: StreamItemData[]
   allStreams: StreamItemData[]
   workspaceId: string
@@ -370,6 +408,9 @@ export function StreamSection({
   titleActionLabel,
   onTitleNavigate,
   scopeAllHref,
+  scopeAllTitle,
+  filterAffordance,
+  filterActive,
   items,
   allStreams,
   workspaceId,
@@ -418,6 +459,9 @@ export function StreamSection({
         titleActionLabel={titleActionLabel}
         onTitleNavigate={onTitleNavigate}
         scopeAllHref={scopeAllHref}
+        scopeAllTitle={scopeAllTitle}
+        filterAffordance={filterAffordance}
+        filterActive={filterActive}
         state={state}
         onToggle={onToggle}
         unreadAggregate={unreadAggregate}
@@ -471,6 +515,9 @@ export function TieredStreamSection({
   titleActionLabel,
   onTitleNavigate,
   scopeAllHref,
+  scopeAllTitle,
+  filterAffordance,
+  filterActive,
   items,
   allStreams,
   workspaceId,
@@ -533,6 +580,9 @@ export function TieredStreamSection({
         titleActionLabel={titleActionLabel}
         onTitleNavigate={onTitleNavigate}
         scopeAllHref={scopeAllHref}
+        scopeAllTitle={scopeAllTitle}
+        filterAffordance={filterAffordance}
+        filterActive={filterActive}
         state={state}
         onToggle={onToggle}
         unreadAggregate={unreadAggregate}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.test.tsx
@@ -1,0 +1,129 @@
+import { createRef } from "react"
+import { describe, expect, it, beforeEach, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+import { render, screen } from "@/test"
+import { StreamTypes, Visibilities, MAX_BOARD_SCOPE_STREAMS } from "@threa/types"
+import { SidebarStreamList } from "./sidebar-stream-list"
+import type { StreamItemData } from "./types"
+import type { SidebarBoardMode } from "./board-sidebar-mode"
+import type { ResolvedSection } from "./resolve-sections"
+import * as contextsModule from "@/contexts"
+
+function makeStream(id: string): StreamItemData {
+  return {
+    id,
+    workspaceId: "workspace_1",
+    type: StreamTypes.CHANNEL,
+    displayName: id,
+    slug: id,
+    description: null,
+    visibility: Visibilities.PUBLIC,
+    parentStreamId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: "2026-03-03T09:00:00Z",
+    updatedAt: "2026-03-03T09:00:00Z",
+    archivedAt: null,
+    urgency: "activity",
+    section: "recent",
+    lastMessagePreview: null,
+  } as StreamItemData
+}
+
+function makeBoardMode(over: Partial<SidebarBoardMode> = {}): SidebarBoardMode {
+  return {
+    workspaceId: "workspace_1",
+    includedStreamIds: new Set<string>(),
+    excludedStreamIds: new Set<string>(),
+    mutedStreamIds: new Set<string>(),
+    focusHref: (id: string) => `/w/workspace_1/board?in=${id}`,
+    applyInclude: vi.fn(),
+    applyExclude: vi.fn(),
+    scopeAllHref: (ids: readonly string[]) => `/w/workspace_1/board?in=${ids.join(",")}`,
+    labelFocusHref: (labelId: string) => `/w/workspace_1/board?label=${labelId}`,
+    typeFocusHref: (type: string) => `/w/workspace_1/board?is=${type}`,
+    unreadFocusHref: () => `/w/workspace_1/board?unread=true`,
+    clearAxisHref: (param: string) => `/w/workspace_1/board?cleared=${param}`,
+    setMuted: vi.fn(),
+    statsForStream: () => null,
+    lensTotals: null,
+    ...over,
+  } as SidebarBoardMode
+}
+
+function renderList(streams: StreamItemData[], search: string) {
+  const section: ResolvedSection = {
+    section: {
+      id: "custom:sec_1",
+      spec: { kind: "custom", sectionId: "sec_1", name: "Reading list", streamIds: streams.map((s) => s.id) },
+    },
+    items: streams,
+  } as unknown as ResolvedSection
+
+  render(
+    <MemoryRouter initialEntries={[`/w/workspace_1/board${search}`]}>
+      <SidebarStreamList
+        workspaceId="workspace_1"
+        hasError={false}
+        hasUserStreams
+        processedStreams={streams}
+        resolvedSections={[section]}
+        labelsById={new Map()}
+        getUnreadCount={() => 0}
+        getMentionCount={() => 0}
+        getSectionState={() => "open"}
+        toggleSectionState={vi.fn()}
+        onCreateScratchpad={vi.fn()}
+        onCreateChannel={vi.fn()}
+        onFileStreamToSection={vi.fn()}
+        onAssignStreamLabel={vi.fn()}
+        onStreamMovedFromLabel={vi.fn()}
+        homeHintFor={() => null}
+        scrollContainerRef={createRef<HTMLDivElement>()}
+        boardMode={makeBoardMode()}
+      />
+    </MemoryRouter>
+  )
+}
+
+describe("SidebarStreamList — Scope all over the cap", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(contextsModule, "useSidebar").mockReturnValue({
+      collapseOnMobile: vi.fn(),
+      setMenuOpen: vi.fn(),
+    } as unknown as ReturnType<typeof contextsModule.useSidebar>)
+  })
+
+  const oversized = Array.from({ length: MAX_BOARD_SCOPE_STREAMS + 3 }, (_, i) => makeStream(`stream_${i}`))
+  const capped = oversized.slice(0, MAX_BOARD_SCOPE_STREAMS).map((s) => s.id)
+
+  it("scopes to the capped id list", () => {
+    renderList(oversized, "")
+
+    expect(screen.getByRole("link", { name: /^Scope board to the first/ })).toHaveAttribute(
+      "href",
+      `/w/workspace_1/board?in=${capped.join(",")}`
+    )
+  })
+
+  it("reads active (and clears) once the URL holds the capped list, naming the clear", () => {
+    renderList(oversized, `?in=${capped.join(",")}`)
+
+    const link = screen.getByRole("link", { name: "Clear board scope Reading list" })
+    expect(link).toHaveAttribute("href", "/w/workspace_1/board?cleared=in")
+    expect(link).toHaveAttribute("aria-current", "true")
+  })
+
+  it("still reads active for a section within the cap", () => {
+    const small = [makeStream("stream_a"), makeStream("stream_b")]
+    renderList(small, "?in=stream_b,stream_a")
+
+    expect(screen.getByRole("link", { name: "Clear board scope Reading list" })).toHaveAttribute(
+      "href",
+      "/w/workspace_1/board?cleared=in"
+    )
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -336,9 +336,9 @@ export function SidebarStreamList({
           // Normalize exactly as scopeAllSearch does (dedupe, keep-first cap) so
           // the active check compares against the ids the URL can actually hold —
           // an uncapped comparison never matches for an oversized section.
-          const scopeIds = canScopeAll
-            ? Array.from(new Set(items.map(boardScopeStreamId).filter(Boolean))).slice(0, MAX_BOARD_SCOPE_STREAMS)
-            : []
+          const dedupedScopeIds = canScopeAll ? Array.from(new Set(items.map(boardScopeStreamId).filter(Boolean))) : []
+          const dedupedScopeIdCount = dedupedScopeIds.length
+          const scopeIds = dedupedScopeIds.slice(0, MAX_BOARD_SCOPE_STREAMS)
           const scopeAllActive = canScopeAll && sameMembers(selection.scopeStreamIds, scopeIds)
           if (scopeAllActive) filterActive = true
           let scopeAllHref: string | undefined = undefined
@@ -352,8 +352,8 @@ export function SidebarStreamList({
           // scoping to a prefix of the section.
           let scopeAllTitle: string | undefined = undefined
           if (scopeAllActive) scopeAllTitle = `Clear board scope ${headerLabel}`
-          else if (canScopeAll && items.length > MAX_BOARD_SCOPE_STREAMS)
-            scopeAllTitle = `Scope board to the first ${MAX_BOARD_SCOPE_STREAMS} of ${items.length} streams`
+          else if (canScopeAll && dedupedScopeIdCount > MAX_BOARD_SCOPE_STREAMS)
+            scopeAllTitle = `Scope board to the first ${MAX_BOARD_SCOPE_STREAMS} of ${dedupedScopeIdCount} streams`
 
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -9,7 +9,17 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core"
+import { useLocation } from "react-router-dom"
+import { MAX_BOARD_SCOPE_STREAMS } from "@threa/types"
 import { useSidebar, type CollapseState } from "@/contexts"
+import { useBoardSelection } from "@/hooks/use-board-selection"
+import {
+  BOARD_LABEL_PARAM,
+  BOARD_SCOPE_PARAM,
+  BOARD_TYPE_PARAM,
+  BOARD_UNREAD_PARAM,
+  BOARD_UNREAD_ON,
+} from "@/components/board/board-filter-params"
 import { Button } from "@/components/ui/button"
 import { LabelChip } from "@/components/labels/label-chip"
 import { useInputMode } from "@/hooks/use-input-mode"
@@ -37,6 +47,19 @@ const MORE_DEFAULT: CollapseState = "collapsed"
 /** Key for the inline "more" expander of a parent section. */
 function moreKey(parent: string): string {
   return `${parent}:more`
+}
+
+/** The board's axis is filtered to exactly this one value — what makes a section
+ *  header's filter read as active (and its click un-toggle). */
+function isSoleValue<T>(selected: readonly T[], value: T): boolean {
+  return selected.length === 1 && selected[0] === value
+}
+
+/** The board's `?in=` scope is exactly this section's streams, order-insensitive. */
+function sameMembers(selected: readonly string[], ids: readonly string[]): boolean {
+  const wanted = new Set(ids)
+  if (selected.length !== wanted.size || wanted.size === 0) return false
+  return selected.every((id) => wanted.has(id))
 }
 
 interface AddWiring {
@@ -153,6 +176,11 @@ export function SidebarStreamList({
   // Opening a label from its section header should close the sidebar on mobile,
   // matching stream rows and quick links (no-op on desktop).
   const { collapseOnMobile } = useSidebar()
+  // The live board selection, so a section header can tell whether the board is
+  // already filtered to its own axis (INV-35: the same derivation the board block
+  // and the filter chips read).
+  const { selection } = useBoardSelection()
+  const unreadFilterOn = new URLSearchParams(useLocation().search).get(BOARD_UNREAD_PARAM) === BOARD_UNREAD_ON
   const [draggingStreamId, setDraggingStreamId] = useState<string | null>(null)
   // Distance constraint so a click still navigates the row's link — a drag only
   // begins once the pointer has moved past the threshold.
@@ -269,20 +297,31 @@ export function SidebarStreamList({
           // § "Feature parity").
           let titleHref = label ? `/w/${workspaceId}/labels/${label.id}` : undefined
           let titleActionLabel: string | undefined = undefined
+          // Board mode: the affordance is a FILTER, so it also un-toggles —
+          // when the board is already filtered to exactly this section's axis the
+          // link points at the clearing URL and the icon reads active.
+          let filterActive = false
           if (label && boardMode) {
-            titleHref = boardMode.labelFocusHref(label.id)
-            titleActionLabel = `Filter board by ${label.name}`
+            filterActive = isSoleValue(selection.scopeLabelIds, label.id)
+            titleHref = filterActive ? boardMode.clearAxisHref(BOARD_LABEL_PARAM) : boardMode.labelFocusHref(label.id)
+            titleActionLabel = filterActive ? `Clear board filter ${label.name}` : `Filter board by ${label.name}`
           }
           // Board mode only, mirroring the label case above: a type section
           // (Channels/DMs/Scratchpads) focuses the board's type axis (`?is=`),
           // and Unread focuses the unread axis (`?unread=true`) — both live
           // aggregate filters, not a one-time snapshot of the current ids.
           if (boardMode && section.spec.kind === "type") {
-            titleHref = boardMode.typeFocusHref(section.spec.streamType)
-            titleActionLabel = `Filter board by ${presentation.label}`
+            filterActive = isSoleValue(selection.scopeStreamTypes, section.spec.streamType)
+            titleHref = filterActive
+              ? boardMode.clearAxisHref(BOARD_TYPE_PARAM)
+              : boardMode.typeFocusHref(section.spec.streamType)
+            titleActionLabel = filterActive
+              ? `Clear board filter ${presentation.label}`
+              : `Filter board by ${presentation.label}`
           } else if (boardMode && section.spec.kind === "unread") {
-            titleHref = boardMode.unreadFocusHref()
-            titleActionLabel = "Filter board by unread"
+            filterActive = unreadFilterOn
+            titleHref = filterActive ? boardMode.clearAxisHref(BOARD_UNREAD_PARAM) : boardMode.unreadFocusHref()
+            titleActionLabel = filterActive ? "Clear board unread filter" : "Filter board by unread"
           }
           const headerLabel = label ? label.name : presentation.label
 
@@ -294,7 +333,27 @@ export function SidebarStreamList({
           // equivalent, so scoping to a frozen id snapshot would be a downgrade.
           const canScopeAll =
             !!boardMode && (section.spec.kind === "smart" || section.spec.kind === "custom") && items.length > 0
-          const scopeAllHref = canScopeAll ? boardMode.scopeAllHref(items.map(boardScopeStreamId)) : undefined
+          // Normalize exactly as scopeAllSearch does (dedupe, keep-first cap) so
+          // the active check compares against the ids the URL can actually hold —
+          // an uncapped comparison never matches for an oversized section.
+          const scopeIds = canScopeAll
+            ? Array.from(new Set(items.map(boardScopeStreamId).filter(Boolean))).slice(0, MAX_BOARD_SCOPE_STREAMS)
+            : []
+          const scopeAllActive = canScopeAll && sameMembers(selection.scopeStreamIds, scopeIds)
+          if (scopeAllActive) filterActive = true
+          let scopeAllHref: string | undefined = undefined
+          if (canScopeAll) {
+            scopeAllHref = scopeAllActive
+              ? boardMode.clearAxisHref(BOARD_SCOPE_PARAM)
+              : boardMode.scopeAllHref(scopeIds)
+          }
+          // Active, the link CLEARS — name it for what it does. Otherwise the
+          // scope caps at MAX_BOARD_SCOPE_STREAMS; say so rather than silently
+          // scoping to a prefix of the section.
+          let scopeAllTitle: string | undefined = undefined
+          if (scopeAllActive) scopeAllTitle = `Clear board scope ${headerLabel}`
+          else if (canScopeAll && items.length > MAX_BOARD_SCOPE_STREAMS)
+            scopeAllTitle = `Scope board to the first ${MAX_BOARD_SCOPE_STREAMS} of ${items.length} streams`
 
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
@@ -319,6 +378,9 @@ export function SidebarStreamList({
               titleActionLabel={titleActionLabel}
               onTitleNavigate={collapseOnMobile}
               scopeAllHref={scopeAllHref}
+              scopeAllTitle={scopeAllTitle}
+              filterAffordance={!!boardMode}
+              filterActive={filterActive}
               icon={presentation.icon}
               items={items}
               allStreams={processedStreams}
@@ -347,6 +409,9 @@ export function SidebarStreamList({
               titleActionLabel={titleActionLabel}
               onTitleNavigate={collapseOnMobile}
               scopeAllHref={scopeAllHref}
+              scopeAllTitle={scopeAllTitle}
+              filterAffordance={!!boardMode}
+              filterActive={filterActive}
               icon={presentation.icon}
               items={items}
               allStreams={processedStreams}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -71,6 +71,7 @@ import {
   toggleIncludeSearch,
   typeFocusSearch,
   unreadFocusSearch,
+  clearAxisSearch,
 } from "@/components/board/board-filter-params"
 import { isBoardPath, type SidebarBoardMode } from "./board-sidebar-mode"
 import { useBoardSidebarStats, ZERO_BOARD_STREAM_STATS } from "@/hooks/use-board-sidebar-stats"
@@ -362,6 +363,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       labelFocusHref: (labelId) => `${location.pathname}${labelFocusSearch(boardSearch, labelId)}`,
       typeFocusHref: (type) => `${location.pathname}${typeFocusSearch(boardSearch, type)}`,
       unreadFocusHref: () => `${location.pathname}${unreadFocusSearch(boardSearch)}`,
+      clearAxisHref: (param) => `${location.pathname}${clearAxisSearch(boardSearch, param)}`,
       setMuted: (streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId)),
       statsForStream: (streamId) =>
         boardSidebarStats ? (boardSidebarStats.byStream.get(streamId) ?? ZERO_BOARD_STREAM_STATS) : null,

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -421,6 +421,7 @@ function makeBoardMode(over: Partial<SidebarBoardMode> = {}): SidebarBoardMode {
     labelFocusHref: (labelId) => `/w/workspace_1/board?label=${labelId}`,
     typeFocusHref: (type) => `/w/workspace_1/board?is=${type}`,
     unreadFocusHref: () => `/w/workspace_1/board?unread=true`,
+    clearAxisHref: (param: string) => `/w/workspace_1/board?cleared=${param}`,
     setMuted: vi.fn(),
     statsForStream: () => null,
     lensTotals: null,

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -5,6 +5,7 @@ import { db } from "@/db"
 import {
   useScopeDraftPreview,
   useBoardSubtopicDraftIndex,
+  useBoardCheckedOutDraftScopes,
   useBoardDraftsReady,
   __clearBoardDraftsRegistry,
 } from "./use-scope-draft-preview"
@@ -89,5 +90,32 @@ describe("useBoardSubtopicDraftIndex", () => {
       preview: "subtopic body",
       isCheckedOut: false,
     })
+  })
+})
+
+describe("useBoardCheckedOutDraftScopes", () => {
+  it("holds an emptied checked-out scope the preview index drops, and releases it when the row goes", async () => {
+    await seed("draft_1", scope, "body", 1000)
+    await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_1" })
+
+    const { result } = renderHook(() => useBoardCheckedOutDraftScopes(workspaceId))
+    const preview = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() => expect([...result.current]).toEqual([scope]))
+
+    const row = await db.drafts.get("draft_1")
+    await db.drafts.put({ ...row!, contentJson: doc(""), clientUpdatedAt: 2000 })
+    await waitFor(() => expect(preview.result.current).toBeNull())
+    expect([...result.current]).toEqual([scope])
+
+    await db.drafts.delete("draft_1")
+    await waitFor(() => expect([...result.current]).toEqual([]))
+  })
+
+  it("excludes a scope with no loaded pointer", async () => {
+    await seed("draft_1", scope, "body", 1000)
+    const { result } = renderHook(() => useBoardCheckedOutDraftScopes(workspaceId))
+    const ready = renderHook(() => useBoardDraftsReady(workspaceId))
+    await waitFor(() => expect(ready.result.current).toBe(true))
+    expect([...result.current]).toEqual([])
   })
 })

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -52,11 +52,15 @@ function bestRow(rows: CachedDraft[], loadedDraftId: string | null): CachedDraft
 interface BoardDraftsSnapshot {
   previewByScope: Map<string, ScopeDraftPreview>
   subtopicByMessageId: Map<string, SubtopicDraftEntry>
+  /** Scopes whose row is checked out into this device's composer, payload or
+   *  not — an empty checked-out row is a composer mid-edit, not a resolved one. */
+  checkedOutScopes: Set<string>
 }
 
 const EMPTY_SNAPSHOT: BoardDraftsSnapshot = {
   previewByScope: new Map(),
   subtopicByMessageId: new Map(),
+  checkedOutScopes: new Set(),
 }
 
 interface BoardDraftsEntry {
@@ -78,8 +82,10 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
   }
   const previewByScope = new Map<string, ScopeDraftPreview>()
   const subtopicByMessageId = new Map<string, SubtopicDraftEntry>()
+  const checkedOutScopes = new Set<string>()
   for (const [scope, scopeRows] of byScope) {
     const loadedDraftId = loadedByScope.get(scope) ?? null
+    if (loadedDraftId !== null && scopeRows.some((row) => row.id === loadedDraftId)) checkedOutScopes.add(scope)
     const best = bestRow(scopeRows, loadedDraftId)
     if (!best) continue
     const preview = toPreview(best, loadedDraftId)
@@ -94,7 +100,7 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
       })
     }
   }
-  return { previewByScope, subtopicByMessageId }
+  return { previewByScope, subtopicByMessageId, checkedOutScopes }
 }
 
 // INV-9 exception: one shared board-drafts liveQuery per workspace, ref-counted
@@ -206,6 +212,22 @@ export function useBoardSubtopicDraftIndex(workspaceId: string): Map<string, Sub
   const subscribe = useBoardDraftsSubscription(workspaceId)
   const getSnapshot = useCallback(
     () => boardDraftsRegistry.get(workspaceId)?.snapshot.subtopicByMessageId ?? EMPTY_SNAPSHOT.subtopicByMessageId,
+    [workspaceId]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
+ * Board scopes whose draft row is checked out into this device's composer,
+ * whether or not it currently holds anything. Membership surfaces (the drafts
+ * view) union this with {@link useBoardScopeDraftIndex}: clearing the text
+ * mid-rewrite empties the payload but the row survives until the draft is sent
+ * or discarded, and only then should the card shed.
+ */
+export function useBoardCheckedOutDraftScopes(workspaceId: string): ReadonlySet<string> {
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(
+    () => boardDraftsRegistry.get(workspaceId)?.snapshot.checkedOutScopes ?? EMPTY_SNAPSHOT.checkedOutScopes,
     [workspaceId]
   )
   return useSyncExternalStore(subscribe, getSnapshot)

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -24,6 +24,7 @@ function filterOf(over: Partial<BoardViewFilter> = {}): BoardViewFilter {
     labels: null,
     excludeLabels: null,
     unread: null,
+    drafts: null,
     showArchived: false,
     archivedRootIds: new Set<string>(),
     ...over,
@@ -47,6 +48,22 @@ function typesFilter(types: BoardScopeStreamType[]): BoardViewFilter {
 
 function unreadFilter(streamIds: string[]): BoardViewFilter {
   return filterOf({ unread: { key: "true", streamIds: new Set(streamIds) } })
+}
+
+function draftsFilter(conversationIds: string[], subtopicMessageIds: string[] = []): BoardViewFilter {
+  return filterOf({
+    drafts: {
+      key: "true",
+      conversationIds: new Set(conversationIds),
+      subtopicMessageIds: new Set(subtopicMessageIds),
+    },
+  })
+}
+
+/** A post whose conversation carries these message ids (sub-topic draft match). */
+function messagesPost(id: string, activityMs: number, messageIds: string[]): CachedBoardPost {
+  const base = post(id, activityMs)
+  return { ...base, conversation: { ...base.conversation, messageIds } } as unknown as CachedBoardPost
 }
 
 function post(id: string, activityMs: number): CachedBoardPost {
@@ -985,6 +1002,65 @@ describe("useStableBoardView — unread filter", () => {
     // key, mirroring the label-scope re-resolution guarantee.
     rerender({ filter: unreadFilter(["stream_x", "stream_other"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+})
+
+describe("useStableBoardView — drafts filter", () => {
+  let liveValue: CachedBoardPost[] | undefined
+  function mockLive(value: CachedBoardPost[] | undefined) {
+    liveValue = value
+    vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
+  }
+  afterEach(() => vi.restoreAllMocks())
+
+  it("shows only conversations carrying a draft", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result } = renderHook(() =>
+      useStableBoardView("ws_1", draftsFilter(["a"]), undefined, undefined, undefined)
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+
+  it("matches a conversation whose message carries a sub-topic draft", () => {
+    mockLive(feed(messagesPost("a", 300, ["msg_1", "msg_2"]), messagesPost("b", 200, ["msg_3"])))
+    const { result } = renderHook(() =>
+      useStableBoardView("ws_1", draftsFilter([], ["msg_2"]), undefined, undefined, undefined)
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+
+  it("drops a committed card as soon as its draft resolves, keeping one that still has a draft", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(
+      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
+      { initialProps: { filter: draftsFilter(["a", "b"]) } }
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    // "a"'s draft is sent — resolving it is the viewer's own act on that card,
+    // so it sheds immediately (unlike reading in the unread view). "b" still
+    // carries a draft and never moves.
+    rerender({ filter: draftsFilter(["b"]) })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+
+    act(() => result.current.commit())
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+  })
+
+  it("a drafts re-resolution (same `?drafts=true` selection) never resets the frozen view", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(
+      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
+      { initialProps: { filter: draftsFilter(["a"]) } }
+    )
+    act(() => result.current.commit())
+
+    act(() => mockLive(feed(post("new", 500), post("a", 300))))
+    rerender({ filter: draftsFilter(["a", "new"]) })
+    // Still frozen: the newcomer waits behind the pill instead of a view reset
+    // committing it wholesale.
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+    expect(result.current.newCount).toBe(1)
   })
 })
 

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -1029,7 +1029,7 @@ describe("useStableBoardView — drafts filter", () => {
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
 
-  it("drops a committed card as soon as its draft resolves, keeping one that still has a draft", () => {
+  it("renders a resolved-draft card with the removal treatment in place, then drops it on the next commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(
       ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
@@ -1037,14 +1037,20 @@ describe("useStableBoardView — drafts filter", () => {
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
-    // "a"'s draft is sent — resolving it is the viewer's own act on that card,
-    // so it sheds immediately (unlike reading in the unread view). "b" still
-    // carries a draft and never moves.
+    // "a"'s draft resolves DURING the send: it sheds immediately, but through
+    // the removal path — the row keeps its slot and its mounted subtree (the
+    // composer that is still sending) instead of vanishing mid-send. "b" still
+    // carries a draft and stays live.
     rerender({ filter: draftsFilter(["b"]) })
-    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+    expect([...result.current.removedIds]).toEqual(["a"])
+    expect([...result.current.draftResolvedIds]).toEqual(["a"])
+    // Still in the raw feed, so no merge successor is claimed for it.
+    expect(result.current.removedSuccessorById.has("a")).toBe(false)
 
     act(() => result.current.commit())
     expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+    expect(result.current.removedIds.size).toBe(0)
   })
 
   it("a drafts re-resolution (same `?drafts=true` selection) never resets the frozen view", () => {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -416,7 +416,9 @@ export interface StableBoardView {
    * so the conversation no longer exists rather than merely falling out of the
    * active filters. They keep their slot: the retained copy still renders, inert,
    * at its full height under an overlay, so nothing below it shifts.
-   * Empty while the feed is still loading.
+   * Empty while the feed is still loading. Also carries cards shed by the drafts
+   * view once their draft resolved (see {@link draftResolvedIds}) — same
+   * treatment, different reason.
    */
   removedIds: ReadonlySet<string>
   /**
@@ -426,6 +428,13 @@ export interface StableBoardView {
    * subscription behind every stub.
    */
   removedSuccessorById: ReadonlyMap<string, RemovedSuccessor | null>
+  /**
+   * The subset of {@link removedIds} shed because their draft resolved, not
+   * because the conversation is gone — the card is still real, it just left the
+   * `?drafts=true` view. Distinguished so the removed-card overlay says so
+   * instead of claiming the conversation left the board.
+   */
+  draftResolvedIds: ReadonlySet<string>
 }
 
 /**
@@ -646,7 +655,7 @@ export function useStableBoardView(
     for (const id of [...retainedRef.current.keys()]) if (!keep.has(id)) retainedRef.current.delete(id)
   }, [])
 
-  const { posts, removedIds, removedSuccessorById } = useMemo(() => {
+  const { posts, removedIds, removedSuccessorById, draftResolvedIds } = useMemo(() => {
     const liveById = new Map((live ?? []).map((post) => [postId(post), post]))
     // Raw membership, not the filtered subset: a card the filters (or the
     // nested-view fold) dropped is still a real conversation, while one absent
@@ -654,6 +663,8 @@ export function useStableBoardView(
     const rawIds = rawLive ? new Set(rawLive.map(postId)) : null
     const out: CachedBoardPost[] = []
     const removed = new Set<string>()
+    const gone = new Set<string>()
+    const draftResolved = new Set<string>()
     for (const id of committed.order) {
       const post = liveById.get(id) ?? retainedRef.current.get(id)
       if (!post) continue
@@ -672,15 +683,26 @@ export function useStableBoardView(
       // view sheds it immediately — unlike reading in the unread view, which the
       // session floor holds in place. Emptying a checked-out draft is editing,
       // not resolving: membership holds (see {@link BoardDraftScope}).
-      if (!matchesDrafts(post, drafts)) continue
-      if (rawIds !== null && !rawIds.has(id)) removed.add(id)
+      // Shedding goes through the REMOVAL path, never a drop from `posts`: the
+      // draft resolves DURING the send (`resolveDraft` runs on submit and on
+      // slash-command dispatch), so dropping the row here would unmount the
+      // composer that is still sending, strand focus, and swallow the optimistic
+      // reply. Retained + inert holds the subtree until the next commit().
+      if (!matchesDrafts(post, drafts)) {
+        draftResolved.add(id)
+        removed.add(id)
+      }
+      if (rawIds !== null && !rawIds.has(id)) {
+        gone.add(id)
+        removed.add(id)
+      }
       out.push(post)
     }
     // Successor resolution runs here, once, off the same raw feed — and only when
     // something was actually removed (the common case scans nothing).
     const successorById = new Map<string, RemovedSuccessor | null>()
-    if (removed.size > 0 && rawLive) {
-      const removedPosts = out.filter((post) => removed.has(postId(post)))
+    if (gone.size > 0 && rawLive) {
+      const removedPosts = out.filter((post) => gone.has(postId(post)))
       for (const post of removedPosts) {
         const openingId = post.openingMessage?.id ?? null
         const successor = openingId
@@ -698,6 +720,7 @@ export function useStableBoardView(
       posts: out,
       removedIds: removed as ReadonlySet<string>,
       removedSuccessorById: successorById as ReadonlyMap<string, RemovedSuccessor | null>,
+      draftResolvedIds: draftResolved as ReadonlySet<string>,
     }
   }, [committed, live, rawLive, unread, drafts, isExcluded])
 
@@ -710,5 +733,6 @@ export function useStableBoardView(
     hasRawPosts: (rawLive?.length ?? 0) > 0,
     removedIds,
     removedSuccessorById,
+    draftResolvedIds,
   }
 }

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -98,9 +98,12 @@ export interface BoardUnreadScope {
  * branch-reply draft, and messages carrying a sub-topic draft (a conversation
  * matches when any of its messages does).
  *
- * Unlike {@link BoardUnreadScope} there is no session floor and no re-check on
- * the committed view: sending or discarding a draft drops the card at the next
- * commit, never mid-read.
+ * Unlike {@link BoardUnreadScope} there is no session floor: the committed view
+ * is re-checked, so losing membership sheds the card immediately — sending or
+ * discarding a draft is the viewer's own act on that card. Clearing the text
+ * mid-rewrite is editing, not resolving, so a checked-out row keeps membership
+ * even with no payload and the card can't be yanked out from under a focused
+ * composer.
  */
 export interface BoardDraftScope {
   key: string
@@ -667,7 +670,8 @@ export function useStableBoardView(
       if (!matchesUnread(post, unread)) continue
       // Resolving a draft is the viewer's own act on that card, so the drafts
       // view sheds it immediately — unlike reading in the unread view, which the
-      // session floor holds in place.
+      // session floor holds in place. Emptying a checked-out draft is editing,
+      // not resolving: membership holds (see {@link BoardDraftScope}).
       if (!matchesDrafts(post, drafts)) continue
       if (rawIds !== null && !rawIds.has(id)) removed.add(id)
       out.push(post)

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -91,6 +91,23 @@ export interface BoardUnreadScope {
   clearedConversationIds?: ReadonlySet<string>
 }
 
+/**
+ * The board's drafts narrowing (`?drafts=true`). `key` is the SELECTION (just
+ * "true" while active) — the view-reset key — while the two sets are the live
+ * resolution off the shared board-drafts snapshot: conversations with a reply or
+ * branch-reply draft, and messages carrying a sub-topic draft (a conversation
+ * matches when any of its messages does).
+ *
+ * Unlike {@link BoardUnreadScope} there is no session floor and no re-check on
+ * the committed view: sending or discarding a draft drops the card at the next
+ * commit, never mid-read.
+ */
+export interface BoardDraftScope {
+  key: string
+  conversationIds: ReadonlySet<string>
+  subtopicMessageIds: ReadonlySet<string>
+}
+
 export interface BoardViewFilter {
   lens: BoardLens
   /** Root-stream scope, or null when unscoped (the whole workspace). */
@@ -108,6 +125,9 @@ export interface BoardViewFilter {
   /** Unread-only narrowing, or null when every conversation shows regardless of
    *  read state. */
   unread: BoardUnreadScope | null
+  /** Drafts-only narrowing, or null when every conversation shows regardless of
+   *  unsent drafts. */
+  drafts: BoardDraftScope | null
   /**
    * Viewer opted into archived cards (`?archived=true`). A view SELECTION like
    * lens/scope — it rides the view-reset key, so toggling it re-commits the feed
@@ -222,6 +242,12 @@ function matchesUnread(post: CachedBoardPost, unread: BoardUnreadScope | null): 
   if (!unread) return true
   if (unread.clearedConversationIds?.has(post.conversation.id)) return false
   return unread.streamIds.has(post.rootStreamId ?? post.conversation.streamId)
+}
+
+function matchesDrafts(post: CachedBoardPost, drafts: BoardDraftScope | null): boolean {
+  if (!drafts) return true
+  if (drafts.conversationIds.has(post.conversation.id)) return true
+  return post.conversation.messageIds?.some((id) => drafts.subtopicMessageIds.has(id)) ?? false
 }
 
 function postId(post: CachedBoardPost): string {
@@ -441,6 +467,7 @@ export function useStableBoardView(
     labels,
     excludeLabels,
     unread,
+    drafts,
     showArchived,
     archivedRootIds,
   } = filter
@@ -499,11 +526,26 @@ export function useStableBoardView(
                 matchesLabelScope(post, labels) &&
                 matchesExcludedLabels(post, excludeLabels) &&
                 matchesUnread(post, unread) &&
+                matchesDrafts(post, drafts) &&
                 !isExcluded(post)
             ),
             (conversationId) => branchParentConversationId(conversationId, index, graph)
           ),
-    [rawLive, lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, unread, isExcluded, graph, index]
+    [
+      rawLive,
+      lens,
+      scope,
+      types,
+      excludeStreams,
+      excludeTypes,
+      labels,
+      excludeLabels,
+      unread,
+      drafts,
+      isExcluded,
+      graph,
+      index,
+    ]
   )
   const [committed, setCommitted] = useState<CommittedView>(EMPTY_VIEW)
   const [buffered, setBuffered] = useState<string[]>([])
@@ -537,7 +579,7 @@ export function useStableBoardView(
   // restores in place (it vanished there; no reorder under the reader), while
   // cards archived before the view committed arrive behind the "N new" pill
   // like any other new content.
-  const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${unread?.key ?? ""}|${showArchived ? "arch" : ""}`
+  const viewKey = `${workspaceId}|${lens}|${scope?.key ?? ""}|${types?.key ?? ""}|${excludeStreams?.key ?? ""}|${excludeTypes?.key ?? ""}|${labels?.key ?? ""}|${excludeLabels?.key ?? ""}|${unread?.key ?? ""}|${drafts?.key ?? ""}|${showArchived ? "arch" : ""}`
   const viewKeyRef = useRef(viewKey)
   let committedInput = committed
   let bufferedInput = buffered
@@ -623,6 +665,10 @@ export function useStableBoardView(
       // {@link BoardUnreadScope}).
       if (isExcluded(post)) continue
       if (!matchesUnread(post, unread)) continue
+      // Resolving a draft is the viewer's own act on that card, so the drafts
+      // view sheds it immediately — unlike reading in the unread view, which the
+      // session floor holds in place.
+      if (!matchesDrafts(post, drafts)) continue
       if (rawIds !== null && !rawIds.has(id)) removed.add(id)
       out.push(post)
     }
@@ -649,7 +695,7 @@ export function useStableBoardView(
       removedIds: removed as ReadonlySet<string>,
       removedSuccessorById: successorById as ReadonlyMap<string, RemovedSuccessor | null>,
     }
-  }, [committed, live, rawLive, unread, isExcluded])
+  }, [committed, live, rawLive, unread, drafts, isExcluded])
 
   return {
     posts,

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, render, screen } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { Fragment, createElement } from "react"
 import * as boardFeedListModule from "@/components/board/board-feed-list"
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
@@ -22,6 +22,8 @@ import * as panelHostModule from "@/components/layout/panel-host"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
 import { db } from "@/db"
 import { __resetConversationMessageSnapshots, seedConversationMessages } from "@/stores/conversation-messages-store"
+import { __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
+import { boardReplyDraftKey, boardBranchReplyDraftKey, boardSubtopicDraftKey } from "@/lib/board/draft-keys"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -714,5 +716,64 @@ describe("BoardPage unread view", () => {
     mountBoard([makePost()])
     await screen.findByText("CC Teams tokens")
     expect(screen.queryByRole("button", { name: "Clear from unread" })).toBeNull()
+  })
+})
+
+describe("BoardPage drafts view", () => {
+  const DRAFTS_ENTRY = `/w/${WORKSPACE_ID}/board?drafts=true`
+
+  async function seedDraft(id: string, scope: string, text: string) {
+    await db.drafts.add({
+      id,
+      workspaceId: WORKSPACE_ID,
+      scope,
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] },
+      attachments: [],
+      clientUpdatedAt: 1000,
+    } as never)
+  }
+
+  beforeEach(async () => {
+    __clearBoardDraftsRegistry()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+  })
+
+  afterEach(async () => {
+    __clearBoardDraftsRegistry()
+    await db.drafts.clear()
+  })
+
+  function draftPosts(): BoardPost[] {
+    return [
+      makePost({ id: "conv_reply", topicSummary: "Reply draft card", messageIds: ["m_r"] }, { id: "m_r" }),
+      makePost({ id: "conv_branch", topicSummary: "Branch draft card", messageIds: ["m_b"] }, { id: "m_b" }),
+      makePost({ id: "conv_sub", topicSummary: "Subtopic draft card", messageIds: ["msg_fork"] }, { id: "msg_fork" }),
+      makePost({ id: "conv_none", topicSummary: "No draft card", messageIds: ["m_n"] }, { id: "m_n" }),
+    ]
+  }
+
+  it("keeps only the cards a board draft key resolves to", async () => {
+    await seedDraft("draft_reply", boardReplyDraftKey("conv_reply"), "reply body")
+    await seedDraft("draft_branch", boardBranchReplyDraftKey("conv_branch"), "branch body")
+    await seedDraft("draft_sub", boardSubtopicDraftKey("stream_1", "msg_fork"), "subtopic body")
+
+    mountBoard(draftPosts(), { entry: DRAFTS_ENTRY })
+
+    expect(await screen.findByText("Reply draft card")).toBeTruthy()
+    await waitFor(() => expect(screen.getByText("Branch draft card")).toBeTruthy())
+    expect(screen.getByText("Subtopic draft card")).toBeTruthy()
+    expect(screen.queryByText("No draft card")).toBeNull()
+  })
+
+  it("shows nothing when no board draft matches a card", async () => {
+    await seedDraft("draft_other", boardReplyDraftKey("conv_elsewhere"), "unrelated body")
+
+    mountBoard(draftPosts(), { entry: DRAFTS_ENTRY })
+
+    await waitFor(() => expect(screen.queryByText("Reply draft card")).toBeNull())
+    expect(screen.queryByText("Branch draft card")).toBeNull()
+    expect(screen.queryByText("Subtopic draft card")).toBeNull()
+    expect(screen.queryByText("No draft card")).toBeNull()
   })
 })

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -766,6 +766,30 @@ describe("BoardPage drafts view", () => {
     expect(screen.queryByText("No draft card")).toBeNull()
   })
 
+  it("keeps a card whose checked-out draft is emptied mid-rewrite, sheds it when the row goes", async () => {
+    const scope = boardReplyDraftKey("conv_reply")
+    await seedDraft("draft_reply", scope, "reply body")
+    await db.composerLoaded.put({ workspaceId: WORKSPACE_ID, scope, draftId: "draft_reply" } as never)
+
+    mountBoard(draftPosts(), { entry: DRAFTS_ENTRY })
+
+    expect(await screen.findByText("Reply draft card")).toBeTruthy()
+
+    const emptied = await db.drafts.get("draft_reply")
+    await db.drafts.put({
+      ...emptied!,
+      contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      clientUpdatedAt: 2000,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(screen.getByText("Reply draft card")).toBeTruthy()
+
+    await db.drafts.delete("draft_reply")
+
+    await waitFor(() => expect(screen.queryByText("Reply draft card")).toBeNull())
+  })
+
   it("shows nothing when no board draft matches a card", async () => {
     await seedDraft("draft_other", boardReplyDraftKey("conv_elsewhere"), "unrelated body")
 

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -766,7 +766,7 @@ describe("BoardPage drafts view", () => {
     expect(screen.queryByText("No draft card")).toBeNull()
   })
 
-  it("keeps a card whose checked-out draft is emptied mid-rewrite, sheds it when the row goes", async () => {
+  it("keeps a card whose checked-out draft is emptied mid-rewrite, marks it removed in place when the row goes", async () => {
     const scope = boardReplyDraftKey("conv_reply")
     await seedDraft("draft_reply", scope, "reply body")
     await db.composerLoaded.put({ workspaceId: WORKSPACE_ID, scope, draftId: "draft_reply" } as never)
@@ -787,7 +787,10 @@ describe("BoardPage drafts view", () => {
 
     await db.drafts.delete("draft_reply")
 
-    await waitFor(() => expect(screen.queryByText("Reply draft card")).toBeNull())
+    // Shed through the removal path: the card keeps its slot (and its mounted
+    // composer subtree) under the removed overlay, which names the reason.
+    await waitFor(() => expect(screen.getByText("No longer a draft.")).toBeTruthy())
+    expect(screen.getByText("Reply draft card")).toBeTruthy()
   })
 
   it("shows nothing when no board draft matches a card", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/hooks/use-conversation-graph"
 import {
   useBoardDraftsReady,
+  useBoardCheckedOutDraftScopes,
   useBoardScopeDraftIndex,
   useBoardSubtopicDraftIndex,
 } from "@/hooks/use-scope-draft-preview"
@@ -331,21 +332,32 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   const draftsOnly = searchParams.get(BOARD_DRAFTS_PARAM) === BOARD_DRAFTS_ON
   const scopeDraftIndex = useBoardScopeDraftIndex(workspaceId)
   const subtopicDraftIndex = useBoardSubtopicDraftIndex(workspaceId)
+  // A scope checked out into a composer counts as a draft even with no payload:
+  // select-all + Backspace mid-rewrite must not yank the card out from under the
+  // focused composer. The row is deleted on send/discard — that is when it sheds.
+  const checkedOutDraftScopes = useBoardCheckedOutDraftScopes(workspaceId)
   // Signature-memoized like `archivedRootSignature`: the draft indexes get a new
   // Map identity on every keystroke, and these sets feed the feed filter.
   const draftConversationSignature = useMemo(() => {
-    const ids: string[] = []
-    for (const scope of scopeDraftIndex.keys()) {
+    const ids = new Set<string>()
+    for (const scope of [...scopeDraftIndex.keys(), ...checkedOutDraftScopes]) {
       const parsed = parseBoardDraftKey(scope)
-      if (parsed && (parsed.kind === "reply" || parsed.kind === "branch-reply")) ids.push(parsed.conversationId)
+      if (parsed && (parsed.kind === "reply" || parsed.kind === "branch-reply")) ids.add(parsed.conversationId)
     }
-    return ids.sort().join(",")
-  }, [scopeDraftIndex])
+    return [...ids].sort().join(",")
+  }, [scopeDraftIndex, checkedOutDraftScopes])
   const draftConversationIds = useMemo(
     () => new Set<string>(draftConversationSignature ? draftConversationSignature.split(",") : []),
     [draftConversationSignature]
   )
-  const subtopicMessageSignature = useMemo(() => [...subtopicDraftIndex.keys()].sort().join(","), [subtopicDraftIndex])
+  const subtopicMessageSignature = useMemo(() => {
+    const ids = new Set<string>(subtopicDraftIndex.keys())
+    for (const scope of checkedOutDraftScopes) {
+      const parsed = parseBoardDraftKey(scope)
+      if (parsed?.kind === "subtopic") ids.add(parsed.messageId)
+    }
+    return [...ids].sort().join(",")
+  }, [subtopicDraftIndex, checkedOutDraftScopes])
   const subtopicDraftMessageIds = useMemo(
     () => new Set<string>(subtopicMessageSignature ? subtopicMessageSignature.split(",") : []),
     [subtopicMessageSignature]

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -31,7 +31,12 @@ import {
   useStreamStructuralIndex,
   collectBranchThreadStreamIds,
 } from "@/hooks/use-conversation-graph"
-import { useBoardDraftsReady } from "@/hooks/use-scope-draft-preview"
+import {
+  useBoardDraftsReady,
+  useBoardScopeDraftIndex,
+  useBoardSubtopicDraftIndex,
+} from "@/hooks/use-scope-draft-preview"
+import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { SKELETON_DELAY_MS, useCoordinatedPhase } from "@/contexts/coordinated-loading-context"
 import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/components/composer"
 import { BoardCard, BoardCardSkeleton } from "@/components/board/board-card"
@@ -57,6 +62,8 @@ import {
   BOARD_ARCHIVED_ON,
   BOARD_UNREAD_PARAM,
   BOARD_UNREAD_ON,
+  BOARD_DRAFTS_PARAM,
+  BOARD_DRAFTS_ON,
   clearFiltersSearch,
   parseIdListParam,
   parseLensParam,
@@ -317,6 +324,33 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     [archivedRootSignature]
   )
 
+  // Drafts is a narrowing opt-in (`?drafts=true`), resolved client-side off the
+  // shared board-drafts snapshot the card affordances already read — live as
+  // drafts are written, no refetch. No fail-open gate: the board's reveal holds
+  // first paint on `useBoardDraftsReady`, so the snapshot is settled by then.
+  const draftsOnly = searchParams.get(BOARD_DRAFTS_PARAM) === BOARD_DRAFTS_ON
+  const scopeDraftIndex = useBoardScopeDraftIndex(workspaceId)
+  const subtopicDraftIndex = useBoardSubtopicDraftIndex(workspaceId)
+  // Signature-memoized like `archivedRootSignature`: the draft indexes get a new
+  // Map identity on every keystroke, and these sets feed the feed filter.
+  const draftConversationSignature = useMemo(() => {
+    const ids: string[] = []
+    for (const scope of scopeDraftIndex.keys()) {
+      const parsed = parseBoardDraftKey(scope)
+      if (parsed && (parsed.kind === "reply" || parsed.kind === "branch-reply")) ids.push(parsed.conversationId)
+    }
+    return ids.sort().join(",")
+  }, [scopeDraftIndex])
+  const draftConversationIds = useMemo(
+    () => new Set<string>(draftConversationSignature ? draftConversationSignature.split(",") : []),
+    [draftConversationSignature]
+  )
+  const subtopicMessageSignature = useMemo(() => [...subtopicDraftIndex.keys()].sort().join(","), [subtopicDraftIndex])
+  const subtopicDraftMessageIds = useMemo(
+    () => new Set<string>(subtopicMessageSignature ? subtopicMessageSignature.split(",") : []),
+    [subtopicMessageSignature]
+  )
+
   const filter = useMemo<BoardViewFilter>(
     () => ({
       lens,
@@ -328,6 +362,13 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       excludeLabels: excludeLabelStreamIds ? { key: excludeLabelKey, streamIds: excludeLabelStreamIds } : null,
       unread: unreadStreamIds
         ? { key: BOARD_UNREAD_ON, streamIds: unreadStreamIds, clearedConversationIds: clearedUnreadIds }
+        : null,
+      drafts: draftsOnly
+        ? {
+            key: BOARD_DRAFTS_ON,
+            conversationIds: draftConversationIds,
+            subtopicMessageIds: subtopicDraftMessageIds,
+          }
         : null,
       showArchived,
       archivedRootIds,
@@ -348,6 +389,9 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       excludeLabelStreamIds,
       unreadStreamIds,
       clearedUnreadIds,
+      draftsOnly,
+      draftConversationIds,
+      subtopicDraftMessageIds,
       showArchived,
       archivedRootIds,
     ]
@@ -566,7 +610,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // Changing lens OR scope replaces the feed with a different (often much
   // shorter) subset, so jump to the top pre-paint — otherwise a viewer scrolled
   // down the All wall who narrows the view lands past the end of a short list.
-  const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}|${unreadOnly ? "unread" : ""}`
+  const resetKey = `${lens}|${scopeKey}|${typeKey}|${excludeScopeKey}|${excludeTypeKey}|${labelKey}|${excludeLabelKey}|${showArchived ? "arch" : ""}|${unreadOnly ? "unread" : ""}|${draftsOnly ? "drafts" : ""}`
   useLayoutEffect(() => {
     closeAllRevealWindows()
     if (scrollerRef.current) scrollerRef.current.scrollTop = 0
@@ -600,7 +644,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     excludeStreamTypes.length > 0 ||
     scopeLabelIds.length > 0 ||
     excludeLabelIds.length > 0 ||
-    unreadOnly
+    unreadOnly ||
+    draftsOnly
   // The viewer's own just-posted card gets a brief gold-thread flash (the golden
   // thread motif, on the primary action). The flashed id lives in a module store
   // (`setBoardFlash`) that each card subscribes to by its own id, not in page
@@ -826,7 +871,9 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
           excludeStreamIds,
           excludeStreamTypes,
           excludeLabelIds,
-        }) || unreadOnly
+        }) ||
+        unreadOnly ||
+        draftsOnly
       const copy = scoped ? SCOPED_EMPTY_COPY : LENS_EMPTY_COPY[lens]
       stateContent = (
         <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -506,6 +506,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     hasRawPosts,
     removedIds,
     removedSuccessorById,
+    draftResolvedIds,
   } = useStableBoardView(workspaceId, filter, exclusions, seed, seenCardsRef)
   // After a refetch settles, `isLoading` is already false but the seed effect
   // writes IDB on the next tick, so the IDB feed can be momentarily empty while
@@ -806,6 +807,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
                 streamType={streamType}
                 dmPeerUserId={dmPeerUserId}
                 successor={removedSuccessorById.get(row.post.conversation.id) ?? null}
+                emptyLabel={draftResolvedIds.has(row.post.conversation.id) ? "No longer a draft." : undefined}
               />
             </div>
           )
@@ -831,6 +833,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       labelsFor,
       removedIds,
       removedSuccessorById,
+      draftResolvedIds,
       isFetchNextPageError,
       isFetchingNextPage,
       fetchNextPage,


### PR DESCRIPTION
## Problem

Two board-sidebar asks: "The sections header rows should make it possible to filter for them" — the verbs existed (label/type/unread/scope-all links wired since the board-sidebar work) but were hover-invisible `reveal-actions` with a navigate arrow, no active state, and no way to un-toggle. And "filter by drafts to make it easier to find back to messages I've started to write on but not yet finished" — no such axis existed.

## Solution

**Section headers.** In board mode the filter affordance is an always-visible dimmed `ListFilter` (touch included; chats mode byte-identical), with an active state (`aria-current` + tint) whose link flips to the clearing URL and whose name flips to "Clear board scope/filter …". Scope-all normalizes (dedupe + `MAX_BOARD_SCOPE_STREAMS` cap) for both the href and the active comparison — the adversarial verify caught that an oversized section (the common "Everything else" bucket) could apply a capped scope it then never recognized as active, leaving a dead control; oversized sections also say "first 50 of N".

**`?drafts=true`.** Client-side over the reveal-gated board draft index (no server change; the unread axis is the template): reply + branch-reply drafts match by conversation, sub-topic drafts by anchor message. New `clearAxisSearch` unifies the per-axis clearing builders. The toggle is labelled **With drafts** (a second "Drafts" row under the Drafts quick link read as the same thing). Resolving a draft drops the card via the committed re-check — acting on the card is the viewer's own act, unlike the unread view's involuntary reads (which keep their session floor). Accepted boundaries: a draft synced away by another device also drops its card; a branch child with a draft surfaces standalone (matches every other axis); board drafts only — stream-composer drafts wait for the board⇄timeline draft-sharing effort.

## Test plan

- [x] Adversarial verify (Opus high): 5 findings, all fixed (capped-section dead toggle, lying active label, unshed resolved drafts, untested key→scope derivation, duplicate "Drafts" label)
- [x] Targeted: sections, sidebar-stream-list (new), board-mode-block, use-stable-board-view, board page (incl. a real-draft-keys "drafts view" block), board-filter-params — 143 + 214 pre-fix, tsc clean
- [x] Falsified: matchesDrafts, committed re-check, cap normalize, kind predicate, active-state — each turned exactly its tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788358289&installation_model_id=20758&pr_number=1755&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1755&signature=c8e481a0dcb89b5c5aaf4bb74497bdde019c40c5b927ff775292a18b369eba12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->