### PR TITLE
feat(board): live trace counts from the module store + running-trace chip

### DIFF
--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -20,6 +20,7 @@ import * as userProfileModule from "@/components/user-profile"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+import { seedAgentActivity, __resetAgentActivityStore } from "@/stores/agent-activity-store"
 
 const WS = "ws_1"
 const CONV = "conv_1"
@@ -93,6 +94,15 @@ function multiMemoEvent(id: string, seconds: number): CachedEvent {
         { memoId: "memo_2", title: "Two", knowledgeType: "fact", sourceMessageIds: ["r1"] },
       ],
     },
+    id
+  )
+}
+
+function sessionStartedEvent(id: string, seconds: number, sessionId: string, triggerMessageId: string): CachedEvent {
+  return event(
+    "agent_session:started",
+    seconds,
+    { sessionId, personaId: "persona_1", personaName: "Ariadne", triggerMessageId, startedAt: at(seconds) },
     id
   )
 }
@@ -172,6 +182,7 @@ const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), 
 
 beforeEach(async () => {
   seq = 0
+  __resetAgentActivityStore()
   __clearBoardRailRegistry()
   __clearConversationGraphRegistry()
   await db.events.clear()
@@ -323,5 +334,89 @@ describe("BoardCard ledger events", () => {
     expect(await screen.findByText(/Saved to memory/)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Postgres upserts need the index" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /^Memo: Postgres upserts need the index/ })).toBeNull()
+  })
+})
+
+/** The card header's reserved chip slot (INV-21) — empty when no agent runs. */
+function chipSlot(): HTMLElement | null {
+  return document.querySelector("[data-running-chip-slot]")
+}
+
+describe("BoardCard running agent sessions", () => {
+  const running = (overrides: Partial<Parameters<typeof seedAgentActivity>[1][number]> = {}) => ({
+    sessionId: "sess_1",
+    streamId: STREAM,
+    rootStreamId: STREAM,
+    personaName: "Ariadne",
+    startedAt: at(11),
+    ...overrides,
+  })
+
+  it("paints the stored step count on a row mounted after the progress tick", async () => {
+    // The regression: the row used to seed from the cached `started` event (no
+    // counts) and miss the join-time tick, so it sat at "0 steps" forever.
+    seedAgentActivity(WS, [running({ stepCount: 7, messageCount: 2 })])
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      sessionStartedEvent("evt_sess", 11, "sess_1", "r1"),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    expect(await screen.findByText("Ariadne is working…")).toBeInTheDocument()
+    expect(screen.getByText("7 steps • 2 messages sent")).toBeInTheDocument()
+  })
+
+  it("keeps a running session a full row even once later replies push it into the ledger", async () => {
+    seedAgentActivity(WS, [running({ stepCount: 3, messageCount: 0 })])
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      sessionStartedEvent("evt_sess", 11, "sess_1", "r1"),
+      messageEvent("r2", 12, "Second reply."),
+      messageEvent("r3", 13, "Third reply."),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    // Full card (title + live counts), not a thin ledger line and not swallowed
+    // by a coalesced group.
+    expect(await screen.findByText("Ariadne is working…")).toBeInTheDocument()
+    expect(screen.getByText("3 steps • 0 messages sent")).toBeInTheDocument()
+  })
+
+  it("shows a header chip for this conversation's running session and none when idle", async () => {
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      sessionStartedEvent("evt_sess", 11, "sess_1", "r1"),
+    ])
+    await db.conversations.put(post())
+
+    const idle = mount()
+    expect(await screen.findByText("First reply.")).toBeInTheDocument()
+    expect(chipSlot()?.textContent).toBe("")
+    idle.unmount()
+
+    seedAgentActivity(WS, [running({ stepCount: 4 })])
+    mount()
+    await screen.findByText("First reply.")
+    const chip = within(chipSlot()!).getByRole("link", { name: /Ariadne is working — open agent trace/ })
+    expect(chip).toHaveTextContent(/Ariadne\s*· 4 steps/)
+    expect(chip).toHaveAttribute("href", expect.stringContaining("sess_1"))
+  })
+
+  it("does not light the chip for a sibling conversation's session on the same stream", async () => {
+    // Same stream, but its trigger message is not a member of this conversation,
+    // so the card resolves no session row for it.
+    seedAgentActivity(WS, [running({ sessionId: "sess_other" })])
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      sessionStartedEvent("evt_other", 11, "sess_other", "msg_elsewhere"),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    expect(await screen.findByText("First reply.")).toBeInTheDocument()
+    expect(chipSlot()?.textContent).toBe("")
+    expect(screen.queryByText("Ariadne is working…")).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -454,7 +454,7 @@ describe("BoardCard agent activity", () => {
 
   it("shows Stop + Redirect on a running session, and Redirect opens the card composer in place", async () => {
     const user = userEvent.setup()
-    // A running session's row mounts the live progress rail (useAgentActivity),
+    // A running session's row reads live progress from the agent-activity store,
     // which reads the socket — give it a fake one.
     const { socket } = fakeSocket()
     vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -14,6 +14,11 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
 import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 import { __resetCollapseCacheForTests } from "@/lib/markdown/collapse-cache"
+import {
+  upsertAgentSession,
+  updateAgentSessionProgress,
+  __resetAgentActivityStore,
+} from "@/stores/agent-activity-store"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
 import { db, type CachedEvent, type CachedStream } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
@@ -196,6 +201,7 @@ function fakeSocket() {
 const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
 
 beforeEach(async () => {
+  __resetAgentActivityStore()
   __clearBoardRailRegistry()
   __clearConversationGraphRegistry()
   __resetCollapseCacheForTests()
@@ -387,13 +393,12 @@ describe("BoardCard agent activity", () => {
     expect(screen.getByText(/completed/)).toBeTruthy()
   })
 
-  it("live-updates a running session's step count from agent_session:progress", async () => {
+  it("live-updates a running session's step count from the agent activity store", async () => {
     // A session started from the card's opening message but not yet terminal: its
-    // events carry no counts, so the card rides the same ephemeral progress rail
-    // the timeline does (useAgentActivity). Without it the card sat at "0 steps"
-    // for the whole run.
-    const { socket, handlers } = fakeSocket()
-    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    // events carry no counts. They arrive as `agent_session:progress` ticks, folded
+    // into the module store by workspace-sync's single subscription — the row reads
+    // them there, so it is live whenever it mounts, not only when it was mounted at
+    // room-join time. Without it the card sat at "0 steps" for the whole run.
     await db.events.bulkPut([
       sessionEvent("agent_session:started", 30, {
         sessionId: "sess_C",
@@ -403,24 +408,22 @@ describe("BoardCard agent activity", () => {
         messageCount: 0,
       }),
     ])
+    upsertAgentSession(WS, {
+      sessionId: "sess_C",
+      streamId: STREAM,
+      rootStreamId: STREAM,
+      personaName: "Ariadne",
+      startedAt: "2026-06-22T12:00:30.000Z",
+    })
     mountCard()
 
-    expect(await screen.findByText(/0 steps/)).toBeTruthy()
+    expect(await screen.findByText("0 steps • 0 messages sent")).toBeTruthy()
 
     act(() => {
-      handlers.get("agent_session:progress")?.({
-        workspaceId: WS,
-        streamId: STREAM,
-        sessionId: "sess_C",
-        triggerMessageId: "m_open",
-        personaName: "Ariadne",
-        stepCount: 3,
-        messageCount: 1,
-        currentStepType: "tool_call",
-      })
+      updateAgentSessionProgress(WS, "sess_C", { stepCount: 3, messageCount: 1 })
     })
 
-    expect(await screen.findByText(/3 steps/)).toBeTruthy()
+    expect(await screen.findByText("3 steps • 1 message sent")).toBeTruthy()
   })
 
   it("shows 'Interrupted, retrying…' from a persisted interrupted event (survives refresh)", async () => {

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -26,6 +26,9 @@ import {
   type BranchExpansion,
 } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { AgentRunningChip } from "@/components/timeline/agent-activity-header-chip"
+import { getSessionId } from "@/components/timeline/session-grouping"
+import { useAgentSessionActivities } from "@/stores/agent-activity-store"
 import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
 import {
   useConversationGraph,
@@ -340,6 +343,31 @@ export function BoardCard({
   const eventRows = useMemo(
     () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds, currentUserId }),
     [railEvents, conversation.id, memberMessageIds, currentUserId]
+  )
+
+  // The card's own running agent sessions: session ids come from the rows the
+  // card already resolved (conversation-scoped by construction — a sibling
+  // conversation's session on the same stream is not among them), live counts from
+  // the activity store. Covers the long-running session whose `started` event has
+  // scrolled above the card's "N earlier" boundary.
+  const cardSessionIds = useMemo(
+    () =>
+      eventRows.flatMap((row) => {
+        if (row.kind !== "session") return []
+        const sessionId = row.events.reduce<string | null>((found, event) => found ?? getSessionId(event), null)
+        return sessionId ? [sessionId] : []
+      }),
+    [eventRows]
+  )
+  const runningSessions = useAgentSessionActivities(workspaceId, cardSessionIds)
+  const runningChipEntries = useMemo(
+    () =>
+      runningSessions.map((session) => ({
+        sessionId: session.sessionId,
+        personaName: session.personaName,
+        stepCount: session.stepCount ?? 0,
+      })),
+    [runningSessions]
   )
 
   // Per-thread-boundary grouping: soft-thread seams, nested branch conversations,
@@ -984,6 +1012,14 @@ export function BoardCard({
   // (INV-21) so the badge arriving or clearing never restructures it; the pill
   // borrows the sidebar unread badge's visual language, destructive-tinted like
   // the lead tint it summarizes.
+  // Live "an agent is working on this conversation" pill, mirroring the stream
+  // header chip. Its slot is always in the header (INV-21) so arriving or
+  // clearing never restructures the row.
+  const runningChip = (
+    <span data-running-chip-slot className="flex shrink-0 items-center">
+      <AgentRunningChip entries={runningChipEntries} />
+    </span>
+  )
   const massBadge = (
     <span data-mass-badge-slot className="flex shrink-0 items-center">
       {massBadgeMode !== "off" && unread.count > 0 && (
@@ -1139,6 +1175,7 @@ export function BoardCard({
                   >
                     {conversation.topicSummary}
                   </span>
+                  {runningChip}
                   {massBadge}
                   {unreadDot}
                   {headerActions}
@@ -1156,6 +1193,7 @@ export function BoardCard({
                 {locatorLink("sm")}
                 {subtopicLabel}
                 <div className="ml-auto flex items-center gap-1.5">
+                  {runningChip}
                   {massBadge}
                   {unreadDot}
                   <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1017,7 +1017,9 @@ export function BoardCard({
   // clearing never restructures the row.
   const runningChip = (
     <span data-running-chip-slot className="flex shrink-0 items-center">
-      <AgentRunningChip entries={runningChipEntries} />
+      {/* Mounted only with entries: the chip reads useTrace, so the idle card
+          must not require a TraceProvider (and skips the component entirely). */}
+      {runningChipEntries.length > 0 && <AgentRunningChip entries={runningChipEntries} />}
     </span>
   )
   const massBadge = (

--- a/apps/frontend/src/components/board/board-row-item.effects.test.tsx
+++ b/apps/frontend/src/components/board/board-row-item.effects.test.tsx
@@ -6,7 +6,11 @@ import type { StreamEvent } from "@threa/types"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import * as contextsModule from "@/contexts"
 import * as hooksModule from "@/hooks"
-import * as agentActivityModule from "@/hooks/use-agent-activity"
+import {
+  upsertAgentSession,
+  updateAgentSessionProgress,
+  __resetAgentActivityStore,
+} from "@/stores/agent-activity-store"
 import * as workspacesModule from "@/hooks/use-workspaces"
 import * as relativeTimeModule from "@/components/relative-time"
 import { BoardEventRowItem } from "./board-row-item"
@@ -76,8 +80,9 @@ describe("BoardEventRowItem session effects", () => {
 })
 
 // A RUNNING board session is the same live card the timeline mounts — same
-// component, same live counts/substep off `useAgentActivity`, same stop/steer
-// affordances — not a board-only summary that only catches up at completion.
+// component, live counts/substep read from the agent-activity store by session
+// id, same stop/steer affordances — not a board-only summary that only catches
+// up at completion.
 describe("BoardEventRowItem running session", () => {
   const started = sessionEvent("agent_session:started", {
     sessionId: "session_live",
@@ -96,6 +101,7 @@ describe("BoardEventRowItem running session", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks()
+    __resetAgentActivityStore()
     vi.spyOn(contextsModule, "useTrace").mockReturnValue({
       getTraceUrl: (sessionId: string) => `/trace/${sessionId}`,
     } as ReturnType<typeof contextsModule.useTrace>)
@@ -118,19 +124,18 @@ describe("BoardEventRowItem running session", () => {
   }
 
   it("streams the session's live progress instead of waiting for the terminal event", () => {
-    vi.spyOn(agentActivityModule, "useAgentActivity").mockReturnValue(
-      new Map([
-        [
-          "msg_1",
-          {
-            sessionId: "session_live",
-            stepCount: 4,
-            messageCount: 1,
-            substep: "Updating your notification settings",
-          },
-        ],
-      ]) as never
-    )
+    upsertAgentSession("ws_1", {
+      sessionId: "session_live",
+      streamId: "stream_1",
+      rootStreamId: "stream_1",
+      personaName: "Ariadne",
+      startedAt: "2026-02-19T18:00:00.000Z",
+    })
+    updateAgentSessionProgress("ws_1", "session_live", {
+      stepCount: 4,
+      messageCount: 1,
+      substep: "Updating your notification settings",
+    })
     const stop = vi.fn()
     vi.spyOn(hooksModule, "useStopAgentSession").mockReturnValue(stop as never)
     vi.spyOn(hooksModule, "useSteerAgentSession").mockReturnValue(vi.fn() as never)
@@ -145,7 +150,6 @@ describe("BoardEventRowItem running session", () => {
   })
 
   it("stops the running session through the board's own wiring", async () => {
-    vi.spyOn(agentActivityModule, "useAgentActivity").mockReturnValue(new Map() as never)
     const stop = vi.fn()
     vi.spyOn(hooksModule, "useStopAgentSession").mockReturnValue(stop as never)
     vi.spyOn(hooksModule, "useSteerAgentSession").mockReturnValue(vi.fn() as never)

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -441,6 +441,13 @@ describe("injectUnreadDivider", () => {
   })
 })
 
+function sessionEventRow(key: string, minute: number, opts: { terminal?: boolean } = {}): BoardEventRow {
+  const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
+  const events = [{ id: `${key}:started`, createdAt, eventType: "agent_session:started" }]
+  if (opts.terminal) events.push({ id: `${key}:done`, createdAt, eventType: "agent_session:completed" })
+  return { kind: "session", key, sortMs: new Date(createdAt).getTime(), streamId: "root", events } as BoardEventRow
+}
+
 describe("foldLedgerEventRows", () => {
   const rows = () =>
     buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [memoEventRow("e1", 1), memoEventRow("e2", 2)])
@@ -467,6 +474,38 @@ describe("foldLedgerEventRows", () => {
       "b"
     )
     expect(folded.map((r) => r.kind)).toEqual(["message", "message", "event", "event"])
+  })
+
+  it("keeps a still-running session row fully rendered in the ledger region", () => {
+    const folded = foldLedgerEventRows(
+      buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [sessionEventRow("s1", 1)]),
+      "b"
+    )
+    expect(folded.map((r) => r.kind)).toEqual(["message", "event", "message"])
+  })
+
+  it("hoists a running session out of an adjacent run, still grouping the rest", () => {
+    const folded = foldLedgerEventRows(
+      buildBoardRows(
+        [msg("a", "u1", 0), msg("b", "u1", 6)],
+        [memoEventRow("e1", 1), sessionEventRow("s1", 2), memoEventRow("e2", 3), memoEventRow("e3", 4)]
+      ),
+      "b"
+    )
+    expect(folded.map((r) => r.kind)).toEqual(["message", "ledger-event", "event", "ledger-event-group", "message"])
+    const group = folded[3]
+    expect(group.kind === "ledger-event-group" && group.rows.map((r) => r.key)).toEqual(["e2", "e3"])
+  })
+
+  it("still folds a terminated session row into the ledger", () => {
+    const folded = foldLedgerEventRows(
+      buildBoardRows(
+        [msg("a", "u1", 0), msg("b", "u1", 4)],
+        [memoEventRow("e1", 1), sessionEventRow("s1", 2, { terminal: true })]
+      ),
+      "b"
+    )
+    expect(folded.map((r) => r.kind)).toEqual(["message", "ledger-event-group", "message"])
   })
 
   it("is a no-op when the whole card is the full tail", () => {

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -441,7 +441,7 @@ describe("injectUnreadDivider", () => {
   })
 })
 
-function sessionEventRow(key: string, minute: number, opts: { terminal?: boolean } = {}): BoardEventRow {
+function foldSessionRow(key: string, minute: number, opts: { terminal?: boolean } = {}): BoardEventRow {
   const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
   const events = [{ id: `${key}:started`, createdAt, eventType: "agent_session:started" }]
   if (opts.terminal) events.push({ id: `${key}:done`, createdAt, eventType: "agent_session:completed" })
@@ -478,7 +478,7 @@ describe("foldLedgerEventRows", () => {
 
   it("keeps a still-running session row fully rendered in the ledger region", () => {
     const folded = foldLedgerEventRows(
-      buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [sessionEventRow("s1", 1)]),
+      buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 4)], [foldSessionRow("s1", 1)]),
       "b"
     )
     expect(folded.map((r) => r.kind)).toEqual(["message", "event", "message"])
@@ -488,7 +488,7 @@ describe("foldLedgerEventRows", () => {
     const folded = foldLedgerEventRows(
       buildBoardRows(
         [msg("a", "u1", 0), msg("b", "u1", 6)],
-        [memoEventRow("e1", 1), sessionEventRow("s1", 2), memoEventRow("e2", 3), memoEventRow("e3", 4)]
+        [memoEventRow("e1", 1), foldSessionRow("s1", 2), memoEventRow("e2", 3), memoEventRow("e3", 4)]
       ),
       "b"
     )
@@ -501,7 +501,7 @@ describe("foldLedgerEventRows", () => {
     const folded = foldLedgerEventRows(
       buildBoardRows(
         [msg("a", "u1", 0), msg("b", "u1", 4)],
-        [memoEventRow("e1", 1), sessionEventRow("s1", 2, { terminal: true })]
+        [memoEventRow("e1", 1), foldSessionRow("s1", 2, { terminal: true })]
       ),
       "b"
     )

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -12,8 +12,7 @@ import { DelegationEvent } from "@/components/timeline/delegation-event"
 import { CommandEvent } from "@/components/timeline/command-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
 import { useSocket, useTrace } from "@/contexts"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useAgentActivity, type MessageAgentActivity } from "@/hooks/use-agent-activity"
+import { useAgentSessionActivity } from "@/stores/agent-activity-store"
 import { LedgerEventGroup, LedgerEventRow, type LedgerEventDescriptor } from "@/components/board/ledger-row"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import { coalesceLedgerItems, ledgerEventContent, type LedgerItemKind } from "@/lib/board/ledger"
@@ -195,12 +194,38 @@ export function foldLedgerEventRows(rows: BoardRow[], fullTailStartMessageId: st
     const row = rows[index]
     const depth = row.displayDepth ?? 0
     if (segmentDepth !== null && depth !== segmentDepth) flush()
+    // A session with no terminal event is still running: it must keep its full
+    // card so the spinner and live counts render. Session rows sort at their
+    // START time, so once the agent replies the row falls into the ledger region
+    // — folding it (or burying it in a coalesced group) would drop the only live
+    // state on the card. Flush around it and emit it untouched.
+    if (isRunningSessionRow(row)) {
+      flush()
+      segmentDepth = null
+      out.push(row)
+      continue
+    }
     segmentDepth = depth
     segment.push(row)
   }
   flush()
   out.push(...rows.slice(end))
   return out
+}
+
+const SESSION_TERMINAL_EVENT_TYPES = new Set<string>([
+  "agent_session:completed",
+  "agent_session:failed",
+  "agent_session:deleted",
+])
+
+/** A session row whose group carries no completed/failed/deleted event. */
+export function isRunningSessionRow(row: BoardRow): boolean {
+  return (
+    row.kind === "event" &&
+    row.row.kind === "session" &&
+    !row.row.events.some((event) => SESSION_TERMINAL_EVENT_TYPES.has(event.eventType))
+  )
 }
 
 /** A board row as a coalescing item: only event rows can join a run. */
@@ -605,22 +630,15 @@ function LedgerMemoPreview({
   )
 }
 
-const SESSION_TERMINAL_EVENT_TYPES = new Set<string>([
-  "agent_session:completed",
-  "agent_session:failed",
-  "agent_session:deleted",
-])
-
 /**
  * An agent-session row on a board card / conversation panel. A terminal session
  * carries its final step + message counts in its own payload, so it renders the
  * shared card straight. A still-running session has no counts in its events — they
  * arrive as ephemeral `agent_session:progress` socket ticks — so it delegates to
- * {@link BoardRunningSessionRow}, which mounts the same live rail the timeline runs
- * (`useAgentActivity`, event-list.tsx). Without that subscription the card sits at
- * "0 steps" until the terminal event lands. Splitting keeps the subscription off
- * the many past-trace rows a board carries, and confines a progress-tick re-render
- * to this leaf instead of the whole card.
+ * {@link BoardRunningSessionRow}, which reads them from the module-level agent
+ * activity store. The store is fed by workspace-sync's single subscription, so a
+ * row mounted long after the join-time bootstrap tick (virtua recycle, card
+ * remount, reorder) still paints the live count instead of sitting at "0 steps".
  */
 function BoardAgentSessionRow({
   events,
@@ -649,25 +667,15 @@ function BoardRunningSessionRow({
   const streamId = events[0]!.streamId
   const stopAgentSession = useStopAgentSession(socket, workspaceId, streamId)
   const steerAgentSession = useSteerAgentSession(workspaceId, streamId)
-  const userId = useWorkspaceUserId(workspaceId)
-  const activity = useAgentActivity(events, socket, workspaceId, userId)
   const sessionId = events.reduce<string | null>((found, event) => found ?? getSessionId(event), null)
-  // `useAgentActivity` keys by trigger message and also carries socket-only
-  // sessions from other rows on the shared socket, so match this row's session by
-  // id — the same lookup event-list.tsx does off the activity map.
-  let live: MessageAgentActivity | undefined
-  if (sessionId != null) {
-    for (const entry of activity.values()) {
-      if (entry.sessionId === sessionId) {
-        live = entry
-        break
-      }
-    }
-  }
+  const live = useAgentSessionActivity(workspaceId, sessionId)
+  const hasCounts = live?.stepCount !== undefined || live?.messageCount !== undefined
   return (
     <AgentSessionEvent
       events={events}
-      liveCounts={live ? { stepCount: live.stepCount, messageCount: live.messageCount } : undefined}
+      liveCounts={
+        live && hasCounts ? { stepCount: live.stepCount ?? 0, messageCount: live.messageCount ?? 0 } : undefined
+      }
       liveSubstep={live?.substep ?? null}
       onStopSession={stopAgentSession}
       onRedirect={onRedirectSession}

--- a/apps/frontend/src/components/timeline/agent-activity-header-chip.tsx
+++ b/apps/frontend/src/components/timeline/agent-activity-header-chip.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom"
 import { Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { useTrace, useAgentActivitySummary } from "@/contexts"
+import { useTrace, useAgentActivitySummary, type AgentActivitySummaryEntry } from "@/contexts"
 
 /**
  * Top-bar chip shown while ≥1 agent session runs in the open stream (root or its
@@ -14,6 +14,24 @@ import { useTrace, useAgentActivitySummary } from "@/contexts"
  */
 export function AgentActivityHeaderChip({ compact = false }: { compact?: boolean }) {
   const summary = useAgentActivitySummary()
+  return <AgentRunningChip entries={summary} compact={compact} />
+}
+
+/**
+ * Presentational core of the chip, over a caller-supplied set of running
+ * sessions. The board card scopes its own set by session id (its conversation's
+ * rows) rather than by stream, so a sibling conversation's agent can't light it;
+ * the stream header passes the provider summary. Same copy either way — do not
+ * fork it.
+ */
+export function AgentRunningChip({
+  entries,
+  compact = false,
+}: {
+  entries: readonly AgentActivitySummaryEntry[]
+  compact?: boolean
+}) {
+  const summary = entries
   const { getTraceUrl } = useTrace()
 
   if (summary.length === 0) return null

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -15,9 +15,7 @@ import type {
 } from "@threa/types"
 import { THREAD_ANCHORABLE_EVENT_TYPES } from "@threa/types"
 import { getStepInlineLabel } from "@/lib/step-config"
-import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
-import { db } from "@/db"
+import { decryptAgentSubstepText } from "@/lib/crypto/agent-substep"
 
 export interface MessageAgentActivity {
   sessionId: string
@@ -296,20 +294,13 @@ export function useAgentActivity(
         return
       }
       if (typeof payload.ciphertext === "string" && payload.envelope) {
-        const session = getE2eSessionState(workspaceId, userId ?? "")
-        if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return
-        const { privateKey, keyId } = session
         const { ciphertext, envelope, streamId: substepStreamId, sessionId, updatedAt } = payload
         void (async () => {
-          // The substep's stream may be a thread, which shares its root's SSK —
-          // resolve the key against the root.
-          const rootStreamId = (await db.streams.get(substepStreamId))?.rootStreamId ?? undefined
-          const decrypted = await tryDecryptMessagePayload(
-            { contentMarkdown: "", ciphertext, envelope },
-            { privateKey, recipientKeyId: keyId, workspaceId, streamId: substepStreamId, rootStreamId }
-          ).catch(() => null)
-          if (decrypted?.contentMarkdown)
-            applySubstep(sessionId, decrypted.contentMarkdown, updatedAt, stepCountAtArrival)
+          const text = await decryptAgentSubstepText(
+            { streamId: substepStreamId, ciphertext, envelope },
+            { workspaceId, userId: userId ?? "" }
+          )
+          if (text) applySubstep(sessionId, text, updatedAt, stepCountAtArrival)
         })()
       }
     },

--- a/apps/frontend/src/lib/crypto/agent-substep.ts
+++ b/apps/frontend/src/lib/crypto/agent-substep.ts
@@ -1,0 +1,32 @@
+import { db } from "@/db"
+import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+
+/**
+ * Decrypt an agent substep's sealed phase text. Both live substep consumers (the
+ * per-message trace hook and the workspace sync store path) share this resolve +
+ * decrypt sequence (INV-35). Returns null when the session is locked, the stream
+ * row isn't known, or the open fails — the substep is ephemeral, so a miss is
+ * skipped silently.
+ */
+export async function decryptAgentSubstepText(
+  payload: { streamId: string; ciphertext: string; envelope: unknown },
+  context: { workspaceId: string; userId: string }
+): Promise<string | null> {
+  const session = getE2eSessionState(context.workspaceId, context.userId)
+  if (session.status !== "unlocked" || !session.privateKey || !session.keyId) return null
+  // The substep's stream may be a thread, which shares its root's SSK —
+  // resolve the key against the root.
+  const rootStreamId = (await db.streams.get(payload.streamId))?.rootStreamId ?? undefined
+  const decrypted = await tryDecryptMessagePayload(
+    { contentMarkdown: "", ciphertext: payload.ciphertext, envelope: payload.envelope },
+    {
+      privateKey: session.privateKey,
+      recipientKeyId: session.keyId,
+      workspaceId: context.workspaceId,
+      streamId: payload.streamId,
+      rootStreamId,
+    }
+  ).catch(() => null)
+  return decrypted?.contentMarkdown || null
+}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, BoardView, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import * as boardStoreModule from "@/stores/board-store"
-import { ServicesProvider, SidebarProvider, PanelProvider, MediaGalleryProvider } from "@/contexts"
+import { ServicesProvider, SidebarProvider, PanelProvider, MediaGalleryProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
@@ -185,14 +185,16 @@ function mountBoard(
         <ServicesProvider services={{ conversations: { listByWorkspace, getBoardMessages } as never }}>
           <SidebarProvider>
             <MemoryRouter initialEntries={[entry]}>
-              <PanelProvider>
-                <MediaGalleryProvider>
-                  <LocationProbe />
-                  <Routes>
-                    <Route path="/w/:workspaceId/board" element={<BoardPage />} />
-                  </Routes>
-                </MediaGalleryProvider>
-              </PanelProvider>
+              <TraceProvider>
+                <PanelProvider>
+                  <MediaGalleryProvider>
+                    <LocationProbe />
+                    <Routes>
+                      <Route path="/w/:workspaceId/board" element={<BoardPage />} />
+                    </Routes>
+                  </MediaGalleryProvider>
+                </PanelProvider>
+              </TraceProvider>
             </MemoryRouter>
           </SidebarProvider>
         </ServicesProvider>

--- a/apps/frontend/src/stores/agent-activity-store.test.ts
+++ b/apps/frontend/src/stores/agent-activity-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
 import type { ActiveAgentSession } from "@threa/types"
 import {
   seedAgentActivity,
@@ -7,6 +8,8 @@ import {
   getAgentActivityForStream,
   getAgentSession,
   updateAgentSessionProgress,
+  useAgentSessionActivities,
+  useAgentSessionActivity,
   __resetAgentActivityStore,
 } from "./agent-activity-store"
 
@@ -146,6 +149,45 @@ describe("agent-activity-store", () => {
       stepCount: 4,
       messageCount: 2,
       substep: "Evaluating results…",
+    })
+  })
+
+  describe("comparator scoping (a tick only invalidates what renders it)", () => {
+    it("a substep-only tick leaves the stream snapshot referentially identical", () => {
+      upsertAgentSession(WS, session({ sessionId: "s1" }))
+      const before = getAgentActivityForStream(WS, "stream_a")
+      act(() => updateAgentSessionProgress(WS, "s1", { substep: "Reading docs" }))
+      expect(getAgentActivityForStream(WS, "stream_a")).toBe(before)
+    })
+
+    it("a substep-only tick does not re-render the plural (chip) hook, but a stepCount change does", () => {
+      upsertAgentSession(WS, session({ sessionId: "s1", stepCount: 1 }))
+      let renders = 0
+      const { result } = renderHook(() => {
+        renders += 1
+        return useAgentSessionActivities(WS, ["s1"])
+      })
+      const initialRenders = renders
+      const first = result.current
+
+      act(() => updateAgentSessionProgress(WS, "s1", { substep: "Reading docs" }))
+      expect(renders).toBe(initialRenders)
+      expect(result.current).toBe(first)
+
+      act(() => updateAgentSessionProgress(WS, "s1", { stepCount: 2 }))
+      expect(renders).toBeGreaterThan(initialRenders)
+      expect(result.current[0]).toMatchObject({ stepCount: 2 })
+    })
+
+    it("the singular (row) hook sees both a substep tick and a stepCount change", () => {
+      upsertAgentSession(WS, session({ sessionId: "s1", stepCount: 1 }))
+      const { result } = renderHook(() => useAgentSessionActivity(WS, "s1"))
+
+      act(() => updateAgentSessionProgress(WS, "s1", { substep: "Reading docs" }))
+      expect(result.current).toMatchObject({ stepCount: 1, substep: "Reading docs" })
+
+      act(() => updateAgentSessionProgress(WS, "s1", { stepCount: 2, substep: "Evaluating" }))
+      expect(result.current).toMatchObject({ stepCount: 2, substep: "Evaluating" })
     })
   })
 })

--- a/apps/frontend/src/stores/agent-activity-store.test.ts
+++ b/apps/frontend/src/stores/agent-activity-store.test.ts
@@ -5,6 +5,8 @@ import {
   upsertAgentSession,
   removeAgentSession,
   getAgentActivityForStream,
+  getAgentSession,
+  updateAgentSessionProgress,
   __resetAgentActivityStore,
 } from "./agent-activity-store"
 
@@ -83,5 +85,67 @@ describe("agent-activity-store", () => {
     upsertAgentSession(WS, session({ sessionId: "s1", streamId: "stream_b" }))
     expect(getAgentActivityForStream(WS, "stream_a")).toEqual([])
     expect(getAgentActivityForStream(WS, "stream_b").map((s) => s.sessionId)).toEqual(["s1"])
+  })
+
+  it("folds a progress tick into a tracked session's live counts", () => {
+    upsertAgentSession(WS, session({ sessionId: "s1" }))
+    updateAgentSessionProgress(WS, "s1", { stepCount: 3, messageCount: 1 })
+    expect(getAgentSession(WS, "s1")).toEqual({
+      ...session({ sessionId: "s1" }),
+      stepCount: 3,
+      messageCount: 1,
+      substep: null,
+    })
+  })
+
+  it("ignores progress for a session it doesn't track (untracked stays absent)", () => {
+    updateAgentSessionProgress(WS, "ghost", { stepCount: 9 })
+    expect(getAgentSession(WS, "ghost")).toBeUndefined()
+  })
+
+  it("a later `started` upsert keeps counts a progress tick already delivered", () => {
+    upsertAgentSession(WS, session({ sessionId: "s1" }))
+    updateAgentSessionProgress(WS, "s1", { stepCount: 4, messageCount: 2, substep: "Reading docs" })
+    upsertAgentSession(WS, session({ sessionId: "s1", personaName: "Ada" }))
+    expect(getAgentSession(WS, "s1")).toMatchObject({ stepCount: 4, messageCount: 2, substep: "Reading docs" })
+  })
+
+  it("a step advance drops the previous step's substep", () => {
+    upsertAgentSession(WS, session({ sessionId: "s1" }))
+    updateAgentSessionProgress(WS, "s1", { stepCount: 1, substep: "Evaluating results" })
+    updateAgentSessionProgress(WS, "s1", { stepCount: 2, messageCount: 0 })
+    expect(getAgentSession(WS, "s1")).toMatchObject({ stepCount: 2, substep: null })
+  })
+
+  it("a tick on one session leaves another session's counts untouched", () => {
+    upsertAgentSession(WS, session({ sessionId: "s1" }))
+    upsertAgentSession(WS, session({ sessionId: "s2", streamId: "stream_b" }))
+    updateAgentSessionProgress(WS, "s1", { stepCount: 5 })
+    updateAgentSessionProgress(WS, "s2", { stepCount: 7 })
+    updateAgentSessionProgress(WS, "s1", { stepCount: 6 })
+    expect(getAgentSession(WS, "s2")).toMatchObject({ stepCount: 7 })
+  })
+
+  it("counts seeded by the join-time bootstrap tick survive until the next change", () => {
+    // The join emits a progress tick before any row mounts; a row mounting later
+    // must read the stored count, not 0.
+    upsertAgentSession(WS, session({ sessionId: "s1", stepCount: 8, messageCount: 3 }))
+    expect(getAgentSession(WS, "s1")).toMatchObject({ stepCount: 8, messageCount: 3 })
+  })
+
+  it("a reconnect re-seed keeps a still-running session's live progress", () => {
+    // Reconnect order: the rejoin's bootstrap tick lands first, THEN the workspace
+    // bootstrap re-seed. The bootstrap projection carries no progress fields, so a
+    // blind replace would blank the row back to "0 steps • 0 messages sent".
+    seedAgentActivity(WS, [session({ sessionId: "s1" })])
+    updateAgentSessionProgress(WS, "s1", { stepCount: 4, messageCount: 2, substep: "Evaluating results…" })
+
+    seedAgentActivity(WS, [session({ sessionId: "s1" })])
+
+    expect(getAgentSession(WS, "s1")).toMatchObject({
+      stepCount: 4,
+      messageCount: 2,
+      substep: "Evaluating results…",
+    })
   })
 })

--- a/apps/frontend/src/stores/agent-activity-store.ts
+++ b/apps/frontend/src/stores/agent-activity-store.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
 import type { ActiveAgentSession } from "@threa/types"
 
 /**
@@ -24,6 +24,8 @@ const workspaces = new Map<string, Map<string, ActiveAgentSession>>()
 const keyListeners = new Map<string, Set<() => void>>()
 // Content-stable snapshot per key (referential stability for useSyncExternalStore)
 const keySnapshots = new Map<string, ActiveAgentSession[]>()
+// `${workspaceId}:${sessionId}` -> listeners subscribed to that one session
+const sessionListeners = new Map<string, Set<() => void>>()
 
 const EMPTY: readonly ActiveAgentSession[] = Object.freeze([])
 
@@ -31,12 +33,28 @@ function subKey(workspaceId: string, streamId: string): string {
   return `${workspaceId}:${streamId}`
 }
 
+function sameSession(a: ActiveAgentSession, b: ActiveAgentSession): boolean {
+  return (
+    a.sessionId === b.sessionId &&
+    a.streamId === b.streamId &&
+    a.rootStreamId === b.rootStreamId &&
+    a.personaName === b.personaName &&
+    a.stepCount === b.stepCount &&
+    a.messageCount === b.messageCount &&
+    a.substep === b.substep
+  )
+}
+
 function sameSnapshot(a: readonly ActiveAgentSession[], b: readonly ActiveAgentSession[]): boolean {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i++) {
-    if (a[i].sessionId !== b[i].sessionId || a[i].personaName !== b[i].personaName) return false
+    if (a[i] !== b[i] && !sameSession(a[i], b[i])) return false
   }
   return true
+}
+
+function notifySession(workspaceId: string, sessionId: string): void {
+  for (const listener of sessionListeners.get(subKey(workspaceId, sessionId)) ?? []) listener()
 }
 
 /** Recompute the cached snapshot for one stream key and notify iff its content changed. */
@@ -58,23 +76,44 @@ function recomputeKey(workspaceId: string, streamId: string): void {
   for (const listener of keyListeners.get(key) ?? []) listener()
 }
 
-/** Replace the whole running set for a workspace (bootstrap / reconnect re-seed). */
+/**
+ * Replace the whole running set for a workspace (bootstrap / reconnect re-seed).
+ * Membership is authoritative — an entry absent from the seed is dropped (INV-53).
+ * Progress the seed doesn't carry (the bootstrap projection has no
+ * `stepCount`/`messageCount`/`substep`) keeps the tracked value, so a reconnect
+ * re-seed can't reset a still-running session's counts to undefined.
+ */
 export function seedAgentActivity(workspaceId: string, sessions: ActiveAgentSession[]): void {
   const previous = workspaces.get(workspaceId)
   const affectedStreams = new Set<string>()
   for (const entry of previous?.values() ?? []) affectedStreams.add(entry.streamId)
 
   const next = new Map<string, ActiveAgentSession>()
+  const affectedSessions = new Set<string>(previous?.keys() ?? [])
   for (const session of sessions) {
-    next.set(session.sessionId, { ...session })
+    const existing = previous?.get(session.sessionId)
+    next.set(session.sessionId, {
+      ...session,
+      stepCount: session.stepCount ?? existing?.stepCount,
+      messageCount: session.messageCount ?? existing?.messageCount,
+      substep: session.substep ?? existing?.substep,
+    })
     affectedStreams.add(session.streamId)
+    affectedSessions.add(session.sessionId)
   }
   workspaces.set(workspaceId, next)
 
   for (const streamId of affectedStreams) recomputeKey(workspaceId, streamId)
+  for (const sessionId of affectedSessions) notifySession(workspaceId, sessionId)
 }
 
-/** Add or refresh one running session (live `started`/`progress`). */
+/**
+ * Add or refresh one running session (live `started`/`progress`). Progress fields
+ * the incoming event doesn't carry (`stepCount`/`messageCount`/`substep` are
+ * absent on `started`/`activity_started` and on the bootstrap projection) keep the
+ * value already tracked, so a late `started` can't wipe counts a progress tick
+ * already delivered.
+ */
 export function upsertAgentSession(workspaceId: string, session: ActiveAgentSession): void {
   let ws = workspaces.get(workspaceId)
   if (!ws) {
@@ -82,19 +121,50 @@ export function upsertAgentSession(workspaceId: string, session: ActiveAgentSess
     workspaces.set(workspaceId, ws)
   }
   const existing = ws.get(session.sessionId)
-  if (
-    existing &&
-    existing.rootStreamId === session.rootStreamId &&
-    existing.personaName === session.personaName &&
-    existing.streamId === session.streamId
-  ) {
-    return
+  const next: ActiveAgentSession = {
+    ...session,
+    stepCount: session.stepCount ?? existing?.stepCount,
+    messageCount: session.messageCount ?? existing?.messageCount,
+    substep: session.substep ?? existing?.substep,
   }
-  ws.set(session.sessionId, { ...session })
-  if (existing && existing.streamId !== session.streamId) {
+  if (existing && sameSession(existing, next)) return
+  ws.set(session.sessionId, next)
+  if (existing && existing.streamId !== next.streamId) {
     recomputeKey(workspaceId, existing.streamId)
   }
-  recomputeKey(workspaceId, session.streamId)
+  recomputeKey(workspaceId, next.streamId)
+  notifySession(workspaceId, next.sessionId)
+}
+
+/**
+ * Fold a live progress tick into an already-tracked session. No-op for an
+ * untracked id — the caller upserts in that case (it needs the resolved root
+ * stream, which this path deliberately avoids re-reading per step). A step
+ * advance drops the previous step's substep, which is stale by definition.
+ */
+export function updateAgentSessionProgress(
+  workspaceId: string,
+  sessionId: string,
+  progress: { stepCount?: number; messageCount?: number; substep?: string | null }
+): void {
+  const ws = workspaces.get(workspaceId)
+  const existing = ws?.get(sessionId)
+  if (!ws || !existing) return
+  const stepCount = progress.stepCount ?? existing.stepCount
+  const stepAdvanced = progress.stepCount !== undefined && progress.stepCount !== existing.stepCount
+  let substep = existing.substep
+  if (progress.substep !== undefined) substep = progress.substep
+  else if (stepAdvanced) substep = null
+  const next: ActiveAgentSession = {
+    ...existing,
+    stepCount,
+    messageCount: progress.messageCount ?? existing.messageCount,
+    substep,
+  }
+  if (sameSession(existing, next)) return
+  ws.set(sessionId, next)
+  recomputeKey(workspaceId, next.streamId)
+  notifySession(workspaceId, sessionId)
 }
 
 /** Remove a session by id on any terminal signal. */
@@ -104,6 +174,7 @@ export function removeAgentSession(workspaceId: string, sessionId: string): void
   if (!ws || !existing) return
   ws.delete(sessionId)
   recomputeKey(workspaceId, existing.streamId)
+  notifySession(workspaceId, sessionId)
 }
 
 /** True if a session with this id is already tracked in the workspace. */
@@ -149,9 +220,88 @@ export function useAgentActivityForStream(
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
+/** Non-reactive read of one running session by id; undefined when not running. */
+export function getAgentSession(workspaceId: string, sessionId: string): ActiveAgentSession | undefined {
+  return workspaces.get(workspaceId)?.get(sessionId)
+}
+
+function subscribeSessions(workspaceId: string | undefined, sessionIds: readonly string[]) {
+  return (onChange: () => void) => {
+    if (!workspaceId) return () => {}
+    const keys = sessionIds.map((id) => subKey(workspaceId, id))
+    for (const key of keys) {
+      let set = sessionListeners.get(key)
+      if (!set) {
+        set = new Set()
+        sessionListeners.set(key, set)
+      }
+      set.add(onChange)
+    }
+    return () => {
+      for (const key of keys) {
+        const set = sessionListeners.get(key)
+        if (!set) continue
+        set.delete(onChange)
+        if (set.size === 0) sessionListeners.delete(key)
+      }
+    }
+  }
+}
+
+/**
+ * Reactive read of ONE session's live state by id — the board's running-session
+ * row reads its own session here instead of keeping a workspace-wide subscription
+ * per row, so an unrelated session's tick doesn't re-render it.
+ */
+export function useAgentSessionActivity(
+  workspaceId: string | undefined,
+  sessionId: string | null | undefined
+): ActiveAgentSession | undefined {
+  const ids = useMemo(() => (sessionId ? [sessionId] : []), [sessionId])
+  const subscribe = useMemo(() => subscribeSessions(workspaceId, ids), [workspaceId, ids])
+  const getSnapshot = useCallback(
+    () => (workspaceId && sessionId ? getAgentSession(workspaceId, sessionId) : undefined),
+    [workspaceId, sessionId]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
+ * Reactive read of a caller-chosen SET of sessions (a board card's own
+ * conversation rows), most recently started first, skipping ids that aren't
+ * running. Scoping by id — not by stream — is what keeps a sibling conversation's
+ * agent off this card.
+ */
+export function useAgentSessionActivities(
+  workspaceId: string | undefined,
+  sessionIds: readonly string[]
+): readonly ActiveAgentSession[] {
+  const key = sessionIds.join(",")
+  const ids = useMemo(() => (key ? key.split(",") : []), [key])
+  const subscribe = useMemo(() => subscribeSessions(workspaceId, ids), [workspaceId, ids])
+  const cache = useRef<readonly ActiveAgentSession[]>(EMPTY)
+  const getSnapshot = useCallback(() => {
+    const next = workspaceId
+      ? ids
+          .map((id) => getAgentSession(workspaceId, id))
+          .filter((entry): entry is ActiveAgentSession => entry !== undefined)
+          .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+      : []
+    if (next.length === 0) {
+      cache.current = EMPTY
+      return EMPTY
+    }
+    if (sameSnapshot(cache.current, next)) return cache.current
+    cache.current = next
+    return next
+  }, [workspaceId, ids])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
 /** Test-only: wipe all state between cases. */
 export function __resetAgentActivityStore(): void {
   workspaces.clear()
   keyListeners.clear()
   keySnapshots.clear()
+  sessionListeners.clear()
 }

--- a/apps/frontend/src/stores/agent-activity-store.ts
+++ b/apps/frontend/src/stores/agent-activity-store.ts
@@ -45,10 +45,34 @@ function sameSession(a: ActiveAgentSession, b: ActiveAgentSession): boolean {
   )
 }
 
-function sameSnapshot(a: readonly ActiveAgentSession[], b: readonly ActiveAgentSession[]): boolean {
+/**
+ * Identity only — no progress fields. The stream-key snapshot compares with this
+ * so a progress/substep tick (several per second in a research loop) cannot churn
+ * the array every sidebar row subscribes to; by-id subscribers still get every
+ * tick through `notifySession`.
+ */
+function sameSessionIdentity(a: ActiveAgentSession, b: ActiveAgentSession): boolean {
+  return (
+    a.sessionId === b.sessionId &&
+    a.streamId === b.streamId &&
+    a.rootStreamId === b.rootStreamId &&
+    a.personaName === b.personaName
+  )
+}
+
+/** Exactly what a board card's running chip renders. */
+function sameSessionChip(a: ActiveAgentSession, b: ActiveAgentSession): boolean {
+  return a.sessionId === b.sessionId && a.personaName === b.personaName && a.stepCount === b.stepCount
+}
+
+function sameList(
+  a: readonly ActiveAgentSession[],
+  b: readonly ActiveAgentSession[],
+  equal: (x: ActiveAgentSession, y: ActiveAgentSession) => boolean
+): boolean {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i] && !sameSession(a[i], b[i])) return false
+    if (a[i] !== b[i] && !equal(a[i], b[i])) return false
   }
   return true
 }
@@ -70,7 +94,7 @@ function recomputeKey(workspaceId: string, streamId: string): void {
     if (prev === undefined) return
     keySnapshots.delete(key)
   } else {
-    if (prev && sameSnapshot(prev, sessions)) return
+    if (prev && sameList(prev, sessions, sameSessionIdentity)) return
     keySnapshots.set(key, sessions)
   }
   for (const listener of keyListeners.get(key) ?? []) listener()
@@ -291,7 +315,7 @@ export function useAgentSessionActivities(
       cache.current = EMPTY
       return EMPTY
     }
-    if (sameSnapshot(cache.current, next)) return cache.current
+    if (sameList(cache.current, next, sameSessionChip)) return cache.current
     cache.current = next
     return next
   }, [workspaceId, ids])

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -32,7 +32,8 @@ import {
   type Activity,
 } from "@threa/types"
 import { assignmentId } from "@/hooks/use-labels"
-import { getAgentActivityForStream, __resetAgentActivityStore } from "@/stores/agent-activity-store"
+import { getAgentActivityForStream, getAgentSession, __resetAgentActivityStore } from "@/stores/agent-activity-store"
+import * as agentSubstep from "@/lib/crypto/agent-substep"
 import { getCachedWorkspaceTables, subscribeWorkspaceCache } from "@/stores/workspace-store"
 import type { Socket } from "socket.io-client"
 
@@ -4085,6 +4086,92 @@ describe("agent-activity sidebar socket handlers", () => {
     })
     expect(getAgentActivityForStream("ws_1", "stream_ch").map((s) => s.sessionId)).toEqual(["sess_p"])
 
+    cleanup()
+  })
+
+  it("folds live counts from progress ticks onto a tracked session", async () => {
+    await putStream("stream_ch", null)
+    const queryClient = new QueryClient()
+    const { socket, emitAsync } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    await emitAsync("agent_session:started", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_c", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
+    })
+    // The join-time bootstrap tick: it lands before any board row mounts, so the
+    // counts must survive in the store for a late-mounting row to read.
+    await emitAsync("agent_session:progress", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      sessionId: "sess_c",
+      personaName: "Ariadne",
+      stepCount: 5,
+      messageCount: 1,
+    })
+    expect(getAgentSession("ws_1", "sess_c")).toMatchObject({ stepCount: 5, messageCount: 1 })
+
+    await emitAsync("agent_session:substep", {
+      sessionId: "sess_c",
+      streamId: "stream_ch",
+      substep: "Reading the migration",
+      updatedAt: "2026-07-16T00:00:02.000Z",
+    })
+    expect(getAgentSession("ws_1", "sess_c")).toMatchObject({ substep: "Reading the migration" })
+
+    cleanup()
+  })
+
+  it("decrypts a sealed substep, and skips it when the session is locked", async () => {
+    await putStream("stream_ch", null)
+    const queryClient = new QueryClient()
+    const { socket, emitAsync } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    await emitAsync("agent_session:started", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_e", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
+    })
+
+    const decrypt = vi.spyOn(agentSubstep, "decryptAgentSubstepText").mockResolvedValue("Planning queries…")
+    await emitAsync("agent_session:substep", {
+      workspaceId: "ws_1",
+      sessionId: "sess_e",
+      streamId: "stream_ch",
+      ciphertext: "c1",
+      envelope: { v: 1 },
+      updatedAt: "2026-07-16T00:00:02.000Z",
+    })
+    expect(getAgentSession("ws_1", "sess_e")).toMatchObject({ substep: "Planning queries…" })
+
+    // Locked session (or a failed open): the helper returns null and the ephemeral
+    // substep is skipped rather than blanking the applied one.
+    decrypt.mockResolvedValue(null)
+    await emitAsync("agent_session:substep", {
+      workspaceId: "ws_1",
+      sessionId: "sess_e",
+      streamId: "stream_ch",
+      ciphertext: "c2",
+      envelope: { v: 1 },
+      updatedAt: "2026-07-16T00:00:03.000Z",
+    })
+    expect(getAgentSession("ws_1", "sess_e")).toMatchObject({ substep: "Planning queries…" })
+
+    // A redelivery of the older substep (stream room + parent room) is dropped.
+    decrypt.mockResolvedValue("Evaluating results…")
+    await emitAsync("agent_session:substep", {
+      workspaceId: "ws_1",
+      sessionId: "sess_e",
+      streamId: "stream_ch",
+      ciphertext: "c1",
+      envelope: { v: 1 },
+      updatedAt: "2026-07-16T00:00:01.000Z",
+    })
+    expect(getAgentSession("ws_1", "sess_e")).toMatchObject({ substep: "Planning queries…" })
+
+    decrypt.mockRestore()
     cleanup()
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -4174,6 +4174,72 @@ describe("agent-activity sidebar socket handlers", () => {
     decrypt.mockRestore()
     cleanup()
   })
+
+  it("skips the substep decrypt entirely for a session it doesn't track", async () => {
+    await putStream("stream_ch", null)
+    const queryClient = new QueryClient()
+    const { socket, emitAsync } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    const decrypt = vi.spyOn(agentSubstep, "decryptAgentSubstepText").mockResolvedValue("Planning queries…")
+    await emitAsync("agent_session:substep", {
+      workspaceId: "ws_1",
+      sessionId: "sess_untracked",
+      streamId: "stream_ch",
+      ciphertext: "c1",
+      envelope: { v: 1 },
+      updatedAt: "2026-07-16T00:00:02.000Z",
+    })
+
+    expect(decrypt).not.toHaveBeenCalled()
+    decrypt.mockRestore()
+    cleanup()
+  })
+
+  it("applies a terminal event without waiting on a pending substep decrypt", async () => {
+    await putStream("stream_ch", null)
+    const queryClient = new QueryClient()
+    const { socket, emit, emitAsync } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    await emitAsync("agent_session:started", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_slow", personaName: "Ariadne", startedAt: "2026-07-16T00:00:00.000Z" } },
+    })
+
+    let resolveDecrypt: (text: string | null) => void = () => {}
+    const pending = new Promise<string | null>((resolve) => {
+      resolveDecrypt = resolve
+    })
+    const decrypt = vi.spyOn(agentSubstep, "decryptAgentSubstepText").mockReturnValue(pending)
+
+    emit("agent_session:substep", {
+      workspaceId: "ws_1",
+      sessionId: "sess_slow",
+      streamId: "stream_ch",
+      ciphertext: "c1",
+      envelope: { v: 1 },
+      updatedAt: "2026-07-16T00:00:02.000Z",
+    })
+
+    // The decrypt is still open; the terminal event must not queue behind it.
+    await emitAsync("agent_session:completed", {
+      workspaceId: "ws_1",
+      streamId: "stream_ch",
+      event: { payload: { sessionId: "sess_slow" } },
+    })
+    expect(getAgentSession("ws_1", "sess_slow")).toBeUndefined()
+
+    // The late decrypt lands on a removed session and is a no-op.
+    resolveDecrypt("Planning queries…")
+    await pending
+    await Promise.resolve()
+    expect(getAgentSession("ws_1", "sess_slow")).toBeUndefined()
+
+    decrypt.mockRestore()
+    cleanup()
+  })
 })
 
 /** A board row anchored in `streamId` under `rootStreamId`, as the board store writes it. */

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1406,9 +1406,9 @@ export function registerWorkspaceSocketHandlers(
       })
     })
 
-  // `updatedAt` of the substep currently applied per session. The queue serializes
-  // the async decrypt below, but the same substep can arrive twice (stream room +
-  // parent room), so an older-or-equal stamp is dropped rather than re-applied.
+  // `updatedAt` of the substep currently applied per session. Decrypts run outside
+  // the queue and therefore race each other, so this stamp — not arrival order —
+  // decides: an older-or-equal stamp is dropped rather than applied.
   const appliedSubstepAt = new Map<string, string>()
 
   const applySubstepText = (sessionId: string, text: string, updatedAt: string): void => {
@@ -1421,21 +1421,28 @@ export function registerWorkspaceSocketHandlers(
   // Ephemeral phase text for the current step. An E2E session's substep is sealed
   // under the stream key, so decrypt it the same way the trace hook does; a locked
   // session or a failed open just skips (the substep is ephemeral).
-  const handleAgentSessionSubstep = (payload: AgentSessionSubstepPayload) =>
-    enqueueAgentActivity(async () => {
-      if (typeof payload.substep === "string" && payload.substep) {
-        applySubstepText(payload.sessionId, payload.substep, payload.updatedAt)
-        return
-      }
-      if (typeof payload.ciphertext !== "string" || !payload.envelope) return
-      const userId = refs.getCurrentUser()?.id
-      if (!userId) return
-      const text = await decryptAgentSubstepText(
-        { streamId: payload.streamId, ciphertext: payload.ciphertext, envelope: payload.envelope },
-        { workspaceId, userId }
-      )
-      if (text) applySubstepText(payload.sessionId, text, payload.updatedAt)
-    })
+  // The decrypt runs OUTSIDE `agentActivityQueue`: a chatty tool loop would
+  // otherwise backlog the serial queue and leave a terminal
+  // `agent_session:completed` waiting behind pending opens (spinner still lit
+  // after the agent finished). Only the synchronous apply is enqueued. An
+  // untracked session bails before any crypto.
+  const handleAgentSessionSubstep = async (payload: AgentSessionSubstepPayload): Promise<void> => {
+    if (!hasAgentSession(workspaceId, payload.sessionId)) return
+    const plaintext = payload.substep
+    if (typeof plaintext === "string" && plaintext) {
+      await enqueueAgentActivity(() => applySubstepText(payload.sessionId, plaintext, payload.updatedAt))
+      return
+    }
+    if (typeof payload.ciphertext !== "string" || !payload.envelope) return
+    const userId = refs.getCurrentUser()?.id
+    if (!userId) return
+    const text = await decryptAgentSubstepText(
+      { streamId: payload.streamId, ciphertext: payload.ciphertext, envelope: payload.envelope },
+      { workspaceId, userId }
+    )
+    if (!text) return
+    await enqueueAgentActivity(() => applySubstepText(payload.sessionId, text, payload.updatedAt))
+  }
 
   const handleAgentActivityEnded = (payload: AgentActivityEndedPayload) =>
     enqueueAgentActivity(() => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -30,8 +30,10 @@ import {
   upsertAgentSession,
   removeAgentSession,
   hasAgentSession,
+  updateAgentSessionProgress,
 } from "@/stores/agent-activity-store"
 import { seedActiveCalls, upsertActiveCall, removeActiveCall } from "@/stores/active-calls-store"
+import { decryptAgentSubstepText } from "@/lib/crypto/agent-substep"
 import type { CallStartedEventPayload } from "@threa/types"
 import type { SyncEventSource } from "./socket-event-gate"
 import type { QueryClient } from "@tanstack/react-query"
@@ -56,6 +58,7 @@ import type {
   Activity,
   AgentSessionStartedPayload,
   AgentSessionProgressPayload,
+  AgentSessionSubstepPayload,
   AgentActivityStartedPayload,
   AgentActivityEndedPayload,
   ActivityCreatedPayload,
@@ -1366,7 +1369,16 @@ export function registerWorkspaceSocketHandlers(
       // has joined (trace-emitter emits to streamRoom + parentRoom, never workspace-
       // wide). Once the session is tracked, nothing the sidebar renders changes —
       // skip the IDB lookup and the no-op upsert entirely.
-      if (hasAgentSession(workspaceId, payload.sessionId)) return
+      // Once tracked, only the live counts change — fold them in without the IDB
+      // lookup. The board's running-session rows read them from here, so a row
+      // mounted after the join-time bootstrap tick still paints a real step count.
+      if (hasAgentSession(workspaceId, payload.sessionId)) {
+        updateAgentSessionProgress(workspaceId, payload.sessionId, {
+          stepCount: payload.stepCount,
+          messageCount: payload.messageCount,
+        })
+        return
+      }
       const rootStreamId = await resolveRootStreamId(payload.streamId)
       if (!rootStreamId) return
       upsertAgentSession(workspaceId, {
@@ -1376,6 +1388,8 @@ export function registerWorkspaceSocketHandlers(
         personaName: payload.personaName,
         // Progress carries no start time; anchor sort order to arrival.
         startedAt: new Date().toISOString(),
+        stepCount: payload.stepCount,
+        messageCount: payload.messageCount,
       })
     })
 
@@ -1392,8 +1406,42 @@ export function registerWorkspaceSocketHandlers(
       })
     })
 
+  // `updatedAt` of the substep currently applied per session. The queue serializes
+  // the async decrypt below, but the same substep can arrive twice (stream room +
+  // parent room), so an older-or-equal stamp is dropped rather than re-applied.
+  const appliedSubstepAt = new Map<string, string>()
+
+  const applySubstepText = (sessionId: string, text: string, updatedAt: string): void => {
+    const applied = appliedSubstepAt.get(sessionId)
+    if (applied !== undefined && updatedAt <= applied) return
+    appliedSubstepAt.set(sessionId, updatedAt)
+    updateAgentSessionProgress(workspaceId, sessionId, { substep: text })
+  }
+
+  // Ephemeral phase text for the current step. An E2E session's substep is sealed
+  // under the stream key, so decrypt it the same way the trace hook does; a locked
+  // session or a failed open just skips (the substep is ephemeral).
+  const handleAgentSessionSubstep = (payload: AgentSessionSubstepPayload) =>
+    enqueueAgentActivity(async () => {
+      if (typeof payload.substep === "string" && payload.substep) {
+        applySubstepText(payload.sessionId, payload.substep, payload.updatedAt)
+        return
+      }
+      if (typeof payload.ciphertext !== "string" || !payload.envelope) return
+      const userId = refs.getCurrentUser()?.id
+      if (!userId) return
+      const text = await decryptAgentSubstepText(
+        { streamId: payload.streamId, ciphertext: payload.ciphertext, envelope: payload.envelope },
+        { workspaceId, userId }
+      )
+      if (text) applySubstepText(payload.sessionId, text, payload.updatedAt)
+    })
+
   const handleAgentActivityEnded = (payload: AgentActivityEndedPayload) =>
-    enqueueAgentActivity(() => removeAgentSession(workspaceId, payload.sessionId))
+    enqueueAgentActivity(() => {
+      appliedSubstepAt.delete(payload.sessionId)
+      removeAgentSession(workspaceId, payload.sessionId)
+    })
 
   // agent_session:completed/failed reach this socket in two shapes: the
   // stream-scoped outbox form `{ workspaceId, streamId, event }`, and a flat
@@ -1410,7 +1458,9 @@ export function registerWorkspaceSocketHandlers(
     enqueueAgentActivity(() => {
       if (payload.workspaceId !== undefined && payload.workspaceId !== workspaceId) return
       const sessionId = (payload.event?.payload as { sessionId?: string } | undefined)?.sessionId ?? payload.sessionId
-      if (sessionId) removeAgentSession(workspaceId, sessionId)
+      if (!sessionId) return
+      appliedSubstepAt.delete(sessionId)
+      removeAgentSession(workspaceId, sessionId)
     })
 
   // Handle stream display name updated (from auto-naming service)
@@ -2276,6 +2326,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("agent_session:started", handleAgentSessionStartedActivity)
   socket.on("agent_session:progress", handleAgentSessionProgressActivity)
   socket.on("agent_session:activity_started", handleAgentActivityStarted)
+  socket.on("agent_session:substep", handleAgentSessionSubstep)
   socket.on("agent_session:activity_ended", handleAgentActivityEnded)
   socket.on("agent_session:completed", handleAgentSessionEndedActivity)
   socket.on("agent_session:failed", handleAgentSessionEndedActivity)
@@ -2346,6 +2397,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("agent_session:started", handleAgentSessionStartedActivity)
     socket.off("agent_session:progress", handleAgentSessionProgressActivity)
     socket.off("agent_session:activity_started", handleAgentActivityStarted)
+    socket.off("agent_session:substep", handleAgentSessionSubstep)
     socket.off("agent_session:activity_ended", handleAgentActivityEnded)
     socket.off("agent_session:completed", handleAgentSessionEndedActivity)
     socket.off("agent_session:failed", handleAgentSessionEndedActivity)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1784,6 +1784,10 @@ export interface WorkspaceBootstrap {
  * thread) whose sidebar row lights up; `rootStreamId` is its non-thread ancestor
  * used for access filtering (`COALESCE(streams.root_stream_id, streams.id)`).
  * `personaName` is the persona or bot display name driving the session.
+ *
+ * `stepCount` / `messageCount` / `substep` are live progress, folded in from the
+ * `agent_session:progress` and `agent_session:substep` room events; the bootstrap
+ * projection omits them, so they read 0 / null until the first tick.
  */
 export interface ActiveAgentSession {
   sessionId: string
@@ -1791,6 +1795,9 @@ export interface ActiveAgentSession {
   rootStreamId: string
   personaName: string
   startedAt: string
+  stepCount?: number
+  messageCount?: number
+  substep?: string | null
 }
 
 /**


### PR DESCRIPTION
## Problem

Kris (prod dogfood): board trace cards render the wrong step count, and the ledger gives no sign an agent trace is running. Both structural: `BoardRunningSessionRow` kept per-row activity state that resets when virtua recycles the card — a late-mounted row misses the join-time bootstrap tick and shows "0 steps" until the next progress event (minutes, for a slow tool call). And session rows sort at their **start** time, so once the agent replies, the fold collapses a still-running session to a static `Bot · Ariadne · running` ledger line — or swallows it into a group summary.

## Solution

- `ActiveAgentSession` carries `stepCount`/`messageCount`/`substep`; workspace-sync's single subscription folds progress ticks into the module store (join-time bootstrap included), so any row mounting later reads warm counts by session id. Adversarial verify caught two regressions in the first cut, both fixed: the reconnect **seed** deterministically lands after the rejoin tick and was clobbering live counts (now merges with `??` fallbacks; membership stays authoritative per INV-53), and **sealed substeps** (E2E scratchpads — the primary agent surface) were dropped by the sync path where the removed per-row hook used to decrypt them (now a shared `decryptAgentSubstepText` helper used by both; ordering via the serialized activity queue + a per-session `updatedAt` stamp).
- `BoardRunningSessionRow` reads the store; its per-row `useAgentActivity` (a workspace-wide map per row, re-rendering on every unrelated tick) is gone.
- `foldLedgerEventRows` flushes around any running session — a live trace always renders the full `AgentSessionEvent` with its spinner, never a ledger line or a group entry.
- The stream top bar's running pill is extracted as `AgentRunningChip` (copy not forked; the timeline header now wraps it) and sits in the card header's fixed-footprint slot (INV-21), **conversation-scoped** by the card's own session rows — a sibling conversation's agent on the same stream can't light the card. Covers the long-running session whose started event sits above the "N earlier" boundary.

## Test plan

- [x] Adversarial verify (Opus high): 2 findings (seed clobber 92, sealed-substep drop 80), both fixed; session-end cleanup, snapshot identity, fold ordering, chip coverage, INV-21 all re-derived clean
- [x] Targeted: agent-activity-store, workspace-sync, board-card ×2, board-row-item, agent-session-event, types — 262 + 194 + 154 across passes; tsc + eslint clean
- [x] Falsified ×7: early-out, null session id, fold flush, chip entries, stream-scoped source, seed fallbacks, ordering guard

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788365400&installation_model_id=20758&pr_number=1757&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1757&signature=f122bba1c7087a7c1e73c414a9fab45384c84030b524dd6e18603b1df9c60105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->