### PR TITLE
fix(drafts): stop one composer's send destroying another's unsent text

### DIFF
--- a/apps/frontend/src/hooks/use-draft-composer.double-editor.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.double-editor.test.ts
@@ -134,20 +134,31 @@ describe("two composers on one draft scope (board card + conversation panel)", (
       await seedDraftCacheFromIdb(workspaceId)
     })
 
-    const composer = mountComposer()
+    // The sender must be CO-MOUNTED, or the rescue exits on the composer-count
+    // gate and this asserts nothing: what is under test is the content gate, i.e.
+    // that every send path empties its editor before resolving. The idle sibling
+    // never engages, so only the sender can reach the rescue.
+    const idleSibling = mountComposer()
+    const sender = mountComposer()
     await act(async () => {
-      composer.result.current.handleContentChange(makeDoc("A2"))
+      sender.result.current.handleContentChange(makeDoc("A2"))
     })
     // The send path empties the editor, then resolves the row.
     await act(async () => {
-      composer.result.current.setContent({ type: "doc", content: [{ type: "paragraph" }] })
+      sender.result.current.setContent({ type: "doc", content: [{ type: "paragraph" }] })
     })
     await act(async () => {
-      await composer.result.current.resolveDraft()
+      await sender.result.current.resolveDraft()
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
     })
 
     expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
-    expect(composer.result.current.content).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+    expect(sender.result.current.content).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+    // The idle sibling never engaged, so it takes the blank path: the send is
+    // visible there rather than leaving a stale body on screen.
+    expect(idleSibling.result.current.content).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
   })
 
   it("creates nothing when a LONE composer's pointer is torn down while engaged", async () => {

--- a/apps/frontend/src/hooks/use-draft-composer.double-editor.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.double-editor.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act, cleanup, waitFor } from "@testing-library/react"
+import { useDraftComposer } from "./use-draft-composer"
+import * as useAttachmentsModule from "./use-attachments"
+import * as currentUserHook from "./use-current-workspace-user-id"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
+import { upsertLoadedDraft, clearLoadedDraft } from "./use-draft-message"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
+import { resetApplyWindow } from "@/stores/apply-window"
+import { readStagedDraft } from "@/lib/drafts/draft-staging"
+import { db } from "@/db"
+import type { JSONContent } from "@threa/types"
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+const workspaceId = "ws_double"
+// The board card and the conversation panel host the SAME conversation's reply
+// composer under one scope (`boardReplyDraftKey`), so both are live editors on
+// one draft row.
+const draftKey = "board:reply:conv_1"
+
+const LOCKED_SESSION = {
+  status: "locked",
+  keyId: null,
+  publicKey: null,
+  privateKey: null,
+  deviceTrusted: false,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+const UPLOADED_ATTACHMENT = {
+  id: "att_1",
+  status: "uploaded",
+  filename: "shot.png",
+  mimeType: "image/png",
+  sizeBytes: 1024,
+}
+
+function stubAttachments(snapshot: unknown[] = []) {
+  vi.spyOn(useAttachmentsModule, "useAttachments").mockReturnValue({
+    pendingAttachments: [],
+    getPendingAttachmentsSnapshot: () => snapshot,
+    fileInputRef: { current: null },
+    handleFileSelect: vi.fn(),
+    uploadFile: vi.fn(),
+    removeAttachment: vi.fn(),
+    cancelUpload: vi.fn(),
+    uploadedIds: [],
+    isUploading: false,
+    isReserving: false,
+    hasFailed: false,
+    clear: vi.fn(),
+    restore: vi.fn(),
+    imageCount: 0,
+  } as unknown as ReturnType<typeof useAttachmentsModule.useAttachments>)
+}
+
+function mountComposer() {
+  return renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId: draftKey }))
+}
+
+/** Every place the scope's text can still live after the other editor sends. */
+async function recoverableBodies(): Promise<string[]> {
+  const rows = await db.drafts.where("scope").equals(draftKey).toArray()
+  const bodies = rows.map((row) => JSON.stringify(row.contentJson))
+  const staged = readStagedDraft(workspaceId, draftKey)
+  if (staged) bodies.push(JSON.stringify(staged.contentJson))
+  return bodies
+}
+
+describe("two composers on one draft scope (board card + conversation panel)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetApplyWindow()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    localStorage.clear()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+    stubAttachments()
+  })
+
+  afterEach(() => {
+    // Unmount every composer: the mounted-per-scope registry is module-level, so
+    // a leaked mount would make the next case look like a shared scope.
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it("keeps the second editor's unsent text recoverable after the first editor sends", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("A"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const panel = mountComposer()
+    const card = mountComposer()
+    expect(panel.result.current.content).toEqual(makeDoc("A"))
+    expect(card.result.current.content).toEqual(makeDoc("A"))
+
+    // The user types in the card; its debounced save lands on the shared row.
+    await act(async () => {
+      card.result.current.handleContentChange(makeDoc("B"))
+    })
+    await act(async () => {
+      await card.result.current.flushDraft()
+    })
+
+    // The panel never re-read the same-id body change — it still holds "A" and
+    // sends that, resolving (removing) the shared row.
+    expect(panel.result.current.content).toEqual(makeDoc("A"))
+    await act(async () => {
+      await panel.result.current.resolveDraft()
+    })
+
+    // The card still shows "B" on screen, but it must also survive its unmount.
+    expect(card.result.current.content).toEqual(makeDoc("B"))
+    card.unmount()
+
+    const bodies = await recoverableBodies()
+    expect(bodies.some((body) => body.includes('"B"'))).toBe(true)
+  })
+
+  it("does not resurrect the sender's own just-sent body", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("A"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const composer = mountComposer()
+    await act(async () => {
+      composer.result.current.handleContentChange(makeDoc("A2"))
+    })
+    // The send path empties the editor, then resolves the row.
+    await act(async () => {
+      composer.result.current.setContent({ type: "doc", content: [{ type: "paragraph" }] })
+    })
+    await act(async () => {
+      await composer.result.current.resolveDraft()
+    })
+
+    expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+    expect(composer.result.current.content).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+  })
+
+  it("creates nothing when a LONE composer's pointer is torn down while engaged", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("A"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const composer = mountComposer()
+    await act(async () => {
+      composer.result.current.handleContentChange(makeDoc("B"))
+    })
+
+    // A deliberate teardown of the scope's pointer (discard / relocate / purge)
+    // with no second composer alive: nothing may be re-created under this scope.
+    await act(async () => {
+      await clearLoadedDraft(workspaceId, draftKey)
+    })
+    await act(async () => {
+      composer.rerender()
+    })
+    // Let any write the effect started reach IDB before asserting none did.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+    expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+    // Pre-existing flicker guard: an engaged editor keeps its text either way.
+    expect(composer.result.current.content).toEqual(makeDoc("B"))
+  })
+
+  it("leaves a draft deleted elsewhere deleted, even with two composers mounted", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("A"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const panel = mountComposer()
+    const card = mountComposer()
+    await act(async () => {
+      card.result.current.handleContentChange(makeDoc("B"))
+    })
+
+    // The row goes away without this device resolving it on send — a
+    // `draft:deleted` from another device, or a discard. Two composers are alive,
+    // so the count alone would let the rescue fire and resurrect what the user
+    // deleted; only the resolved-on-send marker separates the two.
+    await act(async () => {
+      await clearLoadedDraft(workspaceId, draftKey)
+    })
+    await act(async () => {
+      panel.rerender()
+      card.rerender()
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    })
+
+    expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+    expect(card.result.current.content).toEqual(makeDoc("B"))
+  })
+
+  it("carries the live attachments into the rescued row", async () => {
+    stubAttachments([UPLOADED_ATTACHMENT])
+
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("A"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const panel = mountComposer()
+    const card = mountComposer()
+    await act(async () => {
+      card.result.current.handleContentChange(makeDoc("B"))
+    })
+    await act(async () => {
+      await panel.result.current.resolveDraft()
+    })
+
+    await waitFor(async () => {
+      const rows = await db.drafts.where("scope").equals(draftKey).toArray()
+      expect(rows.map((row) => row.attachments)).toEqual([
+        [{ id: "att_1", filename: "shot.png", mimeType: "image/png", sizeBytes: 1024 }],
+      ])
+    })
+  })
+})

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -4,6 +4,31 @@ import { useAttachments, type PendingAttachment, type UploadResult } from "./use
 import type { JSONContent } from "@threa/types"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import type { DraftContextRef } from "@/lib/context-bag/types"
+import type { DraftAttachment } from "@/db"
+import { wasDraftResolvedLocally } from "@/sync/draft-resolution-guard"
+
+// Mounted composers per draft scope. More than one live composer on a scope is a
+// precondition for the rescue below: with only this one, a vanishing loaded
+// pointer is always this composer's own teardown. Ref-counted like
+// `boardDraftsRegistry` in `use-scope-draft-preview.ts` (INV-9 exception:
+// process-wide by construction).
+const mountedComposersByScope = new Map<string, number>()
+
+function registerComposer(key: string): () => void {
+  mountedComposersByScope.set(key, (mountedComposersByScope.get(key) ?? 0) + 1)
+  return () => {
+    const next = (mountedComposersByScope.get(key) ?? 1) - 1
+    if (next <= 0) mountedComposersByScope.delete(key)
+    else mountedComposersByScope.set(key, next)
+  }
+}
+
+/** Uploaded (non-temp, non-failed) attachments in the shape the draft row stores. */
+function persistableAttachments(pending: PendingAttachment[]): DraftAttachment[] {
+  return pending
+    .filter((a) => a.status !== "error" && !a.id.startsWith("temp_"))
+    .map((a) => ({ id: a.id, filename: a.filename, mimeType: a.mimeType, sizeBytes: a.sizeBytes }))
+}
 
 export interface UseDraftComposerOptions {
   workspaceId: string
@@ -181,6 +206,9 @@ export function useDraftComposer({
   const savedAttachmentsRef = useRef(savedAttachments)
   savedAttachmentsRef.current = savedAttachments
 
+  const scopeRegistryKey = `${workspaceId} ${draftKey}`
+  useEffect(() => registerComposer(scopeRegistryKey), [scopeRegistryKey])
+
   // Persist the live editor content into the loaded draft row immediately
   // (sealed for E2E), but ONLY when it is non-empty. A stash/restore can fire
   // while the editor is still mid-hydration (transiently empty) — taking the
@@ -320,18 +348,33 @@ export function useDraftComposer({
   useEffect(() => {
     const prev = prevLoadedIdRef.current
     prevLoadedIdRef.current = loadedDraftId ?? null
-    if (prev && !loadedDraftId && !(userEngagedRef.current && hasDocContent(contentRef.current))) {
-      userEngagedRef.current = false
-      setContent(initialContent)
-      clearAttachments()
+    if (!prev || loadedDraftId) return
+    if (userEngagedRef.current && hasDocContent(contentRef.current)) {
+      // With another composer live on this scope, the vanishing pointer can be
+      // THAT editor's send resolving the shared row while this one holds newer
+      // unsent text that exists only in React state — persist it rather than
+      // merely declining to blank. Both conditions are load-bearing: alone on the
+      // scope the null is a deliberate teardown (relocate/stash/clear/purge), and
+      // only a local resolve-on-send marks the id, so a remote `draft:deleted`
+      // reads false and stays deleted instead of being resurrected by whichever
+      // device happens to hold the composer open.
+      if ((mountedComposersByScope.get(scopeRegistryKey) ?? 0) > 1 && wasDraftResolvedLocally(prev)) {
+        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot())).catch((err) => {
+          console.error("Failed to persist draft rescued from a resolved row", err)
+        })
+      }
+      return
     }
-  }, [loadedDraftId, initialContent, clearAttachments])
+    userEngagedRef.current = false
+    setContent(initialContent)
+    clearAttachments()
+  }, [loadedDraftId, initialContent, clearAttachments, saveDraft, scopeRegistryKey, getPendingAttachmentsSnapshot])
 
   // When attachments change, persist to draft storage. Reserved-but-still-
   // uploading attachments persist too: their id is already real, and a draft
   // restore after a reload re-claims the resumed upload job by that id.
   useEffect(() => {
-    const uploaded = pendingAttachments.filter((a) => a.status !== "error" && !a.id.startsWith("temp_"))
+    const uploaded = persistableAttachments(pendingAttachments)
 
     // After a scope change, keep skipping persistence until we have stopped
     // seeing any uploaded attachments that belonged to the previous scope.
@@ -351,12 +394,7 @@ export function useDraftComposer({
     if (hasInitialized.current && uploadedToPersist.length > 0) {
       // Sync each attachment to draft storage
       for (const a of uploadedToPersist) {
-        addDraftAttachment({
-          id: a.id,
-          filename: a.filename,
-          mimeType: a.mimeType,
-          sizeBytes: a.sizeBytes,
-        })
+        addDraftAttachment(a)
       }
     }
   }, [pendingAttachments, addDraftAttachment])

--- a/apps/frontend/src/sync/draft-resolution-guard.ts
+++ b/apps/frontend/src/sync/draft-resolution-guard.ts
@@ -48,6 +48,23 @@ export function markDraftResolved(draftId: string, version: number): void {
 }
 
 /**
+ * True when THIS device resolved-on-send the draft that just disappeared. The
+ * discriminator a composer needs when its loaded pointer goes null: only a local
+ * send marks an id here, so a null that is a remote `draft:deleted` or a
+ * deliberate teardown (discard, stash, relocate, purge) reads false and must not
+ * be treated as "another editor sent the row out from under me".
+ */
+export function wasDraftResolvedLocally(draftId: string): boolean {
+  const rec = draftResolvedVersion.get(draftId)
+  if (rec === undefined) return false
+  if (rec.expiresAt <= Date.now()) {
+    draftResolvedVersion.delete(draftId)
+    return false
+  }
+  return true
+}
+
+/**
  * True when an inbound draft row is an echo/re-seed of a draft this device just
  * resolved (same id, at or below the resolved version). A strictly newer version
  * is a real edit from elsewhere and is NOT suppressed.


### PR DESCRIPTION
## Problem

A board card and the conversation panel for the same conversation mount the **same** composer under the **same** draft scope: both render `InlineComposerForm draftKey={boardReplyDraftKey(post.conversation.id)}` (`board-reply-composer.tsx:232,255`), from `board-card.tsx:1287` and `conversation-panel.tsx:1147`. Opening a card's panel does not unmount the card — the board column stays mounted in both layouts and mobile only marks it `inert` (`pages/board.tsx:1010-1041`). Two live editors, one draft row.

That destroys unsent text today:

1. Card and panel both hydrate body A.
2. The user types B in the card; the debounce persists B to the shared row.
3. The panel still shows A. A second composer only applies a body on the **rising edge** of availability into an empty editor (`use-draft-composer.ts:288-305`), so an ordinary same-id body change never reaches it.
4. The user sends from the panel. It sends **A**, then `resolveLoadedDraft` removes the row.
5. B survives only in the card's React state — the removal-blank deliberately spares an engaged editor (`use-draft-composer.ts:319-328`) — and `clearStagedDraft` has already wiped the crash-recovery buffer (`use-draft-message.ts:317`).
6. The card unmounts (scroll recycle, navigation, reload). B is gone from IDB, localStorage and the server.

Found while planning board⇄timeline draft sharing, which makes this configuration routine rather than incidental. It is not caused by that feature and lands ahead of it.

## Solution

When the loaded pointer goes null under an engaged editor, persist that editor's content back into the scope instead of merely declining to blank. Gated on two conditions, both load-bearing:

- **Another composer is live on the scope** — a module-level ref-counted `Map<scope, count>`, registered on mount and released on unmount/scope change, shaped like `boardDraftsRegistry` in `use-scope-draft-preview.ts`. Alone on a scope, a null pointer is always this composer's own teardown, and re-saving would resurrect a row under a scope nothing renders — the `relocateLoadedDraft` incident already recorded at `use-draft-message.ts:433-436`.
- **The vanished draft was resolved-on-send by this device** — `wasDraftResolvedLocally`, a new reader over the existing `(draftId, version)` tombstone that only `resolveLoadedDraft` writes. A remote `draft:deleted`, a discard, a stash, a relocate and a purge do not mark it, so a draft deleted on another device stays deleted.

The rescue carries the editor's attachments (`persistableAttachments(getPendingAttachmentsSnapshot())`, extracted so the attachment-persistence effect and the rescue share one mapping, INV-35) and catches its own write failure.

Decisions:

- **Persist-on-orphan over a single-editor claim** — a claim would silently deaden one of two composers the user can see.
- **Persist-on-orphan over two-way live sync** between editors on one scope: a much larger design, and preventing destruction is the bar here.
- **Gate inside the engaged branch, not around it.** Pre-change, an engaged editor with content was never blanked (the flicker guard returned early), so gating the whole branch would have regressed `use-draft-composer.test.ts > preserves in-progress edits when the loaded pointer briefly flickers to null`. Alone on a scope, behaviour is byte-identical to before.

### Known issues

- Two engaged editors both rescuing is last-writer-wins: one body overwrites the other. Before this change **both** were lost, so one surviving is strictly better; the correct fix (each rescue writing a detached stash sibling) needs a draft-layer API that does not belong in this PR.
- The registry counts `useDraftComposer` instances, not visible composers. A surface mounting the hook twice on one scope for a non-editor reason would enable the rescue; no such call site was found, but they were not exhaustively enumerated.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-composer.ts` | Mounted-composer registry; rescue in the removal-blank effect; `persistableAttachments` extracted and shared with the attachment-persistence effect |
| `apps/frontend/src/sync/draft-resolution-guard.ts` | `wasDraftResolvedLocally` — reads the existing resolve tombstone to separate a local send from a remote delete |
| `apps/frontend/src/hooks/use-draft-composer.double-editor.test.ts` | **new** — 5 cases: the loss and its recovery, no resurrection of the sender's own body, lone-composer teardown writes nothing, remote delete stays deleted with two composers mounted, attachments carried |

## Test plan

- [x] `use-draft-composer.double-editor`, `use-draft-composer`, `use-draft-message`, `board-inline-composer` (vitest) — 4 files, **129 pass**
- [x] `bunx tsc --noEmit -p apps/frontend` — clean
- [x] Falsification: neutralising the rescue turns the loss test red; neutralising the resolved-on-send condition turns the remote-delete test red. Both restored green.
- [ ] No browser/E2E pass — the card + panel co-mount is established from the component tree and a hook-level test, not by driving the real UI. The sharing stack's UI chunk carries a Playwright pass.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-3cd745/ — this is the plan's **chunk 0**, which was conditional on reproducing the bug. Verdict: reachable, reproduced, fixed. Chunks 1-5 build board⇄timeline draft sharing on top.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788465468&installation_model_id=20758&pr_number=1763&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1763&signature=60fc4a361ff828ed93bc848332f19ab8a962ac45c9156c5bc4ed329f568a684f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->