### PR TITLE
feat(agents): reach the agent agenda the way you reach files

### DIFF
--- a/apps/frontend/src/components/agent-outcomes/agent-outcomes-explorer.integration.test.tsx
+++ b/apps/frontend/src/components/agent-outcomes/agent-outcomes-explorer.integration.test.tsx
@@ -1,0 +1,100 @@
+import type { AgentOutcomeSummary, ListAgentOutcomesResponse } from "@threa/types"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, userEvent, waitFor } from "@/test"
+import * as agentOutcomesApiModule from "@/api/agent-outcomes"
+import * as preferencesModule from "@/contexts/preferences-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import { AgentOutcomesExplorer } from "./agent-outcomes-explorer"
+
+function followUp(): AgentOutcomeSummary {
+  return {
+    kind: "follow_up",
+    id: "fup_1",
+    streamId: "str_design",
+    title: "Check in on the migration",
+    status: "pending",
+    scheduledFor: "2026-08-01T18:00:00.000Z",
+    claimedByLabel: null,
+    statusNote: null,
+    resultMessageId: null,
+    actorType: "persona",
+    actorId: "persona_1",
+    createdAt: "2026-07-28T09:00:00.000Z",
+    statusChangedAt: "2026-07-28T09:00:00.000Z",
+    occursAt: "2026-08-01T18:00:00.000Z",
+    anchorEventId: "event_1",
+  } as AgentOutcomeSummary
+}
+
+function page(items: AgentOutcomeSummary[]): ListAgentOutcomesResponse {
+  return { items, nextCursor: null, outstandingCount: items.length }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="search">{location.search}</div>
+}
+
+function renderExplorer(initialEntry: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <LocationProbe />
+        <AgentOutcomesExplorer workspaceId="ws_1" />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe("AgentOutcomesExplorer", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([])
+    vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([])
+    vi.spyOn(preferencesModule, "usePreferences").mockReturnValue({
+      preferences: { dateFormat: "YYYY-MM-DD", timeFormat: "24h", timezone: "UTC" } as never,
+    } as unknown as ReturnType<typeof preferencesModule.usePreferences>)
+  })
+
+  it("stays closed — and fetches nothing — until the URL says otherwise", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([followUp()]))
+
+    renderExplorer("/w/ws_1/s/str_design")
+
+    expect(screen.queryByText("Check in on the migration")).not.toBeInTheDocument()
+    // The dialog is unmounted, so the shell's query must never have been armed.
+    await waitFor(() => expect(listSpy).not.toHaveBeenCalled())
+  })
+
+  it("opens over the current route from the marker, scoped to the stream it was opened from", async () => {
+    const listSpy = vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([followUp()]))
+
+    renderExplorer("/w/ws_1/s/str_design?agenda=&aStreams=str_design")
+
+    expect(await screen.findByText("Check in on the migration")).toBeInTheDocument()
+    expect(listSpy.mock.calls[0]?.[1]).toMatchObject({ streamIds: ["str_design"] })
+  })
+
+  it("closing strips only this surface's params, leaving the host route's own", async () => {
+    vi.spyOn(agentOutcomesApiModule.agentOutcomesApi, "list").mockResolvedValue(page([followUp()]))
+
+    renderExplorer("/w/ws_1/s/str_design?thread=stream_t&agenda=&aStreams=str_design&aState=all")
+    await screen.findByText("Check in on the migration")
+
+    await userEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    await waitFor(() => {
+      const search = new URLSearchParams(screen.getByTestId("search").textContent ?? "")
+      expect({
+        agenda: search.has("agenda"),
+        scope: search.has("aStreams"),
+        state: search.has("aState"),
+        thread: search.get("thread"),
+      }).toEqual({ agenda: false, scope: false, state: false, thread: "stream_t" })
+    })
+  })
+})

--- a/apps/frontend/src/components/agent-outcomes/agent-outcomes-explorer.tsx
+++ b/apps/frontend/src/components/agent-outcomes/agent-outcomes-explorer.tsx
@@ -1,0 +1,31 @@
+import { ResponsiveDialog, ResponsiveDialogContent, ResponsiveDialogTitle } from "@/components/ui/responsive-dialog"
+import { useOutcomesUrlState } from "./use-outcomes-url-state"
+import { OutcomesShell } from "./outcomes-shell"
+
+interface AgentOutcomesExplorerProps {
+  workspaceId: string
+}
+
+/**
+ * The outcomes view over whatever the viewer was looking at, opened from a
+ * stream menu or the command palette — the same surface `/outcomes` renders
+ * full-page. Mounted once per workspace route (beside `AttachmentExplorer`) and
+ * driven entirely by the URL marker, so every entry point is a link-shaped
+ * `open()` rather than its own copy of the dialog.
+ */
+export function AgentOutcomesExplorer({ workspaceId }: AgentOutcomesExplorerProps) {
+  const { isOpen, close } = useOutcomesUrlState()
+
+  return (
+    <ResponsiveDialog open={isOpen} onOpenChange={(open) => (open ? null : close())}>
+      <ResponsiveDialogContent
+        desktopClassName="overflow-hidden p-0 gap-0 shadow-lg sm:!fixed sm:!top-[12%] sm:!translate-y-0 sm:!flex sm:!flex-col sm:max-w-[920px] sm:rounded-2xl sm:!h-[76vh]"
+        drawerClassName="overflow-hidden p-0 h-[92dvh]"
+        hideCloseButton
+      >
+        <ResponsiveDialogTitle className="sr-only">Agent agenda</ResponsiveDialogTitle>
+        <OutcomesShell workspaceId={workspaceId} mode="modal" enabled={isOpen} />
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/agent-outcomes/index.ts
+++ b/apps/frontend/src/components/agent-outcomes/index.ts
@@ -1,3 +1,4 @@
 export { OutcomesShell } from "./outcomes-shell"
 export { OutcomesList } from "./outcomes-list"
-export { OUTCOMES_PARAM, useOutcomesUrlState, type OutcomesFilters } from "./use-outcomes-url-state"
+export { AgentOutcomesExplorer } from "./agent-outcomes-explorer"
+export { OUTCOMES_PARAM, outcomesSearch, useOutcomesUrlState, type OutcomesFilters } from "./use-outcomes-url-state"

--- a/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
+++ b/apps/frontend/src/components/agent-outcomes/use-outcomes-url-state.ts
@@ -90,6 +90,17 @@ export function writeOutcomesFiltersToParams(params: URLSearchParams, next: Part
 const OUTCOMES_KEYS = [OUTCOMES_PARAM, STREAMS_PARAM, STATE_PARAM, KIND_PARAM, QUERY_PARAM, SELECTED_PARAM]
 
 /**
+ * The search string that opens this surface, for the entry points that are
+ * navigation rather than an action — a `<Link>` on a card, not a menu item
+ * (INV-40). Same writer as `open()`, so the two produce identical URLs.
+ */
+export function outcomesSearch(current: URLSearchParams, overrides: Partial<OutcomesFilters> = {}): string {
+  const next = writeOutcomesFiltersToParams(current, overrides)
+  next.set(OUTCOMES_PARAM, "")
+  return `?${next.toString()}`
+}
+
+/**
  * Outcomes view state lives entirely in URL search params (INV-59) so refresh,
  * back/forward, and a shared link all land on the same view. Mirrors
  * `use-explorer-url-state` — same open/close/update contract, and `close` strips

--- a/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
@@ -41,6 +41,7 @@ function renderQuickLinks(props: Partial<Parameters<typeof SidebarQuickLinks>[0]
         isActivityPage={false}
         isMemoryPage={false}
         isFilesPage={false}
+        isAgendaPage={false}
         isLabelsPage={false}
         unreadActivityCount={0}
         {...props}
@@ -110,6 +111,7 @@ describe("SidebarQuickLinks", () => {
           isActivityPage={false}
           isMemoryPage={false}
           isFilesPage={false}
+          isAgendaPage={false}
           isLabelsPage={false}
           unreadActivityCount={0}
         />

--- a/apps/frontend/src/components/layout/sidebar/quick-links.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.tsx
@@ -1,4 +1,14 @@
-import { Bell, Bookmark, Brain, CalendarClock, FileEdit, Paperclip, Tag, type LucideIcon } from "lucide-react"
+import {
+  Bell,
+  Bookmark,
+  Brain,
+  CalendarClock,
+  FileEdit,
+  ListChecks,
+  Paperclip,
+  Tag,
+  type LucideIcon,
+} from "lucide-react"
 import type { ReactNode } from "react"
 import { Link } from "react-router-dom"
 import type { SidebarQuickLink, SidebarQuickLinkKey } from "@threa/types"
@@ -18,6 +28,7 @@ export const QUICK_LINK_META: Record<SidebarQuickLinkKey, { label: string; icon:
   saved: { label: "Saved", icon: Bookmark },
   files: { label: "Files", icon: Paperclip },
   scheduled: { label: "Scheduled", icon: CalendarClock },
+  agenda: { label: "Agent agenda", icon: ListChecks },
   memory: { label: "Memory", icon: Brain },
   labels: { label: "Labels", icon: Tag },
   activity: { label: "Activity", icon: Bell },
@@ -36,6 +47,7 @@ interface SidebarQuickLinksProps {
   isActivityPage: boolean
   isMemoryPage: boolean
   isFilesPage: boolean
+  isAgendaPage: boolean
   isLabelsPage: boolean
   unreadActivityCount: number
 }
@@ -74,6 +86,7 @@ export function SidebarQuickLinks({
   isActivityPage,
   isMemoryPage,
   isFilesPage,
+  isAgendaPage,
   isLabelsPage,
   unreadActivityCount,
 }: SidebarQuickLinksProps) {
@@ -97,6 +110,7 @@ export function SidebarQuickLinks({
       signalSlot: countSlot(savedCount),
     },
     files: { to: `/w/${workspaceId}/files`, isActive: isFilesPage, unreadCount: 0, signalSlot: null },
+    agenda: { to: `/w/${workspaceId}/agenda`, isActive: isAgendaPage, unreadCount: 0, signalSlot: null },
     scheduled: {
       to: `/w/${workspaceId}/scheduled`,
       isActive: isScheduledPage,

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -255,6 +255,28 @@ describe("ScratchpadItem", () => {
     })
   })
 
+  it("opens the outcomes view scoped to the scratchpad", async () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad()}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    fireEvent.click(screen.getByText("Agent agenda…"))
+
+    await waitFor(() => {
+      const search = new URLSearchParams(screen.getByTestId("location-search").textContent ?? "")
+      expect({ open: search.has("agenda"), scope: search.get("aStreams") }).toEqual({
+        open: true,
+        scope: "stream_scratchpad_1",
+      })
+    })
+  })
+
   it("shows the AI companion badge on companion-on scratchpads", () => {
     renderWithRouter(
       <ScratchpadItem

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -7,6 +7,7 @@ import {
   FileEdit,
   FolderPlus,
   Link2,
+  ListChecks,
   Lock,
   MessageSquareText,
   Paperclip,
@@ -18,6 +19,7 @@ import {
 import { Link, useNavigate } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useOutcomesUrlState } from "@/components/agent-outcomes"
 import { SectionPicker } from "./section-picker"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { DraftIndicator } from "@/components/draft-indicator"
@@ -93,6 +95,7 @@ export function ScratchpadItem({
   const { collapseOnMobile } = useSidebar()
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
   const itemRef = useRef<HTMLAnchorElement>(null)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
@@ -203,6 +206,12 @@ export function ScratchpadItem({
               onSelect: () => openExplorer({ streamIds: [streamWithPreview.id] }),
             } satisfies SidebarActionItem,
             {
+              id: "view-outcomes",
+              label: "Agent agenda…",
+              icon: ListChecks,
+              onSelect: () => openOutcomes({ streamIds: [streamWithPreview.id] }),
+            } satisfies SidebarActionItem,
+            {
               id: "add-to-section",
               label: "Add to section…",
               icon: FolderPlus,
@@ -219,7 +228,16 @@ export function ScratchpadItem({
         separatorBefore: !isDraft || boardActions.length > 0,
       },
     ],
-    [handleArchive, isDraft, openStreamSettings, openExplorer, streamWithPreview.id, workspaceId, boardActions]
+    [
+      handleArchive,
+      isDraft,
+      openStreamSettings,
+      openExplorer,
+      openOutcomes,
+      streamWithPreview.id,
+      workspaceId,
+      boardActions,
+    ]
   )
 
   const drawerPreview: SidebarActionPreview | null =

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -206,6 +206,7 @@ describe("moveQuickLink", () => {
       "saved",
       "files",
       "scheduled",
+      "agenda",
       "memory",
       "labels",
     ])

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
@@ -69,6 +69,7 @@ describe("SidebarEditorDialog", () => {
       "Reorder Saved",
       "Reorder Files",
       "Reorder Scheduled",
+      "Reorder Agent agenda",
       "Reorder Memory",
       "Reorder Labels",
       "Reorder Activity",

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -146,6 +146,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const unmuteStream = useUnmuteStream(workspaceId)
   const isMemoryPage = splat === "memory" || location.pathname.endsWith("/memory")
   const isFilesPage = splat === "files" || location.pathname.endsWith("/files")
+  const isAgendaPage = splat === "agenda" || location.pathname.endsWith("/agenda")
   const isLabelsPage = splat === "labels" || location.pathname.includes("/labels")
 
   const memberStreamIds = useMemo(() => {
@@ -400,6 +401,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       isActivityPage={isActivityPage}
       isMemoryPage={isMemoryPage}
       isFilesPage={isFilesPage}
+      isAgendaPage={isAgendaPage}
       isLabelsPage={isLabelsPage}
       unreadActivityCount={unreadActivityCount}
     />

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -210,6 +210,37 @@ describe("StreamItem", () => {
     expect(search.get("streams")).toBe("stream_general")
   })
 
+  it("opens the outcomes view scoped to the stream", async () => {
+    const stream = createStream()
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    fireEvent.touchStart(screen.getByRole("link", { name: /general/i }), {
+      touches: [{ clientX: 16, clientY: 16 }],
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Agent agenda…" }))
+
+    const search = new URLSearchParams(screen.getByTestId("location-search").textContent ?? "")
+    expect({ open: search.has("agenda"), scope: search.get("aStreams") }).toEqual({
+      open: true,
+      scope: "stream_general",
+    })
+  })
+
   it("keeps compact hover previews hidden on mobile", () => {
     const stream = createStream()
 

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -7,6 +7,7 @@ import {
   FolderPlus,
   Hash,
   Link2,
+  ListChecks,
   Loader2,
   Lock,
   MessageSquareText,
@@ -18,6 +19,7 @@ import {
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useOutcomesUrlState } from "@/components/agent-outcomes"
 import { SectionPicker } from "./section-picker"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
@@ -394,6 +396,7 @@ export function StreamItem({
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
   const { collapseOnMobile } = useSidebar()
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [sectionPickerOpen, setSectionPickerOpen] = useState(false)
@@ -508,6 +511,12 @@ export function StreamItem({
             onSelect: () => openExplorer({ streamIds: [stream.id] }),
           },
           {
+            id: "view-outcomes",
+            label: "Agent agenda…",
+            icon: ListChecks,
+            onSelect: () => openOutcomes({ streamIds: [stream.id] }),
+          },
+          {
             id: "add-to-section",
             label: "Add to section…",
             icon: FolderPlus,
@@ -516,7 +525,7 @@ export function StreamItem({
         ]
     if (boardActions.length === 0) return base
     return [...boardActions, ...base.map((a, i) => (i === 0 ? { ...a, separatorBefore: true } : a))]
-  }, [isVirtualDraft, openStreamSettings, openExplorer, stream.id, workspaceId, boardActions])
+  }, [isVirtualDraft, openStreamSettings, openExplorer, openOutcomes, stream.id, workspaceId, boardActions])
 
   let drawerPreview: SidebarActionPreview | null = null
   if (preview?.content) {

--- a/apps/frontend/src/components/quick-switcher/commands.test.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.test.ts
@@ -83,6 +83,7 @@ describe("commands", () => {
     function makeContext() {
       const navigate = vi.fn()
       const openExplorer = vi.fn()
+      const openOutcomes = vi.fn()
       const context = {
         workspaceId: WORKSPACE_ID,
         navigate,
@@ -96,12 +97,13 @@ describe("commands", () => {
         openSettings: vi.fn(),
         openWorkspaceSettings: vi.fn(),
         openExplorer,
+        openOutcomes,
         openStreamSettings: vi.fn(),
         requestArchiveStream: vi.fn(),
         openLabelPicker: vi.fn(),
         createSavedTodo: vi.fn(async () => {}),
       } as unknown as CommandContext
-      return { context, navigate, openExplorer }
+      return { context, navigate, openExplorer, openOutcomes }
     }
 
     /** The palette destination each sidebar quick link must be reachable through. */
@@ -109,6 +111,7 @@ describe("commands", () => {
       drafts: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/drafts`),
       saved: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/saved`),
       files: ({ openExplorer }) => expect(openExplorer).toHaveBeenCalled(),
+      agenda: ({ openOutcomes }) => expect(openOutcomes).toHaveBeenCalled(),
       scheduled: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/scheduled`),
       memory: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/memory`),
       labels: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/labels`),

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -9,6 +9,7 @@ import {
   Hash,
   LayoutGrid,
   ListTodo,
+  ListChecks,
   Paperclip,
   PenSquare,
   Search,
@@ -25,6 +26,7 @@ import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
 import { SETTINGS_TAB_CONFIG } from "@/components/settings/tab-config"
 import type { WorkspaceSettingsTab } from "@/components/workspace-settings/tab-config"
 import type { ExplorerFilters } from "@/components/attachment-explorer"
+import type { OutcomesFilters } from "@/components/agent-outcomes"
 
 /**
  * Commands can request an input prompt via this interface.
@@ -60,6 +62,8 @@ export interface CommandContext {
   /** Open the workspace settings dialog at a tab (URL-param driven, like openSettings). */
   openWorkspaceSettings: (tab: WorkspaceSettingsTab) => void
   openExplorer: (overrides?: Partial<ExplorerFilters>) => void
+  /** Open the outcomes view (follow-ups + delegated tasks) over the current route. */
+  openOutcomes: (overrides?: Partial<OutcomesFilters>) => void
   /**
    * The stream currently in view (route param), or null on non-stream routes.
    * Contextual stream commands (archive, settings, files, labels) read this to
@@ -267,6 +271,16 @@ export const commands: Command[] = [
     action: ({ closeDialog, openExplorer }) => {
       closeDialog()
       openExplorer({ streamIds: [] })
+    },
+  },
+  {
+    id: "view-agenda",
+    label: "View Agent Agenda",
+    icon: ListChecks,
+    keywords: ["follow-up", "follow ups", "delegation", "delegated", "agent", "tasks", "agenda", "outcomes"],
+    action: ({ closeDialog, openOutcomes }) => {
+      closeDialog()
+      openOutcomes({ streamIds: [] })
     },
   },
   {

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -31,6 +31,7 @@ import { useE2eUnlockOptional } from "@/components/encryption/e2e-unlock-provide
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { useCreateChannel } from "@/components/create-channel"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useOutcomesUrlState } from "@/components/agent-outcomes"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { WS_SETTINGS_PARAM, type WorkspaceSettingsTab } from "@/components/workspace-settings/tab-config"
 import { LabelPicker } from "@/components/labels/label-picker"
@@ -90,6 +91,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
   const { openSettings } = useSettings()
   const { openCreateChannel } = useCreateChannel()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
   const { openStreamSettings } = useStreamSettings()
   const archiveStream = useArchiveStream(workspaceId)
   const currentStreamName = useStreamName(workspaceId, currentStreamId ?? "")
@@ -280,6 +282,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       openSettings,
       openWorkspaceSettings,
       openExplorer,
+      openOutcomes,
       currentStreamId,
       currentStreamName,
       openStreamSettings: handleOpenStreamSettings,
@@ -300,6 +303,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       openSettings,
       openWorkspaceSettings,
       openExplorer,
+      openOutcomes,
       currentStreamId,
       currentStreamName,
       handleOpenStreamSettings,

--- a/apps/frontend/src/components/quick-switcher/stream-commands.ts
+++ b/apps/frontend/src/components/quick-switcher/stream-commands.ts
@@ -1,4 +1,4 @@
-import { Archive, FileCode2, Paperclip, Settings, Tag, Trash2 } from "lucide-react"
+import { Archive, FileCode2, ListChecks, Paperclip, Settings, Tag, Trash2 } from "lucide-react"
 import { queueSnippetRequest } from "@/stores/snippet-request-store"
 import type { Command } from "./commands"
 
@@ -49,6 +49,17 @@ export const streamCommands: Command[] = [
       if (!currentStreamId) return
       closeDialog()
       openExplorer({ streamIds: [currentStreamId] })
+    },
+  },
+  {
+    id: "stream-agenda",
+    label: "Agent agenda in this stream",
+    icon: ListChecks,
+    keywords: ["follow-up", "follow ups", "delegation", "delegated", "agent", "current stream"],
+    action: ({ currentStreamId, openOutcomes, closeDialog }) => {
+      if (!currentStreamId) return
+      closeDialog()
+      openOutcomes({ streamIds: [currentStreamId] })
     },
   },
   {

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -2,6 +2,7 @@ import { useSearchParams, useParams } from "react-router-dom"
 import { useMemo, useCallback, useEffect, useState, useRef } from "react"
 import { createPortal } from "react-dom"
 import {
+  ListChecks,
   MessageSquare,
   ChevronLeft,
   MoreHorizontal,
@@ -44,6 +45,7 @@ import { onDraftPromoted } from "@/lib/draft-promotions"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useOutcomesUrlState } from "@/components/agent-outcomes"
 import { StreamLoadingIndicator } from "@/components/loading"
 import {
   StreamContent,
@@ -84,6 +86,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
   const { streamId: mainViewStreamId } = useParams<{ streamId: string }>()
 
   const isMainViewStream = (streamId: string) => {
@@ -289,6 +292,14 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     icon: Paperclip,
     onSelect: () => {
       if (panelId) openExplorer({ streamIds: [panelId] })
+    },
+  })
+  panelMenuActions.push({
+    id: "view-outcomes",
+    label: "Agent agenda…",
+    icon: ListChecks,
+    onSelect: () => {
+      if (panelId) openOutcomes({ streamIds: [panelId] })
     },
   })
   const setDraftPortalTarget = useCallback((el: HTMLElement | null) => {

--- a/apps/frontend/src/components/timeline/follow-up-event.test.tsx
+++ b/apps/frontend/src/components/timeline/follow-up-event.test.tsx
@@ -50,6 +50,24 @@ describe("FollowUpScheduledEvent", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
   })
 
+  it("links the note into the agent agenda, at this follow-up", () => {
+    render(
+      <MemoryRouter>
+        <FollowUpScheduledEvent event={scheduledEvent(SCHEDULED_PAYLOAD)} workspaceId="ws_1" />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole("link", { name: "check the deploy went green" })
+    const search = new URLSearchParams(link.getAttribute("href")!.split("?")[1])
+
+    expect({
+      open: search.has("agenda"),
+      stream: search.get("aStreams"),
+      state: search.get("aState"),
+      selected: search.get("aSelected"),
+    }).toEqual({ open: true, stream: "stream_1", state: "all", selected: "agfu_1" })
+  })
+
   it("cancels via the API and flips the same button to Cancelled (INV-63: no success toast)", async () => {
     const cancel = vi.spyOn(agentFollowUpsApi, "cancel").mockResolvedValue({ cancelled: true })
 

--- a/apps/frontend/src/components/timeline/follow-up-event.tsx
+++ b/apps/frontend/src/components/timeline/follow-up-event.tsx
@@ -2,7 +2,9 @@ import { useState, type ReactNode } from "react"
 import { toast } from "sonner"
 import { Clock, Check, Loader2 } from "lucide-react"
 import type { AgentFollowUpScheduledEventPayload, StreamEvent } from "@threa/types"
+import { Link, useSearchParams } from "react-router-dom"
 import { agentFollowUpsApi } from "@/api"
+import { outcomesSearch } from "@/components/agent-outcomes"
 import { useActors } from "@/hooks"
 import { formatFireTime, formatFullDateTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
@@ -34,6 +36,7 @@ interface FollowUpScheduledEventProps {
  */
 export function FollowUpScheduledEvent({ event, workspaceId, cancelledByEvent = false }: FollowUpScheduledEventProps) {
   const { getActorName } = useActors(workspaceId)
+  const [searchParams] = useSearchParams()
   const payload = event.payload as AgentFollowUpScheduledEventPayload | undefined
   const [optimisticallyCancelled, setOptimisticallyCancelled] = useState(false)
   const [cancelling, setCancelling] = useState(false)
@@ -89,14 +92,21 @@ export function FollowUpScheduledEvent({ event, workspaceId, cancelledByEvent = 
         </span>
 
         <div className="min-w-0 flex-1">
-          <p
+          <Link
+            to={{
+              search: outcomesSearch(searchParams, {
+                streamIds: [event.streamId],
+                state: "all",
+                selectedOutcomeId: payload.followUpId,
+              }),
+            }}
             className={cn(
-              "truncate text-[13px] font-medium",
+              "block truncate text-[13px] font-medium hover:underline",
               cancelled ? "text-muted-foreground line-through" : "text-foreground/90"
             )}
           >
             {payload.note}
-          </p>
+          </Link>
           <p className="mt-0.5 truncate text-[11px] text-muted-foreground" title={formatFullDateTime(scheduledFor)}>
             {actorName} · fires {formatFireTime(scheduledFor)}
           </p>

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -67,6 +67,14 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
     global: true,
   },
   {
+    id: "openAgentAgenda",
+    label: "Agent Agenda",
+    description: "Open follow-ups and delegated tasks",
+    defaultKey: "mod+shift+o",
+    category: "navigation",
+    global: true,
+  },
+  {
     id: "copyStreamLink",
     label: "Copy Link",
     // Default avoids plain mod+L — browsers reserve that to focus the address

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useParams, useSearchParams, useNavigate } from "react-router-dom"
 import {
+  ListChecks,
   MoreHorizontal,
   Pencil,
   Archive,
@@ -43,6 +44,7 @@ import { usePanel, useSidebar, StreamAgentActivityProvider } from "@/contexts"
 import { useUserProfile } from "@/components/user-profile"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { useExplorerUrlState } from "@/components/attachment-explorer"
+import { useOutcomesUrlState } from "@/components/agent-outcomes"
 import { TimelineView, AgentActivityHeaderChip } from "@/components/timeline"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { LabelStack } from "@/components/labels/label-stack"
@@ -207,6 +209,7 @@ export function StreamPage() {
   const { openUserProfile } = useUserProfile()
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
   const dmPeers = useWorkspaceDmPeers(workspaceId ?? "")
   const workspaceMetadata = useWorkspaceMetadata(workspaceId ?? "")
   // For an unlocked encrypted stream, the tamper-evident decrypted name; null
@@ -363,6 +366,12 @@ export function StreamPage() {
     label: "Browse files…",
     icon: Paperclip,
     onSelect: () => openExplorer({ streamIds: [streamId] }),
+  })
+  streamMenuActions.push({
+    id: "view-outcomes",
+    label: "Agent agenda…",
+    icon: ListChecks,
+    onSelect: () => openOutcomes({ streamIds: [streamId] }),
   })
   if (isScratchpad) {
     // Hide the rename affordance while locked rather than let it fall back to

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -74,6 +74,7 @@ import { AccountSwitcherDialog, LogoutScopeDialog } from "@/components/account-s
 import { StreamSettingsDialog } from "@/components/stream-settings/stream-settings-dialog"
 import { CreateChannelDialog } from "@/components/create-channel"
 import { AttachmentExplorer, useExplorerUrlState } from "@/components/attachment-explorer"
+import { AgentOutcomesExplorer, useOutcomesUrlState } from "@/components/agent-outcomes"
 import { SearchPanelProvider, useSearchPanel } from "@/components/search"
 import { E2eUnlockProvider } from "@/components/encryption/e2e-unlock-provider"
 import { CallDock, CallLaunchProvider, IncomingCallOverlay } from "@/components/call"
@@ -105,6 +106,7 @@ interface WorkspaceKeyboardHandlerProps {
 function WorkspaceKeyboardHandler({ onOpenSwitcher, currentStreamId, children }: WorkspaceKeyboardHandlerProps) {
   const { openSettings } = useSettings()
   const { open: openExplorer } = useExplorerUrlState()
+  const { open: openOutcomes } = useOutcomesUrlState()
 
   useKeyboardShortcuts({
     openQuickSwitcher: () => onOpenSwitcher("stream"),
@@ -112,6 +114,10 @@ function WorkspaceKeyboardHandler({ onOpenSwitcher, currentStreamId, children }:
     openSettings: () => openSettings(),
     openAttachmentExplorer: () =>
       openExplorer({
+        streamIds: currentStreamId ? [currentStreamId] : [],
+      }),
+    openAgentAgenda: () =>
+      openOutcomes({
         streamIds: currentStreamId ? [currentStreamId] : [],
       }),
   })
@@ -539,6 +545,7 @@ export function WorkspaceLayout() {
                                           <StreamSettingsDialog workspaceId={workspaceId} />
                                           <CreateChannelDialog workspaceId={workspaceId} />
                                           <AttachmentExplorer workspaceId={workspaceId} />
+                                          <AgentOutcomesExplorer workspaceId={workspaceId} />
                                           <TraceDialogContainer />
                                           <Toaster />
                                         </TraceProvider>

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -80,7 +80,16 @@ export type SidebarBasePreset = (typeof SIDEBAR_BASE_PRESETS)[number]
  * reorder them and set each one's visibility; the set itself is fixed (these are
  * the workspace's standing views).
  */
-export const SIDEBAR_QUICK_LINKS = ["drafts", "saved", "files", "scheduled", "memory", "labels", "activity"] as const
+export const SIDEBAR_QUICK_LINKS = [
+  "drafts",
+  "saved",
+  "files",
+  "scheduled",
+  "agenda",
+  "memory",
+  "labels",
+  "activity",
+] as const
 export type SidebarQuickLinkKey = (typeof SIDEBAR_QUICK_LINKS)[number]
 
 /** Whether a stored/wire key is one of the current quick links. */


### PR DESCRIPTION
## Problem

The agenda page landed in #1672 as a route and nothing else: `/w/:workspaceId/agenda` was reachable only by typing the URL. No sidebar entry, no stream affordance, no palette command — and a scheduled follow-up in the timeline pointed nowhere, so the surface that tracks it was invisible from the place it was created.

## Solution

Files is the shipped precedent for "a workspace view that is also a per-stream view", so this copies its shape rather than inventing a second one.

- `AgentOutcomesExplorer` mirrors `AttachmentExplorer`: one `ResponsiveDialog` mounted per workspace route in `workspace-layout`, driven entirely by the URL marker (`?agenda=`). Every entry point is an `open()` writing search params — no second copy of the dialog, no local open state (INV-59). The shell already had `mode: "modal"`; nothing mounted it.
- "Agent agenda…" in the four stream menus Files uses — sidebar stream row, sidebar scratchpad row, stream page header, stream panel — each scoped to that stream.
- Palette: `View Agent Agenda` (workspace-wide) and `Agent agenda in this stream`, plus `mod+shift+o` beside Files' `mod+shift+a`. `commands.test.ts` already asserts every quick-link key is reachable from the palette, so the new key had to come with a command.
- Sidebar quick link `agenda` → the page. Stored configs pick it up on read (`normalizeSidebarConfig` appends unknown keys as `show`), so existing users get it without a migration.
- The `agent:follow_up_scheduled` card's note is now a `<Link>` into the view at that follow-up (`state=all`, `aSelected=<id>`) — a link, not a button, because it navigates (INV-40).

Search params are namespaced (`aStreams`, `aState`, …) because the attachment explorer is mounted on the same routes and owns the bare names.

## Test plan

- [x] Frontend vitest across quick-switcher, sidebar, agent-outcomes, timeline and pages — 1251 pass / 0 fail; new coverage for the overlay (closed → no fetch, opens scoped, close strips only its own params), both sidebar menus, and the follow-up link
- [x] `bun run typecheck` 0 errors · lint clean
- [ ] Staging: the label moved to this PR so the top of the stack casts the deployment

## Naming

Renamed from "Outcomes" on Kris's call: the default view is `outstanding`, so the surface opens on work that hasn't happened yet — "outcomes" names the tail. "Agent" earns its place because the workspace already has "Saved" to-dos, which a bare "Agenda" would be confused with. User-facing only: labels, `/agenda` route, `?agenda=&a*` params, and the `agenda` quick-link key. The API and types stay `agent-outcomes` — accurate for a record of follow-ups plus delegations, and renaming them would touch all four PRs.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

