### PR TITLE
fix(board): make new pill actionable and restore mobile headers

### DIFF
--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -82,7 +82,7 @@ const getBoardMessages = vi.fn().mockResolvedValue([])
 const markRead = vi.fn().mockResolvedValue({ streams: [] })
 const markUnread = vi.fn().mockResolvedValue({ streams: [] })
 
-function mountCard(onSeen?: () => void) {
+function mountCard() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
@@ -90,13 +90,7 @@ function mountCard(onSeen?: () => void) {
         <ServicesProvider services={{ conversations: { markRead, markUnread, getBoardMessages } as never }}>
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <PanelProvider>
-              <BoardCard
-                workspaceId={WS}
-                post={makePost()}
-                contextLabel="#general"
-                streamType="channel"
-                onSeen={onSeen}
-              />
+              <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
             </PanelProvider>
           </MemoryRouter>
         </ServicesProvider>
@@ -204,26 +198,5 @@ describe("BoardCard viewport auto-read (full wiring: real card, real controller,
     })
 
     expect(markRead).toHaveBeenCalledWith(WS, "conv_1", "m_open")
-  })
-})
-
-describe("BoardCard onSeen", () => {
-  it("fires once on the card's first intersection and never again", async () => {
-    const onSeen = vi.fn()
-    mountCard(onSeen)
-    await act(async () => {})
-
-    const cardEl = document.querySelector(".board-card-hover")
-    expect(cardEl, "the card root should render").toBeTruthy()
-    const io = FakeIntersectionObserver.instances.find((instance) => instance.observed.has(cardEl!))
-    expect(io, "an IntersectionObserver should be observing the card root").toBeTruthy()
-
-    expect(onSeen).not.toHaveBeenCalled()
-    act(() => io!.fire([{ target: cardEl!, isIntersecting: true }]))
-    expect(onSeen).toHaveBeenCalledTimes(1)
-
-    act(() => io!.fire([{ target: cardEl!, isIntersecting: false }]))
-    act(() => io!.fire([{ target: cardEl!, isIntersecting: true }]))
-    expect(onSeen).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1448,6 +1448,14 @@ describe("BoardCard sticky header", () => {
     expect(header?.className).toContain("mb-1.5")
     expect(header?.className).toContain("sm:pt-4")
   })
+
+  it("hides a named conversation's context row only on phone widths", async () => {
+    mountCard(makePost({ topicSummary: "Rotate the API tokens" }))
+
+    const contextRow = (await screen.findByRole("link", { name: "#general" })).parentElement
+    expect(contextRow?.className).toContain("hidden")
+    expect(contextRow?.className).toContain("sm:flex")
+  })
 })
 
 describe("BoardCard backfill arming", () => {

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1379,7 +1379,7 @@ describe("BoardCard ledger", () => {
 /** Installs a controllable IntersectionObserver: jsdom ships none, and the card
  *  fails open without one. Returns a setter that drives every live observer. */
 function stubIntersectionObserver(initiallyIntersecting: boolean) {
-  type Entry = {
+  interface Entry {
     isIntersecting: boolean
     target: Element
     boundingClientRect: { top: number }

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1379,9 +1379,15 @@ describe("BoardCard ledger", () => {
 /** Installs a controllable IntersectionObserver: jsdom ships none, and the card
  *  fails open without one. Returns a setter that drives every live observer. */
 function stubIntersectionObserver(initiallyIntersecting: boolean) {
-  type Entry = { isIntersecting: boolean; target: Element }
+  type Entry = {
+    isIntersecting: boolean
+    target: Element
+    boundingClientRect: { top: number }
+    rootBounds: { top: number }
+  }
   const live = new Set<{ cb: (entries: Entry[]) => void; targets: Set<Element> }>()
   let intersecting = initiallyIntersecting
+  let targetTop = 0
   class Stub {
     private entry = { cb: (_: Entry[]) => {}, targets: new Set<Element>() }
     constructor(cb: (entries: Entry[]) => void) {
@@ -1390,7 +1396,9 @@ function stubIntersectionObserver(initiallyIntersecting: boolean) {
     }
     observe(target: Element) {
       this.entry.targets.add(target)
-      this.entry.cb([{ isIntersecting: intersecting, target }])
+      this.entry.cb([
+        { isIntersecting: intersecting, target, boundingClientRect: { top: targetTop }, rootBounds: { top: 0 } },
+      ])
     }
     unobserve(target: Element) {
       this.entry.targets.delete(target)
@@ -1400,13 +1408,47 @@ function stubIntersectionObserver(initiallyIntersecting: boolean) {
     }
   }
   vi.stubGlobal("IntersectionObserver", Stub)
-  return (next: boolean) => {
+  return (next: boolean, nextTargetTop = next ? 0 : 1) => {
     intersecting = next
+    targetTop = nextTargetTop
     act(() => {
-      for (const { cb, targets } of live) cb([...targets].map((target) => ({ isIntersecting: next, target })))
+      for (const { cb, targets } of live)
+        cb(
+          [...targets].map((target) => ({
+            isIntersecting: next,
+            target,
+            boundingClientRect: { top: targetTop },
+            rootBounds: { top: 0 },
+          }))
+        )
     })
   }
 }
+
+describe("BoardCard sticky header", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("pins on phone widths and trims only the pinned mobile header", async () => {
+    const setIntersecting = stubIntersectionObserver(true)
+    mountCard(makePost())
+
+    await screen.findByText("Opening body.")
+    const header = document.querySelector<HTMLElement>("[data-board-card-header]")
+    expect(header).not.toBeNull()
+    expect(header?.className).toContain("sticky")
+    expect(header?.className).toContain("top-0")
+    expect(header?.className).not.toContain("pt-2")
+
+    setIntersecting(false)
+    expect(header?.className).not.toContain("pt-2")
+
+    setIntersecting(false, -1)
+    expect(header?.className).toContain("pt-2")
+    expect(header?.className).toContain("pb-1.5")
+    expect(header?.className).toContain("mb-1.5")
+    expect(header?.className).toContain("sm:pt-4")
+  })
+})
 
 describe("BoardCard backfill arming", () => {
   afterEach(() => vi.unstubAllGlobals())

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1449,12 +1449,19 @@ describe("BoardCard sticky header", () => {
     expect(header?.className).toContain("sm:pt-4")
   })
 
-  it("hides a named conversation's context row only on phone widths", async () => {
+  it("shows context at rest but drops it from the pinned phone header", async () => {
+    const setIntersecting = stubIntersectionObserver(true)
     mountCard(makePost({ topicSummary: "Rotate the API tokens" }))
 
     const contextRow = (await screen.findByRole("link", { name: "#general" })).parentElement
+    const spacer = document.querySelector<HTMLElement>("[data-board-card-context-spacer]")
+    expect(contextRow?.className).not.toContain("hidden")
+    expect(spacer?.className).toContain("h-0")
+
+    setIntersecting(false, -1)
     expect(contextRow?.className).toContain("hidden")
     expect(contextRow?.className).toContain("sm:flex")
+    expect(spacer?.className).toContain("h-6")
   })
 })
 

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -103,10 +103,6 @@ interface BoardCardProps {
    * state, so the card's unread rows stay unread.
    */
   onClearUnread?: () => void
-  /** Fired ONCE, on the card's first intersection with the viewport — "the viewer
-   *  has laid eyes on this card in this session". Drives the board's re-buffering:
-   *  an unseen card that gains activity goes back behind the "N new" pill. */
-  onSeen?: () => void
 }
 
 /** How many trailing messages a nested branch previews on a collapsed card; the
@@ -140,7 +136,6 @@ export function BoardCard({
   scrollerRef,
   listRef,
   removed = false,
-  onSeen,
   onClearUnread,
 }: BoardCardProps) {
   const { conversation } = post
@@ -536,22 +531,11 @@ export function BoardCard({
   // so off-screen cards on a long board don't suppress streams the user can't
   // see. The same signal gates the backfill below.
   const [cardInViewport, setCardInViewport] = useState(false)
-  // Same observer answers "has the viewer seen this card" (`onSeen`, first
-  // intersection only) — seen-ness is latched in a ref so a later re-intersection
-  // can't re-fire it, and the callback is held in a ref so the observer isn't
-  // torn down when the parent hands a fresh closure.
-  const onSeenRef = useRef(onSeen)
-  onSeenRef.current = onSeen
-  const seenFiredRef = useRef(false)
   useEffect(() => {
     const el = cardRef.current
     if (!el || typeof IntersectionObserver === "undefined") return
     const observer = new IntersectionObserver(([entry]) => {
       setCardInViewport(entry.isIntersecting)
-      if (entry.isIntersecting && !seenFiredRef.current) {
-        seenFiredRef.current = true
-        onSeenRef.current?.()
-      }
     })
     observer.observe(el)
     return () => observer.disconnect()
@@ -792,7 +776,13 @@ export function BoardCard({
     // Radix scroll viewport (the conversation panel). Match either so the pinned-
     // header elevation resolves against the real scroll root in both surfaces.
     const root = sentinel.closest("[data-board-scroll-viewport],[data-radix-scroll-area-viewport]")
-    const observer = new IntersectionObserver(([entry]) => setHeaderStuck(!entry.isIntersecting), { root })
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const rootTop = entry.rootBounds?.top ?? root?.getBoundingClientRect().top ?? 0
+        setHeaderStuck(!entry.isIntersecting && entry.boundingClientRect.top < rootTop)
+      },
+      { root }
+    )
     observer.observe(sentinel)
     return () => observer.disconnect()
   }, [])
@@ -1146,15 +1136,15 @@ export function BoardCard({
           <div ref={stuckSentinelRef} aria-hidden className="h-0" />
           {/* Header pins to the scroll-viewport top while the card's messages
               scroll under it (bg-card covers them), so the locator + topic stay
-              legible in a long card. The negative margins + re-padding fill the
-              header to the card edges; at rest it looks identical to an unpinned
-              header. A hairline + shadow fade in once pinned (headerStuck) to lift
-              it off the messages; the border is always present but transparent so
-              the elevation never shifts layout (INV-21). */}
+              legible in a long card. On phones it trims a little vertical padding
+              once pinned; an equal bottom margin holds the header's footprint, so
+              content does not jump. Desktop keeps its normal density. */}
           <div
+            data-board-card-header
             className={cn(
-              "z-10 -mx-3 -mt-3 rounded-t-xl border-b border-transparent bg-card px-3 pt-3 pb-2 transition-[box-shadow,border-color] duration-200 sm:sticky sm:top-0 sm:-mx-4 sm:-mt-4 sm:px-4 sm:pt-4",
-              headerStuck && "sm:border-border/60 sm:shadow-[0_4px_12px_-6px_rgb(0_0_0/0.4)]"
+              "sticky top-0 z-10 -mx-3 -mt-3 rounded-t-xl border-b border-transparent bg-card px-3 pt-3 pb-2 transition-[box-shadow,border-color,padding,margin] duration-200 sm:-mx-4 sm:-mt-4 sm:px-4 sm:pt-4",
+              headerStuck &&
+                "mb-1.5 border-border/60 pt-2 pb-1.5 shadow-[0_4px_12px_-6px_rgb(0_0_0/0.4)] sm:mb-0 sm:pt-4 sm:pb-2"
             )}
           >
             {/* Title-led when the extractor (or a rename) set a topic: the topic is

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1172,7 +1172,7 @@ export function BoardCard({
                   {unreadDot}
                   {headerActions}
                 </div>
-                <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <div className="mt-1 hidden items-center gap-1.5 text-xs text-muted-foreground sm:flex">
                   {locatorLink("xs")}
                   <span className="shrink-0 opacity-50">·</span>
                   <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1135,10 +1135,9 @@ export function BoardCard({
               (see the observer above). In flow but h-0, so it shifts nothing. */}
           <div ref={stuckSentinelRef} aria-hidden className="h-0" />
           {/* Header pins to the scroll-viewport top while the card's messages
-              scroll under it (bg-card covers them), so the locator + topic stay
-              legible in a long card. On phones it trims a little vertical padding
-              once pinned; an equal bottom margin holds the header's footprint, so
-              content does not jump. Desktop keeps its normal density. */}
+              scroll under it. On phones, named cards drop the context row once
+              pinned so only the name follows; the spacer below replaces that row,
+              while the pinned margin replaces the trimmed padding. */}
           <div
             data-board-card-header
             className={cn(
@@ -1172,7 +1171,12 @@ export function BoardCard({
                   {unreadDot}
                   {headerActions}
                 </div>
-                <div className="mt-1 hidden items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+                <div
+                  className={cn(
+                    "mt-1 flex items-center gap-1.5 text-xs text-muted-foreground",
+                    headerStuck && "hidden sm:flex"
+                  )}
+                >
                   {locatorLink("xs")}
                   <span className="shrink-0 opacity-50">·</span>
                   <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
@@ -1206,6 +1210,9 @@ export function BoardCard({
               </button>
             )}
           </div>
+          {conversation.topicSummary && (
+            <div data-board-card-context-spacer aria-hidden className={cn("h-0 sm:hidden", headerStuck && "h-6")} />
+          )}
 
           <div
             className={cn(bodyCollapsed && "overflow-hidden")}

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -6,12 +6,24 @@ import * as graphModule from "./use-conversation-graph"
 import type { CachedBoardPost } from "@/db"
 import {
   reconcileStableView,
-  useStableBoardView,
+  useStableBoardView as useStableBoardViewImpl,
   type BoardExclusionState,
   type BoardViewFilter,
   type BoardSeedState,
   type CommittedView,
 } from "./use-stable-board-view"
+
+/** Keeps the existing call sites focused on their own axis while the retired
+ * viewport-seen input remains accepted only inside this test file. */
+function useStableBoardView(
+  workspaceId: string,
+  filter: BoardViewFilter,
+  exclusions: BoardExclusionState | undefined,
+  seed: BoardSeedState | undefined,
+  _retiredSeenRef?: { readonly current: ReadonlySet<string> }
+) {
+  return useStableBoardViewImpl(workspaceId, filter, exclusions, seed)
+}
 
 /** Build a full filter from overrides — every axis off unless named. */
 function filterOf(over: Partial<BoardViewFilter> = {}): BoardViewFilter {
@@ -1192,131 +1204,23 @@ describe("useStableBoardView seed gate", () => {
   })
 })
 
-describe("useStableBoardView — unseen re-buffering", () => {
+describe("useStableBoardView — existing-card activity", () => {
   let liveValue: CachedBoardPost[] | undefined
   function mockLive(value: CachedBoardPost[] | undefined) {
     liveValue = value
     vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
   }
-  function seenRefOf(...ids: string[]): { current: ReadonlySet<string> } {
-    return { current: new Set(ids) }
-  }
 
   afterEach(() => vi.restoreAllMocks())
 
-  it("re-buffers an UNSEEN committed card that gains activity, and reveals it at its live position", () => {
+  it("counts only new conversations, never activity on an already-committed card", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
+
+    act(() => mockLive(feed(post("b", 900), post("new", 700), post("a", 300))))
+    rerender()
+
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-
-    act(() => mockLive(feed(post("b", 900), post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
-    expect(result.current.newCount).toBe(1)
-
-    act(() => result.current.commit())
-    expect(result.current.posts.map((p) => p.id)).toEqual(["b", "a"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("freezes a SEEN committed card that gains activity — no motion under the eye, no count", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a", "b")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    act(() => mockLive(feed(post("b", 900), post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("keeps an UNSEEN committed card whose activity is unchanged — presence alone never re-buffers", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    act(() => mockLive(feed(post("a", 300), post("b", 200))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("never re-buffers the viewer's own pending post, seen or not", () => {
-    mockLive(feed(post("a", 300)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    act(() => mockLive(feed(pendingPost("mine", 600), post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
-    expect(result.current.newCount).toBe(0)
-    // The pending card is committed but unseen; a later bump must not pull it back.
-    act(() => mockLive(feed(pendingPost("mine", 900), post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("does not re-buffer a card that left the raw feed (a removed stub, not activity)", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    act(() => mockLive(feed(post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect([...result.current.removedIds]).toEqual(["b"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("behaves exactly as today when no seenRef is passed (back-compat)", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
-    act(() => mockLive(feed(post("b", 900), post("a", 300))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("keeps the paged/buffered floor at the ORIGINAL committed window when a card is re-buffered", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-
-    // b (unseen) is re-buffered out of the order. c:250 is above the committed
-    // floor (200), so it stays behind the pill; a floor that rose to a's 300 when
-    // b left would page c in below the frozen window instead.
-    act(() => mockLive(feed(post("b", 900), post("a", 300), post("c", 250))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
-    expect(result.current.newCount).toBe(2)
-  })
-
-  it("skips re-buffering entirely when it would empty the order (an empty order re-arms the first commit)", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf()
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, seen))
-    act(() => mockLive(feed(post("b", 900), post("a", 800))))
-    rerender()
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect(result.current.newCount).toBe(0)
-  })
-
-  it("arms only when a seenRef is passed — a bump that happened pre-paint re-buffers at the first armed reconcile", () => {
-    mockLive(feed(post("a", 300), post("b", 200)))
-    const seen = seenRefOf("a")
-    const { result, rerender } = renderHook(
-      ({ armed }: { armed: boolean }) =>
-        useStableBoardView("ws_1", ALL, undefined, undefined, armed ? seen : undefined),
-      { initialProps: { armed: false } }
-    )
-    act(() => mockLive(feed(post("b", 900), post("a", 300))))
-    rerender({ armed: false })
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
-    expect(result.current.newCount).toBe(0)
-
-    // Arming compares live against the (unchanged) committed activity, so the
-    // pre-paint bump is picked up now — b is genuinely unseen, so that is correct.
-    rerender({ armed: true })
-    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
     expect(result.current.newCount).toBe(1)
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -6,24 +6,12 @@ import * as graphModule from "./use-conversation-graph"
 import type { CachedBoardPost } from "@/db"
 import {
   reconcileStableView,
-  useStableBoardView as useStableBoardViewImpl,
+  useStableBoardView,
   type BoardExclusionState,
   type BoardViewFilter,
   type BoardSeedState,
   type CommittedView,
 } from "./use-stable-board-view"
-
-/** Keeps the existing call sites focused on their own axis while the retired
- * viewport-seen input remains accepted only inside this test file. */
-function useStableBoardView(
-  workspaceId: string,
-  filter: BoardViewFilter,
-  exclusions: BoardExclusionState | undefined,
-  seed: BoardSeedState | undefined,
-  _retiredSeenRef?: { readonly current: ReadonlySet<string> }
-) {
-  return useStableBoardViewImpl(workspaceId, filter, exclusions, seed)
-}
 
 /** Build a full filter from overrides — every axis off unless named. */
 function filterOf(over: Partial<BoardViewFilter> = {}): BoardViewFilter {
@@ -198,7 +186,7 @@ describe("useStableBoardView", () => {
 
   it("reports loading until the IDB read resolves, then the empty state", () => {
     mockLive(undefined)
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     expect(result.current.isLoading).toBe(true)
     act(() => mockLive([]))
     rerender()
@@ -208,7 +196,7 @@ describe("useStableBoardView", () => {
 
   it("holds order frozen and surfaces a fresh arrival as the new count", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     act(() => mockLive(feed(post("new", 500), post("a", 300), post("b", 200))))
@@ -224,7 +212,7 @@ describe("useStableBoardView", () => {
 
   it("reveals the viewer's own pending post at top the moment it lands", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     act(() => mockLive(feed(pendingPost("mine", 600), post("a", 300))))
     rerender()
     expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
@@ -233,7 +221,7 @@ describe("useStableBoardView", () => {
 
   it("reveals a pending post that materializes arbitrarily later (a queued scratchpad send), no arm window", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     // An unrelated arrival buffers first; then, much later (past any old 8s arm),
     // the viewer's own scratchpad card finally lands from the drain.
     act(() => mockLive(feed(post("other", 500), post("a", 300))))
@@ -249,7 +237,7 @@ describe("useStableBoardView", () => {
 
   it("reveals ONLY the viewer's own pending card, leaving other users' arrivals buffered", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     // Two unrelated new conversations accumulate, then the viewer posts.
     act(() => mockLive(feed(pendingPost("mine", 900), post("x", 700), post("y", 600), post("a", 300))))
     rerender()
@@ -260,7 +248,7 @@ describe("useStableBoardView", () => {
 
   it("marks a committed card that left the raw feed as removed, keeping its slot until the next commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     // "b" is merged away / emptied — its IDB row is gone.
     act(() => mockLive(feed(post("a", 300))))
     rerender()
@@ -280,7 +268,7 @@ describe("useStableBoardView", () => {
       openingMessage: { id: "m_open" },
     } as unknown as CachedBoardPost
     mockLive(feed(post("a", 300), ghost))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     // "b" merged into "c", which now carries its opening message.
     const successor = {
       ...post("c", 400),
@@ -303,7 +291,7 @@ describe("useStableBoardView", () => {
   it("reports no successor when nothing holds the removed card's opening message", () => {
     const ghost = { ...post("b", 200), openingMessage: { id: "m_open" } } as unknown as CachedBoardPost
     mockLive(feed(post("a", 300), ghost))
-    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     act(() => mockLive(feed(post("a", 300))))
     rerender()
     expect([...result.current.removedIds]).toEqual(["b"])
@@ -314,9 +302,7 @@ describe("useStableBoardView", () => {
     const mine = { ...post("m", 300), isMine: true } as CachedBoardPost
     const plain = { ...post("a", 200), isMine: true } as CachedBoardPost
     mockLive(feed(mine, plain))
-    const { result, rerender } = renderHook(() =>
-      useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined)
-    )
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["m", "a"])
     // "a" stops matching the lens but its row is still in the raw feed.
     act(() => mockLive(feed(mine, { ...plain, isMine: false } as CachedBoardPost)))
@@ -327,7 +313,7 @@ describe("useStableBoardView", () => {
 
   it("resets the committed view when the workspace changes", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(({ ws }) => useStableBoardView(ws, ALL, undefined, undefined, undefined), {
+    const { result, rerender } = renderHook(({ ws }) => useStableBoardView(ws, ALL, undefined, undefined), {
       initialProps: { ws: "ws_1" },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
@@ -341,7 +327,7 @@ describe("useStableBoardView", () => {
     const mine = { ...post("m", 300), isMine: true } as CachedBoardPost
     const other = { ...post("n", 200), isMine: false } as CachedBoardPost
     mockLive(feed(mine, other))
-    const { result } = renderHook(() => useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["m"])
   })
 
@@ -350,7 +336,7 @@ describe("useStableBoardView", () => {
     const plain = { ...post("a", 250), isMine: false } as CachedBoardPost
     mockLive(feed(mine, plain))
     const { result, rerender } = renderHook(
-      ({ lens }) => useStableBoardView("ws_1", lensFilter(lens), undefined, undefined, undefined),
+      ({ lens }) => useStableBoardView("ws_1", lensFilter(lens), undefined, undefined),
       {
         initialProps: { lens: "all" as BoardLens },
       }
@@ -372,12 +358,9 @@ describe("useStableBoardView", () => {
     const mine = { ...lensPost("s", 300, { isMine: true }), rootStreamId: "chan_a" } as CachedBoardPost
     const other = { ...lensPost("d", 400, {}), rootStreamId: "chan_b" } as CachedBoardPost
     mockLive(feed(mine, other))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: lensFilter("mine") },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: lensFilter("mine") },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
     rerender({ filter: scopeFilter(["chan_b"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["d"])
@@ -395,12 +378,9 @@ describe("useStableBoardView", () => {
     const scoped = { ...lensPost("s", 300, {}), rootStreamId: "chan_a" } as CachedBoardPost // chan_a only
     const mineLow = { ...lensPost("x", 200, { isMine: true }), rootStreamId: "chan_b" } as CachedBoardPost // mine, below s's floor
     mockLive(feed(scoped, mineLow))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: scopeFilter(["chan_a"]) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: scopeFilter(["chan_a"]) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
     rerender({ filter: lensFilter("mine") })
@@ -424,9 +404,7 @@ describe("useStableBoardView", () => {
     const mine = lensPost("s", 300, { isMine: true })
     const idle = lensPost("i", 200, { isMine: true })
     mockLive(feed(mine, idle))
-    const { result, rerender } = renderHook(() =>
-      useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined, undefined)
-    )
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", lensFilter("mine"), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["s", "i"])
 
     // The mention on `s` is deleted with fresh activity — it no longer matches.
@@ -447,12 +425,9 @@ describe("useStableBoardView", () => {
     // top there via reconcile, no arm to carry across the reset.
     const mine = lensPost("s", 300, { isMine: true })
     mockLive(feed(mine))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: lensFilter("mine") },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: lensFilter("mine") },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
     // Navigate to All, then the authored card lands after the fresh view's commit.
@@ -472,9 +447,7 @@ describe("useStableBoardView", () => {
     const threadUnderScope = scopedPost("t", 250, "stream_root")
     const outOfScope = scopedPost("z", 400, "stream_other")
     mockLive(feed(inScope, threadUnderScope, outOfScope))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", scopeFilter(["stream_root"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", scopeFilter(["stream_root"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "t"])
   })
 
@@ -484,9 +457,7 @@ describe("useStableBoardView", () => {
       conversation: { ...post("l", 300).conversation, streamId: "stream_root" },
     } as CachedBoardPost
     mockLive(feed(legacy))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", scopeFilter(["stream_root"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", scopeFilter(["stream_root"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["l"])
   })
 
@@ -500,18 +471,14 @@ describe("useStableBoardView", () => {
     const threadUnderChannel = typedPost("t", 250, "channel")
     const dmPost = typedPost("d", 400, "dm")
     mockLive(feed(channelPost, threadUnderChannel, dmPost))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", typesFilter(["channel"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", typesFilter(["channel"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["c", "t"])
   })
 
   it("fails open for cached rows without rootStreamType — the board surfaces, never hides", () => {
     const legacy = post("l", 300) // no rootStreamType field
     mockLive(feed(legacy))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", typesFilter(["dm"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", typesFilter(["dm"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["l"])
   })
 
@@ -519,12 +486,9 @@ describe("useStableBoardView", () => {
     const channelPost = typedPost("c", 300, "channel")
     const dmPost = typedPost("d", 400, "dm")
     mockLive(feed(channelPost, dmPost))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: typesFilter(["channel"]) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: typesFilter(["channel"]) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["c"])
     rerender({ filter: typesFilter(["dm"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["d"])
@@ -567,7 +531,7 @@ describe("useStableBoardView", () => {
     } as unknown as ReturnType<typeof graphModule.useConversationGraph>)
 
     mockLive(feed(child, other, parent))
-    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     // One card per root discussion: the child folds into the parent, whose
     // effective activity (900) now outranks "other" (500).
     expect(result.current.posts.map((p) => p.id)).toEqual(["parent", "other"])
@@ -612,7 +576,7 @@ describe("useStableBoardView", () => {
     // The live feed holds only the child (its parent didn't match the filters):
     // never vanish content — the child stays a standalone card.
     mockLive(feed(child))
-    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["child"])
   })
 
@@ -620,12 +584,9 @@ describe("useStableBoardView", () => {
     const a = scopedPost("a", 300, "stream_one")
     const b = scopedPost("b", 400, "stream_two")
     mockLive(feed(a, b))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: scopeFilter(["stream_one"]) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: scopeFilter(["stream_one"]) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
 
     // A structurally-equal scope (same key, fresh Set identity) must NOT reset.
@@ -677,7 +638,7 @@ describe("useStableBoardView — negative & label filters", () => {
     const other = anchoredPost("z", 400, "stream_ok", "stream_ok")
     mockLive(feed(inChannel, inThread, other))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", excludeStreamsFilter(["stream_gh"]), undefined, undefined, undefined)
+      useStableBoardView("ws_1", excludeStreamsFilter(["stream_gh"]), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["z"])
   })
@@ -687,7 +648,7 @@ describe("useStableBoardView — negative & label filters", () => {
     const inThread = anchoredPost("t", 250, "thread_1", "stream_c")
     mockLive(feed(inChannel, inThread))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", excludeStreamsFilter(["thread_1"]), undefined, undefined, undefined)
+      useStableBoardView("ws_1", excludeStreamsFilter(["thread_1"]), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
@@ -699,7 +660,7 @@ describe("useStableBoardView — negative & label filters", () => {
       scope: { key: "stream_x", ids: new Set(["stream_x"]) },
       excludeStreams: { key: "stream_x", ids: new Set(["stream_x"]) },
     })
-    const { result } = renderHook(() => useStableBoardView("ws_1", filter, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", filter, undefined, undefined))
     expect(result.current.posts).toEqual([])
   })
 
@@ -709,7 +670,7 @@ describe("useStableBoardView — negative & label filters", () => {
     const legacy = post("l", 200) // no rootStreamType
     mockLive(feed(dmPost, channelPost, legacy))
     const filter = filterOf({ excludeTypes: { key: "dm", ids: new Set<BoardScopeStreamType>(["dm"]) } })
-    const { result } = renderHook(() => useStableBoardView("ws_1", filter, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", filter, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["c", "l"])
   })
 
@@ -719,22 +680,14 @@ describe("useStableBoardView — negative & label filters", () => {
     const unlabeled = anchoredPost("z", 400, "stream_plain", "stream_plain")
     mockLive(feed(onLabeledRoot, onLabeledAnchor, unlabeled))
     const { result } = renderHook(() =>
-      useStableBoardView(
-        "ws_1",
-        labelsFilter("label_x", ["stream_lab", "stream_lab2"]),
-        undefined,
-        undefined,
-        undefined
-      )
+      useStableBoardView("ws_1", labelsFilter("label_x", ["stream_lab", "stream_lab2"]), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
   })
 
   it("a label scope that resolves to no streams matches NOTHING, not everything", () => {
     mockLive(feed(post("a", 300)))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", labelsFilter("label_x", []), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", labelsFilter("label_x", []), undefined, undefined))
     expect(result.current.posts).toEqual([])
     expect(result.current.hasRawPosts).toBe(true)
   })
@@ -744,7 +697,7 @@ describe("useStableBoardView — negative & label filters", () => {
     const other = anchoredPost("z", 400, "stream_ok", "stream_ok")
     mockLive(feed(labeled, other))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", excludeLabelsFilter("label_code", ["stream_code"]), undefined, undefined, undefined)
+      useStableBoardView("ws_1", excludeLabelsFilter("label_code", ["stream_code"]), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["z"])
   })
@@ -753,12 +706,9 @@ describe("useStableBoardView — negative & label filters", () => {
     const a = anchoredPost("a", 300, "stream_a", "stream_a")
     const b = anchoredPost("b", 200, "stream_b", "stream_b")
     mockLive(feed(a, b))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: excludeLabelsFilter("label_x", []) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: excludeLabelsFilter("label_x", []) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     // stream_a gets labeled while the view is open: same filter key, new
@@ -802,7 +752,7 @@ describe("useStableBoardView — hide & mute exclusions", () => {
 
   it("drops a hidden card immediately — even after it was committed and retained (the crux)", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(({ excl }) => useStableBoardView("ws_1", ALL, excl, undefined, undefined), {
+    const { result, rerender } = renderHook(({ excl }) => useStableBoardView("ws_1", ALL, excl, undefined), {
       initialProps: { excl: NO_EXCL },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
@@ -817,7 +767,7 @@ describe("useStableBoardView — hide & mute exclusions", () => {
   it("revives a hidden card once its activity passes the watermark", () => {
     const excl = exclOf({ hidden: new Map([["a", 350]]) })
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(({ e }) => useStableBoardView("ws_1", ALL, e, undefined, undefined), {
+    const { result, rerender } = renderHook(({ e }) => useStableBoardView("ws_1", ALL, e, undefined), {
       initialProps: { e: excl },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual([])
@@ -830,7 +780,7 @@ describe("useStableBoardView — hide & mute exclusions", () => {
   it("drops a muted stream's cards when mute is active", () => {
     mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", ALL, exclOf({ muted: new Set(["stream_x"]) }), undefined, undefined)
+      useStableBoardView("ws_1", ALL, exclOf({ muted: new Set(["stream_x"]) }), undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
   })
@@ -838,21 +788,21 @@ describe("useStableBoardView — hide & mute exclusions", () => {
   it("keeps a muted stream's cards when mute is inactive (an explicit ?in= scope)", () => {
     mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", ALL, exclOf({ muted: new Set(["stream_x"]), muteActive: false }), undefined, undefined)
+      useStableBoardView("ws_1", ALL, exclOf({ muted: new Set(["stream_x"]), muteActive: false }), undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
   })
 
   it("drops a `rootArchived` card while showArchived is off", () => {
     mockLive(feed(archivedPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
-    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
   })
 
   it("keeps a `rootArchived` card once showArchived opts in", () => {
     mockLive(feed(archivedPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", filterOf({ showArchived: true }), undefined, undefined, undefined)
+      useStableBoardView("ws_1", filterOf({ showArchived: true }), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
   })
@@ -862,12 +812,9 @@ describe("useStableBoardView — hide & mute exclusions", () => {
     // committed and retained; toggling archived off must drop it NOW (the server
     // won't re-seed it to evict it from IDB), driven purely by `post.rootArchived`.
     mockLive(feed(archivedPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: filterOf({ showArchived: true }) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: filterOf({ showArchived: true }) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     rerender({ filter: ALL })
@@ -883,13 +830,7 @@ describe("useStableBoardView — hide & mute exclusions", () => {
       feed(streamPost("a", 300, "stream_x"), staleActivePost("b", 200, "stream_y"), streamPost("c", 100, "stream_z"))
     )
     const { result } = renderHook(() =>
-      useStableBoardView(
-        "ws_1",
-        filterOf({ archivedRootIds: new Set(["stream_x", "stream_y"]) }),
-        undefined,
-        undefined,
-        undefined
-      )
+      useStableBoardView("ws_1", filterOf({ archivedRootIds: new Set(["stream_x", "stream_y"]) }), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["c"])
   })
@@ -901,7 +842,6 @@ describe("useStableBoardView — hide & mute exclusions", () => {
         "ws_1",
         filterOf({ showArchived: true, archivedRootIds: new Set(["stream_x", "stream_y"]) }),
         undefined,
-        undefined,
         undefined
       )
     )
@@ -911,23 +851,16 @@ describe("useStableBoardView — hide & mute exclusions", () => {
   it("keeps a `rootArchived: false` card whose root is not in the archived index", () => {
     mockLive(feed(staleActivePost("a", 300, "stream_x")))
     const { result } = renderHook(() =>
-      useStableBoardView(
-        "ws_1",
-        filterOf({ archivedRootIds: new Set(["stream_other"]) }),
-        undefined,
-        undefined,
-        undefined
-      )
+      useStableBoardView("ws_1", filterOf({ archivedRootIds: new Set(["stream_other"]) }), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
 
   it("drops a committed card the instant its root joins the archived index", () => {
     mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      { initialProps: { filter: filterOf() } }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: filterOf() },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     // A fresh arrival waits behind the "N new" pill — the reader's view is frozen.
@@ -951,7 +884,7 @@ describe("useStableBoardView — hide & mute exclusions", () => {
     // board can show its empty state instead of a perpetual seed skeleton.
     mockLive(feed(post("a", 300)))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", ALL, exclOf({ hidden: new Map([["a", 400]]) }), undefined, undefined)
+      useStableBoardView("ws_1", ALL, exclOf({ hidden: new Map([["a", 400]]) }), undefined)
     )
     expect(result.current.posts).toEqual([])
     expect(result.current.isLoading).toBe(false)
@@ -975,7 +908,7 @@ describe("useStableBoardView — unread filter", () => {
     } as CachedBoardPost
     mockLive(feed(streamPost("a", 300, "stream_unread"), streamPost("b", 200, "stream_read"), legacy))
     const { result } = renderHook(() =>
-      useStableBoardView("ws_1", unreadFilter(["stream_unread", "stream_anchor"]), undefined, undefined, undefined)
+      useStableBoardView("ws_1", unreadFilter(["stream_unread", "stream_anchor"]), undefined, undefined)
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "c"])
   })
@@ -985,12 +918,9 @@ describe("useStableBoardView — unread filter", () => {
     // just because it's no longer in `live` — reading it while sitting on
     // `?unread=true` is a voluntary action, same class as hide/mute.
     mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: unreadFilter(["stream_x", "stream_y"]) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: unreadFilter(["stream_x", "stream_y"]) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     // "stream_x" gets read — its id drops out of the live unread set. No commit.
@@ -1000,12 +930,9 @@ describe("useStableBoardView — unread filter", () => {
 
   it("a live unread re-resolution (same `?unread=true` selection) never resets the frozen view", () => {
     mockLive(feed(streamPost("a", 300, "stream_x")))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      {
-        initialProps: { filter: unreadFilter(["stream_x"]) },
-      }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: unreadFilter(["stream_x"]) },
+    })
     act(() => result.current.commit())
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
 
@@ -1027,26 +954,21 @@ describe("useStableBoardView — drafts filter", () => {
 
   it("shows only conversations carrying a draft", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", draftsFilter(["a"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", draftsFilter(["a"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
 
   it("matches a conversation whose message carries a sub-topic draft", () => {
     mockLive(feed(messagesPost("a", 300, ["msg_1", "msg_2"]), messagesPost("b", 200, ["msg_3"])))
-    const { result } = renderHook(() =>
-      useStableBoardView("ws_1", draftsFilter([], ["msg_2"]), undefined, undefined, undefined)
-    )
+    const { result } = renderHook(() => useStableBoardView("ws_1", draftsFilter([], ["msg_2"]), undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
   })
 
   it("renders a resolved-draft card with the removal treatment in place, then drops it on the next commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      { initialProps: { filter: draftsFilter(["a", "b"]) } }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: draftsFilter(["a", "b"]) },
+    })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
 
     // "a"'s draft resolves DURING the send: it sheds immediately, but through
@@ -1067,10 +989,9 @@ describe("useStableBoardView — drafts filter", () => {
 
   it("a drafts re-resolution (same `?drafts=true` selection) never resets the frozen view", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(
-      ({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined, undefined),
-      { initialProps: { filter: draftsFilter(["a"]) } }
-    )
+    const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter, undefined, undefined), {
+      initialProps: { filter: draftsFilter(["a"]) },
+    })
     act(() => result.current.commit())
 
     act(() => mockLive(feed(post("new", 500), post("a", 300))))
@@ -1093,7 +1014,7 @@ describe("useStableBoardView seed gate", () => {
 
   it("holds the stale feed until the seeded rows LAND in the feed, not merely until the query settles", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed, undefined), {
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
       initialProps: { seed: { settled: false, newest: { id: "conv_fresh", activityMs: 900 } } },
     })
     expect(result.current.posts).toEqual([])
@@ -1120,7 +1041,7 @@ describe("useStableBoardView seed gate", () => {
     // a reply to Y, so the seed's newest id is already present — id-presence alone
     // would open the gate on the stale order.
     mockLive(feed(post("x", 400), post("y", 200)))
-    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed, undefined), {
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
       initialProps: { seed: { settled: true, newest: { id: "y", activityMs: 900 } } },
     })
     expect(result.current.posts).toEqual([])
@@ -1137,7 +1058,7 @@ describe("useStableBoardView seed gate", () => {
 
   it("the offline/timeout escape hatch commits what it has, and buffers arrivals after it", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed, undefined), {
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
       initialProps: { seed: { settled: true, newest: null } },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
@@ -1150,7 +1071,7 @@ describe("useStableBoardView seed gate", () => {
 
   it("commits the LATEST live feed when the gate opens, not the snapshot it held", () => {
     mockLive(feed(post("a", 300)))
-    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed, undefined), {
+    const { result, rerender } = renderHook(({ seed }) => useStableBoardView("ws_1", ALL, undefined, seed), {
       initialProps: { seed: { settled: false, newest: { id: "c", activityMs: 500 } } },
     })
     act(() => mockLive(feed(post("b", 400))))
@@ -1165,7 +1086,7 @@ describe("useStableBoardView seed gate", () => {
 
   it("a workspace switch re-arms the gate — the previous workspace's cached rows never commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
-    const { result, rerender } = renderHook(({ ws, seed }) => useStableBoardView(ws, ALL, undefined, seed, undefined), {
+    const { result, rerender } = renderHook(({ ws, seed }) => useStableBoardView(ws, ALL, undefined, seed), {
       initialProps: { ws: "ws_1", seed: { settled: true, newest: null } },
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
@@ -1185,7 +1106,7 @@ describe("useStableBoardView seed gate", () => {
       )
     )
     const { result, rerender } = renderHook(
-      ({ lens, seed }) => useStableBoardView("ws_1", lensFilter(lens), undefined, seed, undefined),
+      ({ lens, seed }) => useStableBoardView("ws_1", lensFilter(lens), undefined, seed),
       { initialProps: { lens: "all" as BoardLens, seed: { settled: true, newest: null } as BoardSeedState } }
     )
     expect(result.current.posts.map((p) => p.id)).toEqual(["decided", "plain"])
@@ -1198,7 +1119,7 @@ describe("useStableBoardView seed gate", () => {
 
   it("no seed argument means no gating (existing call sites commit immediately)", () => {
     mockLive(feed(post("a", 300)))
-    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined, undefined))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL, undefined, undefined))
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
     expect(result.current.isLoading).toBe(false)
   })

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -290,26 +290,17 @@ function sameIds(a: string[], b: string[]): boolean {
  *    Revealing ONLY the pending card leaves unrelated arrivals still buffered, so
  *    posting never reorders the cards the viewer was reading (board-view-design.md
  *    "don't move shit on me").
- *  - **Any other at-or-above-floor arrival** — a new conversation from someone
- *    else, or a card bumped up. Revealing it would reorder the view, so it waits
- *    in the buffer and is surfaced as the "N new" pill count instead.
- *
- * A COMMITTED card the viewer has not yet SEEN this session (`seen`) and whose
- * live activity has passed its committed value is pulled back out of the order
- * and re-buffered, so replies to an old card count behind the pill instead of
- * reading as nothing. Safe because a committed-but-unseen card is strictly BELOW
- * the viewport — anything at or above it has intersected and is therefore seen —
- * so removing it shifts nothing on screen. (An ultra-fast fling can outrun the
- * intersection callbacks; those cards weren't meaningfully seen, and re-buffering
- * them is the correct outcome.) A seen card never moves and never counts.
+ *  - **Any other at-or-above-floor NEW conversation** — waits in the buffer so
+ *    revealing it cannot reorder the view under the reader. Activity on a
+ *    committed card updates that card in place and never contributes to the pill;
+ *    the control must always reveal a genuinely new card when tapped.
  *
  * Returns the same `committed` reference when nothing pages in or reveals, so the
  * caller can skip a state write.
  */
 export function reconcileStableView(
   committed: CommittedView,
-  live: CachedBoardPost[],
-  seen?: ReadonlySet<string>
+  live: CachedBoardPost[]
 ): { committed: CommittedView; buffered: string[] } {
   // First snapshot (initial load, or after a workspace reset): commit wholesale.
   // An empty feed has nothing to commit — keep the (empty) committed reference so
@@ -319,67 +310,32 @@ export function reconcileStableView(
   }
 
   const committedSet = new Set(committed.order)
-  // Unseen committed cards that gained activity leave the frozen order and go
-  // back behind the pill (see the safety invariant above). Armed only once at
-  // least one card of THIS committed view has been seen: observers report a
-  // beat after paint (IO records land after layout, later than React's effect
-  // flush), so "no committed card seen yet" means the view hasn't had a
-  // seeable frame — re-buffering then would strip cards the viewer never had a
-  // chance to see. Self-re-arms on every view reset by construction.
-  const rebuffered = new Set<string>()
-  const armed = seen !== undefined && seen.size > 0 && committed.order.some((id) => seen.has(id))
-  if (seen && armed) {
-    for (const post of live) {
-      const id = postId(post)
-      if (!committedSet.has(id) || seen.has(id) || post._status === "pending") continue
-      const committedMs = committed.activityById.get(id)
-      if (committedMs !== undefined && postMs(post) > committedMs) rebuffered.add(id)
-    }
-  }
-  // Floor comes from the whole committed window — every activity entry, including
-  // cards a previous pass re-buffered out of the order — because "older than the
-  // frozen window" is a property of what the viewer committed, not of which cards
-  // happen to have left it.
   let floor = Infinity
   for (const ms of committed.activityById.values()) if (ms < floor) floor = ms
-
-  // Removing every committed card would leave an empty order, which re-arms the
-  // wholesale-commit branch on the next pass — discarding the frozen view and
-  // silently clearing the pill. Skip the removals entirely; they re-evaluate on
-  // the next reconcile.
-  if (rebuffered.size > 0 && rebuffered.size >= committed.order.length) rebuffered.clear()
-  const order = rebuffered.size === 0 ? committed.order : committed.order.filter((id) => !rebuffered.has(id))
 
   const paged: CachedBoardPost[] = []
   const revealed: CachedBoardPost[] = []
   const buffered: string[] = []
   for (const post of live) {
     const id = postId(post)
-    if (committedSet.has(id) && !rebuffered.has(id)) continue
+    if (committedSet.has(id)) continue
     if (post._status === "pending") revealed.push(post)
-    else if (rebuffered.has(id)) buffered.push(id)
     else if (postMs(post) < floor) paged.push(post)
     else buffered.push(id)
   }
 
-  if (paged.length === 0 && revealed.length === 0 && rebuffered.size === 0) {
-    return { committed, buffered }
-  }
+  if (paged.length === 0 && revealed.length === 0) return { committed, buffered }
 
   // The viewer's own pending posts prepend at top (newest); paged-in older rows
   // append below the frozen window. Both activity-desc; the committed cards
   // between keep their frozen positions.
   revealed.sort((a, b) => postMs(b) - postMs(a))
   paged.sort((a, b) => postMs(b) - postMs(a))
-  // A re-buffered card keeps its committed activity entry even though it left the
-  // order: that entry is what holds the window's floor still, so the next pass
-  // classifies arrivals against the window the viewer committed rather than one
-  // that rose when the card departed. It is dropped at the next `commit()`.
   const activityById = new Map(committed.activityById)
   for (const post of [...revealed, ...paged]) activityById.set(postId(post), postMs(post))
   return {
     committed: {
-      order: [...revealed.map(postId), ...order, ...paged.map(postId)],
+      order: [...revealed.map(postId), ...committed.order, ...paged.map(postId)],
       activityById,
     },
     buffered,
@@ -463,12 +419,7 @@ export function useStableBoardView(
   workspaceId: string,
   filter: BoardViewFilter,
   exclusions: BoardExclusionState = NO_EXCLUSIONS,
-  seed: BoardSeedState | undefined,
-  // A REF, not a Set: seen-ness is written by intersection callbacks and read at
-  // reconcile time, and must never force a re-render of the feed. REQUIRED so a
-  // caller that wants no re-buffering has to say `undefined` on purpose —
-  // dropping the argument silently was how the wiring went missing.
-  seenRef: { readonly current: ReadonlySet<string> } | undefined
+  seed: BoardSeedState | undefined
 ): StableBoardView {
   const {
     lens,
@@ -637,8 +588,8 @@ export function useStableBoardView(
     liveRef.current = live
     for (const post of live) retainedRef.current.set(postId(post), post)
     // `reconcileStableView` reveals the viewer's own pending post (at top) and
-    // paged-in older rows; everything else stays buffered behind the pill.
-    const next = reconcileStableView(committedInput, live, seenRef?.current)
+    // paged-in older rows; only genuinely new conversations stay buffered.
+    const next = reconcileStableView(committedInput, live)
     if (next.committed !== committedInput) {
       hasCommittedForWorkspaceRef.current = true
       setCommitted(next.committed)

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -543,7 +543,7 @@ describe("BoardPage", () => {
     ] as never)
     mountBoard([makePost({ id: "conv_sp", streamId: "stream_sp" })])
 
-    expect(await screen.findByText("My Notes")).toBeTruthy() // header locator = scratchpad name
+    expect(await screen.findByRole("link", { name: "My Notes" })).toBeTruthy()
   })
 
   it("resolves a DM peer as the card's stream locator", async () => {
@@ -556,8 +556,7 @@ describe("BoardPage", () => {
     vi.mocked(workspaceStoreModule.useWorkspaceUsers).mockReturnValue([{ id: "usr_pierre", name: "Pierre" }] as never)
     mountBoard([makePost({ id: "conv_dm", streamId: "stream_dm", messageIds: ["d1"] }, { id: "d1" })])
 
-    // The DM peer's name is the header locator (where the post lives).
-    expect(await screen.findByText("Pierre")).toBeTruthy()
+    expect(await screen.findByRole("link", { name: "Pierre" })).toBeTruthy()
   })
 
   it("keeps the board column mounted, hidden and inert behind a fullscreen mobile panel", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -27,26 +27,6 @@ import { boardReplyDraftKey, boardBranchReplyDraftKey, boardSubtopicDraftKey } f
 
 const WORKSPACE_ID = "ws_1"
 
-class FakeIntersectionObserver {
-  static instances: FakeIntersectionObserver[] = []
-  observed = new Set<Element>()
-  constructor(private callback: IntersectionObserverCallback) {
-    FakeIntersectionObserver.instances.push(this)
-  }
-  observe(el: Element) {
-    this.observed.add(el)
-  }
-  unobserve(el: Element) {
-    this.observed.delete(el)
-  }
-  disconnect() {
-    this.observed.clear()
-  }
-  fire(entries: Array<{ target: Element; isIntersecting: boolean }>) {
-    this.callback(entries as unknown as IntersectionObserverEntry[], this as unknown as IntersectionObserver)
-  }
-}
-
 function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): ConversationWithStaleness {
   const now = "2026-06-22T12:00:00.000Z"
   return {
@@ -599,48 +579,32 @@ describe("BoardPage", () => {
     expect(hidden?.className).toContain("invisible")
   })
 
-  it("counts a bumped UNSEEN card behind the pill while a bumped SEEN card stays frozen", async () => {
-    const seenPost = makePost(
-      { id: "conv_seen", messageIds: ["m_seen"], lastActivityAt: "2026-06-22T12:00:00.000Z" },
-      { id: "m_seen", contentMarkdown: "Seen card body." }
+  it("does not show the new pill for activity on cards already in the view", async () => {
+    const first = makePost(
+      { id: "conv_first", messageIds: ["m_first"], lastActivityAt: "2026-06-22T12:00:00.000Z" },
+      { id: "m_first", contentMarkdown: "First card body." }
     )
-    const unseenPost = makePost(
-      { id: "conv_unseen", messageIds: ["m_unseen"], lastActivityAt: "2026-06-22T11:00:00.000Z" },
-      { id: "m_unseen", contentMarkdown: "Unseen card body." }
+    const second = makePost(
+      { id: "conv_second", messageIds: ["m_second"], lastActivityAt: "2026-06-22T11:00:00.000Z" },
+      { id: "m_second", contentMarkdown: "Second card body." }
     )
-    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
-    FakeIntersectionObserver.instances = []
-    const { rerenderWith } = mountBoard([seenPost, unseenPost])
-    const seenBody = await screen.findByText("Seen card body.")
-    await screen.findByText("Unseen card body.")
+    const { rerenderWith } = mountBoard([first, second])
+    await screen.findByText("First card body.")
+    await screen.findByText("Second card body.")
 
-    // Fire the card-level observer for the first card only: that is the real
-    // `onSeen` wiring, which lands the id in the page's seen ref.
-    const cardEl = seenBody.closest("div.board-card-hover")
-    expect(cardEl, "the card root should carry the board-card class").toBeTruthy()
-    const observers = FakeIntersectionObserver.instances.filter((instance) => instance.observed.has(cardEl!))
-    expect(observers.length, "an IntersectionObserver should be watching the card root").toBeGreaterThan(0)
-    await act(async () => {
-      for (const observer of observers) observer.fire([{ target: cardEl!, isIntersecting: true }])
-    })
-
-    // Both cards gain activity; only the unseen one goes back behind the pill.
     await act(async () => {
       rerenderWith([
         makePost(
-          { id: "conv_unseen", messageIds: ["m_unseen"], lastActivityAt: "2026-06-22T14:00:00.000Z" },
-          { id: "m_unseen", contentMarkdown: "Unseen card body." }
+          { id: "conv_second", messageIds: ["m_second"], lastActivityAt: "2026-06-22T14:00:00.000Z" },
+          { id: "m_second", contentMarkdown: "Second card body." }
         ),
-        makePost(
-          { id: "conv_seen", messageIds: ["m_seen"], lastActivityAt: "2026-06-22T13:00:00.000Z" },
-          { id: "m_seen", contentMarkdown: "Seen card body." }
-        ),
+        first,
       ])
     })
 
-    expect(await screen.findByText("1 update available")).toBeTruthy()
-    expect(screen.getByText("Seen card body.")).toBeTruthy()
-    expect(screen.queryByText("Unseen card body.")).toBeNull()
+    expect(screen.queryByText(/update available/)).toBeNull()
+    expect(screen.getByText("First card body.")).toBeTruthy()
+    expect(screen.getByText("Second card body.")).toBeTruthy()
   })
 })
 

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -458,10 +458,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // escape hatch — `newest: null` then means "commit whatever you have".
   const [seedTimedOut, setSeedTimedOut] = useState(false)
   const seedWorkspaceRef = useRef(workspaceId)
-  // Cards the viewer has laid eyes on this session (first intersection, per card).
-  // Per-session and per-workspace, never persisted: a seen card stays frozen, an
-  // unseen one that gains activity goes back behind the "N new" pill.
-  const seenCardsRef = useRef<Set<string>>(new Set())
   // A fresh board visit is a fresh "open": drop last visit's divider latches
   // before any card renders (parents render first, so this beats an effect).
   const visitRef = useRef(false)
@@ -474,7 +470,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   let timedOut = seedTimedOut
   if (seedWorkspaceRef.current !== workspaceId) {
     seedWorkspaceRef.current = workspaceId
-    seenCardsRef.current = new Set()
     resetBoardUnreadLatches()
     timedOut = false
     if (seedTimedOut) setSeedTimedOut(false)
@@ -507,7 +502,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     removedIds,
     removedSuccessorById,
     draftResolvedIds,
-  } = useStableBoardView(workspaceId, filter, exclusions, seed, seenCardsRef)
+  } = useStableBoardView(workspaceId, filter, exclusions, seed)
   // After a refetch settles, `isLoading` is already false but the seed effect
   // writes IDB on the next tick, so the IDB feed can be momentarily empty while
   // the query already holds posts. Treat that window as loading so the feed
@@ -593,9 +588,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // its ref to the Virtualizer via `scrollRef`, exactly like the timeline —
   // virtua then maintains scroll position across item measurement and above-fold
   // reflow, which is what the hand-rolled `useBoardScrollAnchor` used to do.
-  const markCardSeen = useCallback((conversationId: string) => {
-    seenCardsRef.current.add(conversationId)
-  }, [])
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const listRef = useRef<VirtualizerHandle | null>(null)
   const registerScroller = useCallback((node: HTMLDivElement | null) => {
@@ -822,7 +814,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
               dmPeerUserId={dmPeerUserId}
               scrollerRef={scrollerRef}
               listRef={listRef}
-              onSeen={() => markCardSeen(row.post.conversation.id)}
               onClearUnread={unreadOnly ? () => clearUnreadCard(row.post.conversation.id) : undefined}
             />
           </div>
@@ -839,7 +830,6 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       fetchNextPage,
       loadMoreLabel,
       workspaceId,
-      markCardSeen,
       unreadOnly,
       clearUnreadCard,
     ]

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -880,8 +880,9 @@ Shipped, all flag-gated behind `board-view`:
 
 - **The board** — workspace-wide feed at `/w/:ws/board`, message-led cards
   grouped by recency, authored posts via the board composer. Long-card headers
-  follow the feed on desktop and mobile; the phone header keeps only the
-  conversation name and trims its vertical padding while pinned.
+  follow the feed on desktop and mobile. Phones show the stream/date row at
+  rest, but only the conversation name follows the scroll; the pinned name row
+  also trims its vertical padding.
 - **Sync data plane** — conversations in IDB, `conversation:*` through
   `SocketEventGate`, synchronous determinable assign + bump
   (#1100/#1106/#1109/#1111).

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -880,8 +880,8 @@ Shipped, all flag-gated behind `board-view`:
 
 - **The board** — workspace-wide feed at `/w/:ws/board`, message-led cards
   grouped by recency, authored posts via the board composer. Long-card headers
-  follow the feed on desktop and mobile; the pinned phone header trims its
-  vertical padding.
+  follow the feed on desktop and mobile; the phone header keeps only the
+  conversation name and trims its vertical padding while pinned.
 - **Sync data plane** — conversations in IDB, `conversation:*` through
   `SocketEventGate`, synchronous determinable assign + bump
   (#1100/#1106/#1109/#1111).

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -419,9 +419,9 @@ effect and add it to `scrollTop`.
    disappears is the worst case for a stable list (removal shifts everything below).
    Tombstone in place until commit, or remove with anchor compensation. Above-
    viewport removals are absorbed by the anchor.
-3. **Count semantics.** Pill = new conversations. Seen-card activity = in-place dot,
-   not the pill (else "12 new" when nothing is actually new to look at). Decide
-   whether a seen card bumping past the current top counts as "new."
+3. **Count semantics.** Pill = new conversations only. Activity on any committed
+   card updates it in place and never counts, whether or not the card has entered
+   the viewport — tapping the pill must always reveal a genuinely new card.
 4. **Reconnect re-seed.** The reconnect bootstrap updates IDB (truth) but must NOT
    mutate the committed view — it only grows the buffer/pill. Big post-disconnect
    counts are expected.
@@ -453,11 +453,12 @@ The projection layer landed as `useStableBoardView`
   while committed. A card that vanishes from the live feed (delete / lost access)
   keeps rendering from last-known content until the next commit (tombstone-in-
   place, edge 2), so a removal never shifts the rows below it.
-- **Buffer + "N new" pill** — a live id newer than the committed floor that isn't
-  committed → buffered, counted in the pill; an id below the floor is older content
-  paged in by "Load more" → appended below the frozen window with no pill (the
-  `reconcileStableView` split, edge 1's pragmatic v1 take — the client cursor is
-  captured per page so re-return/skip is rare and self-heals via socket→IDB).
+- **Buffer + "N new" pill** — a new live id newer than the committed floor →
+  buffered, counted in the pill; activity on a committed id updates in place and
+  never counts. An id below the floor is older content paged in by "Load more" →
+  appended below the frozen window with no pill (the `reconcileStableView` split,
+  edge 1's pragmatic v1 take — the client cursor is captured per page so
+  re-return/skip is rare and self-heals via socket→IDB).
 - **Commit triggers** — pill click (scroll to top, then commit) and remount; the
   viewer's own authored post arms a one-shot `revealNext` so it surfaces instead of
   hiding behind its own pill. At-top still buffers (edge 5).
@@ -878,7 +879,9 @@ updates in place, it never re-sorts siblings).
 Shipped, all flag-gated behind `board-view`:
 
 - **The board** — workspace-wide feed at `/w/:ws/board`, message-led cards
-  grouped by recency, authored posts via the board composer.
+  grouped by recency, authored posts via the board composer. Long-card headers
+  follow the feed on desktop and mobile; the pinned phone header trims its
+  vertical padding.
 - **Sync data plane** — conversations in IDB, `conversation:*` through
   `SocketEventGate`, synchronous determinable assign + bump
   (#1100/#1106/#1109/#1111).


### PR DESCRIPTION
## Problem

The board’s “N new” pill counted activity bumps on conversations already represented in the committed view. Tapping it could therefore restore the same card without revealing anything new. Board-card headers were also sticky only from the `sm` breakpoint up, leaving long cards without context on phones.

## Solution

- `reconcileStableView` now buffers only conversation IDs absent from the committed view. Existing-card message/activity updates remain live in place and never inflate the pill.
- Removed the retired per-card viewport-seen latch and its observer plumbing.
- Made card headers sticky at every width. A pinned phone header trims 6px of vertical padding and replaces it with equal margin, preserving the card footprint; below-viewport virtualized cards are explicitly excluded from the stuck state.
- Updated the board design record and regression coverage for pill semantics, page integration, and mobile sticky-state geometry.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | New-conversation-only buffering; removed seen-card rebuffering |
| `apps/frontend/src/components/board/board-card.tsx` | Mobile sticky header and directional stuck detection |
| `apps/frontend/src/pages/board.tsx` | Removed retired seen-card wiring |
| `docs/board-view-design.md` | Recorded settled pill and mobile-header behavior |

## Test plan

- [x] Focused frontend suites — 161 passed
- [x] Frontend lint + typecheck
- [x] Commit gates — monorepo lint, typecheck, Dockerfile/migration checks, API docs check
- [x] Sol/high combined review — one mobile virtualization issue found and fixed

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788475596&installation_model_id=20758&pr_number=1773&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1773&signature=1e794e78d4efcb7aecb5627f1e58dfb2c39b3b87ba9eb5eb0a8cd76e3072bd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->