### PR TITLE
feat(board): slash-command chips on cards and the conversation panel

### DIFF
--- a/apps/backend/src/features/commands/events.test.ts
+++ b/apps/backend/src/features/commands/events.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Querier } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
+import { StreamEventRepository } from "../streams"
+import { insertCommandDispatchedEvent } from "./events"
+
+const insertedEvent = {
+  id: "evt_1",
+  streamId: "stream_1",
+  sequence: 1n,
+  broadcastSequence: null,
+  eventType: "command_dispatched" as const,
+  payload: {},
+  actorId: "usr_1",
+  actorType: "user" as const,
+  createdAt: new Date("2026-07-28T10:00:00.000Z"),
+}
+
+function baseParams() {
+  return {
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    userId: "usr_1",
+    commandId: "cmd_1",
+    name: "compact",
+    args: "",
+  }
+}
+
+describe("insertCommandDispatchedEvent conversation ref", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("stamps the dispatching conversation on the payload", async () => {
+    const insert = spyOn(StreamEventRepository, "insert").mockResolvedValue(insertedEvent)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+    await insertCommandDispatchedEvent({} as Querier, { ...baseParams(), conversationId: "conv_1" })
+
+    expect(insert.mock.calls[0][1].payload).toEqual({
+      commandId: "cmd_1",
+      name: "compact",
+      args: "",
+      status: "dispatched",
+      conversationId: "conv_1",
+    })
+  })
+
+  it("omits the field for a stream-level dispatch", async () => {
+    const insert = spyOn(StreamEventRepository, "insert").mockResolvedValue(insertedEvent)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+    await insertCommandDispatchedEvent({} as Querier, baseParams())
+
+    expect(insert.mock.calls[0][1].payload).toEqual({
+      commandId: "cmd_1",
+      name: "compact",
+      args: "",
+      status: "dispatched",
+    })
+  })
+})

--- a/apps/backend/src/features/commands/events.ts
+++ b/apps/backend/src/features/commands/events.ts
@@ -63,6 +63,8 @@ export async function insertCommandDispatchedEvent(
     eventId?: string
     name: string
     args: string
+    /** The conversation the dispatching composer wrote into, when it had one. */
+    conversationId?: string
     executionKind?: "server" | "bot-runtime"
   }
 ): Promise<StreamEvent> {
@@ -76,6 +78,7 @@ export async function insertCommandDispatchedEvent(
       name: params.name,
       args: params.args,
       status: "dispatched",
+      ...(params.conversationId && { conversationId: params.conversationId }),
       ...(params.executionKind && { executionKind: params.executionKind }),
     } satisfies CommandDispatchedPayload,
     actorId: params.userId,

--- a/apps/backend/src/features/commands/handlers.test.ts
+++ b/apps/backend/src/features/commands/handlers.test.ts
@@ -4,6 +4,7 @@ import type { Pool, PoolClient } from "pg"
 import { CommandKinds } from "@threa/types"
 import { createCommandHandlers } from "./handlers"
 import { CommandDispatchRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
 import { StreamEventRepository } from "../streams"
 import * as streamsModule from "../streams"
 
@@ -146,5 +147,36 @@ describe("command dispatch idempotency", () => {
       status: 202,
       commandId: "cmd_existing",
     })
+  })
+  it("stamps the dispatching conversation onto a fresh server-command event", async () => {
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1" } as never)
+    spyOn(CommandDispatchRepository, "findByClientId").mockResolvedValue(null)
+    spyOn(CommandDispatchRepository, "claim").mockResolvedValue(true)
+    const insert = spyOn(StreamEventRepository, "insert").mockResolvedValue(event)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    const handlers = createCommandHandlers({
+      pool: makePool(),
+      commandAvailabilityService: {
+        resolveCommand: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        listStreamCommands: mock(async () => []),
+        listWorkspaceCommands: mock(() => []),
+      } as never,
+      botRuntimeService: {} as never,
+    })
+    const req = {
+      user: { id: "usr_1" },
+      workspaceId: "ws_1",
+      body: {
+        streamId: "stream_1",
+        command: "/stop",
+        clientCommandId: "temp_cmd_1",
+        conversationId: "conv_1",
+      },
+    } as Request
+    const res = makeResponse()
+
+    await handlers.dispatch(req, res)
+
+    expect((insert.mock.calls[0][1].payload as { conversationId?: string }).conversationId).toBe("conv_1")
   })
 })

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -17,6 +17,7 @@ const dispatchCommandSchema = z.object({
   command: z.string().min(1, "command is required"),
   streamId: z.string().min(1, "streamId is required"),
   clientCommandId: z.string().min(1).max(255).optional(),
+  conversationId: z.string().min(1).optional(),
 })
 
 interface Dependencies {
@@ -136,7 +137,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
         })
       }
 
-      const { command: commandString, streamId, clientCommandId } = result.data
+      const { command: commandString, streamId, clientCommandId, conversationId } = result.data
       const parsed = parseCommand(commandString)
       if (!parsed) {
         return res.status(400).json({
@@ -214,6 +215,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
             eventId: evtId,
             name: parsed.name,
             args: parsed.args,
+            conversationId,
             executionKind: CommandKinds.SERVER,
           })
           return { commandId: cmdId, command: parsed.name, args: parsed.args, event }
@@ -246,6 +248,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           eventId: evtId,
           name: parsed.name,
           args: parsed.args,
+          conversationId,
           executionKind: CommandKinds.BOT_RUNTIME,
         })
 

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner"
 import type { Socket } from "socket.io-client"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { BoardPostMessage } from "@threa/types"
+import { StreamTypes, type BoardPostMessage } from "@threa/types"
 import { BoardCard } from "./board-card"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { ServicesProvider, PanelProvider, TraceProvider, MediaGalleryProvider } from "@/contexts"
@@ -15,7 +15,7 @@ import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 import { __resetCollapseCacheForTests } from "@/lib/markdown/collapse-cache"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
-import { db, type CachedEvent } from "@/db"
+import { db, type CachedEvent, type CachedStream } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
@@ -128,17 +128,19 @@ function sessionEvent(
   }
 }
 
-/** A command lifecycle event on the card's stream, author-scoped like the wire. */
+/** A command lifecycle event, author-scoped like the wire. Hosted on the card's
+ *  stream unless a host stream is named (a branch-reply command). */
 function commandEvent(
   eventType: "command_dispatched" | "command_completed" | "command_failed",
   seconds: number,
   actorId: string,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  hostStreamId: string = STREAM
 ): CachedEvent {
   return {
     id: `${eventType}_${seconds}`,
     workspaceId: WS,
-    streamId: STREAM,
+    streamId: hostStreamId,
     sequence: String(seconds),
     _sequenceNum: seconds,
     eventType,
@@ -148,6 +150,30 @@ function commandEvent(
     createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
     _cachedAt: seconds,
   }
+}
+
+/** A cached stream row: the card's channel when `parentStreamId` is null, else a
+ *  thread hanging off `parentAnchorId`. */
+function threadStream(
+  id: string,
+  parentStreamId: string | null,
+  rootStreamId: string | null,
+  parentAnchorId: string | null
+): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: parentStreamId ? StreamTypes.THREAD : StreamTypes.CHANNEL,
+    displayName: null,
+    slug: id,
+    description: null,
+    visibility: "public",
+    parentStreamId,
+    parentAnchorId,
+    rootStreamId,
+    createdAt: "2026-06-22T11:00:00.000Z",
+    updatedAt: "2026-06-22T11:00:00.000Z",
+  } as unknown as CachedStream
 }
 
 /** A socket that records its listeners so a test can fire an ephemeral event
@@ -321,6 +347,44 @@ describe("BoardCard agent activity", () => {
     expect(await screen.findByText("/compact")).toBeTruthy()
     expect(screen.getByText("completed")).toBeTruthy()
     expect(screen.queryByText("/kick")).toBeNull()
+  })
+
+  it("renders the command chip for a command hosted on an overflowed branch stream", async () => {
+    // The board used to place event rows by `event.streamId`: a slash command typed
+    // into a deep branch reply is hosted on that branch's thread stream, which
+    // collapses behind a `continue thread` row, so the chip vanished. Card-level
+    // proof (resolver + row builder + render) of the depth-0 anchoring pinned in
+    // board-row-item.test.ts. Graph mirrors that test: root→t1→t2→t3, rel-depth 3.
+    await db.streams.bulkPut([
+      threadStream(STREAM, null, null, null),
+      threadStream("t1", STREAM, STREAM, "m_open"),
+      threadStream("t2", "t1", STREAM, "m_b1"),
+      threadStream("t3", "t2", STREAM, "m_b2"),
+    ])
+    await db.events.bulkPut([
+      messageEvent("m_open", "Opening body.", 10),
+      messageEvent("m_b1", "Branch one.", 20, undefined, "t1"),
+      messageEvent("m_b2", "Branch two.", 30, undefined, "t2"),
+      messageEvent("m_b3", "Branch three.", 40, undefined, "t3"),
+      commandEvent(
+        "command_dispatched",
+        50,
+        "usr_me",
+        { commandId: "cmd_deep", name: "compact", args: "", status: "dispatched", conversationId: "conv_1" },
+        "t3"
+      ),
+      commandEvent("command_completed", 51, "usr_me", { commandId: "cmd_deep" }, "t3"),
+    ])
+    const post = makePost({ messageIds: ["m_open", "m_b1", "m_b2", "m_b3"] })
+    mountCard({ ...post, streamIds: [STREAM, "t1", "t2", "t3"] } as unknown as BoardViewPost)
+
+    // The host stream really is collapsed behind the spanning-overflow row — the
+    // chip's host row is not rendered, so the chip can only survive by anchoring
+    // to the conversation.
+    expect(await screen.findByText("Continue this thread")).toBeTruthy()
+    expect(screen.queryByText("Branch three.")).toBeNull()
+    expect(await screen.findByText("/compact")).toBeTruthy()
+    expect(screen.getByText(/completed/)).toBeTruthy()
   })
 
   it("live-updates a running session's step count from agent_session:progress", async () => {
@@ -884,10 +948,17 @@ describe("BoardCard unread dot on a deleted opening", () => {
 
 /** A `message_created` row on the card's stream, seeded into IDB so the card's
  *  rail reads it like the timeline does. */
-function messageEvent(messageId: string, contentMarkdown: string, seconds: number, deletedAt?: string): CachedEvent {
+function messageEvent(
+  messageId: string,
+  contentMarkdown: string,
+  seconds: number,
+  deletedAt?: string,
+  hostStreamId: string = STREAM
+): CachedEvent {
   return {
     ...sessionEvent("agent_session:started", seconds, { messageId, contentMarkdown, reactions: {}, deletedAt }),
     id: `evt_${messageId}`,
+    streamId: hostStreamId,
     eventType: "message_created",
     actorId: "usr_me",
     actorType: "user",

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -128,6 +128,28 @@ function sessionEvent(
   }
 }
 
+/** A command lifecycle event on the card's stream, author-scoped like the wire. */
+function commandEvent(
+  eventType: "command_dispatched" | "command_completed" | "command_failed",
+  seconds: number,
+  actorId: string,
+  payload: Record<string, unknown>
+): CachedEvent {
+  return {
+    id: `${eventType}_${seconds}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType,
+    payload,
+    actorId,
+    actorType: "user",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
 /** A socket that records its listeners so a test can fire an ephemeral event
  *  (`agent_session:progress`) the way the backend's trace-emitter does. */
 function fakeSocket() {
@@ -275,6 +297,30 @@ describe("BoardCard agent activity", () => {
     ])
     mountCard()
     expect(await screen.findByText("Session complete")).toBeTruthy()
+  })
+
+  it("renders the command chip for a command dispatched into this conversation, and drops another member's", async () => {
+    await db.events.bulkPut([
+      commandEvent("command_dispatched", 50, "usr_me", {
+        commandId: "cmd_1",
+        name: "compact",
+        args: "",
+        status: "dispatched",
+        conversationId: "conv_1",
+      }),
+      commandEvent("command_completed", 51, "usr_me", { commandId: "cmd_1" }),
+      commandEvent("command_dispatched", 52, "usr_other", {
+        commandId: "cmd_other",
+        name: "kick",
+        args: "",
+        status: "dispatched",
+        conversationId: "conv_1",
+      }),
+    ])
+    mountCard()
+    expect(await screen.findByText("/compact")).toBeTruthy()
+    expect(screen.getByText("completed")).toBeTruthy()
+    expect(screen.queryByText("/kick")).toBeNull()
   })
 
   it("live-updates a running session's step count from agent_session:progress", async () => {

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -338,8 +338,8 @@ export function BoardCard({
     return set
   }, [conversation.messageIds, knownMessages])
   const eventRows = useMemo(
-    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
-    [railEvents, conversation.id, memberMessageIds]
+    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds, currentUserId }),
+    [railEvents, conversation.id, memberMessageIds, currentUserId]
   )
 
   // Per-thread-boundary grouping: soft-thread seams, nested branch conversations,

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -119,6 +119,12 @@ interface InlineComposerFormProps {
    */
   scheduleTarget?: { streamId: string; conversationId: string }
   /**
+   * The conversation a slash command dispatched from here belongs to — the card
+   * draws the command chip on it. Omitted where the target doesn't exist yet (a
+   * new sub-topic, a still-pending branch), and the command stays stream-level.
+   */
+  commandConversationId?: string
+  /**
    * Stash row to check out once the composer mounts. Set by a resting
    * affordance that advertised a stashed/roamed draft (the loaded pointer is
    * device-local, so the row won't hydrate by itself) — opening must surface
@@ -166,6 +172,7 @@ export function InlineComposerForm({
   onQuoteConsumed,
   rejectE2e,
   scheduleTarget,
+  commandConversationId,
   restoreStashedIdOnMount,
   focusSignal,
   onSubmit,
@@ -203,7 +210,7 @@ export function InlineComposerForm({
   // switching cards without hijacking the ambient draft slot.
   const stash = useStashComposer(composer, workspaceId, draftKey)
   const scheduleMessage = useScheduleMessage(workspaceId)
-  const { planSend, dispatchCommand } = useComposerCommandSend(workspaceId, streamId)
+  const { planSend, dispatchCommand } = useComposerCommandSend(workspaceId, streamId, commandConversationId)
 
   // Check out the advertised stash row once (mount-captured; the guard ref, not
   // the effect deps, enforces once — `stash` is a fresh object every render).

--- a/apps/frontend/src/components/board/board-reply-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.test.tsx
@@ -29,6 +29,7 @@ const FormStub = (props: InlineComposerFormProps) => (
     data-reply-target-title={props.replyTarget?.title ?? ""}
     data-reply-target-move={props.replyTarget?.moveDraftToKey ?? ""}
     data-schedule-conv={props.scheduleTarget?.conversationId ?? ""}
+    data-command-conv={props.commandConversationId ?? ""}
   />
 )
 
@@ -86,6 +87,9 @@ describe("BoardReplyComposer alwaysDocked (docked-composer semantics)", () => {
     const form = screen.getByTestId("form-stub")
     expect(form).toHaveAttribute("data-draft-key", "board:branch-reply:conv_branch")
     expect(form).toHaveAttribute("data-schedule-conv", "conv_branch")
+    // Commands stamp the PARENT conversation even when armed to a branch — the
+    // chip renders on the parent surface (resolveBoardEventRows runs there only).
+    expect(form).toHaveAttribute("data-command-conv", "conv_1")
     expect(form).toHaveAttribute("data-reply-target-title", "Sub-topic")
     // The × moves the branch draft back to the conversation's ROOT reply scope.
     expect(form).toHaveAttribute("data-reply-target-move", "board:reply:conv_1")

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -282,6 +282,9 @@ function BoardReplyComposerForm({
       scheduleTarget={
         armedReply ? armedReply.scheduleTarget : { streamId: rootStreamId, conversationId: post.conversation.id }
       }
+      // Always the parent conversation, armed branch replies included: chips
+      // render via resolveBoardEventRows, which only the parent surface runs.
+      commandConversationId={post.conversation.id}
       restoreStashedIdOnMount={restoreStashedId}
       autoFocus={autoFocus}
       focusSignal={focusSignal}

--- a/apps/frontend/src/components/board/board-row-item.render.test.tsx
+++ b/apps/frontend/src/components/board/board-row-item.render.test.tsx
@@ -6,6 +6,7 @@ import { BOARD_EVENT_ROW_TYPES, type EventType } from "@threa/types"
 // eslint-disable-next-line no-restricted-imports -- test builds the rail's own row type, not a component data read
 import type { CachedEvent } from "@/db"
 import * as hooksModule from "@/hooks"
+import * as contextsModule from "@/contexts"
 import { PanelProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { resolveBoardEventRows, type BoardEventRow } from "@/lib/board/board-event-rows"
@@ -48,7 +49,21 @@ const SESSION_FIXTURE: CachedEvent[] = [
   cachedEvent("agent_session:completed", { sessionId: "sess_1", stepCount: 3, duration: 1200, messageCount: 1 }),
 ]
 
+const COMMAND_FIXTURE: CachedEvent[] = [
+  cachedEvent("command_dispatched", {
+    commandId: "cmd_1",
+    name: "compact",
+    args: "",
+    status: "dispatched",
+    conversationId: CONV,
+  }),
+  cachedEvent("command_completed", { commandId: "cmd_1" }),
+]
+
 const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
+  command_dispatched: COMMAND_FIXTURE,
+  command_completed: COMMAND_FIXTURE,
+  command_failed: COMMAND_FIXTURE,
   "agent_session:started": SESSION_FIXTURE,
   "agent_session:completed": SESSION_FIXTURE,
   "agent_session:failed": SESSION_FIXTURE,
@@ -80,7 +95,11 @@ const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
 }
 
 function rowsFor(events: CachedEvent[]): BoardEventRow[] {
-  return resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set([MEMBER_MESSAGE]) })
+  return resolveBoardEventRows(events, {
+    conversationId: CONV,
+    memberMessageIds: new Set([MEMBER_MESSAGE]),
+    currentUserId: "persona_1",
+  })
 }
 
 function renderRow(row: BoardEventRow) {
@@ -107,6 +126,9 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof hooksModule.useActors>)
   vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(false)
   vi.spyOn(hooksModule, "useInputMode").mockReturnValue("mouse")
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
 })
 
 describe("BoardEventRowItem renders every spec-declared board row", () => {
@@ -134,6 +156,9 @@ describe("BoardEventRowItem renders every spec-declared board row", () => {
       "memos:captured": ["memo"],
       "agent:follow_up_scheduled": ["followUp"],
       "delegation:created": ["delegation"],
+      command_dispatched: ["command"],
+      command_completed: ["command"],
+      command_failed: ["command"],
     })
     // A kind that renders nothing produces `[]`, and `[]` can be pasted into the
     // expectation above to make it green. This half names the offending type and

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -38,6 +38,30 @@ function memoEventRow(key: string, minute: number, streamId = "root"): BoardEven
   } as BoardEventRow
 }
 
+function commandEventRow(key: string, minute: number, streamId: string): BoardEventRow {
+  const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
+  return {
+    kind: "command",
+    key,
+    sortMs: new Date(createdAt).getTime(),
+    streamId,
+    events: [{ id: key, createdAt }],
+  } as BoardEventRow
+}
+
+function sessionEventRow(key: string, minute: number, streamId: string): BoardEventRow {
+  const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
+  return {
+    kind: "session",
+    key,
+    sortMs: new Date(createdAt).getTime(),
+    streamId,
+    events: [{ id: key, createdAt }],
+  } as BoardEventRow
+}
+
+const rowKinds = (rows: BoardRow[]) => rows.map((r) => r.kind)
+
 describe("buildBoardRows", () => {
   it("groups consecutive same-author messages as continuations", () => {
     const rows = buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 1), msg("c", "u2", 2)], [])
@@ -250,6 +274,32 @@ describe("buildBranchedBoardRows continuation", () => {
     expect(rows.map((r) => (r.kind === "message" ? r.message.id : r.kind))).toEqual(["a", "event", "b"])
     const orphanRow = rows[1]
     expect(orphanRow.kind === "event" && orphanRow.displayDepth).toBe(0)
+  })
+
+  it("a command row hosted on an overflowed branch still lands at depth 0 (session rows keep today's shape)", () => {
+    // A slash command typed into a deeply nested branch reply is hosted on that
+    // branch's thread stream, which collapses into a `continue-thread` row. The
+    // chip anchors to the conversation, not the host stream, so it must survive.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["t1", streamNode("root", "root", "a")],
+      ["t2", streamNode("t1", "root", "m1")],
+      ["t3", streamNode("t2", "root", "m2")],
+    ])
+    const grouping = groupBranches(
+      [msg("a", "u1", 0, "root"), msg("m1", "u1", 1, "t1"), msg("m2", "u1", 2, "t2"), msg("m3", "u1", 3, "t3")],
+      { streams, conversation: { streamId: "root" } }
+    )
+    expect(rowKinds(buildBranchedBoardRows(grouping, [], new Map()))).toContain("continue-thread")
+
+    const rows = buildBranchedBoardRows(
+      grouping,
+      [commandEventRow("cmd", 4, "t3"), sessionEventRow("sess", 5, "t3")],
+      new Map()
+    )
+    const eventRows = rows.filter((r) => r.kind === "event")
+    expect(eventRows.map((r) => (r.kind === "event" ? r.row.key : ""))).toEqual(["cmd"])
+    expect(eventRows[0].kind === "event" && eventRows[0].displayDepth).toBe(0)
   })
 
   it("splits orphan events across a soft seam by time", () => {

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react"
-import { Bot, Clock, Sparkles, TerminalSquare } from "lucide-react"
+import { Bot, Clock, Sparkles, SquareSlash, TerminalSquare } from "lucide-react"
 import type { StreamEvent } from "@threa/types"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { isContinuation } from "@/lib/message-grouping"
@@ -9,6 +9,7 @@ import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import { DelegationEvent } from "@/components/timeline/delegation-event"
+import { CommandEvent } from "@/components/timeline/command-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
 import { useSocket, useTrace } from "@/contexts"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -460,6 +461,14 @@ export function BoardEventRowItem({
           />
         </div>
       )
+    case "command":
+      // Same horizontal inset the timeline gives the chip (event-list wraps it
+      // in px-3 sm:px-6) — bare, its hover highlight bleeds past the content column.
+      return (
+        <div className="px-3 sm:px-6">
+          <CommandEvent events={row.events as StreamEvent[]} />
+        </div>
+      )
     case "memo":
       return <MemoCapturedEvent event={row.event as StreamEvent} workspaceId={workspaceId} />
     case "followUp":
@@ -488,6 +497,7 @@ export function BoardEventRowItem({
 
 const LEDGER_EVENT_ICONS: Record<BoardEventRow["kind"], ReactNode> = {
   session: <Bot className="size-3" />,
+  command: <SquareSlash className="size-3" />,
   memo: <Sparkles className="size-3 text-amber-500" />,
   followUp: <Clock className="size-3" />,
   delegation: <TerminalSquare className="size-3" />,

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -278,8 +278,17 @@ export function buildBranchedBoardRows(
   const firstMs = earliestMessageMs(grouping.roots)
   const renderedForkIds = new Set<string>()
   const eventsByStream = new Map<string, BoardEventRow[]>()
+  // Command rows resolve to the conversation the command was typed into, not to
+  // the stream hosting them — a branch-reply command lives on the branch thread
+  // stream, which can be collapsed behind an overflow row. Anchoring them in the
+  // card's main flow keeps "the chip lands on the card you typed into" true.
+  const anchoredEvents: BoardEventRow[] = []
   for (const event of eventRows) {
     if (event.sortMs < firstMs) continue
+    if (event.kind === "command") {
+      anchoredEvents.push(event)
+      continue
+    }
     const list = eventsByStream.get(event.streamId)
     if (list) list.push(event)
     else eventsByStream.set(event.streamId, [event])
@@ -291,10 +300,11 @@ export function buildBranchedBoardRows(
     for (const child of node.children) collectStreamIds(child)
   }
   for (const node of grouping.roots) collectStreamIds(node)
-  const orphanEvents: BoardEventRow[] = []
+  const orphanEvents: BoardEventRow[] = [...anchoredEvents]
   for (const [streamId, list] of eventsByStream) {
     if (!groupedStreamIds.has(streamId)) orphanEvents.push(...list)
   }
+  orphanEvents.sort((a, b) => a.sortMs - b.sortMs)
 
   const out: BoardRow[] = []
 

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -201,6 +201,28 @@ describe("useInlineBranchComposer ?stash= deep-link consumer", () => {
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(result.current.openComposer).toBeNull()
   })
+
+  it("stamps the parent conversation on both inline composers so a slash command chips onto this card", async () => {
+    const { result } = mountHook("draft_none")
+
+    act(() => result.current.openNewSubtopic("stream_9", "msg_fork"))
+    const subtopicForm = result.current.renderAfterMessage("msg_fork") as ReactElement<{
+      commandConversationId?: string
+    }>
+    expect(subtopicForm.props.commandConversationId).toBe(PARENT_ID)
+
+    const branch = {
+      conversationId: "conv_branch",
+      threadStreamId: "stream_thread_1",
+      forkMessageId: "msg_fork_b",
+      title: "Sub-topic",
+      messages: [],
+      pending: false,
+    } as unknown as BranchConversationView
+    act(() => result.current.openBranchReply(branch))
+    const branchForm = result.current.renderBranchTail(branch) as ReactElement<{ commandConversationId?: string }>
+    expect(branchForm.props.commandConversationId).toBe(PARENT_ID)
+  })
 })
 
 describe("useInlineBranchComposer pending→real hand-off", () => {

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -488,6 +488,10 @@ export function useInlineBranchComposer(params: {
             scheduleTarget={
               branch.pending ? undefined : { streamId: branch.threadStreamId, conversationId: branch.conversationId }
             }
+            // The PARENT conversation, not the branch: command chips render via
+            // resolveBoardEventRows, which only the parent card/panel runs — a
+            // child-stamped chip would land on no visible surface.
+            commandConversationId={conversationId}
             restoreStashedIdOnMount={openComposer.restoreStashedId ?? null}
             onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
             onClose={closeComposer}

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -429,6 +429,7 @@ export function useInlineBranchComposer(params: {
             draftKey={boardSubtopicDraftKey(streamId, messageId)}
             placeholder="Start a sub-topic…"
             rejectE2e={E2E_SUBTOPIC_MESSAGE}
+            commandConversationId={conversationId}
             restoreStashedIdOnMount={openComposer.restoreStashedId ?? null}
             onSubmit={(sendInput) => submitNewSubtopic(streamId, messageId, sendInput)}
             onClose={closeComposer}

--- a/apps/frontend/src/components/composer/use-composer-command-send.test.tsx
+++ b/apps/frontend/src/components/composer/use-composer-command-send.test.tsx
@@ -33,8 +33,8 @@ function doc(...content: JSONContent[]): JSONContent {
   return { type: "doc", content: [{ type: "paragraph", content }] }
 }
 
-function hook(streamId: string | undefined = "stream_conversation") {
-  return renderHook(() => useComposerCommandSend("ws_1", streamId)).result
+function hook(streamId: string | undefined = "stream_conversation", conversationId?: string) {
+  return renderHook(() => useComposerCommandSend("ws_1", streamId, conversationId)).result
 }
 
 describe("useComposerCommandSend planSend", () => {
@@ -84,6 +84,21 @@ describe("useComposerCommandSend dispatchCommand", () => {
     expect({ queuedFor: queuedFor[0], call: queueCommand.mock.calls[0][0] }).toEqual({
       queuedFor: "stream_conversation",
       call: { commandMarkdown: "/compact", commandName: "compact" },
+    })
+  })
+
+  it("stamps the composer's conversation on the dispatch so the card can draw the chip", async () => {
+    const result = hook("stream_conversation", "conv_1")
+    await result.current.dispatchCommand({
+      kind: "command",
+      commandName: "compact",
+      clientActionId: null,
+      commandMarkdown: "/compact",
+    })
+    expect(queueCommand.mock.calls[0][0]).toEqual({
+      commandMarkdown: "/compact",
+      commandName: "compact",
+      conversationId: "conv_1",
     })
   })
 })

--- a/apps/frontend/src/components/composer/use-composer-command-send.ts
+++ b/apps/frontend/src/components/composer/use-composer-command-send.ts
@@ -29,7 +29,16 @@ export type ComposerSendPlan = ComposerCommandPlan | ComposerSteerMessagePlan | 
  * so a command the palette just offered is always dispatchable and nothing the
  * palette doesn't know is intercepted — unknown `/text` still sends as text.
  */
-export function useComposerCommandSend(workspaceId: string, streamId: string | undefined) {
+export function useComposerCommandSend(
+  workspaceId: string,
+  streamId: string | undefined,
+  /**
+   * The conversation this composer writes into, stamped on the dispatch so the
+   * card can draw the chip. Absent for a stream-level composer (the timeline),
+   * whose commands stay off the board.
+   */
+  conversationId?: string
+) {
   const availableCommands = useStreamCommands(workspaceId, streamId)
   const startDiscussWithAriadne = useDiscussWithAriadne(workspaceId)
   const { queueCommand } = useCommandDispatchQueue(workspaceId, streamId ?? "")
@@ -90,9 +99,13 @@ export function useComposerCommandSend(workspaceId: string, streamId: string | u
         }
         return
       }
-      await queueCommand({ commandMarkdown: plan.commandMarkdown, commandName: plan.commandName })
+      await queueCommand({
+        commandMarkdown: plan.commandMarkdown,
+        commandName: plan.commandName,
+        ...(conversationId && { conversationId }),
+      })
     },
-    [queueCommand, startDiscussWithAriadne, streamId]
+    [conversationId, queueCommand, startDiscussWithAriadne, streamId]
   )
 
   return { availableCommands, planSend, dispatchCommand }

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -644,8 +644,8 @@ function ConversationPanelBody({
     return set
   }, [conversation.messageIds, all])
   const eventRows = useMemo(
-    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
-    [railEvents, conversation.id, memberMessageIds]
+    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds, currentUserId }),
+    [railEvents, conversation.id, memberMessageIds, currentUserId]
   )
 
   // Per-thread-boundary grouping — same derivation as the board card (the panel

--- a/apps/frontend/src/components/timeline/command-grouping.ts
+++ b/apps/frontend/src/components/timeline/command-grouping.ts
@@ -1,0 +1,38 @@
+import {
+  COMMAND_EVENT_TYPES,
+  type CommandCompletedPayload,
+  type CommandDispatchedPayload,
+  type CommandEventType,
+  type CommandFailedPayload,
+  type StreamEvent,
+} from "@threa/types"
+
+/**
+ * Command-group primitives, shared by the timeline (`event-list.tsx`) and the
+ * board/conversation projection (`lib/board/board-event-rows.ts`). One definition
+ * so both views group a command the same way and apply the same author rule.
+ * Works on any {@link StreamEvent}-shaped row (the board passes IDB `CachedEvent`s,
+ * a structural superset).
+ */
+
+export function isCommandEvent(event: Pick<StreamEvent, "eventType">): boolean {
+  return COMMAND_EVENT_TYPES.includes(event.eventType as CommandEventType)
+}
+
+export function getCommandId(event: Pick<StreamEvent, "eventType" | "payload">): string | null {
+  if (!isCommandEvent(event)) return null
+  const payload = event.payload as CommandDispatchedPayload | CommandCompletedPayload | CommandFailedPayload
+  return payload.commandId ?? null
+}
+
+/**
+ * Command events are delivered stream-wide over the socket while REST filters
+ * them author-side, so every surface that draws them re-applies the author rule
+ * itself — otherwise a card leaks another member's invocations.
+ */
+export function isOwnCommandEvent(
+  event: Pick<StreamEvent, "actorId">,
+  currentUserId: string | null | undefined
+): boolean {
+  return event.actorId === currentUserId
+}

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,17 +1,13 @@
 import { memo, useMemo } from "react"
 import {
-  COMMAND_EVENT_TYPES,
   ConversationStatuses,
-  type CommandEventType,
   type StreamEvent,
-  type CommandDispatchedPayload,
-  type CommandCompletedPayload,
-  type CommandFailedPayload,
   type DelegationStatusChangedEventPayload,
   type BotAccessStatusChangedEventPayload,
   type CallEndedEventPayload,
 } from "@threa/types"
 import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "./session-grouping"
+import { getCommandId, isOwnCommandEvent } from "./command-grouping"
 import type { MessageAgentActivity } from "@/hooks"
 import { useSocket, useCoordinatedLoading } from "@/contexts"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
@@ -75,16 +71,6 @@ export interface BatchTimelineState {
   hoveredTargetId: string | null
   /** Toggles one message in the current selection. */
   onToggleMessage: (messageId: string) => void
-}
-
-function isCommandEvent(event: StreamEvent): boolean {
-  return COMMAND_EVENT_TYPES.includes(event.eventType as CommandEventType)
-}
-
-function getCommandId(event: StreamEvent): string | null {
-  if (!isCommandEvent(event)) return null
-  const payload = event.payload as CommandDispatchedPayload | CommandCompletedPayload | CommandFailedPayload
-  return payload.commandId
 }
 
 /**
@@ -691,7 +677,7 @@ export function groupTimelineItems(events: StreamEvent[], currentUserId: string 
 
     if (commandId) {
       // Skip command events that aren't from the current user
-      if (event.actorId !== currentUserId) continue
+      if (!isOwnCommandEvent(event, currentUserId)) continue
 
       if (!commandGroups.has(commandId)) {
         commandGroups.set(commandId, [])

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -9,7 +9,9 @@ import type { BoardViewPost } from "./use-stable-board-view"
 
 /**
  * Event types the board rail reads alongside `message_created`: the non-message
- * rows the board draws (agent sessions, memo captures, follow-ups, delegations —
+ * rows the board draws (agent sessions, memo captures, follow-ups, delegations,
+ * command chips — the whole command lifecycle derives, so completed/failed reach
+ * the card that its dispatch named —
  * derived from the shared STREAM_ROW_SPEC) plus the two patches that carry no row
  * of their own: `agent:follow_up_cancelled` flips a scheduled card to "Cancelled",
  * `delegation:status_changed` advances a delegation card's status. Registering a

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.test.ts
@@ -97,6 +97,36 @@ describe("cancelCommandDispatch", () => {
     expect((await db.events.get(`${commandId}:failed`))?._anchorSequenceNum).toBe(4)
   })
 
+  it("forwards the queued conversation ref to the dispatch request", async () => {
+    const dispatched = commandEvent(commandId, "command_dispatched")
+    dispatched._status = "pending"
+    await db.events.put(dispatched)
+    await db.pendingOperations.add({
+      id: "op_conv",
+      workspaceId: "ws_1",
+      type: "dispatch_command",
+      payload: { streamId, command: "/thinking low", optimisticEventId: commandId, conversationId: "conv_1" },
+      createdAt: 1,
+      retryCount: 0,
+    })
+    const dispatch = vi.spyOn(commandsApi, "dispatch").mockResolvedValue({ success: false, error: "Unknown command" })
+
+    await processOperationQueue(
+      { update: vi.fn(), delete: vi.fn() },
+      { add: vi.fn(), remove: vi.fn() },
+      undefined,
+      undefined,
+      () => true
+    )
+
+    expect(dispatch.mock.calls[0][1]).toEqual({
+      streamId,
+      command: "/thinking low",
+      clientCommandId: commandId,
+      conversationId: "conv_1",
+    })
+  })
+
   it("refuses cancellation after an ambiguous transient failure", async () => {
     const dispatched = commandEvent(commandId, "command_dispatched")
     dispatched._status = "pending"

--- a/apps/frontend/src/hooks/use-command-dispatch-queue.ts
+++ b/apps/frontend/src/hooks/use-command-dispatch-queue.ts
@@ -111,7 +111,7 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
   )
 
   const queueCommand = useCallback(
-    async (params: { commandMarkdown: string; commandName: string }) => {
+    async (params: { commandMarkdown: string; commandName: string; conversationId?: string }) => {
       if (!currentUserId) {
         throw new Error("Cannot dispatch command: user identity not resolved yet")
       }
@@ -134,6 +134,7 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
             name: params.commandName,
             args: parseCommandArgs(params.commandMarkdown),
             status: "dispatched",
+            ...(params.conversationId && { conversationId: params.conversationId }),
             executionKind: CommandKinds.BOT_RUNTIME,
           },
           actorId: currentUserId,
@@ -152,6 +153,7 @@ export function useCommandDispatchQueue(workspaceId: string, streamId: string) {
           streamId,
           command: params.commandMarkdown,
           optimisticEventId,
+          ...(params.conversationId && { conversationId: params.conversationId }),
         })
       })
 

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -275,6 +275,81 @@ describe("resolveBoardEventRows", () => {
   })
 })
 
+describe("resolveBoardEventRows command chips", () => {
+  const ME = "usr_me"
+
+  function dispatched(overrides: { id?: string; commandId: string; conversationId?: string; actorId?: string }) {
+    return cachedEvent({
+      id: overrides.id,
+      eventType: "command_dispatched",
+      createdAt: "2026-07-04T10:00:00Z",
+      actorId: overrides.actorId ?? ME,
+      payload: {
+        commandId: overrides.commandId,
+        name: "compact",
+        args: "",
+        status: "dispatched",
+        ...(overrides.conversationId ? { conversationId: overrides.conversationId } : {}),
+      },
+    })
+  }
+
+  it("groups a dispatched+completed pair into one row on the conversation the dispatch names", () => {
+    const events = [
+      dispatched({ id: "cmd_evt", commandId: "cmd_1", conversationId: CONV }),
+      cachedEvent({
+        id: "cmd_done",
+        eventType: "command_completed",
+        createdAt: "2026-07-04T10:00:09Z",
+        actorId: ME,
+        payload: { commandId: "cmd_1" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: ME,
+    })
+    expect(rows).toEqual([
+      {
+        kind: "command",
+        key: "cmd_1",
+        sortMs: new Date("2026-07-04T10:00:00Z").getTime(),
+        streamId: "stream_1",
+        events,
+      },
+    ])
+  })
+
+  it("excludes another member's command", () => {
+    const rows = resolveBoardEventRows(
+      [dispatched({ commandId: "cmd_2", conversationId: CONV, actorId: "usr_other" })],
+      {
+        conversationId: CONV,
+        memberMessageIds: new Set(),
+        currentUserId: ME,
+      }
+    )
+    expect(rows).toEqual([])
+  })
+
+  it("draws nothing for a stream-level (refless) dispatch — the timeline composer's commands stay off cards", () => {
+    const rows = resolveBoardEventRows(
+      [
+        dispatched({ commandId: "cmd_3" }),
+        cachedEvent({
+          eventType: "command_completed",
+          createdAt: "2026-07-04T10:00:09Z",
+          actorId: ME,
+          payload: { commandId: "cmd_3" },
+        }),
+      ],
+      { conversationId: CONV, memberMessageIds: new Set(), currentUserId: ME }
+    )
+    expect(rows).toEqual([])
+  })
+})
+
 const MEMBER_MESSAGE = "msg_member"
 
 /**
@@ -290,7 +365,27 @@ const SESSION_FIXTURE: CachedEvent[] = [
   }),
 ]
 
+const USER = "usr_me"
+
+const COMMAND_FIXTURE: CachedEvent[] = [
+  cachedEvent({
+    eventType: "command_dispatched",
+    createdAt: "2026-07-04T10:00:00Z",
+    actorId: USER,
+    payload: { commandId: "cmd_fixture", name: "compact", args: "", status: "dispatched", conversationId: CONV },
+  }),
+  cachedEvent({
+    eventType: "command_completed",
+    createdAt: "2026-07-04T10:00:05Z",
+    actorId: USER,
+    payload: { commandId: "cmd_fixture" },
+  }),
+]
+
 const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
+  command_dispatched: COMMAND_FIXTURE,
+  command_completed: COMMAND_FIXTURE,
+  command_failed: COMMAND_FIXTURE,
   "agent_session:started": SESSION_FIXTURE,
   "agent_session:completed": SESSION_FIXTURE,
   "agent_session:failed": SESSION_FIXTURE,
@@ -326,6 +421,7 @@ describe("resolveBoardEventRows covers every spec-declared board row type", () =
       resolved[type] = resolveBoardEventRows(events, {
         conversationId: CONV,
         memberMessageIds: new Set([MEMBER_MESSAGE]),
+        currentUserId: USER,
       }).map((row) => row.kind)
     }
     expect(resolved).toEqual({
@@ -337,6 +433,9 @@ describe("resolveBoardEventRows covers every spec-declared board row type", () =
       "memos:captured": ["memo"],
       "agent:follow_up_scheduled": ["followUp"],
       "delegation:created": ["delegation"],
+      command_dispatched: ["command"],
+      command_completed: ["command"],
+      command_failed: ["command"],
     })
     // The object comparison above pins WHICH kind each type resolves to, but it
     // stays satisfiable by pasting the produced diff back in — a type whose

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -321,6 +321,33 @@ describe("resolveBoardEventRows command chips", () => {
     ])
   })
 
+  it("joins a command_failed event to its dispatched row", () => {
+    const events = [
+      dispatched({ id: "cmd_evt_f", commandId: "cmd_fail", conversationId: CONV }),
+      cachedEvent({
+        id: "cmd_bad",
+        eventType: "command_failed",
+        createdAt: "2026-07-04T10:00:07Z",
+        actorId: ME,
+        payload: { commandId: "cmd_fail", error: "boom" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: ME,
+    })
+    expect(rows).toEqual([
+      {
+        kind: "command",
+        key: "cmd_fail",
+        sortMs: new Date("2026-07-04T10:00:00Z").getTime(),
+        streamId: "stream_1",
+        events,
+      },
+    ])
+  })
+
   it("excludes another member's command", () => {
     const rows = resolveBoardEventRows(
       [dispatched({ commandId: "cmd_2", conversationId: CONV, actorId: "usr_other" })],
@@ -382,10 +409,20 @@ const COMMAND_FIXTURE: CachedEvent[] = [
   }),
 ]
 
+const COMMAND_FAILED_FIXTURE: CachedEvent[] = [
+  COMMAND_FIXTURE[0],
+  cachedEvent({
+    eventType: "command_failed",
+    createdAt: "2026-07-04T10:00:06Z",
+    actorId: USER,
+    payload: { commandId: "cmd_fixture", error: "boom" },
+  }),
+]
+
 const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
   command_dispatched: COMMAND_FIXTURE,
   command_completed: COMMAND_FIXTURE,
-  command_failed: COMMAND_FIXTURE,
+  command_failed: COMMAND_FAILED_FIXTURE,
   "agent_session:started": SESSION_FIXTURE,
   "agent_session:completed": SESSION_FIXTURE,
   "agent_session:failed": SESSION_FIXTURE,

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -1,6 +1,7 @@
 import { STREAM_ROW_SPEC, type DelegationStatusChangedEventPayload, type MemosCapturedEventPayload } from "@threa/types"
 import type { CachedEvent } from "@/db"
 import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "@/components/timeline/session-grouping"
+import { getCommandId, isOwnCommandEvent } from "@/components/timeline/command-grouping"
 
 /**
  * A non-message stream event, resolved to the conversation it should draw on for
@@ -14,6 +15,7 @@ export type BoardEventRow =
   | { kind: "session"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
   | { kind: "memo"; key: string; sortMs: number; streamId: string; event: CachedEvent }
   | { kind: "followUp"; key: string; sortMs: number; streamId: string; event: CachedEvent; cancelled: boolean }
+  | { kind: "command"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
   | {
       kind: "delegation"
       key: string
@@ -33,6 +35,12 @@ export interface ResolveBoardEventRowsCtx {
    * design specifies for showing traces without new delivery.
    */
   memberMessageIds: Set<string>
+  /**
+   * Whose commands the card may draw. Command events are stream-scoped over the
+   * socket, so without this every member's IDB would render everyone's
+   * invocations — the same author rule the timeline applies.
+   */
+  currentUserId?: string | null
 }
 
 function timeMs(event: CachedEvent): number {
@@ -48,6 +56,9 @@ function timeMs(event: CachedEvent): number {
  *   the conversation id their payload names.
  * - `trigger-message` rows (agent sessions) are grouped by session id; the group
  *   shows iff the session's `started` event names a trigger that is a member.
+ * - command events are grouped by `commandId` into one chip row, author-scoped,
+ *   placed on the conversation the dispatch names (a stream-level dispatch names
+ *   none and draws nowhere).
  * - `agent:follow_up_cancelled` is a patch, not a row: it flips the matching
  *   scheduled card's `cancelled` flag (mirrors the timeline's cancel handling).
  * - `delegation:status_changed` is likewise a patch: the latest one per
@@ -72,9 +83,29 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
   }
 
   const sessions = new Map<string, { events: CachedEvent[]; trigger: string | null }>()
+  const commands = new Map<
+    string,
+    { events: CachedEvent[]; dispatched: CachedEvent | null; conversation: string | null }
+  >()
   const rows: BoardEventRow[] = []
 
   for (const event of events) {
+    if (STREAM_ROW_SPEC[event.eventType].grouping === "command") {
+      const commandId = getCommandId(event)
+      if (!commandId) continue
+      if (!isOwnCommandEvent(event, ctx.currentUserId)) continue
+      let command = commands.get(commandId)
+      if (!command) {
+        command = { events: [], dispatched: null, conversation: null }
+        commands.set(commandId, command)
+      }
+      command.events.push(event)
+      if (event.eventType === "command_dispatched") {
+        command.dispatched = event
+        command.conversation = (event.payload as { conversationId?: string })?.conversationId ?? null
+      }
+      continue
+    }
     const ref = STREAM_ROW_SPEC[event.eventType].conversationRef
     if (ref === "trigger-message") {
       const sessionId = getSessionId(event)
@@ -154,6 +185,21 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
       sortMs: timeMs(slot.events[0]),
       streamId: slot.events[0].streamId,
       events: slot.events,
+    })
+  }
+
+  // A command lands on the card its dispatch names. `command_completed` /
+  // `command_failed` carry no conversation at all — they reach the row through
+  // the group's `commandId`, which is why the group, not the event, is placed.
+  for (const [commandId, command] of commands) {
+    if (!command.dispatched || command.conversation !== ctx.conversationId) continue
+    const ordered = [...command.events].sort((a, b) => timeMs(a) - timeMs(b))
+    rows.push({
+      kind: "command",
+      key: commandId,
+      sortMs: timeMs(command.dispatched),
+      streamId: command.dispatched.streamId,
+      events: ordered,
     })
   }
 

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -7,6 +7,7 @@ import {
   type AgentSessionFailedPayload,
   type AgentSessionStartedPayload,
   type AttachmentSummary,
+  type CommandDispatchedPayload,
   type DelegationCreatedEventPayload,
   type LinkPreviewContentType,
   type LinkPreviewSummary,
@@ -219,6 +220,19 @@ export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCt
         label: personaName ?? "Agent",
         meta,
         href: sessionId ? ctx.traceUrl(sessionId) : undefined,
+      }
+    }
+    case "command": {
+      const dispatched = row.events.find((event) => event.eventType === "command_dispatched")
+      const name = (dispatched?.payload as CommandDispatchedPayload | undefined)?.name
+      let meta = "running"
+      if (row.events.some((event) => event.eventType === "command_failed")) meta = "failed"
+      else if (row.events.some((event) => event.eventType === "command_completed")) meta = "completed"
+      return {
+        key: row.key,
+        kind: "command",
+        label: name ? `/${name}` : "Command",
+        meta,
       }
     }
     case "memo": {

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -234,6 +234,7 @@ async function executeOperation(
           streamId: payload.streamId as string,
           command: payload.command as string,
           clientCommandId: optimisticEventId,
+          ...(payload.conversationId ? { conversationId: payload.conversationId as string } : {}),
         })
         if (!result.success) throw new ApiError(400, "COMMAND_DISPATCH_FAILED", result.error)
         await db.transaction("rw", [db.events, db.pendingOperations], async () => {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1980,6 +1980,8 @@ export interface DispatchCommandInput {
   command: string
   streamId: string
   clientCommandId?: string
+  /** The conversation the dispatching composer writes into, when it has one. */
+  conversationId?: string
 }
 
 export interface DispatchCommandResponse {
@@ -2002,6 +2004,13 @@ export interface CommandDispatchedPayload {
   name: string
   args: string
   status: "dispatched"
+  /**
+   * The conversation the dispatching composer was writing into, when there is
+   * one. Stamped only by the board/panel composers — a stream-level dispatch
+   * (the timeline composer) carries none and stays off the cards. The lifecycle
+   * events that follow are refless; they join by `commandId`.
+   */
+  conversationId?: string
   /** Missing means legacy server command. */
   executionKind?: Extract<CommandKind, "server" | "bot-runtime">
 }

--- a/packages/types/src/stream-rows.test.ts
+++ b/packages/types/src/stream-rows.test.ts
@@ -82,6 +82,9 @@ describe("STREAM_ROW_SPEC", () => {
         "memos:captured",
         "agent:follow_up_scheduled",
         "delegation:created",
+        "command_dispatched",
+        "command_completed",
+        "command_failed",
       ])
     )
     // None of them are message bodies (those are `self-message`, handled directly).

--- a/packages/types/src/stream-rows.ts
+++ b/packages/types/src/stream-rows.ts
@@ -14,8 +14,10 @@ import { EVENT_TYPES, type EventType } from "./constants"
  *                        (memos:captured → `conversationId`,
  *                        agent:follow_up_scheduled → `sourceConversationId`).
  * - `none`             — never drawn on conversation surfaces (channel chrome like
- *                        member/description events, author-scoped command events,
- *                        and patch-style rows).
+ *                        member/description events, and patch-style rows).
+ *                        Command events moved to `source-conversation`: the
+ *                        dispatching composer stamps `payload.conversationId`,
+ *                        terminal events join by `commandId`.
  */
 export type ConversationRef = "self-message" | "trigger-message" | "source-conversation" | "none"
 
@@ -143,7 +145,9 @@ const COMMAND: StreamRowSpec = {
   authorGroupable: false,
   patchesRow: false,
   broadcastSlot: false,
-  conversationRef: "none",
+  // Only `command_dispatched` carries the id; `command_completed`/`command_failed`
+  // are refless and reach their row by `commandId` inside the group.
+  conversationRef: "source-conversation",
   bumps: false,
   threadable: false,
 }


### PR DESCRIPTION
## Problem

"I don't see the output of slash commands on the board, at least not their chips." Structural: a slash command produces only events (`command_dispatched`/`command_completed`/`command_failed`), never a message; the timeline groups them into one collapsible `CommandEvent` chip, but the spec marked COMMAND `conversationRef: "none"`, so `BOARD_EVENT_ROW_TYPES` excluded them by derivation — the rail never queried them, the resolver had no command kind, and a `/compact` dispatched from a card gave zero feedback.

## Solution

- `CommandDispatchedPayload.conversationId` (optional), stamped by the dispatching composer through `useComposerCommandSend` → the dispatch queue's optimistic event → the `dispatch_command` op → `insertCommandDispatchedEvent`. Always the **parent** conversation, branch/armed composers included — adversarial verify caught that a child-stamped chip lands on no visible surface (only the parent card/panel runs `resolveBoardEventRows`). Timeline dispatches stay refless and deliberately draw nowhere on cards (pinned by test).
- COMMAND spec → `conversationRef: "source-conversation"`; all three types share the spec, so completed/failed ride the rail by derivation and join their row by `commandId` (an orphan terminal event is skipped; the row re-forms when the dispatch lands). Optimistic→server swap is single-transaction — no ghost chip.
- The board renders the timeline's `CommandEvent` verbatim (with the timeline's `px-3 sm:px-6` inset) plus a ledger line (`/compact · running|completed|failed`); the author-only rule is one shared `isOwnCommandEvent` consumed by both surfaces, so other members' commands can't leak onto cards (their events do arrive stream-scoped over the socket). Conversation panel gets everything through the same rail/resolver.
- Scope: invocation + status chip — a command's real output arrives as agent messages/sessions already visible on cards. A client-spoofed `conversationId` only misplaces the spoofer's own chip in their own view (both render paths gate on own-author).

## Test plan

- [x] Adversarial verify (Opus high): 2 findings (missing inset, child-stamped branch refs), both fixed; spec-flip blast radius (broadcast slots, INV-61, catch-up) re-derived clean
- [x] Targeted: types 154 (stream-rows spec), backend commands 23 (payload passthrough), frontend board-event-rows/board-card/ledger/composer chain — all green; tscs + eslint clean
- [x] Falsified: author predicate, backend stamp, composer stamp, op→API passthrough — each turned exactly its tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360007&installation_model_id=20758&pr_number=1756&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1756&signature=9fb332a9d44b7f6ca3efbe9d8b3d684682bd35bd8669157203f451dcb13a10fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->