### PR TITLE
perf: stream:activity is the only sidebar preview writer

### DIFF
--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -2094,3 +2094,129 @@ describe("EventService stream-context projection", () => {
     expect(StreamContextRepository.deleteByMessageId).toHaveBeenCalledWith(expect.anything(), "ws_1", "msg_del")
   })
 })
+
+describe("EventService.createMessage outbox pairing (the sidebar's single preview writer)", () => {
+  const createdAt = new Date("2026-08-04T10:00:00.000Z")
+
+  beforeEach(() => {
+    spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
+      callback({})) as any)
+    spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(7)
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_1",
+      workspaceId: "ws_1",
+      type: "scratchpad",
+      parentStreamId: null,
+      parentAnchorId: null,
+    } as any)
+    spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: "evt_1",
+      streamId: params.streamId,
+      sequence: 42n,
+      eventType: params.eventType,
+      payload: params.payload,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      createdAt,
+    })) as any)
+    spyOn(MessageRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: params.id,
+      streamId: params.streamId,
+      sequence: params.sequence,
+      authorId: params.authorId,
+      authorType: params.authorType,
+      contentJson: params.contentJson,
+      contentMarkdown: params.contentMarkdown,
+      replyCount: 0,
+      clientMessageId: null,
+      sentVia: null,
+      reactions: {},
+      metadata: {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt,
+    })) as any)
+    spyOn(MessageRepository, "findByClientMessageId").mockResolvedValue(null)
+    spyOn(ReadStateRepository, "advance").mockResolvedValue(undefined as any)
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("createMessage emits stream:activity alongside message:created", async () => {
+    const service = new EventService({} as any)
+    await service.createMessage({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "usr_1",
+      authorType: "user",
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }] },
+      contentMarkdown: "hello",
+    })
+
+    const calls = (OutboxRepository.insert as any).mock.calls as unknown[][]
+    const created = calls.find((call) => call[1] === "message:created")
+    const activity = calls.find((call) => call[1] === "stream:activity")
+
+    // The sidebar preview is written from `stream:activity` alone, so this
+    // pairing — and the markdown it carries — is load-bearing.
+    expect({
+      createdEventId: (created?.[2] as any)?.event?.id,
+      createdStreamId: (created?.[2] as any)?.streamId,
+      activity: activity?.[2],
+      activityFollowsCreated: calls.indexOf(activity!) > calls.indexOf(created!),
+    }).toEqual({
+      createdEventId: "evt_1",
+      createdStreamId: "stream_1",
+      activity: {
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        authorId: "usr_1",
+        sequence: "42",
+        messageOrdinal: 7,
+        lastMessagePreview: {
+          authorId: "usr_1",
+          authorType: "user",
+          content: "hello",
+          createdAt: createdAt.toISOString(),
+        },
+      },
+      activityFollowsCreated: true,
+    })
+  })
+})
+
+/**
+ * The client-side single preview writer rests on two source-level properties the
+ * mocked-transaction test above cannot see: `message:created` is emitted from
+ * exactly ONE site, and `stream:activity` rides with it. A second emit site added
+ * anywhere in `apps/backend/src` keeps that test green while silently freezing the
+ * sidebar for those messages — the preview is written from `stream:activity` alone.
+ *
+ * Same shape as the INV-68 ratchet: one recorded count, which may only go down.
+ */
+describe("message:created has exactly one outbox emit site", () => {
+  const EXPECTED_EMIT_SITES = { "features/messaging/event-service.ts": 1 }
+
+  async function countEmitSites(root: string): Promise<Record<string, number>> {
+    const { Glob } = await import("bun")
+    const counts: Record<string, number> = {}
+    for await (const file of new Glob("**/*.ts").scan({ cwd: root, absolute: true })) {
+      if (file.endsWith(".test.ts")) continue
+      const source = await Bun.file(file).text()
+      const matches = source.match(/OutboxRepository\.insert\(\s*[^,]+,\s*"message:created"/g)
+      if (matches) counts[file.slice(root.length + 1)] = matches.length
+    }
+    return counts
+  }
+
+  it("finds the one site, in event-service.ts", async () => {
+    const root = new URL("../../../src", import.meta.url).pathname.replace(/\/$/, "")
+    expect(await countEmitSites(root)).toEqual(EXPECTED_EMIT_SITES)
+  })
+})

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -2207,7 +2207,7 @@ describe("message:created has exactly one outbox emit site", () => {
     const { Glob } = await import("bun")
     const counts: Record<string, number> = {}
     for await (const file of new Glob("**/*.ts").scan({ cwd: root, absolute: true })) {
-      if (file.endsWith(".test.ts")) continue
+      if (file.endsWith(".test.ts") || file.endsWith(".spec.ts")) continue
       const source = await Bun.file(file).text()
       const matches = source.match(/OutboxRepository\.insert\(\s*[^,]+,\s*"message:created"/g)
       if (matches) counts[file.slice(root.length + 1)] = matches.length

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as prosemirror from "@threa/prosemirror"
 import { AuthorTypes, StreamTypes, Visibilities, type AuthorType, type StreamWithPreview } from "@threa/types"
 import {
   buildVirtualDmDrafts,
@@ -294,5 +295,31 @@ describe("truncateContent", () => {
     const out = truncateContent(`${"a".repeat(39)}😀 rest`, 40)
     expect(out).toBe(`${"a".repeat(39)}😀...`)
     expect([...out].every((c) => c.codePointAt(0)! < 0xd800 || c.codePointAt(0)! > 0xdfff)).toBe(true)
+  })
+})
+
+describe("truncateContent — a string preview costs no serialization", () => {
+  const doc = {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text: "hello there" }] }],
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("a string preview renders without serializing a document", () => {
+    const serialize = vi.spyOn(prosemirror, "serializeToMarkdown")
+
+    const fromString = truncateContent("hello there")
+    const stringCalls = serialize.mock.calls.length
+    const fromDoc = truncateContent(doc)
+
+    expect({ fromString, stringCalls, fromDoc, docCalls: serialize.mock.calls.length > stringCalls }).toEqual({
+      fromString: "hello there",
+      stringCalls: 0,
+      fromDoc: "hello there",
+      docCalls: true,
+    })
   })
 })

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -258,8 +258,13 @@ describe("isEventWriteChunkingEnabled", () => {
     const second = await readEventWriteFlagsFresh(db, "ws_1")
 
     expect({ first, second }).toEqual({
-      first: { chunking: true, indexedMessagePatch: true, sharedStreamRegistration: false },
-      second: { chunking: false, indexedMessagePatch: true, sharedStreamRegistration: false },
+      first: { chunking: true, indexedMessagePatch: true, sharedStreamRegistration: false, singlePreviewWriter: false },
+      second: {
+        chunking: false,
+        indexedMessagePatch: true,
+        sharedStreamRegistration: false,
+        singlePreviewWriter: false,
+      },
     })
   })
 })

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -72,7 +72,12 @@ export function skipNoOpEventRewrites(
 // that Dexie must deserialize per read — so resolving the flag from it on every
 // event write costs more than the write. Resolve once per workspace per module
 // instance instead, primed from the network bootstrap and socket flag flips.
-type EventWriteFlags = { chunking: boolean; indexedMessagePatch: boolean; sharedStreamRegistration: boolean }
+type EventWriteFlags = {
+  chunking: boolean
+  indexedMessagePatch: boolean
+  sharedStreamRegistration: boolean
+  singlePreviewWriter: boolean
+}
 
 const flagsByWorkspace = new Map<string, EventWriteFlags>()
 let primeGeneration = 0
@@ -83,6 +88,7 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
     chunking: resolved.eventWriteChunking === "on",
     indexedMessagePatch: resolved.indexedMessagePatch === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
+    singlePreviewWriter: resolved.singlePreviewWriter === "on",
   }
 }
 
@@ -148,6 +154,11 @@ export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspac
 /** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
 export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
   return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch
+}
+
+/** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */
+export async function isSinglePreviewWriterEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
+  return (await getEventWriteFlags(database, workspaceId)).singlePreviewWriter
 }
 
 /**

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
@@ -124,6 +124,41 @@ describe("runBootstrapSync account routing", () => {
     expect(row.lastMessagePreview).toMatchObject({ authorId: "user_1" })
   })
 
+  it("derives the preview from markdown even when the event carries contentJson", async () => {
+    const workosUserId = "user_acct_preview"
+    const streamId = "stream_preview1"
+    const accountDb = new ThreaDatabase(accountDbName(workosUserId))
+
+    mockFetch({
+      [`/streams/${streamId}/bootstrap`]: {
+        stream: { id: streamId, workspaceId: "ws_1", type: "channel", slug: "general" },
+        events: [
+          makeEvent({
+            id: "evt_p1",
+            streamId,
+            sequence: "3",
+            payload: {
+              messageId: "evt_p1",
+              contentMarkdown: "hello there",
+              contentJson: {
+                type: "doc",
+                content: [{ type: "paragraph", content: [{ type: "text", text: "hello there" }] }],
+              },
+            },
+          } as never),
+        ],
+      },
+    })
+
+    await runBootstrapSync({ workspaceId: "ws_1", streamId, messageId: null, workosUserId })
+
+    const preview = (await accountDb.streams.get(streamId))?.lastMessagePreview
+    expect({ type: typeof preview?.content, content: preview?.content }).toEqual({
+      type: "string",
+      content: "hello there",
+    })
+  })
+
   it("skips all IndexedDB writes when the target carries no account id", async () => {
     const streamId = "stream_noacct1"
     const fetchMock = mockFetch({

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -113,12 +113,11 @@ function findLatestMessageEvent(events: StreamEvent[]): StreamEvent | null {
 }
 
 function buildPreviewFromEvent(event: StreamEvent): LastMessagePreview {
-  const payload = (event.payload ?? {}) as { contentJson?: unknown; contentMarkdown?: string }
+  const payload = (event.payload ?? {}) as { contentMarkdown?: string }
   return {
     authorId: event.actorId ?? "",
     authorType: event.actorType ?? AuthorTypes.USER,
-    // Sidebar's truncateContent accepts either JSONContent or a markdown string.
-    content: (payload.contentJson ?? payload.contentMarkdown ?? "") as string,
+    content: payload.contentMarkdown ?? "",
     createdAt: event.createdAt,
   }
 }

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -3,7 +3,11 @@ import { QueryClient } from "@tanstack/react-query"
 import { db } from "@/db"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
+import type { Socket } from "socket.io-client"
 import { CatchUpBatch, commitCounterMutation } from "./catch-up-batch"
+import { registerStreamSocketHandlers } from "./stream-sync"
+import { registerWorkspaceSocketHandlers } from "./workspace-sync"
+import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 import { applyStreamsReadAllOrdinals } from "./unread-counters"
 import {
   applyReadStateSnapshotsIdb,
@@ -589,5 +593,131 @@ describe("commitReadStateSnapshot", () => {
       expect(readState?.lastReadEventId).toBe("evt_4")
       expect(readState?.lastReadSequence).toBe("40")
     })
+  })
+})
+
+describe("replayed message:created entries and the preview write", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function entry(streamId: string, index: number) {
+    return {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: `evt_replay_${index}`,
+        streamId,
+        sequence: String(100 + index),
+        eventType: "message_created",
+        payload: {
+          messageId: `evt_replay_${index}`,
+          contentMarkdown: `replayed ${index}`,
+          contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "x" }] }] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: "2026-08-04T10:00:00.000Z",
+      },
+    }
+  }
+
+  async function replay(streamId: string, singlePreviewWriter: boolean): Promise<number> {
+    resetEventWriteFlags()
+    primeEventWriteFlags("ws_1", {
+      workspace: { singlePreviewWriter: singlePreviewWriter ? "on" : "off" },
+      user: {},
+    })
+    await db.events.clear()
+    await db.streams.clear()
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      lastMessagePreview: null,
+      _cachedAt: Date.now(),
+    } as never)
+
+    const previewWrites = vi.spyOn(db.streams, "update")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+    for (let index = 0; index < 3; index += 1) await emit("message:created", entry(streamId, index))
+    cleanup()
+    const calls = previewWrites.mock.calls.length
+    previewWrites.mockRestore()
+    return calls
+  }
+
+  it("live message:created delivery writes no preview when the single writer is on", async () => {
+    const on = await replay("stream_replay_on", true)
+    const off = await replay("stream_replay_off", false)
+    expect({ on, off }).toEqual({ on: 0, off: 3 })
+    resetEventWriteFlags()
+  })
+
+  it("a catch-up replay's batched stream:activity previews land on flush, last write winning", async () => {
+    const streamId = "stream_replay_batch"
+    await db.streams.clear()
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      lastMessagePreview: null,
+      _cachedAt: Date.now(),
+    } as never)
+
+    const queryClient = new QueryClient()
+    const batch = new CatchUpBatch(queryClient, "ws_1")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => undefined,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+      getCatchUpBatch: () => batch,
+    })
+
+    const activity = (content: string, createdAt: string) => ({
+      workspaceId: "ws_1",
+      streamId,
+      authorId: "user_1",
+      sequence: "100",
+      messageOrdinal: 1,
+      lastMessagePreview: { authorId: "user_1", authorType: "user" as const, content, createdAt },
+    })
+
+    await emit("stream:activity", activity("first replayed", "2026-08-04T10:00:00.000Z"))
+    await emit("stream:activity", activity("last replayed", "2026-08-04T10:00:01.000Z"))
+
+    // Buffered, not written — the replay must not touch the row per entry.
+    expect((await db.streams.get(streamId))?.lastMessagePreview).toBeNull()
+
+    await batch.flush()
+
+    expect((await db.streams.get(streamId))?.lastMessagePreview).toEqual({
+      authorId: "user_1",
+      authorType: "user",
+      content: "last replayed",
+      createdAt: "2026-08-04T10:00:01.000Z",
+    })
+
+    cleanup()
   })
 })

--- a/apps/frontend/src/sync/stream-sync.perf.test.ts
+++ b/apps/frontend/src/sync/stream-sync.perf.test.ts
@@ -5,6 +5,7 @@ import type { PerformanceSample, StreamEvent } from "@threa/types"
 import { db } from "@/db"
 import { NO_CAPTURE, PerfCapture, armPerfCapture, getPerfCapture } from "@/lib/perf/capture"
 import { registerStreamSocketHandlers } from "./stream-sync"
+import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 
 function createTestSocket() {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
@@ -81,10 +82,14 @@ async function resetTables(): Promise<void> {
   })
 }
 
-beforeEach(resetTables)
+beforeEach(async () => {
+  await resetTables()
+  primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "off" }, user: {} })
+})
 
 afterEach(() => {
   armPerfCapture(NO_CAPTURE)
+  resetEventWriteFlags()
 })
 
 describe("message:created sub-marks", () => {

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -4368,7 +4368,11 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
 
   function enableSharing(enabled: boolean) {
     primeEventWriteFlags("ws_1", {
-      workspace: { sharedStreamRegistration: enabled ? "on" : "off" },
+      // `singlePreviewWriter` is pinned off, not inherited: these cases count
+      // `db.streams.update` calls to tell one apply from two, and that writer
+      // only exists on this arm. Inheriting a default scheduled to flip would
+      // silently retarget the assertion at nothing.
+      workspace: { sharedStreamRegistration: enabled ? "on" : "off", singlePreviewWriter: "off" },
       user: {},
     })
   }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -4702,3 +4702,192 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     releaseC()
   })
 })
+
+describe("registerStreamSocketHandlers — stream:activity is the single preview writer", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  function enableSinglePreviewWriter(enabled: boolean) {
+    primeEventWriteFlags("ws_1", {
+      workspace: { singlePreviewWriter: enabled ? "on" : "off" },
+      user: {},
+    })
+  }
+
+  const contentJson = {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text: "live" }] }],
+  }
+
+  function messageCreated(streamId: string, id: string, sequence: string, payload: Record<string, unknown> = {}) {
+    return {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id,
+        streamId,
+        sequence,
+        eventType: "message_created",
+        payload: { messageId: id, contentMarkdown: "live", contentJson, ...payload },
+        actorId: "user_7",
+        actorType: "user",
+        createdAt: "2026-08-04T10:00:00.000Z",
+      },
+    }
+  }
+
+  const bootstrapPreview = {
+    authorId: "user_1",
+    authorType: "user" as const,
+    content: "from the bootstrap",
+    createdAt: "2026-08-04T09:00:00.000Z",
+  }
+
+  async function seedStream(streamId: string) {
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      lastMessagePreview: bootstrapPreview,
+      _cachedAt: Date.now(),
+    } as never)
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.streamContextItems.clear()
+    await db.pendingMessages.clear()
+    await db.slots.clear()
+    resetEventWriteFlags()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    resetEventWriteFlags()
+  })
+
+  it("a live message writes no preview and no bootstrap cache entry", async () => {
+    enableSinglePreviewWriter(true)
+    const streamId = "stream_single_writer"
+    await seedStream(streamId)
+
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      streams: [{ id: streamId, lastMessagePreview: bootstrapPreview }],
+    } as unknown as WorkspaceBootstrap)
+    const bootstrapBefore = queryClient.getQueryData(workspaceKeys.bootstrap("ws_1"))
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", messageCreated(streamId, "evt_single", "10"))
+
+    expect({
+      persisted: (await db.events.get("evt_single"))?.sequence,
+      preview: (await db.streams.get(streamId))?.lastMessagePreview,
+      bootstrapUnchanged: queryClient.getQueryData(workspaceKeys.bootstrap("ws_1")) === bootstrapBefore,
+    }).toEqual({ persisted: "10", preview: bootstrapPreview, bootstrapUnchanged: true })
+
+    cleanup()
+  })
+
+  it("the flag off writes the preview exactly as today", async () => {
+    enableSinglePreviewWriter(false)
+    const streamId = "stream_single_writer_off"
+    await seedStream(streamId)
+
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      streams: [{ id: streamId, lastMessagePreview: bootstrapPreview }],
+    } as unknown as WorkspaceBootstrap)
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", messageCreated(streamId, "evt_single_off", "10"))
+
+    const written = {
+      authorId: "user_7",
+      authorType: "user",
+      content: contentJson,
+      createdAt: "2026-08-04T10:00:00.000Z",
+    }
+    expect({
+      preview: (await db.streams.get(streamId))?.lastMessagePreview,
+      cached: queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streams[0]
+        .lastMessagePreview,
+    }).toEqual({ preview: written, cached: written })
+
+    cleanup()
+  })
+
+  it("a message:created applied without a SyncEngine still writes the event and does not throw", async () => {
+    enableSinglePreviewWriter(true)
+    const streamId = "stream_no_engine"
+    const queryClient = new QueryClient()
+
+    // No workspace handlers registered — the raw-socket surface a draft panel
+    // mounted outside the SyncEngine provider gets (D2). Nothing writes the
+    // preview there, and nothing reads one either.
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit("message:created", messageCreated(streamId, "evt_no_engine", "10"))
+
+    expect({
+      persisted: (await db.events.get("evt_no_engine"))?.sequence,
+      row: await db.streams.get(streamId),
+    }).toEqual({ persisted: "10", row: undefined })
+
+    cleanup()
+  })
+
+  it("the share-fallback invalidation still fires for a map-less share-bearing event", async () => {
+    enableSinglePreviewWriter(true)
+    const streamId = "stream_share_fallback"
+    await seedStream(streamId)
+
+    const queryClient = new QueryClient()
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined)
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    await emit(
+      "message:created",
+      messageCreated(streamId, "evt_share_fallback", "10", {
+        contentJson: {
+          type: "doc",
+          content: [{ type: "sharedMessage", attrs: { messageId: "msg_src", streamId: "stream_src" } }],
+        },
+      })
+    )
+
+    expect(invalidateQueries.mock.calls.map((call) => call[0]?.queryKey)).toEqual([
+      streamKeys.bootstrap("ws_1", streamId),
+      streamKeys.events("ws_1", streamId),
+    ])
+
+    cleanup()
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -2,6 +2,7 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   isEventWriteChunkingEnabled,
   isIndexedMessagePatchEnabled,
+  isSinglePreviewWriterEnabled,
   isNoOpRewrite,
   isSharedStreamRegistrationEnabledSync,
   putEventsBounded,
@@ -1239,6 +1240,8 @@ function bindStreamSocketHandlers(
       let gapAfterSequence: string | null = null
 
       const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
+      // Same primed map, so this resolves without a second IDB read.
+      const singlePreviewWriter = await isSinglePreviewWriterEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
       // Read after the transaction only: the `return` it drives stays inside the
       // callback, so the write path's control flow is unchanged.
@@ -1345,34 +1348,39 @@ function bindStreamSocketHandlers(
         seedDecryption(newEvent.id, optimisticPlaintext)
       }
 
-      // Update sidebar preview in both TanStack cache and IDB so the sort order
-      // and preview text survive cold starts (offline-first).
-      const newPreview: LastMessagePreview = {
-        authorId: newEvent.actorId ?? "",
-        authorType: newEvent.actorType ?? "user",
-        content: newPayload.contentJson as string,
-        createdAt: newEvent.createdAt,
-      }
+      // `stream:activity` is emitted in the same backend transaction as this
+      // event and carries the server markdown, so it is the single preview
+      // writer; this arm only exists as the kill switch.
+      if (!singlePreviewWriter) {
+        // Update sidebar preview in both TanStack cache and IDB so the sort order
+        // and preview text survive cold starts (offline-first).
+        const newPreview: LastMessagePreview = {
+          authorId: newEvent.actorId ?? "",
+          authorType: newEvent.actorType ?? "user",
+          content: newPayload.contentJson as string,
+          createdAt: newEvent.createdAt,
+        }
 
-      const stopPreviewWrite = getPerfCapture().time("stream.previewWrite")
-      try {
-        await db.streams.update(streamId, {
-          lastMessagePreview: newPreview,
-          _cachedAt: Date.now(),
-        })
+        const stopPreviewWrite = getPerfCapture().time("stream.previewWrite")
+        try {
+          await db.streams.update(streamId, {
+            lastMessagePreview: newPreview,
+            _cachedAt: Date.now(),
+          })
 
-        queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-          if (!old) return old
-          return {
-            ...old,
-            streams: old.streams.map((stream) => {
-              if (stream.id !== streamId) return stream
-              return { ...stream, lastMessagePreview: newPreview }
-            }),
-          }
-        })
-      } finally {
-        stopPreviewWrite()
+          queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+            if (!old) return old
+            return {
+              ...old,
+              streams: old.streams.map((stream) => {
+                if (stream.id !== streamId) return stream
+                return { ...stream, lastMessagePreview: newPreview }
+              }),
+            }
+          })
+        } finally {
+          stopPreviewWrite()
+        }
       }
 
       if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(newPayload.contentJson)) {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -4349,3 +4349,87 @@ describe("stream:member_removed board cleanup", () => {
     cleanup()
   })
 })
+
+describe("stream:activity is the single preview writer", () => {
+  const serverPreview = {
+    authorId: "member_2",
+    authorType: "user" as const,
+    content: "**bold** from the server",
+    createdAt: "2026-08-04T10:00:00.000Z",
+  }
+
+  function activity(streamId: string) {
+    return {
+      workspaceId: "ws_1",
+      streamId,
+      authorId: "member_2",
+      sequence: "9",
+      messageOrdinal: 6,
+      lastMessagePreview: serverPreview,
+    }
+  }
+
+  async function seedStreamRow(streamId: string) {
+    await db.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      rootStreamId: streamId,
+      lastMessagePreview: null,
+      _cachedAt: Date.now(),
+    } as never)
+  }
+
+  function register(queryClient: QueryClient, currentStreamId?: string) {
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, {
+      getCurrentStreamId: () => currentStreamId,
+      getCurrentUser: () => ({ id: "workos_1" }),
+      subscribeStream: vi.fn(),
+    })
+    return { emit, cleanup }
+  }
+
+  beforeEach(async () => {
+    await Promise.all([db.streams.clear(), db.unreadState.clear()])
+  })
+
+  it("stream:activity writes the server markdown as the preview content", async () => {
+    const streamId = "stream_activity_markdown"
+    await seedStreamRow(streamId)
+    const queryClient = new QueryClient()
+    const { emit, cleanup } = register(queryClient)
+
+    emit("stream:activity", activity(streamId))
+
+    await vi.waitFor(async () => {
+      const stored = (await db.streams.get(streamId))?.lastMessagePreview
+      expect({ preview: stored, isString: typeof stored?.content === "string" }).toEqual({
+        preview: serverPreview,
+        isString: true,
+      })
+    })
+
+    cleanup()
+  })
+
+  it("a stream:activity for the currently-open stream still commits its preview", async () => {
+    const streamId = "stream_activity_open"
+    await seedStreamRow(streamId)
+    const queryClient = new QueryClient()
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined)
+    const { emit, cleanup } = register(queryClient, streamId)
+
+    emit("stream:activity", activity(streamId))
+
+    await vi.waitFor(async () => {
+      expect((await db.streams.get(streamId))?.lastMessagePreview).toEqual(serverPreview)
+    })
+    expect(
+      invalidateQueries.mock.calls.some(
+        (call) => JSON.stringify(call[0]?.queryKey) === JSON.stringify(streamKeys.bootstrap("ws_1", streamId))
+      )
+    ).toBe(false)
+
+    cleanup()
+  })
+})

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -66,6 +66,7 @@ export const FEATURE_FLAGS = {
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
   sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
+  singlePreviewWriter: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS


### PR DESCRIPTION
## Problem

One logical message wrote the same sidebar preview **four times**: `handleMessageCreated` did a `db.streams.update` plus a full `WorkspaceBootstrap.streams` array rebuild via `setQueryData`, and `handleStreamActivity` did the same pair again through `commitPreview`.

Worse than the duplication, `message:created` wrote `content: newPayload.contentJson as string` — a ProseMirror `JSONContent` **object** into a field declared `string` (`LastMessagePreview.content`). Every other writer stores real markdown. Because `truncateContent` branches on `typeof content === "string"` and otherwise calls `serializeToMarkdown`, and `StreamItemPreview` calls it inline in JSX with no memo (`stream-item.tsx:349`, `:534`), every sidebar row that handler touched **re-serialized a whole ProseMirror document on every sidebar render, for the rest of the session**.

## Solution

`stream:activity` becomes the only preview writer, behind `singlePreviewWriter`. On the flag-on arm `message:created` no longer constructs the preview, writes `db.streams`, or rebuilds the bootstrap array. Everything else in the handler is untouched: event write, gap report, context rows, decrypt seed, and the share-fallback invalidation all still run.

**Nothing needs to enforce ordering, because the two events are never separated.** `event-service.ts` inserts `message:created` and then `stream:activity` adjacently on the same transaction client, from the only site that emits either; both are stream-scoped so the audience is identical, and the broadcast handler sequences by ascending outbox id, so `stream:activity` always carries the higher `syncId` — including through catch-up, which resumes in ascending `syncId` order. An adversarial pass verified that by grepping `apps/backend/src` rather than taking the design's word for it: exactly one `message_created` event type and one `message:created` insert.

That uniqueness is now **pinned rather than trusted** — a source-level ratchet with a recorded per-file count (INV-33 shape) reddens if a second emitter appears, instead of the sidebar silently ceasing to re-sort. A client-side fallback writer was rejected: it would reintroduce the duplicate write it exists to remove, and would be exercised approximately never and therefore rot (INV-11 — fail loudly at the test, not silently at runtime).

Two things the review turned up that the plan had wrong:

- **The service worker was a second object-valued writer**, and preferred `contentJson` (`sw-bootstrap-prefetch.ts` `buildPreviewFromEvent`). Tapping a push notification planted the same object into the same string-typed field, so after this change it would have been the *only* remaining producer of the per-render serialization cost. It now takes the markdown, with the payload type narrowed so the cast cannot quietly return.
- **The catch-up replay preview leg had no test anywhere.** After this change it is the only thing writing previews during a reconnect, and the next chunk rewrites exactly that code — a dropped leg would leave every test green while a returning user's sidebar stayed frozen at pre-disconnect values. It now has a real case: a live `CatchUpBatch`, two activities for one stream, asserting the row is still `null` before `flush()` and equals the last payload after.

No migration for rows already holding an object (INV-36): the next `stream:activity` heals each one, and `truncateContent` handles both shapes meanwhile. Memoising the sidebar render stays PR 6's.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/stream-sync.ts` | Preview write + bootstrap rebuild gated off; kill-switch arm verbatim |
| `apps/frontend/src/lib/sw-bootstrap-prefetch.ts` | Preview derives from markdown, not `contentJson` |
| `apps/frontend/src/db/event-writes.ts` | `isSinglePreviewWriterEnabled`, same primed cache, no second IDB read |
| `packages/types/src/feature-flags.ts` | `singlePreviewWriter`, default `off` |
| `apps/backend/src/features/messaging/event-service.test.ts` | Pairing case + one-emit-site ratchet |
| `apps/frontend/src/sync/read-state.test.ts` | Live case renamed to what it checks; real catch-up replay case added |
| `apps/frontend/src/sync/stream-sync.perf.test.ts` | Primes its arm explicitly instead of inheriting a default that is scheduled to flip |
| `apps/frontend/src/sync/{stream-sync,workspace-sync}.test.ts`, `sidebar/utils.test.ts`, `sw-bootstrap-prefetch.test.ts` | Coverage for both arms, the string-preview render path, and the SW writer |

## Test plan

- [x] 7 frontend files — 353 pass, 0 fail · `event-service.test.ts` — 53 pass, 0 fail
- [x] `bun run typecheck` — 0 errors · `bun run lint` — clean
- [x] Every new test neutralised and confirmed red, then restored
- [ ] Device capture — needs the build deployed and the flags on

Two neutralisations are worth recording. A bare `db.streams.update` on a missing row is a **silent no-op**, so the no-engine case was neutralised with `put` instead — an `update`-based one would have looked like it bit without ever biting. And rather than only checking the fix, the perf-test arm fix was validated against its predicted future failure: with the flag's registry default flipped to `on`, the file passes with the fix and throws without it.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/pr3-plan-e0082c/ — chunk 3 of 4. §1.2 has the type-lie analysis, §3 D1 the pairing argument.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788469055&installation_model_id=20758&pr_number=1768&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1768&signature=02e3a42afe76b539178df080f6571caaa88eff502622f0222809e9b4f863270c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->