### PR TITLE
feat(drafts): pile membership is own scope, top level, and your conversation

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -103,6 +103,7 @@ function draftComposerStub() {
 function stashComposerStub() {
   return {
     drafts: [],
+    claimableDrafts: [],
     handleStashDraft: vi.fn().mockResolvedValue(undefined),
     handleRestoreStashed: vi.fn().mockResolvedValue(undefined),
     handleDeleteStashed: vi.fn().mockResolvedValue(undefined),
@@ -372,6 +373,24 @@ describe("InlineComposerForm restore-on-mount", () => {
     render(<Anchored>{form({ restoreStashedIdOnMount: "draft_adv" })}</Anchored>)
     await waitFor(() => expect(stashStub.handleRestoreStashed).toHaveBeenCalledWith("draft_adv"))
     expect(stashStub.handleRestoreStashed).toHaveBeenCalledTimes(1)
+  })
+
+  it("hands the picker the claimable (scope-exact) list, not the landing-site-wide pile", async () => {
+    // Restore can't leave a scope safely until chunk 4, so the widened pile is
+    // computed but not rendered. Wiring `drafts` here must be a deliberate change.
+    const wide = { id: "draft_foreign", scope: "stream:stream_1" }
+    const claimable = { id: "draft_own", scope: "board:reply:conv_1" }
+    stashStub.drafts = [wide, claimable] as never
+    stashStub.claimableDrafts = [claimable] as never
+
+    render(<Anchored>{form()}</Anchored>)
+
+    await waitFor(() => expect(editorSpy).toHaveBeenCalled())
+    const props = editorSpy.mock.calls.at(-1)![0] as MessageComposerProps
+    for (const trigger of [props.stashedDraftsTrigger, props.stashedDraftsTriggerFab]) {
+      const pickerProps = (trigger as { props: { drafts: { id: string }[] } }).props
+      expect(pickerProps.drafts.map((draft) => draft.id)).toEqual(["draft_own"])
+    }
   })
 
   it("does nothing without a restore id", async () => {

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -553,7 +553,7 @@ export function InlineComposerForm({
   // Inline drafts are plaintext (no `e2eStreamId` on the composer above), so the
   // picker's own `contentJson` fallback previews suffice — no decrypt pass.
   const stashPickerProps = {
-    drafts: stash.drafts,
+    drafts: stash.claimableDrafts,
     canStashCurrent: composer.canSend,
     // Stashing disposes of the current composition — end the compose session so
     // the next one can't inherit its openedAt/horizon (trace discarded).
@@ -563,6 +563,7 @@ export function InlineComposerForm({
     },
     onRestore: stash.handleRestoreStashed,
     onDelete: stash.handleDeleteStashed,
+    onOpenChange: stash.setPileOpen,
     controlsDisabled: composer.isSending,
   } as const
 

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react"
 import { FileEdit, FilePlus, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -34,6 +34,11 @@ interface StashedDraftsPickerProps {
   onRestore: (id: string) => void
   /** Called when the user clicks the trash icon on a row. */
   onDelete: (id: string) => void
+  /**
+   * Called when the popover opens/closes. The host latches pile membership while
+   * it is open, so a row can't vanish mid-pick when its landing stream moves.
+   */
+  onOpenChange?: (open: boolean) => void
   /** When `controlsDisabled`, the trigger button is disabled (e.g. composer is sending). */
   controlsDisabled?: boolean
   /**
@@ -71,10 +76,12 @@ export function StashedDraftsPicker({
   onStashCurrent,
   onRestore,
   onDelete,
+  onOpenChange,
   controlsDisabled = false,
   size = "compact",
 }: StashedDraftsPickerProps) {
   const [open, setOpen] = useState(false)
+  useEffect(() => onOpenChange?.(open), [open, onOpenChange])
   const [draftToDelete, setDraftToDelete] = useState<string | null>(null)
   const closeFabDrawer = useFabDrawerClose()
   const bridge = useStashedDraftsBridge()

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -31,7 +31,6 @@ import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as shareHandoffModule from "@/stores/share-handoff-store"
 import * as boardReplyComposerModule from "@/components/board/board-reply-composer"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
-import * as stashedDraftsModule from "@/hooks/use-stashed-drafts"
 import { boardReplyDraftKey } from "@/lib/board/draft-keys"
 import {
   FLOATING_COMPOSER_HEIGHT_VAR,
@@ -49,6 +48,18 @@ import { registerWorkspaceSocketHandlers } from "@/sync/workspace-sync"
 
 const WORKSPACE_ID = "ws_1"
 const CONVERSATION_ID = "conv_1"
+
+/** A stashed draft row on disk — what a `?stash=` deep link points at. */
+function seedStashRow(id: string, scope: string) {
+  return db.drafts.put({
+    id,
+    workspaceId: WORKSPACE_ID,
+    scope,
+    contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "x" }] }] },
+    attachments: [],
+    clientUpdatedAt: 1000,
+  } as never)
+}
 
 function makeMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
   return {
@@ -252,6 +263,7 @@ beforeEach(async () => {
   // The panel seeds its backfill into IDB now, so a leaked conversation's rows
   // would widen the next test's member set.
   await db.conversationMessages.clear()
+  await db.drafts.clear()
   __resetConversationMessageSnapshots()
   // Default composer stub: the real form (desktop always-open since the
   // thread-semantics ruling) pulls auth/mention providers this harness doesn't
@@ -453,14 +465,7 @@ describe("ConversationPanel", () => {
     // The drafts explorer deep-links a stashed board reply to the panel; the
     // collapsed resting affordance mounts no composer, so the panel itself must
     // open the form for the stash restore to have a consumer.
-    vi.spyOn(stashedDraftsModule, "useStashedDrafts").mockImplementation(
-      (_ws, scope) =>
-        ({
-          drafts: scope === boardReplyDraftKey(CONVERSATION_ID) ? [{ id: "draft_owned" }] : [],
-          isLoaded: true,
-          deleteStashedDraft: vi.fn(),
-        }) as unknown as ReturnType<typeof stashedDraftsModule.useStashedDrafts>
-    )
+    await seedStashRow("draft_owned", boardReplyDraftKey(CONVERSATION_ID))
     let captured: number | undefined
     vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
       captured = props.openReplySignal
@@ -474,11 +479,7 @@ describe("ConversationPanel", () => {
   it("ignores a ?stash= param whose row is not in its reply scope's pile", async () => {
     // A foreign scope's stash id (e.g. a thread draft on the same route) must be
     // left for its own host — opening here would strand the restore.
-    vi.spyOn(stashedDraftsModule, "useStashedDrafts").mockReturnValue({
-      drafts: [],
-      isLoaded: true,
-      deleteStashedDraft: vi.fn(),
-    } as unknown as ReturnType<typeof stashedDraftsModule.useStashedDrafts>)
+    await seedStashRow("draft_foreign", "thread:msg_9")
     let captured: number | undefined
     vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
       captured = props.openReplySignal
@@ -486,6 +487,11 @@ describe("ConversationPanel", () => {
     })
     mountPanel({ cached: asCached(makePost()), stashParam: "draft_foreign" })
     await screen.findByText("Opening message body.")
+    // The row read is an IDB point query — give it time to land, or a panel that
+    // opened on ANY param would still read 0 here.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60))
+    })
     expect(captured).toBe(0)
   })
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -480,18 +480,29 @@ describe("ConversationPanel", () => {
     // A foreign scope's stash id (e.g. a thread draft on the same route) must be
     // left for its own host — opening here would strand the restore.
     await seedStashRow("draft_foreign", "thread:msg_9")
+    const originalGet = db.drafts.get.bind(db.drafts) as (
+      key: string
+    ) => ReturnType<typeof db.drafts.get>
+    let rowQueryResolved = false
+    vi.spyOn(db.drafts, "get").mockImplementation(
+      ((key: string) => {
+        const request = originalGet(key)
+        if (key === "draft_foreign") void request.then(() => (rowQueryResolved = true))
+        return request
+      }) as typeof db.drafts.get
+    )
     let captured: number | undefined
+    let renderedAfterQuery = false
     vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
       captured = props.openReplySignal
+      if (rowQueryResolved) renderedAfterQuery = true
       return <></>
     })
     mountPanel({ cached: asCached(makePost()), stashParam: "draft_foreign" })
     await screen.findByText("Opening message body.")
-    // The row read is an IDB point query — give it time to land, or a panel that
-    // opened on ANY param would still read 0 here.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 60))
-    })
+    // The foreign-row lookup must resolve and propagate through React before the
+    // negative assertion; otherwise the initial collapsed render proves nothing.
+    await waitFor(() => expect(renderedAfterQuery).toBe(true))
     expect(captured).toBe(0)
   })
 

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -69,7 +69,7 @@ import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
 import { useActors, useVisibleStreams, useEffectiveArchived } from "@/hooks"
-import { useStashedDrafts } from "@/hooks/use-stashed-drafts"
+import { useStashParamDraftRow } from "@/hooks/use-stash-composer"
 import { boardReplyDraftKey, boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -302,18 +302,23 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   // consumes the restore and strips the param — this bump only FOCUSES the
   // footer so the restored draft is where the user is looking. Ownership-checked
   // so a foreign scope's param (e.g. a thread draft on the same route) is left
-  // for its own host.
-  const [searchParams] = useSearchParams()
-  const stashParam = searchParams.get("stash")
+  // for its own host. The test is the deep-linked row's own scope — the same
+  // claim boundary the footer's restore uses — not pile membership, which is now
+  // landing-site-wide and would focus this footer for a draft belonging to the
+  // timeline composer.
+  const stashParamRow = useStashParamDraftRow(workspaceId)
+  const stashParam = stashParamRow?.draftId ?? null
   const replyScope = conversationId ? boardReplyDraftKey(conversationId) : undefined
-  const stashedReplyDrafts = useStashedDrafts(workspaceId, stashParam ? replyScope : undefined)
   const stashOpenedRef = useRef<string | null>(null)
   useEffect(() => {
     if (!stashParam || stashOpenedRef.current === stashParam) return
-    if (!stashedReplyDrafts.drafts.some((draft) => draft.id === stashParam)) return
+    if (!replyScope || stashParamRow?.scope !== replyScope) return
+    // Already checked out here — the deep link has nothing left to restore, so
+    // revisiting the URL must not pop the composer open again.
+    if (stashParamRow.isLoadedForScope) return
     stashOpenedRef.current = stashParam
     setOpenReplySignal((n) => n + 1)
-  }, [stashParam, stashedReplyDrafts.drafts])
+  }, [stashParam, stashParamRow?.scope, stashParamRow?.isLoadedForScope, replyScope])
 
   // Keep the conversation's streams (root + threads) caught up + joined while the
   // panel is open, so the rail is live and offline-first. Its own SyncEngine slot,

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -207,31 +207,33 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   // Decrypt-on-read previews for the pile (sealed rows via the shared cache,
   // plaintext from contentJson); every entry shares this thread's encrypted root.
   const stashPreviewInputs = useMemo(
-    () => stash.drafts.map((draft) => ({ draft, rootStreamId: e2eRoot })),
-    [stash.drafts, e2eRoot]
+    () => stash.claimableDrafts.map((draft) => ({ draft, rootStreamId: e2eRoot })),
+    [stash.claimableDrafts, e2eRoot]
   )
   const stashPreviews = useDecryptedDraftPreviews(workspaceId, stashPreviewInputs)
 
   const stashedDraftsTrigger = stashScope ? (
     <StashedDraftsPicker
-      drafts={stash.drafts}
+      drafts={stash.claimableDrafts}
       previewById={stashPreviews}
       canStashCurrent={composer.canSend}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}
+      onOpenChange={stash.setPileOpen}
       controlsDisabled={composer.isSending}
     />
   ) : undefined
 
   const stashedDraftsTriggerFab = stashScope ? (
     <StashedDraftsPicker
-      drafts={stash.drafts}
+      drafts={stash.claimableDrafts}
       previewById={stashPreviews}
       canStashCurrent={composer.canSend}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}
+      onOpenChange={stash.setPileOpen}
       controlsDisabled={composer.isSending}
       size="fab"
     />

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -270,8 +270,8 @@ function MessageInputComponent({
   // shared cache; plaintext rows resolve from contentJson). All entries share
   // this stream's encrypted root.
   const stashPreviewInputs = useMemo(
-    () => stash.drafts.map((draft) => ({ draft, rootStreamId: e2eRootStreamId })),
-    [stash.drafts, e2eRootStreamId]
+    () => stash.claimableDrafts.map((draft) => ({ draft, rootStreamId: e2eRootStreamId })),
+    [stash.claimableDrafts, e2eRootStreamId]
   )
   const stashPreviews = useDecryptedDraftPreviews(workspaceId, stashPreviewInputs)
 
@@ -793,23 +793,25 @@ function MessageInputComponent({
     onStashDraft: stash.handleStashDraft,
     stashedDraftsTrigger: (
       <StashedDraftsPicker
-        drafts={stash.drafts}
+        drafts={stash.claimableDrafts}
         previewById={stashPreviews}
         canStashCurrent={composer.canSend}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}
+        onOpenChange={stash.setPileOpen}
         controlsDisabled={composer.isSending}
       />
     ),
     stashedDraftsTriggerFab: (
       <StashedDraftsPicker
-        drafts={stash.drafts}
+        drafts={stash.claimableDrafts}
         previewById={stashPreviews}
         canStashCurrent={composer.canSend}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}
+        onOpenChange={stash.setPileOpen}
         controlsDisabled={composer.isSending}
         size="fab"
       />

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -59,6 +59,7 @@ export {
   useStashedDrafts,
   type UseStashedDraftsResult,
   type StashedDraftOrigin,
+  type StashedDraftSource,
   type CachedDraft,
 } from "./use-stashed-drafts"
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -55,7 +55,12 @@ export {
 
 export { useDraftMessage, getDraftMessageKey } from "./use-draft-message"
 
-export { useStashedDrafts, type UseStashedDraftsResult, type CachedDraft } from "./use-stashed-drafts"
+export {
+  useStashedDrafts,
+  type UseStashedDraftsResult,
+  type StashedDraftOrigin,
+  type CachedDraft,
+} from "./use-stashed-drafts"
 
 export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } from "./use-stash-composer"
 

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -102,7 +102,7 @@ function truncatePreview(content: string, maxLength: number = 80): string {
  * qualification predicate shared by the explorer build and the sidebar summary
  * so a draft counts identically in both — the badge can't drift from the list.
  */
-function draftHasPayload(draft: CachedDraft): boolean {
+export function draftHasPayload(draft: CachedDraft): boolean {
   return draft.ciphertext != null || !isEmptyContent(draft.contentJson) || (draft.attachments?.length ?? 0) > 0
 }
 
@@ -144,7 +144,7 @@ function resolveRootStreamId(
  * or a stream not in cache) is treated as not-archived, so a draft is never
  * hidden on missing data.
  */
-function isStreamArchived(
+export function isStreamArchived(
   streamId: string | null,
   streamMap: Map<string, CachedStream>,
   archivedStreamIds: ReadonlySet<string>

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -1,10 +1,9 @@
-import { useLiveQuery } from "dexie-react-hooks"
 import { useCallback, useMemo } from "react"
 import { db, type CachedBoardPost, type CachedDraft, type CachedStream } from "@/db"
-import { draftScopesSignature, useBoardDraftContext } from "./use-board-draft-context"
+import { draftScopesSignature, useBoardDraftContext, useThreadAnchorContext } from "./use-board-draft-context"
 import { createConversationPanelId } from "@/contexts"
 import { parseBoardDraftKey, type ParsedBoardDraftKey } from "@/lib/board/draft-keys"
-import { THREAD_ANCHORABLE_EVENT_TYPES, type CompanionMode } from "@threa/types"
+import { type CompanionMode } from "@threa/types"
 import {
   deleteDraftScratchpadFromCache,
   useComposerLoadedFromStore,
@@ -316,62 +315,37 @@ export function streamIdsWithLoadedDraft(drafts: UnifiedDraft[]): Set<string> {
 
 /**
  * Map of a thread draft's parent message id → its host stream, built from cached
- * `message_created` events. Shared by the explorer ({@link useAllDrafts}) and the
- * sidebar badge ({@link useDraftSummary}) so both resolve a
+ * `message_created` events. Shared by the explorer ({@link useAllDrafts}), the
+ * sidebar badge ({@link useDraftSummary}) and the composer pile's home-stream
+ * resolution (`useStashedDrafts`) so all three resolve a
  * `thread:{parentMessageId}` draft's host stream — and therefore its archival —
- * the same way. The events read is gated on a thread-scoped draft existing: with
- * none it returns an empty map without subscribing to `db.events`, so the
- * always-mounted sidebar pays nothing in the common case. A parent not yet in
- * cache resolves to no entry (the draft counts, degrading to visible rather than
- * being hidden on missing data).
+ * the same way. It reads through the shared, ref-counted
+ * {@link useThreadAnchorContext}: one subscription for every consumer, keyed on
+ * the anchor ids the drafts actually reference, so with no thread draft it reads
+ * nothing at all and with one it does keyed lookups rather than a pass over every
+ * synced stream's events. A parent not yet in cache resolves to no entry (the
+ * draft counts, degrading to visible rather than being hidden on missing data).
  */
-function useDraftThreadStreamMap(
-  allDrafts: CachedDraft[],
-  cachedStreams: CachedStream[] | undefined
+export function useDraftThreadStreamMap(
+  workspaceId: string,
+  allDrafts: CachedDraft[]
 ): Map<string, { streamId: string; anchorId: string }> {
-  // Prefix-checking each `|`-split scope avoids false positives on a scope that
-  // merely contains the substring `thread:` in a non-prefix spot.
-  const hasThreadDrafts = useMemo(() => allDrafts.some((draft) => draft.scope.startsWith("thread:")), [allDrafts])
+  return useThreadAnchorContext(workspaceId, useThreadAnchorSignature(allDrafts)).streamByAnchorId
+}
 
-  // Stable stream ID key — only changes when the set of IDs changes, not on
-  // every useLiveQuery re-fire of cachedStreams (which returns a new array ref
-  // even when the same streams are present).
-  const streamIdKey = useMemo(
+/** The anchor ids a set of drafts' `thread:` scopes reference — the shared
+ *  anchor context's gate, stable across keystrokes. */
+export function useThreadAnchorSignature(allDrafts: CachedDraft[]): string {
+  return useMemo(
     () =>
-      (cachedStreams ?? [])
-        .map((s) => s.id)
-        .sort()
-        .join(","),
-    [cachedStreams]
+      draftScopesSignature(
+        allDrafts
+          .filter((draft) => draft.scope.startsWith("thread:"))
+          .map((draft) => draft.scope.slice("thread:".length))
+          .filter(Boolean)
+      ),
+    [allDrafts]
   )
-
-  // Only query events when there are thread drafts, to avoid the expensive scan
-  // in the common case.
-  const cachedEvents = useLiveQuery(
-    () => {
-      if (!hasThreadDrafts || !streamIdKey) return []
-      return db.events.where("streamId").anyOf(streamIdKey.split(",")).toArray()
-    },
-    [streamIdKey, hasThreadDrafts],
-    []
-  )
-
-  // A thread draft keys on its anchor's canonical id: a message anchor is
-  // `payload.messageId`; a threadable card anchor is the event's own stable id.
-  return useMemo(() => {
-    const map = new Map<string, { streamId: string; anchorId: string }>()
-    for (const event of cachedEvents ?? []) {
-      if (event.eventType === "message_created") {
-        const payload = event.payload as { messageId?: string }
-        if (payload.messageId) {
-          map.set(payload.messageId, { streamId: event.streamId, anchorId: payload.messageId })
-        }
-      } else if (THREAD_ANCHORABLE_EVENT_TYPES.includes(event.eventType)) {
-        map.set(event.id, { streamId: event.streamId, anchorId: event.id })
-      }
-    }
-    return map
-  }, [cachedEvents])
 }
 
 /**
@@ -429,7 +403,7 @@ export function useAllDrafts(workspaceId: string) {
 
   // Parent-message → host-stream map for thread drafts (shared with the sidebar
   // badge so both resolve thread-draft location/archival identically).
-  const messageToStreamMap = useDraftThreadStreamMap(allDrafts, cachedStreams)
+  const messageToStreamMap = useDraftThreadStreamMap(workspaceId, allDrafts)
 
   const draftsById = useMemo(() => {
     const map = new Map<string, CachedDraft>()
@@ -634,8 +608,8 @@ export interface DraftSummary {
  * Shares {@link draftHasPayload}, {@link isStreamArchived}, and
  * {@link useDraftThreadStreamMap} with the explorer, so archived channel/DM AND
  * thread-reply drafts (including nested threads under an archived root) are hidden
- * from the badge and the list alike. The shared thread map reads `db.events` only
- * when a thread draft exists, so the always-mounted sidebar stays cheap otherwise.
+ * from the badge and the list alike. The shared thread map reads nothing until a
+ * thread draft exists, so the always-mounted sidebar stays cheap otherwise.
  * Board drafts still resolve their host stream only in the explorer (that needs
  * the conversation lookups), so the badge can over-count a board reply under an
  * archived root — rare, and the explorer still hides it.
@@ -677,7 +651,7 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
   // thread reply under an archived root in step with the explorer. Gated on a
   // thread draft existing (see `useDraftThreadStreamMap`), so the always-mounted
   // sidebar reads no events until the user actually has one.
-  const messageToStreamMap = useDraftThreadStreamMap(allDrafts, cachedStreams)
+  const messageToStreamMap = useDraftThreadStreamMap(workspaceId, allDrafts)
 
   return useMemo(() => {
     let draftCount = 0

--- a/apps/frontend/src/hooks/use-board-draft-context.test.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.test.ts
@@ -49,3 +49,53 @@ describe("useBoardDraftContext — shared subscription failure", () => {
     await waitFor(() => expect(second.result.current.boardPostMap.size).toBe(1))
   })
 })
+
+describe("useBoardDraftContext — shared subscription ref-counting", () => {
+  // The error path deletes an entry and a later subscriber rebuilds it under the
+  // same key. A cleanup that re-looked-up by key would then decrement the
+  // REPLACEMENT, tearing it down while its own owner is still mounted — the
+  // entry serves an empty context for the page's lifetime and every pile
+  // silently collapses to scope-exact. Exactly the failure the error observer
+  // exists to prevent, one layer down.
+  it("an unmount after a failed query does not tear down the rebuilt entry", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    const bulkGet = vi.spyOn(db.conversations, "bulkGet").mockRejectedValue(new Error("boom"))
+
+    const failed = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(error).toHaveBeenCalled())
+
+    bulkGet.mockRestore()
+    await db.conversations.put({
+      id: "conv_1",
+      workspaceId,
+      _lastActivityMs: 1,
+      _cachedAt: 1,
+      conversation: { id: "conv_1", streamId: "stream_s", messageIds: ["msg_1"] },
+      openingMessage: { id: "msg_1" },
+      recentMessages: [],
+    } as never)
+
+    const rebuilt = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(rebuilt.result.current.boardPostMap.size).toBe(1))
+
+    // The stale consumer goes away. Its cleanup must touch only the entry it
+    // incremented, which is already orphaned.
+    failed.unmount()
+
+    // The live consumer's subscription must still be alive: a later write to the
+    // row it watches has to reach it. If the stale cleanup tore down the rebuilt
+    // entry, this value stays stale forever and nothing says so.
+    await db.conversations.put({
+      id: "conv_1",
+      workspaceId,
+      _lastActivityMs: 3,
+      _cachedAt: 3,
+      conversation: { id: "conv_1", streamId: "stream_moved", messageIds: ["msg_1"] },
+      openingMessage: { id: "msg_1" },
+      recentMessages: [],
+    } as never)
+    await waitFor(() =>
+      expect(rebuilt.result.current.boardPostMap.get("conv_1")?.conversation.streamId).toBe("stream_moved")
+    )
+  })
+})

--- a/apps/frontend/src/hooks/use-board-draft-context.test.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { db } from "@/db"
+import { __clearBoardDraftContextRegistry, useBoardDraftContext } from "./use-board-draft-context"
+
+const workspaceId = "ws_ctx"
+
+beforeEach(async () => {
+  __clearBoardDraftContextRegistry()
+  await db.conversations.clear()
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  __clearBoardDraftContextRegistry()
+  vi.restoreAllMocks()
+})
+
+describe("useBoardDraftContext — shared subscription failure", () => {
+  // Dexie drops a liveQuery rejection when the subscriber passes only a `next`
+  // callback, AND a first-run rejection leaves the observable with no tracked
+  // ranges, so it never re-queries. Without an error observer this registry
+  // would serve an empty context for the page's lifetime with nothing logged —
+  // every composer's pile silently collapsing to scope-exact (INV-11).
+  it("logs and drops the entry when the query rejects, instead of serving empty forever", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.spyOn(db.conversations, "bulkGet").mockRejectedValue(new Error("boom"))
+
+    const { result } = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+
+    await waitFor(() => expect(error).toHaveBeenCalled())
+    expect(error.mock.calls[0]?.[0]).toContain("[draft-context] shared query failed")
+    expect(result.current.boardPostMap.size).toBe(0)
+
+    // The failed entry is gone rather than latched at empty, so the next
+    // consumer rebuilds it instead of inheriting a dead subscription.
+    vi.mocked(db.conversations.bulkGet).mockRestore()
+    await db.conversations.put({
+      id: "conv_1",
+      workspaceId,
+      _lastActivityMs: 1,
+      _cachedAt: 1,
+      conversation: { id: "conv_1", streamId: "stream_s", messageIds: ["msg_1"] },
+      openingMessage: { id: "msg_1" },
+      recentMessages: [],
+    } as never)
+
+    const second = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(second.result.current.boardPostMap.size).toBe(1))
+  })
+})

--- a/apps/frontend/src/hooks/use-board-draft-context.test.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
-import { db } from "@/db"
+import { db, type CachedBoardPost } from "@/db"
 import { __clearBoardDraftContextRegistry, useBoardDraftContext } from "./use-board-draft-context"
 
 const workspaceId = "ws_ctx"
+
+function conversationRow(params: { streamId: string; lastActivityMs: number; cachedAt: number }): CachedBoardPost {
+  return {
+    id: "conv_1",
+    workspaceId,
+    _lastActivityMs: params.lastActivityMs,
+    _cachedAt: params.cachedAt,
+    conversation: { id: "conv_1", streamId: params.streamId, messageIds: ["msg_1"] },
+    openingMessage: { id: "msg_1" },
+    recentMessages: [],
+    totalReplies: 0,
+    streamIds: [params.streamId],
+    hasCapturedMemo: false,
+    settlingMessageIds: [],
+    isMine: false,
+  } as unknown as CachedBoardPost
+}
 
 beforeEach(async () => {
   __clearBoardDraftContextRegistry()
@@ -35,15 +52,7 @@ describe("useBoardDraftContext — shared subscription failure", () => {
     // The failed entry is gone rather than latched at empty, so the next
     // consumer rebuilds it instead of inheriting a dead subscription.
     vi.mocked(db.conversations.bulkGet).mockRestore()
-    await db.conversations.put({
-      id: "conv_1",
-      workspaceId,
-      _lastActivityMs: 1,
-      _cachedAt: 1,
-      conversation: { id: "conv_1", streamId: "stream_s", messageIds: ["msg_1"] },
-      openingMessage: { id: "msg_1" },
-      recentMessages: [],
-    } as never)
+    await db.conversations.put(conversationRow({ streamId: "stream_s", lastActivityMs: 1, cachedAt: 1 }))
 
     const second = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
     await waitFor(() => expect(second.result.current.boardPostMap.size).toBe(1))
@@ -65,15 +74,7 @@ describe("useBoardDraftContext — shared subscription ref-counting", () => {
     await waitFor(() => expect(error).toHaveBeenCalled())
 
     bulkGet.mockRestore()
-    await db.conversations.put({
-      id: "conv_1",
-      workspaceId,
-      _lastActivityMs: 1,
-      _cachedAt: 1,
-      conversation: { id: "conv_1", streamId: "stream_s", messageIds: ["msg_1"] },
-      openingMessage: { id: "msg_1" },
-      recentMessages: [],
-    } as never)
+    await db.conversations.put(conversationRow({ streamId: "stream_s", lastActivityMs: 1, cachedAt: 1 }))
 
     const rebuilt = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
     await waitFor(() => expect(rebuilt.result.current.boardPostMap.size).toBe(1))
@@ -85,15 +86,7 @@ describe("useBoardDraftContext — shared subscription ref-counting", () => {
     // The live consumer's subscription must still be alive: a later write to the
     // row it watches has to reach it. If the stale cleanup tore down the rebuilt
     // entry, this value stays stale forever and nothing says so.
-    await db.conversations.put({
-      id: "conv_1",
-      workspaceId,
-      _lastActivityMs: 3,
-      _cachedAt: 3,
-      conversation: { id: "conv_1", streamId: "stream_moved", messageIds: ["msg_1"] },
-      openingMessage: { id: "msg_1" },
-      recentMessages: [],
-    } as never)
+    await db.conversations.put(conversationRow({ streamId: "stream_moved", lastActivityMs: 3, cachedAt: 3 }))
     await waitFor(() =>
       expect(rebuilt.result.current.boardPostMap.get("conv_1")?.conversation.streamId).toBe("stream_moved")
     )

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -1,5 +1,5 @@
-import { useLiveQuery } from "dexie-react-hooks"
-import { useMemo } from "react"
+import { liveQuery, type Subscription } from "dexie"
+import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { db, type CachedBoardPost } from "@/db"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 
@@ -12,118 +12,170 @@ export interface BoardDraftContext {
   parentPostByBranchConversationId: Map<string, CachedBoardPost>
 }
 
+const EMPTY_CONTEXT: BoardDraftContext = {
+  boardPostMap: new Map(),
+  hostPostByMessageId: new Map(),
+  parentPostByBranchConversationId: new Map(),
+}
+
 /** Stable signature over a set of draft scopes — the gate every query below keys on. */
 export function draftScopesSignature(scopes: Iterable<string>): string {
   return [...new Set(scopes)].sort().join("|")
 }
 
+interface ScopeKeys {
+  conversationIdKey: string
+  branchConversationIdKey: string
+  subtopicMessageIdKey: string
+}
+
+function scopeKeys(scopesSignature: string): ScopeKeys {
+  const conversationIds = new Set<string>()
+  const branchConversationIds = new Set<string>()
+  const subtopicMessageIds = new Set<string>()
+  for (const scope of scopesSignature.split("|")) {
+    const parsed = parseBoardDraftKey(scope)
+    if (!parsed) continue
+    if (parsed.kind === "subtopic") subtopicMessageIds.add(parsed.messageId)
+    else conversationIds.add(parsed.conversationId)
+    if (parsed.kind === "branch-reply") branchConversationIds.add(parsed.conversationId)
+  }
+  return {
+    conversationIdKey: [...conversationIds].sort().join(","),
+    branchConversationIdKey: [...branchConversationIds].sort().join(","),
+    subtopicMessageIdKey: [...subtopicMessageIds].sort().join(","),
+  }
+}
+
+// Sub-topic drafts name only their fork message; branch drafts name a child
+// conversation whose parent must be derived structurally (its anchor thread's
+// parent message → the conversation holding it — sub-topic conversations carry
+// no `parentConversationId`). Both resolve to the HOSTING conversation the
+// explorer deep-links to, since that surface hosts the draft's composer.
+async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Promise<BoardDraftContext> {
+  const { conversationIdKey, branchConversationIdKey, subtopicMessageIdKey } = keys
+  if (!conversationIdKey && !subtopicMessageIdKey) return EMPTY_CONTEXT
+
+  const convIds = conversationIdKey ? conversationIdKey.split(",") : []
+  const branchIds = new Set(branchConversationIdKey ? branchConversationIdKey.split(",") : [])
+  const referencedRows = convIds.length > 0 ? await db.conversations.bulkGet(convIds) : []
+  const referenced = referencedRows.filter(
+    (row): row is CachedBoardPost => row !== undefined && row.workspaceId === workspaceId
+  )
+
+  const forkMessageIds = new Set(subtopicMessageIdKey ? subtopicMessageIdKey.split(",") : [])
+  const branchPosts = referenced.filter((row) => branchIds.has(row.id))
+  const threadRows =
+    branchPosts.length > 0 ? await db.streams.bulkGet(branchPosts.map((row) => row.conversation.streamId)) : []
+  const forkByBranchConversationId = new Map<string, string>()
+  branchPosts.forEach((row, i) => {
+    const forkAnchorId = threadRows[i]?.parentAnchorId ?? threadRows[i]?.parentMessageId
+    if (forkAnchorId) {
+      forkByBranchConversationId.set(row.id, forkAnchorId)
+      forkMessageIds.add(forkAnchorId)
+    }
+  })
+
+  const hostPostByMessageId = new Map<string, CachedBoardPost>()
+  let hostRows: CachedBoardPost[] = []
+  if (forkMessageIds.size > 0) {
+    const rows = await db.conversations.where("workspaceId").equals(workspaceId).toArray()
+    hostRows = rows.filter((row) => row.conversation.messageIds?.some((id: string) => forkMessageIds.has(id)))
+    for (const post of hostRows) {
+      for (const id of post.conversation.messageIds ?? []) {
+        if (forkMessageIds.has(id)) hostPostByMessageId.set(id, post)
+      }
+    }
+  }
+  const parentPostByBranchConversationId = new Map<string, CachedBoardPost>()
+  for (const [branchId, forkId] of forkByBranchConversationId) {
+    const host = hostPostByMessageId.get(forkId)
+    if (host) parentPostByBranchConversationId.set(branchId, host)
+  }
+
+  const boardPostMap = new Map<string, CachedBoardPost>()
+  for (const post of [...referenced, ...hostRows]) boardPostMap.set(post.id, post)
+  return { boardPostMap, hostPostByMessageId, parentPostByBranchConversationId }
+}
+
+interface BoardDraftContextEntry {
+  context: BoardDraftContext
+  listeners: Set<() => void>
+  subscription: Subscription
+  refCount: number
+}
+
+// INV-9 exception: one shared liveQuery per (workspace, referenced-id set),
+// ref-counted like `boardDraftsRegistry` in `use-scope-draft-preview.ts`. Two
+// consumers — the drafts explorer's location labels and the composer pile's
+// landing sites — mount this at once, and a per-mount `useLiveQuery` would run
+// the whole read (including the workspace-wide conversations scan the fork path
+// takes) once per consumer.
+const boardDraftContextRegistry = new Map<string, BoardDraftContextEntry>()
+
+function subscribeBoardDraftContext(
+  registryKey: string,
+  workspaceId: string,
+  keys: ScopeKeys,
+  listener: () => void
+): () => void {
+  let entry = boardDraftContextRegistry.get(registryKey)
+  if (!entry) {
+    const created: BoardDraftContextEntry = {
+      context: EMPTY_CONTEXT,
+      listeners: new Set(),
+      refCount: 0,
+      subscription: { unsubscribe() {} } as Subscription,
+    }
+    // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
+    // the callback re-reads the live entry so a late emission after teardown no-ops.
+    boardDraftContextRegistry.set(registryKey, created)
+    created.subscription = liveQuery(() => loadBoardDraftContext(workspaceId, keys)).subscribe((context) => {
+      const live = boardDraftContextRegistry.get(registryKey)
+      if (!live) return
+      live.context = context
+      for (const notify of live.listeners) notify()
+    })
+    entry = created
+  }
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  return () => {
+    const current = boardDraftContextRegistry.get(registryKey)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) {
+      current.subscription.unsubscribe()
+      boardDraftContextRegistry.delete(registryKey)
+    }
+  }
+}
+
 /**
  * The cached conversations a set of `board:*` draft scopes references, resolved
  * once for every consumer (the drafts explorer's location labels, the composer
- * pile's landing sites) so the two can't drift (INV-35). Every query is keyed on
- * an id signature derived from `scopesSignature`, never on the drafts array, so a
- * keystroke's draft write doesn't re-fire it — the property an always-mounted
- * composer depends on.
+ * pile's landing sites) so the two can't drift (INV-35). Keyed on the ids the
+ * scopes reference, never on the drafts array, so a keystroke's draft write
+ * doesn't re-fire it — the property an always-mounted composer depends on.
  */
 export function useBoardDraftContext(workspaceId: string, scopesSignature: string): BoardDraftContext {
-  const boardConversationIdKey = useMemo(() => {
-    const ids = new Set<string>()
-    for (const scope of scopesSignature.split("|")) {
-      const parsed = parseBoardDraftKey(scope)
-      if (parsed && parsed.kind !== "subtopic") ids.add(parsed.conversationId)
-    }
-    return [...ids].sort().join(",")
-  }, [scopesSignature])
-
-  const boardBranchConversationIdKey = useMemo(() => {
-    const ids = new Set<string>()
-    for (const scope of scopesSignature.split("|")) {
-      const parsed = parseBoardDraftKey(scope)
-      if (parsed?.kind === "branch-reply") ids.add(parsed.conversationId)
-    }
-    return [...ids].sort().join(",")
-  }, [scopesSignature])
-
-  // Sub-topic drafts name only their fork message; branch drafts name a child
-  // conversation whose parent must be derived structurally (its anchor thread's
-  // parent message → the conversation holding it — sub-topic conversations
-  // carry no `parentConversationId`). Both resolve to the HOSTING conversation
-  // the explorer deep-links to, since that surface hosts the draft's composer.
-  const subtopicMessageIdKey = useMemo(() => {
-    const ids = new Set<string>()
-    for (const scope of scopesSignature.split("|")) {
-      const parsed = parseBoardDraftKey(scope)
-      if (parsed?.kind === "subtopic") ids.add(parsed.messageId)
-    }
-    return [...ids].sort().join(",")
-  }, [scopesSignature])
-
-  const emptyBoardContext = useMemo(
-    () => ({
-      posts: [] as CachedBoardPost[],
-      hostPostByMessageId: new Map<string, CachedBoardPost>(),
-      parentPostByBranchConversationId: new Map<string, CachedBoardPost>(),
-    }),
-    []
+  const keys = useMemo(() => scopeKeys(scopesSignature), [scopesSignature])
+  const registryKey = `${workspaceId} ${keys.conversationIdKey} ${keys.branchConversationIdKey} ${keys.subtopicMessageIdKey}`
+  const subscribe = useCallback(
+    (onChange: () => void) => subscribeBoardDraftContext(registryKey, workspaceId, keys, onChange),
+    [registryKey, workspaceId, keys]
   )
-
-  const boardDraftContext = useLiveQuery(
-    async () => {
-      if (!boardConversationIdKey && !subtopicMessageIdKey) return emptyBoardContext
-      const convIds = boardConversationIdKey ? boardConversationIdKey.split(",") : []
-      const branchIds = new Set(boardBranchConversationIdKey ? boardBranchConversationIdKey.split(",") : [])
-      const referencedRows = convIds.length > 0 ? await db.conversations.bulkGet(convIds) : []
-      const referenced = referencedRows.filter(
-        (row): row is CachedBoardPost => row !== undefined && row.workspaceId === workspaceId
-      )
-
-      const forkMessageIds = new Set(subtopicMessageIdKey ? subtopicMessageIdKey.split(",") : [])
-      const branchPosts = referenced.filter((row) => branchIds.has(row.id))
-      const threadRows =
-        branchPosts.length > 0 ? await db.streams.bulkGet(branchPosts.map((row) => row.conversation.streamId)) : []
-      const forkByBranchConversationId = new Map<string, string>()
-      branchPosts.forEach((row, i) => {
-        const forkAnchorId = threadRows[i]?.parentAnchorId ?? threadRows[i]?.parentMessageId
-        if (forkAnchorId) {
-          forkByBranchConversationId.set(row.id, forkAnchorId)
-          forkMessageIds.add(forkAnchorId)
-        }
-      })
-
-      const hostPostByMessageId = new Map<string, CachedBoardPost>()
-      let hostRows: CachedBoardPost[] = []
-      if (forkMessageIds.size > 0) {
-        const rows = await db.conversations.where("workspaceId").equals(workspaceId).toArray()
-        hostRows = rows.filter((row) => row.conversation.messageIds?.some((id: string) => forkMessageIds.has(id)))
-        for (const post of hostRows) {
-          for (const id of post.conversation.messageIds ?? []) {
-            if (forkMessageIds.has(id)) hostPostByMessageId.set(id, post)
-          }
-        }
-      }
-      const parentPostByBranchConversationId = new Map<string, CachedBoardPost>()
-      for (const [branchId, forkId] of forkByBranchConversationId) {
-        const host = hostPostByMessageId.get(forkId)
-        if (host) parentPostByBranchConversationId.set(branchId, host)
-      }
-      return { posts: [...referenced, ...hostRows], hostPostByMessageId, parentPostByBranchConversationId }
-    },
-    [boardConversationIdKey, boardBranchConversationIdKey, subtopicMessageIdKey, workspaceId, emptyBoardContext],
-    emptyBoardContext
+  const getSnapshot = useCallback(
+    () => boardDraftContextRegistry.get(registryKey)?.context ?? EMPTY_CONTEXT,
+    [registryKey]
   )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
 
-  const posts = boardDraftContext.posts
-
-  const boardPostMap = useMemo(() => {
-    const map = new Map<string, CachedBoardPost>()
-    for (const post of posts ?? []) map.set(post.id, post)
-    return map
-  }, [posts])
-
-  const { hostPostByMessageId, parentPostByBranchConversationId } = boardDraftContext
-
-  return useMemo(
-    () => ({ boardPostMap, hostPostByMessageId, parentPostByBranchConversationId }),
-    [boardPostMap, hostPostByMessageId, parentPostByBranchConversationId]
-  )
+/** Tear down every shared board-draft-context subscription — for tests, so a
+ *  module-level registry can't leak a liveQuery (or a snapshot) across cases. */
+export function __clearBoardDraftContextRegistry(): void {
+  for (const entry of boardDraftContextRegistry.values()) entry.subscription.unsubscribe()
+  boardDraftContextRegistry.clear()
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -1,5 +1,6 @@
 import { liveQuery, type Subscription } from "dexie"
 import { useCallback, useMemo, useSyncExternalStore } from "react"
+import { THREAD_ANCHORABLE_EVENT_TYPES } from "@threa/types"
 import { db, type CachedBoardPost } from "@/db"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 
@@ -98,42 +99,44 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
   return { boardPostMap, hostPostByMessageId, parentPostByBranchConversationId }
 }
 
-interface BoardDraftContextEntry {
-  context: BoardDraftContext
+interface SharedEntry<T> {
+  value: T
   listeners: Set<() => void>
   subscription: Subscription
   refCount: number
 }
 
 // INV-9 exception: one shared liveQuery per (workspace, referenced-id set),
-// ref-counted like `boardDraftsRegistry` in `use-scope-draft-preview.ts`. Two
-// consumers — the drafts explorer's location labels and the composer pile's
-// landing sites — mount this at once, and a per-mount `useLiveQuery` would run
-// the whole read (including the workspace-wide conversations scan the fork path
-// takes) once per consumer.
-const boardDraftContextRegistry = new Map<string, BoardDraftContextEntry>()
+// ref-counted like `boardDraftsRegistry` in `use-scope-draft-preview.ts`. Several
+// consumers — the drafts explorer's location labels, the sidebar badge, and the
+// composer pile (which mounts in the timeline, the board card and the stream
+// panel at once) — subscribe simultaneously, and a per-mount `useLiveQuery` would
+// run the whole read once per consumer on every write it observes.
+const boardDraftContextRegistry = new Map<string, SharedEntry<BoardDraftContext>>()
+const threadAnchorContextRegistry = new Map<string, SharedEntry<ThreadAnchorContext>>()
 
-function subscribeBoardDraftContext(
+function subscribeShared<T>(
+  registry: Map<string, SharedEntry<T>>,
   registryKey: string,
-  workspaceId: string,
-  keys: ScopeKeys,
+  empty: T,
+  query: () => Promise<T>,
   listener: () => void
 ): () => void {
-  let entry = boardDraftContextRegistry.get(registryKey)
+  let entry = registry.get(registryKey)
   if (!entry) {
-    const created: BoardDraftContextEntry = {
-      context: EMPTY_CONTEXT,
+    const created: SharedEntry<T> = {
+      value: empty,
       listeners: new Set(),
       refCount: 0,
       subscription: { unsubscribe() {} } as Subscription,
     }
     // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
     // the callback re-reads the live entry so a late emission after teardown no-ops.
-    boardDraftContextRegistry.set(registryKey, created)
-    created.subscription = liveQuery(() => loadBoardDraftContext(workspaceId, keys)).subscribe((context) => {
-      const live = boardDraftContextRegistry.get(registryKey)
+    registry.set(registryKey, created)
+    created.subscription = liveQuery(query).subscribe((value) => {
+      const live = registry.get(registryKey)
       if (!live) return
-      live.context = context
+      live.value = value
       for (const notify of live.listeners) notify()
     })
     entry = created
@@ -141,13 +144,13 @@ function subscribeBoardDraftContext(
   entry.listeners.add(listener)
   entry.refCount += 1
   return () => {
-    const current = boardDraftContextRegistry.get(registryKey)
+    const current = registry.get(registryKey)
     if (!current) return
     current.listeners.delete(listener)
     current.refCount -= 1
     if (current.refCount <= 0) {
       current.subscription.unsubscribe()
-      boardDraftContextRegistry.delete(registryKey)
+      registry.delete(registryKey)
     }
   }
 }
@@ -163,19 +166,101 @@ export function useBoardDraftContext(workspaceId: string, scopesSignature: strin
   const keys = useMemo(() => scopeKeys(scopesSignature), [scopesSignature])
   const registryKey = `${workspaceId} ${keys.conversationIdKey} ${keys.branchConversationIdKey} ${keys.subtopicMessageIdKey}`
   const subscribe = useCallback(
-    (onChange: () => void) => subscribeBoardDraftContext(registryKey, workspaceId, keys, onChange),
+    (onChange: () => void) =>
+      subscribeShared(
+        boardDraftContextRegistry,
+        registryKey,
+        EMPTY_CONTEXT,
+        () => loadBoardDraftContext(workspaceId, keys),
+        onChange
+      ),
     [registryKey, workspaceId, keys]
   )
   const getSnapshot = useCallback(
-    () => boardDraftContextRegistry.get(registryKey)?.context ?? EMPTY_CONTEXT,
+    () => boardDraftContextRegistry.get(registryKey)?.value ?? EMPTY_CONTEXT,
     [registryKey]
   )
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
-/** Tear down every shared board-draft-context subscription — for tests, so a
- *  module-level registry can't leak a liveQuery (or a snapshot) across cases. */
+/**
+ * What a set of thread/card anchor ids resolves to: the stream holding the
+ * anchored row (a `thread:` draft's home) and the conversation that owns it (the
+ * pile's same-conversation route).
+ */
+export interface ThreadAnchorContext {
+  /** Anchor id → the stream holding the anchored message/card. */
+  streamByAnchorId: Map<string, { streamId: string; anchorId: string }>
+  /** Anchor id → the conversation that contains it, where one is cached. */
+  conversationIdByAnchorId: Map<string, string>
+}
+
+const EMPTY_ANCHOR_CONTEXT: ThreadAnchorContext = { streamByAnchorId: new Map(), conversationIdByAnchorId: new Map() }
+
+// Both reads are keyed lookups over the ids actually referenced: the sparse
+// `payload.messageId` index (v47) for message anchors, the primary key for card
+// anchors and for the conversation-backfill rows. Nothing scans the events table
+// or the whole workspace, so an always-mounted composer's subscription re-fires
+// only on writes touching an id it asked for.
+async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string): Promise<ThreadAnchorContext> {
+  if (!anchorIdKey) return EMPTY_ANCHOR_CONTEXT
+  const anchorIds = anchorIdKey.split("|")
+
+  const streamByAnchorId = new Map<string, { streamId: string; anchorId: string }>()
+  const messageRows = await db.events.where("payload.messageId").anyOf(anchorIds).toArray()
+  for (const event of messageRows) {
+    if (event.eventType !== "message_created") continue
+    if (event.workspaceId != null && event.workspaceId !== workspaceId) continue
+    const messageId = (event.payload as { messageId?: string }).messageId
+    if (messageId) streamByAnchorId.set(messageId, { streamId: event.streamId, anchorId: messageId })
+  }
+  const cardRows = await db.events.bulkGet(anchorIds)
+  for (const event of cardRows) {
+    if (!event || !THREAD_ANCHORABLE_EVENT_TYPES.includes(event.eventType)) continue
+    if (event.workspaceId != null && event.workspaceId !== workspaceId) continue
+    streamByAnchorId.set(event.id, { streamId: event.streamId, anchorId: event.id })
+  }
+
+  const conversationIdByAnchorId = new Map<string, string>()
+  const conversationRows = await db.conversationMessages.bulkGet(anchorIds)
+  for (const row of conversationRows) {
+    if (row?.workspaceId === workspaceId) conversationIdByAnchorId.set(row.messageId, row.conversationId)
+  }
+
+  return { streamByAnchorId, conversationIdByAnchorId }
+}
+
+/**
+ * The cached rows a set of anchor ids points at, resolved once for every
+ * consumer (the drafts explorer, the sidebar badge, the composer pile). The
+ * signature is the anchor ids themselves, so a keystroke's draft write doesn't
+ * re-fire it and an anchor nobody references is never read.
+ */
+export function useThreadAnchorContext(workspaceId: string, anchorIdsSignature: string): ThreadAnchorContext {
+  const registryKey = `${workspaceId} ${anchorIdsSignature}`
+  const subscribe = useCallback(
+    (onChange: () => void) =>
+      subscribeShared(
+        threadAnchorContextRegistry,
+        registryKey,
+        EMPTY_ANCHOR_CONTEXT,
+        () => loadThreadAnchorContext(workspaceId, anchorIdsSignature),
+        onChange
+      ),
+    [registryKey, workspaceId, anchorIdsSignature]
+  )
+  const getSnapshot = useCallback(
+    () => threadAnchorContextRegistry.get(registryKey)?.value ?? EMPTY_ANCHOR_CONTEXT,
+    [registryKey]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** Tear down every shared subscription — for tests, so a module-level registry
+ *  can't leak a liveQuery (or a snapshot) across cases. */
 export function __clearBoardDraftContextRegistry(): void {
-  for (const entry of boardDraftContextRegistry.values()) entry.subscription.unsubscribe()
-  boardDraftContextRegistry.clear()
+  for (const registry of [boardDraftContextRegistry, threadAnchorContextRegistry]) {
+    for (const entry of registry.values()) entry.subscription.unsubscribe()
+    registry.clear()
+  }
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -160,14 +160,21 @@ function subscribeShared<T>(
   }
   entry.listeners.add(listener)
   entry.refCount += 1
+  // Hold the entry this subscriber incremented, not the key. The error path
+  // above can delete an entry and a later subscriber rebuild it under the same
+  // key, and a cleanup that re-looked-up would then decrement the REPLACEMENT —
+  // unsubscribing it while its own owner is still mounted, which serves `empty`
+  // for the page's lifetime and collapses every pile to scope-exact: exactly the
+  // failure the error observer exists to prevent, one layer down.
+  const owned = entry
   return () => {
-    const current = registry.get(registryKey)
-    if (!current) return
-    current.listeners.delete(listener)
-    current.refCount -= 1
-    if (current.refCount <= 0) {
-      current.subscription.unsubscribe()
-      registry.delete(registryKey)
+    owned.listeners.delete(listener)
+    owned.refCount -= 1
+    if (owned.refCount <= 0) {
+      owned.subscription.unsubscribe()
+      // Only if it is still the registered one — an orphan tears down its own
+      // subscription and leaves the replacement alone.
+      if (registry.get(registryKey) === owned) registry.delete(registryKey)
     }
   }
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -133,11 +133,28 @@ function subscribeShared<T>(
     // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
     // the callback re-reads the live entry so a late emission after teardown no-ops.
     registry.set(registryKey, created)
-    created.subscription = liveQuery(query).subscribe((value) => {
-      const live = registry.get(registryKey)
-      if (!live) return
-      live.value = value
-      for (const notify of live.listeners) notify()
+    created.subscription = liveQuery(query).subscribe({
+      next(value) {
+        const live = registry.get(registryKey)
+        if (!live) return
+        live.value = value
+        for (const notify of live.listeners) notify()
+      },
+      // An error observer is not optional here. Without one Dexie drops the
+      // rejection silently, and a FIRST-run failure also leaves the observable
+      // with no tracked ranges, so it never re-queries — the entry would serve
+      // `empty` for the page's lifetime and every pile would collapse to
+      // scope-exact with no signal (INV-11). Dropping the entry lets the next
+      // subscriber rebuild it; `useLiveQuery`, which this replaced, surfaced the
+      // same failure by re-throwing in render.
+      error(err: unknown) {
+        console.error(`[draft-context] shared query failed for ${registryKey}`, err)
+        const live = registry.get(registryKey)
+        if (!live) return
+        registry.delete(registryKey)
+        live.subscription.unsubscribe()
+        for (const notify of live.listeners) notify()
+      },
     })
     entry = created
   }

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, type ChangeEvent, type RefObject } from "react"
+import { useState, useCallback, useEffect, useRef, useSyncExternalStore, type ChangeEvent, type RefObject } from "react"
 import { useDraftMessage } from "./use-draft-message"
 import { useAttachments, type PendingAttachment, type UploadResult } from "./use-attachments"
 import type { JSONContent } from "@threa/types"
@@ -7,21 +7,53 @@ import type { DraftContextRef } from "@/lib/context-bag/types"
 import type { DraftAttachment } from "@/db"
 import { wasDraftResolvedLocally } from "@/sync/draft-resolution-guard"
 
-// Mounted composers per draft scope. More than one live composer on a scope is a
-// precondition for the rescue below: with only this one, a vanishing loaded
-// pointer is always this composer's own teardown. Ref-counted like
-// `boardDraftsRegistry` in `use-scope-draft-preview.ts` (INV-9 exception:
-// process-wide by construction).
-const mountedComposersByScope = new Map<string, number>()
+// Mounted composers per draft scope, in mount order. More than one live composer
+// on a scope is a precondition for the rescue below: with only this one, a
+// vanishing loaded pointer is always this composer's own teardown. The order is
+// what makes the `?stash=` claim single-valued — the first still-mounted composer
+// on a scope owns the param, so a board card and a conversation panel on the same
+// scope can't both restore it. Registry like `boardDraftsRegistry` in
+// `use-scope-draft-preview.ts` (INV-9 exception: process-wide by construction).
+const mountedComposersByScope = new Map<string, string[]>()
+const composerRegistryListeners = new Set<() => void>()
 
-function registerComposer(key: string): () => void {
-  mountedComposersByScope.set(key, (mountedComposersByScope.get(key) ?? 0) + 1)
+function mountedComposerCount(key: string): number {
+  return mountedComposersByScope.get(key)?.length ?? 0
+}
+
+function registerComposer(key: string, token: string): () => void {
+  const tokens = mountedComposersByScope.get(key)
+  if (tokens) tokens.push(token)
+  else mountedComposersByScope.set(key, [token])
+  for (const notify of composerRegistryListeners) notify()
   return () => {
-    const next = (mountedComposersByScope.get(key) ?? 1) - 1
-    if (next <= 0) mountedComposersByScope.delete(key)
-    else mountedComposersByScope.set(key, next)
+    const live = mountedComposersByScope.get(key)
+    if (!live) return
+    const at = live.indexOf(token)
+    if (at >= 0) live.splice(at, 1)
+    if (live.length === 0) mountedComposersByScope.delete(key)
+    for (const notify of composerRegistryListeners) notify()
   }
 }
+
+function subscribeComposerRegistry(listener: () => void): () => void {
+  composerRegistryListeners.add(listener)
+  return () => composerRegistryListeners.delete(listener)
+}
+
+/**
+ * Whether this composer is the one host that consumes a `?stash=` deep link for
+ * its scope. Exactly one mounted composer per scope answers true; the rest defer,
+ * leaving the param for the claimant rather than each restoring it.
+ */
+function useIsStashClaimant(scopeRegistryKey: string, token: string): boolean {
+  return useSyncExternalStore(
+    subscribeComposerRegistry,
+    () => mountedComposersByScope.get(scopeRegistryKey)?.[0] === token
+  )
+}
+
+let composerTokenSeq = 0
 
 /** Uploaded (non-temp, non-failed) attachments in the shape the draft row stores. */
 function persistableAttachments(pending: PendingAttachment[]): DraftAttachment[] {
@@ -118,6 +150,13 @@ export interface DraftComposerState {
   isDecrypting: boolean
   /** An E2E draft whose sealed body couldn't be decrypted (wrong recipient / garbled). */
   decryptFailed: boolean
+  /**
+   * True for the single host that consumes a `?stash=<id>` deep link for this
+   * scope. Several composers can mount one scope (a board card and the
+   * conversation panel's footer are the standing case) — only the first one
+   * mounted restores the deep-linked row.
+   */
+  isStashClaimant: boolean
 }
 
 export function useDraftComposer({
@@ -207,7 +246,11 @@ export function useDraftComposer({
   savedAttachmentsRef.current = savedAttachments
 
   const scopeRegistryKey = `${workspaceId} ${draftKey}`
-  useEffect(() => registerComposer(scopeRegistryKey), [scopeRegistryKey])
+  const composerTokenRef = useRef<string | null>(null)
+  if (composerTokenRef.current === null) composerTokenRef.current = `composer_${++composerTokenSeq}`
+  const composerToken = composerTokenRef.current
+  useEffect(() => registerComposer(scopeRegistryKey, composerToken), [scopeRegistryKey, composerToken])
+  const isStashClaimant = useIsStashClaimant(scopeRegistryKey, composerToken)
 
   // Persist the live editor content into the loaded draft row immediately
   // (sealed for E2E), but ONLY when it is non-empty. A stash/restore can fire
@@ -358,7 +401,7 @@ export function useDraftComposer({
       // only a local resolve-on-send marks the id, so a remote `draft:deleted`
       // reads false and stays deleted instead of being resurrected by whichever
       // device happens to hold the composer open.
-      if ((mountedComposersByScope.get(scopeRegistryKey) ?? 0) > 1 && wasDraftResolvedLocally(prev)) {
+      if (mountedComposerCount(scopeRegistryKey) > 1 && wasDraftResolvedLocally(prev)) {
         saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot())).catch((err) => {
           console.error("Failed to persist draft rescued from a resolved row", err)
         })
@@ -498,5 +541,6 @@ export function useDraftComposer({
     isLoaded: isDraftLoaded,
     isDecrypting,
     decryptFailed,
+    isStashClaimant,
   }
 }

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -7,8 +7,9 @@ import { db } from "@/db"
 import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
 import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 import { useDraftComposer } from "./use-draft-composer"
-import { useStashComposer } from "./use-stash-composer"
-import { upsertLoadedDraft, stashLoadedDraft } from "./use-draft-message"
+import { useStashComposer, useStashParamDraftRow } from "./use-stash-composer"
+import { upsertLoadedDraft, stashLoadedDraft, restoreStashedDraftToComposer } from "./use-draft-message"
+import * as draftMessageModule from "./use-draft-message"
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
 
@@ -134,6 +135,25 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
     await waitFor(() => expect(result.current.stash.drafts.some((d) => d.id === ambientId)).toBe(true))
   })
 
+  it("refuses to restore a row this scope cannot claim", async () => {
+    const { bigId } = await seedStashAndAmbient()
+    const restoreSpy = vi.spyOn(draftMessageModule, "restoreStashedDraftToComposer")
+    const foreignKey = "board:reply:conv_1"
+
+    // Restore is a pointer move within the row's own scope; adopting a foreign row
+    // is chunk 4's job. Until then a foreign id must not migrate the row's scope.
+    const { result } = renderHook(() => useRestoreHarness(foreignKey, foreignKey), { wrapper })
+    await waitFor(() => expect(result.current.composer.isLoaded).toBe(true))
+
+    await act(async () => {
+      await result.current.stash.handleRestoreStashed(bigId)
+    })
+
+    expect(restoreSpy).not.toHaveBeenCalled()
+    expect((await db.composerLoaded.get(foreignKey))?.draftId).not.toBe(bigId)
+    expect((await db.drafts.get(bigId))?.scope).toBe(draftKey)
+  })
+
   it("?stash= auto-restore is consumed only by the host whose scope owns the row", async () => {
     const { bigId } = await seedStashAndAmbient()
     const foreignKey = "board:reply:conv_1"
@@ -155,5 +175,58 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
     // The owning host consumes it and checks the row out.
     renderHook(() => useRestoreHarness(), { wrapper: urlWrapper })
     await waitFor(async () => expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId))
+  })
+
+  it("restores exactly once when two composers are mounted on the same scope", async () => {
+    const { bigId, ambientId } = await seedStashAndAmbient()
+
+    function urlWrapper({ children }: { children: ReactNode }) {
+      return createElement(MemoryRouter, { initialEntries: [`/?stash=${bigId}`] }, children)
+    }
+
+    // A board card and the conversation panel's footer are the standing case:
+    // both mount the same scope, so membership alone let both restore — the
+    // second restore would stash the first's just-restored row straight back.
+    const restoreSpy = vi.spyOn(draftMessageModule, "restoreStashedDraftToComposer")
+    const { result } = renderHook(() => ({ first: useRestoreHarness(), second: useRestoreHarness() }), {
+      wrapper: urlWrapper,
+    })
+    await waitFor(() => expect(result.current.first.composer.isLoaded).toBe(true))
+    await waitFor(() => expect(result.current.second.composer.isLoaded).toBe(true))
+
+    expect(result.current.first.composer.isStashClaimant).toBe(true)
+    expect(result.current.second.composer.isStashClaimant).toBe(false)
+
+    await waitFor(async () => expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    })
+    // One restore, not two: the non-claimant left the param alone.
+    expect(restoreSpy.mock.calls.map((call) => call[2])).toEqual([bigId])
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId)
+    expect(await db.drafts.get(ambientId)).toBeDefined()
+  })
+
+  // The conversation panel keys "should I pop the footer composer open?" on this
+  // flag. Without it, revisiting a deep link whose draft is already checked out
+  // re-opens and refocuses the composer for a restore that has nothing left to do.
+  it("reports a deep-linked row as already loaded once its own scope holds it", async () => {
+    const { bigId } = await seedStashAndAmbient()
+
+    function urlWrapper({ children }: { children: ReactNode }) {
+      return createElement(MemoryRouter, { initialEntries: [`/?stash=${bigId}`] }, children)
+    }
+
+    // No composer harness here: mounting one would consume the param itself and
+    // race the assertion. The flag is read by hosts that only OBSERVE the param.
+    const { result } = renderHook(() => useStashParamDraftRow(workspaceId), { wrapper: urlWrapper })
+    await waitFor(() => expect(result.current?.draftId).toBe(bigId))
+    expect(result.current?.isLoadedForScope).toBe(false)
+
+    await act(async () => {
+      await restoreStashedDraftToComposer(workspaceId, draftKey, bigId)
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    await waitFor(() => expect(result.current?.isLoadedForScope).toBe(true))
   })
 })

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db } from "@/db"
-import { useComposerLoadedFromStore } from "@/stores/draft-store"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { restoreStashedDraftToComposer, stashLoadedDraft } from "./use-draft-message"
 import { useStashedDrafts, type CachedDraft, type StashedDraftOrigin } from "./use-stashed-drafts"
@@ -53,13 +52,21 @@ export function useStashParamDraftRow(
 ): { draftId: string; scope: string; isLoadedForScope: boolean } | null {
   const [searchParams] = useSearchParams()
   const draftId = searchParams.get("stash")
-  const row = useLiveQuery(() => (draftId ? db.drafts.get(draftId) : undefined), [draftId])
-  const loaded = useComposerLoadedFromStore(workspaceId)
-  if (!draftId || !row || row.workspaceId !== workspaceId) return null
+  // The pointer is read inside the SAME point query as the row, not through the
+  // workspace-wide composer-loaded store: this hook mounts per board card, and a
+  // store subscription would re-render every one of them whenever any composer
+  // anywhere checks a draft in or out.
+  const found = useLiveQuery(async () => {
+    if (!draftId) return undefined
+    const draft = await db.drafts.get(draftId)
+    if (!draft) return undefined
+    const pointer = await db.composerLoaded.get(draft.scope)
+    return { draft, isLoadedForScope: pointer?.draftId === draftId }
+  }, [draftId])
+  if (!draftId || !found || found.draft.workspaceId !== workspaceId) return null
   // Already checked out into its own scope's composer: a deep link to it has
   // nothing to restore, so a consumer must not treat it as a pending one.
-  const isLoadedForScope = loaded.some((entry) => entry.scope === row.scope && entry.draftId === draftId)
-  return { draftId, scope: row.scope, isLoadedForScope }
+  return { draftId, scope: found.draft.scope, isLoadedForScope: found.isLoadedForScope }
 }
 
 export function useStashComposer(

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -2,14 +2,21 @@ import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db } from "@/db"
+import { useComposerLoadedFromStore } from "@/stores/draft-store"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { restoreStashedDraftToComposer, stashLoadedDraft } from "./use-draft-message"
-import { useStashedDrafts, type CachedDraft } from "./use-stashed-drafts"
+import { useStashedDrafts, type CachedDraft, type StashedDraftOrigin } from "./use-stashed-drafts"
 import type { DraftComposerState } from "./use-draft-composer"
 
 export interface UseStashComposerResult {
-  /** Stashed drafts for the current scope, newest first. Empty when `scope` is undefined. */
+  /** The landing-site-wide pile, newest first. Not rendered yet — restore can't leave a scope safely until chunk 4. */
   drafts: CachedDraft[]
+  /** What the picker renders and what `handleRestoreStashed` accepts: this scope's own rows. */
+  claimableDrafts: CachedDraft[]
+  /** Where each pile row came from, keyed by draft id (structured; the caller formats). */
+  originByDraftId: Map<string, StashedDraftOrigin>
+  /** Tell the pile whether the picker is open, so membership latches while it is. */
+  setPileOpen: (open: boolean) => void
   /** Snapshot the current composer content into the stash, clear the editor. Empty composer → silent no-op. */
   handleStashDraft: () => Promise<void>
   /** Swap: stash current content first (if any), then load the chosen stashed row into the composer. */
@@ -41,12 +48,18 @@ export interface UseStashComposerResult {
  * to mount per board card. Returns null when there is no param, the row hasn't
  * synced yet, or it belongs to another workspace.
  */
-export function useStashParamDraftRow(workspaceId: string): { draftId: string; scope: string } | null {
+export function useStashParamDraftRow(
+  workspaceId: string
+): { draftId: string; scope: string; isLoadedForScope: boolean } | null {
   const [searchParams] = useSearchParams()
   const draftId = searchParams.get("stash")
   const row = useLiveQuery(() => (draftId ? db.drafts.get(draftId) : undefined), [draftId])
+  const loaded = useComposerLoadedFromStore(workspaceId)
   if (!draftId || !row || row.workspaceId !== workspaceId) return null
-  return { draftId, scope: row.scope }
+  // Already checked out into its own scope's composer: a deep link to it has
+  // nothing to restore, so a consumer must not treat it as a pending one.
+  const isLoadedForScope = loaded.some((entry) => entry.scope === row.scope && entry.draftId === draftId)
+  return { draftId, scope: row.scope, isLoadedForScope }
 }
 
 export function useStashComposer(
@@ -77,6 +90,13 @@ export function useStashComposer(
   const handleRestoreStashed = useCallback(
     async (id: string) => {
       if (!scope) return
+      // Restore is a pointer move within the row's own scope: hydration is
+      // pointer-based, so a foreign row would render here and the next debounced
+      // save would rewrite its `scope` to this host's — a silent migration pushed
+      // through a coalescing enqueue that can lose the move server-side. Adopting
+      // or moving a foreign row is chunk 4's job; until then a non-claimable id
+      // does not restore.
+      if (!stashedDrafts.claimableDrafts.some((draft) => draft.id === id)) return
       // Swap semantics: flush whatever the composer holds into its row first so
       // switching drafts never silently destroys work — it stays as a stash entry
       // once the pointer moves off it. `flushDraft` only persists a non-empty
@@ -94,7 +114,7 @@ export function useStashComposer(
       // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
       composer.markNeedsRehydrate()
     },
-    [composer, workspaceId, scope]
+    [composer, workspaceId, scope, stashedDrafts.claimableDrafts]
   )
 
   const handleDeleteStashed = useCallback(
@@ -114,12 +134,15 @@ export function useStashComposer(
   useEffect(() => {
     const stashId = searchParams.get("stash")
     if (!stashId || !scope || !composer.isLoaded) return
-    // Only the host whose scope owns the row consumes the param. Several hosts
-    // can mount this hook at once (stream composer + thread panel + inline
-    // reply forms); restoring a foreign id would point THIS scope's loaded
-    // draft at another scope's row, splitting one draft across two composers.
-    // Skipping (without stripping) leaves the param for the owning host.
-    if (!stashedDrafts.drafts.some((draft) => draft.id === stashId)) return
+    // Two gates, both load-bearing. The row must belong to THIS scope
+    // (`claimableDrafts`, not the landing-site-wide pile): restoring a foreign id
+    // would point this scope's loaded draft at another scope's row, splitting one
+    // draft across two composers. And this composer must hold the scope's claim —
+    // a board card and the conversation panel's footer mount the same scope, so
+    // membership alone let both restore. A non-claimant skips WITHOUT stripping,
+    // leaving the param for the claimant.
+    if (!composer.isStashClaimant) return
+    if (!stashedDrafts.claimableDrafts.some((draft) => draft.id === stashId)) return
     if (pendingStashRestoreRef.current === stashId) return
 
     pendingStashRestoreRef.current = stashId
@@ -136,10 +159,21 @@ export function useStashComposer(
         console.error("Failed to auto-restore stashed draft from URL", err)
       }
     )
-  }, [searchParams, setSearchParams, scope, composer.isLoaded, stashedDrafts.drafts, handleRestoreStashed])
+  }, [
+    searchParams,
+    setSearchParams,
+    scope,
+    composer.isLoaded,
+    composer.isStashClaimant,
+    stashedDrafts.claimableDrafts,
+    handleRestoreStashed,
+  ])
 
   return {
     drafts: stashedDrafts.drafts,
+    claimableDrafts: stashedDrafts.claimableDrafts,
+    originByDraftId: stashedDrafts.originByDraftId,
+    setPileOpen: stashedDrafts.setPileOpen,
     handleStashDraft,
     handleRestoreStashed,
     handleDeleteStashed,

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -126,24 +126,54 @@ function seedConversation(
   } as never)
 }
 
+/** Seed a `message_created` event so a `thread:<anchor>` draft resolves a host stream. */
+function seedThreadAnchor(messageId: string, streamId: string): Promise<unknown> {
+  return db.events.put({
+    id: `evt_${messageId}`,
+    workspaceId: pileWorkspaceId,
+    streamId,
+    eventType: "message_created",
+    payload: { messageId },
+    sequence: "1",
+    _sequenceNum: 1,
+    actorId: null,
+    actorType: null,
+    createdAt: new Date(1000).toISOString(),
+  } as never)
+}
+
 async function expectPile(scope: string, ids: string[]) {
   const { result, unmount } = renderHook(() => useStashedDrafts(pileWorkspaceId, scope))
   await waitFor(() => expect(result.current.drafts.map((d) => d.id).sort()).toEqual([...ids].sort()))
   unmount()
 }
 
-describe("useStashedDrafts — landing-site membership", () => {
+/** A conversation-backfill row: the point-read route from a message to its conversation. */
+function seedConversationMessage(messageId: string, conversationId: string, streamId: string): Promise<unknown> {
+  return db.conversationMessages.put({
+    messageId,
+    id: messageId,
+    conversationId,
+    workspaceId: pileWorkspaceId,
+    streamId,
+    _cachedAt: 1,
+  } as never)
+}
+
+describe("useStashedDrafts — pile membership", () => {
   beforeEach(async () => {
     __clearBoardDraftContextRegistry()
     await db.conversations.clear()
+    await db.conversationMessages.clear()
     await db.streams.clear()
+    await db.events.clear()
   })
 
   afterEach(() => {
     __clearBoardDraftContextRegistry()
   })
 
-  it("shares a pile both ways between a stream and a conversation that lands flat in it", async () => {
+  it("shares a pile both ways between a stream and a conversation anchored in it", async () => {
     await seedStream("stream_s")
     await seedConversation("conv_1", "stream_s")
     await db.drafts.bulkAdd([
@@ -155,47 +185,167 @@ describe("useStashedDrafts — landing-site membership", () => {
     await expectPile("stream:stream_s", ["draft_stream", "draft_conv"])
   })
 
-  it("keeps a lone channel conversation's reply out of every flat pile (its reply opens a thread)", async () => {
+  // Replying to a conversation is a top-level act in its stream, so a lone
+  // conversation's reply — which would convert its opener into a thread — is
+  // still something the user might have said in the channel instead.
+  it("includes a lone channel conversation's reply in the channel's pile, tiered borrowed", async () => {
     await seedStream("stream_s")
     await seedConversation("conv_lone", "stream_s", { messageIds: ["msg_1"], openingMessageId: "msg_1" })
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
       draftRow({ id: "draft_lone", scope: "board:reply:conv_lone" }),
-      draftRow({ id: "draft_lone_2", scope: "board:reply:conv_lone", clientUpdatedAt: 900 }),
     ])
 
-    await expectPile("stream:stream_s", ["draft_stream"])
-    // Its own host lands nested, so its pile stays scope-exact: siblings only.
-    await expectPile("board:reply:conv_lone", ["draft_lone", "draft_lone_2"])
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_stream", "draft_lone"]))
+    expect(result.current.originByDraftId.get("draft_lone")).toEqual({
+      kind: "conversation",
+      conversationId: "conv_lone",
+      tier: "borrowed",
+    })
   })
 
-  it("never shares a thread, branch or sub-topic draft into another host's pile", async () => {
-    await seedStream("stream_s")
-    await seedConversation("conv_1", "stream_s")
-    await seedConversation("conv_branch", "stream_s")
-    await db.drafts.bulkAdd([
-      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
-      draftRow({ id: "draft_thread", scope: "thread:msg_9" }),
-      draftRow({ id: "draft_branch", scope: "board:branch-reply:conv_branch" }),
-      draftRow({ id: "draft_subtopic", scope: "board:subtopic:stream_s:msg_1" }),
-    ])
-
-    await expectPile("stream:stream_s", ["draft_stream"])
-    await expectPile("board:reply:conv_1", ["draft_stream"])
-  })
-
-  it("follows a conversation that moved into a thread: T's pile, not S's", async () => {
+  it("keeps a conversation that drifted into a thread in the channel's pile", async () => {
     await seedStream("stream_s")
     await seedStream("stream_t", { type: "thread", rootStreamId: "stream_s" })
     await seedConversation("conv_moved", "stream_s", { lastActiveStreamId: "stream_t" })
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_s", scope: "stream:stream_s" }),
-      draftRow({ id: "draft_t", scope: "stream:stream_t" }),
       draftRow({ id: "draft_moved", scope: "board:reply:conv_moved" }),
     ])
 
-    await expectPile("stream:stream_s", ["draft_s"])
-    await expectPile("stream:stream_t", ["draft_t", "draft_moved"])
+    await expectPile("stream:stream_s", ["draft_s", "draft_moved"])
+  })
+
+  it("reaches a top-level draft downward into a thread composer's pile", async () => {
+    await seedStream("stream_s")
+    await seedThreadAnchor("msg_9", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_thread", scope: "thread:msg_9" }),
+    ])
+
+    await expectPile("thread:msg_9", ["draft_thread", "draft_stream"])
+  })
+
+  // The one exclusion the top-level host route does NOT cover: no conversation
+  // owns this thread, so the draft is only reachable where it was written.
+  it("keeps a draft in a conversation-less thread in its own pile only", async () => {
+    await seedStream("stream_s")
+    await seedThreadAnchor("msg_9", "stream_s")
+    await seedConversation("conv_1", "stream_s", { messageIds: ["msg_1"] })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_thread", scope: "thread:msg_9" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_stream", "draft_conv"])
+    await expectPile("board:reply:conv_1", ["draft_conv", "draft_stream"])
+  })
+
+  it("does not match two unresolvable conversations to each other", async () => {
+    await seedStream("stream_s")
+    await seedThreadAnchor("msg_a", "stream_s")
+    await seedThreadAnchor("msg_b", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_a", scope: "thread:msg_a" }),
+      draftRow({ id: "draft_b", scope: "thread:msg_b" }),
+      // The control row: top level, so it reaches BOTH threads (R2). Without it
+      // an all-own pile would satisfy the assertion on its very first frame,
+      // before the shared context has resolved anything.
+      draftRow({ id: "draft_top", scope: "stream:stream_s" }),
+    ])
+
+    await expectPile("thread:msg_a", ["draft_a", "draft_top"])
+    await expectPile("thread:msg_b", ["draft_b", "draft_top"])
+  })
+
+  it("puts a thread stream's draft in its conversation's pile and at top level, never in another conversation's", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_tc", { type: "thread", rootStreamId: "stream_s", parentAnchorId: "msg_c" })
+    await seedThreadAnchor("msg_c", "stream_s")
+    await seedConversation("conv_c", "stream_s", { messageIds: ["msg_c"] })
+    await seedConversation("conv_d", "stream_s", { messageIds: ["msg_d"] })
+    await seedConversationMessage("msg_c", "conv_c", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_in_c_thread", scope: "stream:stream_tc" }),
+      // A top-level control row: it belongs in every pile here, so D's assertion
+      // waits for a settled pile instead of passing on the empty first frame.
+      draftRow({ id: "draft_top", scope: "stream:stream_s" }),
+    ])
+
+    await expectPile("board:reply:conv_c", ["draft_in_c_thread", "draft_top"])
+    await expectPile("stream:stream_tc", ["draft_in_c_thread", "draft_top"])
+    await expectPile("stream:stream_s", ["draft_in_c_thread", "draft_top"])
+    await expectPile("board:reply:conv_d", ["draft_top"])
+  })
+
+  it("puts a sub-topic fork off a conversation's message in that conversation's pile, never in another's", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_c", "stream_s", { messageIds: ["msg_c"] })
+    await seedConversation("conv_d", "stream_s", { messageIds: ["msg_d"] })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_fork", scope: "board:subtopic:stream_s:msg_c" }),
+      draftRow({ id: "draft_top", scope: "stream:stream_s" }),
+    ])
+
+    await expectPile("board:reply:conv_c", ["draft_fork", "draft_top"])
+    await expectPile("stream:stream_s", ["draft_fork", "draft_top"])
+    await expectPile("board:reply:conv_d", ["draft_top"])
+  })
+
+  it("puts a branch reply under a conversation in that conversation's pile", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_tb", { type: "thread", rootStreamId: "stream_s", parentAnchorId: "msg_c" })
+    await seedConversation("conv_c", "stream_s", { messageIds: ["msg_c"] })
+    await seedConversation("conv_branch", "stream_tb", { messageIds: ["msg_branch"] })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_branch", scope: "board:branch-reply:conv_branch" }),
+      draftRow({ id: "draft_top", scope: "stream:stream_s" }),
+    ])
+
+    await expectPile("board:reply:conv_c", ["draft_branch", "draft_top"])
+  })
+
+  it("keeps a draft under a different root stream out of the pile", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_other")
+    await seedStream("stream_other_t", { type: "thread", rootStreamId: "stream_other" })
+    await seedConversation("conv_other", "stream_other")
+    await seedThreadAnchor("msg_other", "stream_other")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_other", scope: "stream:stream_other" }),
+      draftRow({ id: "draft_other_thread_stream", scope: "stream:stream_other_t" }),
+      draftRow({ id: "draft_other_conv", scope: "board:reply:conv_other" }),
+      draftRow({ id: "draft_other_anchor", scope: "thread:msg_other" }),
+      draftRow({ id: "draft_other_subtopic", scope: "board:subtopic:stream_other:msg_z" }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_stream"])
+  })
+
+  it("orders own rows before borrowed rows, each group newest first", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "own_old", scope: "stream:stream_s", clientUpdatedAt: 100 }),
+      draftRow({ id: "own_new", scope: "stream:stream_s", clientUpdatedAt: 400 }),
+      draftRow({ id: "borrowed_old", scope: "board:reply:conv_1", clientUpdatedAt: 200 }),
+      draftRow({ id: "borrowed_new", scope: "board:reply:conv_1", clientUpdatedAt: 500 }),
+    ])
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() =>
+      expect(result.current.drafts.map((d) => d.id)).toEqual(["own_new", "own_old", "borrowed_new", "borrowed_old"])
+    )
+    expect([...result.current.originByDraftId.values()].map((origin) => origin.tier)).toEqual([
+      "own",
+      "own",
+      "borrowed",
+      "borrowed",
+    ])
   })
 
   it("excludes a draft checked out into ANY scope's composer on this device", async () => {
@@ -212,7 +362,7 @@ describe("useStashedDrafts — landing-site membership", () => {
     await expectPile("board:reply:conv_1", ["draft_conv"])
   })
 
-  it("excludes an empty draft, an archived landing stream, an E2E host, and an uncached conversation", async () => {
+  it("excludes an empty borrowed draft, an archived home, an E2E host, and an uncached conversation", async () => {
     await seedStream("stream_s")
     await seedStream("stream_archived", { archivedAt: "2026-01-01T00:00:00Z" })
     await seedStream("stream_sealed", { e2eEnabled: true })
@@ -221,7 +371,7 @@ describe("useStashedDrafts — landing-site membership", () => {
     await seedConversation("conv_sealed", "stream_sealed")
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
-      draftRow({ id: "draft_empty", scope: "stream:stream_s", contentJson: EMPTY_DOC }),
+      draftRow({ id: "draft_empty", scope: "board:reply:conv_1", contentJson: EMPTY_DOC }),
       draftRow({ id: "draft_uncached", scope: "board:reply:conv_missing" }),
       draftRow({ id: "draft_archived", scope: "stream:stream_archived" }),
       draftRow({ id: "draft_archived_conv", scope: "board:reply:conv_archived" }),
@@ -253,25 +403,30 @@ describe("useStashedDrafts — landing-site membership", () => {
     await waitFor(() => expect(result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_conv", "draft_stream"]))
   })
 
-  it("reports each row's origin as structured data", async () => {
+  it("reports each row's origin and tier as structured data", async () => {
     await seedStream("stream_s")
-    await seedConversation("conv_1", "stream_s")
+    await seedConversation("conv_1", "stream_s", { messageIds: ["msg_1", "msg_9"] })
+    await seedThreadAnchor("msg_9", "stream_s")
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
       draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+      draftRow({ id: "draft_thread", scope: "thread:msg_9" }),
+      draftRow({ id: "draft_subtopic", scope: "board:subtopic:stream_s:msg_1" }),
     ])
 
     const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
-    await waitFor(() => expect(result.current.originByDraftId.size).toBe(2))
+    await waitFor(() => expect(result.current.originByDraftId.size).toBe(4))
     expect(Object.fromEntries(result.current.originByDraftId)).toEqual({
-      draft_stream: { kind: "stream", streamId: "stream_s" },
-      draft_conv: { kind: "conversation", conversationId: "conv_1" },
+      draft_stream: { kind: "stream", streamId: "stream_s", tier: "own" },
+      draft_conv: { kind: "conversation", conversationId: "conv_1", tier: "borrowed" },
+      draft_thread: { kind: "thread", anchorId: "msg_9", streamId: "stream_s", tier: "borrowed" },
+      draft_subtopic: { kind: "subtopic", streamId: "stream_s", messageId: "msg_1", tier: "borrowed" },
     })
   })
 
-  it("holds membership while the picker is open, even as the landing site moves", async () => {
+  it("holds membership while the picker is open, even as the home stream moves", async () => {
     await seedStream("stream_s")
-    await seedStream("stream_t", { type: "thread", rootStreamId: "stream_s" })
+    await seedStream("stream_other")
     await seedConversation("conv_1", "stream_s")
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
@@ -283,7 +438,7 @@ describe("useStashedDrafts — landing-site membership", () => {
 
     act(() => result.current.setPileOpen(true))
     await act(async () => {
-      await seedConversation("conv_1", "stream_s", { lastActiveStreamId: "stream_t" })
+      await seedConversation("conv_1", "stream_other")
       await new Promise((resolve) => setTimeout(resolve, 30))
     })
     expect(result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_conv", "draft_stream"])
@@ -336,5 +491,75 @@ describe("useStashedDrafts — landing-site membership", () => {
     ])
 
     await expectPile("board:reply:conv_lone", ["draft_lone", "draft_lone_empty"])
+  })
+
+  // A `thread:` HOST resolves its own anchor even with no thread-scoped draft in
+  // the workspace: the anchor set the shared context is keyed on includes the
+  // host's, not just the drafts'. Without that the draft-thread panel — whose own
+  // row does not exist until the debounce fires — opens onto an empty pile.
+  it("resolves a thread host's home with no thread-scoped draft anywhere", async () => {
+    await seedStream("stream_s")
+    await seedThreadAnchor("msg_9", "stream_s")
+    await db.drafts.add(draftRow({ id: "draft_stream", scope: "stream:stream_s" }))
+
+    await expectPile("thread:msg_9", ["draft_stream"])
+    expect(await db.drafts.where("scope").startsWith("thread:").count()).toBe(0)
+  })
+})
+
+describe("useStashedDrafts — the worked example: two conversations in one channel", () => {
+  beforeEach(async () => {
+    __clearBoardDraftContextRegistry()
+    await db.conversations.clear()
+    await db.conversationMessages.clear()
+    await db.streams.clear()
+    await db.events.clear()
+
+    // stream_s holds two root messages, each the opener of its own conversation.
+    // A has a thread (four replies, so a real thread stream); B has none, only a
+    // draft reply in a draft thread.
+    await seedStream("stream_s")
+    await seedStream("stream_ta", { type: "thread", rootStreamId: "stream_s", parentAnchorId: "msg_a1" })
+    await seedThreadAnchor("msg_a1", "stream_s")
+    await seedThreadAnchor("msg_b1", "stream_s")
+    await seedConversation("conv_a", "stream_s", { messageIds: ["msg_a1"], openingMessageId: "msg_a1" })
+    await seedConversation("conv_b", "stream_s", { messageIds: ["msg_b1"], openingMessageId: "msg_b1" })
+    await seedConversationMessage("msg_a1", "conv_a", "stream_s")
+    await seedConversationMessage("msg_b1", "conv_b", "stream_s")
+
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_b_thread", scope: "thread:msg_b1" }),
+      draftRow({ id: "draft_a_thread", scope: "stream:stream_ta" }),
+      draftRow({ id: "draft_top", scope: "stream:stream_s" }),
+    ])
+  })
+
+  afterEach(() => {
+    __clearBoardDraftContextRegistry()
+  })
+
+  it("continues B's draft-thread reply from B's conversation view and from the draft thread itself", async () => {
+    await expectPile("board:reply:conv_b", ["draft_b_thread", "draft_top"])
+    await expectPile("thread:msg_b1", ["draft_b_thread", "draft_top"])
+  })
+
+  it("continues A's thread draft from A's conversation view", async () => {
+    await expectPile("board:reply:conv_a", ["draft_a_thread", "draft_top"])
+  })
+
+  it("shows a top-level draft in both conversation views", async () => {
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_a"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toContain("draft_top"))
+    await expectPile("board:reply:conv_b", ["draft_b_thread", "draft_top"])
+  })
+
+  it("shows either conversation's draft in the top-level stream composer", async () => {
+    await expectPile("stream:stream_s", ["draft_top", "draft_a_thread", "draft_b_thread"])
+  })
+
+  it("keeps each conversation's draft out of the other conversation's pile", async () => {
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_a"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toContain("draft_a_thread"))
+    expect(result.current.drafts.map((d) => d.id)).not.toContain("draft_b_thread")
   })
 })

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
 import { stashLoadedDraft, restoreStashedDraftToComposer, upsertLoadedDraft } from "./use-draft-message"
 import type { JSONContent } from "@threa/types"
-import { db } from "@/db"
+import { db, type CachedDraft } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
+import { __clearBoardDraftContextRegistry } from "./use-board-draft-context"
+import { useStashedDrafts } from "./use-stashed-drafts"
 
 const makeDoc = (text: string): JSONContent => ({
   type: "doc",
@@ -76,5 +79,262 @@ describe("restoreStashedDraftToComposer (pointer-move restore)", () => {
     // Both rows survive (nothing deleted) — `second` is now the stash entry.
     expect(await db.drafts.get(first.id)).toBeDefined()
     expect(await db.drafts.get(second.id)).toBeDefined()
+  })
+})
+
+const pileWorkspaceId = "ws_pile"
+
+function draftRow(overrides: Partial<CachedDraft> & { id: string; scope: string }): CachedDraft {
+  return {
+    workspaceId: pileWorkspaceId,
+    contentJson: makeDoc(overrides.id),
+    attachments: [],
+    clientUpdatedAt: 1000,
+    baseVersion: 1,
+    ...overrides,
+  } as CachedDraft
+}
+
+function seedStream(id: string, overrides: Record<string, unknown> = {}): Promise<unknown> {
+  return db.streams.put({
+    id,
+    workspaceId: pileWorkspaceId,
+    type: "channel",
+    visibility: "private",
+    rootStreamId: null,
+    archivedAt: null,
+    ...overrides,
+  } as never)
+}
+
+/** A cached board post: `messageIds` + the opening id drive `planBoardReply`,
+ *  `recentMessages` the recency-biased landing stream. */
+function seedConversation(
+  id: string,
+  streamId: string,
+  opts: { messageIds?: string[]; openingMessageId?: string | null; lastActiveStreamId?: string } = {}
+): Promise<unknown> {
+  const openingMessageId = opts.openingMessageId === undefined ? "msg_1" : opts.openingMessageId
+  return db.conversations.put({
+    id,
+    workspaceId: pileWorkspaceId,
+    _lastActivityMs: 1,
+    _cachedAt: 1,
+    conversation: { id, streamId, messageIds: opts.messageIds ?? ["msg_1", "msg_2"] },
+    openingMessage: openingMessageId ? { id: openingMessageId } : null,
+    recentMessages: opts.lastActiveStreamId ? [{ streamId: opts.lastActiveStreamId }] : [],
+  } as never)
+}
+
+async function expectPile(scope: string, ids: string[]) {
+  const { result, unmount } = renderHook(() => useStashedDrafts(pileWorkspaceId, scope))
+  await waitFor(() => expect(result.current.drafts.map((d) => d.id).sort()).toEqual([...ids].sort()))
+  unmount()
+}
+
+describe("useStashedDrafts — landing-site membership", () => {
+  beforeEach(async () => {
+    __clearBoardDraftContextRegistry()
+    await db.conversations.clear()
+    await db.streams.clear()
+  })
+
+  afterEach(() => {
+    __clearBoardDraftContextRegistry()
+  })
+
+  it("shares a pile both ways between a stream and a conversation that lands flat in it", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1", clientUpdatedAt: 2000 }),
+    ])
+
+    await expectPile("board:reply:conv_1", ["draft_stream", "draft_conv"])
+    await expectPile("stream:stream_s", ["draft_stream", "draft_conv"])
+  })
+
+  it("keeps a lone channel conversation's reply out of every flat pile (its reply opens a thread)", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_lone", "stream_s", { messageIds: ["msg_1"], openingMessageId: "msg_1" })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_lone", scope: "board:reply:conv_lone" }),
+      draftRow({ id: "draft_lone_2", scope: "board:reply:conv_lone", clientUpdatedAt: 900 }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_stream"])
+    // Its own host lands nested, so its pile stays scope-exact: siblings only.
+    await expectPile("board:reply:conv_lone", ["draft_lone", "draft_lone_2"])
+  })
+
+  it("never shares a thread, branch or sub-topic draft into another host's pile", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await seedConversation("conv_branch", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_thread", scope: "thread:msg_9" }),
+      draftRow({ id: "draft_branch", scope: "board:branch-reply:conv_branch" }),
+      draftRow({ id: "draft_subtopic", scope: "board:subtopic:stream_s:msg_1" }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_stream"])
+    await expectPile("board:reply:conv_1", ["draft_stream"])
+  })
+
+  it("follows a conversation that moved into a thread: T's pile, not S's", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_t", { type: "thread", rootStreamId: "stream_s" })
+    await seedConversation("conv_moved", "stream_s", { lastActiveStreamId: "stream_t" })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_s", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_t", scope: "stream:stream_t" }),
+      draftRow({ id: "draft_moved", scope: "board:reply:conv_moved" }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_s"])
+    await expectPile("stream:stream_t", ["draft_t", "draft_moved"])
+  })
+
+  it("excludes a draft checked out into ANY scope's composer on this device", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+    ])
+    // Live-typed in the timeline composer: the conversation's picker must not
+    // offer it, or a move would vacate it under a live editor.
+    await db.composerLoaded.put({ scope: "stream:stream_s", workspaceId: pileWorkspaceId, draftId: "draft_stream" })
+
+    await expectPile("board:reply:conv_1", ["draft_conv"])
+  })
+
+  it("excludes an empty draft, an archived landing stream, an E2E host, and an uncached conversation", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_archived", { archivedAt: "2026-01-01T00:00:00Z" })
+    await seedStream("stream_sealed", { e2eEnabled: true })
+    await seedConversation("conv_1", "stream_s")
+    await seedConversation("conv_archived", "stream_archived")
+    await seedConversation("conv_sealed", "stream_sealed")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_empty", scope: "stream:stream_s", contentJson: EMPTY_DOC }),
+      draftRow({ id: "draft_uncached", scope: "board:reply:conv_missing" }),
+      draftRow({ id: "draft_archived", scope: "stream:stream_archived" }),
+      draftRow({ id: "draft_archived_conv", scope: "board:reply:conv_archived" }),
+      draftRow({ id: "draft_sealed", scope: "stream:stream_sealed" }),
+      draftRow({ id: "draft_sealed_conv", scope: "board:reply:conv_sealed" }),
+    ])
+
+    await expectPile("stream:stream_s", ["draft_stream"])
+    // An archived or sealed host keeps a scope-exact pile — never widened, and
+    // its rows never leak into another host's.
+    await expectPile("stream:stream_archived", ["draft_archived"])
+    await expectPile("stream:stream_sealed", ["draft_sealed"])
+    await expectPile("board:reply:conv_sealed", ["draft_sealed_conv"])
+  })
+
+  it("resolves a conversation that caches only after the first frame (unknown is never latched)", async () => {
+    await seedStream("stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_late" }),
+    ])
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_stream"]))
+
+    await act(async () => {
+      await seedConversation("conv_late", "stream_s")
+    })
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_conv", "draft_stream"]))
+  })
+
+  it("reports each row's origin as structured data", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+    ])
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() => expect(result.current.originByDraftId.size).toBe(2))
+    expect(Object.fromEntries(result.current.originByDraftId)).toEqual({
+      draft_stream: { kind: "stream", streamId: "stream_s" },
+      draft_conv: { kind: "conversation", conversationId: "conv_1" },
+    })
+  })
+
+  it("holds membership while the picker is open, even as the landing site moves", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_t", { type: "thread", rootStreamId: "stream_s" })
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+    ])
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() => expect(result.current.drafts).toHaveLength(2))
+
+    act(() => result.current.setPileOpen(true))
+    await act(async () => {
+      await seedConversation("conv_1", "stream_s", { lastActiveStreamId: "stream_t" })
+      await new Promise((resolve) => setTimeout(resolve, 30))
+    })
+    expect(result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_conv", "draft_stream"])
+
+    act(() => result.current.setPileOpen(false))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_stream"]))
+  })
+
+  it("claimable rows stay this host's own scope even when the pile is wider", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
+    ])
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(result.current.drafts).toHaveLength(2))
+    expect(result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_conv"])
+  })
+
+  it("never offers or claims a row already checked out by another scope on this device", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_shared", scope: "board:reply:conv_1" }),
+      draftRow({ id: "draft_sibling", scope: "board:reply:conv_1", clientUpdatedAt: 900 }),
+    ])
+    // Restored into the timeline composer from the drafts explorer: the row's own
+    // scope still says `board:reply:conv_1`, so a scope-exact claimable list would
+    // hand the same row to a second composer.
+    await db.composerLoaded.put({ scope: "stream:stream_s", workspaceId: pileWorkspaceId, draftId: "draft_shared" })
+
+    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_sibling"]))
+    expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_sibling"])
+  })
+
+  // The scope-exact branch deliberately applies NO payload filter. A draft can
+  // carry only context refs ("Discuss with Ariadne" seeds exactly that shape:
+  // empty body, no attachments), the drafts explorer already skips those, and
+  // its own scope's picker is the last surface that can reach it — filtering
+  // here would strand the row while it keeps syncing.
+  it("keeps a body-less row in its own scope's pile — the explorer already hides it", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_lone", "stream_s", { messageIds: ["msg_1"], openingMessageId: "msg_1" })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_lone", scope: "board:reply:conv_lone" }),
+      draftRow({ id: "draft_lone_empty", scope: "board:reply:conv_lone", contentJson: EMPTY_DOC }),
+    ])
+
+    await expectPile("board:reply:conv_lone", ["draft_lone", "draft_lone_empty"])
   })
 })

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -1,12 +1,13 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 import { type CachedDraft, type CachedStream } from "@/db"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+import { isDraftInHostPile, resolveDraftHomeStream, type DraftPileContext } from "@/lib/drafts/home-stream"
 import { hasSeededDraftCache, useComposerLoadedFromStore, useDraftsFromStore } from "@/stores/draft-store"
 import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
 import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { draftHasPayload, isStreamArchived } from "./use-all-drafts"
-import { useDraftLandingSites } from "./use-draft-landing-sites"
+import { draftScopesSignature, useBoardDraftContext, useThreadAnchorContext } from "./use-board-draft-context"
 
 // Re-exported so components (which cannot import from `@/db` per INV-15) can
 // still get the row type they render without reaching into the data layer.
@@ -15,10 +16,22 @@ import { useDraftLandingSites } from "./use-draft-landing-sites"
 export type { CachedDraft }
 
 /** Where a pile row came from, as structured data — chunk 5 renders it (INV-46). */
-export type StashedDraftOrigin = { kind: "stream"; streamId: string } | { kind: "conversation"; conversationId: string }
+export type StashedDraftSource =
+  | { kind: "stream"; streamId: string }
+  | { kind: "conversation"; conversationId: string }
+  | { kind: "branch"; conversationId: string }
+  | { kind: "thread"; anchorId: string; streamId: string | null }
+  | { kind: "subtopic"; streamId: string; messageId: string }
+
+/**
+ * A pile row's provenance. `tier` is the safety the widened pile carries in
+ * presentation instead of exclusion: `own` is this host's exact scope, `borrowed`
+ * is somewhere else under the same root stream.
+ */
+export type StashedDraftOrigin = StashedDraftSource & { tier: "own" | "borrowed" }
 
 export interface UseStashedDraftsResult {
-  /** The pile the picker renders: every draft that lands where this host's does, minus the loaded ones. */
+  /** The pile the picker renders: every draft that could have been written under this host's root stream, minus the loaded ones. Own rows first, then borrowed; each group newest first. */
   drafts: CachedDraft[]
   /**
    * The subset this host may restore: its own scope's rows, minus any row already
@@ -27,7 +40,7 @@ export interface UseStashedDraftsResult {
    * their debounced saves fight over its `scope` and body.
    */
   claimableDrafts: CachedDraft[]
-  /** Where each pile row came from, keyed by draft id. */
+  /** Where each pile row came from, and its tier, keyed by draft id. */
   originByDraftId: Map<string, StashedDraftOrigin>
   /** True once the draft cache has been seeded (used to suppress empty-flash in the picker). */
   isLoaded: boolean
@@ -35,25 +48,30 @@ export interface UseStashedDraftsResult {
   deleteStashedDraft: (id: string) => Promise<void>
   /**
    * Tell the pile the picker is open. Membership is latched while it is: the
-   * landing stream is live data (a conversation can move into a thread mid-pick)
-   * and a row must not disappear under the user's cursor.
+   * home stream is live data (a conversation can cache or move mid-pick) and a
+   * row must not disappear under the user's cursor.
    */
   setPileOpen: (open: boolean) => void
 }
 
-/** A draft scope that could land flat — the only ones worth resolving a landing site for. */
-function couldLandFlat(scope: string): boolean {
-  if (scope.startsWith("stream:")) return true
-  return parseBoardDraftKey(scope)?.kind === "reply"
-}
-
-function draftOrigin(scope: string): StashedDraftOrigin | null {
+function draftSource(
+  scope: string,
+  streamByAnchorId: ReadonlyMap<string, { streamId: string }>
+): StashedDraftSource | null {
   if (scope.startsWith("stream:")) {
     const streamId = scope.slice("stream:".length)
     return streamId ? { kind: "stream", streamId } : null
   }
+  if (scope.startsWith("thread:")) {
+    const anchorId = scope.slice("thread:".length)
+    if (!anchorId) return null
+    return { kind: "thread", anchorId, streamId: streamByAnchorId.get(anchorId)?.streamId ?? null }
+  }
   const board = parseBoardDraftKey(scope)
-  return board?.kind === "reply" ? { kind: "conversation", conversationId: board.conversationId } : null
+  if (!board) return null
+  if (board.kind === "reply") return { kind: "conversation", conversationId: board.conversationId }
+  if (board.kind === "branch-reply") return { kind: "branch", conversationId: board.conversationId }
+  return { kind: "subtopic", streamId: board.streamId, messageId: board.messageId }
 }
 
 /** Encrypted directly, or under an encrypted root. An uncached stream fails closed. */
@@ -66,23 +84,23 @@ function isStreamEncrypted(streamId: string, streamMap: Map<string, CachedStream
 }
 
 /**
- * The stashed drafts a composer offers — every draft that would land in the same
- * place this host's own draft would, except the ones checked out into a composer
- * on this device.
+ * The stashed drafts a composer offers — every draft the user could plausibly
+ * have written from here, except the ones checked out into a composer on this
+ * device.
  *
- * "The same place" is the LANDING SITE: same stream, top level. A `stream:<S>`
- * draft and a board reply to a conversation that is live in S both land flat in
- * S, so they share one pile; a thread reply, a branch reply, a sub-topic fork and
- * a board reply that would convert its lone opener into a thread all land
- * somewhere nested and are never shared. When this host's own scope doesn't land
- * flat — or lands in a stream that is archived, encrypted, or uncached — the pile
- * stays scope-exact, which is also what every nested composer gets with no
- * special case.
+ * "Could have written here" is {@link isDraftInHostPile}: one root stream, then
+ * own scope / same conversation / a top-level draft / a top-level host offering
+ * this root's conversations. A draft in a thread that is part of no conversation
+ * is the one thing left out; two different conversations never share a pile.
+ * What keeps the rest safe is presentation, not exclusion: a row from another
+ * scope is tiered `borrowed` and ordered after every `own` row.
  *
- * `unknown` (a conversation this device hasn't cached) is never membership, and
- * the exclusion is re-derived every render rather than latched: the board-post
- * map is empty on the first frame, so a `board:reply:` scope resolves `unknown`
- * transiently before it flips.
+ * An unresolvable home (an uncached conversation, an uncached thread anchor) is
+ * never membership, and the exclusion is re-derived every render rather than
+ * latched: the board-post map is empty on the first frame, so a `board:reply:`
+ * scope resolves `null` transiently before it flips. When this host's own home
+ * is unresolvable — or is archived, encrypted, or uncached (a scratchpad, which
+ * has no `db.streams` row, lands here) — the pile stays scope-exact.
  *
  * Stash and restore are pointer moves (see `useStashComposer`): the loaded draft
  * is simply detached/attached via the `composerLoaded` pointer, so a sealed E2E
@@ -117,20 +135,80 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
   }, [cachedStreams])
 
   const candidates = useMemo(
-    () =>
-      allDrafts.filter(
-        (draft) => couldLandFlat(draft.scope) && !loadedAnywhere.has(draft.id) && draftHasPayload(draft)
-      ),
+    () => allDrafts.filter((draft) => !loadedAnywhere.has(draft.id) && draftHasPayload(draft)),
     [allDrafts, loadedAnywhere]
   )
 
-  const landingScopes = useMemo(() => {
+  const pileScopes = useMemo(() => {
     const scopes = candidates.map((draft) => draft.scope)
-    if (scope && couldLandFlat(scope)) scopes.push(scope)
-    return scopes
+    return scope ? [...scopes, scope] : scopes
   }, [candidates, scope])
 
-  const landingSites = useDraftLandingSites(workspaceId, landingScopes)
+  // Only the board scopes actually in play. A plain `board:reply:` scope keeps
+  // `useBoardDraftContext` on its `bulkGet` path; a branch or sub-topic scope is
+  // what puts it on the workspace-wide `db.conversations` scan, and those are the
+  // only scopes whose owning conversation can't be named without it.
+  const boardContextSignature = useMemo(
+    () => draftScopesSignature(pileScopes.filter((candidate) => parseBoardDraftKey(candidate) !== null)),
+    [pileScopes]
+  )
+
+  // The anchor ids the pile has to resolve: a `thread:` scope's own anchor, the
+  // anchor a thread stream hangs off (so a `stream:<threadId>` draft can name its
+  // conversation), and a sub-topic's fork message. Keyed lookups, no scan.
+  const anchorIdsSignature = useMemo(() => {
+    const anchorIds: string[] = []
+    for (const candidate of pileScopes) {
+      if (candidate.startsWith("thread:")) {
+        anchorIds.push(candidate.slice("thread:".length))
+        continue
+      }
+      if (candidate.startsWith("stream:")) {
+        const row = streamMap.get(candidate.slice("stream:".length))
+        const anchorId = row?.parentAnchorId ?? row?.parentMessageId
+        if (anchorId) anchorIds.push(anchorId)
+        continue
+      }
+      const board = parseBoardDraftKey(candidate)
+      if (board?.kind === "subtopic") anchorIds.push(board.messageId)
+    }
+    return draftScopesSignature(anchorIds.filter(Boolean))
+  }, [pileScopes, streamMap])
+
+  const { boardPostMap, hostPostByMessageId, parentPostByBranchConversationId } = useBoardDraftContext(
+    workspaceId,
+    boardContextSignature
+  )
+  const { streamByAnchorId, conversationIdByAnchorId } = useThreadAnchorContext(workspaceId, anchorIdsSignature)
+
+  // A message's owning conversation, from every source already loaded: the
+  // per-anchor backfill rows, the fork hosts, and the message lists of the
+  // conversations the scopes themselves name.
+  const conversationIdByMessageId = useMemo(() => {
+    const map = new Map<string, string>(conversationIdByAnchorId)
+    for (const [messageId, post] of hostPostByMessageId) map.set(messageId, post.id)
+    for (const post of boardPostMap.values()) {
+      for (const messageId of post.conversation.messageIds ?? []) map.set(messageId, post.id)
+    }
+    return map
+  }, [conversationIdByAnchorId, hostPostByMessageId, boardPostMap])
+
+  const parentConversationIdByBranchId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [branchId, post] of parentPostByBranchConversationId) map.set(branchId, post.id)
+    return map
+  }, [parentPostByBranchConversationId])
+
+  const pileContext = useMemo<DraftPileContext>(
+    () => ({
+      streamById: streamMap,
+      boardPostByConversationId: boardPostMap,
+      threadAnchorStreamById: streamByAnchorId,
+      conversationIdByMessageId,
+      parentConversationIdByBranchId,
+    }),
+    [streamMap, boardPostMap, streamByAnchorId, conversationIdByMessageId, parentConversationIdByBranchId]
+  )
 
   const scopeExact = useMemo(() => {
     if (!workspaceId || !scope) return []
@@ -147,25 +225,31 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     )
   }, [allDrafts, workspaceId, scope, loadedAnywhere])
 
+  const comparePile = useCallback(
+    (a: CachedDraft, b: CachedDraft) => {
+      const tier = (draft: CachedDraft) => (draft.scope === scope ? 0 : 1)
+      return tier(a) - tier(b) || b.clientUpdatedAt - a.clientUpdatedAt
+    },
+    [scope]
+  )
+
   const livePile = useMemo(() => {
     if (!workspaceId || !scope) return []
-    const host = landingSites.get(scope)
-    if (host?.kind !== "flat") return scopeExact
-    const landingStreamId = host.streamId
+    const home = resolveDraftHomeStream(scope, pileContext)
+    if (!home) return scopeExact
     // A stream we can't confirm is plaintext and active keeps the pile private:
     // a plaintext board draft must never be offered into a sealed composer, and
     // an archived stream's pile is nobody else's business.
-    if (isStreamEncrypted(landingStreamId, streamMap)) return scopeExact
-    if (isStreamArchived(landingStreamId, streamMap, archivedStreamIds)) return scopeExact
+    if (isStreamEncrypted(home, streamMap)) return scopeExact
+    if (isStreamArchived(home, streamMap, archivedStreamIds)) return scopeExact
 
-    return candidates
-      .filter((draft) => {
-        if (draft.id === loadedId) return false
-        const site = landingSites.get(draft.scope)
-        return site?.kind === "flat" && site.streamId === landingStreamId
-      })
+    const borrowed = candidates
+      .filter(
+        (draft) => draft.scope !== scope && draft.id !== loadedId && isDraftInHostPile(scope, draft.scope, pileContext)
+      )
       .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
-  }, [workspaceId, scope, landingSites, scopeExact, candidates, loadedId, streamMap, archivedStreamIds])
+    return [...scopeExact, ...borrowed]
+  }, [workspaceId, scope, pileContext, scopeExact, candidates, loadedId, streamMap, archivedStreamIds])
 
   // Latch while the picker is open — see `setPileOpen`.
   const [pileOpen, setPileOpen] = useState(false)
@@ -186,22 +270,25 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     for (const id of latchedIdsRef.current) {
       const row = draftsById.get(id)
       // A row that was deleted, emptied or checked out into a composer still goes
-      // — the latch holds membership against a moving landing site, not the row.
-      if (!row || !draftHasPayload(row) || loadedAnywhere.has(row.id)) continue
+      // — the latch holds membership against a moving home stream, not the row.
+      // "Emptied" applies to borrowed rows only; an own row carrying just context
+      // refs is legitimately body-less (see `scopeExact`).
+      if (!row || loadedAnywhere.has(row.id)) continue
+      if (row.scope !== scope && !draftHasPayload(row)) continue
       rows.set(id, row)
     }
     for (const row of livePile) rows.set(row.id, row)
-    return [...rows.values()].sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
-  }, [pileOpen, livePile, draftsById, loadedAnywhere])
+    return [...rows.values()].sort(comparePile)
+  }, [pileOpen, livePile, draftsById, loadedAnywhere, comparePile, scope])
 
   const originByDraftId = useMemo(() => {
     const map = new Map<string, StashedDraftOrigin>()
     for (const draft of drafts) {
-      const origin = draftOrigin(draft.scope)
-      if (origin) map.set(draft.id, origin)
+      const source = draftSource(draft.scope, streamByAnchorId)
+      if (source) map.set(draft.id, { ...source, tier: draft.scope === scope ? "own" : "borrowed" })
     }
     return map
-  }, [drafts])
+  }, [drafts, scope, streamByAnchorId])
 
   const isLoaded = hasSeededDraftCache(workspaceId)
   const syncEngine = useOptionalSyncEngine()

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -1,8 +1,12 @@
-import { useCallback, useMemo } from "react"
-import { type CachedDraft } from "@/db"
+import { useCallback, useMemo, useRef, useState } from "react"
+import { type CachedDraft, type CachedStream } from "@/db"
+import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { hasSeededDraftCache, useComposerLoadedFromStore, useDraftsFromStore } from "@/stores/draft-store"
+import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
 import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
+import { draftHasPayload, isStreamArchived } from "./use-all-drafts"
+import { useDraftLandingSites } from "./use-draft-landing-sites"
 
 // Re-exported so components (which cannot import from `@/db` per INV-15) can
 // still get the row type they render without reaching into the data layer.
@@ -10,38 +14,194 @@ import { useOptionalSyncEngine } from "@/sync/sync-engine"
 // scope — there is no separate stash entity, plaintext or sealed.
 export type { CachedDraft }
 
+/** Where a pile row came from, as structured data — chunk 5 renders it (INV-46). */
+export type StashedDraftOrigin = { kind: "stream"; streamId: string } | { kind: "conversation"; conversationId: string }
+
 export interface UseStashedDraftsResult {
-  /** Stashed drafts for the current scope (every draft except the loaded one), newest first. */
+  /** The pile the picker renders: every draft that lands where this host's does, minus the loaded ones. */
   drafts: CachedDraft[]
+  /**
+   * The subset this host may restore: its own scope's rows, minus any row already
+   * checked out by a composer on this device. A row checked out under one scope is
+   * neither offered nor claimable under another — two scopes holding one row make
+   * their debounced saves fight over its `scope` and body.
+   */
+  claimableDrafts: CachedDraft[]
+  /** Where each pile row came from, keyed by draft id. */
+  originByDraftId: Map<string, StashedDraftOrigin>
   /** True once the draft cache has been seeded (used to suppress empty-flash in the picker). */
   isLoaded: boolean
   /** Delete a stashed row (and mirror the removal to the backend). */
   deleteStashedDraft: (id: string) => Promise<void>
+  /**
+   * Tell the pile the picker is open. Membership is latched while it is: the
+   * landing stream is live data (a conversation can move into a thread mid-pick)
+   * and a row must not disappear under the user's cursor.
+   */
+  setPileOpen: (open: boolean) => void
+}
+
+/** A draft scope that could land flat — the only ones worth resolving a landing site for. */
+function couldLandFlat(scope: string): boolean {
+  if (scope.startsWith("stream:")) return true
+  return parseBoardDraftKey(scope)?.kind === "reply"
+}
+
+function draftOrigin(scope: string): StashedDraftOrigin | null {
+  if (scope.startsWith("stream:")) {
+    const streamId = scope.slice("stream:".length)
+    return streamId ? { kind: "stream", streamId } : null
+  }
+  const board = parseBoardDraftKey(scope)
+  return board?.kind === "reply" ? { kind: "conversation", conversationId: board.conversationId } : null
+}
+
+/** Encrypted directly, or under an encrypted root. An uncached stream fails closed. */
+function isStreamEncrypted(streamId: string, streamMap: Map<string, CachedStream>): boolean {
+  const stream = streamMap.get(streamId)
+  if (!stream) return true
+  if (stream.e2eEnabled) return true
+  const root = stream.rootStreamId ? streamMap.get(stream.rootStreamId) : null
+  return root?.e2eEnabled === true
 }
 
 /**
- * The stashed drafts for a specific scope (a stream or a thread's parent
- * message) — every draft for the scope except the one loaded into the composer.
- * Pass `undefined` for `scope` while the host is still resolving what to target;
- * the hook returns an empty list and silently no-ops.
+ * The stashed drafts a composer offers — every draft that would land in the same
+ * place this host's own draft would, except the ones checked out into a composer
+ * on this device.
+ *
+ * "The same place" is the LANDING SITE: same stream, top level. A `stream:<S>`
+ * draft and a board reply to a conversation that is live in S both land flat in
+ * S, so they share one pile; a thread reply, a branch reply, a sub-topic fork and
+ * a board reply that would convert its lone opener into a thread all land
+ * somewhere nested and are never shared. When this host's own scope doesn't land
+ * flat — or lands in a stream that is archived, encrypted, or uncached — the pile
+ * stays scope-exact, which is also what every nested composer gets with no
+ * special case.
+ *
+ * `unknown` (a conversation this device hasn't cached) is never membership, and
+ * the exclusion is re-derived every render rather than latched: the board-post
+ * map is empty on the first frame, so a `board:reply:` scope resolves `unknown`
+ * transiently before it flips.
  *
  * Stash and restore are pointer moves (see `useStashComposer`): the loaded draft
  * is simply detached/attached via the `composerLoaded` pointer, so a sealed E2E
  * draft rides the same path with no plaintext snapshot (E2EE-4). This hook owns
- * only the read (`drafts`) and delete; deletion routes through the same
- * `deleteDraftById` the Drafts explorer uses so the two surfaces can't drift.
+ * only the read and delete; deletion routes through the same `deleteDraftById`
+ * the Drafts explorer uses so the two surfaces can't drift.
  */
 export function useStashedDrafts(workspaceId: string, scope: string | undefined): UseStashedDraftsResult {
   const allDrafts = useDraftsFromStore(workspaceId)
   const loaded = useComposerLoadedFromStore(workspaceId)
+  const cachedStreams = useWorkspaceStreamsRaw(workspaceId)
+
   const loadedId = scope ? (loaded.find((row) => row.scope === scope)?.draftId ?? null) : null
+  // Loaded in ANY scope on this device, not just this host's: a draft the user is
+  // live-typing in another composer must never be offered here.
+  const loadedAnywhere = useMemo(() => {
+    const ids = new Set<string>()
+    for (const row of loaded) if (row.draftId) ids.add(row.draftId)
+    return ids
+  }, [loaded])
+
+  const streamMap = useMemo(() => {
+    const map = new Map<string, CachedStream>()
+    for (const stream of cachedStreams ?? []) map.set(stream.id, stream)
+    return map
+  }, [cachedStreams])
+
+  const archivedStreamIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const stream of cachedStreams ?? []) if (stream.archivedAt) ids.add(stream.id)
+    return ids
+  }, [cachedStreams])
+
+  const candidates = useMemo(
+    () =>
+      allDrafts.filter(
+        (draft) => couldLandFlat(draft.scope) && !loadedAnywhere.has(draft.id) && draftHasPayload(draft)
+      ),
+    [allDrafts, loadedAnywhere]
+  )
+
+  const landingScopes = useMemo(() => {
+    const scopes = candidates.map((draft) => draft.scope)
+    if (scope && couldLandFlat(scope)) scopes.push(scope)
+    return scopes
+  }, [candidates, scope])
+
+  const landingSites = useDraftLandingSites(workspaceId, landingScopes)
+
+  const scopeExact = useMemo(() => {
+    if (!workspaceId || !scope) return []
+    return (
+      allDrafts
+        // No payload filter here, deliberately: a draft carrying only context refs
+        // (seeded by "Discuss with Ariadne") has an empty body and no attachments,
+        // and the explorer already skips it — the scope's own picker is the last
+        // surface that can reach it, so filtering here would strand it while it
+        // keeps syncing. `loadedAnywhere` is not optional: a row checked out under
+        // any scope on this device must be claimable from none.
+        .filter((draft) => draft.scope === scope && !loadedAnywhere.has(draft.id))
+        .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
+    )
+  }, [allDrafts, workspaceId, scope, loadedAnywhere])
+
+  const livePile = useMemo(() => {
+    if (!workspaceId || !scope) return []
+    const host = landingSites.get(scope)
+    if (host?.kind !== "flat") return scopeExact
+    const landingStreamId = host.streamId
+    // A stream we can't confirm is plaintext and active keeps the pile private:
+    // a plaintext board draft must never be offered into a sealed composer, and
+    // an archived stream's pile is nobody else's business.
+    if (isStreamEncrypted(landingStreamId, streamMap)) return scopeExact
+    if (isStreamArchived(landingStreamId, streamMap, archivedStreamIds)) return scopeExact
+
+    return candidates
+      .filter((draft) => {
+        if (draft.id === loadedId) return false
+        const site = landingSites.get(draft.scope)
+        return site?.kind === "flat" && site.streamId === landingStreamId
+      })
+      .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
+  }, [workspaceId, scope, landingSites, scopeExact, candidates, loadedId, streamMap, archivedStreamIds])
+
+  // Latch while the picker is open — see `setPileOpen`.
+  const [pileOpen, setPileOpen] = useState(false)
+  const latchedIdsRef = useRef<string[] | null>(null)
+  const draftsById = useMemo(() => {
+    const map = new Map<string, CachedDraft>()
+    for (const draft of allDrafts) map.set(draft.id, draft)
+    return map
+  }, [allDrafts])
 
   const drafts = useMemo(() => {
-    if (!workspaceId || !scope) return []
-    return allDrafts
-      .filter((draft) => draft.scope === scope && draft.id !== loadedId)
-      .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
-  }, [allDrafts, workspaceId, scope, loadedId])
+    if (!pileOpen) {
+      latchedIdsRef.current = null
+      return livePile
+    }
+    if (!latchedIdsRef.current) latchedIdsRef.current = livePile.map((draft) => draft.id)
+    const rows = new Map<string, CachedDraft>()
+    for (const id of latchedIdsRef.current) {
+      const row = draftsById.get(id)
+      // A row that was deleted, emptied or checked out into a composer still goes
+      // — the latch holds membership against a moving landing site, not the row.
+      if (!row || !draftHasPayload(row) || loadedAnywhere.has(row.id)) continue
+      rows.set(id, row)
+    }
+    for (const row of livePile) rows.set(row.id, row)
+    return [...rows.values()].sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
+  }, [pileOpen, livePile, draftsById, loadedAnywhere])
+
+  const originByDraftId = useMemo(() => {
+    const map = new Map<string, StashedDraftOrigin>()
+    for (const draft of drafts) {
+      const origin = draftOrigin(draft.scope)
+      if (origin) map.set(draft.id, origin)
+    }
+    return map
+  }, [drafts])
 
   const isLoaded = hasSeededDraftCache(workspaceId)
   const syncEngine = useOptionalSyncEngine()
@@ -54,5 +214,5 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     [workspaceId, syncEngine]
   )
 
-  return { drafts, isLoaded, deleteStashedDraft }
+  return { drafts, claimableDrafts: scopeExact, originByDraftId, isLoaded, deleteStashedDraft, setPileOpen }
 }

--- a/apps/frontend/src/lib/drafts/home-stream.test.ts
+++ b/apps/frontend/src/lib/drafts/home-stream.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+import {
+  isDraftInHostPile,
+  isTopLevelDraftScope,
+  resolveDraftConversation,
+  resolveDraftHomeStream,
+  type DraftPileContext,
+} from "./home-stream"
+
+const context: DraftPileContext = {
+  streamById: new Map([
+    ["stream_s", { rootStreamId: null }],
+    ["stream_t", { rootStreamId: "stream_s" }],
+    ["stream_tc", { rootStreamId: "stream_s", parentAnchorId: "msg_c" }],
+    ["stream_other", { rootStreamId: null }],
+  ]),
+  boardPostByConversationId: new Map([
+    ["conv_s", { conversation: { streamId: "stream_s" } }],
+    ["conv_t", { conversation: { streamId: "stream_t" } }],
+    ["conv_c", { conversation: { streamId: "stream_s" } }],
+    ["conv_d", { conversation: { streamId: "stream_s" } }],
+    ["conv_branch", { conversation: { streamId: "stream_tc" } }],
+  ]),
+  threadAnchorStreamById: new Map([
+    ["msg_1", { streamId: "stream_t" }],
+    ["msg_c", { streamId: "stream_s" }],
+    ["msg_loose", { streamId: "stream_s" }],
+  ]),
+  conversationIdByMessageId: new Map([
+    ["msg_c", "conv_c"],
+    ["msg_d", "conv_d"],
+  ]),
+  parentConversationIdByBranchId: new Map([["conv_branch", "conv_c"]]),
+}
+
+describe("resolveDraftHomeStream", () => {
+  it("resolves every scope under one root to that root", () => {
+    expect(resolveDraftHomeStream("stream:stream_s", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("stream:stream_t", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("thread:msg_1", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("board:reply:conv_s", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("board:reply:conv_t", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("board:branch-reply:conv_t", context)).toBe("stream_s")
+    expect(resolveDraftHomeStream("board:subtopic:stream_t:msg_9", context)).toBe("stream_s")
+  })
+
+  it("keeps another root separate", () => {
+    expect(resolveDraftHomeStream("stream:stream_other", context)).toBe("stream_other")
+  })
+
+  it("treats an uncached stream as its own root (a scratchpad has no row)", () => {
+    expect(resolveDraftHomeStream("stream:draft_9", context)).toBe("draft_9")
+  })
+
+  it("returns null for anything unresolvable", () => {
+    expect(resolveDraftHomeStream("board:reply:conv_missing", context)).toBeNull()
+    expect(resolveDraftHomeStream("thread:msg_missing", context)).toBeNull()
+    expect(resolveDraftHomeStream("stream:", context)).toBeNull()
+    expect(resolveDraftHomeStream("nonsense", context)).toBeNull()
+  })
+})
+
+describe("resolveDraftConversation", () => {
+  it("names the conversation a scope's message would belong to", () => {
+    expect(resolveDraftConversation("board:reply:conv_c", context)).toBe("conv_c")
+    expect(resolveDraftConversation("board:branch-reply:conv_branch", context)).toBe("conv_c")
+    expect(resolveDraftConversation("board:subtopic:stream_s:msg_c", context)).toBe("conv_c")
+    expect(resolveDraftConversation("thread:msg_c", context)).toBe("conv_c")
+    expect(resolveDraftConversation("stream:stream_tc", context)).toBe("conv_c")
+  })
+
+  it("returns null for a top-level scope and for an unresolvable owner", () => {
+    expect(resolveDraftConversation("stream:stream_s", context)).toBeNull()
+    expect(resolveDraftConversation("thread:msg_loose", context)).toBeNull()
+    expect(resolveDraftConversation("nonsense", context)).toBeNull()
+  })
+
+  it("falls back to the branch itself when its parent is not cached", () => {
+    expect(resolveDraftConversation("board:branch-reply:conv_orphan", context)).toBe("conv_orphan")
+  })
+})
+
+describe("isTopLevelDraftScope", () => {
+  it("is true for a root stream and a conversation reply, false below them", () => {
+    expect(isTopLevelDraftScope("stream:stream_s", context)).toBe(true)
+    expect(isTopLevelDraftScope("board:reply:conv_c", context)).toBe(true)
+    expect(isTopLevelDraftScope("stream:stream_t", context)).toBe(false)
+    expect(isTopLevelDraftScope("thread:msg_c", context)).toBe(false)
+    expect(isTopLevelDraftScope("board:subtopic:stream_s:msg_c", context)).toBe(false)
+  })
+})
+
+describe("isDraftInHostPile", () => {
+  it("takes the own, same-conversation, top-level-draft and top-level-host routes", () => {
+    expect(isDraftInHostPile("thread:msg_c", "thread:msg_c", context)).toBe(true)
+    expect(isDraftInHostPile("board:reply:conv_c", "thread:msg_c", context)).toBe(true)
+    expect(isDraftInHostPile("thread:msg_loose", "stream:stream_s", context)).toBe(true)
+    expect(isDraftInHostPile("stream:stream_s", "thread:msg_c", context)).toBe(true)
+  })
+
+  it("keeps one conversation's drafts out of another's pile", () => {
+    expect(isDraftInHostPile("board:reply:conv_d", "thread:msg_c", context)).toBe(false)
+    expect(isDraftInHostPile("board:reply:conv_d", "board:reply:conv_c", context)).toBe(false)
+  })
+
+  it("leaves a conversation-less thread draft in its own pile only", () => {
+    expect(isDraftInHostPile("stream:stream_s", "thread:msg_loose", context)).toBe(false)
+    expect(isDraftInHostPile("board:reply:conv_c", "thread:msg_loose", context)).toBe(false)
+  })
+
+  it("never matches two unknowns, and never crosses roots", () => {
+    expect(isDraftInHostPile("thread:msg_loose", "thread:msg_missing", context)).toBe(false)
+    expect(isDraftInHostPile("stream:stream_other", "stream:stream_s", context)).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/drafts/home-stream.ts
+++ b/apps/frontend/src/lib/drafts/home-stream.ts
@@ -30,10 +30,12 @@ export interface DraftPileContext extends DraftHomeContext {
 }
 
 /**
- * The root stream a draft's message would land under — its "home". Coarser than
- * {@link resolveDraftLandingSite} on purpose: everything under one root (the root
- * itself, its threads, the conversations anchored in it) shares a home, and the
- * landing site stays the finer answer for origin labels and adopt-vs-move.
+ * The root stream a draft's message would land under — its "home". Deliberately
+ * coarse: everything under one root (the root itself, its threads, the
+ * conversations anchored in it) shares a home, and {@link isDraftInHostPile}
+ * does the finer work of deciding which of them may see each other. Origin
+ * labels read {@link resolveDraftConversation}; adopt-vs-move reads the row's
+ * `StashedDraftSource`.
  *
  * `null` means unresolvable — an uncached conversation or an uncached thread
  * anchor — and is never membership (INV-11).

--- a/apps/frontend/src/lib/drafts/home-stream.ts
+++ b/apps/frontend/src/lib/drafts/home-stream.ts
@@ -1,0 +1,138 @@
+import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+
+/** The cached board post fields a home stream is derived from. */
+export interface HomeStreamBoardPost {
+  conversation: { streamId: string }
+}
+
+/** The cached stream fields the pile reads: its root, and (for a thread) the anchor it hangs off. */
+export interface HomeStreamRow {
+  rootStreamId?: string | null
+  parentAnchorId?: string | null
+  parentMessageId?: string | null
+}
+
+export interface DraftHomeContext {
+  /** Cached stream row by id. A missing id is its own root (a scratchpad has no row). */
+  streamById: ReadonlyMap<string, HomeStreamRow>
+  /** Cached board post by conversation id, for `board:reply:` / `board:branch-reply:` scopes. */
+  boardPostByConversationId: ReadonlyMap<string, HomeStreamBoardPost>
+  /** Thread anchor id → the stream holding the anchored message, for `thread:` scopes. */
+  threadAnchorStreamById: ReadonlyMap<string, { streamId: string }>
+}
+
+/** {@link DraftHomeContext} plus what a scope's conversation is resolved from. */
+export interface DraftPileContext extends DraftHomeContext {
+  /** Message/anchor id → the conversation that contains it. */
+  conversationIdByMessageId: ReadonlyMap<string, string>
+  /** Branch conversation id → the conversation whose message the branch forks off. */
+  parentConversationIdByBranchId: ReadonlyMap<string, string>
+}
+
+/**
+ * The root stream a draft's message would land under — its "home". Coarser than
+ * {@link resolveDraftLandingSite} on purpose: everything under one root (the root
+ * itself, its threads, the conversations anchored in it) shares a home, and the
+ * landing site stays the finer answer for origin labels and adopt-vs-move.
+ *
+ * `null` means unresolvable — an uncached conversation or an uncached thread
+ * anchor — and is never membership (INV-11).
+ */
+export function resolveDraftHomeStream(scope: string, context: DraftHomeContext): string | null {
+  const root = (streamId: string): string => context.streamById.get(streamId)?.rootStreamId ?? streamId
+
+  if (scope.startsWith("stream:")) {
+    const streamId = scope.slice("stream:".length)
+    return streamId ? root(streamId) : null
+  }
+  if (scope.startsWith("thread:")) {
+    const anchorId = scope.slice("thread:".length)
+    const info = anchorId ? context.threadAnchorStreamById.get(anchorId) : undefined
+    return info ? root(info.streamId) : null
+  }
+
+  const board = parseBoardDraftKey(scope)
+  if (!board) return null
+  if (board.kind === "subtopic") return root(board.streamId)
+
+  const post = context.boardPostByConversationId.get(board.conversationId)
+  return post ? root(post.conversation.streamId) : null
+}
+
+/**
+ * The conversation a scope's message would belong to, or `null` when it belongs
+ * to none (a top-level scope) or the owner isn't cached. Two `null`s are two
+ * unknowns, never a match (INV-11) — callers compare only non-null ids.
+ *
+ * A branch resolves to its PARENT conversation (a branch of C is part of C),
+ * falling back to the branch itself so a branch whose parent isn't cached still
+ * pairs with its own composer rather than with everything.
+ */
+export function resolveDraftConversation(scope: string, context: DraftPileContext): string | null {
+  if (scope.startsWith("thread:")) {
+    const anchorId = scope.slice("thread:".length)
+    return anchorId ? (context.conversationIdByMessageId.get(anchorId) ?? null) : null
+  }
+  if (scope.startsWith("stream:")) {
+    const streamId = scope.slice("stream:".length)
+    if (!streamId) return null
+    const row = context.streamById.get(streamId)
+    const anchorId = row?.parentAnchorId ?? row?.parentMessageId
+    return anchorId ? (context.conversationIdByMessageId.get(anchorId) ?? null) : null
+  }
+
+  const board = parseBoardDraftKey(scope)
+  if (!board) return null
+  if (board.kind === "reply") return board.conversationId
+  if (board.kind === "branch-reply") {
+    return context.parentConversationIdByBranchId.get(board.conversationId) ?? board.conversationId
+  }
+  return context.conversationIdByMessageId.get(board.messageId) ?? null
+}
+
+/**
+ * Whether writing in this scope is a top-level act in its stream: the root
+ * stream's own composer, or a reply to a conversation (which the user could just
+ * as well have written top level, including a conversation that has drifted into
+ * a thread).
+ */
+export function isTopLevelDraftScope(scope: string, context: DraftHomeContext): boolean {
+  if (scope.startsWith("stream:")) {
+    const streamId = scope.slice("stream:".length)
+    if (!streamId) return false
+    return !context.streamById.get(streamId)?.rootStreamId
+  }
+  return parseBoardDraftKey(scope)?.kind === "reply"
+}
+
+/**
+ * Whether draft `d` belongs in host `H`'s pile — "could I have written this
+ * here". Same root stream throughout, then any of four membership routes:
+ *
+ * - **own** — the same scope.
+ * - **same conversation** — both resolve to one conversation. Two conversations
+ *   never share a pile, which is why the equality is returned rather than
+ *   falling through to the routes below.
+ * - **top-level draft** — a root-stream or conversation-reply draft is a
+ *   plausible alternative from anywhere in the root, threads included.
+ * - **top-level host** — the channel composer offers every draft owned by a
+ *   conversation in this root (a thread, branch or sub-topic of it included), so
+ *   it surfaces there labelled with its conversation.
+ *
+ * The one thing left out: a draft that belongs to no conversation and is not top
+ * level — a draft in a thread that is part of no conversation. It stays in its
+ * own scope's pile.
+ */
+export function isDraftInHostPile(hostScope: string, draftScope: string, context: DraftPileContext): boolean {
+  if (draftScope === hostScope) return true
+
+  const home = resolveDraftHomeStream(hostScope, context)
+  if (!home || resolveDraftHomeStream(draftScope, context) !== home) return false
+
+  const hostConversationId = resolveDraftConversation(hostScope, context)
+  const draftConversationId = resolveDraftConversation(draftScope, context)
+  if (hostConversationId && draftConversationId) return hostConversationId === draftConversationId
+  if (isTopLevelDraftScope(draftScope, context)) return true
+  if (draftConversationId) return isTopLevelDraftScope(hostScope, context)
+  return false
+}


### PR DESCRIPTION
## Problem

`useStashedDrafts` filtered `draft.scope === scope`. That one line is why a reply you started on a board card is invisible from the channel's composer and vice versa — the two surfaces keep separate piles of the same user's unsent text.

Widening it is not just a filter change. A pile that offers a draft the send would file somewhere else is a wrong-place send, and the `?stash=` deep link decides its owner by asking "is this draft in my pile?" — already ambiguous today, because a board card and the conversation panel mount the same scope and both answer yes.

## Solution

Membership has **four routes in**, all requiring the same root stream. This shape is the product owner's, arrived at over two corrections after testing an earlier model in staging: first widen from "where would this draft land" to "where could I plausibly have written it", then narrow from the whole stream to the conversation.

- **Own** — `draft.scope === host.scope`. Tier `own`; everything below is `borrowed`.
- **Same conversation** — and this equality is also the exclusion: conversation A's drafts never appear in conversation B's pile, even though a reply is otherwise "top level".
- **The draft is top level** — `stream:<root>`, or a reply to any conversation. These reach downward into every pile in the root: "I could have just said this in the channel" is always a plausible alternative.
- **You are at top level and the draft belongs to a conversation here** — so a draft living in a conversation's thread, branch or sub-topic still surfaces in the channel composer, to be labelled with its conversation.

That leaves exactly one thing out: a draft in a thread owned by **no** conversation. It stays in its own composer.

Order is all `own` rows then all `borrowed`, each newest-first, so the boundary is renderable. `originByDraftId` carries the tier and the source as structured data — no display strings; the rendering surface formats.

Excluded throughout: a different root stream, a draft checked out under **any** scope on this device (two scopes holding one row make their debounced saves fight over its `scope` and body), an archived or encrypted home, and an unresolvable home. `unknown` is never membership and is re-derived per render rather than latched — the board-post map is empty on the first frame.

**The `?stash=` owner is a claim, not a query.** The mounted-composer registry became ordered; the first still-mounted composer on a scope is the single consumer. `conversation-panel.tsx` dropped its duplicate of the membership test and now skips a deep link whose row is already checked out.

**One shared subscription, not one per mount.** Board context and thread-anchor resolution are ref-counted and keyed on the referenced ids, so the drafts explorer, the sidebar badge and every mounted composer share one read. This *removes* a workspace-wide `db.events` scan that `useDraftThreadStreamMap` was running per mount.

### Residuals, all deliberate

- A `thread:`/`stream:<threadId>` draft whose conversation is neither named by a scope in play nor present in `db.conversationMessages` resolves `null`, so it misses the top-level route until that conversation is opened. Fail-closed (INV-11). The clean fix is a multiEntry index on `conversation.messageIds`, which needs an IDB version bump — chunk 3 bumps anyway, so it goes there rather than being smuggled in here.
- A sub-topic or branch **host** composer now puts its own scope in the board-context signature, which triggers that context's existing workspace-wide conversations scan. Plain `board:reply:` / `stream:` / `thread:` hosts stay on keyed reads.
- `hooks/use-draft-landing-sites.ts` has no callers after the narrowing. Kept for chunk 4's adopt-vs-move; it will read as dead code until then.

### No user-visible change, deliberately

The pickers still render the scope-exact list. Restore is still a pointer move within the row's own scope, so restoring a foreign row would silently migrate that row's `scope` on the first keystroke — through the *coalescing* `enqueueDraftUpsert` rather than the `{ forceNewOp: true }` that exists for scope moves, which is the recorded "cancel-armed-reply left the server row branch-scoped forever" failure. The wide pile is computed and exported for the next chunk; `handleRestoreStashed` also refuses a non-claimable id, so wiring it up later has to be deliberate.

### Known issues

- `livePile`'s `draft.id === loadedId` check is dead (`candidates` already excludes it). Left alone rather than touching a verified predicate.
- `setPileOpen` latches the wide pile, which nothing renders yet; the latch becomes observable when the pile is rendered.
- The "picker receives the scope-exact list" assertion exists for `board-inline-composer` only — `message-input.test.tsx` has no stash surface and `stream-panel` has no test file. The wiring was enumerated by review instead.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-stashed-drafts.ts` | Landing-site membership, `claimableDrafts`, `originByDraftId`, `setPileOpen` |
| `apps/frontend/src/hooks/use-stash-composer.ts` | Restore refuses a non-claimable id; `useStashParamDraftRow` reports `isLoadedForScope` |
| `apps/frontend/src/hooks/use-draft-composer.ts` | Registry becomes an ordered token list; `isStashClaimant` |
| `apps/frontend/src/hooks/use-board-draft-context.ts` | Per-mount `useLiveQuery` → ref-counted shared subscription |
| `apps/frontend/src/hooks/use-draft-landing-sites.ts` | Reads `useWorkspaceStreamsRaw` (no decrypt-overlay churn) |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Exports `draftHasPayload` / `isStreamArchived` instead of duplicating them |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | Optional `onOpenChange` for the latch |
| `apps/frontend/src/components/{timeline/message-input,thread/stream-panel,board/board-inline-composer}.tsx` | Pass the scope-exact list; report picker open |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Uses the shared param row; skips an already-loaded deep link |
| tests | `use-stashed-drafts` (+10, the whole membership table), `use-stash-composer` (+3), `board-inline-composer`, `conversation-panel` |

## Test plan

- [x] `use-stashed-drafts`, `home-stream`, `landing-site`, `use-stash-composer`, `use-all-drafts`, `pages/drafts`, `conversation-panel`, `board-inline-composer`, `stashed-drafts-picker`, `message-input`, `quick-links`, `use-draft-composer.double-editor` — **all green**; the membership block encodes the product owner's worked example one test per clause
- [x] `bunx tsc --noEmit -p apps/frontend` — clean
- [x] Falsification: restoring root-wide membership reds 8 tests including both "never in another conversation's pile" cases; dropping the host from the anchor signature reds 6 including the thread-host case; the claimant, two-scope-checkout and non-claimable-restore tests were each written failing first
- [x] A false-pass shape was found and closed while falsifying: `expectPile(scope, [])` satisfies `waitFor` on the empty first frame, so every exclusion assertion now carries a control row that must appear
- [ ] No browser pass — nothing renders differently in this chunk, so there is nothing to screenshot yet

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-3cd745/ — chunk 2 of 0-5. Chunk 3 adds the durable composer target, chunk 4 the adopt-vs-move restore that switches this pile on, chunk 5 the picker UI.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
