### PR TITLE
perf: the five performance flags default on

### DIFF
--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -201,10 +201,13 @@ describe("isEventWriteChunkingEnabled", () => {
     expect(get).toHaveBeenCalledTimes(1)
   })
 
-  it("a pre-#1455 flat row neither throws nor enables", async () => {
-    await putMetadata({ eventWriteChunking: "on" })
+  it("a pre-#1455 flat row neither throws nor overrides the registry default", async () => {
+    // A flat legacy row is IGNORED (coerced away), so the resolved value is the
+    // registry default — "on" since the go-live flip — never the flat row's own
+    // field, and never a crash.
+    await putMetadata({ eventWriteChunking: "off" })
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
   })
 
   it("a primed value wins without reading the row", async () => {
@@ -217,10 +220,13 @@ describe("isEventWriteChunkingEnabled", () => {
   })
 
   it("resetEventWriteFlags clears the primed value", async () => {
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    // Primed "off" (an explicit override), then reset: with no persisted row
+    // the resolve falls back to the registry default "on" — proving the primed
+    // override was dropped, not retained.
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
     resetEventWriteFlags()
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(false)
+    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
   })
 
   it("a prime landing mid-read wins over the older persisted row", async () => {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1262,7 +1262,10 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
 
     it("with bootstrapDiff off, every row is rewritten", async () => {
-      const off = (): WorkspaceBootstrap => diffBootstrap({ featureFlags: { workspace: {}, user: {} } })
+      // Explicit off override — the registry default is "on" since the go-live
+      // flip, so empty layers no longer select this arm.
+      const off = (): WorkspaceBootstrap =>
+        diffBootstrap({ featureFlags: { workspace: { bootstrapDiff: "off" }, user: {} } })
       await applyWorkspaceBootstrap("ws_1", off(), Date.now() - 5000)
       await stampCachedAt(1)
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,17 +54,17 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
-  bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  boundedTimelineRead: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
+  bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
+  boundedTimelineRead: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
-  eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
+  eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
+  indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
-  sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
+  sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS


### PR DESCRIPTION
## Problem

The Stack #1745 levers (plus `bootstrapDiff` from #1737) have soaked for a day on Kris's account with clean traces and no regressions observed. Time to make them live for everyone.

## Solution

Flip the five performance flags to `default: "on"`: `bootstrapDiff`, `eventWriteChunking`, `sharedWorkspaceReads`, `indexedMessagePatch`, `boundedTimelineRead`.

- **The flags stay** as kill switches — every blocker found during the stack's review lived in the flag-off arm or a flip/upgrade boundary, so the off-arm keeps its insurance value until a broader soak passes; deleting the flags and the off-arm code is a separate, larger cleanup PR deliberately deferred.
- All five flip in one build, so the documented rollout-order hazard (`eventWriteChunking` before `boundedTimelineRead`) cannot produce a bad intermediate: defaults resolve per build, not per flag arrival.
- Three tests pinned the old defaults; each now selects its arm explicitly (flat-legacy-row → registry default; reset → default; bootstrap off-arm → explicit `bootstrapDiff: "off"` override).

Soak evidence (prod capture `perfcap_01KZ70NRG1…`, build dbbf547, all flags on): bootstrap preRead 27ms / tx 64ms (was ~1.6s/1.8s under load), rowsSkipped 1,016 vs 3 written; `liveQuery.load` median 43ms, total 1.2s over a long active session (was 5.3s); `timeline.tailLoad` median 0.2ms; `timeline.derive` 224 samples totalling 2ms; long-task total 357ms vs 1.2–2.0s baseline.

## Test plan

- [x] Targeted vitest across the flag-sensitive suites (event-writes, workspace-table-registry, stream-store, workspace-sync, stream-sync, use-events; `--maxWorkers=2`): 343/0; typecheck via pre-commit
- [ ] Broad suites on CI

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460672&installation_model_id=20758&pr_number=1761&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1761&signature=d2ae291c8022c184909d6465ddff0a2ed67e5d8406a16fc59def72f1ac8950e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->