### PR TITLE
feat(trace): count real tool calls and collapse repeat chips

### DIFF
--- a/apps/frontend/src/components/trace/trace-step-list.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.test.tsx
@@ -5,6 +5,31 @@ import { MemoryRouter } from "react-router-dom"
 import { PI_TOOL_TRACE_FORMAT, PiToolTraceSectionLabels, type AgentSessionStep } from "@threa/types"
 import { TraceStepList } from "./trace-step-list"
 import * as relativeTimeModule from "@/components/relative-time"
+import { clearDecryptCache, seedDecryption } from "@/lib/crypto/decrypt-cache"
+
+function toolUse(id: string, stepNumber: number, headline: string): AgentSessionStep {
+  return createStep({
+    id,
+    stepNumber,
+    content: JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline,
+      sections: [{ label: PiToolTraceSectionLabels.ARGUMENTS, body: "Arguments omitted for safety.", lang: null }],
+    }),
+  })
+}
+
+function toolResult(id: string, stepNumber: number, headline: string): AgentSessionStep {
+  return createStep({
+    id,
+    stepNumber,
+    content: JSON.stringify({
+      format: PI_TOOL_TRACE_FORMAT,
+      headline,
+      sections: [{ label: PiToolTraceSectionLabels.OUTPUT, body: "Tool output omitted for safety.", lang: null }],
+    }),
+  })
+}
 
 function createStep(overrides: Partial<AgentSessionStep> = {}): AgentSessionStep {
   return {
@@ -48,6 +73,7 @@ function renderList(steps: AgentSessionStep[], isSessionRunning = false, highlig
 describe("TraceStepList", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    clearDecryptCache()
     vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((() => (
       <span>just now</span>
     )) as unknown as typeof relativeTimeModule.RelativeTime)
@@ -231,6 +257,119 @@ describe("TraceStepList", () => {
     expect(screen.getByText("Working")).toBeInTheDocument()
     expect(screen.getByText("2 tool calls")).toBeInTheDocument()
     expect(screen.queryByText("Thinking")).not.toBeInTheDocument()
+  })
+
+  it("counts paired use/result steps as one call each and collapses repeats into one chip", () => {
+    renderList([
+      toolUse("use_1", 1, "Running shell command"),
+      toolResult("res_1", 2, "Running shell command"),
+      toolUse("use_2", 3, "Running shell command"),
+      toolResult("res_2", 4, "Running shell command"),
+    ])
+
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command ×2")).toBeInTheDocument()
+    expect(screen.queryByText("Running shell command")).not.toBeInTheDocument()
+  })
+
+  it("keeps distinct tools as their own chips within a mixed run", () => {
+    renderList([
+      toolUse("use_1", 1, "Running shell command"),
+      toolResult("res_1", 2, "Running shell command"),
+      toolUse("use_2", 3, "Running shell command"),
+      toolResult("res_2", 4, "Running shell command"),
+      toolUse("use_3", 5, "Reading file src/app.ts"),
+      toolResult("res_3", 6, "Reading file src/app.ts"),
+    ])
+
+    expect(screen.getByText("3 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command ×2")).toBeInTheDocument()
+    expect(screen.getByText("Reading file src/app.ts")).toBeInTheDocument()
+  })
+
+  it("says one call and drops the repeat suffix for a single tool call", () => {
+    renderList([toolUse("use_1", 1, "Running shell command"), toolResult("res_1", 2, "Running shell command")])
+
+    expect(screen.getByText("1 tool call")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command")).toBeInTheDocument()
+  })
+
+  it("shows the overflow affordance over deduped chips, not steps", () => {
+    const steps = ["alpha", "alpha", "bravo", "charlie", "delta"].flatMap((name, index) => [
+      toolUse(`use_${index}`, index * 2 + 1, `Running ${name}`),
+      toolResult(`res_${index}`, index * 2 + 2, `Running ${name}`),
+    ])
+    renderList(steps)
+
+    expect(screen.getByText("5 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("Running alpha ×2")).toBeInTheDocument()
+    // 4 deduped chips, 3 shown → one hidden, even though 10 steps went in.
+    expect(screen.getByText("+1")).toBeInTheDocument()
+  })
+
+  it("counts a parallel batch of the same tool as one call per use", () => {
+    renderList([
+      toolUse("use_1", 1, "Running shell command"),
+      toolUse("use_2", 2, "Running shell command"),
+      toolResult("res_1", 3, "Running shell command"),
+      toolResult("res_2", 4, "Running shell command"),
+    ])
+
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command ×2")).toBeInTheDocument()
+  })
+
+  it("counts a parallel batch whose results come back out of order", () => {
+    renderList([
+      toolUse("use_1", 1, "Running shell command"),
+      toolUse("use_2", 2, "Reading file src/app.ts"),
+      toolResult("res_2", 3, "Reading file src/app.ts"),
+      toolResult("res_1", 4, "Running shell command"),
+    ])
+
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+  })
+
+  it("keeps a mixed parallel batch as one chip per distinct tool", () => {
+    renderList([
+      toolUse("use_1", 1, "Running shell command"),
+      toolUse("use_2", 2, "Reading file src/app.ts"),
+      toolResult("res_1", 3, "Running shell command"),
+      toolResult("res_2", 4, "Reading file src/app.ts"),
+    ])
+
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command")).toBeInTheDocument()
+    expect(screen.getByText("Reading file src/app.ts")).toBeInTheDocument()
+  })
+
+  it("binds a result whose headline degraded to the open call instead of fabricating one", () => {
+    renderList([toolUse("use_1", 1, "Running shell command"), toolResult("res_1", 2, "Used bash")])
+
+    expect(screen.getByText("1 tool call")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command")).toBeInTheDocument()
+    expect(screen.queryByText("Used bash")).not.toBeInTheDocument()
+  })
+
+  it("groups and chips sealed steps from the decrypt cache", () => {
+    const sealedContent = (headline: string, label: string) =>
+      JSON.stringify({ format: PI_TOOL_TRACE_FORMAT, headline, sections: [{ label, body: "sealed", lang: null }] })
+    seedDecryption("sealed_use", {
+      contentMarkdown: sealedContent("Running shell command", PiToolTraceSectionLabels.ARGUMENTS),
+      contentJson: { type: "doc", content: [] },
+    })
+    seedDecryption("sealed_result", {
+      contentMarkdown: sealedContent("Running shell command", PiToolTraceSectionLabels.OUTPUT),
+      contentJson: { type: "doc", content: [] },
+    })
+
+    renderList([
+      createStep({ id: "sealed_use", stepNumber: 1, content: undefined }),
+      createStep({ id: "sealed_result", stepNumber: 2, content: undefined }),
+    ])
+
+    expect(screen.getByText("1 tool call")).toBeInTheDocument()
+    expect(screen.getByText("Running shell command")).toBeInTheDocument()
   })
 
   it("leaves non-bot tool steps as regular trace rows", () => {

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -1,6 +1,7 @@
-import { useRef, useEffect, useState, type ReactNode } from "react"
-import { PI_TOOL_TRACE_FORMAT, type AgentSessionStep, type AgentStepType } from "@threa/types"
+import { useRef, useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from "react"
+import { PI_TOOL_TRACE_FORMAT, PiToolTraceSectionLabels, type AgentSessionStep, type AgentStepType } from "@threa/types"
 import type { StreamingSubstep } from "@/hooks/use-agent-trace"
+import { getCachedDecryption, getDecryptCacheVersion, subscribeDecryptCacheVersion } from "@/lib/crypto/decrypt-cache"
 import { TraceStep } from "./trace-step"
 import { cn } from "@/lib/utils"
 import { STEP_DISPLAY_CONFIG } from "@/lib/step-config"
@@ -17,7 +18,6 @@ const WORK_CONFIG = STEP_DISPLAY_CONFIG.tool_call
 const workHue = (alpha?: number) =>
   `hsl(${WORK_CONFIG.hue} ${WORK_CONFIG.saturation}% ${WORK_CONFIG.lightness}%${alpha === undefined ? "" : ` / ${alpha}`})`
 
-/** The row's own `N tool calls` carries the total, so the chips never need a "+N" tail. */
 const MAX_TOOL_CHIPS = 3
 /** A phone fits two chips on the wrapped line; a third truncates all of them to noise. */
 const MAX_TOOL_CHIPS_MOBILE = 2
@@ -50,6 +50,13 @@ export function TraceStepList({
   onSteerSession,
 }: TraceStepListProps) {
   const highlightRef = useRef<HTMLDivElement>(null)
+  // Grouping and the collapsed-row chips read a sealed step's plaintext out of
+  // the module-global decrypt cache (the same entry `TraceStep` fills a level
+  // down), so the list needs to re-render when one lands. One global-version
+  // subscription for the whole list, not one per step: a trace is a bounded
+  // list rendered inside a dialog, and per-key subscriptions here would fan out
+  // across every step for a value only the group summary reads.
+  useSyncExternalStore(subscribeDecryptCacheVersion, getDecryptCacheVersion, getDecryptCacheVersion)
   const displayItems = groupBotWorkByThinking(steps)
   let latestPhaseIndex = -1
   for (let index = displayItems.length - 1; index >= 0; index--) {
@@ -135,13 +142,19 @@ function BotWorkingSection({
   const [detailsOpen, setDetailsOpen] = useState(errorCount > 0)
   const open = containsHighlight || detailsOpen
   const lastTool = tools.at(-1)!
-  const preview = active ? toolPreview(lastTool.content) : null
+  const preview = active ? toolPreview(resolveStepContent(lastTool)) : null
 
   useEffect(() => {
     if (errorCount > 0) setDetailsOpen(true)
   }, [errorCount])
-  const toolLabel = `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
-  const chips = tools.slice(0, isMobile ? MAX_TOOL_CHIPS_MOBILE : MAX_TOOL_CHIPS)
+  // A tool call is two steps on the wire (the use and its result), so the count
+  // and the chips are derived from paired calls, never from step rows.
+  const calls = useMemo(() => deriveToolCalls(tools), [tools])
+  const callCount = calls.length
+  const toolLabel = `${callCount} tool ${callCount === 1 ? "call" : "calls"}`
+  const allChips = dedupeChips(calls)
+  const chips = allChips.slice(0, isMobile ? MAX_TOOL_CHIPS_MOBILE : MAX_TOOL_CHIPS)
+  const hiddenChipCount = allChips.length - chips.length
 
   return (
     <div
@@ -188,9 +201,12 @@ function BotWorkingSection({
           )}
           {!preview && !open && (
             <span className="order-last flex min-w-0 basis-full items-center gap-1.5 overflow-hidden sm:order-none sm:basis-0 sm:flex-1">
-              {chips.map((step) => (
-                <ToolChip key={step.id} step={step} />
+              {chips.map((chip) => (
+                <ToolChip key={chip.key} chip={chip} />
               ))}
+              {hiddenChipCount > 0 && (
+                <span className="shrink-0 text-[10.5px] tabular-nums text-muted-foreground">+{hiddenChipCount}</span>
+              )}
             </span>
           )}
 
@@ -209,9 +225,9 @@ function BotWorkingSection({
   )
 }
 
-function ToolChip({ step }: { step: AgentSessionStep }) {
-  const isError = step.stepType === "tool_error"
-  const label = toolPreview(step.content)?.headline ?? "Tool call"
+function ToolChip({ chip }: { chip: ToolChipItem }) {
+  const isError = chip.isError
+  const label = chip.count > 1 ? `${chip.headline} ×${chip.count}` : chip.headline
   return (
     <span
       className={cn(
@@ -223,6 +239,96 @@ function ToolChip({ step }: { step: AgentSessionStep }) {
       {label}
     </span>
   )
+}
+
+interface ToolCall {
+  /** Identity for React keys: the id of the step that opened the call. */
+  key: string
+  headline: string
+  isError: boolean
+}
+
+type ToolChipItem = ToolCall & { count: number }
+
+/**
+ * One entry per tool call the agent actually made.
+ *
+ * A single call reaches the trace as TWO steps sharing one headline — the tool
+ * use and its result — so counting `tool_call` rows doubles the number the
+ * agent would recognise. The payload carries no tool id (the redactor strips
+ * arguments, not just values), so the pairing identity is the section label:
+ * Arguments/Details opens a call, Output/Error output closes the open one with
+ * the same headline. Steps carrying neither label (truncated or undecryptable
+ * traces) fall back to collapsing a consecutive same-headline run into one call.
+ */
+function deriveToolCalls(tools: AgentSessionStep[]): ToolCall[] {
+  const calls: ToolCall[] = []
+  // Parallel tool batches arrive as [useA, useB, resA, resB], so a single open
+  // slot mispairs them; results bind FIFO, headline match preferred.
+  const openIndices: number[] = []
+
+  for (const step of tools) {
+    const content = resolveStepContent(step)
+    const headline = toolPreview(content)?.headline ?? "Tool call"
+    const role = toolStepRole(content)
+    const isError = step.stepType === "tool_error"
+
+    if (role === "result" && openIndices.length > 0) {
+      const matchAt = openIndices.findIndex((index) => calls[index].headline === headline)
+      const [closedIndex] = openIndices.splice(matchAt >= 0 ? matchAt : 0, 1)
+      if (isError) calls[closedIndex].isError = true
+      continue
+    }
+    if (role === "unknown" && openIndices.length === 0) {
+      const last = calls.at(-1)
+      if (last && last.headline === headline) {
+        if (isError) last.isError = true
+        continue
+      }
+    }
+    calls.push({ key: step.id, headline, isError })
+    if (role === "use") openIndices.push(calls.length - 1)
+  }
+
+  return calls
+}
+
+/** Consecutive identical calls become one chip carrying how many times it ran. */
+function dedupeChips(calls: ToolCall[]): ToolChipItem[] {
+  const chips: ToolChipItem[] = []
+  for (const call of calls) {
+    const last = chips.at(-1)
+    if (last && last.headline === call.headline && last.isError === call.isError) {
+      last.count += 1
+      continue
+    }
+    chips.push({ ...call, count: 1 })
+  }
+  return chips
+}
+
+function toolStepRole(content: unknown): "use" | "result" | "unknown" {
+  const parsed = parseToolTrace(content)
+  const sections: unknown[] = Array.isArray(parsed?.sections) ? parsed.sections : []
+  for (const section of sections) {
+    if (!section || typeof section !== "object" || !("label" in section)) continue
+    const label = section.label
+    if (label === PiToolTraceSectionLabels.OUTPUT || label === PiToolTraceSectionLabels.ERROR_OUTPUT) return "result"
+    if (label === PiToolTraceSectionLabels.ARGUMENTS || label === PiToolTraceSectionLabels.DETAILS) return "use"
+  }
+  return "unknown"
+}
+
+/**
+ * A sealed step's `content` is undefined here — decryption happens inside
+ * `TraceStep`, a level below the grouping. Read the same module-global cache
+ * entry it fills so sealed traces group and chip like plaintext ones instead of
+ * silently falling out of the Working section.
+ */
+function resolveStepContent(step: AgentSessionStep): unknown {
+  if (step.content !== undefined && step.content !== null) return step.content
+  const cached = getCachedDecryption(step.id)
+  return cached?.status === "decrypted" ? cached.value?.contentMarkdown : undefined
 }
 
 function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem[] {
@@ -252,7 +358,8 @@ function groupBotWorkByThinking(steps: AgentSessionStep[]): TraceStepDisplayItem
 function isLowLevelBotToolStep(step: AgentSessionStep): boolean {
   if (step.stepType !== "tool_call" && step.stepType !== "tool_error") return false
   if (!step.completedAt) return false
-  return parseToolTrace(step.content)?.format === PI_TOOL_TRACE_FORMAT || looksLikeTruncatedToolTrace(step.content)
+  const content = resolveStepContent(step)
+  return parseToolTrace(content)?.format === PI_TOOL_TRACE_FORMAT || looksLikeTruncatedToolTrace(content)
 }
 
 function toolPreview(content: unknown): { headline: string; detail: string | null } | null {


### PR DESCRIPTION
## Problem

Kris (screenshot): "agent traces are not clear enough" — a WORKING row in the trace dialog reads `2 tool calls` / `4 tool calls` followed by three chips all saying **Running shell command**, so a 15-step trace is a wall of identical labels. Root cause isn't presentation taste: **every tool call emits two steps** — the call and its result (`toolUseStep`/`toolResultStep`) — carrying the *same* headline, so two bash calls render four chips and the row counts four calls the agent never made.

The tool input (the command string) is redacted on the user's own machine in headline mode and is not on the client for plaintext streams, so this PR is presentation only — no redaction rules touched, no extension or wire change.

## Solution

- **Pair steps into calls** by their section label (`Arguments`/`Details` opens, `Output`/`Error output` closes) through an **open-call queue**: Claude Code batches parallel tools into one transcript line, so traces arrive `[useA, useB, resA, resB]` — adversarial verify caught that a single-open-call rule reports `2N−1` calls for N parallel calls, and mixed parallel tools degrade to the old step count. FIFO close, oldest-open fallback, orphan results still count as their own call. A **degraded result headline** (`Used bash`, which pi emits after a reconnect clears its pending-call map) closes its call instead of fabricating a phantom one — headline equality is a preference, not a precondition.
- **Collapse consecutive identical chips** into one with a `×N` suffix; `MAX_TOOL_CHIPS` (3, mobile 2) now bounds deduped chips, with a `+N` for the remainder (needed once chip count stopped tracking call count).
- **Sealed sessions get chips at all**: the chip layer read `step.content`, which is `undefined` for sealed steps (decryption happens a level down in `TraceStep`), so E2E traces fell out of the Working section entirely. It now reads the same `step.id`-keyed decrypt cache, with one list-level subscription.

Known, below threshold, recorded for the trace follow-up: the `+N` can be clipped at ≤360px with max-width chips; `subscribeDecryptCacheVersion` is global, so an open dialog re-renders on unrelated decrypts; sealed steps live in an LRU shared with message bodies whose eviction doesn't notify.

## Test plan

- [x] Adversarial verify (Opus high): 2 findings (parallel-batch over-count, phantom call from a degraded headline), both fixed; label survival through the backend sanitizer, both redaction modes, still-running calls, OWN_TOOL_RE filtering, and the sealed cache key/shape all re-derived clean
- [x] Targeted: trace-step-list (27) + trace-dialog — green; tsc + eslint clean
- [x] Falsified: dedupe, pairing, and the single-open-call revert — each turned exactly its tests red

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788370431&installation_model_id=20758&pr_number=1759&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1759&signature=74d6c52d910b57823f12d48acdbbb23fb043f157ba196a6ff483727eff38f564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->