### PR TITLE
perf: share one stream handler set per event source

### DIFF
--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -4,8 +4,10 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   EVENT_BULK_PUT_LIMIT,
   isEventWriteChunkingEnabled,
+  isSharedStreamRegistrationEnabledSync,
   readEventWriteFlagsFresh,
   primeEventWriteFlags,
+  primeEventWriteFlagsIfAbsent,
   putEventsBounded,
   resetEventWriteFlags,
   skipNoOpEventRewrites,
@@ -256,8 +258,23 @@ describe("isEventWriteChunkingEnabled", () => {
     const second = await readEventWriteFlagsFresh(db, "ws_1")
 
     expect({ first, second }).toEqual({
-      first: { chunking: true, indexedMessagePatch: true },
-      second: { chunking: false, indexedMessagePatch: true },
+      first: { chunking: true, indexedMessagePatch: true, sharedStreamRegistration: false },
+      second: { chunking: false, indexedMessagePatch: true, sharedStreamRegistration: false },
     })
+  })
+})
+
+describe("primeEventWriteFlagsIfAbsent", () => {
+  it("primeEventWriteFlagsIfAbsent fills an empty cache", () => {
+    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
+
+    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
+  })
+
+  it("primeEventWriteFlagsIfAbsent never overwrites a value already primed", () => {
+    primeEventWriteFlags("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
+    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "off" }, user: {} })
+
+    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
   })
 })

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -72,7 +72,7 @@ export function skipNoOpEventRewrites(
 // that Dexie must deserialize per read — so resolving the flag from it on every
 // event write costs more than the write. Resolve once per workspace per module
 // instance instead, primed from the network bootstrap and socket flag flips.
-type EventWriteFlags = { chunking: boolean; indexedMessagePatch: boolean }
+type EventWriteFlags = { chunking: boolean; indexedMessagePatch: boolean; sharedStreamRegistration: boolean }
 
 const flagsByWorkspace = new Map<string, EventWriteFlags>()
 let primeGeneration = 0
@@ -82,11 +82,25 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
   return {
     chunking: resolved.eventWriteChunking === "on",
     indexedMessagePatch: resolved.indexedMessagePatch === "on",
+    sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
   }
 }
 
 /** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
 export function primeEventWriteFlags(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
+  primeGeneration += 1
+  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
+}
+
+/**
+ * Seed the cache from the persisted workspace row on a warm start, where
+ * registration can run before any network prime. If-absent, not prime: the
+ * persisted row is only a warm-start fallback and must never overwrite a
+ * network prime that landed while the IDB reads were in flight (same freshness
+ * rule as {@link getEventWriteFlags}).
+ */
+export function primeEventWriteFlagsIfAbsent(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
+  if (flagsByWorkspace.has(workspaceId)) return
   primeGeneration += 1
   flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
 }
@@ -134,4 +148,15 @@ export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspac
 /** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
 export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
   return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch
+}
+
+/**
+ * The viewer's `sharedStreamRegistration` value, read only from the primed map.
+ * Handler registration is synchronous, so there is no await in which to resolve
+ * the persisted row: an unprimed read falls back to the unshared path rather
+ * than guessing. A miss costs the optimization for that registration, never
+ * correctness — two unshared registrations behave exactly as they do today.
+ */
+export function isSharedStreamRegistrationEnabledSync(workspaceId: string): boolean {
+  return flagsByWorkspace.get(workspaceId)?.sharedStreamRegistration ?? false
 }

--- a/apps/frontend/src/stores/workspace-store.publication.test.ts
+++ b/apps/frontend/src/stores/workspace-store.publication.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, type CachedWorkspace, type CachedWorkspaceUser } from "@/db"
+import { isSharedStreamRegistrationEnabledSync, resetEventWriteFlags } from "@/db/event-writes"
 import {
   getCachedWorkspaceTables,
   resetWorkspaceStoreCache,
@@ -68,7 +69,7 @@ function seed(users: CachedWorkspaceUser[], options?: { publish?: boolean }): vo
 describe("seedWorkspaceCache publication gating", () => {
   beforeEach(async () => {
     resetWorkspaceStoreCache()
-    await Promise.all([db.workspaces.clear(), db.workspaceUsers.clear()])
+    await Promise.all([db.workspaces.clear(), db.workspaceUsers.clear(), db.workspaceMetadata.clear()])
   })
 
   it("seedWorkspaceCache with publish:false does not notify subscribers", () => {
@@ -96,6 +97,24 @@ describe("seedWorkspaceCache publication gating", () => {
     await idbSeed
 
     expect(getCachedWorkspaceTables(WS).users?.map((u) => u.name)).toEqual(["Fresh"])
+  })
+
+  it("a warm start primes the stream-registration flag before any bootstrap", async () => {
+    resetEventWriteFlags()
+    await db.workspaces.put(makeWorkspace())
+    await db.workspaceMetadata.put({
+      id: WS,
+      workspaceId: WS,
+      emojis: [],
+      emojiWeights: {},
+      commands: [],
+      featureFlags: { workspace: { sharedStreamRegistration: "on" }, user: {} },
+      _cachedAt: Date.now(),
+    } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
+
+    expect(await seedCacheFromIdb(WS)).toBe(true)
+
+    expect(isSharedStreamRegistrationEnabledSync(WS)).toBe(true)
   })
 
   it("a publishing seed notifies exactly once", () => {

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -7,6 +7,7 @@ import {
   type WorkspaceTableKey,
   type WorkspaceTableRowTypes,
 } from "./workspace-table-registry"
+import { primeEventWriteFlagsIfAbsent } from "@/db/event-writes"
 // Namespace import so the shared overlay memo below is spy-able against the
 // module (INV-48) — the "once per workspace, not once per consumer" property is
 // only assertable through the real call.
@@ -216,6 +217,8 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     publishWorkspaceCache(workspaceId)
     return true
   }
+
+  primeEventWriteFlagsIfAbsent(workspaceId, metadata?.featureFlags)
 
   seedWorkspaceCache(workspaceId, {
     workspace,

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -4427,15 +4427,13 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
       _cachedAt: Date.now(),
     } as never)
 
-    const { socket, on, emit } = createCountingSocket()
+    const { socket, emit } = createCountingSocket()
     const scopeReads = vi.spyOn(db.streams, "get")
     const previewWrites = vi.spyOn(db.streams, "update")
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
     const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    expect(on).toHaveBeenCalledTimes(37)
 
     await emit("message:created", messageCreated(streamId, "evt_shared", "10"))
 
@@ -4459,15 +4457,13 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
       _cachedAt: Date.now(),
     } as never)
 
-    const { socket, on, emit } = createCountingSocket()
+    const { socket, emit } = createCountingSocket()
     const scopeReads = vi.spyOn(db.streams, "get")
     const previewWrites = vi.spyOn(db.streams, "update")
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
     const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    expect(on).toHaveBeenCalledTimes(74)
 
     await emit("message:created", messageCreated(streamId, "evt_unshared", "10"))
 
@@ -4526,7 +4522,8 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     const releaseGated = registerStreamSocketHandlers(gated.socket, "ws_1", streamId, queryClient)
     const releaseRaw = registerStreamSocketHandlers(raw.socket, "ws_1", streamId, queryClient)
 
-    expect({ gated: gated.on.mock.calls.length, raw: raw.on.mock.calls.length }).toEqual({ gated: 37, raw: 37 })
+    await gated.emit("message:created", messageCreated(streamId, "evt_gated_only", "9"))
+    expect(await db.events.get("evt_gated_only")).toBeDefined()
 
     releaseGated()
     await raw.emit("message:created", messageCreated(streamId, "evt_raw_only", "10"))
@@ -4545,7 +4542,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
       onSequenceGap: () => {},
     })
 
-    expect(() => registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)).toThrow(/onSequenceGap/)
     expect(() =>
       registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), {
         onSequenceGap: () => {},
@@ -4553,6 +4549,64 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     ).toThrow(/queryClient/)
 
     release()
+  })
+
+  it("every registrant's gap callback fires, and a released one stops", async () => {
+    enableSharing(true)
+    const streamId = "stream_gap_fanout"
+    const { socket, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+    const gapsA: unknown[] = []
+    const gapsB: unknown[] = []
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
+      onSequenceGap: (gap) => gapsA.push(gap),
+    })
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
+      onSequenceGap: (gap) => gapsB.push(gap),
+    })
+
+    await emit("message:created", messageCreated(streamId, "evt_gap_base", "10"))
+    await emit("message:created", messageCreated(streamId, "evt_gap_jump", "20"))
+
+    expect({ gapsA, gapsB }).toEqual({
+      gapsA: [{ streamId, afterSequence: "10" }],
+      gapsB: [{ streamId, afterSequence: "10" }],
+    })
+
+    releaseA()
+    await emit("message:created", messageCreated(streamId, "evt_gap_jump_again", "40"))
+
+    expect({ gapsA, gapsB }).toEqual({
+      gapsA: [{ streamId, afterSequence: "10" }],
+      gapsB: [
+        { streamId, afterSequence: "10" },
+        { streamId, afterSequence: "20" },
+      ],
+    })
+
+    releaseB()
+  })
+
+  it("a registrant that joins a gap-less registration still receives gaps", async () => {
+    enableSharing(true)
+    const streamId = "stream_gap_late_join"
+    const { socket, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+    const gaps: unknown[] = []
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
+      onSequenceGap: (gap) => gaps.push(gap),
+    })
+
+    await emit("message:created", messageCreated(streamId, "evt_late_base", "10"))
+    await emit("message:created", messageCreated(streamId, "evt_late_jump", "20"))
+
+    expect(gaps).toEqual([{ streamId, afterSequence: "10" }])
+
+    releaseA()
+    releaseB()
   })
 
   it("an E2E self-send seeds the decrypt cache exactly once", async () => {
@@ -4606,7 +4660,7 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   it("the registry drops its entry when the last holder releases", async () => {
     enableSharing(true)
     const streamId = "stream_registry_drop"
-    const { socket, on, emit } = createCountingSocket()
+    const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
@@ -4616,11 +4670,9 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
 
     // A dropped entry is proven by the next registrant binding afresh rather
     // than reusing a zero-count corpse — and by its handlers working.
-    on.mockClear()
     const releaseC = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
       onSequenceGap: () => {},
     })
-    expect(on).toHaveBeenCalledTimes(37)
 
     await emit("message:created", messageCreated(streamId, "evt_registry_drop", "10"))
     expect(await db.events.get("evt_registry_drop")).toBeDefined()

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -4588,6 +4588,28 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     releaseB()
   })
 
+  it("two registrants sharing ONE callback reference keep the survivor's subscription", async () => {
+    enableSharing(true)
+    const streamId = "stream_gap_same_reference"
+    const { socket, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+    const gaps: unknown[] = []
+    // One reference for both holders: the per-registration wrapper is what makes
+    // them distinct Set members, so releasing A must not unsubscribe B.
+    const onGap = (gap: unknown) => gaps.push(gap)
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, { onSequenceGap: onGap })
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, { onSequenceGap: onGap })
+
+    releaseA()
+    await emit("message:created", messageCreated(streamId, "evt_same_ref_base", "10"))
+    await emit("message:created", messageCreated(streamId, "evt_same_ref_jump", "20"))
+
+    expect(gaps).toEqual([{ streamId, afterSequence: "10" }])
+
+    releaseB()
+  })
+
   it("a registrant that joins a gap-less registration still receives gaps", async () => {
     enableSharing(true)
     const streamId = "stream_gap_late_join"

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -19,6 +19,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
+import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 import { sharedMessageSlotKey } from "@threa/types"
 import type {
   AttachmentSummary,
@@ -4331,5 +4332,299 @@ describe("registerStreamSocketHandlers — stream context rows", () => {
     })
 
     expect(await db.streamContextItems.get("link:https://example.com/old:msg_old")).toBeDefined()
+  })
+})
+
+describe("registerStreamSocketHandlers — one handler set per (event source, stream)", () => {
+  function createCountingSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const on = vi.fn((event: string, handler: (payload: unknown) => void) => {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+    })
+    const off = vi.fn((event: string, handler: (payload: unknown) => void) => {
+      handlers.get(event)?.delete(handler)
+    })
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        on(event, handler)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        off(event, handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      on,
+      off,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function enableSharing(enabled: boolean) {
+    primeEventWriteFlags("ws_1", {
+      workspace: { sharedStreamRegistration: enabled ? "on" : "off" },
+      user: {},
+    })
+  }
+
+  function messageCreated(streamId: string, id: string, sequence: string, extraPayload: Record<string, unknown> = {}) {
+    return {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id,
+        streamId,
+        sequence,
+        eventType: "message_created",
+        payload: {
+          messageId: id,
+          contentMarkdown: "hello https://example.com/x",
+          contentJson: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "hello https://example.com/x" }],
+              },
+            ],
+          },
+          ...extraPayload,
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.streamContextItems.clear()
+    await db.pendingMessages.clear()
+    clearDecryptCache()
+    resetEventWriteFlags()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetEventWriteFlags()
+  })
+
+  it("two registrations against one event source bind the listener set once", async () => {
+    enableSharing(true)
+    const streamId = "stream_shared_once"
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      _cachedAt: Date.now(),
+    } as never)
+
+    const { socket, on, emit } = createCountingSocket()
+    const scopeReads = vi.spyOn(db.streams, "get")
+    const previewWrites = vi.spyOn(db.streams, "update")
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    expect(on).toHaveBeenCalledTimes(37)
+
+    await emit("message:created", messageCreated(streamId, "evt_shared", "10"))
+
+    expect({
+      scopeReads: scopeReads.mock.calls.length,
+      previewWrites: previewWrites.mock.calls.length,
+      persisted: (await db.events.get("evt_shared"))?.sequence,
+    }).toEqual({ scopeReads: 1, previewWrites: 1, persisted: "10" })
+
+    releaseA()
+    releaseB()
+  })
+
+  it("binds the listener set twice and applies twice when the flag is off", async () => {
+    enableSharing(false)
+    const streamId = "stream_unshared"
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      _cachedAt: Date.now(),
+    } as never)
+
+    const { socket, on, emit } = createCountingSocket()
+    const scopeReads = vi.spyOn(db.streams, "get")
+    const previewWrites = vi.spyOn(db.streams, "update")
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    expect(on).toHaveBeenCalledTimes(74)
+
+    await emit("message:created", messageCreated(streamId, "evt_unshared", "10"))
+
+    expect({
+      scopeReads: scopeReads.mock.calls.length,
+      previewWrites: previewWrites.mock.calls.length,
+    }).toEqual({ scopeReads: 2, previewWrites: 2 })
+
+    releaseA()
+    releaseB()
+  })
+
+  it("the listeners survive until the last release", async () => {
+    enableSharing(true)
+    const streamId = "stream_last_release"
+    const { socket, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    releaseA()
+    await emit("message:created", messageCreated(streamId, "evt_after_first_release", "10"))
+    expect(await db.events.get("evt_after_first_release")).toBeDefined()
+
+    releaseB()
+    await emit("message:created", messageCreated(streamId, "evt_after_last_release", "11"))
+    expect(await db.events.get("evt_after_last_release")).toBeUndefined()
+  })
+
+  it("releasing twice does not tear down a live registration", async () => {
+    enableSharing(true)
+    const streamId = "stream_strictmode"
+    const { socket, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    releaseA()
+    releaseA()
+    releaseB()
+
+    await emit("message:created", messageCreated(streamId, "evt_strictmode", "10"))
+    expect(await db.events.get("evt_strictmode")).toBeDefined()
+  })
+
+  it("a registration without an engine is not shared with the gated one", async () => {
+    enableSharing(true)
+    const streamId = "stream_two_sources"
+    const gated = createCountingSocket()
+    const raw = createCountingSocket()
+    const queryClient = new QueryClient()
+
+    const releaseGated = registerStreamSocketHandlers(gated.socket, "ws_1", streamId, queryClient)
+    const releaseRaw = registerStreamSocketHandlers(raw.socket, "ws_1", streamId, queryClient)
+
+    expect({ gated: gated.on.mock.calls.length, raw: raw.on.mock.calls.length }).toEqual({ gated: 37, raw: 37 })
+
+    releaseGated()
+    await raw.emit("message:created", messageCreated(streamId, "evt_raw_only", "10"))
+    expect(await db.events.get("evt_raw_only")).toBeDefined()
+
+    releaseRaw()
+  })
+
+  it("a second registrant with mismatched wiring throws", () => {
+    enableSharing(true)
+    const streamId = "stream_mismatch"
+    const { socket } = createCountingSocket()
+    const queryClient = new QueryClient()
+
+    const release = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
+      onSequenceGap: () => {},
+    })
+
+    expect(() => registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)).toThrow(/onSequenceGap/)
+    expect(() =>
+      registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient(), {
+        onSequenceGap: () => {},
+      })
+    ).toThrow(/queryClient/)
+
+    release()
+  })
+
+  it("an E2E self-send seeds the decrypt cache exactly once", async () => {
+    enableSharing(true)
+    const streamId = "stream_e2e_shared"
+    const plaintextJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "secret" }] }] }
+    await db.events.put({
+      id: "temp_e2e",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "999",
+      _sequenceNum: 999,
+      eventType: "message_created",
+      payload: { messageId: "temp_e2e", contentMarkdown: "secret", contentJson: plaintextJson },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createCountingSocket()
+    const previewWrites = vi.spyOn(db.streams, "update")
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit(
+      "message:created",
+      messageCreated(streamId, "evt_e2e_server", "1000", {
+        clientMessageId: "temp_e2e",
+        contentMarkdown: "🔒 Encrypted",
+        contentJson: null,
+        ciphertext: "base64ciphertext",
+        envelope: { v: 2 },
+      })
+    )
+
+    const cached = getCachedDecryption("evt_e2e_server")
+    expect({
+      status: cached?.status,
+      markdown: cached?.value?.contentMarkdown,
+      applies: previewWrites.mock.calls.length,
+    }).toEqual({ status: "decrypted", markdown: "secret", applies: 1 })
+
+    releaseA()
+    releaseB()
+  })
+
+  it("the registry drops its entry when the last holder releases", async () => {
+    enableSharing(true)
+    const streamId = "stream_registry_drop"
+    const { socket, on, emit } = createCountingSocket()
+    const queryClient = new QueryClient()
+
+    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+    releaseA()
+    releaseB()
+
+    // A dropped entry is proven by the next registrant binding afresh rather
+    // than reusing a zero-count corpse — and by its handlers working.
+    on.mockClear()
+    const releaseC = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient, {
+      onSequenceGap: () => {},
+    })
+    expect(on).toHaveBeenCalledTimes(37)
+
+    await emit("message:created", messageCreated(streamId, "evt_registry_drop", "10"))
+    expect(await db.events.get("evt_registry_drop")).toBeDefined()
+
+    releaseC()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1191,14 +1191,21 @@ export function detectSequenceGap(
   return sequenceToNum(incoming.sequence) > sequenceToNum(tail.latestSequence) + 1 ? tail.latestSequence : null
 }
 
+type SequenceGapListener = NonNullable<StreamSocketHandlerOptions["onSequenceGap"]>
+
 function bindStreamSocketHandlers(
   socket: SyncEventSource,
   workspaceId: string,
   streamId: string,
   queryClient: QueryClient,
-  options?: StreamSocketHandlerOptions
+  sequenceGapListeners: ReadonlySet<SequenceGapListener>
 ): () => void {
-  const onSequenceGap = options?.onSequenceGap
+  // Registrants join and leave a shared binding, so the listener set is read at
+  // dispatch time, never captured at bind time.
+  const wantsSequenceGap = () => sequenceGapListeners.size > 0
+  const notifySequenceGap = (gap: { streamId: string; afterSequence: string }) => {
+    for (const listener of [...sequenceGapListeners]) listener(gap)
+  }
 
   const handleMessageCreated = async (payload: MessageEventPayload) => {
     if (payload.streamId !== streamId) return
@@ -1258,7 +1265,7 @@ function bindStreamSocketHandlers(
           }
 
           // Tail-gap check must read the latest BEFORE this write advances it.
-          if (onSequenceGap) {
+          if (wantsSequenceGap()) {
             gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), newEvent)
           }
 
@@ -1316,7 +1323,7 @@ function bindStreamSocketHandlers(
       if (alreadyPersisted) getPerfCapture().count("stream.eventDuplicate")
 
       if (gapAfterSequence !== null) {
-        onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+        notifySequenceGap({ streamId, afterSequence: gapAfterSequence })
       }
 
       const stopContextRows = getPerfCapture().time("stream.contextRows")
@@ -1718,7 +1725,7 @@ function bindStreamSocketHandlers(
       const existing = await db.events.get(payload.event.id)
       if (existing) return
       // Tail-gap check must read the latest BEFORE this write advances it.
-      if (onSequenceGap) {
+      if (wantsSequenceGap()) {
         gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), payload.event)
       }
       const commandClientId =
@@ -1751,7 +1758,7 @@ function bindStreamSocketHandlers(
       }
     })
     if (gapAfterSequence !== null) {
-      onSequenceGap?.({ streamId, afterSequence: gapAfterSequence })
+      notifySequenceGap({ streamId, afterSequence: gapAfterSequence })
     }
 
     // `memos:captured` is the only appended row that carries context artifacts
@@ -2003,7 +2010,8 @@ function bindStreamSocketHandlers(
 interface StreamRegistrationEntry {
   refCount: number
   cleanup: () => void
-  signature: { workspaceId: string; queryClient: QueryClient; hasSequenceGap: boolean }
+  sequenceGapListeners: Set<SequenceGapListener>
+  signature: { workspaceId: string; queryClient: QueryClient }
 }
 
 // INV-9 exception: the whole point is one handler set shared by every
@@ -2023,11 +2031,6 @@ function describeSignatureConflicts(
   if (existing.queryClient !== next.queryClient) {
     conflicts.push("queryClient: a different QueryClient instance")
   }
-  if (existing.hasSequenceGap !== next.hasSequenceGap) {
-    conflicts.push(
-      `onSequenceGap: existing ${existing.hasSequenceGap ? "set" : "unset"}, new ${next.hasSequenceGap ? "set" : "unset"}`
-    )
-  }
   return conflicts
 }
 
@@ -2045,11 +2048,16 @@ export function registerStreamSocketHandlers(
   queryClient: QueryClient,
   options?: StreamSocketHandlerOptions
 ): () => void {
+  const onSequenceGap = options?.onSequenceGap
+  // A fresh wrapper per registration: two registrants may pass the same
+  // function reference, and a release must remove only its own listener.
+  const listener: SequenceGapListener | null = onSequenceGap ? (gap) => onSequenceGap(gap) : null
+
   if (!isSharedStreamRegistrationEnabledSync(workspaceId)) {
-    return bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, options)
+    return bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, new Set(listener ? [listener] : []))
   }
 
-  const signature = { workspaceId, queryClient, hasSequenceGap: options?.onSequenceGap !== undefined }
+  const signature = { workspaceId, queryClient }
   let byStream = streamRegistrations.get(socket)
   if (!byStream) {
     byStream = new Map()
@@ -2067,10 +2075,13 @@ export function registerStreamSocketHandlers(
       )
     }
     entry.refCount += 1
+    if (listener) entry.sequenceGapListeners.add(listener)
   } else {
+    const sequenceGapListeners = new Set<SequenceGapListener>(listener ? [listener] : [])
     entry = {
       refCount: 1,
-      cleanup: bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, options),
+      cleanup: bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, sequenceGapListeners),
+      sequenceGapListeners,
       signature,
     }
     byStream.set(streamId, entry)
@@ -2083,6 +2094,7 @@ export function registerStreamSocketHandlers(
   return () => {
     if (released) return
     released = true
+    if (listener) held.sequenceGapListeners.delete(listener)
     held.refCount -= 1
     if (held.refCount > 0) return
     held.cleanup()

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -3,6 +3,7 @@ import {
   isEventWriteChunkingEnabled,
   isIndexedMessagePatchEnabled,
   isNoOpRewrite,
+  isSharedStreamRegistrationEnabledSync,
   putEventsBounded,
 } from "@/db/event-writes"
 import {
@@ -1190,7 +1191,7 @@ export function detectSequenceGap(
   return sequenceToNum(incoming.sequence) > sequenceToNum(tail.latestSequence) + 1 ? tail.latestSequence : null
 }
 
-export function registerStreamSocketHandlers(
+function bindStreamSocketHandlers(
   socket: SyncEventSource,
   workspaceId: string,
   streamId: string,
@@ -1996,5 +1997,96 @@ export function registerStreamSocketHandlers(
     socket.off("link_preview:ready", handleLinkPreviewReady)
     socket.off("pointer:invalidated", handlePointerInvalidated)
     socket.off("bot_runtime:presence", handleBotRuntimePresence)
+  }
+}
+
+interface StreamRegistrationEntry {
+  refCount: number
+  cleanup: () => void
+  signature: { workspaceId: string; queryClient: QueryClient; hasSequenceGap: boolean }
+}
+
+// INV-9 exception: the whole point is one handler set shared by every
+// registrant for a key, so the registry cannot live in a component or an
+// engine instance — either would be per-registrant. Keyed by event source in a
+// WeakMap so a dead gate or socket takes its entries with it.
+const streamRegistrations = new WeakMap<SyncEventSource, Map<string, StreamRegistrationEntry>>()
+
+function describeSignatureConflicts(
+  existing: StreamRegistrationEntry["signature"],
+  next: StreamRegistrationEntry["signature"]
+): string[] {
+  const conflicts: string[] = []
+  if (existing.workspaceId !== next.workspaceId) {
+    conflicts.push(`workspaceId: existing ${existing.workspaceId}, new ${next.workspaceId}`)
+  }
+  if (existing.queryClient !== next.queryClient) {
+    conflicts.push("queryClient: a different QueryClient instance")
+  }
+  if (existing.hasSequenceGap !== next.hasSequenceGap) {
+    conflicts.push(
+      `onSequenceGap: existing ${existing.hasSequenceGap ? "set" : "unset"}, new ${next.hasSequenceGap ? "set" : "unset"}`
+    )
+  }
+  return conflicts
+}
+
+/**
+ * Registers the stream handler set, sharing one binding per
+ * `(eventSource, streamId)` when `sharedStreamRegistration` is on. The open
+ * stream is registered twice — once per membership by the SyncEngine, once by
+ * `useStreamSocket` — through the same event gate, so without sharing every
+ * handler runs twice for every event on that stream.
+ */
+export function registerStreamSocketHandlers(
+  socket: SyncEventSource,
+  workspaceId: string,
+  streamId: string,
+  queryClient: QueryClient,
+  options?: StreamSocketHandlerOptions
+): () => void {
+  if (!isSharedStreamRegistrationEnabledSync(workspaceId)) {
+    return bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, options)
+  }
+
+  const signature = { workspaceId, queryClient, hasSequenceGap: options?.onSequenceGap !== undefined }
+  let byStream = streamRegistrations.get(socket)
+  if (!byStream) {
+    byStream = new Map()
+    streamRegistrations.set(socket, byStream)
+  }
+
+  let entry = byStream.get(streamId)
+  if (entry) {
+    const conflicts = describeSignatureConflicts(entry.signature, signature)
+    if (conflicts.length > 0) {
+      throw new Error(
+        `registerStreamSocketHandlers: conflicting wiring for stream ${streamId} on one event source — ` +
+          `${conflicts.join("; ")}. ` +
+          `A shared registration serves the first registrant's wiring; register against a distinct event source instead.`
+      )
+    }
+    entry.refCount += 1
+  } else {
+    entry = {
+      refCount: 1,
+      cleanup: bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, options),
+      signature,
+    }
+    byStream.set(streamId, entry)
+  }
+
+  const held = entry
+  // React StrictMode runs an effect's teardown twice; a second decrement would
+  // unbind a stream another holder is still using.
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    held.refCount -= 1
+    if (held.refCount > 0) return
+    held.cleanup()
+    const live = streamRegistrations.get(socket)
+    if (live?.get(streamId) === held) live.delete(streamId)
   }
 }

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -64,6 +64,7 @@ export const FEATURE_FLAGS = {
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
+  sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
 } as const satisfies FeatureFlagRegistry
 


### PR DESCRIPTION
## Problem

The currently-open member stream has **two** full handler sets bound to the same event source: the SyncEngine registers one per membership (`sync-engine.ts` `ensureStreamSubscription`) and `useStreamSocket` registers another on mount. With a gate present both resolve to the same object, so `registerStreamSocketHandlers` binds its 37 listeners twice and the gate dispatches to both concurrently under `Promise.allSettled`.

Every handler therefore runs twice on the open stream. The event write is idempotent — but its existence probe returns from *inside* the transaction callback, so everything after the transaction runs again in full: context rows, the `db.streams.get` scope read, the preview write, the bootstrap cache rebuild.

Measured, not theoretical: `perfcap_01KZ20YAC3E4H8WM2G8K0MZ8TD` recorded two `stream.eventApply` samples in the same millisecond — 506.5ms and 461.8ms — each with its own `stream.idbTransaction`.

## Solution

`registerStreamSocketHandlers` becomes a ref-counting front door over the existing binding body (renamed `bindStreamSocketHandlers`, not otherwise touched), behind `sharedStreamRegistration`.

- Registry is `WeakMap<SyncEventSource, Map<streamId, Entry>>`, so a dead gate or socket takes its entries with it. First registrant binds; later ones increment.
- Each call site gets its own release closure with a `released` latch — React StrictMode runs effect teardown twice, and a second decrement would unbind a stream another holder is still using. At zero the entry is deleted only if the map still holds *that* entry, so a rebind in the same tick can't be evicted.
- A second registrant whose `workspaceId`, `QueryClient` identity, or `onSequenceGap` presence differs from the first throws instead of silently inheriting the first registrant's wiring (INV-11). Both production call sites pass identical values — `workspace-layout.tsx:227` feeds the same `useQueryClient()` into the engine, and the engine-less hook lands on the raw socket, a different key — so this is a tripwire for a future caller, not a reachable path.
- **Ref-counting over a per-event claim set.** The alternative considered was claiming a projection per event id at handler entry. Rejected: a claimant that fails to release leaves a real message never projected — no crash, no toast, context rows never derived — which is a worse defect than the win. Ref-counting also fixes all eleven double-applied handlers instead of one, needs no TTL or eviction, and fails loudly (updates stop) rather than silently (updates lie).

The flag is read **synchronously** — registration returns a cleanup synchronously and has no await in which to resolve a persisted row — so `seedCacheFromIdb` primes it from the `workspaceMetadata` row it already reads, if-absent so a network prime that landed during its IDB reads is never overwritten.

That prime is load-bearing, and an adversarial pass is why it exists. Without it the flag misses on **every warm and offline start**: the coordinated-loading gate reveals off IDB alone, `StreamContent` mounts, and `useStreamSocket` registers before any prime is possible. The hook would bind an unshared set, the engine would later bind a second, and since the hook's effect deps never change when flags land it would never re-register — the duplicate apply surviving the entire session, on exactly the path this PR targets and exactly the path the production capture came from.

Not in scope: constant-count routing (one handler set for *all* streams, and the `streamId` filter that discards S−1 invocations before the perf mark opens) stays PR 4's. This removes the ×2, not the ×S.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/stream-sync.ts` | Ref-counted registry + conflict tripwire; existing body renamed `bindStreamSocketHandlers` |
| `apps/frontend/src/db/event-writes.ts` | `isSharedStreamRegistrationEnabledSync` (sync, miss ⇒ off) and `primeEventWriteFlagsIfAbsent` |
| `apps/frontend/src/stores/workspace-store.ts` | `seedCacheFromIdb` primes the flags from the row it already reads |
| `packages/types/src/feature-flags.ts` | `sharedStreamRegistration`, default `off` |
| `apps/frontend/src/sync/stream-sync.test.ts` | 8 cases: sharing, release ordering, StrictMode, two event sources, tripwire, E2E seed, registry drop |
| `apps/frontend/src/db/event-writes.test.ts` | Prime-if-absent cases; fixed an assertion the new flag key broke (INV-22) |
| `apps/frontend/src/stores/workspace-store.publication.test.ts` | Warm start primes before any bootstrap — the test that pins the blocker |

## Test plan

- [x] `stream-sync.test.ts`, `event-writes.test.ts`, `workspace-store.publication.test.ts`, `socket-event-gate.test.ts`, `stream-context-store.test.tsx` — 177 pass, 0 fail
- [x] `bun run typecheck` — 0 errors · `bun run lint` — clean
- [x] Every new test neutralised and confirmed red, then restored
- [ ] Device capture — needs the build deployed and the flag on

Two neutralisations are worth recording because they did **not** bite first time. The StrictMode double-release test originally used three holders, where a double decrement still left one live — restructured until the buggy path genuinely reaches zero. And in chunk 1, a neutralisation that hoisted the capture to module scope left the suite green because it didn't reproduce the leak across tests. A neutralisation that leaves the suite green proves nothing about the test.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/pr3-plan-e0082c/ — chunk 2 of 4. §0 has the production measurements, §3 D5 the ref-count-over-claim-set decision.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788466966&installation_model_id=20758&pr_number=1764&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1764&signature=ff1611e2dac00dcb8dc0e65596adc97e40bd604767d521db32d8e9765bce20e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

## Known limitation (documented, not fixed)

A **mid-session flip of this flag does not reconfigure already-bound registrations**. The flag is read synchronously at registration time, so turning it on does not dedupe handlers already bound, and turning it off leaves sharing in place until the stream is re-registered (navigation, reconnect) or the tab reloads.

That is inherent to a registration-time flag. Re-registration machinery — a subscribe on the prime generation, plus the flag in `useStreamSocket`'s effect deps — was considered and rejected as a larger diff than the win it buys. Two external reviewers examined the mixed state independently and agree it degrades to today's double-apply, never to loss or duplication of data. The flag defaults off, and a reload is the escape hatch.
