### PR TITLE
perf: coalesce the live counter and preview commit

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -10,7 +10,7 @@ import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { resetActorLookups } from "@/stores/actor-lookup"
-import { resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration, resetEventWriteFlags } from "@/db/event-writes"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -82,6 +82,10 @@ function flushModuleStoreCaches(): void {
   resetWorkspaceTableRegistry()
   resetActorLookups()
   resetEventWriteFlags()
+  // The `db` proxy is repointed on a switch, so any write deferred past this
+  // point would land in the new account's database — deferred writers capture
+  // this generation and bail when it moves.
+  bumpAccountGeneration()
   resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -258,12 +258,19 @@ describe("isEventWriteChunkingEnabled", () => {
     const second = await readEventWriteFlagsFresh(db, "ws_1")
 
     expect({ first, second }).toEqual({
-      first: { chunking: true, indexedMessagePatch: true, sharedStreamRegistration: false, singlePreviewWriter: false },
+      first: {
+        chunking: true,
+        indexedMessagePatch: true,
+        sharedStreamRegistration: false,
+        singlePreviewWriter: false,
+        coalescedLiveCommit: false,
+      },
       second: {
         chunking: false,
         indexedMessagePatch: true,
         sharedStreamRegistration: false,
         singlePreviewWriter: false,
+        coalescedLiveCommit: false,
       },
     })
   })

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -77,6 +77,7 @@ type EventWriteFlags = {
   indexedMessagePatch: boolean
   sharedStreamRegistration: boolean
   singlePreviewWriter: boolean
+  coalescedLiveCommit: boolean
 }
 
 const flagsByWorkspace = new Map<string, EventWriteFlags>()
@@ -89,6 +90,7 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
     indexedMessagePatch: resolved.indexedMessagePatch === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
     singlePreviewWriter: resolved.singlePreviewWriter === "on",
+    coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
   }
 }
 
@@ -159,6 +161,11 @@ export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, work
 /** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */
 export async function isSinglePreviewWriterEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
   return (await getEventWriteFlags(database, workspaceId)).singlePreviewWriter
+}
+
+/** The viewer's `coalescedLiveCommit` value, resolved through the same primed cache. */
+export async function isCoalescedLiveCommitEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
+  return (await getEventWriteFlags(database, workspaceId)).coalescedLiveCommit
 }
 
 /**

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -163,9 +163,14 @@ export async function isSinglePreviewWriterEnabled(database: ThreaDatabase, work
   return (await getEventWriteFlags(database, workspaceId)).singlePreviewWriter
 }
 
-/** The viewer's `coalescedLiveCommit` value, resolved through the same primed cache. */
-export async function isCoalescedLiveCommitEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).coalescedLiveCommit
+/**
+ * The viewer's `coalescedLiveCommit` value, read only from the primed map so the
+ * synchronous commit seams can re-read it per event. A backoffice flip re-primes
+ * the map, so arming and disarming both take effect on the next event; an
+ * unprimed read takes the immediate path rather than guessing.
+ */
+export function isCoalescedLiveCommitEnabledSync(workspaceId: string): boolean {
+  return flagsByWorkspace.get(workspaceId)?.coalescedLiveCommit ?? false
 }
 
 /**

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -82,6 +82,22 @@ type EventWriteFlags = {
 
 const flagsByWorkspace = new Map<string, EventWriteFlags>()
 let primeGeneration = 0
+let accountGeneration = 0
+
+/**
+ * Bumped on every account switch (the `flushModuleStoreCaches` site), so a
+ * deferred writer that captured the generation can tell that the global `db`
+ * proxy was repointed under it and refuse to write account A's rows into
+ * account B's database.
+ */
+export function bumpAccountGeneration(): void {
+  accountGeneration += 1
+}
+
+/** The current account generation — capture it before deferring a write. */
+export function getAccountGeneration(): number {
+  return accountGeneration
+}
 
 function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)

--- a/apps/frontend/src/stores/stream-context-store.ts
+++ b/apps/frontend/src/stores/stream-context-store.ts
@@ -1,6 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedStreamContextItem } from "@/db"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { MESSAGE_BODY_CONTEXT_CATEGORIES, type StreamContextItem, type StreamContextScope } from "@threa/types"
 
 export type { CachedStreamContextItem }
@@ -124,6 +125,7 @@ export async function seedStreamContextItems(
  */
 export async function putLocalContextRows(rows: CachedStreamContextItem[]): Promise<void> {
   if (rows.length === 0) return
+  getPerfCapture().count("stream.idbTransaction")
   await db.transaction("rw", db.streamContextItems, async () => {
     // Never downgrade a reconciled row. Event re-delivery is routine (catch-up
     // replays every sync-log entry through these handlers, and the gate's resume

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -13,6 +13,13 @@ import {
   type ResolvedReadAllFrontier,
 } from "./read-state"
 
+/** One drain's worth of buffered work, detached from the batch. */
+type PendingFold = {
+  mutators: CounterMutator[]
+  previews: Map<string, LastMessagePreview | null>
+  snapshots: StreamReadFrontierSnapshot[]
+}
+
 /** One absolute (or relative) counter mutation, expressed as pure state math. */
 export type CounterMutator = (state: UnreadCounterState) => UnreadCounterState
 
@@ -209,10 +216,30 @@ export class LiveCommitBatch {
     // The chain carries the swallowed copy: `.then(onFulfilled)` on a rejected
     // promise skips its callback and propagates, so one rejection (a mutator
     // throwing inside publish) would poison every later flush permanently.
-    this.chain = attempt.catch((error) => {
-      console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
-    })
+    this.chain = attempt.catch(this.logFlushFailure)
     return attempt
+  }
+
+  /** Drain, then run `fn` — on the batch's OWN chain, so anything buffered after
+   *  this call queues BEHIND `fn` instead of racing it. Branching off `flush()`'s
+   *  returned promise inverts order: that promise settles when its drain runs,
+   *  and that drain commits whatever was buffered by then, which can be newer
+   *  than `fn`. */
+  runAfterDrain(fn: () => void): void {
+    this.scheduled = false
+    // Taken NOW, not when the drain runs: a commit that re-reads the buffers at
+    // execution time would sweep up whatever was buffered after this call and
+    // publish it BEFORE `fn`.
+    const drained = this.takePending()
+    this.chain = this.chain
+      .then(() => this.commit(drained))
+      .catch(this.logFlushFailure)
+      .then(fn)
+      .catch(this.logFlushFailure)
+  }
+
+  private readonly logFlushFailure = (error: unknown): void => {
+    console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
   }
 
   /** Stop writing on behalf of a torn-down workspace: a flush already scheduled
@@ -234,22 +261,28 @@ export class LiveCommitBatch {
     })
   }
 
-  private async commit(): Promise<void> {
+  private takePending(): PendingFold {
+    const pending = {
+      mutators: this.counterMutators,
+      previews: this.streamPreviews,
+      snapshots: this.readAllSnapshots,
+    }
+    this.counterMutators = []
+    this.streamPreviews = new Map()
+    this.readAllSnapshots = []
+    return pending
+  }
+
+  private async commit(pending?: PendingFold): Promise<void> {
     this.flushing = true
     try {
-      await this.runCommit()
+      await this.runCommit(pending ?? this.takePending())
     } finally {
       this.flushing = false
     }
   }
 
-  private async runCommit(): Promise<void> {
-    const mutators = this.counterMutators
-    const previews = this.streamPreviews
-    const snapshots = this.readAllSnapshots
-    this.counterMutators = []
-    this.streamPreviews = new Map()
-    this.readAllSnapshots = []
+  private async runCommit({ mutators, previews, snapshots }: PendingFold): Promise<void> {
     if (this.destroyed) return
     if (getAccountGeneration() !== this.accountGeneration) return
     if (mutators.length === 0 && previews.size === 0 && snapshots.length === 0) return

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query"
 import type { LastMessagePreview, StreamReadFrontierSnapshot, WorkspaceBootstrap } from "@threa/types"
 import { db } from "@/db"
+import { getAccountGeneration } from "@/db/event-writes"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { activityKeys } from "@/hooks/use-activity"
@@ -136,8 +137,13 @@ export function commitStreamPreview(
 export class LiveCommitBatch {
   private counterMutators: CounterMutator[] = []
   private streamPreviews = new Map<string, LastMessagePreview | null>()
+  private readAllSnapshots: StreamReadFrontierSnapshot[] = []
   private scheduled = false
   private destroyed = false
+  /** The account this batch belongs to. `db` is a proxy repointed on an account
+   *  switch, so a flush resolving after one would write these rows into the
+   *  other account's database. */
+  private readonly accountGeneration = getAccountGeneration()
   /** Latches the engine reseed request until a flush succeeds. */
   private reseedRequested = false
   /** Flushes run one at a time and in schedule order, so an awaited `flush()`
@@ -166,6 +172,27 @@ export class LiveCommitBatch {
     this.schedule()
   }
 
+  /** Buffer one read-all payload's additive frontier snapshots, resolved and
+   *  persisted at flush time inside the same transaction as the counter fold —
+   *  the live mirror of {@link CatchUpBatch.applyReadAllFrontiers}. The counter
+   *  half arrives through {@link applyCounter}, so a read-all and the activity
+   *  that preceded it fold in DELIVERY order: routing read-all around this
+   *  buffer would let its drop-held-rows transaction open at handler time and
+   *  run BEFORE the fold that inserts the held activity, resurrecting a mention
+   *  the user already read. */
+  applyReadAllFrontiers(frontiers: StreamReadFrontierSnapshot[] | undefined): void {
+    if (this.destroyed || !frontiers || frontiers.length === 0) return
+    this.readAllSnapshots.push(...frontiers)
+    this.schedule()
+  }
+
+  /** Whether anything is buffered and not yet committed. Callers taking the
+   *  immediate path (the flag flipped off mid-task) drain first, so a pending
+   *  fold can't land on top of a newer immediate commit. */
+  hasPending(): boolean {
+    return this.counterMutators.length > 0 || this.streamPreviews.size > 0 || this.readAllSnapshots.length > 0
+  }
+
   /** Commit everything buffered so far. Awaited by the engine when a catch-up
    *  window opens, so a live fold can never interleave into a replay fold. */
   flush(): Promise<void> {
@@ -186,6 +213,7 @@ export class LiveCommitBatch {
     this.destroyed = true
     this.counterMutators = []
     this.streamPreviews.clear()
+    this.readAllSnapshots = []
   }
 
   private schedule(): void {
@@ -201,41 +229,66 @@ export class LiveCommitBatch {
   private async commit(): Promise<void> {
     const mutators = this.counterMutators
     const previews = this.streamPreviews
+    const snapshots = this.readAllSnapshots
     this.counterMutators = []
     this.streamPreviews = new Map()
+    this.readAllSnapshots = []
     if (this.destroyed) return
-    if (mutators.length === 0 && previews.size === 0) return
+    if (getAccountGeneration() !== this.accountGeneration) return
+    if (mutators.length === 0 && previews.size === 0 && snapshots.length === 0) return
 
-    // The fold runs after the handler returns, so `stream.activityApply` timed
-    // inside the handler no longer covers it — time it here so the coalesced arm
-    // stays comparable with the immediate arm's sample.
-    const stopActivityApply = getPerfCapture().time("stream.activityApply")
+    // Its OWN mark, never the handler's: the handler-body `stream.activityApply`
+    // fires per event in both arms, so folding this sample into that name would
+    // mix an N-sample buffer-push population with one persist-and-publish sample
+    // and make the arms unreadable.
+    const stopFold = getPerfCapture().time("stream.liveCommitFold")
+    const haveFrontiers = snapshots.length > 0
+    let resolved: ResolvedReadAllFrontier[] = []
     try {
       getPerfCapture().count("stream.idbTransaction")
-      await db.transaction("rw", [db.streams, db.unreadState], async () => {
-        await putCountersIdb(this.workspaceId, mutators)
-        await putPreviewsIdb(previews)
-      })
+      await db.transaction(
+        "rw",
+        haveFrontiers ? [db.streams, db.unreadState, db.streamReadState] : [db.streams, db.unreadState],
+        async () => {
+          await putCountersIdb(this.workspaceId, mutators)
+          await putPreviewsIdb(previews)
+          if (haveFrontiers) {
+            resolved = await resolveReadAllFrontiers(this.queryClient, this.workspaceId, snapshots)
+            await putReadAllFrontiersIdb(this.workspaceId, resolved)
+          }
+        }
+      )
     } catch (error) {
-      stopActivityApply()
-      console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
-      // At most one reseed until a flush succeeds: a persistently failing IDB
-      // would otherwise turn every message into a forced full bootstrap, each of
-      // which fails the same way. Only a dropped counter fold needs the reseed —
-      // a dropped preview is non-critical and the next bootstrap carries it.
-      if (mutators.length > 0 && !this.reseedRequested) {
-        this.reseedRequested = true
-        this.onFlushFailed?.()
-      }
+      stopFold()
+      this.reportFailure(error, mutators.length > 0)
       return
     }
 
     try {
-      this.reseedRequested = false
       if (this.destroyed) return
+      if (getAccountGeneration() !== this.accountGeneration) return
       this.publish(mutators, previews)
+      publishReadAllFrontiersToCache(this.queryClient, this.workspaceId, resolved)
+      this.reseedRequested = false
+    } catch (error) {
+      // A publish failure drops the fold just as a transaction failure does, and
+      // a held-set `upsertActivity` cannot self-heal from the next event — so it
+      // takes the same one-shot reseed rather than being left as a residual.
+      this.reportFailure(error, mutators.length > 0)
     } finally {
-      stopActivityApply()
+      stopFold()
+    }
+  }
+
+  /** One-shot reseed latch: a persistently failing IDB would otherwise turn
+   *  every message into a forced full bootstrap, each of which fails the same
+   *  way. Only a dropped counter fold needs it — a dropped preview is
+   *  non-critical and the next bootstrap carries it. */
+  private reportFailure(error: unknown, hadCounters: boolean): void {
+    console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
+    if (hadCounters && !this.reseedRequested) {
+      this.reseedRequested = true
+      this.onFlushFailed?.()
     }
   }
 

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query"
 import type { LastMessagePreview, StreamReadFrontierSnapshot, WorkspaceBootstrap } from "@threa/types"
 import { db } from "@/db"
+import { getPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { activityKeys } from "@/hooks/use-activity"
 import { diffCounterStreams, toCounterState, withCounterState, type UnreadCounterState } from "./unread-counters"
@@ -101,6 +102,7 @@ async function putPreviewsIdb(previews: Map<string, LastMessagePreview | null>):
 export function commitCounterMutation(queryClient: QueryClient, workspaceId: string, mutate: CounterMutator): void {
   const mutators = [mutate]
   applyCountersToCache(queryClient, workspaceId, mutators)
+  getPerfCapture().count("stream.idbTransaction")
   void db.transaction("rw", [db.unreadState], () => putCountersIdb(workspaceId, mutators))
 }
 
@@ -113,6 +115,7 @@ export function commitStreamPreview(
 ): void {
   const previews = new Map([[streamId, preview]])
   applyPreviewsToCache(queryClient, workspaceId, previews)
+  getPerfCapture().count("stream.idbTransaction")
   void db.transaction("rw", [db.streams], () => putPreviewsIdb(previews))
 }
 
@@ -135,6 +138,8 @@ export class LiveCommitBatch {
   private streamPreviews = new Map<string, LastMessagePreview | null>()
   private scheduled = false
   private destroyed = false
+  /** Latches the engine reseed request until a flush succeeds. */
+  private reseedRequested = false
   /** Flushes run one at a time and in schedule order, so an awaited `flush()`
    *  drains everything buffered before it (the catch-up window's guarantee). */
   private chain: Promise<void> = Promise.resolve()
@@ -201,19 +206,37 @@ export class LiveCommitBatch {
     if (this.destroyed) return
     if (mutators.length === 0 && previews.size === 0) return
 
+    // The fold runs after the handler returns, so `stream.activityApply` timed
+    // inside the handler no longer covers it — time it here so the coalesced arm
+    // stays comparable with the immediate arm's sample.
+    const stopActivityApply = getPerfCapture().time("stream.activityApply")
     try {
+      getPerfCapture().count("stream.idbTransaction")
       await db.transaction("rw", [db.streams, db.unreadState], async () => {
         await putCountersIdb(this.workspaceId, mutators)
         await putPreviewsIdb(previews)
       })
     } catch (error) {
+      stopActivityApply()
       console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
-      this.onFlushFailed?.()
+      // At most one reseed until a flush succeeds: a persistently failing IDB
+      // would otherwise turn every message into a forced full bootstrap, each of
+      // which fails the same way. Only a dropped counter fold needs the reseed —
+      // a dropped preview is non-critical and the next bootstrap carries it.
+      if (mutators.length > 0 && !this.reseedRequested) {
+        this.reseedRequested = true
+        this.onFlushFailed?.()
+      }
       return
     }
 
-    if (this.destroyed) return
-    this.publish(mutators, previews)
+    try {
+      this.reseedRequested = false
+      if (this.destroyed) return
+      this.publish(mutators, previews)
+    } finally {
+      stopActivityApply()
+    }
   }
 
   /** One bootstrap replacement for the whole fold. Falls back to the helpers

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -38,6 +38,20 @@ export function applyCountersToCache(queryClient: QueryClient, workspaceId: stri
   }
 }
 
+/** The bootstrap with the latest preview per stream applied. */
+function withPreviews(
+  bootstrap: WorkspaceBootstrap,
+  previews: Map<string, LastMessagePreview | null>
+): WorkspaceBootstrap {
+  if (previews.size === 0) return bootstrap
+  return {
+    ...bootstrap,
+    streams: bootstrap.streams.map((stream) =>
+      previews.has(stream.id) ? { ...stream, lastMessagePreview: previews.get(stream.id) ?? null } : stream
+    ),
+  }
+}
+
 /** Apply the latest preview per stream to the query cache (drop-on-empty — the
  *  preview is non-critical and the next bootstrap carries it). */
 function applyPreviewsToCache(
@@ -47,14 +61,7 @@ function applyPreviewsToCache(
 ): void {
   if (previews.size === 0) return
   queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
-    old
-      ? {
-          ...old,
-          streams: old.streams.map((stream) =>
-            previews.has(stream.id) ? { ...stream, lastMessagePreview: previews.get(stream.id) ?? null } : stream
-          ),
-        }
-      : old
+    old ? withPreviews(old, previews) : old
   )
 }
 
@@ -107,6 +114,125 @@ export function commitStreamPreview(
   const previews = new Map([[streamId, preview]])
   applyPreviewsToCache(queryClient, workspaceId, previews)
   void db.transaction("rw", [db.streams], () => putPreviewsIdb(previews))
+}
+
+/**
+ * Coalesces the counter and preview writes of ONE task's live events into a
+ * single IDB transaction and a single bootstrap-cache replacement, through the
+ * same helpers `CatchUpBatch` folds with. One `stream:activity` otherwise costs
+ * two transactions and two whole-`streams`-array rebuilds; a burst costs two per
+ * message.
+ *
+ * The flush is a `queueMicrotask`, never a timer or a frame, so the badge and
+ * the sidebar still settle inside the task that delivered the events.
+ *
+ * Order is persist-then-publish, matching {@link CatchUpBatch.flush}: the caches
+ * never publish state the IDB lacks, so a failed flush publishes nothing at all
+ * rather than half of a fold.
+ */
+export class LiveCommitBatch {
+  private counterMutators: CounterMutator[] = []
+  private streamPreviews = new Map<string, LastMessagePreview | null>()
+  private scheduled = false
+  private destroyed = false
+  /** Flushes run one at a time and in schedule order, so an awaited `flush()`
+   *  drains everything buffered before it (the catch-up window's guarantee). */
+  private chain: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly queryClient: QueryClient,
+    private readonly workspaceId: string,
+    /** Invoked when a flush's transaction rejects and its fold is dropped. The
+     *  engine owns the recovery (a forced full snapshot reseed): a dropped
+     *  `upsertActivity` is a held-set insert, so it cannot self-heal from the
+     *  next message the way an absolute ordinal mutator does. */
+    private readonly onFlushFailed?: () => void
+  ) {}
+
+  applyCounter(mutate: CounterMutator): void {
+    if (this.destroyed) return
+    this.counterMutators.push(mutate)
+    this.schedule()
+  }
+
+  setStreamPreview(streamId: string, preview: LastMessagePreview | null): void {
+    if (this.destroyed) return
+    this.streamPreviews.set(streamId, preview)
+    this.schedule()
+  }
+
+  /** Commit everything buffered so far. Awaited by the engine when a catch-up
+   *  window opens, so a live fold can never interleave into a replay fold. */
+  flush(): Promise<void> {
+    this.scheduled = false
+    const attempt = this.chain.then(() => this.commit())
+    // The chain carries the swallowed copy: `.then(onFulfilled)` on a rejected
+    // promise skips its callback and propagates, so one rejection (a mutator
+    // throwing inside publish) would poison every later flush permanently.
+    this.chain = attempt.catch((error) => {
+      console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
+    })
+    return attempt
+  }
+
+  /** Stop writing on behalf of a torn-down workspace: a flush already scheduled
+   *  runs as a no-op rather than persisting against a repointed database. */
+  destroy(): void {
+    this.destroyed = true
+    this.counterMutators = []
+    this.streamPreviews.clear()
+  }
+
+  private schedule(): void {
+    if (this.scheduled) return
+    this.scheduled = true
+    queueMicrotask(() => {
+      if (!this.scheduled) return
+      // The chain logs it; this only keeps the fire-and-forget copy handled.
+      void this.flush().catch(() => {})
+    })
+  }
+
+  private async commit(): Promise<void> {
+    const mutators = this.counterMutators
+    const previews = this.streamPreviews
+    this.counterMutators = []
+    this.streamPreviews = new Map()
+    if (this.destroyed) return
+    if (mutators.length === 0 && previews.size === 0) return
+
+    try {
+      await db.transaction("rw", [db.streams, db.unreadState], async () => {
+        await putCountersIdb(this.workspaceId, mutators)
+        await putPreviewsIdb(previews)
+      })
+    } catch (error) {
+      console.error("Live commit batch flush failed", { workspaceId: this.workspaceId, error })
+      this.onFlushFailed?.()
+      return
+    }
+
+    if (this.destroyed) return
+    this.publish(mutators, previews)
+  }
+
+  /** One bootstrap replacement for the whole fold. Falls back to the helpers
+   *  when the bootstrap isn't cached, so the counter path still invalidates
+   *  (the event landed before the queryFn populated it) and the preview path
+   *  still drops. */
+  private publish(mutators: CounterMutator[], previews: Map<string, LastMessagePreview | null>): void {
+    const key = workspaceKeys.bootstrap(this.workspaceId)
+    if (!this.queryClient.getQueryData<WorkspaceBootstrap>(key)) {
+      applyCountersToCache(this.queryClient, this.workspaceId, mutators)
+      applyPreviewsToCache(this.queryClient, this.workspaceId, previews)
+      return
+    }
+    this.queryClient.setQueryData<WorkspaceBootstrap>(key, (old) => {
+      if (!old) return old
+      const counted = mutators.length === 0 ? old : withCounterState(old, fold(mutators, toCounterState(old)))
+      return withPreviews(counted, previews)
+    })
+  }
 }
 
 /**

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -149,6 +149,7 @@ export class LiveCommitBatch {
   /** Flushes run one at a time and in schedule order, so an awaited `flush()`
    *  drains everything buffered before it (the catch-up window's guarantee). */
   private chain: Promise<void> = Promise.resolve()
+  private flushing = false
 
   constructor(
     private readonly queryClient: QueryClient,
@@ -193,6 +194,13 @@ export class LiveCommitBatch {
     return this.counterMutators.length > 0 || this.streamPreviews.size > 0 || this.readAllSnapshots.length > 0
   }
 
+  /** Whether a commit has emptied the buffers but not yet published. Immediate
+   *  callers drain on this too: `hasPending()` alone is false in that window, so
+   *  an older in-flight fold would publish on top of a newer direct commit. */
+  isFlushing(): boolean {
+    return this.flushing
+  }
+
   /** Commit everything buffered so far. Awaited by the engine when a catch-up
    *  window opens, so a live fold can never interleave into a replay fold. */
   flush(): Promise<void> {
@@ -227,6 +235,15 @@ export class LiveCommitBatch {
   }
 
   private async commit(): Promise<void> {
+    this.flushing = true
+    try {
+      await this.runCommit()
+    } finally {
+      this.flushing = false
+    }
+  }
+
+  private async runCommit(): Promise<void> {
     const mutators = this.counterMutators
     const previews = this.streamPreviews
     const snapshots = this.readAllSnapshots

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -11,7 +11,7 @@ import {
 import type { Socket } from "socket.io-client"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration, primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
@@ -556,7 +556,33 @@ describe("LiveCommitBatch", () => {
     expect({ off: await counts(false), on: await counts(true) }).toEqual({ off: 2, on: 1 })
   })
 
-  it("the coalesced arm still records one stream.activityApply per fold, around the persist and publish", async () => {
+  it("the fold has its own mark: stream.activityApply stays one handler sample per event in both arms", async () => {
+    const marks = async (coalesced: boolean) => {
+      const queryClient = new QueryClient()
+      await seedFixture(queryClient, ["stream_1"])
+      const harness = await register(queryClient, coalesced)
+      const capture = new PerfCapture()
+      armPerfCapture(capture)
+
+      for (const ordinal of [6, 7, 8]) harness.emit("stream:activity", activity("stream_1", ordinal))
+      await settle()
+
+      armPerfCapture(NO_CAPTURE)
+      harness.cleanup()
+      const of = (name: string) => capture.snapshot().filter((sample) => sample.name === name)
+      return { apply: of("stream.activityApply").length, fold: of("stream.liveCommitFold").length }
+    }
+
+    // One handler sample per event in each arm — the same population, so the
+    // arms are readable against each other. The fold's persist-and-publish is a
+    // separate name emitted once per flush, and only when the flag is armed.
+    expect({ off: await marks(false), on: await marks(true) }).toEqual({
+      off: { apply: 3, fold: 0 },
+      on: { apply: 3, fold: 1 },
+    })
+  })
+
+  it("the fold's own mark carries a duration", async () => {
     const queryClient = new QueryClient()
     await seedFixture(queryClient, ["stream_1"])
     const harness = await register(queryClient, true)
@@ -564,18 +590,124 @@ describe("LiveCommitBatch", () => {
     armPerfCapture(capture)
 
     harness.emit("stream:activity", activity("stream_1", 6))
-    const beforeFlush = capture.snapshot().filter((sample) => sample.name === "stream.activityApply").length
+    const beforeFlush = capture.snapshot().filter((sample) => sample.name === "stream.liveCommitFold").length
     await settle()
-    const samples = capture.snapshot().filter((sample) => sample.name === "stream.activityApply")
+    const samples = capture.snapshot().filter((sample) => sample.name === "stream.liveCommitFold")
 
     armPerfCapture(NO_CAPTURE)
-    // The handler-body sample is chunk 1's; the fold's is the one that covers
-    // the transaction and the publication, so it lands only after the flush.
     expect({ beforeFlush, afterFlush: samples.length, valued: typeof samples.at(-1)?.value }).toEqual({
-      beforeFlush: 1,
-      afterFlush: 2,
+      beforeFlush: 0,
+      afterFlush: 1,
       valued: "number",
     })
+
+    harness.cleanup()
+  })
+
+  it("a read_all delivered after a held activity in the same drain does not leave the activity behind", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    // One drain, delivery order preserved: the mention lands, then the user's
+    // other device marks everything read. Routed around the batch, read-all's
+    // transaction opens at handler time and drops nothing (the row is still
+    // buffered), so the mention is resurrected and then sticks.
+    harness.emit("activity:created", {
+      workspaceId: WORKSPACE_ID,
+      targetUserId: "member_1",
+      activity: {
+        id: "act_new",
+        activityType: "mention",
+        streamId: "stream_1",
+        messageId: "msg_new",
+        actorId: "member_2",
+        actorType: "user",
+        context: {},
+        createdAt: "2026-08-04T10:00:00.000Z",
+        isSelf: false,
+        emoji: null,
+      },
+    })
+    harness.emit("stream:read_all", {
+      workspaceId: WORKSPACE_ID,
+      authorId: "member_1",
+      streamIds: ["stream_1"],
+      reads: [{ streamId: "stream_1", lastReadOrdinal: 5 }],
+    })
+    await settle()
+
+    expect({
+      idb: (await db.unreadState.get(WORKSPACE_ID))?.unreadActivities?.map((row) => row.id),
+      cache: bootstrapOf(queryClient)?.unreadActivities?.map((row) => row.id),
+    }).toEqual({ idb: [], cache: [] })
+
+    harness.cleanup()
+  })
+
+  it("a publish failure reseeds like a persist failure, once per successful commit", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const onFlushFailed = vi.fn()
+    const batch = new LiveCommitBatch(queryClient, WORKSPACE_ID, onFlushFailed)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    const setQueryData = vi.spyOn(queryClient, "setQueryData").mockImplementationOnce(() => {
+      throw new TypeError("bad bootstrap shape")
+    })
+
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 3 } }))
+    await settle()
+    const afterFirst = onFlushFailed.mock.calls.length
+
+    // A successful commit clears the latch, so a later publish failure reseeds again.
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 4 } }))
+    await settle()
+    setQueryData.mockImplementationOnce(() => {
+      throw new TypeError("bad bootstrap shape")
+    })
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 5 } }))
+    await settle()
+
+    expect({ afterFirst, total: onFlushFailed.mock.calls.length }).toEqual({ afterFirst: 1, total: 2 })
+    batch.destroy()
+  })
+
+  it("flipping the flag off drains the pending fold before the next immediate commit", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    // Buffered under the armed flag; the flip lands in the same task, so the
+    // newer immediate commit must not be overwritten by the older fold.
+    harness.emit("stream:activity", activity("stream_1", 6))
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
+    harness.emit("stream:activity", activity("stream_1", 7))
+    await settle()
+
+    expect({
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
+
+    harness.cleanup()
+  })
+
+  it("a fold buffered before an account switch writes nothing after it", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const before = bootstrapOf(queryClient)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    // What flushModuleStoreCaches does on a switch, before `db` is repointed.
+    bumpAccountGeneration()
+    await settle()
+
+    expect({
+      bootstrapUnchanged: bootstrapOf(queryClient) === before,
+      idbOrdinal: (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1,
+      preview: (await db.streams.get("stream_1"))?.lastMessagePreview,
+    }).toEqual({ bootstrapUnchanged: true, idbOrdinal: 5, preview: null })
 
     harness.cleanup()
   })

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import {
+  DEFAULT_SIDEBAR_CONFIG,
+  DEFAULT_QUICK_LINKS,
+  SIDEBAR_CONFIG_VERSION,
+  type Activity,
+  type StreamMember,
+  type WorkspaceBootstrap,
+} from "@threa/types"
+import type { Socket } from "socket.io-client"
+import Dexie from "dexie"
+import { db } from "@/db"
+import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
+import { registerWorkspaceSocketHandlers } from "./workspace-sync"
+
+const WORKSPACE_ID = "ws_live"
+
+const preview = {
+  authorId: "member_2",
+  authorType: "user" as const,
+  content: "hello from the server",
+  createdAt: "2026-08-04T10:00:00.000Z",
+}
+
+function makeBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
+  return {
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "Test",
+      slug: "test",
+      createdBy: "user_1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    users: [],
+    streams: [],
+    streamMemberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+    labels: [],
+    labelAssignments: [],
+    emojis: [],
+    emojiWeights: {},
+    commands: [],
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    mutedStreamIds: [],
+    featureFlags: { workspace: {}, user: {} },
+    sidebarConfig: DEFAULT_SIDEBAR_CONFIG,
+    userPreferences: {
+      workspaceId: WORKSPACE_ID,
+      userId: "user_1",
+      theme: "system",
+      messageSendMode: "enter",
+      messageDisplay: "default",
+      accessibility: {
+        fontSize: "medium",
+        fontFamily: "default",
+        reducedMotion: false,
+        highContrast: false,
+      },
+      keyboardShortcuts: {},
+      quickLinks: DEFAULT_QUICK_LINKS,
+      sidebarConfigVersion: SIDEBAR_CONFIG_VERSION,
+    },
+    ...overrides,
+  } as unknown as WorkspaceBootstrap
+}
+
+function workspaceUser() {
+  return {
+    id: "member_1",
+    workspaceId: WORKSPACE_ID,
+    workosUserId: "workos_1",
+    email: "a@b.c",
+    name: "A",
+    slug: "a",
+    role: "member",
+    avatarUrl: null,
+    createdAt: new Date().toISOString(),
+  } as never
+}
+
+function membership(streamId: string): StreamMember {
+  return {
+    id: `mem_${streamId}`,
+    streamId,
+    userId: "member_1",
+    role: "member",
+    joinedAt: new Date().toISOString(),
+  } as unknown as StreamMember
+}
+
+function activityRow(id: string, streamId: string): Activity {
+  return {
+    id,
+    workspaceId: WORKSPACE_ID,
+    userId: "member_1",
+    activityType: "message",
+    streamId,
+    messageId: `msg_${id}`,
+    actorId: "member_2",
+    actorType: "user",
+    context: {},
+    readAt: null,
+    createdAt: "2026-08-04T09:00:00.000Z",
+    isSelf: false,
+    emoji: null,
+  } as unknown as Activity
+}
+
+function createTestSocket() {
+  const handlers = new Map<string, Set<(payload: unknown) => unknown>>()
+  const socket = {
+    on(event: string, handler: (payload: unknown) => void) {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return this
+    },
+    off(event: string, handler: (payload: unknown) => void) {
+      handlers.get(event)?.delete(handler)
+      return this
+    },
+  } as unknown as Socket
+  return {
+    socket,
+    emit(event: string, payload: unknown) {
+      handlers.get(event)?.forEach((handler) => handler(payload))
+    },
+  }
+}
+
+function activity(streamId: string, messageOrdinal: number) {
+  return {
+    workspaceId: WORKSPACE_ID,
+    streamId,
+    authorId: "member_2",
+    sequence: String(messageOrdinal),
+    messageOrdinal,
+    lastMessagePreview: { ...preview, content: `message ${messageOrdinal}` },
+  }
+}
+
+async function seedFixture(queryClient: QueryClient, streamIds: string[]) {
+  const unreadActivities = streamIds.map((streamId, index) => activityRow(`act_${index}`, streamId))
+  queryClient.setQueryData(
+    workspaceKeys.bootstrap(WORKSPACE_ID),
+    makeBootstrap({
+      users: [workspaceUser()],
+      streams: streamIds.map(
+        (id) => ({ id, workspaceId: WORKSPACE_ID, rootStreamId: id, lastMessagePreview: null }) as never
+      ),
+      streamMemberships: streamIds.map(membership),
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: Object.fromEntries(streamIds.map((id) => [id, 1])),
+      unreadActivityCount: streamIds.length,
+      unreadActivities,
+      messageCounts: Object.fromEntries(streamIds.map((id) => [id, 5])),
+    })
+  )
+
+  const now = Date.now()
+  for (const streamId of streamIds) {
+    await db.streams.put({
+      id: streamId,
+      workspaceId: WORKSPACE_ID,
+      rootStreamId: streamId,
+      lastMessagePreview: null,
+      _cachedAt: now,
+    } as never)
+  }
+  await db.unreadState.put({
+    id: WORKSPACE_ID,
+    workspaceId: WORKSPACE_ID,
+    unreadCounts: {},
+    mentionCounts: {},
+    activityCounts: Object.fromEntries(streamIds.map((id) => [id, 1])),
+    unreadActivityCount: streamIds.length,
+    unreadActivities,
+    latestOrdinals: Object.fromEntries(streamIds.map((id) => [id, 5])),
+    mutedStreamIds: [],
+    counterTouchedAt: {},
+    _cachedAt: now,
+  } as never)
+}
+
+type Harness = {
+  emit: (event: string, payload: unknown) => void
+  cleanup: () => void
+  liveBatch: LiveCommitBatch
+  setCatchUpBatch: (batch: CatchUpBatch | null) => void
+}
+
+/** Registers the workspace handlers exactly as the SyncEngine does, with the
+ *  flag primed and the async seam read already resolved. */
+async function register(queryClient: QueryClient, coalesced: boolean): Promise<Harness> {
+  primeEventWriteFlags(WORKSPACE_ID, {
+    workspace: { coalescedLiveCommit: coalesced ? "on" : "off" },
+    user: {},
+  })
+  const liveBatch = new LiveCommitBatch(queryClient, WORKSPACE_ID)
+  let catchUpBatch: CatchUpBatch | null = null
+  const { socket, emit } = createTestSocket()
+  const cleanup = registerWorkspaceSocketHandlers(socket, WORKSPACE_ID, queryClient, {
+    getCurrentStreamId: () => undefined,
+    getCurrentUser: () => ({ id: "workos_1" }),
+    subscribeStream: vi.fn(),
+    getCatchUpBatch: () => catchUpBatch,
+    getLiveCommitBatch: () => liveBatch,
+  })
+  // The seam resolves the flag from the primed map on a microtask.
+  await Promise.resolve()
+  await Promise.resolve()
+  return {
+    emit,
+    cleanup: () => {
+      cleanup()
+      liveBatch.destroy()
+    },
+    liveBatch,
+    setCatchUpBatch: (batch) => {
+      catchUpBatch = batch
+    },
+  }
+}
+
+/** Resolve every scheduled microtask flush and its awaited IDB work. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function bootstrapOf(queryClient: QueryClient): WorkspaceBootstrap | undefined {
+  return queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(WORKSPACE_ID))
+}
+
+describe("LiveCommitBatch", () => {
+  beforeEach(async () => {
+    resetEventWriteFlags()
+    await Promise.all([db.streams.clear(), db.unreadState.clear()])
+  })
+
+  afterEach(() => {
+    resetEventWriteFlags()
+    vi.restoreAllMocks()
+  })
+
+  it("one stream:activity commits one transaction and one cache publication", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const transaction = vi.spyOn(Dexie.prototype, "transaction")
+    const setQueryData = vi.spyOn(queryClient, "setQueryData")
+    const harness = await register(queryClient, true)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    expect({
+      transactions: transaction.mock.calls.length,
+      publications: setQueryData.mock.calls.length,
+      unread: bootstrapOf(queryClient)?.unreadCounts.stream_1,
+      // The coalesced arm's own composition: the counter fold and the preview
+      // land in the SAME bootstrap replacement, so the cache-side preview must
+      // advance too, not just db.streams.
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+    }).toEqual({
+      transactions: 1,
+      publications: 1,
+      unread: 1,
+      cachePreview: "message 6",
+      idbPreview: "message 6",
+    })
+
+    harness.cleanup()
+  })
+
+  it("the flag off keeps today's two transactions and two publications", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const transaction = vi.spyOn(Dexie.prototype, "transaction")
+    const setQueryData = vi.spyOn(queryClient, "setQueryData")
+    const harness = await register(queryClient, false)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
+      transactions: 2,
+      publications: 2,
+    })
+
+    harness.cleanup()
+  })
+
+  it("five activities in one task fold into one flush", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const transaction = vi.spyOn(Dexie.prototype, "transaction")
+    const setQueryData = vi.spyOn(queryClient, "setQueryData")
+    const harness = await register(queryClient, true)
+
+    for (let ordinal = 6; ordinal <= 10; ordinal += 1) harness.emit("stream:activity", activity("stream_1", ordinal))
+    await settle()
+
+    expect({
+      transactions: transaction.mock.calls.length,
+      publications: setQueryData.mock.calls.length,
+      unread: bootstrapOf(queryClient)?.unreadCounts.stream_1,
+      preview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      ordinal: (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1,
+    }).toEqual({
+      transactions: 1,
+      publications: 1,
+      unread: 5,
+      preview: "message 10",
+      cachePreview: "message 10",
+      ordinal: 10,
+    })
+
+    harness.cleanup()
+  })
+
+  it("the counter value after a fold equals the value the per-event path settles on", async () => {
+    const ordinals = [6, 7, 8]
+
+    const coalescedClient = new QueryClient()
+    await seedFixture(coalescedClient, ["stream_1", "stream_2"])
+    const coalescedHarness = await register(coalescedClient, true)
+    for (const ordinal of ordinals) {
+      coalescedHarness.emit("stream:activity", activity("stream_1", ordinal))
+      coalescedHarness.emit("stream:activity", activity("stream_2", ordinal))
+    }
+    await settle()
+    const coalescedState = await db.unreadState.get(WORKSPACE_ID)
+    const coalescedBootstrap = bootstrapOf(coalescedClient)
+    coalescedHarness.cleanup()
+
+    await db.streams.clear()
+    await db.unreadState.clear()
+    resetEventWriteFlags()
+
+    const immediateClient = new QueryClient()
+    await seedFixture(immediateClient, ["stream_1", "stream_2"])
+    const immediateHarness = await register(immediateClient, false)
+    for (const ordinal of ordinals) {
+      immediateHarness.emit("stream:activity", activity("stream_1", ordinal))
+      immediateHarness.emit("stream:activity", activity("stream_2", ordinal))
+    }
+    await settle()
+    const immediateState = await db.unreadState.get(WORKSPACE_ID)
+    const immediateBootstrap = bootstrapOf(immediateClient)
+    immediateHarness.cleanup()
+
+    const idbSlice = (state: typeof coalescedState) => ({
+      unreadCounts: state?.unreadCounts,
+      mentionCounts: state?.mentionCounts,
+      activityCounts: state?.activityCounts,
+      unreadActivityCount: state?.unreadActivityCount,
+      latestOrdinals: state?.latestOrdinals,
+    })
+    const bootstrapSlice = (bootstrap: WorkspaceBootstrap | undefined) => ({
+      unreadCounts: bootstrap?.unreadCounts,
+      mentionCounts: bootstrap?.mentionCounts,
+      activityCounts: bootstrap?.activityCounts,
+      unreadActivityCount: bootstrap?.unreadActivityCount,
+      messageCounts: bootstrap?.messageCounts,
+    })
+
+    expect({ idb: idbSlice(coalescedState), bootstrap: bootstrapSlice(coalescedBootstrap) }).toEqual({
+      idb: idbSlice(immediateState),
+      bootstrap: bootstrapSlice(immediateBootstrap),
+    })
+    expect(coalescedState?.unreadCounts.stream_1).toBe(3)
+  })
+
+  it("a failed flush publishes nothing", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const before = bootstrapOf(queryClient)
+    vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    expect({
+      bootstrapUnchanged: bootstrapOf(queryClient) === before,
+      unread: bootstrapOf(queryClient)?.unreadCounts.stream_1,
+      logged: consoleError.mock.calls.length,
+    }).toEqual({ bootstrapUnchanged: true, unread: undefined, logged: 1 })
+
+    harness.cleanup()
+  })
+
+  it("a throwing publish does not poison the chain — the next activity still commits and publishes", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    // A mutator dereferencing an unexpected bootstrap shape throws out of the
+    // single setQueryData — i.e. out of publish(), past commit()'s try.
+    vi.spyOn(queryClient, "setQueryData").mockImplementationOnce(() => {
+      throw new TypeError("bad bootstrap shape")
+    })
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    harness.emit("stream:activity", activity("stream_1", 7))
+    await settle()
+
+    expect({
+      unread: bootstrapOf(queryClient)?.unreadCounts.stream_1,
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+      ordinal: (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1,
+      logged: consoleError.mock.calls.length,
+    }).toEqual({ unread: 2, cachePreview: "message 7", idbPreview: "message 7", ordinal: 7, logged: 1 })
+
+    harness.cleanup()
+  })
+
+  it("a failed flush reports the failure so the engine can reseed", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const onFlushFailed = vi.fn()
+    const batch = new LiveCommitBatch(queryClient, WORKSPACE_ID, onFlushFailed)
+    vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    batch.setStreamPreview("stream_1", { ...preview, content: "message 6" })
+    await settle()
+
+    expect(onFlushFailed).toHaveBeenCalledTimes(1)
+    batch.destroy()
+  })
+
+  it("a catch-up window opening flushes the live batch first", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    // A live activity buffered in the same task the catch-up window opens in.
+    harness.emit("stream:activity", activity("stream_1", 6))
+
+    // What SyncEngine.performActiveCatchUp does before installing the batch.
+    await harness.liveBatch.flush()
+    const afterLiveFlush = (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1
+
+    const catchUpBatch = new CatchUpBatch(queryClient, WORKSPACE_ID)
+    harness.setCatchUpBatch(catchUpBatch)
+    harness.emit("stream:activity", activity("stream_1", 7))
+    await catchUpBatch.flush()
+    harness.setCatchUpBatch(null)
+    await settle()
+
+    expect({
+      afterLiveFlush,
+      ordinal: (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1,
+      unread: (await db.unreadState.get(WORKSPACE_ID))?.unreadCounts.stream_1,
+      preview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+    }).toEqual({ afterLiveFlush: 6, ordinal: 7, unread: 2, preview: "message 7" })
+
+    harness.cleanup()
+  })
+
+  it("an activity for a stream with no bootstrap cache invalidates rather than dropping", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined)
+
+    // The counter arm reads the bootstrap synchronously in the handler, so drive
+    // the batch directly for the case where the cache is gone by flush time.
+    harness.liveBatch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 9 } }))
+    queryClient.removeQueries({ queryKey: workspaceKeys.bootstrap(WORKSPACE_ID) })
+    await settle()
+
+    expect(
+      invalidateQueries.mock.calls.some(
+        (call) => JSON.stringify(call[0]?.queryKey) === JSON.stringify(workspaceKeys.bootstrap(WORKSPACE_ID))
+      )
+    ).toBe(true)
+    expect((await db.unreadState.get(WORKSPACE_ID))?.unreadCounts.stream_1).toBe(9)
+
+    harness.cleanup()
+  })
+
+  it("a flush scheduled before teardown does not write afterwards", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const before = bootstrapOf(queryClient)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    harness.liveBatch.destroy()
+    await settle()
+
+    expect({
+      bootstrapUnchanged: bootstrapOf(queryClient) === before,
+      idbOrdinal: (await db.unreadState.get(WORKSPACE_ID))?.latestOrdinals?.stream_1,
+      preview: (await db.streams.get("stream_1"))?.lastMessagePreview,
+    }).toEqual({ bootstrapUnchanged: true, idbOrdinal: 5, preview: null })
+
+    harness.cleanup()
+  })
+})

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -201,7 +201,8 @@ type Harness = {
 }
 
 /** Registers the workspace handlers exactly as the SyncEngine does, with the
- *  flag primed and the async seam read already resolved. */
+ *  flag primed. `commitCounter`/`commitPreview` read the flag synchronously per
+ *  event, so a mid-task flip takes effect on the next event with no reconnect. */
 async function register(queryClient: QueryClient, coalesced: boolean): Promise<Harness> {
   primeEventWriteFlags(WORKSPACE_ID, {
     workspace: { coalescedLiveCommit: coalesced ? "on" : "off" },
@@ -217,9 +218,6 @@ async function register(queryClient: QueryClient, coalesced: boolean): Promise<H
     getCatchUpBatch: () => catchUpBatch,
     getLiveCommitBatch: () => liveBatch,
   })
-  // The seam resolves the flag from the primed map on a microtask.
-  await Promise.resolve()
-  await Promise.resolve()
   return {
     emit,
     cleanup: () => {
@@ -682,6 +680,43 @@ describe("LiveCommitBatch", () => {
     harness.emit("stream:activity", activity("stream_1", 6))
     primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
     harness.emit("stream:activity", activity("stream_1", 7))
+    await settle()
+
+    expect({
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
+
+    harness.cleanup()
+  })
+
+  it("flipping the flag off drains a fold that is already in flight", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const realTransaction = Dexie.prototype.transaction
+    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
+      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
+      return gate.then(() => running) as never
+    })
+
+    // A is buffered and its commit begins: the buffers are already empty and the
+    // transaction is awaiting, so `hasPending()` alone reads false here.
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect({ pending: harness.liveBatch.hasPending(), flushing: harness.liveBatch.isFlushing() }).toEqual({
+      pending: false,
+      flushing: true,
+    })
+
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
+    harness.emit("stream:activity", activity("stream_1", 7))
+    release()
     await settle()
 
     expect({

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -12,6 +12,7 @@ import type { Socket } from "socket.io-client"
 import Dexie from "dexie"
 import { db } from "@/db"
 import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
 import { registerWorkspaceSocketHandlers } from "./workspace-sync"
@@ -438,11 +439,145 @@ describe("LiveCommitBatch", () => {
     vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
     vi.spyOn(console, "error").mockImplementation(() => {})
 
-    batch.setStreamPreview("stream_1", { ...preview, content: "message 6" })
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 3 } }))
     await settle()
 
     expect(onFlushFailed).toHaveBeenCalledTimes(1)
     batch.destroy()
+  })
+
+  it("a preview-only failed flush does not ask the engine to reseed", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const onFlushFailed = vi.fn()
+    const batch = new LiveCommitBatch(queryClient, WORKSPACE_ID, onFlushFailed)
+    vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    batch.setStreamPreview("stream_1", { ...preview, content: "message 6" })
+    await settle()
+
+    expect(onFlushFailed).not.toHaveBeenCalled()
+    batch.destroy()
+  })
+
+  it("consecutive failing flushes request exactly one reseed until one succeeds", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const onFlushFailed = vi.fn()
+    const batch = new LiveCommitBatch(queryClient, WORKSPACE_ID, onFlushFailed)
+    const transaction = vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    for (let ordinal = 6; ordinal <= 8; ordinal += 1) {
+      batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: ordinal } }))
+      await settle()
+    }
+    const afterThreeFailures = onFlushFailed.mock.calls.length
+
+    transaction.mockRestore()
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 9 } }))
+    await settle()
+
+    vi.spyOn(Dexie.prototype, "transaction").mockRejectedValue(new Error("QuotaExceeded") as never)
+    batch.applyCounter((state) => ({ ...state, unreadCounts: { ...state.unreadCounts, stream_1: 10 } }))
+    await settle()
+
+    expect({ afterThreeFailures, total: onFlushFailed.mock.calls.length }).toEqual({
+      afterThreeFailures: 1,
+      total: 2,
+    })
+    batch.destroy()
+  })
+
+  it("flipping the flag off disarms the coalescing on the next event, with no reconnect", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    // What a `feature_flags:updated` socket event does to the module map.
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
+    const transaction = vi.spyOn(Dexie.prototype, "transaction")
+    const setQueryData = vi.spyOn(queryClient, "setQueryData")
+
+    harness.emit("stream:activity", activity("stream_1", 7))
+    await settle()
+
+    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
+      transactions: 2,
+      publications: 2,
+    })
+
+    harness.cleanup()
+  })
+
+  it("flipping the flag on arms the coalescing on the next event, with no reconnect", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, false)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await settle()
+
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
+    const transaction = vi.spyOn(Dexie.prototype, "transaction")
+    const setQueryData = vi.spyOn(queryClient, "setQueryData")
+
+    harness.emit("stream:activity", activity("stream_1", 7))
+    await settle()
+
+    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
+      transactions: 1,
+      publications: 1,
+    })
+
+    harness.cleanup()
+  })
+
+  it("the activity path's stream.idbTransaction count falls from two to one", async () => {
+    const counts = async (coalesced: boolean): Promise<number> => {
+      const queryClient = new QueryClient()
+      await seedFixture(queryClient, ["stream_1"])
+      const harness = await register(queryClient, coalesced)
+      const capture = new PerfCapture()
+      armPerfCapture(capture)
+
+      harness.emit("stream:activity", activity("stream_1", 6))
+      await settle()
+
+      armPerfCapture(NO_CAPTURE)
+      harness.cleanup()
+      return capture.snapshot().filter((sample) => sample.name === "stream.idbTransaction").length
+    }
+
+    expect({ off: await counts(false), on: await counts(true) }).toEqual({ off: 2, on: 1 })
+  })
+
+  it("the coalesced arm still records one stream.activityApply per fold, around the persist and publish", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    const beforeFlush = capture.snapshot().filter((sample) => sample.name === "stream.activityApply").length
+    await settle()
+    const samples = capture.snapshot().filter((sample) => sample.name === "stream.activityApply")
+
+    armPerfCapture(NO_CAPTURE)
+    // The handler-body sample is chunk 1's; the fold's is the one that covers
+    // the transaction and the publication, so it lands only after the flush.
+    expect({ beforeFlush, afterFlush: samples.length, valued: typeof samples.at(-1)?.value }).toEqual({
+      beforeFlush: 1,
+      afterFlush: 2,
+      valued: "number",
+    })
+
+    harness.cleanup()
   })
 
   it("a catch-up window opening flushes the live batch first", async () => {

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -727,6 +727,41 @@ describe("LiveCommitBatch", () => {
     harness.cleanup()
   })
 
+  it("an off-then-on flip during an in-flight fold still lands the newest commit last", async () => {
+    const queryClient = new QueryClient()
+    await seedFixture(queryClient, ["stream_1"])
+    const harness = await register(queryClient, true)
+
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const realTransaction = Dexie.prototype.transaction
+    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
+      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
+      return gate.then(() => running) as never
+    })
+
+    harness.emit("stream:activity", activity("stream_1", 6))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Off: #7 takes the deferred immediate arm while #6's commit is in flight.
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
+    harness.emit("stream:activity", activity("stream_1", 7))
+    // Back on: #8 buffers, and must publish AFTER the deferred #7.
+    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
+    harness.emit("stream:activity", activity("stream_1", 8))
+    release()
+    await settle()
+
+    expect({
+      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
+      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
+    }).toEqual({ cachePreview: "message 8", idbPreview: "message 8" })
+
+    harness.cleanup()
+  })
+
   it("a fold buffered before an account switch writes nothing after it", async () => {
     const queryClient = new QueryClient()
     await seedFixture(queryClient, ["stream_1"])

--- a/apps/frontend/src/sync/stream-sync.perf.test.ts
+++ b/apps/frontend/src/sync/stream-sync.perf.test.ts
@@ -108,6 +108,15 @@ describe("message:created sub-marks", () => {
     expect(samplesNamed(capture, "stream.eventDuplicate")).toEqual([])
   })
 
+  it("the message path counts one idbTransaction per write transaction it opens", async () => {
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
+
+    await deliver("stream_perf", ["evt_count"])
+
+    expect(samplesNamed(capture, "stream.idbTransaction")).toHaveLength(1)
+  })
+
   it("a re-delivered message records eventDuplicate", async () => {
     const capture = new PerfCapture()
     armPerfCapture(capture)

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1627,6 +1627,64 @@ describe("SyncEngine sync cursor (active mode)", () => {
     engine.destroy()
   })
 
+  it("resumes the gate (drains the buffer) even when the live-commit flush before catch-up rejects", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
+    const catchUp = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
+      .mockResolvedValue(emptyPage("11"))
+    const deps = makeCounterDeps(catchUp)
+    const engine = new SyncEngine(deps)
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    // The pre-window drain rejects (a mutator threw out of publish on the
+    // preceding flush). It sits outside the try whose finally resumes the gate.
+    const liveBatch = (engine as unknown as { liveCommitBatch: { flush: () => Promise<void> } }).liveCommitBatch
+    vi.spyOn(liveBatch, "flush").mockRejectedValueOnce(new TypeError("bad bootstrap shape"))
+
+    const socket = new MockSocket()
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
+
+    socket.trigger("workspace_user:added", userAddedLivePayload("12", "user_after_reject"))
+    resolveFirstPage!({ entries: [], head: "11" })
+
+    await vi.waitFor(async () => {
+      expect(await db.workspaceUsers.get("user_after_reject")).toBeDefined()
+    })
+
+    errorSpy.mockRestore()
+    engine.destroy()
+  })
+
+  it("a failed live-commit flush forces the same full snapshot reseed as a failed catch-up flush", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const deps = makeCounterDeps(catchUp)
+    const engine = new SyncEngine(deps)
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    await engine.onConnect(asSocket(new MockSocket()))
+    await vi.waitFor(() => expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1))
+
+    const liveBatch = (engine as unknown as { liveCommitBatch: { setStreamPreview: (id: string, p: unknown) => void } })
+      .liveCommitBatch
+    vi.spyOn(db.streams, "update").mockRejectedValue(new Error("QuotaExceeded") as never)
+    liveBatch.setStreamPreview("stream_x", {
+      authorId: "member_other",
+      authorType: "user",
+      content: "dropped",
+      createdAt: new Date().toISOString(),
+    })
+
+    await vi.waitFor(() => {
+      expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(2)
+    })
+
+    vi.mocked(db.streams.update).mockRestore?.()
+    errorSpy.mockRestore()
+    engine.destroy()
+  })
+
   it("does not re-apply a buffered ABSOLUTE counter duplicate at or below the catch-up position", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1666,21 +1666,19 @@ describe("SyncEngine sync cursor (active mode)", () => {
     await engine.onConnect(asSocket(new MockSocket()))
     await vi.waitFor(() => expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1))
 
-    const liveBatch = (engine as unknown as { liveCommitBatch: { setStreamPreview: (id: string, p: unknown) => void } })
-      .liveCommitBatch
-    vi.spyOn(db.streams, "update").mockRejectedValue(new Error("QuotaExceeded") as never)
-    liveBatch.setStreamPreview("stream_x", {
-      authorId: "member_other",
-      authorType: "user",
-      content: "dropped",
-      createdAt: new Date().toISOString(),
-    })
+    const liveBatch = (
+      engine as unknown as { liveCommitBatch: { applyCounter: (mutate: (state: never) => never) => void } }
+    ).liveCommitBatch
+    vi.spyOn(db.unreadState, "get").mockRejectedValue(new Error("QuotaExceeded") as never)
+    // A counter fold, not a preview: only a dropped counter fold can hold a
+    // held-set insert, so only it asks the engine to reseed.
+    liveBatch.applyCounter((state) => state)
 
     await vi.waitFor(() => {
       expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(2)
     })
 
-    vi.mocked(db.streams.update).mockRestore?.()
+    vi.mocked(db.unreadState.get).mockRestore?.()
     errorSpy.mockRestore()
     engine.destroy()
   })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -23,7 +23,7 @@ import { applyDraftsBootstrap, type DraftsServiceLike } from "./draft-sync"
 import { waitForInitialReveal } from "./reveal-gate"
 import { SyncLogCursor } from "./sync-log-cursor"
 import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
-import { CatchUpBatch } from "./catch-up-batch"
+import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
 import { beginApplyWindow, endApplyWindow } from "@/stores/apply-window"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { SyncStatusStore } from "./sync-status"
@@ -185,6 +185,12 @@ export class SyncEngine {
    *  fold into it instead of writing per-entry; flushed once when the window
    *  closes (see performActiveCatchUp). Null → live, write-immediately. */
   private activeCatchUpBatch: CatchUpBatch | null = null
+  /** Coalesces one task's live counter/preview writes into one transaction and
+   *  one cache publication (feature-gated in the handler seams). Flushed before
+   *  a catch-up window opens so a live fold never interleaves into a replay
+   *  fold, and destroyed with the engine so a scheduled flush can't write
+   *  against a torn-down workspace. */
+  private readonly liveCommitBatch: LiveCommitBatch
 
   // Heartbeat (active mode): the highest workspace head observed in catch-up
   // responses. The cursor is per-user filtered and can sit permanently below
@@ -222,6 +228,12 @@ export class SyncEngine {
 
   constructor(private deps: SyncEngineDeps) {
     this.workspaceId = deps.workspaceId
+    this.liveCommitBatch = new LiveCommitBatch(deps.queryClient, deps.workspaceId, () => {
+      // Same recovery the catch-up flush failure takes: a dropped fold can hold
+      // an `activity:created` held-set insert, which no later message re-adds,
+      // and a slim reconnect does NOT re-fetch the workspace counters.
+      if (!this.isDestroyed) void this.runBootstrap(true, { forceFull: true })
+    })
     this.eventGate = deps.syncService
       ? new SocketEventGate(this.workspaceId, {
           onApplied: (syncId) => this.syncLogCursor?.advance(syncId),
@@ -372,6 +384,7 @@ export class SyncEngine {
         getCurrentUser: () => this.currentUser,
         subscribeStream: (streamId: string) => void this.subscribeStream(streamId),
         getCatchUpBatch: () => this.activeCatchUpBatch,
+        getLiveCommitBatch: () => this.liveCommitBatch,
       }
     )
 
@@ -636,6 +649,7 @@ export class SyncEngine {
    */
   destroy(): void {
     this.isDestroyed = true
+    this.liveCommitBatch.destroy()
     this.cleanupAllHandlers()
     this.subscribedStreams.clear()
     if (this.operationQueueRetryTimer) clearTimeout(this.operationQueueRetryTimer)
@@ -1499,6 +1513,18 @@ export class SyncEngine {
     // unread/activity badges and the activity-sorted sidebar paint the final
     // state once at flush rather than flickering through every replayed entry.
     // runCatchUp single-flights, so at most one batch is active at a time.
+    // Drain buffered live commits BEFORE the window opens: a live fold left
+    // buffered here would flush inside the replay and land on top of it.
+    try {
+      await this.liveCommitBatch.flush()
+    } catch (error) {
+      // Same rule as the catch-up batch flush below: this runs OUTSIDE the try
+      // whose finally owns gate.resume, so an escaping rejection would leave the
+      // gate paused forever — live delivery stops until a reload. The batch has
+      // already logged and reseeded; carry on into the replay.
+      console.error("Live commit batch pre-catch-up flush failed", { workspaceId: this.workspaceId, error })
+    }
+
     const catchUpBatch = new CatchUpBatch(this.deps.queryClient, this.workspaceId)
     this.activeCatchUpBatch = catchUpBatch
 

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import { db } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { LiveCommitBatch } from "./catch-up-batch"
 import type { Activity } from "@threa/types"
 import {
   applyStreamActivityOrdinal,
@@ -740,5 +744,49 @@ describe("pruneCounterTouches", () => {
     expect(pruneCounterTouches({ s1: 100, s2: 200, s3: 300 }, 200)).toEqual({ s2: 200, s3: 300 })
     expect(pruneCounterTouches(undefined, 200)).toEqual({})
     expect(pruneCounterTouches({ s1: 100 }, undefined)).toEqual({})
+  })
+})
+
+describe("coalesced live commit", () => {
+  const seeded = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 5 } })
+
+  it("out-of-order ordinals converge under coalescing", async () => {
+    const workspaceId = "ws_fold"
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), {
+      streams: [],
+      streamMemberships: [],
+      ...seeded,
+      // The bootstrap's ordinal field is `messageCounts` (toCounterState).
+      messageCounts: seeded.latestOrdinals,
+    })
+    await db.unreadState.put({ id: workspaceId, workspaceId, ...seeded, mutedStreamIds: [] } as never)
+
+    const batch = new LiveCommitBatch(queryClient, workspaceId)
+    // Two activities for one stream, delivered in the wrong order in one task.
+    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 7, { isOwnMessage: false, isViewing: false }))
+    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 6, { isOwnMessage: false, isViewing: false }))
+    await batch.flush()
+
+    const perEvent = applyStreamActivityOrdinal(
+      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false }),
+      "s1",
+      6,
+      { isOwnMessage: false, isViewing: false }
+    )
+    const folded = queryClient.getQueryData<{
+      unreadCounts: Record<string, number>
+      messageCounts: Record<string, number>
+    }>(workspaceKeys.bootstrap(workspaceId))
+    const persisted = await db.unreadState.get(workspaceId)
+
+    expect({
+      cache: { unreadCounts: folded?.unreadCounts, latestOrdinals: folded?.messageCounts },
+      idb: { unreadCounts: persisted?.unreadCounts, latestOrdinals: persisted?.latestOrdinals },
+    }).toEqual({
+      cache: { unreadCounts: perEvent.unreadCounts, latestOrdinals: perEvent.latestOrdinals },
+      idb: { unreadCounts: perEvent.unreadCounts, latestOrdinals: perEvent.latestOrdinals },
+    })
+    expect(perEvent.unreadCounts.s1).toBe(3)
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -715,10 +715,7 @@ export function registerWorkspaceSocketHandlers(
   const commitImmediate = (commit: () => void): void => {
     const pending = refs.getLiveCommitBatch?.() ?? null
     if (pending?.hasPending() || pending?.isFlushing()) {
-      void pending
-        .flush()
-        .catch(() => {})
-        .then(commit)
+      pending.runAfterDrain(commit)
       return
     }
     commit()

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -703,20 +703,39 @@ export function registerWorkspaceSocketHandlers(
   // batch when one is active, else commit immediately (live). Read-pointer
   // mirrors and feed invalidations are not coalesced — they stay on their own
   // immediate paths in the handlers below.
+  /** The live batch when the flag is armed, else null. Re-read per event: a
+   *  backoffice flip re-primes the flag map, so arming and disarming both take
+   *  effect on the next event. */
+  const armedLiveBatch = (): LiveCommitBatch | null =>
+    isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
+
+  /** Run an immediate (unbatched) commit, draining a still-pending fold first.
+   *  Without this, an off-flip mid-task lets an older buffered preview flush
+   *  AFTER a newer immediate commit and overwrite it in cache and IDB. */
+  const commitImmediate = (commit: () => void): void => {
+    const pending = refs.getLiveCommitBatch?.() ?? null
+    if (pending?.hasPending()) {
+      void pending
+        .flush()
+        .catch(() => {})
+        .then(commit)
+      return
+    }
+    commit()
+  }
+
   const commitCounter = (mutate: CounterMutator): void => {
     const batch = refs.getCatchUpBatch?.() ?? null
     if (batch) {
       batch.applyCounter(mutate)
       return
     }
-    // Re-read per event: a backoffice flip re-primes the flag map, so turning
-    // the flag off disarms every connected client on its next event.
-    const live = isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
+    const live = armedLiveBatch()
     if (live) {
       live.applyCounter(mutate)
       return
     }
-    commitCounterMutation(queryClient, workspaceId, mutate)
+    commitImmediate(() => commitCounterMutation(queryClient, workspaceId, mutate))
   }
 
   const commitPreview = (streamId: string, preview: LastMessagePreview | null): void => {
@@ -725,14 +744,12 @@ export function registerWorkspaceSocketHandlers(
       batch.setStreamPreview(streamId, preview)
       return
     }
-    // Re-read per event: a backoffice flip re-primes the flag map, so turning
-    // the flag off disarms every connected client on its next event.
-    const live = isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
+    const live = armedLiveBatch()
     if (live) {
       live.setStreamPreview(streamId, preview)
       return
     }
-    commitStreamPreview(queryClient, workspaceId, streamId, preview)
+    commitImmediate(() => commitStreamPreview(queryClient, workspaceId, streamId, preview))
   }
 
   // Activity-feed invalidation seam. During catch-up it marks the feed stale on
@@ -1195,12 +1212,16 @@ export function registerWorkspaceSocketHandlers(
     // replay touched), else committed live through commitReadAll. The additive
     // `frontiers` snapshot carries each updated stream's post-write watermark;
     // legacy payloads omit it — counter behavior only, frontier rows untouched.
-    const batch = refs.getCatchUpBatch?.() ?? null
+    // The live batch takes the same pair, so a read-all and the events before it
+    // commit from ONE ordered buffer: routing it around the batch would open its
+    // transaction at handler time and drop held rows BEFORE the buffered fold
+    // inserts them, resurrecting an already-read mention.
+    const batch = refs.getCatchUpBatch?.() ?? armedLiveBatch()
     if (batch) {
       batch.applyCounter((state) => applyStreamsReadAllOrdinals(state, payload.reads))
       batch.applyReadAllFrontiers(payload.frontiers)
     } else {
-      void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers)
+      commitImmediate(() => void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers))
     }
 
     // Standalone frontier (read cutover): read_all carries ordinals, no event

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -714,7 +714,7 @@ export function registerWorkspaceSocketHandlers(
    *  AFTER a newer immediate commit and overwrite it in cache and IDB. */
   const commitImmediate = (commit: () => void): void => {
     const pending = refs.getLiveCommitBatch?.() ?? null
-    if (pending?.hasPending()) {
+    if (pending?.hasPending() || pending?.isFlushing()) {
       void pending
         .flush()
         .catch(() => {})

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -110,7 +110,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isCoalescedLiveCommitEnabled, isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
+import { isCoalescedLiveCommitEnabledSync, isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -699,14 +699,6 @@ export function registerWorkspaceSocketHandlers(
 ): () => void {
   const abortController = new AbortController()
 
-  // Resolved once per registration rather than per event: the seams are
-  // synchronous, and an unresolved read simply takes today's immediate path,
-  // which costs the coalescing for the first events and never correctness.
-  let coalescedLiveCommit = false
-  void isCoalescedLiveCommitEnabled(db, workspaceId).then((enabled) => {
-    coalescedLiveCommit = enabled
-  })
-
   // The seams every flickering write routes through: fold into the catch-up
   // batch when one is active, else commit immediately (live). Read-pointer
   // mirrors and feed invalidations are not coalesced — they stay on their own
@@ -717,7 +709,9 @@ export function registerWorkspaceSocketHandlers(
       batch.applyCounter(mutate)
       return
     }
-    const live = coalescedLiveCommit ? (refs.getLiveCommitBatch?.() ?? null) : null
+    // Re-read per event: a backoffice flip re-primes the flag map, so turning
+    // the flag off disarms every connected client on its next event.
+    const live = isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
     if (live) {
       live.applyCounter(mutate)
       return
@@ -731,7 +725,9 @@ export function registerWorkspaceSocketHandlers(
       batch.setStreamPreview(streamId, preview)
       return
     }
-    const live = coalescedLiveCommit ? (refs.getLiveCommitBatch?.() ?? null) : null
+    // Re-read per event: a backoffice flip re-primes the flag map, so turning
+    // the flag off disarms every connected client on its next event.
+    const live = isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
     if (live) {
       live.setStreamPreview(streamId, preview)
       return

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -110,7 +110,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
+import { isCoalescedLiveCommitEnabled, isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -126,7 +126,13 @@ import {
   upsertActivity,
 } from "./unread-counters"
 import { isAutoReadAttentiveNow } from "@/lib/auto-read-attention"
-import { commitCounterMutation, commitStreamPreview, type CatchUpBatch, type CounterMutator } from "./catch-up-batch"
+import {
+  commitCounterMutation,
+  commitStreamPreview,
+  type CatchUpBatch,
+  type CounterMutator,
+  type LiveCommitBatch,
+} from "./catch-up-batch"
 import {
   commitReadAll,
   commitReadStateSnapshot,
@@ -685,9 +691,21 @@ export function registerWorkspaceSocketHandlers(
      *  and sidebar order never flicker through intermediate replay values.
      *  Absent → live, write-immediately. */
     getCatchUpBatch?: () => CatchUpBatch | null
+    /** The engine's live-commit batch, used when `coalescedLiveCommit` is on:
+     *  one task's counter and preview writes fold into one transaction and one
+     *  cache publication instead of two of each per event. */
+    getLiveCommitBatch?: () => LiveCommitBatch | null
   }
 ): () => void {
   const abortController = new AbortController()
+
+  // Resolved once per registration rather than per event: the seams are
+  // synchronous, and an unresolved read simply takes today's immediate path,
+  // which costs the coalescing for the first events and never correctness.
+  let coalescedLiveCommit = false
+  void isCoalescedLiveCommitEnabled(db, workspaceId).then((enabled) => {
+    coalescedLiveCommit = enabled
+  })
 
   // The seams every flickering write routes through: fold into the catch-up
   // batch when one is active, else commit immediately (live). Read-pointer
@@ -699,6 +717,11 @@ export function registerWorkspaceSocketHandlers(
       batch.applyCounter(mutate)
       return
     }
+    const live = coalescedLiveCommit ? (refs.getLiveCommitBatch?.() ?? null) : null
+    if (live) {
+      live.applyCounter(mutate)
+      return
+    }
     commitCounterMutation(queryClient, workspaceId, mutate)
   }
 
@@ -706,6 +729,11 @@ export function registerWorkspaceSocketHandlers(
     const batch = refs.getCatchUpBatch?.() ?? null
     if (batch) {
       batch.setStreamPreview(streamId, preview)
+      return
+    }
+    const live = coalescedLiveCommit ? (refs.getLiveCommitBatch?.() ?? null) : null
+    if (live) {
+      live.setStreamPreview(streamId, preview)
       return
     }
     commitStreamPreview(queryClient, workspaceId, streamId, preview)

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -109,6 +109,22 @@ measurement of the same population. `timeline.tailLoad` is emitted by the bounde
 tail read alone: it exists in the on arm only, so its presence is what proves the
 flag armed, and its duration is the cost of the read a live arrival triggers.
 
+### Reading `stream.idbTransaction` / `stream.activityApply` (scenarios 4, 15)
+
+`stream.idbTransaction` counts the per-message write transactions the sync path
+opens: the event-write transaction (`stream-sync.ts`), the local context-row
+transaction (`putLocalContextRows`), and the counter and preview commits
+(`commitCounterMutation`, `commitStreamPreview`, or the single
+`LiveCommitBatch.commit` that replaces both when `coalescedLiveCommit` is on).
+It does not count catch-up flushes — those are per window, not per message — so
+read it only in a live-delivery scenario.
+
+`stream.activityApply` moves with the flag. With `coalescedLiveCommit` off it
+times `handleStreamActivity`'s body, which does the commits inline; with it on
+the commits are buffered and the mark is emitted by `LiveCommitBatch.commit`
+around the fold's persist and publish. Both arms therefore measure the same
+work — the transaction plus the bootstrap publication — and are comparable.
+
 ### Scenario 13 — reading the unchanged warm refresh
 
 `workspace-wide` is the only profile that crosses Dexie's 50-row threshold in

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -92,7 +92,7 @@ there is no gap to catch up on.
 | 12  | Restore → switch stream → return → navigate away and back | `--profile drafts` plus `--profile large-stream`                                               | `editor.externalSync`, `stream.subscriptions`, `liveQuery.rerun`, `bootstrap.publish`                                                                                                                                                                         |
 | 13  | Unchanged warm refresh, wide workspace                    | `--profile workspace-wide`, then hard-refresh twice with no new messages (read the third load) | `bootstrap.preRead` + `bootstrap.tx` (the comparable number), `bootstrap.rowsWritten`, `bootstrap.rowsSkipped`, `bootstrap.diff`, `bootstrap.storePublish`, `bootstrap.cachePublish`, `bootstrap.cleanup`                                                     |
 | 14  | One incoming message into a deep scroll-back window       | `--profile large-stream`, scroll up ten pages, then post from a second client                  | `timeline.tailLoad` (bounded and flat as the scroll-back deepens), `liveQuery.load`, `timeline.derive` (samples sum to the whole derivation chain — one per memo in it), `timeline.windowItems` (identical between arms — a change here is a correctness bug) |
-| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.previewWrite`, `stream.activityApply`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                                                  |
+| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.previewWrite`, `stream.activityApply`, `stream.liveCommitFold`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                         |
 
 ### Reading `liveQuery.rerun` / `liveQuery.load` (scenarios 7, 8, 14)
 
@@ -119,11 +119,25 @@ transaction (`putLocalContextRows`), and the counter and preview commits
 It does not count catch-up flushes — those are per window, not per message — so
 read it only in a live-delivery scenario.
 
-`stream.activityApply` moves with the flag. With `coalescedLiveCommit` off it
-times `handleStreamActivity`'s body, which does the commits inline; with it on
-the commits are buffered and the mark is emitted by `LiveCommitBatch.commit`
-around the fold's persist and publish. Both arms therefore measure the same
-work — the transaction plus the bootstrap publication — and are comparable.
+`stream.activityApply` is the handler body in BOTH arms — one sample per
+`stream:activity`. It is not the same work in each: with `coalescedLiveCommit`
+off it covers two synchronous `setQueryData` calls plus the _setup_ of two
+fire-and-forget IDB transactions (`void db.transaction(...)` — the sample stops
+before the persist settles); with the flag on those calls are replaced by two
+buffer pushes, so the sample is near zero. Read it as "what the handler costs
+the task", never as the cost of the write.
+
+The fold has its own name, `stream.liveCommitFold`, emitted only in the on arm —
+one sample per flush, covering the awaited transaction and the single bootstrap
+publication. Its presence proves the flag armed; its count against the
+`stream.activityApply` count is the coalescing ratio. The two names are separate
+populations on purpose: mixed under one name, N near-zero handler samples plus
+one awaited fold sample makes the arm look faster or slower depending on which
+statistic the reader takes.
+
+Caveat for scenario 15 with `sharedStreamRegistration` on: the cheap duplicate
+apply disappears, so the mean of `stream.eventApply` **rises** even though the
+total work halves. Compare sample counts × mean, not means.
 
 ### Scenario 13 — reading the unchanged warm refresh
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -57,6 +57,7 @@ export const FEATURE_FLAGS = {
   bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   boundedTimelineRead: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
+  coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -36,6 +36,7 @@ export const PERF_MARK_NAMES = [
   "stream.contextRows",
   "stream.previewWrite",
   "stream.activityApply",
+  "stream.liveCommitFold",
   "stream.eventDuplicate",
   "liveQuery.rerun",
   "liveQuery.load",


### PR DESCRIPTION
## Problem

After chunk 3 made `stream:activity` the only preview writer, one message still cost **two IDB transactions and two whole-`WorkspaceBootstrap` replacements**, because the preview and the counter commit independently: `commitStreamPreview` does `applyPreviewsToCache` plus its own `rw[db.streams]`, and `commitCounterMutation` does `applyCountersToCache` plus its own `rw[db.unreadState]`.

Both are also fire-and-forget and publish to the query cache **before** writing IDB — the reverse of `CatchUpBatch.flush`, whose own comment states the rule: "the caches never publish state the IDB lacks".

## Solution

`LiveCommitBatch`, beside `CatchUpBatch` and reusing its helpers, behind `coalescedLiveCommit`.

- Buffers counter mutators and per-stream previews (last-wins per stream), schedules exactly one `queueMicrotask` flush — no rAF, no timer, so nothing is deferred across a frame.
- Persists in **one** `rw[db.streams, db.unreadState]` transaction via the existing `putCountersIdb`/`putPreviewsIdb`, and publishes only after (D4). A burst arriving in one task folds to one of each.
- `commit()` swaps the buffers before its first `await`, so mutations arriving while a transaction is open land in the next fold rather than being dropped. Flushes run in schedule order on a chain, which is what lets the engine `await` it as a genuine barrier before a catch-up window opens.

**Deviation from the plan, deliberate.** It specified publishing through `applyCountersToCache` and `applyPreviewsToCache` verbatim *and* an acceptance test seeing one cache publication. Those conflict — two helpers means two `setQueryData` calls, i.e. two whole-bootstrap replacements, the exact cost being removed. So `publish()` composes `withCounterState(fold(...))` and a newly extracted pure `withPreviews` into one `setQueryData`, and delegates to both helpers verbatim when the bootstrap is not cached, preserving the invalidate-on-missing-cache branch. Review verified the composed result equals the two sequential helpers on every branch — same order, same empty-skips, same presence test, disjoint keys, and `replaceEqualDeep` short-circuiting per key so the object graph stays reference-identical. `applyPreviewsToCache` is byte-equivalent after the extraction, so `CatchUpBatch`'s replay path is untouched.

**A blocker found in review, worth stating plainly.** `commit()`'s try/catch covered only the transaction, and `flush()` chained with `.then()` and no `.catch` — so a single throw out of `publish()` would reject the chain permanently, skipping every later flush while mutations kept buffering: unread badges and sidebar previews frozen for the session behind one console line. It compounded, because the engine awaited that flush **outside** the `try` whose `finally` owns `gate.resume()`, with the gate already paused — every subsequent catch-up would reject before entering the try, never resume the gate, and live socket delivery would stop entirely, silent and unrecoverable without a reload. A comment 160 lines away in the same file states exactly this rule for the neighbouring flush. Fixed both halves: `flush()` returns the attempt but stores a swallowed copy so the next flush always runs, and the drain is wrapped so control always reaches the `finally`. For calibration, today that same throw costs one event — the gate's `Promise.allSettled` absorbs it.

A failed transaction now also invokes an `onFlushFailed` hook, which the engine wires to the same `runBootstrap(true, { forceFull: true })` reseed its catch-up failure path uses: absolute-ordinal mutators self-heal on the next message, but a dropped `upsertActivity` is a held-set insert and would undercount the badge until an unrelated bootstrap. The buffer is not retained — unbounded growth under a persistent quota failure is a worse shape.

Unread ordinal math is untouched; only *when* mutators are applied changed.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/catch-up-batch.ts` | `LiveCommitBatch`; `withPreviews` extracted as a pure function. `CatchUpBatch` untouched |
| `apps/frontend/src/sync/workspace-sync.ts` | Third arm on the `commitCounter`/`commitPreview` seams; handler bodies unchanged |
| `apps/frontend/src/sync/sync-engine.ts` | Owns the batch, drains it before a catch-up window (wrapped), destroys it, supplies the reseed hook |
| `apps/frontend/src/db/event-writes.ts` | `isCoalescedLiveCommitEnabled`, same primed cache |
| `packages/types/src/feature-flags.ts` | `coalescedLiveCommit`, default `off` |
| `apps/frontend/src/sync/live-commit-batch.test.ts` | **new** — coalescing, convergence, failure, barrier, teardown, missing cache |
| `apps/frontend/src/sync/{unread-counters,sync-engine}.test.ts` | Out-of-order convergence through the fold; gate-resume and reseed on flush failure |

## Test plan

- [x] 8 frontend files — 455 pass, 0 fail
- [x] `bun run typecheck` — 0 errors · `bun run lint` — clean
- [x] Every new test neutralised and confirmed red, then restored
- [ ] Device capture — needs the build deployed and the flags on

Two neutralisations **did not bite** and were replaced rather than accepted: removing the `scheduled` guard, and making `schedule()` call `flush()` directly — the promise chain coalesces regardless, so neither proved the batching. Separately, `slice`-based neutralisations are invisible here because the ordinal math is max-merged, so dropping a lower ordinal changes nothing; that test's real content is that the fold runs against the cache's own current state.

Known residual: a throw escaping `publish()` logs and drops the fold without the reseed hook, which is scoped to the transaction catch. Persistence has already succeeded there, so nothing is lost from IDB and ordinal state self-heals on the next message; a held-set activity insert stays cache-stale until a refetch. Not a regression — the same throw costs the same today.

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/pr3-plan-e0082c/ — chunk 4 of 4, the last in the stack. §3 D3 and D4 cover the batch and the persist-then-publish order.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788471296&installation_model_id=20758&pr_number=1770&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1770&signature=cb1700f99c570741edd0d73e1d184276614ee7282617f591273f27403d6cbb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

## Changes after review (external + CodeRabbit)

Two external reviewers ran with every in-house finding declared out of bounds. Between them and CodeRabbit's review of this PR, seven further defects landed here:

- **`stream:read_all` bypassed the batch** (blocker once armed). Only the counter and preview seams learned about `LiveCommitBatch`; the read-all live path still committed synchronously. A mark-all-read and an arriving mention spliced in one gate drain therefore committed in the wrong order — the read-all dropped held rows *before* the mention was inserted, leaving an unread badge for something already read. It stuck, because the write stamps `counterTouchedAt` and the next bootstrap merge then prefers the local phantom over the server's truth. Read-all frontiers now buffer into the same ordered batch that `CatchUpBatch` already holds them in, so delivery order is preserved by construction rather than by a drain a third path could slip past.
- **Cross-account write.** `isSyncEngineCurrent` checks workspace and destroyed-ness but not the account, so two accounts sharing a workspace keep one engine — and a queued fold could resolve the repointed database and write one account's unread state into another's. The fold now captures an account generation (bumped by the existing `flushModuleStoreCaches`) and bails when it changes. The lifecycle gap itself is pre-existing and out of scope.
- **A publish failure** now takes the same one-shot reseed as a persist failure. A dropped held-set activity cannot self-heal from the next event the way an absolute ordinal can — this retires a residual the PR previously documented and defended.
- **The on→off drain covered only buffered folds, not in-flight ones.** `hasPending()` reads the buffers, which `commit()` empties before awaiting its transaction, so a mid-flight fold read as "nothing to drain": the direct commit published the newer preview and the older fold published over it. The batch now reports `isFlushing()` and the drain checks both. Tracking in-flight state, rather than routing every immediate commit through the chain, keeps the flag-off arm synchronous on the same stack as before.
- **The fold reports under its own mark.** Both external reviewers independently found that `stream.activityApply` measured different work and different cardinalities in each arm while the docs claimed they were comparable — off-arm samples end before the fire-and-forget persist settles; on-arm samples are bimodal (per-event buffer pushes plus one per-fold commit). Mixing them yields a confident wrong rollout decision either way.
- The reproduction matrix now names the populations honestly, including that `sharedStreamRegistration` on makes mean `stream.eventApply` **rise** while total work halves, because the cheap duplicate apply disappears.

Measured correction to the plan: the per-message IDB transaction count goes **3 → 2**, not the 7-8 → 2 the plan asserted from a static read of the call graph.

Final gates: 478 tests pass / 0 fail across the enumerated files; typecheck and lint clean; full CI (all four frontend shards, Tests, Lint, Typecheck, Extension Tests, browser suites) green over the whole stack diff via a throwaway probe PR, since stacked PRs skip those jobs.
