### PR TITLE
feat(composer): link selected text from pasted URLs

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -85,6 +85,7 @@
     "embla-carousel-react": "^8.6.0",
     "hash-wasm": "^4.12.0",
     "input-otp": "^1.4.2",
+    "linkifyjs": "^4.3.2",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.561.0",
     "next-themes": "^0.4.6",

--- a/apps/frontend/src/components/editor/paste-link-over-selection.test.ts
+++ b/apps/frontend/src/components/editor/paste-link-over-selection.test.ts
@@ -13,7 +13,13 @@ afterEach(() => {
 function createTestEditor(markdown: string): Editor {
   const editor = new Editor({
     element: document.createElement("div"),
-    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    extensions: createEditorExtensions({
+      placeholder: "Type a message...",
+      mentionSuggestion: {
+        items: () => [],
+        render: () => ({ onStart: () => {}, onUpdate: () => {}, onExit: () => {}, onKeyDown: () => false }),
+      },
+    }),
     content: parseMarkdown(markdown),
   })
   openEditors.push(editor)
@@ -39,6 +45,22 @@ describe("pasteLinkOverSelection", () => {
 
     expect(pasteLinkOverSelection(editor, "https://example.com/docs")).toBe(true)
     expect(serializeToMarkdown(editor.getJSON())).toBe("Read **[the docs](https://example.com/docs)** today")
+  })
+
+  it("links a mixed inline-code selection as one phrase by dropping the incompatible code mark", () => {
+    const editor = createTestEditor("plain `code` tail")
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size - 1 })
+
+    expect(pasteLinkOverSelection(editor, "https://example.com")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("[plain code tail](https://example.com)")
+  })
+
+  it("declines selections containing inline atoms instead of creating nested links", () => {
+    const editor = createTestEditor("ask [@alice](user:usr_01) docs")
+    editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size - 1 })
+
+    expect(pasteLinkOverSelection(editor, "https://example.com")).toBe(false)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("ask [@alice](user:usr_01) docs")
   })
 
   it("normalizes bare domains and email addresses without misclassifying URLs with userinfo", () => {
@@ -89,23 +111,23 @@ describe("handleBeforeInputLinkPaste", () => {
   }
 
   it.each([
-    ["insertText", "https://example.com", ""],
-    ["insertFromPaste", "https://example.com", ""],
-    ["insertFromPaste", null, "https://example.com"],
-    ["insertReplacementText", "https://example.com", ""],
-  ])("links selected text for %s beforeinput events", (inputType, data, dataTransferText) => {
+    ["insertText", "https://example.com", "", true],
+    ["insertFromPaste", "https://example.com", "", true],
+    ["insertFromPaste", null, "https://example.com", true],
+    ["insertReplacementText", "https://example.com", "", false],
+  ])("links selected text for %s beforeinput events", (inputType, data, dataTransferText, collapsed) => {
     const editor = createTestEditor("selected text")
     selectText(editor, "selected")
-    const inputEvent = event(inputType, data, dataTransferText)
+    const inputEvent = event(inputType, data, dataTransferText, collapsed)
 
     expect(handleBeforeInputLinkPaste(editor, inputEvent)).toBe(true)
     expect(inputEvent.preventDefault).toHaveBeenCalledOnce()
     expect(serializeToMarkdown(editor.getJSON())).toBe("[selected](https://example.com) text")
   })
 
-  it("leaves spellcheck replacement ranges to the browser", () => {
+  it("leaves spellcheck replacement ranges to the browser when the editor selection is collapsed", () => {
     const editor = createTestEditor("selected text")
-    selectText(editor, "selected")
+    editor.commands.focus("end")
     const inputEvent = event("insertReplacementText", "https://example.com", "", false)
 
     expect(handleBeforeInputLinkPaste(editor, inputEvent)).toBe(false)

--- a/apps/frontend/src/components/editor/paste-link-over-selection.test.ts
+++ b/apps/frontend/src/components/editor/paste-link-over-selection.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Editor } from "@tiptap/core"
+import { createEditorExtensions } from "./editor-extensions"
+import { parseMarkdown, serializeToMarkdown } from "./editor-markdown"
+import { handleBeforeInputLinkPaste, pasteLinkOverSelection } from "./paste-link-over-selection"
+
+const openEditors: Editor[] = []
+
+afterEach(() => {
+  while (openEditors.length > 0) openEditors.pop()?.destroy()
+})
+
+function createTestEditor(markdown: string): Editor {
+  const editor = new Editor({
+    element: document.createElement("div"),
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content: parseMarkdown(markdown),
+  })
+  openEditors.push(editor)
+  return editor
+}
+
+function selectText(editor: Editor, text: string): void {
+  let range: { from: number; to: number } | null = null
+  editor.state.doc.descendants((node, pos) => {
+    const index = node.isText ? (node.text ?? "").indexOf(text) : -1
+    if (index === -1) return true
+    range = { from: pos + index, to: pos + index + text.length }
+    return false
+  })
+  if (!range) throw new Error(`Text not found: ${text}`)
+  editor.commands.setTextSelection(range)
+}
+
+describe("pasteLinkOverSelection", () => {
+  it("turns selected text into a link without replacing it or dropping its marks", () => {
+    const editor = createTestEditor("Read **the docs** today")
+    selectText(editor, "the docs")
+
+    expect(pasteLinkOverSelection(editor, "https://example.com/docs")).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("Read **[the docs](https://example.com/docs)** today")
+  })
+
+  it("normalizes bare domains and email addresses without misclassifying URLs with userinfo", () => {
+    const domainEditor = createTestEditor("the website")
+    selectText(domainEditor, "website")
+    expect(pasteLinkOverSelection(domainEditor, "example.com/path")).toBe(true)
+    expect(serializeToMarkdown(domainEditor.getJSON())).toBe("the [website](http://example.com/path)")
+
+    const emailEditor = createTestEditor("email support")
+    selectText(emailEditor, "support")
+    expect(pasteLinkOverSelection(emailEditor, "help@example.com")).toBe(true)
+    expect(serializeToMarkdown(emailEditor.getJSON())).toBe("email [support](mailto:help@example.com)")
+
+    const userInfoEditor = createTestEditor("private site")
+    selectText(userInfoEditor, "site")
+    expect(pasteLinkOverSelection(userInfoEditor, "https://user@example.com")).toBe(true)
+    expect(serializeToMarkdown(userInfoEditor.getJSON())).toBe("private [site](https://user@example.com)")
+  })
+
+  it("leaves the paste path alone without selected text or a valid safe link", () => {
+    const editor = createTestEditor("keep this text")
+    editor.commands.focus("end")
+
+    expect(pasteLinkOverSelection(editor, "https://example.com")).toBe(false)
+
+    selectText(editor, "this")
+    expect(pasteLinkOverSelection(editor, "not a link")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "javascript:alert(1)")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "example..com")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "example.com,")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "https://example..com")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "https://-example.com")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "https://%zz.com")).toBe(false)
+    expect(pasteLinkOverSelection(editor, "https://example.com:99999")).toBe(false)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("keep this text")
+  })
+})
+
+describe("handleBeforeInputLinkPaste", () => {
+  function event(inputType: string, data: string | null, dataTransferText = "", collapsed = true) {
+    return {
+      inputType,
+      data,
+      dataTransfer: dataTransferText ? { getData: () => dataTransferText } : null,
+      getTargetRanges: () => [{ collapsed }],
+      preventDefault: vi.fn(),
+    } as unknown as InputEvent & { preventDefault: ReturnType<typeof vi.fn> }
+  }
+
+  it.each([
+    ["insertText", "https://example.com", ""],
+    ["insertFromPaste", "https://example.com", ""],
+    ["insertFromPaste", null, "https://example.com"],
+    ["insertReplacementText", "https://example.com", ""],
+  ])("links selected text for %s beforeinput events", (inputType, data, dataTransferText) => {
+    const editor = createTestEditor("selected text")
+    selectText(editor, "selected")
+    const inputEvent = event(inputType, data, dataTransferText)
+
+    expect(handleBeforeInputLinkPaste(editor, inputEvent)).toBe(true)
+    expect(inputEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(serializeToMarkdown(editor.getJSON())).toBe("[selected](https://example.com) text")
+  })
+
+  it("leaves spellcheck replacement ranges to the browser", () => {
+    const editor = createTestEditor("selected text")
+    selectText(editor, "selected")
+    const inputEvent = event("insertReplacementText", "https://example.com", "", false)
+
+    expect(handleBeforeInputLinkPaste(editor, inputEvent)).toBe(false)
+    expect(inputEvent.preventDefault).not.toHaveBeenCalled()
+    expect(serializeToMarkdown(editor.getJSON())).toBe("selected text")
+  })
+})

--- a/apps/frontend/src/components/editor/paste-link-over-selection.ts
+++ b/apps/frontend/src/components/editor/paste-link-over-selection.ts
@@ -1,0 +1,54 @@
+import type { Editor } from "@tiptap/core"
+import { isAllowedUri } from "@tiptap/extension-link"
+import { find } from "linkifyjs"
+
+const HOSTNAME_PROTOCOLS = new Set(["http:", "https:", "ftp:", "ftps:"])
+const HOST_LABEL = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
+
+function hasValidHostname(url: URL): boolean {
+  if (!HOSTNAME_PROTOCOLS.has(url.protocol)) return true
+
+  const hostname = url.hostname.replace(/\.$/u, "")
+  if (hostname.startsWith("[") && hostname.endsWith("]")) return true
+  return !!hostname && hostname.split(".").every((label) => HOST_LABEL.test(label))
+}
+
+function pastedLinkHref(text: string): string | null {
+  const value = text.trim()
+  if (!value) return null
+
+  const link = find(value, { defaultProtocol: "http" }).find((item) => item.isLink && item.value === value)
+  if (!link || !isAllowedUri(link.href)) return null
+
+  try {
+    if (!hasValidHostname(new URL(link.href))) return null
+  } catch {
+    return null
+  }
+
+  return link.href
+}
+
+export function pasteLinkOverSelection(editor: Editor, text: string): boolean {
+  const { from, to, empty } = editor.state.selection
+  if (empty || !editor.state.doc.textBetween(from, to)) return false
+
+  const href = pastedLinkHref(text)
+  if (!href) return false
+
+  return editor.commands.setLink({ href })
+}
+
+export function handleBeforeInputLinkPaste(editor: Editor, event: InputEvent): boolean {
+  const isReplacement = event.inputType === "insertReplacementText"
+  const targetRanges = typeof event.getTargetRanges === "function" ? event.getTargetRanges() : []
+  const replacesTargetRange = isReplacement && targetRanges.some((range) => !range.collapsed)
+  const canBePaste = event.inputType === "insertText" || event.inputType === "insertFromPaste" || isReplacement
+  if (!canBePaste || replacesTargetRange || editor.view.composing) return false
+
+  const text = event.data ?? event.dataTransfer?.getData("text/plain")
+  if (!text || !pasteLinkOverSelection(editor, text)) return false
+
+  event.preventDefault()
+  return true
+}

--- a/apps/frontend/src/components/editor/paste-link-over-selection.ts
+++ b/apps/frontend/src/components/editor/paste-link-over-selection.ts
@@ -29,22 +29,52 @@ function pastedLinkHref(text: string): string | null {
   return link.href
 }
 
+function selectionLinkConflicts(editor: Editor): Set<string> | null {
+  const { from, to } = editor.state.selection
+  const linkType = editor.state.schema.marks.link
+  const conflictingMarks = new Set<string>()
+  let hasText = false
+  let unsupported = false
+
+  editor.state.doc.nodesBetween(from, to, (node, _pos, parent) => {
+    if (node.isInline && !node.isText) {
+      unsupported = true
+      return false
+    }
+    if (!node.isText) return true
+
+    hasText = true
+    if (!parent?.type.allowsMarkType(linkType)) {
+      unsupported = true
+      return false
+    }
+    for (const mark of node.marks) {
+      if (mark.type.excludes(linkType) || linkType.excludes(mark.type)) conflictingMarks.add(mark.type.name)
+    }
+    return true
+  })
+
+  return hasText && !unsupported ? conflictingMarks : null
+}
+
 export function pasteLinkOverSelection(editor: Editor, text: string): boolean {
-  const { from, to, empty } = editor.state.selection
-  if (empty || !editor.state.doc.textBetween(from, to)) return false
+  if (editor.state.selection.empty) return false
 
   const href = pastedLinkHref(text)
-  if (!href) return false
+  const conflictingMarks = selectionLinkConflicts(editor)
+  if (!href || !conflictingMarks) return false
 
-  return editor.commands.setLink({ href })
+  const chain = editor.chain()
+  for (const mark of conflictingMarks) chain.unsetMark(mark)
+  return chain.setLink({ href }).run()
 }
 
 export function handleBeforeInputLinkPaste(editor: Editor, event: InputEvent): boolean {
-  const isReplacement = event.inputType === "insertReplacementText"
-  const targetRanges = typeof event.getTargetRanges === "function" ? event.getTargetRanges() : []
-  const replacesTargetRange = isReplacement && targetRanges.some((range) => !range.collapsed)
-  const canBePaste = event.inputType === "insertText" || event.inputType === "insertFromPaste" || isReplacement
-  if (!canBePaste || replacesTargetRange || editor.view.composing) return false
+  const canBePaste =
+    event.inputType === "insertText" ||
+    event.inputType === "insertFromPaste" ||
+    event.inputType === "insertReplacementText"
+  if (!canBePaste || editor.view.composing) return false
 
   const text = event.data ?? event.dataTransfer?.getData("text/plain")
   if (!text || !pasteLinkOverSelection(editor, text)) return false

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -17,6 +17,7 @@ import {
 } from "./editor-markdown"
 import { serializeClipboardSlice } from "./clipboard-copy"
 import { insertPlainText, isPlainTextPaste } from "./plain-text-paste"
+import { handleBeforeInputLinkPaste, pasteLinkOverSelection } from "./paste-link-over-selection"
 import {
   useMentionSuggestion,
   useChannelSuggestion,
@@ -693,6 +694,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           return false
         }
 
+        if (!pasteAsPlainText && pasteLinkOverSelection(editorRef.current, text)) {
+          event.preventDefault()
+          return true
+        }
+
         // A bare memo link pastes as an embed card rather than a plain URL.
         if (!pasteAsPlainText && enableMemoEmbed) {
           const memoId = parseMemoUrl(text.trim())
@@ -754,10 +760,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
             return true
           }
 
-          // Gboard / SwiftKey clipboard-bar paste of a bare in-app link arrives
-          // as insertText (not a paste event), so chip it here too — otherwise
-          // mobile pastes would keep the raw URL the desktop path replaces.
+          // Gboard / SwiftKey clipboard-bar pastes can bypass the paste event.
           const inputEvent = event as InputEvent
+          if (handleBeforeInputLinkPaste(editor, inputEvent)) {
+            return true
+          }
           if (
             inputEvent.inputType === "insertText" &&
             !editor.view.composing &&

--- a/bun.lock
+++ b/bun.lock
@@ -283,6 +283,7 @@
         "embla-carousel-react": "^8.6.0",
         "hash-wasm": "^4.12.0",
         "input-otp": "^1.4.2",
+        "linkifyjs": "^4.3.2",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.561.0",
         "next-themes": "^0.4.6",


### PR DESCRIPTION
## Problem

`RichEditor` consumes external text in its custom paste handler before TipTap’s `linkOnPaste` plugin can act. Pasting a URL over highlighted text therefore replaced the text instead of linking it. Mobile clipboard bars can bypass `paste` entirely and had the same gap through `beforeinput`.

## Solution

Selected text now becomes a link when the clipboard contains one exact, safe URL.

- `pasteLinkOverSelection` uses Linkify’s URL detection, TipTap’s URI allowlist, and URL/hostname validation before applying the link mark; existing text and compatible marks remain intact; incompatible inline-code marks are removed so the full phrase links.
- The selection path runs before memo embeds and in-app chips, so an explicit selection wins. Selections containing pointer atoms fall back to normal paste rather than creating nested links; paste-without-formatting remains plain.
- `handleBeforeInputLinkPaste` covers `insertText`, `insertFromPaste`, data-transfer payloads, and clipboard-style replacements while leaving spellcheck replacement ranges native.
- Desktop and mobile share the same conversion path (INV-29/43).

## Files

| File | Change |
| ---- | ------ |
| `paste-link-over-selection.ts` | **New:** URL validation and desktop/mobile selection linking |
| `paste-link-over-selection.test.ts` | **New:** selection, safety, normalization, and mobile input coverage |
| `rich-editor.tsx` | Runs selection linking before existing paste conversions |
| `apps/frontend/package.json`, `bun.lock` | Declares the already-transitive Linkify dependency directly |

## Test plan

- [x] `bun run --cwd apps/frontend test` — 5,950 passed
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun run --cwd apps/frontend lint`
- [x] Commit hooks — monorepo lint, typecheck, Dockerfile, migration, and OpenAPI checks

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788368068&installation_model_id=20758&pr_number=1758&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1758&signature=0fd6d243d738d57ced786a7bd83123971da12eb025d9c002afd6bf6ddec6bf42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
