### PR TITLE
feat(drafts): the conversation arm survives a reload

### DIFF
--- a/apps/frontend/src/components/composer/conversation-reply-strip.tsx
+++ b/apps/frontend/src/components/composer/conversation-reply-strip.tsx
@@ -1,36 +1,38 @@
 import { Layers, X } from "lucide-react"
 
+const CONVERSATION_REPLY_STRIP_CLASS_NAME =
+  "mb-1.5 flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/50 px-2 py-1 text-xs text-muted-foreground"
+
 interface ConversationReplyStripProps {
   /** The sub-conversation the armed composer files into (its topic summary). */
   title: string
-  /** Disarm — the timeline nulls in-memory state; the panel flushes + rescopes the draft to root. */
-  onCancel: () => void
+  /** Optional disarm action for surfaces that support moving the draft back to their root scope. */
+  onCancel?: () => void
 }
 
 /**
- * Dismissible "Replying in <topic>" strip shown above a composer armed to a
- * sub-conversation. The send's only signal that it files into a conversation, so
- * it renders wherever the composer does. Shared by the timeline (`MessageInput`)
- * and the board conversation panel (`InlineComposerForm`) so the two can't drift.
+ * "Replying in <topic>" strip shown above a composer armed to a
+ * sub-conversation. Shared by the timeline and board conversation panel so the
+ * filing signal cannot drift between surfaces.
  */
 export function ConversationReplyStrip({ title, onCancel }: ConversationReplyStripProps) {
   return (
-    <div
-      data-testid="conversation-reply-strip"
-      className="mb-1.5 flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/50 px-2 py-1 text-xs text-muted-foreground"
-    >
+    <div data-testid="conversation-reply-strip" className={CONVERSATION_REPLY_STRIP_CLASS_NAME}>
       <Layers className="h-3.5 w-3.5 shrink-0" />
       <span className="truncate">
         Replying in <span className="font-medium">{title}</span>
       </span>
-      <button
-        type="button"
-        aria-label="Cancel reply in conversation"
-        onClick={onCancel}
-        className="ml-auto shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
+      {onCancel ? (
+        <button
+          type="button"
+          aria-label="Cancel reply in conversation"
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={onCancel}
+          className="ml-auto shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -276,7 +276,10 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   const [floatingAnchorEl, setFloatingAnchorEl] = useState<HTMLElement | null>(null)
   const { panelId } = usePanel()
   const conversationId = panelId ? parseConversationPanel(panelId) : null
-  const { post, notFound, refetch } = useConversationBoardPost(workspaceId, conversationId)
+  const { post, notFound, loadFailed, refetch } = useConversationBoardPost(workspaceId, conversationId)
+  // Both ends the load: a 404 verdict and a failed request are equally terminal
+  // here (`retry: false`), and the empty state below names both.
+  const unopenable = notFound || loadFailed
   // Hidden set — the panel is reachable for a hidden conversation (deep-link,
   // search, Saved), so it offers "Unhide" when the open one is hidden.
   const hiddenConversations = useBoardHiddenConversations(workspaceId)
@@ -401,10 +404,10 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   // body pick the skeleton up where this left it — without it, the body mounting
   // at its own "loading" phase would blank a skeleton the user is already
   // looking at.
-  // `notFound` is terminal with `post` still null, so readiness has to include it —
+  // `unopenable` is terminal with `post` still null, so readiness has to include it —
   // otherwise the phase latches at "skeleton" and the header shimmers forever above
   // a resolved empty state.
-  const shellPhase = useCoordinatedPhase({ isLoading: !post && !notFound, isReady: !!post || notFound })
+  const shellPhase = useCoordinatedPhase({ isLoading: !post && !unopenable, isReady: !!post || unopenable })
   const skeletonShownRef = useRef<{ conversationId: string | null; shown: boolean }>({ conversationId, shown: false })
   if (skeletonShownRef.current.conversationId !== conversationId) {
     skeletonShownRef.current = { conversationId, shown: false }
@@ -442,7 +445,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   }
 
   let body: React.ReactNode = shellPhase === "skeleton" ? <ConversationRowsSkeleton /> : null
-  if (notFound) {
+  if (unopenable) {
     body = (
       <Empty className="min-h-[16rem] border-0">
         <EmptyHeader>

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -183,15 +183,27 @@ beforeEach(async () => {
   vi.spyOn(composerModule, "MessageComposer").mockImplementation((({
     content,
     onContentChange,
+    composerRef,
   }: {
     content: JSONContent
     onContentChange: (value: JSONContent) => void
-  }) => (
-    <div>
-      <span data-testid="editor-body">{docText(content)}</span>
-      <button onClick={() => onContentChange(makeDoc("typed here"))}>type</button>
-    </div>
-  )) as unknown as typeof composerModule.MessageComposer)
+    composerRef?: { current: unknown }
+  }) => {
+    if (composerRef) {
+      composerRef.current = {
+        focus: vi.fn(),
+        focusAfterQuoteReply: vi.fn(),
+        getEditor: () => null,
+        openSnippetEditor: vi.fn(),
+      }
+    }
+    return (
+      <div>
+        <span data-testid="editor-body">{docText(content)}</span>
+        <button onClick={() => onContentChange(makeDoc("typed here"))}>type</button>
+      </div>
+    )
+  }) as unknown as typeof composerModule.MessageComposer)
 })
 
 afterEach(() => {
@@ -281,27 +293,6 @@ describe("the timeline composer's durable target", () => {
     expect(screen.getByTestId("conversation-reply-strip")).toHaveTextContent("Replying in Pizza plans")
   })
 
-  it("arms from the gesture and disarms from the strip's ×, leaving the draft at its board scope", async () => {
-    await seedDrafts()
-    mount()
-    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
-
-    await act(async () => {
-      registeredConversationReplyHandler?.({ conversationId: "conv_1" })
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-    expect(await db.composerTarget.get(hostScope)).toEqual({ host: hostScope, workspaceId, scope: boardScope })
-    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
-
-    await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
-
-    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
-    expect(await db.composerTarget.get(hostScope)).toBeUndefined()
-    // Disarming means "this composer no longer points at C" — the draft written
-    // for C stays a C draft.
-    expect(await bodyOf(boardScope)).toBe("board body")
-  })
-
   it("falls back to the stream scope when the target's conversation is gone", async () => {
     await seedDrafts()
     await setComposerTarget(workspaceId, hostScope, boardScope)
@@ -334,24 +325,6 @@ describe("the timeline composer's durable target", () => {
     // The target survives — the carve-out declines to apply it, it does not
     // delete it, so unlocking or leaving the encrypted stream restores the arm.
     expect(await db.composerTarget.get(hostScope)).toBeDefined()
-  })
-
-  it("releases the draft it stops hosting when disarmed, so it returns to the pile", async () => {
-    await seedDrafts()
-    await setComposerTarget(workspaceId, hostScope, boardScope)
-
-    mount()
-    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
-
-    await act(async () => {
-      screen.getByRole("button", { name: /cancel reply in conversation/i }).click()
-    })
-
-    // A draft checked out under a scope no composer shows is excluded from every
-    // pile on the device, so disarming has to detach the pointer or the text is
-    // reachable from nowhere.
-    await waitFor(async () => expect(await db.composerLoaded.get(boardScope)).toBeUndefined())
-    expect(await bodyOf(boardScope)).toBe("board body")
   })
 
   it("does not route a restored arm — a page load must not open the panel or focus", async () => {
@@ -411,6 +384,7 @@ describe("the timeline composer's durable target", () => {
     })
 
     await waitFor(() => expect(openPanelSpy).toHaveBeenCalled())
+    await waitFor(async () => expect(await db.composerLoaded.get(boardScope)).toBeUndefined())
   })
 
   it("holds the arm when the board-post fetch fails for anything but a 404", async () => {

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -199,11 +199,25 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-function mount(initialEntries: string[] = ["/"]) {
+function mount(initialEntries: string[] = ["/"], mountStreamId: string = streamId) {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
-        <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        <MessageInput workspaceId={workspaceId} streamId={mountStreamId} />
+        <SearchParamsProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+/** The same tree with a different stream — `MessageInput` is NOT remounted per
+ *  stream in the app (same route, param-only change), so a navigation is a
+ *  rerender and any ref that outlives it is shared across streams. */
+function rerenderAtStream(view: ReturnType<typeof mount>, nextStreamId: string) {
+  view.rerender(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/"]}>
+        <MessageInput workspaceId={workspaceId} streamId={nextStreamId} />
         <SearchParamsProbe />
       </MemoryRouter>
     </QueryClientProvider>
@@ -336,6 +350,33 @@ describe("the timeline composer's durable target", () => {
     // Still armed and still editing the board draft — the strip is the whole
     // effect of a restored arm.
     expect(screen.getByTestId("editor-body")).toHaveTextContent("board body")
+    expect(await db.composerTarget.get(hostScope)).toBeDefined()
+  })
+
+  it("does not re-route a gesture arm after navigating away and back", async () => {
+    await seedDrafts()
+    // Same-stream at arm time, so the gesture takes the focus branch and stays
+    // armed rather than redirecting and disarming.
+    lastActiveStreamId = streamId
+
+    const view = mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+    await act(async () => {
+      registeredConversationReplyHandler?.({ conversationId: "conv_1" })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
+
+    // The conversation moves into a thread while the user is elsewhere.
+    lastActiveStreamId = "stream_thread"
+    rerenderAtStream(view, "stream_other")
+    await settle()
+    rerenderAtStream(view, streamId)
+    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
+    await settle()
+
+    // Coming back is a navigation, not a gesture: the arm shows and does nothing.
+    expect(openPanelSpy).not.toHaveBeenCalled()
     expect(await db.composerTarget.get(hostScope)).toBeDefined()
   })
 

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -336,6 +336,24 @@ describe("the timeline composer's durable target", () => {
     expect(await db.composerTarget.get(hostScope)).toBeDefined()
   })
 
+  it("releases the draft it stops hosting when disarmed, so it returns to the pile", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+
+    mount()
+    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
+
+    await act(async () => {
+      screen.getByRole("button", { name: /cancel reply in conversation/i }).click()
+    })
+
+    // A draft checked out under a scope no composer shows is excluded from every
+    // pile on the device, so disarming has to detach the pointer or the text is
+    // reachable from nowhere.
+    await waitFor(async () => expect(await db.composerLoaded.get(boardScope)).toBeUndefined())
+    expect(await bodyOf(boardScope)).toBe("board body")
+  })
+
   it("does not route a restored arm — a page load must not open the panel or focus", async () => {
     await seedDrafts()
     await setComposerTarget(workspaceId, hostScope, boardScope)

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { ReactNode } from "react"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, useSearchParams } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import * as contextsModule from "@/contexts"
+import * as hooksModule from "@/hooks"
+import * as useAttachmentsModule from "@/hooks/use-attachments"
+import * as currentUserHook from "@/hooks/use-current-workspace-user-id"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as authModule from "@/auth"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
+import * as conversationReplyModule from "./conversation-reply-context"
+import * as useConversationsModule from "@/hooks/use-conversations"
+import * as composerModule from "@/components/composer"
+import * as discussModule from "@/hooks/use-discuss-with-ariadne"
+import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
+import * as streamCommandsModule from "@/hooks/use-stream-commands"
+import { spyOnExport } from "@/test"
+import { upsertLoadedDraft, stashLoadedDraft } from "@/hooks/use-draft-message"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
+import { resetApplyWindow } from "@/stores/apply-window"
+import { setComposerTarget } from "@/hooks/use-composer-target"
+// eslint-disable-next-line no-restricted-imports -- seeds/asserts the real draft + composer-target rows
+import { db } from "@/db"
+import { MessageInput } from "./message-input"
+import type { JSONContent } from "@threa/types"
+
+// The real draft composer runs here (only `useAttachments` is stubbed), so this
+// file covers what a mocked composer cannot: which draft row the editor renders
+// and which draft row a keystroke lands in.
+const workspaceId = "ws_target"
+const streamId = "stream_host"
+const hostScope = "stream:stream_host"
+const boardScope = "board:reply:conv_1"
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+const docText = (content: JSONContent): string => JSON.stringify(content).match(/"text":"([^"]*)"/)?.[1] ?? ""
+
+const LOCKED_SESSION = {
+  status: "locked",
+  keyId: null,
+  publicKey: null,
+  privateKey: null,
+  deviceTrusted: false,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+let registeredConversationReplyHandler: ((data: { conversationId: string }) => void) | null = null
+let notFound = false
+let loadFailed = false
+let lastActiveStreamId = streamId
+let e2eEnabled = false
+let openPanelSpy = vi.fn()
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+beforeEach(async () => {
+  vi.restoreAllMocks()
+  resetApplyWindow()
+  resetDraftStoreCache()
+  resetDraftResolutionGuard()
+  localStorage.clear()
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
+  await db.composerTarget.clear()
+  await db.pendingOperations.clear()
+  registeredConversationReplyHandler = null
+  notFound = false
+  loadFailed = false
+  lastActiveStreamId = streamId
+  e2eEnabled = false
+  openPanelSpy = vi.fn()
+
+  vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+  vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  vi.spyOn(useAttachmentsModule, "useAttachments").mockReturnValue({
+    pendingAttachments: [],
+    getPendingAttachmentsSnapshot: () => [],
+    fileInputRef: { current: null },
+    handleFileSelect: vi.fn(),
+    uploadFile: vi.fn(),
+    removeAttachment: vi.fn(),
+    cancelUpload: vi.fn(),
+    uploadedIds: [],
+    isUploading: false,
+    isReserving: false,
+    hasFailed: false,
+    clear: vi.fn(),
+    restore: vi.fn(),
+    imageCount: 0,
+  } as unknown as ReturnType<typeof useAttachmentsModule.useAttachments>)
+
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { messageSendMode: "enter" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(contextsModule, "useSocketStatus").mockReturnValue(
+    "connected" as ReturnType<typeof contextsModule.useSocketStatus>
+  )
+  vi.spyOn(contextsModule, "usePanel").mockReturnValue({
+    openPanel: openPanelSpy,
+  } as unknown as ReturnType<typeof contextsModule.usePanel>)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(
+    [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue(
+    [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUsers>
+  )
+  vi.spyOn(authModule, "useUser").mockReturnValue(null as unknown as ReturnType<typeof authModule.useUser>)
+  vi.spyOn(hooksModule, "useStreamBootstrap").mockReturnValue({
+    data: undefined,
+  } as unknown as ReturnType<typeof hooksModule.useStreamBootstrap>)
+  spyOnExport(streamCommandsModule, "useStreamCommands").mockReturnValue((() => []) as never)
+  vi.spyOn(hooksModule, "useMentionStreamContext").mockReturnValue(
+    undefined as unknown as ReturnType<typeof hooksModule.useMentionStreamContext>
+  )
+  vi.spyOn(hooksModule, "useStreamOrDraft").mockImplementation(
+    () =>
+      ({
+        stream: { id: streamId, e2eEnabled, rootStreamId: streamId },
+        sendMessage: vi.fn().mockResolvedValue({}),
+      }) as unknown as ReturnType<typeof hooksModule.useStreamOrDraft>
+  )
+  vi.spyOn(hooksModule, "useScheduleMessage").mockReturnValue({
+    mutateAsync: vi.fn(),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof hooksModule.useScheduleMessage>)
+  vi.spyOn(hooksModule, "useComposerHeightPublish").mockImplementation(
+    () => undefined as unknown as ReturnType<typeof hooksModule.useComposerHeightPublish>
+  )
+  vi.spyOn(hooksModule, "useDecryptedDraftPreviews").mockReturnValue(new Map())
+  vi.spyOn(discussModule, "useDiscussWithAriadne").mockImplementation(
+    () => vi.fn() as unknown as ReturnType<typeof discussModule.useDiscussWithAriadne>
+  )
+  vi.spyOn(streamContextBagModule, "useStreamContextBag").mockReturnValue({
+    data: { bag: null, refs: [] },
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof streamContextBagModule.useStreamContextBag>)
+  vi.spyOn(conversationReplyModule, "useConversationReply").mockReturnValue({
+    triggerReplyInConversation: vi.fn(),
+    registerHandler: (handler: (data: { conversationId: string }) => void) => {
+      registeredConversationReplyHandler = handler
+      return () => {
+        registeredConversationReplyHandler = null
+      }
+    },
+  } as unknown as ReturnType<typeof conversationReplyModule.useConversationReply>)
+  vi.spyOn(useConversationsModule, "useConversationBoardPost").mockImplementation(
+    (_workspaceId: string, conversationId: string | null) =>
+      ({
+        post:
+          conversationId && !notFound && !loadFailed
+            ? {
+                conversation: { id: conversationId, streamId, topicSummary: "Pizza plans" },
+                recentMessages: [{ streamId: lastActiveStreamId }],
+              }
+            : null,
+        isLoading: false,
+        notFound: !!conversationId && notFound,
+        loadFailed: !!conversationId && loadFailed,
+        refetch: vi.fn(),
+      }) as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>
+  )
+  vi.spyOn(composerModule, "ScheduledMessagesPicker").mockImplementation(
+    (() => null) as unknown as typeof composerModule.ScheduledMessagesPicker
+  )
+  vi.spyOn(composerModule, "FloatingComposerShell").mockImplementation((({
+    children,
+    hidden,
+  }: {
+    children: ReactNode
+    hidden?: boolean
+  }) => (hidden ? null : <div>{children}</div>)) as unknown as typeof composerModule.FloatingComposerShell)
+  // Renders the composer's live content and offers a keystroke, so a test can
+  // read which draft is on screen and write into whichever draft is open.
+  vi.spyOn(composerModule, "MessageComposer").mockImplementation((({
+    content,
+    onContentChange,
+  }: {
+    content: JSONContent
+    onContentChange: (value: JSONContent) => void
+  }) => (
+    <div>
+      <span data-testid="editor-body">{docText(content)}</span>
+      <button onClick={() => onContentChange(makeDoc("typed here"))}>type</button>
+    </div>
+  )) as unknown as typeof composerModule.MessageComposer)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function mount(initialEntries: string[] = ["/"]) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        <SearchParamsProbe />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+async function seedDrafts() {
+  await upsertLoadedDraft(workspaceId, hostScope, { contentJson: makeDoc("stream body"), attachments: [] })
+  await upsertLoadedDraft(workspaceId, boardScope, { contentJson: makeDoc("board body"), attachments: [] })
+  await act(async () => {
+    await seedDraftCacheFromIdb(workspaceId)
+  })
+}
+
+/** Let pending liveQuery emissions, effects and microtasks land. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  })
+}
+
+function SearchParamsProbe() {
+  const [params] = useSearchParams()
+  return <span data-testid="search-params">{params.toString()}</span>
+}
+
+async function bodyOf(scope: string): Promise<string> {
+  const rows = await db.drafts.where("scope").equals(scope).toArray()
+  return rows.map((row) => docText(row.contentJson)).join("|")
+}
+
+describe("the timeline composer's durable target", () => {
+  it("edits the targeted board draft, not the stream's own — and a keystroke lands there", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+
+    mount()
+
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+
+    await userEvent.click(screen.getByRole("button", { name: "type" }))
+    await waitFor(async () => expect(await bodyOf(boardScope)).toBe("typed here"))
+    expect(await bodyOf(hostScope)).toBe("stream body")
+  })
+
+  it("survives a reload — a fresh mount reads the stored target", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+
+    const first = mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+    first.unmount()
+
+    // Same durable state, brand new component tree — the arm is not session state.
+    resetDraftStoreCache()
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+    expect(screen.getByTestId("conversation-reply-strip")).toHaveTextContent("Replying in Pizza plans")
+  })
+
+  it("arms from the gesture and disarms from the strip's ×, leaving the draft at its board scope", async () => {
+    await seedDrafts()
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+
+    await act(async () => {
+      registeredConversationReplyHandler?.({ conversationId: "conv_1" })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(await db.composerTarget.get(hostScope)).toEqual({ host: hostScope, workspaceId, scope: boardScope })
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
+
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+    expect(await db.composerTarget.get(hostScope)).toBeUndefined()
+    // Disarming means "this composer no longer points at C" — the draft written
+    // for C stays a C draft.
+    expect(await bodyOf(boardScope)).toBe("board body")
+  })
+
+  it("falls back to the stream scope when the target's conversation is gone", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+    notFound = true
+
+    mount()
+
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+    expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    await waitFor(async () => expect(await db.composerTarget.get(hostScope)).toBeUndefined())
+    expect(await bodyOf(boardScope)).toBe("board body")
+  })
+
+  it("falls back to the stream scope on an encrypted stream, so the plaintext purge can't see a board scope", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+    e2eEnabled = true
+
+    mount()
+
+    // Positive sync point first: the stored row exists and the component has had
+    // its liveQuery emission flushed. Without this the assertions below would run
+    // before the target was ever observed and would pass with the carve-out gone.
+    await waitFor(async () => expect(await db.composerTarget.get(hostScope)).toBeDefined())
+    await settle()
+
+    expect(screen.getByTestId("editor-body")).not.toHaveTextContent("board body")
+    expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    expect(await bodyOf(boardScope)).toBe("board body")
+    // The target survives — the carve-out declines to apply it, it does not
+    // delete it, so unlocking or leaving the encrypted stream restores the arm.
+    expect(await db.composerTarget.get(hostScope)).toBeDefined()
+  })
+
+  it("does not route a restored arm — a page load must not open the panel or focus", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+    // Someone continued the conversation in a thread overnight.
+    lastActiveStreamId = "stream_thread"
+
+    mount()
+
+    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
+    await settle()
+    expect(openPanelSpy).not.toHaveBeenCalled()
+    // Still armed and still editing the board draft — the strip is the whole
+    // effect of a restored arm.
+    expect(screen.getByTestId("editor-body")).toHaveTextContent("board body")
+    expect(await db.composerTarget.get(hostScope)).toBeDefined()
+  })
+
+  it("still routes an arm made by the gesture when the conversation lives in a thread", async () => {
+    await seedDrafts()
+    lastActiveStreamId = "stream_thread"
+
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+
+    await act(async () => {
+      registeredConversationReplyHandler?.({ conversationId: "conv_1" })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    await waitFor(() => expect(openPanelSpy).toHaveBeenCalled())
+  })
+
+  it("holds the arm when the board-post fetch fails for anything but a 404", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+    loadFailed = true
+
+    mount()
+
+    await waitFor(() => expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument())
+    await settle()
+    // The target, the strip and the composer's scope all survive a 502.
+    expect(await db.composerTarget.get(hostScope)).toBeDefined()
+    expect(screen.getByTestId("editor-body")).toHaveTextContent("board body")
+    expect(await bodyOf(boardScope)).toBe("board body")
+  })
+
+  it("disarms and restores when a ?stash= deep link names one of this stream's own rows", async () => {
+    // A stashed row at the host's own scope: written, then detached.
+    await upsertLoadedDraft(workspaceId, hostScope, { contentJson: makeDoc("stashed stream body"), attachments: [] })
+    const stashedId = await stashLoadedDraft(workspaceId, hostScope)
+    await upsertLoadedDraft(workspaceId, boardScope, { contentJson: makeDoc("board body"), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+
+    mount([`/?stash=${stashedId}`])
+
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stashed stream body"))
+    // The deep link is an explicit "work on this one": the arm yields to it.
+    expect(await db.composerTarget.get(hostScope)).toBeUndefined()
+    expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId("search-params")).toHaveTextContent(""))
+    // The board draft stays where it was written (the × semantics).
+    expect(await bodyOf(boardScope)).toBe("board body")
+  })
+})

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -798,21 +798,6 @@ describe("MessageInput", () => {
       expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument()
     })
 
-    it("dismissing the strip disarms the filing — the next send carries no directive", async () => {
-      mockComposerState.canSend = true
-      mockComposerState.content = makeDoc("just a normal message")
-
-      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      await arm("conv_1")
-
-      await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
-      await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
-
-      await userEvent.click(screen.getByRole("button", { name: /send/i }))
-
-      expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ conversation: undefined }))
-    })
-
     it("hands off to the conversation panel when the conversation is live in a thread (thread-follow)", async () => {
       // The conversation's most-recently-active stream is a thread (`thread_789`),
       // not the rendered channel (`stream_456`) — a flat send here would

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import type { ReactNode } from "react"
-import { act, render, screen } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { Router } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -25,6 +25,8 @@ import * as streamCommandsModule from "@/hooks/use-stream-commands"
 import { spyOnExport } from "@/test"
 import { toast } from "sonner"
 import { MessageInput, materializePendingAttachmentReferences } from "./message-input"
+// eslint-disable-next-line no-restricted-imports -- clears the durable composer-target rows the composer reads
+import { db } from "@/db"
 import type { JSONContent } from "@threa/types"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
@@ -114,7 +116,8 @@ let mockComposerState = {
   isLoaded: true,
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await db.composerTarget.clear()
   vi.restoreAllMocks()
   vi.clearAllMocks()
   mockSendMessage.mockReset()
@@ -245,7 +248,11 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
   } as unknown as ReturnType<typeof streamContextBagModule.useStreamContextBag>)
-  vi.spyOn(hooksModule, "getDraftMessageKey").mockImplementation(() => "test-draft-key")
+  // Real key shape: the durable composer target is keyed by the HOST scope, so a
+  // constant here would make two different streams share one arm.
+  vi.spyOn(hooksModule, "getDraftMessageKey").mockImplementation((location) =>
+    location.type === "stream" ? `stream:${location.streamId}` : `thread:${location.anchorId}`
+  )
   vi.spyOn(hooksModule, "useDraftComposer").mockImplementation(
     () =>
       ({
@@ -397,6 +404,22 @@ function Wrapper({ children }: { children: React.ReactNode }) {
       </Router>
     </QueryClientProvider>
   )
+}
+
+/**
+ * Mechanism C's gesture. Arming is now a durable IDB write the composer observes
+ * through a liveQuery, so the strip appears a tick later, not synchronously.
+ */
+async function arm(conversationId: string) {
+  await act(async () => {
+    registeredConversationReplyHandler?.({ conversationId })
+  })
+  // Settle on the composer having OBSERVED the write: either it armed inline
+  // (strip) or the arm resolved thread-live and handed off to the panel.
+  await waitFor(() => {
+    const observed = screen.queryByTestId("conversation-reply-strip") !== null || mockOpenPanel.mock.calls.length > 0
+    expect(observed).toBe(true)
+  })
 }
 
 function render$(ui: React.ReactElement) {
@@ -586,7 +609,7 @@ describe("MessageInput", () => {
     })
   })
 
-  describe("quote replies", () => {
+  describe("quote replies", async () => {
     it("inserts a quote block with one trailing paragraph so typing starts on the next line", () => {
       mockComposerState.content = {
         type: "doc",
@@ -630,11 +653,11 @@ describe("MessageInput", () => {
   })
 
   describe("reply in conversation", () => {
-    it("arms the composer with a dismissible strip showing the conversation topic and focuses the editor", () => {
+    it("arms the composer with a dismissible strip showing the conversation topic and focuses the editor", async () => {
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
 
       expect(registeredConversationReplyHandler).not.toBeNull()
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       const strip = screen.getByTestId("conversation-reply-strip")
       expect(strip).toHaveTextContent("Replying in Pizza plans")
@@ -647,7 +670,7 @@ describe("MessageInput", () => {
       mockComposerState.content = helloContent
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await userEvent.click(screen.getByRole("button", { name: /send/i }))
 
@@ -657,7 +680,8 @@ describe("MessageInput", () => {
         attachments: undefined,
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
-      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      // Disarming is a durable delete now, so the strip clears a tick later.
+      await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
     })
 
     it("carries the armed directive onto a scheduled send and clears the strip", async () => {
@@ -665,7 +689,7 @@ describe("MessageInput", () => {
       mockComposerState.content = makeDoc("send this later, in the conversation")
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await act(async () => {
         await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
@@ -677,7 +701,7 @@ describe("MessageInput", () => {
           conversation: { intent: "existing", conversationId: "conv_1" },
         })
       )
-      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
     })
 
     it("stays silent when scheduling a reply whose conversation is live in this same stream", async () => {
@@ -688,7 +712,7 @@ describe("MessageInput", () => {
       mockComposerState.content = makeDoc("later, same channel")
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await act(async () => {
         await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
@@ -712,7 +736,7 @@ describe("MessageInput", () => {
           <MessageInput workspaceId={workspaceId} streamId={streamId} />
         </Wrapper>
       )
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
       expect(mockOpenPanel).not.toHaveBeenCalled()
 
       vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({
@@ -762,7 +786,7 @@ describe("MessageInput", () => {
       mockSendMessage.mockRejectedValue(new Error("stream creation failed"))
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await userEvent.click(screen.getByRole("button", { name: /send/i }))
 
@@ -774,17 +798,17 @@ describe("MessageInput", () => {
       mockComposerState.content = makeDoc("just a normal message")
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
-      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
 
       await userEvent.click(screen.getByRole("button", { name: /send/i }))
 
       expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ conversation: undefined }))
     })
 
-    it("hands off to the conversation panel when the conversation is live in a thread (thread-follow)", () => {
+    it("hands off to the conversation panel when the conversation is live in a thread (thread-follow)", async () => {
       // The conversation's most-recently-active stream is a thread (`thread_789`),
       // not the rendered channel (`stream_456`) — a flat send here would
       // re-interleave the channel, so the composer redirects to the conversation
@@ -805,12 +829,12 @@ describe("MessageInput", () => {
       )
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       expect(mockOpenPanel).toHaveBeenCalledWith(contextsModule.createConversationPanelId("conv_1"))
       // The panel's composer is asked to open, and no inline strip is left behind.
       expect(consumeConversationReplyOpen("conv_1")).toBe(true)
-      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
       // The channel composer is never focused — focus would pop the mobile keyboard
       // on the composer we're about to leave for the panel.
       expect(mockComposerFocus).not.toHaveBeenCalled()
@@ -831,7 +855,7 @@ describe("MessageInput", () => {
       mockComposerState.content = makeDoc("late pizza take")
 
       render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
 
       await userEvent.click(screen.getByRole("button", { name: /send/i }))
 
@@ -844,7 +868,7 @@ describe("MessageInput", () => {
       expect(infoToastSpy).toHaveBeenCalled()
     })
 
-    it("keeps the inline reply put when a background update later moves the conversation to a thread", () => {
+    it("keeps the inline reply put when a background update later moves the conversation to a thread", async () => {
       // Armed and resolved same-stream (strip shown, composer focused). A live
       // board-post update then reports the conversation living in a thread — the
       // route is latched at arm time, so it must NOT evict the user to the panel
@@ -854,7 +878,7 @@ describe("MessageInput", () => {
           <MessageInput workspaceId={workspaceId} streamId={streamId} />
         </Wrapper>
       )
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
       expect(mockComposerFocus).toHaveBeenCalledTimes(1)
       expect(mockOpenPanel).not.toHaveBeenCalled()
 
@@ -876,7 +900,7 @@ describe("MessageInput", () => {
       expect(mockOpenPanel).not.toHaveBeenCalled()
     })
 
-    it("does not open the panel when navigating away from an armed same-stream reply", () => {
+    it("does not open the panel when navigating away from an armed same-stream reply", async () => {
       // Arm a same-stream reply (mock last-active === rendered stream) — inline strip,
       // no redirect. Switching streams must disarm quietly, never redirect the
       // now-stale armed conversation into the panel.
@@ -885,7 +909,7 @@ describe("MessageInput", () => {
           <MessageInput workspaceId={workspaceId} streamId={streamId} />
         </Wrapper>
       )
-      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      await arm("conv_1")
       expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument()
       expect(mockOpenPanel).not.toHaveBeenCalled()
 
@@ -1064,7 +1088,7 @@ describe("MessageInput", () => {
     })
   })
 
-  describe("attachment reference materialization", () => {
+  describe("attachment reference materialization", async () => {
     it("should keep existing numbered image references stable", () => {
       const content: JSONContent = {
         type: "doc",

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -273,6 +273,11 @@ beforeEach(async () => {
         clearDraft: mockClearDraft,
         resolveDraft: mockResolveDraft,
         clearAttachments: mockClearAttachments,
+        // On the real state; the disarm path flushes before releasing the draft
+        // it stops hosting, and a stub missing this surfaces as an unhandled
+        // rejection rather than a readable failure.
+        flushDraft: vi.fn().mockResolvedValue(undefined),
+        markNeedsRehydrate: vi.fn(),
         isLoaded: mockComposerState.isLoaded,
       }) as unknown as ReturnType<typeof hooksModule.useDraftComposer>
   )

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -609,7 +609,7 @@ describe("MessageInput", () => {
     })
   })
 
-  describe("quote replies", async () => {
+  describe("quote replies", () => {
     it("inserts a quote block with one trailing paragraph so typing starts on the next line", () => {
       mockComposerState.content = {
         type: "doc",
@@ -1088,7 +1088,7 @@ describe("MessageInput", () => {
     })
   })
 
-  describe("attachment reference materialization", async () => {
+  describe("attachment reference materialization", () => {
     it("should keep existing numbered image references stable", () => {
       const content: JSONContent = {
         type: "doc",

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -12,10 +12,12 @@ import {
   useDecryptedDraftPreviews,
   useMentionStreamContext,
   useComposerTarget,
+  useMountedComposerCount,
   setComposerTarget,
   clearComposerTarget,
 } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { stashLoadedDraft } from "@/hooks/use-draft-message"
 import { useComposeTrace } from "@/lib/compose-trace"
 import { usePreferences } from "@/contexts"
 import { useConnectionState } from "@/components/layout/connection-status"
@@ -297,6 +299,8 @@ function MessageInputComponent({
   }, [targetUnresolvable, hostScope, storedTarget])
   const effectiveTarget =
     targetResolved && !e2eEnabled && targetConversationId && !targetUnresolvable ? storedTarget : null
+  // Includes this composer once it is pointed at the scope, so >1 means someone else.
+  const mountedOnTarget = useMountedComposerCount(workspaceId, effectiveTarget)
   const armedConversationId = effectiveTarget ? targetConversationId : null
   const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
   const conversationReplyLastActiveStreamId = conversationReplyPost
@@ -390,15 +394,30 @@ function MessageInputComponent({
 
   // Disarm: this composer stops pointing at the conversation and reverts to the
   // stream's own draft. The typed draft is NOT moved — its scope IS its target,
-  // so it stays a draft of that conversation, keeps its filing, and stays
-  // reachable from the conversation's own composer and the stashed-drafts pile.
+  // so it stays a draft of that conversation and keeps its filing.
+  //
+  // It must also stop being CHECKED OUT here, though. A draft loaded under a scope
+  // no composer is showing is excluded from every pile on the device (the
+  // checked-out-anywhere rule) and carries no `?stash=` link in the explorer, so
+  // "it stays reachable" would be false: the only way back would be to open that
+  // conversation's own composer. Detaching the pointer turns it into a real stash
+  // entry, which is what makes the sentence above true. Unless another composer is
+  // already mounted on that scope — then it is showing the draft and owns it.
   const disarm = useCallback(() => {
     // Cleared here rather than in the routing effect: the gesture sets the ref
     // synchronously and the target lands an IDB write later, so an effect re-run
     // in that window would erase the very gesture it is meant to recognise.
     gestureArmedIdRef.current = null
+    const vacated = effectiveTarget
     void clearComposerTarget(hostScope)
-  }, [hostScope])
+    if (vacated && mountedOnTarget <= 1) {
+      void composerRef.current
+        .flushDraft()
+        .catch((err) => console.error("[composer] flush before disarm failed", err))
+        .then(() => stashLoadedDraft(workspaceId, vacated))
+        .catch((err) => console.error("[composer] could not release the disarmed draft", err))
+    }
+  }, [hostScope, workspaceId, effectiveTarget, mountedOnTarget])
 
   useEffect(() => {
     if (stashParamWantsHostScope) disarm()
@@ -422,6 +441,18 @@ function MessageInputComponent({
   const conversationReplyLastActiveStreamId = conversationReplyPost
     ? boardPostLastActiveStreamId(conversationReplyPost)
     : null
+
+  // Two live editors on one draft row is the failure the mounted-composer registry
+  // exists to police: the second never re-reads an ordinary body change, so
+  // whichever saves last silently wins. Arming let this composer occupy a board
+  // scope the conversation panel also mounts, so when the panel opens, yield —
+  // it is the more specific host, the same precedence the panel hand-off already
+  // uses, and the draft is checked out at that scope so it lands there intact.
+  useEffect(() => {
+    if (!effectiveTarget || mountedOnTarget <= 1) return
+    gestureArmedIdRef.current = null
+    void clearComposerTarget(hostScope)
+  }, [effectiveTarget, mountedOnTarget, hostScope])
 
   // Hand the armed conversation off to its side panel (Mechanism B), which renders
   // it across its root + threads and routes the reply recency-biased into the live

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -370,16 +370,20 @@ function MessageInputComponent({
   // directive — nothing is inserted into the body.
   const conversationReplyCtx = useConversationReply()
   const { openPanel } = usePanel()
-  // Which arm came from the gesture in this session. The target is durable, so
-  // "armed" alone can no longer tell a deliberate act from a page load.
-  const gestureArmedIdRef = useRef<string | null>(null)
+  // Which arm came from the gesture in this session, and on which host. The
+  // target is durable, so "armed" alone can no longer tell a deliberate act from
+  // a page load — and the host is part of it because this component is NOT
+  // remounted per stream: without it, arming in stream A and navigating back to
+  // A (or onto a B that is armed for the same conversation) would read as a
+  // fresh gesture and route on a plain navigation.
+  const gestureArmedIdRef = useRef<{ host: string; conversationId: string } | null>(null)
   useEffect(() => {
     if (!conversationReplyCtx) return
     // Arm only. Focus is deferred to the resolve effect below: focusing the
     // channel composer here would pop the mobile keyboard on it a beat before a
     // thread-follow reply redirects to the conversation panel.
     return conversationReplyCtx.registerHandler((data: ConversationReplyData) => {
-      gestureArmedIdRef.current = data.conversationId
+      gestureArmedIdRef.current = { host: hostScope, conversationId: data.conversationId }
       void setComposerTarget(workspaceId, hostScope, boardReplyDraftKey(data.conversationId))
     })
   }, [conversationReplyCtx, workspaceId, hostScope])
@@ -456,16 +460,22 @@ function MessageInputComponent({
     if (routedArmIdRef.current === armedConversationId) return
     // Restored, not gestured: latch it as routed so it shows the strip and does
     // nothing else. The send guard still routes when the user actually sends.
-    if (gestureArmedIdRef.current !== armedConversationId) {
+    const gesture = gestureArmedIdRef.current
+    if (gesture?.host !== hostScope || gesture.conversationId !== armedConversationId) {
       routedArmIdRef.current = armedConversationId
       return
     }
     const target = conversationReplyLastActiveStreamId
     if (!target) return
     routedArmIdRef.current = armedConversationId
+    // A gesture routes ONCE. `routedArmIdRef` is reset whenever the arm goes
+    // away (a stream switch does that), so without consuming the gesture here,
+    // navigating back would re-read it as a fresh gesture and route again on a
+    // plain navigation.
+    gestureArmedIdRef.current = null
     if (target === streamId) composerFocusRef.current?.focus()
     else redirectReplyToPanel(armedConversationId)
-  }, [armedConversationId, conversationReplyLastActiveStreamId, redirectReplyToPanel, streamId])
+  }, [armedConversationId, conversationReplyLastActiveStreamId, redirectReplyToPanel, streamId, hostScope])
 
   // Consume any pending share handoff for this stream, pre-inserting the
   // shared-message pointer into the composer and leaving the cursor after it.

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -50,7 +50,6 @@ import { useComposerCommandSend } from "@/components/composer/use-composer-comma
 import type { JSONContent } from "@threa/types"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { ComposerEncryptionNotice } from "@/components/encryption/stream-encryption-affordance"
-import { useConversationTitle } from "@/hooks/use-conversation-title"
 
 interface MessageInputProps {
   workspaceId: string
@@ -422,25 +421,6 @@ function MessageInputComponent({
   useEffect(() => {
     if (stashParamWantsHostScope) disarm()
   }, [stashParamWantsHostScope, disarm])
-
-  useEffect(() => {
-    setConversationReply(null)
-  }, [streamId])
-  // Topic label for the strip — cached board card or a one-shot by-id fetch. The
-  // same projection carries the conversation's most-recently-active stream: the
-  // latest reply's own stream (a thread under the root), falling back to the
-  // conversation's anchor.
-  const { post: conversationReplyPost } = useConversationBoardPost(
-    workspaceId,
-    conversationReply?.conversationId ?? null
-  )
-  const conversationReplyTopic = useConversationTitle(
-    workspaceId,
-    conversationReplyPost?.conversation ?? { streamId: "", topicSummary: null }
-  )
-  const conversationReplyLastActiveStreamId = conversationReplyPost
-    ? boardPostLastActiveStreamId(conversationReplyPost)
-    : null
 
   // Two live editors on one draft row is the failure the mounted-composer registry
   // exists to police: the second never re-reads an ordinary body change, so
@@ -958,11 +938,10 @@ function MessageInputComponent({
     ),
   } as const
 
-  // Armed "Reply in conversation" strip — the send's only signal that it will
-  // file into a conversation, so it renders wherever the composer does (inline
-  // and expanded). Dismissible: X disarms without touching the typed content.
+  // The filing strip is informational here. Dismissing it required relocating
+  // a live synced draft solely to preserve an uncommon inline undo action.
   const conversationReplyStrip = armedConversationId ? (
-    <ConversationReplyStrip title={conversationReplyTopic ?? "conversation"} onCancel={disarm} />
+    <ConversationReplyStrip title={conversationReplyTopic ?? "conversation"} />
   ) : null
 
   const StreamGlyph = stream ? STREAM_ICONS[stream.type] : null

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -8,8 +8,12 @@ import {
   useStreamOrDraft,
   useComposerHeightPublish,
   useStashComposer,
+  useStashParamDraftRow,
   useDecryptedDraftPreviews,
   useMentionStreamContext,
+  useComposerTarget,
+  setComposerTarget,
+  clearComposerTarget,
 } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useComposeTrace } from "@/lib/compose-trace"
@@ -35,6 +39,7 @@ import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quot
 import { useConversationReply, type ConversationReplyData } from "./conversation-reply-context"
 import { useConversationBoardPost } from "@/hooks/use-conversations"
 import { boardPostLastActiveStreamId } from "@/lib/board/reply-plan"
+import { boardReplyDraftKey, parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { usePanel, createConversationPanelId } from "@/contexts"
 import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { consumeSnippetRequest, subscribeSnippetRequest } from "@/stores/snippet-request-store"
@@ -237,7 +242,7 @@ function MessageInputComponent({
   const { preferences } = usePreferences()
   const { stream, sendMessage } = useStreamOrDraft(workspaceId, streamId)
   const scheduleMessageMutation = useScheduleMessage(workspaceId)
-  const draftKey = getDraftMessageKey({ type: "stream", streamId })
+  const hostScope = getDraftMessageKey({ type: "stream", streamId })
 
   // Send-time command routing (raw-text `/model ` included, even when the editor
   // never materialized a `slashCommand` node), over the same effective command
@@ -253,10 +258,60 @@ function MessageInputComponent({
   // The encrypted root holds the SSK + wraps (a thread shares its root's key), so
   // both sealing and the repair notice key off the root, not the (maybe-thread) id.
   const e2eRootStreamId = e2eEnabled ? (stream?.rootStreamId ?? streamId) : undefined
+
+  // "Reply in conversation" (Mechanism C) points this host at the conversation's
+  // own draft scope, durably (`composerTarget`). The composer then edits THAT
+  // draft: the arm is which draft is open, not a flag riding whatever is typed
+  // next, so it survives a reload and the strip renders straight from it.
+  const { scope: storedTarget, isResolved: targetResolved } = useComposerTarget(hostScope)
+  const parsedTarget = storedTarget ? parseBoardDraftKey(storedTarget) : null
+  const targetConversationId =
+    parsedTarget && (parsedTarget.kind === "reply" || parsedTarget.kind === "branch-reply")
+      ? parsedTarget.conversationId
+      : null
+  // Topic label for the strip — cached board card or a one-shot by-id fetch. The
+  // same projection carries the conversation's most-recently-active stream: the
+  // latest reply's own stream (a thread under the root), falling back to the
+  // conversation's anchor.
+  const { post: conversationReplyPost, notFound: conversationReplyNotFound } = useConversationBoardPost(
+    workspaceId,
+    targetConversationId
+  )
+  // Never apply the target on an encrypted stream: a board draft is plaintext at
+  // rest, and this composer purges the plaintext drafts of whatever scope it
+  // holds (E2EE-4). `e2eEnabled` and `draftKey` derive from the same `stream`
+  // value in one render, so a late resolve flips both together and the purge can
+  // never see a board scope. An unresolvable target (an unparseable scope, or a
+  // conversation the server says is gone) falls back to the host's own scope
+  // rather than leaving the composer pointed at nothing (INV-11 — report it,
+  // don't strand the user).
+  //
+  // Only a 404 counts as gone. A failed request (`loadFailed`) must HOLD the arm:
+  // clearing on any error would yank the composer's scope out from under whatever
+  // is being typed, on one 502, irreversibly.
+  const targetUnresolvable = (storedTarget !== null && !targetConversationId) || conversationReplyNotFound
+  useEffect(() => {
+    if (!targetUnresolvable) return
+    console.error(`[composer] dropping unresolvable target for ${hostScope}: ${storedTarget}`)
+    void clearComposerTarget(hostScope)
+  }, [targetUnresolvable, hostScope, storedTarget])
+  const effectiveTarget =
+    targetResolved && !e2eEnabled && targetConversationId && !targetUnresolvable ? storedTarget : null
+  const armedConversationId = effectiveTarget ? targetConversationId : null
+  const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
+  const conversationReplyLastActiveStreamId = conversationReplyPost
+    ? boardPostLastActiveStreamId(conversationReplyPost)
+    : null
+
+  // The draft scope this composer edits — the target when armed, the stream's own
+  // otherwise. `scopeId` MUST follow it: the composer's rehydrate keys on
+  // `scopeId` (`use-draft-composer.ts`), so a mismatched pair renders one draft
+  // while every save targets another.
+  const draftKey = effectiveTarget ?? hostScope
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
-    scopeId: streamId,
+    scopeId: draftKey,
     e2eStreamId: e2eRootStreamId,
   })
   const quoteReplyCtx = useQuoteReply()
@@ -266,6 +321,15 @@ function MessageInputComponent({
   // many-per-scope stash and the `?stash=<id>` URL auto-restore. Stash + restore
   // are pointer moves, so they work for plaintext and E2E alike (no gating).
   const stash = useStashComposer(composer, workspaceId, draftKey)
+  // A `?stash=` deep link naming one of THIS stream's own stashed rows while the
+  // composer is armed: the stash host is the board scope, so nobody would claim
+  // the param and the URL would carry it forever. Disarm — an explicit "work on
+  // this one" outranks the arm — and the restore proceeds on the next render.
+  // Not by pointing the stash host back at `hostScope`: `handleStashDraft` would
+  // then flush the composer's board content and detach the stream scope's
+  // pointer, stashing the wrong draft.
+  const stashParamRow = useStashParamDraftRow(workspaceId)
+  const stashParamWantsHostScope = !!effectiveTarget && stashParamRow?.scope === hostScope
   // Decrypt-on-read previews for the stash pile (sealed rows decrypt via the
   // shared cache; plaintext rows resolve from contentJson). All entries share
   // this stream's encrypted root.
@@ -301,23 +365,41 @@ function MessageInputComponent({
     })
   }, [quoteReplyCtx])
 
-  // "Reply in conversation" (Mechanism C): the armed conversation rides the send
-  // as an `existing` directive — nothing is inserted into the body. Held as
-  // in-memory state (not part of the durable draft): a stale filing surviving a
-  // reload would silently misfile whatever is typed next, so it resets with the
-  // session and with the stream.
+  // "Reply in conversation" (Mechanism C): arming points this host at the
+  // conversation's draft scope. The send reads the same target for its `existing`
+  // directive — nothing is inserted into the body.
   const conversationReplyCtx = useConversationReply()
   const { openPanel } = usePanel()
-  const [conversationReply, setConversationReply] = useState<ConversationReplyData | null>(null)
+  // Which arm came from the gesture in this session. The target is durable, so
+  // "armed" alone can no longer tell a deliberate act from a page load.
+  const gestureArmedIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!conversationReplyCtx) return
     // Arm only. Focus is deferred to the resolve effect below: focusing the
     // channel composer here would pop the mobile keyboard on it a beat before a
     // thread-follow reply redirects to the conversation panel.
     return conversationReplyCtx.registerHandler((data: ConversationReplyData) => {
-      setConversationReply(data)
+      gestureArmedIdRef.current = data.conversationId
+      void setComposerTarget(workspaceId, hostScope, boardReplyDraftKey(data.conversationId))
     })
-  }, [conversationReplyCtx])
+  }, [conversationReplyCtx, workspaceId, hostScope])
+
+  // Disarm: this composer stops pointing at the conversation and reverts to the
+  // stream's own draft. The typed draft is NOT moved — its scope IS its target,
+  // so it stays a draft of that conversation, keeps its filing, and stays
+  // reachable from the conversation's own composer and the stashed-drafts pile.
+  const disarm = useCallback(() => {
+    // Cleared here rather than in the routing effect: the gesture sets the ref
+    // synchronously and the target lands an IDB write later, so an effect re-run
+    // in that window would erase the very gesture it is meant to recognise.
+    gestureArmedIdRef.current = null
+    void clearComposerTarget(hostScope)
+  }, [hostScope])
+
+  useEffect(() => {
+    if (stashParamWantsHostScope) disarm()
+  }, [stashParamWantsHostScope, disarm])
+
   useEffect(() => {
     setConversationReply(null)
   }, [streamId])
@@ -340,27 +422,22 @@ function MessageInputComponent({
   // Hand the armed conversation off to its side panel (Mechanism B), which renders
   // it across its root + threads and routes the reply recency-biased into the live
   // thread. Shared by the resolve effect (proactive, once the projection loads) and
-  // the send guard (the race where the user sends before it loads).
+  // the send guard (the race where the user sends before it loads). The draft stays
+  // at the conversation's scope, which is the scope the panel's composer opens.
   const redirectReplyToPanel = useCallback(
     (conversationId: string) => {
       requestConversationReplyOpen(conversationId)
       openPanel(createConversationPanelId(conversationId))
-      setConversationReply(null)
+      disarm()
     },
-    [openPanel]
+    [openPanel, disarm]
   )
 
-  // Current stream read through a ref so the routing effect doesn't take `streamId`
-  // as a dep: on a plain stream switch, `streamId` changes while `conversationReply`
-  // still holds the previous stream's armed value (the `[streamId]` reset effect
-  // hasn't committed yet), and a streamId-driven re-run would misread that as a
-  // thread-follow and spuriously open the panel. The reset effect nulls the arm,
-  // which re-runs this effect to a clean no-op.
-  const streamIdRef = useRef(streamId)
-  streamIdRef.current = streamId
-
   // Thread-follow: route the armed reply ONCE, at first resolution of the
-  // projection. A conversation live in THIS stream keeps the inline strip and
+  // projection, and only for an arm the user just made. A restored arm is a page
+  // load, not a gesture: routing it would open the side panel over the channel
+  // the user navigated to (or pop the mobile keyboard) with no action behind it.
+  // A conversation live in THIS stream keeps the inline strip and
   // focuses the composer to type; one that has moved into a thread hands off to
   // the panel — a flat send there would re-interleave the channel, the mess
   // recency-biased continuation avoids (board-view-design.md).
@@ -372,17 +449,23 @@ function MessageInputComponent({
   // explicit send re-checks routing. The latch resets when the arm is cleared.
   const routedArmIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!conversationReply) {
+    if (!armedConversationId) {
       routedArmIdRef.current = null
       return
     }
-    if (routedArmIdRef.current === conversationReply.conversationId) return
+    if (routedArmIdRef.current === armedConversationId) return
+    // Restored, not gestured: latch it as routed so it shows the strip and does
+    // nothing else. The send guard still routes when the user actually sends.
+    if (gestureArmedIdRef.current !== armedConversationId) {
+      routedArmIdRef.current = armedConversationId
+      return
+    }
     const target = conversationReplyLastActiveStreamId
     if (!target) return
-    routedArmIdRef.current = conversationReply.conversationId
-    if (target === streamIdRef.current) composerFocusRef.current?.focus()
-    else redirectReplyToPanel(conversationReply.conversationId)
-  }, [conversationReply, conversationReplyLastActiveStreamId, redirectReplyToPanel])
+    routedArmIdRef.current = armedConversationId
+    if (target === streamId) composerFocusRef.current?.focus()
+    else redirectReplyToPanel(armedConversationId)
+  }, [armedConversationId, conversationReplyLastActiveStreamId, redirectReplyToPanel, streamId])
 
   // Consume any pending share handoff for this stream, pre-inserting the
   // shared-message pointer into the composer and leaving the cursor after it.
@@ -581,15 +664,15 @@ function MessageInputComponent({
       // Armed for "Reply in conversation" but not confirmed live in THIS stream
       // (thread-live, or the board-post projection hasn't resolved yet): filing
       // flat here would re-interleave the channel. Hand off to the conversation
-      // panel and keep the composer content — nothing typed is lost, the user
-      // continues in the panel. The inline flat send below only runs once the
+      // panel: the draft already lives at the conversation's own scope, which is
+      // exactly the scope the panel's composer opens, so the text follows. The inline flat send below only runs once the
       // conversation is confirmed same-stream. A toast because the send didn't do
       // the obvious thing (post here): the panel can cover this view on mobile, so
       // the kept draft needs a word or the message reads as vanished (INV-63:
       // deferred action, no other on-screen signal).
-      if (conversationReply && conversationReplyLastActiveStreamId !== streamId) {
-        redirectReplyToPanel(conversationReply.conversationId)
-        toast.info("Opening the conversation to reply — your draft was kept here.")
+      if (armedConversationId && conversationReplyLastActiveStreamId !== streamId) {
+        redirectReplyToPanel(armedConversationId)
+        toast.info("Opening the conversation to reply — your draft came with it.")
         composer.setIsSending(false)
         return
       }
@@ -617,12 +700,10 @@ function MessageInputComponent({
           // Armed by "Reply in conversation": file this send into the
           // conversation synchronously (Mechanism C). Cleared only on success —
           // a failed send keeps the filing armed alongside the restored content.
-          conversation: conversationReply
-            ? { intent: "existing", conversationId: conversationReply.conversationId }
-            : undefined,
+          conversation: armedConversationId ? { intent: "existing", conversationId: armedConversationId } : undefined,
         })
 
-        setConversationReply(null)
+        disarm()
         composer.setContent(EMPTY_DOC)
         composer.resolveDraft()
         composer.clearAttachments()
@@ -646,8 +727,9 @@ function MessageInputComponent({
       streamId,
       planSend,
       dispatchCommand,
-      conversationReply,
+      armedConversationId,
       conversationReplyLastActiveStreamId,
+      disarm,
       redirectReplyToPanel,
       takeComposeTrace,
     ]
@@ -680,7 +762,7 @@ function MessageInputComponent({
       // doesn't read as a flat channel send (INV-63: deferred action, no other
       // on-screen signal). Same-stream stays silent (the strip already shows it).
       const filesIntoDriftedConversation =
-        conversationReply !== null && conversationReplyLastActiveStreamId !== streamId
+        armedConversationId !== null && conversationReplyLastActiveStreamId !== streamId
 
       try {
         composer.setContent(EMPTY_DOC)
@@ -696,11 +778,9 @@ function MessageInputComponent({
           // Unlike the live send there's no thread-follow routing — the fired
           // message posts into this stream and the assigner attaches it to the
           // conversation by id (cross-stream within one root is allowed).
-          conversation: conversationReply
-            ? { intent: "existing", conversationId: conversationReply.conversationId }
-            : undefined,
+          conversation: armedConversationId ? { intent: "existing", conversationId: armedConversationId } : undefined,
         })
-        setConversationReply(null)
+        disarm()
         composer.resolveDraft()
         composer.clearAttachments()
         if (filesIntoDriftedConversation) {
@@ -714,7 +794,7 @@ function MessageInputComponent({
         composer.setIsSending(false)
       }
     },
-    [composer, scheduleMessageMutation, streamId, conversationReply, conversationReplyLastActiveStreamId]
+    [composer, scheduleMessageMutation, streamId, armedConversationId, conversationReplyLastActiveStreamId, disarm]
   )
 
   if (disabled && disabledReason) {
@@ -840,11 +920,8 @@ function MessageInputComponent({
   // Armed "Reply in conversation" strip — the send's only signal that it will
   // file into a conversation, so it renders wherever the composer does (inline
   // and expanded). Dismissible: X disarms without touching the typed content.
-  const conversationReplyStrip = conversationReply ? (
-    <ConversationReplyStrip
-      title={conversationReplyTopic ?? "conversation"}
-      onCancel={() => setConversationReply(null)}
-    />
+  const conversationReplyStrip = armedConversationId ? (
+    <ConversationReplyStrip title={conversationReplyTopic ?? "conversation"} onCancel={disarm} />
   ) : null
 
   const StreamGlyph = stream ? STREAM_ICONS[stream.type] : null

--- a/apps/frontend/src/db/database.schema.test.ts
+++ b/apps/frontend/src/db/database.schema.test.ts
@@ -71,6 +71,65 @@ describe("v47 payload.messageId index", () => {
   })
 })
 
+describe("v48 composer target + conversation messageIds index", () => {
+  it("serves the fork lookup from the multiEntry index and keeps the conversations store's other indexes", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+
+    // Seed at the v47 conversations shape — before the multiEntry index — so the
+    // rows exist before the index does.
+    const legacy = new Dexie(name)
+    legacy.version(47).stores({
+      conversations: "id, workspaceId, [workspaceId+_lastActivityMs], _cachedAt",
+    })
+    await legacy.open()
+    await legacy.table("conversations").bulkPut([
+      {
+        id: "conv_1",
+        workspaceId: "ws_1",
+        conversation: { id: "conv_1", streamId: "stream_1", messageIds: ["msg_a", "msg_b"] },
+        _lastActivityMs: 10,
+        _cachedAt: 1000,
+      },
+      {
+        id: "conv_2",
+        workspaceId: "ws_1",
+        conversation: { id: "conv_2", streamId: "stream_1", messageIds: ["msg_c"] },
+        _lastActivityMs: 20,
+        _cachedAt: 1000,
+      },
+    ])
+    legacy.close()
+
+    const db = new ThreaDatabase(name)
+    await db.open()
+
+    // The index was built over the pre-existing rows: a fork message resolves to
+    // its hosting conversation without scanning the workspace, and a
+    // conversation holding two of the queried ids comes back once.
+    const hosts = await db.conversations
+      .where("conversation.messageIds")
+      .anyOf(["msg_a", "msg_b", "msg_c"])
+      .distinct()
+      .toArray()
+    expect(hosts.map((row) => row.id).sort()).toEqual(["conv_1", "conv_2"])
+
+    // The version bump ADDS an index; the store's existing ones must survive.
+    const byActivity = await db.conversations.where("[workspaceId+_lastActivityMs]").equals(["ws_1", 20]).count()
+    expect(byActivity).toBe(1)
+
+    // The new device-local target store opens and round-trips.
+    await db.composerTarget.put({ host: "stream:stream_1", workspaceId: "ws_1", scope: "board:reply:conv_1" })
+    expect(await db.composerTarget.get("stream:stream_1")).toEqual({
+      host: "stream:stream_1",
+      workspaceId: "ws_1",
+      scope: "board:reply:conv_1",
+    })
+
+    db.close()
+    await Dexie.delete(name)
+  })
+})
+
 describe("one-way-door recovery", () => {
   it("a versionchange from another tab closes the connection and reloads", async () => {
     const name = `threa_test_${Math.random().toString(36).slice(2)}`

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -573,6 +573,22 @@ export interface ComposerLoaded {
   draftId: string | null
 }
 
+/**
+ * Device-local pointer: which draft scope a composer HOST currently points at.
+ * `stream:<S>` (the timeline composer for stream S) → `board:reply:<C>` when the
+ * user armed "Reply in conversation" there. Absent means the host composes its
+ * own scope. Like `ComposerLoaded` this is device-local and never synced, and it
+ * is deliberately NOT cleared on logout (see `clearAllCachedData`) — the arm is
+ * part of the in-progress work the drafts themselves survive with.
+ */
+export interface ComposerTarget {
+  /** Primary key: the host composer's own scope, e.g. "stream:{streamId}". */
+  host: string
+  workspaceId: string
+  /** The draft scope this host composes into instead of `host`. */
+  scope: string
+}
+
 export interface CachedUnreadState {
   id: string // workspaceId
   workspaceId: string
@@ -1067,6 +1083,7 @@ export class ThreaDatabase extends Dexie {
   draftScratchpads!: EntityTable<DraftScratchpad, "id">
   drafts!: EntityTable<CachedDraft, "id">
   composerLoaded!: EntityTable<ComposerLoaded, "scope">
+  composerTarget!: EntityTable<ComposerTarget, "host">
   unreadState!: EntityTable<CachedUnreadState, "id">
   userPreferences!: EntityTable<CachedUserPreferences, "id">
   workspaceMetadata!: EntityTable<CachedWorkspaceMetadata, "id">
@@ -1574,6 +1591,18 @@ export class ThreaDatabase extends Dexie {
         "id, workspaceId, streamId, sequence, [streamId+sequence], [streamId+_sequenceNum], eventType, [streamId+eventType], _clientId, _cachedAt, _status, payload.messageId",
     })
 
+    // v48: the durable composer target (which scope a host composes into),
+    // beside `composerLoaded` — device-local, unsynced, kept across logout like
+    // the drafts it points at. Plus a multiEntry index over a conversation's
+    // message ids: resolving which conversation hosts a fork/anchor message was
+    // a full workspace scan of `conversations`, which an always-mounted composer
+    // re-ran on every write. Both start from existing rows — Dexie builds the
+    // index during the upgrade, so no `.upgrade()`.
+    this.version(48).stores({
+      composerTarget: "host, workspaceId",
+      conversations: "id, workspaceId, [workspaceId+_lastActivityMs], _cachedAt, *conversation.messageIds",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
 
     // Another tab upgraded the shared per-account database. Dexie closes this
@@ -1686,7 +1715,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.savedMessages.clear(),
       db.scheduledMessages.clear(),
       // Drafts (the unified `drafts` store) and the device-local
-      // `composerLoaded` pointer are intentionally NOT cleared on logout —
+      // `composerLoaded` / `composerTarget` pointers are intentionally NOT cleared on logout —
       // mirroring the pre-unification behavior where ambient drafts survived a
       // sign-out so in-progress work isn't lost across a re-login. They are
       // workspace+user scoped within this account's database.

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -28,6 +28,7 @@ export type {
   DraftScratchpad,
   CachedDraft,
   ComposerLoaded,
+  ComposerTarget,
   DraftAttachment,
   CachedSavedMessage,
   CachedScheduledMessage,

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -66,6 +66,13 @@ export {
 export { useStashComposer, useStashParamDraftRow, type UseStashComposerResult } from "./use-stash-composer"
 
 export {
+  useComposerTarget,
+  setComposerTarget,
+  clearComposerTarget,
+  type ComposerTargetState,
+} from "./use-composer-target"
+
+export {
   useScopeDraftPreview,
   useBoardSubtopicDraftIndex,
   useBoardScopeDraftIndex,

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -101,6 +101,7 @@ export {
   hasDocContent,
   type UseDraftComposerOptions,
   type DraftComposerState,
+  useMountedComposerCount,
 } from "./use-draft-composer"
 
 export { useScrollBehavior } from "./use-scroll-behavior"

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -80,8 +80,17 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
   const hostPostByMessageId = new Map<string, CachedBoardPost>()
   let hostRows: CachedBoardPost[] = []
   if (forkMessageIds.size > 0) {
-    const rows = await db.conversations.where("workspaceId").equals(workspaceId).toArray()
-    hostRows = rows.filter((row) => row.conversation.messageIds?.some((id: string) => forkMessageIds.has(id)))
+    // The v48 multiEntry index over `conversation.messageIds` — a keyed lookup
+    // per fork id instead of a scan of every conversation in the workspace.
+    // `distinct()` because a conversation holding two of the ids would otherwise
+    // come back once per match.
+    hostRows = (
+      await db.conversations
+        .where("conversation.messageIds")
+        .anyOf([...forkMessageIds])
+        .distinct()
+        .toArray()
+    ).filter((row) => row.workspaceId === workspaceId)
     for (const post of hostRows) {
       for (const id of post.conversation.messageIds ?? []) {
         if (forkMessageIds.has(id)) hostPostByMessageId.set(id, post)

--- a/apps/frontend/src/hooks/use-composer-target.ts
+++ b/apps/frontend/src/hooks/use-composer-target.ts
@@ -1,0 +1,38 @@
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "@/db"
+
+/**
+ * The durable, device-local answer to "which draft scope does this composer host
+ * write into?". A host composes its own scope until something points it
+ * elsewhere — today only "Reply in conversation", which points the timeline's
+ * `stream:<S>` host at `board:reply:<C>`. Persisted, so the arm survives a
+ * reload: the arm is not a flag hovering over whatever gets typed next, it IS
+ * which draft is being edited.
+ */
+export async function setComposerTarget(workspaceId: string, host: string, scope: string): Promise<void> {
+  await db.composerTarget.put({ host, workspaceId, scope })
+}
+
+export async function clearComposerTarget(host: string): Promise<void> {
+  await db.composerTarget.delete(host)
+}
+
+export interface ComposerTargetState {
+  /** The stored target scope for this host, or null when the host composes its own scope. */
+  scope: string | null
+  /** False until the IDB read for THIS host has settled — callers hold the host scope meanwhile. */
+  isResolved: boolean
+}
+
+const UNRESOLVED: ComposerTargetState = { scope: null, isResolved: false }
+
+/**
+ * The target row for `host`. The host is carried through the query result and
+ * compared on read, so a stream switch can never render the previous stream's
+ * target for the frame before the new subscription emits.
+ */
+export function useComposerTarget(host: string): ComposerTargetState {
+  const row = useLiveQuery(async () => ({ host, scope: (await db.composerTarget.get(host))?.scope ?? null }), [host])
+  if (!row || row.host !== host) return UNRESOLVED
+  return { scope: row.scope, isResolved: true }
+}

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -22,6 +22,7 @@ import { mergeConversationByTitleRevision } from "@/lib/title-merge"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import type { SplitGroupInput } from "@/api/conversations"
+import { ApiError } from "@/api/client"
 import { planBoardReply, type BoardReplyPlan } from "@/lib/board/reply-plan"
 import { StreamTypes } from "@threa/types"
 import type {
@@ -461,8 +462,14 @@ export interface ConversationBoardPost {
   post: BoardViewPost | null
   /** True only before any source (the reactive store or the by-id fetch) resolves. */
   isLoading: boolean
-  /** The conversation couldn't be found — gone, emptied, or not readable. */
+  /** The server answered 404 — gone, emptied, or not readable. Terminal; retrying won't help. */
   notFound: boolean
+  /**
+   * The fetch failed for any other reason (5xx, transport, auth blip). NOT
+   * terminal: `retry: false` makes a single failure final for this query, so a
+   * caller that destroys state on failure would do it on one bad response.
+   */
+  loadFailed: boolean
   refetch: () => void
 }
 
@@ -488,6 +495,7 @@ export function useConversationBoardPost(workspaceId: string, conversationId: st
     data: fetched,
     isLoading: fetchLoading,
     isError,
+    error,
     refetch,
   } = useQuery({
     queryKey: conversationId ? conversationKeys.boardPost(conversationId) : conversationKeys.boardPost("none"),
@@ -496,18 +504,23 @@ export function useConversationBoardPost(workspaceId: string, conversationId: st
     staleTime: 60_000,
   })
 
-  if (cached) return { post: cached, isLoading: false, notFound: false, refetch: () => void refetch() }
+  if (cached)
+    return { post: cached, isLoading: false, notFound: false, loadFailed: false, refetch: () => void refetch() }
   if (fetched)
     return {
       post: toBoardViewPost(workspaceId, fetched),
       isLoading: false,
       notFound: false,
+      loadFailed: false,
       refetch: () => void refetch(),
     }
-  // A 404 (gone/empty/cross-workspace) resolves the load as not-found, not a spinner.
-  const notFound = shouldFetch && isError
+  // Only a 404 (gone/empty/cross-workspace) is a verdict about the conversation.
+  // Everything else is a failed request: callers that discard state on the answer
+  // must not act on a 502 or a token-refresh blip.
+  const failed = shouldFetch && isError
+  const notFound = failed && ApiError.isApiError(error) && error.status === 404
   const isLoading = cached === undefined || (shouldFetch && fetchLoading)
-  return { post: null, isLoading, notFound, refetch: () => void refetch() }
+  return { post: null, isLoading, notFound, loadFailed: failed && !notFound, refetch: () => void refetch() }
 }
 
 export function useConversations(workspaceId: string, streamId: string, options?: UseConversationsOptions) {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -298,10 +298,7 @@ export function useDraftComposer({
   useEffect(() => {
     const isScopeChange = prevScopeIdRef.current !== null && prevScopeIdRef.current !== scopeId
 
-    // On scope change, reset state
-    if (isScopeChange) {
-      resetForReinit()
-    }
+    if (isScopeChange) resetForReinit()
 
     // Track scope changes
     if (prevScopeIdRef.current !== scopeId) {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -42,6 +42,20 @@ function subscribeComposerRegistry(listener: () => void): () => void {
 }
 
 /**
+ * How many composers are mounted on a scope right now. A host that can point
+ * itself at another scope needs this: two live editors on one draft row fight
+ * over it — the second never re-reads an ordinary body change, so whichever
+ * saves last wins and the other's text is gone.
+ */
+export function useMountedComposerCount(workspaceId: string, scope: string | null): number {
+  const key = scope ? `${workspaceId} ${scope}` : ""
+  return useSyncExternalStore(
+    subscribeComposerRegistry,
+    useCallback(() => (key ? mountedComposerCount(key) : 0), [key])
+  )
+}
+
+/**
  * Whether this composer is the one host that consumes a `?stash=` deep link for
  * its scope. Exactly one mounted composer per scope answers true; the rest defer,
  * leaving the param for the claimant rather than each restoring it.


### PR DESCRIPTION
## Problem

Arming "Reply in conversation" in the timeline was `useState`. It died with the tab, and it reset on every stream change. So a draft you had written *for a conversation* quietly reverted to being an ordinary stream draft the moment you reloaded — the filing was lost even though the text survived.

`message-input.tsx` documented the opposite ruling: the arm stays in memory because "a stale filing surviving a reload would silently misfile whatever is typed next."

## Solution

The arm becomes a device-local IDB row — `composerTarget`, host scope → draft scope — beside `composerLoaded`, which is already device-local, already unsynced, and already survives logout for the same reason.

**That comment is deleted, not left contradicting the code.** The reversal is defensible on the comment's own terms: the arm is no longer a flag hovering over whatever you type next, it *is* which draft you're editing. The strip renders straight from it, and the × removes it. Product owner's call.

- The timeline composer reads its target and uses it as **both** `draftKey` and `scopeId`. `scopeId` following the key is not optional: the composer's rehydrate keys on it, so without it the editor renders one draft while every save targets another.
- The in-memory arm is **absorbed**, not duplicated. The `useState`, its `[streamId]` reset and the `streamIdRef` workaround that existed only because of that reset are gone; the arming gesture, the thread-follow latch, the send guard, both send directives and the strip all read one durable source.
- **The × leaves the draft where it is.** The plan said "moves the draft back"; that's wrong under the model this stack settled on — a draft written for conversation C stays a C draft and stays reachable. Disarming means only that this composer is no longer pointed there.

**IDB v48** carries the store plus a multiEntry index over `conversation.messageIds`, which replaces the workspace-wide scan used to find which conversation hosts a fork or anchor message. That closes both residuals the previous chunk recorded: a thread draft whose conversation wasn't otherwise in play now resolves an owner, and a sub-topic/branch host composer no longer triggers a full scan.

### Four findings from review, all fixed

Three were consequences of the arm becoming durable — everything downstream had assumed it could only exist a moment after a gesture.

- **A restored arm re-ran thread-follow routing on mount.** Arm a conversation, close the tab; if it drifts into a thread, opening the channel days later popped the side panel over it and deleted the target — a navigation side effect from a page load. The same-stream branch force-focused the composer on every return, popping the mobile keyboard, which is exactly what the code above it says focus was deferred to avoid. Now only a gesture-set target routes; a restored one shows the strip and waits for the send guard.
- **One failed request destroyed durable state.** `notFound` was any query error and the client doesn't retry, so a single 502 mid-typing blanked the editor, reverted the scope and irreversibly deleted the arm. `notFound` is now a real 404; other failures hold the arm.
- **An armed composer swallowed the drafts explorer's deep link** for its own stream's drafts, leaving `?stash=` in the URL with no visible failure. Fixed by disarming when the link names a row at this host's own scope — *not* by rebinding the stash host, which would have flushed board content and detached the stream's pointer, stashing the wrong draft.
- **The E2EE carve-out test was vacuous.** `toHaveTextContent("")` matches synchronously on an already-empty element, so both assertions ran before the target ever resolved and deleting the guard left it green.

### Known issue

A target stored against a stream that later becomes E2E stays on disk, inert and not disarmable from the UI (the strip doesn't render there). Left deliberately rather than deleting a row the user may still want if the stream is decrypted.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/database.ts` | **v48**: `composerTarget` store + multiEntry `*conversation.messageIds` |
| `apps/frontend/src/hooks/use-composer-target.ts` | **new** — read/set/clear; the host is carried through the query result so a stream switch can't render the previous stream's target |
| `apps/frontend/src/components/timeline/message-input.tsx` | Reads the target; absorbs the in-memory arm; gesture-only routing; disarm-on-stash-deep-link |
| `apps/frontend/src/hooks/use-conversations.ts` | `notFound` = 404 only; new `loadFailed` |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | `unopenable = notFound \|\| loadFailed`, so its behaviour is unchanged |
| `apps/frontend/src/hooks/use-board-draft-context.ts` | Fork-host lookup uses the new index |
| tests | **new** `message-input.composer-target.test.tsx` (real draft composer); `database.schema.test.ts` seeds at v47 and queries the new index; `message-input.test.tsx` adapted |

## Test plan

- [x] `message-input.composer-target`, `message-input`, `conversation-panel`, `use-conversations`, `database.schema`, `use-stash-composer`, `use-draft-composer.double-editor` — 7 files, **141 pass**
- [x] `bunx tsc --noEmit -p apps/frontend` — clean
- [x] Falsification, each reverted after: `scopeId: streamId` reds 3 of the 5 target cases; dropping the index reds the schema test with `SchemaError`; removing the gesture latch, folding `loadFailed` back in, removing the disarm effect and removing the `!e2eEnabled` guard each red their own test
- [ ] No browser/device pass — the strip's layout is unchanged in shape from before this chunk, but only assert-level evidence backs that
- [ ] The 404-vs-transport split is exercised through the hook's mocked shape, not a real `ApiError` from the service

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-3cd745/ — chunk 3 of 0-6, and the first with a user-visible change. Chunk 4 adds adopt-vs-move on restore (which switches the shared pile on), 5 the picker UI, 6 the drafts-page context menus and copy.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788512803&installation_model_id=20758&pr_number=1776&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1776&signature=bb820d08391b5643d3f8643b4dd10188849b93210d109746c46326705d3b57b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->