### PR TITLE
feat(drafts): context menus and copy on the drafts page

### DIFF
--- a/apps/frontend/src/components/actions/action-drawer-list.tsx
+++ b/apps/frontend/src/components/actions/action-drawer-list.tsx
@@ -1,0 +1,189 @@
+import { Link } from "react-router-dom"
+import { ChevronDown } from "lucide-react"
+import { Separator } from "@/components/ui/separator"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { type ActionDefinition, type GroupedAction, resolveActionLabel } from "./action-model"
+
+/**
+ * The action list inside a long-press bottom sheet — the rows themselves, not
+ * the sheet. Shared by the timeline's `MessageActionDrawer` (which wraps it in
+ * message chrome: preview, emoji bar, quote-selection view) and the drafts
+ * explorer's `DraftActionDrawer`, so both long-press surfaces render the same
+ * rows and split-button groups over their own context types.
+ */
+export function ActionDrawerList<Context>({
+  items,
+  context,
+  onClose,
+  onAction,
+}: {
+  items: GroupedAction<Context>[]
+  context: Context
+  onClose: () => void
+  onAction: (action: ActionDefinition<Context>) => void
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <DrawerActionItem
+          key={item.kind === "single" ? item.action.id : item.members[0].id}
+          item={item}
+          context={context}
+          onClose={onClose}
+          onAction={onAction}
+        />
+      ))}
+    </>
+  )
+}
+
+function Divider() {
+  return <Separator className="mx-3 my-1 bg-border/50" />
+}
+
+function DrawerActionItem<Context>({
+  item,
+  context,
+  onClose,
+  onAction,
+}: {
+  item: GroupedAction<Context>
+  context: Context
+  onClose: () => void
+  onAction: (action: ActionDefinition<Context>) => void
+}) {
+  if (item.kind === "single") {
+    const action = item.action
+    return (
+      <>
+        {action.separatorBefore && <Divider />}
+        <DrawerActionPrimary action={action} context={context} onClose={onClose} onAction={onAction} />
+      </>
+    )
+  }
+
+  const { members } = item
+  const primary = members[0]
+  return (
+    <>
+      {primary.separatorBefore && <Divider />}
+      <DrawerActionSplitRow members={members} context={context} onClose={onClose} onAction={onAction} />
+    </>
+  )
+}
+
+/** Single-action row body (used both standalone and as the left half of a split row). */
+function DrawerActionPrimary<Context>({
+  action,
+  context,
+  onClose,
+  onAction,
+  className,
+}: {
+  action: ActionDefinition<Context>
+  context: Context
+  onClose: () => void
+  onAction: (action: ActionDefinition<Context>) => void
+  className?: string
+}) {
+  const Icon = action.icon
+  const isDestructive = action.variant === "destructive"
+  const href = action.getHref?.(context)
+  const disabled = action.disabled?.(context) ?? false
+
+  const baseClassName = cn(
+    "flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors",
+    isDestructive ? "text-destructive active:bg-destructive/10" : "active:bg-muted/80"
+  )
+  const iconEl = (
+    <Icon className={cn("h-[18px] w-[18px] shrink-0", isDestructive ? "text-destructive" : "text-muted-foreground")} />
+  )
+
+  if (href) {
+    return (
+      <Link to={href} className={cn(baseClassName, "rounded-lg w-full", className)} onClick={onClose}>
+        {iconEl}
+        <span>{resolveActionLabel(action, context)}</span>
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(baseClassName, "w-full rounded-lg disabled:opacity-50 disabled:active:bg-transparent", className)}
+      disabled={disabled}
+      onClick={() => onAction(action)}
+    >
+      {iconEl}
+      <span>{resolveActionLabel(action, context)}</span>
+    </button>
+  )
+}
+
+/**
+ * Split-row pattern (à la GitHub's merge button): the primary action is the
+ * default tap target on the left; a chevron button on the right opens a small
+ * dropdown listing ALL group members (primary first). Same data model as the
+ * desktop context menu — the action list declares the group via `groupId` and
+ * `groupVisibleActions` collapses adjacent same-group entries into the
+ * `{ members }` shape this row consumes.
+ */
+function DrawerActionSplitRow<Context>({
+  members,
+  context,
+  onClose,
+  onAction,
+}: {
+  members: ActionDefinition<Context>[]
+  context: Context
+  onClose: () => void
+  onAction: (action: ActionDefinition<Context>) => void
+}) {
+  const primary = members[0]
+  return (
+    <div className="flex items-stretch w-full rounded-lg overflow-hidden">
+      <div className="flex-1 min-w-0">
+        <DrawerActionPrimary
+          action={primary}
+          context={context}
+          onClose={onClose}
+          onAction={onAction}
+          className="rounded-none rounded-l-lg"
+        />
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center justify-center w-10 shrink-0 border-l border-border/50 text-muted-foreground active:bg-muted/80 transition-colors rounded-r-lg"
+            aria-label={`Other ${primary.groupId ?? "options"}`}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[220px]">
+          {members.map((member, idx) => {
+            const MemberIcon = member.icon
+            const isPrimary = idx === 0
+            return (
+              <DropdownMenuItem
+                key={member.id}
+                className={cn("gap-2 cursor-pointer", isPrimary && "font-medium")}
+                disabled={member.disabled?.(context) ?? false}
+                onSelect={() => {
+                  onClose()
+                  member.action?.(context)
+                }}
+              >
+                <MemberIcon className="h-4 w-4 text-muted-foreground" />
+                <span>{resolveActionLabel(member, context)}</span>
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/actions/action-dropdown-items.tsx
+++ b/apps/frontend/src/components/actions/action-dropdown-items.tsx
@@ -1,0 +1,167 @@
+import { Link } from "react-router-dom"
+import { ChevronDown } from "lucide-react"
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { type ActionDefinition, type GroupedAction, resolveActionLabel } from "./action-model"
+
+/**
+ * The body of a row context menu: grouped actions rendered as dropdown items.
+ * Shared by the timeline's `MessageContextMenu` and the drafts explorer's
+ * `DraftContextMenu` so both surfaces present the same wording, ordering and
+ * split-button behavior over their own context types.
+ */
+export function ActionDropdownItems<Context>({
+  items,
+  context,
+  onClose,
+}: {
+  items: GroupedAction<Context>[]
+  context: Context
+  onClose: () => void
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <GroupedItem
+          key={item.kind === "single" ? item.action.id : item.members[0].id}
+          item={item}
+          context={context}
+          onClose={onClose}
+        />
+      ))}
+    </>
+  )
+}
+
+function GroupedItem<Context>({
+  item,
+  context,
+  onClose,
+}: {
+  item: GroupedAction<Context>
+  context: Context
+  onClose: () => void
+}) {
+  if (item.kind === "single") {
+    return <SingleAction action={item.action} context={context} onClose={onClose} showSeparatorBefore />
+  }
+
+  // Split-button group: render the primary as a normal item, then a chevron
+  // sub-trigger that opens a sub-menu listing ALL group members (primary
+  // first, then the rest). Radix positions the sub-menu next to the trigger
+  // (side/align are not configurable on `DropdownMenuSubContent`); we nudge
+  // it with `sideOffset` / `alignOffset` for visual breathing room. Same
+  // data model as the mobile drawer (driven by `groupVisibleActions`).
+  const { members } = item
+  const primary = members[0]
+  const PrimaryIcon = primary.icon
+  const isDestructive = primary.variant === "destructive"
+  const primaryDisabled = primary.disabled?.(context) ?? false
+
+  return (
+    <>
+      {primary.separatorBefore && <DropdownMenuSeparator />}
+      <div className="flex items-stretch group/split">
+        <DropdownMenuItem
+          className={cn(
+            "flex-1 gap-2 cursor-pointer rounded-r-none",
+            isDestructive && "text-destructive focus:text-destructive"
+          )}
+          disabled={primaryDisabled}
+          onSelect={() => {
+            onClose()
+            primary.action?.(context)
+          }}
+        >
+          <PrimaryIcon className={cn("h-4 w-4", isDestructive ? "" : "text-muted-foreground")} />
+          {resolveActionLabel(primary, context)}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger
+            className="px-2 cursor-pointer rounded-l-none border-l border-border/50 [&>svg.lucide-chevron-right]:hidden"
+            aria-label={`Other ${primary.groupId ?? "options"}`}
+          >
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent sideOffset={4} alignOffset={-4}>
+            {members.map((member, idx) => {
+              const MemberIcon = member.icon
+              const isPrimary = idx === 0
+              return (
+                <DropdownMenuItem
+                  key={member.id}
+                  className={cn("gap-2 cursor-pointer", isPrimary && "font-medium")}
+                  disabled={member.disabled?.(context) ?? false}
+                  onSelect={() => {
+                    onClose()
+                    member.action?.(context)
+                  }}
+                >
+                  <MemberIcon className="h-4 w-4 text-muted-foreground" />
+                  {resolveActionLabel(member, context)}
+                </DropdownMenuItem>
+              )
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </div>
+    </>
+  )
+}
+
+function SingleAction<Context>({
+  action,
+  context,
+  onClose,
+  showSeparatorBefore,
+}: {
+  action: ActionDefinition<Context>
+  context: Context
+  onClose: () => void
+  showSeparatorBefore?: boolean
+}) {
+  const Icon = action.icon
+  const href = action.getHref?.(context)
+  const separator = showSeparatorBefore && action.separatorBefore ? <DropdownMenuSeparator /> : null
+
+  if (href) {
+    return (
+      <>
+        {separator}
+        <DropdownMenuItem asChild className="gap-2 cursor-pointer">
+          <Link to={href} onClick={onClose}>
+            <Icon className="h-4 w-4 text-muted-foreground" />
+            {resolveActionLabel(action, context)}
+          </Link>
+        </DropdownMenuItem>
+      </>
+    )
+  }
+
+  const isDestructive = action.variant === "destructive"
+
+  return (
+    <>
+      {separator}
+      <DropdownMenuItem
+        className={
+          isDestructive ? "gap-2 cursor-pointer text-destructive focus:text-destructive" : "gap-2 cursor-pointer"
+        }
+        disabled={action.disabled?.(context) ?? false}
+        onSelect={() => {
+          onClose()
+          action.action?.(context)
+        }}
+      >
+        <Icon className={isDestructive ? "h-4 w-4" : "h-4 w-4 text-muted-foreground"} />
+        {resolveActionLabel(action, context)}
+      </DropdownMenuItem>
+    </>
+  )
+}

--- a/apps/frontend/src/components/actions/action-model.ts
+++ b/apps/frontend/src/components/actions/action-model.ts
@@ -1,0 +1,159 @@
+import type { ComponentType } from "react"
+import { FileText, Type } from "lucide-react"
+import { toast } from "sonner"
+import { stripMarkdown } from "@/lib/markdown"
+
+/**
+ * The context-generic action model behind every row context menu (message rows,
+ * drafts-explorer rows). `messageActions` was the original and only shape; the
+ * type parameter is the seam that lets another surface declare its own context
+ * without inheriting message fields, while both render through the same
+ * dropdown/drawer components.
+ */
+export interface ActionDefinition<Context> {
+  id: string
+  /** Visible label — a function when it depends on the row. */
+  label: string | ((context: Context) => string)
+  icon: ComponentType<{ className?: string }>
+  /**
+   * Render a separator before this action. For grouped entries (see
+   * {@link ActionDefinition.groupId}), only the group's primary action's
+   * `separatorBefore` is honored — alternatives ride along the group.
+   */
+  separatorBefore?: boolean
+  /** Visual variant — "destructive" renders in red */
+  variant?: "destructive"
+  /**
+   * Group id for split-button grouping. Adjacent visible actions sharing the
+   * same `groupId` collapse into one row: the first is the primary (default
+   * tap), the rest become alternatives behind a chevron.
+   */
+  groupId?: string
+  /** Controls visibility — evaluated by {@link filterVisibleActions} */
+  when: (context: Context) => boolean
+  /**
+   * Renders the entry inert. Distinct from `when`: use it when the action
+   * belongs on this row but cannot run right now (a sealed draft's body isn't
+   * readable yet), so the affordance stays visible instead of the menu
+   * changing shape as state resolves (INV-21).
+   */
+  disabled?: (context: Context) => boolean
+  /** URL for navigation actions — rendered as <Link> (INV-40) */
+  getHref?: (context: Context) => string | undefined
+  /** Handler for mutation actions — rendered as <button> */
+  action?: (context: Context) => void | Promise<void>
+}
+
+/**
+ * A grouped item in the rendered menu.
+ *
+ * - `single` — an ungrouped action (or a group whose only visible member
+ *   degraded to a standalone row).
+ * - `group` — multiple visible same-`groupId` actions. The renderer shows
+ *   `members[0]` as the row's primary tap target and exposes ALL members in a
+ *   chevron-driven dropdown, so the menu reads as a complete list with the
+ *   default pre-highlighted.
+ */
+export type GroupedAction<Context> =
+  | { kind: "single"; action: ActionDefinition<Context> }
+  | { kind: "group"; members: ActionDefinition<Context>[] }
+
+/** Resolve the visible label for an action, handling the string/function variants. */
+export function resolveActionLabel<Context>(action: ActionDefinition<Context>, context: Context): string {
+  return typeof action.label === "function" ? action.label(context) : action.label
+}
+
+/** Filter actions that should be shown for a given context. */
+export function filterVisibleActions<Context>(
+  actions: ActionDefinition<Context>[],
+  context: Context
+): ActionDefinition<Context>[] {
+  return actions.filter((action) => action.when(context))
+}
+
+/**
+ * Collapse adjacent same-`groupId` actions into split-button groups, leaving
+ * ungrouped actions as `single` items. Order is preserved; grouped items appear
+ * at the position of their first member. A group with only one visible member
+ * degrades to a `single` item — no chevron.
+ */
+export function groupVisibleActions<Context>(actions: ActionDefinition<Context>[]): GroupedAction<Context>[] {
+  const items: GroupedAction<Context>[] = []
+  let i = 0
+  while (i < actions.length) {
+    const action = actions[i]
+    if (!action.groupId) {
+      items.push({ kind: "single", action })
+      i++
+      continue
+    }
+
+    const members: ActionDefinition<Context>[] = [action]
+    let j = i + 1
+    while (j < actions.length && actions[j].groupId === action.groupId) {
+      members.push(actions[j])
+      j++
+    }
+    if (members.length === 1) {
+      items.push({ kind: "single", action })
+    } else {
+      items.push({ kind: "group", members })
+    }
+    i = j
+  }
+  return items
+}
+
+export async function copyToClipboard(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text)
+}
+
+/**
+ * The Copy as Markdown / Copy as Plain text pair — one definition shared by
+ * every surface that offers it, so labels, order, group and the INV-63-allow'd
+ * toasts can't drift between the timeline and the drafts explorer.
+ */
+export function copyContentActions<Context>(options: {
+  /** The markdown to copy for this row. */
+  getMarkdown: (context: Context) => string
+  when?: (context: Context) => boolean
+  disabled?: (context: Context) => boolean
+  separatorBefore?: boolean
+}): ActionDefinition<Context>[] {
+  const when = options.when ?? (() => true)
+  return [
+    {
+      id: "copy-as-markdown",
+      label: "Copy as Markdown",
+      icon: FileText,
+      separatorBefore: options.separatorBefore,
+      groupId: "copy",
+      when,
+      disabled: options.disabled,
+      action: async (context) => {
+        try {
+          await copyToClipboard(options.getMarkdown(context))
+          toast.success("Copied as Markdown") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
+        } catch {
+          toast.error("Failed to copy")
+        }
+      },
+    },
+    {
+      id: "copy-as-plain-text",
+      label: "Copy as Plain text",
+      icon: Type,
+      groupId: "copy",
+      when,
+      disabled: options.disabled,
+      action: async (context) => {
+        try {
+          await copyToClipboard(stripMarkdown(options.getMarkdown(context)))
+          toast.success("Copied as plain text") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
+        } catch {
+          toast.error("Failed to copy")
+        }
+      },
+    },
+  ]
+}

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -240,7 +240,7 @@ describe("StashedDraftsPicker", () => {
     const sealed = makeDraft("draft_e", "placeholder")
     const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
     const preview = (status: DraftPreview["status"], text = ""): Map<string, DraftPreview> =>
-      new Map([["draft_e", { text, status }]])
+      new Map([["draft_e", { text, markdown: text, status }]])
 
     it("renders the host-supplied decrypted body when ready", async () => {
       renderPicker({ drafts: [sealed], previewById: preview("ready", "decrypted body") })

--- a/apps/frontend/src/components/drafts/draft-action-drawer.test.tsx
+++ b/apps/frontend/src/components/drafts/draft-action-drawer.test.tsx
@@ -1,0 +1,63 @@
+import { MemoryRouter } from "react-router-dom"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@/test"
+import { DraftActionDrawer } from "./draft-action-drawer"
+import type { DraftActionContext } from "./draft-actions"
+
+const writeText = vi.fn(async () => {})
+const onDelete = vi.fn()
+
+function renderDrawer(overrides: Partial<DraftActionContext> = {}) {
+  const context: DraftActionContext = {
+    contentMarkdown: "**bold** body",
+    contentStatus: "ready",
+    href: "/w/ws_1/s/stream_1",
+    isStashed: true,
+    onDelete,
+    ...overrides,
+  }
+  return render(
+    <MemoryRouter>
+      <DraftActionDrawer open onOpenChange={() => {}} context={context} label="General" preview="bold body" />
+    </MemoryRouter>
+  )
+}
+
+describe("DraftActionDrawer", () => {
+  beforeEach(() => {
+    writeText.mockClear()
+    onDelete.mockClear()
+    Object.assign(navigator, { clipboard: { writeText } })
+  })
+
+  it("offers restore, copy and delete", async () => {
+    renderDrawer()
+
+    expect(await screen.findByRole("link", { name: "Restore draft" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Copy as Markdown" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Delete draft" })).toBeInTheDocument()
+  })
+
+  it("copies the draft's markdown", async () => {
+    renderDrawer()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy as Markdown" }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("**bold** body"))
+  })
+
+  it("disables copy while a sealed draft is still decrypting", async () => {
+    renderDrawer({ contentMarkdown: "", contentStatus: "decrypting" })
+
+    expect(await screen.findByRole("button", { name: "Copy as Markdown" })).toBeDisabled()
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it("delegates delete to the page's confirm flow", async () => {
+    renderDrawer()
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete draft" }))
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/components/drafts/draft-action-drawer.tsx
+++ b/apps/frontend/src/components/drafts/draft-action-drawer.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useMemo } from "react"
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
+import { ActionDrawerList } from "@/components/actions/action-drawer-list"
+import { groupVisibleActions } from "@/components/actions/action-model"
+import { type DraftAction, type DraftActionContext, getVisibleDraftActions } from "./draft-actions"
+
+/**
+ * Long-press bottom sheet for a drafts-explorer row. The timeline's
+ * `MessageActionDrawer` wraps the same `ActionDrawerList` rows in message
+ * chrome (author preview, emoji bar, quote selection) — none of which a draft
+ * has — so this sheet is that shared list under the row's own label.
+ */
+export function DraftActionDrawer({
+  open,
+  onOpenChange,
+  context,
+  label,
+  preview,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  context: DraftActionContext
+  label: string
+  preview?: string
+}) {
+  const actions = getVisibleDraftActions(context)
+  const groupedActions = useMemo(() => groupVisibleActions(actions), [actions])
+
+  const handleAction = useCallback(
+    (action: DraftAction) => {
+      onOpenChange(false)
+      action.action?.(context)
+    },
+    [context, onOpenChange]
+  )
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[85dvh]">
+        <DrawerTitle className="sr-only">Draft actions</DrawerTitle>
+
+        <div className="px-4 pt-1 pb-3">
+          <div className="rounded-xl bg-muted/60 px-3.5 py-2.5">
+            <p className="mb-0.5 truncate text-[13px] font-medium text-muted-foreground">{label}</p>
+            {preview && <p className="truncate text-sm leading-snug text-foreground/80">{preview}</p>}
+          </div>
+        </div>
+
+        <div
+          data-vaul-no-drag
+          className="flex-1 min-h-0 overflow-y-auto px-2 pb-[max(12px,env(safe-area-inset-bottom))]"
+        >
+          <ActionDrawerList
+            items={groupedActions}
+            context={context}
+            onClose={() => onOpenChange(false)}
+            onAction={handleAction}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/apps/frontend/src/components/drafts/draft-actions.ts
+++ b/apps/frontend/src/components/drafts/draft-actions.ts
@@ -1,0 +1,57 @@
+import { ArrowUpRight, Trash2 } from "lucide-react"
+import { type ActionDefinition, copyContentActions, filterVisibleActions } from "@/components/actions/action-model"
+import type { DraftPreviewStatus } from "@/lib/drafts/decryption"
+
+/** Context for a drafts-explorer row's actions. */
+export interface DraftActionContext {
+  /** The draft's full markdown body — the clipboard payload. */
+  contentMarkdown: string
+  /** Whether the body is readable (a sealed draft isn't until it decrypts). */
+  contentStatus: DraftPreviewStatus
+  /** Where the row opens (a stashed row's href carries `?stash=`); absent when unresolvable. */
+  href?: string
+  /** Restoring a stashed draft vs. opening the stream that holds the loaded one. */
+  isStashed: boolean
+  onDelete: () => void
+}
+
+export type DraftAction = ActionDefinition<DraftActionContext>
+
+/**
+ * A sealed draft's body is not readable until it decrypts, and a body-less
+ * draft (attachments only) has nothing to put on the clipboard. Copy stays
+ * visible and inert in both cases rather than disappearing as the state
+ * resolves (INV-21) — and never copies a status label or an empty string.
+ */
+function copyUnavailable(ctx: DraftActionContext): boolean {
+  return ctx.contentStatus !== "ready" || ctx.contentMarkdown.trim() === ""
+}
+
+export const draftActions: DraftAction[] = [
+  {
+    id: "open-draft",
+    label: (ctx) => (ctx.isStashed ? "Restore draft" : "Open draft"),
+    icon: ArrowUpRight,
+    when: (ctx) => !!ctx.href,
+    getHref: (ctx) => ctx.href,
+  },
+  ...copyContentActions<DraftActionContext>({
+    getMarkdown: (ctx) => ctx.contentMarkdown,
+    disabled: copyUnavailable,
+    separatorBefore: true,
+  }),
+  {
+    id: "delete-draft",
+    label: "Delete draft",
+    icon: Trash2,
+    separatorBefore: true,
+    variant: "destructive",
+    when: () => true,
+    // Opens the page's confirm dialog — the menu never deletes directly.
+    action: (ctx) => ctx.onDelete(),
+  },
+]
+
+export function getVisibleDraftActions(context: DraftActionContext): DraftAction[] {
+  return filterVisibleActions(draftActions, context)
+}

--- a/apps/frontend/src/components/drafts/draft-context-menu.tsx
+++ b/apps/frontend/src/components/drafts/draft-context-menu.tsx
@@ -1,0 +1,39 @@
+import { useMemo, useState } from "react"
+import { EllipsisVertical } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { ActionDropdownItems } from "@/components/actions/action-dropdown-items"
+import { groupVisibleActions } from "@/components/actions/action-model"
+import { type DraftActionContext, getVisibleDraftActions } from "./draft-actions"
+
+/**
+ * Desktop dropdown for a drafts-explorer row — the drafts-side twin of
+ * `MessageContextMenu`, rendering `draftActions` through the same
+ * `ActionDropdownItems` body so wording, grouping and keyboard behavior match
+ * the message surfaces.
+ */
+export function DraftContextMenu({ context, label }: { context: DraftActionContext; label: string }) {
+  const [open, setOpen] = useState(false)
+  const actions = getVisibleDraftActions(context)
+  const groupedActions = useMemo(() => groupVisibleActions(actions), [actions])
+
+  if (actions.length === 0) return null
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="reveal-actions h-7 w-7 shrink-0 text-muted-foreground"
+          aria-label={`Draft actions: ${label}`}
+        >
+          <EllipsisVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[200px]">
+        <ActionDropdownItems items={groupedActions} context={context} onClose={() => setOpen(false)} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/frontend/src/components/drafts/draft-context-menu.tsx
+++ b/apps/frontend/src/components/drafts/draft-context-menu.tsx
@@ -25,7 +25,7 @@ export function DraftContextMenu({ context, label }: { context: DraftActionConte
         <Button
           variant="ghost"
           size="icon"
-          className="reveal-actions h-7 w-7 shrink-0 text-muted-foreground"
+          className="reveal-actions-hover-only hidden h-7 w-7 shrink-0 text-muted-foreground sm:block"
           aria-label={`Draft actions: ${label}`}
         >
           <EllipsisVertical className="h-4 w-4" />

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -224,13 +224,25 @@ function ItemRow({
   const ActionIcon = item.actionIcon
   const touchCapable = useTouchCapable()
 
-  // Additive touch gesture (a mouse never fires it), suppressed in batch mode
-  // where the whole row is a selection toggle. `deferToInteractiveElements`
-  // keeps a hold on the row's own menu button from also opening the drawer.
+  // A long press on a navigating row has to suppress the synthetic click that
+  // follows it, or the drawer opens AND the row routes away underneath it. A
+  // timestamp window, not a boolean: with no synthetic click (the platform does
+  // not always send one) a boolean latch would swallow the user's next real tap.
+  // Same shape as `useSidebarItemDrawer`, whose rows are also links.
+  const suppressClicksUntilRef = useRef(0)
+
+  // Additive touch gesture; a mouse never fires it, and batch mode owns the whole
+  // row as a selection toggle. NOTE: no `deferToInteractiveElements` — these
+  // handlers sit ON the row's own `<a href>`, and that option's `closest()` test
+  // matches the element itself, so it would refuse every touch on the row and the
+  // gesture would never fire at all. The menu button is kept from arming it by
+  // stopping touchstart at its wrapper instead.
   const longPress = useLongPress({
     enabled: touchCapable && !selectionEnabled && !!item.onLongPress,
-    onLongPress: () => item.onLongPress?.(),
-    deferToInteractiveElements: true,
+    onLongPress: () => {
+      suppressClicksUntilRef.current = Date.now() + 750
+      item.onLongPress?.()
+    },
   })
 
   // Roving tabindex in selection mode: active option is the tab stop.
@@ -279,6 +291,8 @@ function ItemRow({
               e.preventDefault()
               e.stopPropagation()
             }}
+            // Holding the ⋮ trigger must not also arm the row's long press.
+            onTouchStart={(e) => e.stopPropagation()}
           >
             {item.contextMenu}
           </div>
@@ -326,7 +340,14 @@ function ItemRow({
         data-index={index}
         className={className}
         onMouseEnter={() => onSelectIndex(index)}
-        onClick={(e) => onClick(e, item)}
+        onClick={(e) => {
+          if (suppressClicksUntilRef.current > Date.now()) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+          }
+          onClick(e, item)
+        }}
         onTouchStart={longPress.handlers.onTouchStart}
         onTouchEnd={longPress.handlers.onTouchEnd}
         onTouchMove={longPress.handlers.onTouchMove}

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -237,6 +237,9 @@ function ItemRow({
   // stopping touchstart at its wrapper instead.
   const longPress = useLongPress({
     enabled: touchCapable && !selectionEnabled && !!item.onLongPress,
+    // The action drawer is Vaul gesture-aware. Mount it only after the held
+    // touch ends so the opening finger cannot drive its first release frame.
+    triggerOnTouchEnd: true,
     onLongPress: () => {
       suppressClicksUntilRef.current = Date.now() + 750
       item.onLongPress?.()

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react"
 import { Link } from "react-router-dom"
 import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { useLongPress } from "@/hooks/use-long-press"
@@ -221,7 +220,6 @@ function ItemRow({
   onSelectionKeyDown: (e: React.KeyboardEvent, index: number, itemId: string) => void
 }) {
   const Icon = item.icon
-  const ActionIcon = item.actionIcon
   const touchCapable = useTouchCapable()
 
   // A long press on a navigating row has to suppress the synthetic click that
@@ -296,21 +294,6 @@ function ItemRow({
           >
             {item.contextMenu}
           </div>
-        )}
-        {!selectionEnabled && !item.contextMenu && item.onAction && ActionIcon && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="reveal-actions h-7 w-7 shrink-0"
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              item.onAction?.()
-            }}
-            aria-label={item.actionLabel}
-          >
-            <ActionIcon className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-          </Button>
         )}
       </div>
     </>

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -5,6 +5,8 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
+import { useLongPress } from "@/hooks/use-long-press"
+import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { URGENCY_COLORS } from "@/components/layout/sidebar/config"
 import type { QuickSwitcherItem } from "./types"
 
@@ -175,131 +177,191 @@ export function ItemList({
       {Object.entries(groups).map(([groupName, groupItems]) => (
         <div key={groupName || "_ungrouped"} role="group" aria-label={groupName || undefined} className="mb-1">
           {groupName && <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">{groupName}</div>}
-          {groupItems.map(({ item, index }) => {
-            const Icon = item.icon
-            const ActionIcon = item.actionIcon
-            const isHighlighted = index === selectedIndex
-            const isChecked = selection?.selectedIds.has(item.id) ?? false
-            // Roving tabindex in selection mode: active option is the tab stop.
-            let rowTabIndex: number | undefined
-            if (selectionEnabled) rowTabIndex = isHighlighted ? 0 : -1
-            const iconFallback = Icon ? (
-              <Icon className="h-3.5 w-3.5 opacity-60" />
-            ) : (
-              item.label.slice(0, 1).toUpperCase()
-            )
-
-            const hasUnread = (item.unreadCount ?? 0) > 0
-            const urgency = item.urgency ?? "quiet"
-            const showUrgencyStrip = urgency !== "quiet"
-
-            let leadingVisual: React.ReactNode = null
-            if (selectionEnabled) {
-              leadingVisual = <SelectionToggle checked={isChecked} large={!!item.avatarUrl} />
-            } else if (item.avatarUrl) {
-              leadingVisual = (
-                <Avatar className="h-7 w-7 rounded-md">
-                  <AvatarImage src={item.avatarUrl} alt={item.label} />
-                  <AvatarFallback className="rounded-md">{iconFallback}</AvatarFallback>
-                </Avatar>
-              )
-            } else if (Icon) {
-              leadingVisual = <Icon className="h-4 w-4 opacity-50" />
-            }
-
-            const itemContent = (
-              <>
-                {showUrgencyStrip && (
-                  <div
-                    className="w-1 flex-shrink-0 rounded-l-[10px] transition-colors duration-300"
-                    style={{ backgroundColor: URGENCY_COLORS[urgency] }}
-                  />
-                )}
-                <div className="flex items-center gap-3 flex-1 min-w-0 px-3 py-3">
-                  {leadingVisual}
-                  <div className="flex flex-col flex-1 min-w-0">
-                    <span className={cn("truncate", hasUnread ? "font-semibold" : "font-normal")}>{item.label}</span>
-                    {item.description && (
-                      <span className="text-xs text-muted-foreground truncate">{item.description}</span>
-                    )}
-                  </div>
-                  {(item.mentionCount ?? 0) > 0 && <MentionIndicator count={item.mentionCount!} className="ml-auto" />}
-                  {!selectionEnabled && item.onAction && ActionIcon && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="reveal-actions h-7 w-7 shrink-0"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        e.stopPropagation()
-                        item.onAction?.()
-                      }}
-                      aria-label={item.actionLabel}
-                    >
-                      <ActionIcon className="h-4 w-4 text-muted-foreground hover:text-destructive" />
-                    </Button>
-                  )}
-                </div>
-              </>
-            )
-
-            const className = cn(
-              "group reveal-host relative flex select-none items-stretch rounded-[10px] text-sm outline-none transition-colors",
-              selectionEnabled ? "cursor-pointer" : "cursor-default",
-              // ring-inset keeps the checked outline from nudging neighbours (INV-21).
-              isChecked && "bg-primary/[0.07] ring-1 ring-primary/45 ring-inset",
-              // In selection mode the highlight tracks real DOM focus, so a
-              // keyboard user sees which focusable row Enter/Space will toggle,
-              // and it can never desync from a separate index-based highlight.
-              !isChecked && selectionEnabled && "hover:bg-muted focus:bg-muted",
-              !isChecked && !selectionEnabled && (isHighlighted ? "bg-muted" : "hover:bg-muted")
-            )
-
-            // In batch mode a row never navigates, so it renders as a toggle
-            // <div> even when it carries an href.
-            if (item.href && !selectionEnabled) {
-              return (
-                <Link
-                  key={item.id}
-                  to={item.href}
-                  role="option"
-                  aria-selected={isHighlighted}
-                  data-index={index}
-                  className={className}
-                  onMouseEnter={() => onSelectIndex(index)}
-                  onClick={(e) => handleClick(e, item)}
-                >
-                  {itemContent}
-                </Link>
-              )
-            }
-
-            return (
-              <div
-                key={item.id}
-                role="option"
-                aria-selected={selectionEnabled ? isChecked : isHighlighted}
-                data-index={index}
-                // Roving tabindex: only the active option is a tab stop, so the
-                // list is one Tab stop and Arrow keys move between options
-                // (handled in handleSelectionKeyDown). Plain nav rows aren't
-                // focusable.
-                tabIndex={rowTabIndex}
-                className={className}
-                // In selection mode the roving anchor follows focus, not hover,
-                // so the sole tab stop can't drift out from under the focused
-                // row (hover highlight is CSS-only via focus:/hover:bg-muted).
-                onMouseEnter={selectionEnabled ? undefined : () => onSelectIndex(index)}
-                onFocus={selectionEnabled ? () => onSelectIndex(index) : undefined}
-                onClick={(e) => handleClick(e, item)}
-                onKeyDown={selectionEnabled ? (e) => handleSelectionKeyDown(e, index, item.id) : undefined}
-              >
-                {itemContent}
-              </div>
-            )
-          })}
+          {groupItems.map(({ item, index }) => (
+            <ItemRow
+              key={item.id}
+              item={item}
+              index={index}
+              isHighlighted={index === selectedIndex}
+              isChecked={selection?.selectedIds.has(item.id) ?? false}
+              selectionEnabled={selectionEnabled}
+              onSelectIndex={onSelectIndex}
+              onClick={handleClick}
+              onSelectionKeyDown={handleSelectionKeyDown}
+            />
+          ))}
         </div>
       ))}
+    </div>
+  )
+}
+
+/**
+ * One list row. A component (not inlined in the map) because a row owns
+ * hook-driven state: the long-press gesture that opens its context drawer on
+ * touch.
+ */
+function ItemRow({
+  item,
+  index,
+  isHighlighted,
+  isChecked,
+  selectionEnabled,
+  onSelectIndex,
+  onClick,
+  onSelectionKeyDown,
+}: {
+  item: QuickSwitcherItem
+  index: number
+  isHighlighted: boolean
+  isChecked: boolean
+  selectionEnabled: boolean
+  onSelectIndex: (index: number) => void
+  onClick: (e: React.MouseEvent, item: QuickSwitcherItem) => void
+  onSelectionKeyDown: (e: React.KeyboardEvent, index: number, itemId: string) => void
+}) {
+  const Icon = item.icon
+  const ActionIcon = item.actionIcon
+  const touchCapable = useTouchCapable()
+
+  // Additive touch gesture (a mouse never fires it), suppressed in batch mode
+  // where the whole row is a selection toggle. `deferToInteractiveElements`
+  // keeps a hold on the row's own menu button from also opening the drawer.
+  const longPress = useLongPress({
+    enabled: touchCapable && !selectionEnabled && !!item.onLongPress,
+    onLongPress: () => item.onLongPress?.(),
+    deferToInteractiveElements: true,
+  })
+
+  // Roving tabindex in selection mode: active option is the tab stop.
+  let rowTabIndex: number | undefined
+  if (selectionEnabled) rowTabIndex = isHighlighted ? 0 : -1
+  const iconFallback = Icon ? <Icon className="h-3.5 w-3.5 opacity-60" /> : item.label.slice(0, 1).toUpperCase()
+
+  const hasUnread = (item.unreadCount ?? 0) > 0
+  const urgency = item.urgency ?? "quiet"
+  const showUrgencyStrip = urgency !== "quiet"
+
+  let leadingVisual: React.ReactNode = null
+  if (selectionEnabled) {
+    leadingVisual = <SelectionToggle checked={isChecked} large={!!item.avatarUrl} />
+  } else if (item.avatarUrl) {
+    leadingVisual = (
+      <Avatar className="h-7 w-7 rounded-md">
+        <AvatarImage src={item.avatarUrl} alt={item.label} />
+        <AvatarFallback className="rounded-md">{iconFallback}</AvatarFallback>
+      </Avatar>
+    )
+  } else if (Icon) {
+    leadingVisual = <Icon className="h-4 w-4 opacity-50" />
+  }
+
+  const itemContent = (
+    <>
+      {showUrgencyStrip && (
+        <div
+          className="w-1 flex-shrink-0 rounded-l-[10px] transition-colors duration-300"
+          style={{ backgroundColor: URGENCY_COLORS[urgency] }}
+        />
+      )}
+      <div className="flex items-center gap-3 flex-1 min-w-0 px-3 py-3">
+        {leadingVisual}
+        <div className="flex flex-col flex-1 min-w-0">
+          <span className={cn("truncate", hasUnread ? "font-semibold" : "font-normal")}>{item.label}</span>
+          {item.description && <span className="text-xs text-muted-foreground truncate">{item.description}</span>}
+        </div>
+        {(item.mentionCount ?? 0) > 0 && <MentionIndicator count={item.mentionCount!} className="ml-auto" />}
+        {!selectionEnabled && item.contextMenu && (
+          // The row is a <Link>; a menu click must never navigate it.
+          <div
+            className="shrink-0"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+          >
+            {item.contextMenu}
+          </div>
+        )}
+        {!selectionEnabled && !item.contextMenu && item.onAction && ActionIcon && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="reveal-actions h-7 w-7 shrink-0"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              item.onAction?.()
+            }}
+            aria-label={item.actionLabel}
+          >
+            <ActionIcon className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+          </Button>
+        )}
+      </div>
+    </>
+  )
+
+  const className = cn(
+    "group reveal-host relative flex select-none items-stretch rounded-[10px] text-sm outline-none transition-colors",
+    selectionEnabled ? "cursor-pointer" : "cursor-default",
+    // ring-inset keeps the checked outline from nudging neighbours (INV-21).
+    isChecked && "bg-primary/[0.07] ring-1 ring-primary/45 ring-inset",
+    // In selection mode the highlight tracks real DOM focus, so a keyboard user
+    // sees which focusable row Enter/Space will toggle, and it can never desync
+    // from a separate index-based highlight.
+    !isChecked && selectionEnabled && "hover:bg-muted focus:bg-muted",
+    !isChecked && !selectionEnabled && (isHighlighted ? "bg-muted" : "hover:bg-muted"),
+    longPress.isPressed && "bg-muted"
+  )
+
+  // In batch mode a row never navigates, so it renders as a toggle <div> even
+  // when it carries an href.
+  if (item.href && !selectionEnabled) {
+    return (
+      <Link
+        to={item.href}
+        role="option"
+        aria-selected={isHighlighted}
+        data-index={index}
+        className={className}
+        onMouseEnter={() => onSelectIndex(index)}
+        onClick={(e) => onClick(e, item)}
+        onTouchStart={longPress.handlers.onTouchStart}
+        onTouchEnd={longPress.handlers.onTouchEnd}
+        onTouchMove={longPress.handlers.onTouchMove}
+        onTouchCancel={longPress.handlers.onTouchCancel}
+        onContextMenu={longPress.handlers.onContextMenu}
+      >
+        {itemContent}
+      </Link>
+    )
+  }
+
+  return (
+    <div
+      role="option"
+      aria-selected={selectionEnabled ? isChecked : isHighlighted}
+      data-index={index}
+      // Roving tabindex: only the active option is a tab stop, so the list is
+      // one Tab stop and Arrow keys move between options (handled in
+      // onSelectionKeyDown). Plain nav rows aren't focusable.
+      tabIndex={rowTabIndex}
+      className={className}
+      // In selection mode the roving anchor follows focus, not hover, so the
+      // sole tab stop can't drift out from under the focused row (hover
+      // highlight is CSS-only via focus:/hover:bg-muted).
+      onMouseEnter={selectionEnabled ? undefined : () => onSelectIndex(index)}
+      onFocus={selectionEnabled ? () => onSelectIndex(index) : undefined}
+      onClick={(e) => onClick(e, item)}
+      onKeyDown={selectionEnabled ? (e) => onSelectionKeyDown(e, index, item.id) : undefined}
+      onTouchStart={longPress.handlers.onTouchStart}
+      onTouchEnd={longPress.handlers.onTouchEnd}
+      onTouchMove={longPress.handlers.onTouchMove}
+      onTouchCancel={longPress.handlers.onTouchCancel}
+      onContextMenu={longPress.handlers.onContextMenu}
+    >
+      {itemContent}
     </div>
   )
 }

--- a/apps/frontend/src/components/quick-switcher/types.ts
+++ b/apps/frontend/src/components/quick-switcher/types.ts
@@ -15,16 +15,7 @@ export interface QuickSwitcherItem {
   group?: string
   href?: string
   onSelect: () => void
-  /** Optional action button (e.g., delete) */
-  onAction?: () => void
-  /** Icon for the action button */
-  actionIcon?: React.ComponentType<{ className?: string }>
-  /** Aria label for the action button */
-  actionLabel?: string
-  /**
-   * Row context menu, rendered in the trailing slot in place of the single
-   * action button. Its clicks never navigate the row.
-   */
+  /** Row context menu, rendered in the trailing slot. Its clicks never navigate the row. */
   contextMenu?: React.ReactNode
   /** Touch long-press on the row (e.g. open the row's action drawer). */
   onLongPress?: () => void

--- a/apps/frontend/src/components/quick-switcher/types.ts
+++ b/apps/frontend/src/components/quick-switcher/types.ts
@@ -21,6 +21,13 @@ export interface QuickSwitcherItem {
   actionIcon?: React.ComponentType<{ className?: string }>
   /** Aria label for the action button */
   actionLabel?: string
+  /**
+   * Row context menu, rendered in the trailing slot in place of the single
+   * action button. Its clicks never navigate the row.
+   */
+  contextMenu?: React.ReactNode
+  /** Touch long-press on the row (e.g. open the row's action drawer). */
+  onLongPress?: () => void
   /** Urgency level for visual indicators (color strip, bold text) */
   urgency?: UrgencyLevel
   /** Number of unread messages */

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -1,26 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Link } from "react-router-dom"
 import type { AuthorType } from "@threa/types"
-import { ChevronDown, ChevronLeft, Quote } from "lucide-react"
+import { ChevronLeft, Quote } from "lucide-react"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
-import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { useActors } from "@/hooks"
 import { getInitials } from "@/lib/initials"
 import { cn } from "@/lib/utils"
 import { buildQuickEmojis } from "@/lib/emoji-picker"
+import { ActionDrawerList } from "@/components/actions/action-drawer-list"
 import {
   type MessageActionContext,
   type MessageAction,
-  type GroupedActionItem,
   getVisibleActions,
   groupVisibleActions,
-  resolveActionLabel,
 } from "./message-actions"
 import { EmojiQuickBar } from "./emoji-quick-bar"
 
@@ -222,15 +218,12 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
               data-vaul-no-drag
               className="flex-1 min-h-0 overflow-y-auto px-2 pb-[max(12px,env(safe-area-inset-bottom))]"
             >
-              {groupedActions.map((item) => (
-                <DrawerActionItem
-                  key={item.kind === "single" ? item.action.id : item.members[0].id}
-                  item={item}
-                  context={context}
-                  onClose={() => handleOpenChange(false)}
-                  onAction={handleAction}
-                />
-              ))}
+              <ActionDrawerList
+                items={groupedActions}
+                context={context}
+                onClose={() => handleOpenChange(false)}
+                onAction={handleAction}
+              />
             </div>
           </>
         )}
@@ -375,154 +368,6 @@ function ExpandedQuoteView({
           </p>
         )}
       </div>
-    </div>
-  )
-}
-
-function Divider() {
-  return <Separator className="mx-3 my-1 bg-border/50" />
-}
-
-function DrawerActionItem({
-  item,
-  context,
-  onClose,
-  onAction,
-}: {
-  item: GroupedActionItem
-  context: MessageActionContext
-  onClose: () => void
-  onAction: (action: MessageAction) => void
-}) {
-  if (item.kind === "single") {
-    const action = item.action
-    return (
-      <>
-        {action.separatorBefore && <Divider />}
-        <DrawerActionPrimary action={action} context={context} onClose={onClose} onAction={onAction} />
-      </>
-    )
-  }
-
-  const { members } = item
-  const primary = members[0]
-  return (
-    <>
-      {primary.separatorBefore && <Divider />}
-      <DrawerActionSplitRow members={members} context={context} onClose={onClose} onAction={onAction} />
-    </>
-  )
-}
-
-/** Single-action row body (used both standalone and as the left half of a split row). */
-function DrawerActionPrimary({
-  action,
-  context,
-  onClose,
-  onAction,
-  className,
-}: {
-  action: MessageAction
-  context: MessageActionContext
-  onClose: () => void
-  onAction: (action: MessageAction) => void
-  className?: string
-}) {
-  const Icon = action.icon
-  const isDestructive = action.variant === "destructive"
-  const href = action.getHref?.(context)
-
-  const baseClassName = cn(
-    "flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors",
-    isDestructive ? "text-destructive active:bg-destructive/10" : "active:bg-muted/80"
-  )
-  const iconEl = (
-    <Icon className={cn("h-[18px] w-[18px] shrink-0", isDestructive ? "text-destructive" : "text-muted-foreground")} />
-  )
-
-  if (href) {
-    return (
-      <Link to={href} className={cn(baseClassName, "rounded-lg w-full", className)} onClick={onClose}>
-        {iconEl}
-        <span>{resolveActionLabel(action, context)}</span>
-      </Link>
-    )
-  }
-
-  return (
-    <button
-      type="button"
-      className={cn(baseClassName, "w-full rounded-lg", className)}
-      onClick={() => onAction(action)}
-    >
-      {iconEl}
-      <span>{resolveActionLabel(action, context)}</span>
-    </button>
-  )
-}
-
-/**
- * Split-row pattern (à la GitHub's merge button): the primary action is the
- * default tap target on the left; a chevron button on the right opens a small
- * dropdown listing ALL group members (primary first). Same data model as the
- * desktop context menu — `messageActions` declares the group via `groupId`
- * and `groupVisibleActions` collapses adjacent same-group entries into the
- * `{ members }` shape this row consumes; the renderer always shows
- * `members[0]` as the row's tap target and the full set in the dropdown.
- */
-function DrawerActionSplitRow({
-  members,
-  context,
-  onClose,
-  onAction,
-}: {
-  members: MessageAction[]
-  context: MessageActionContext
-  onClose: () => void
-  onAction: (action: MessageAction) => void
-}) {
-  const primary = members[0]
-  return (
-    <div className="flex items-stretch w-full rounded-lg overflow-hidden">
-      <div className="flex-1 min-w-0">
-        <DrawerActionPrimary
-          action={primary}
-          context={context}
-          onClose={onClose}
-          onAction={onAction}
-          className="rounded-none rounded-l-lg"
-        />
-      </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center justify-center w-10 shrink-0 border-l border-border/50 text-muted-foreground active:bg-muted/80 transition-colors rounded-r-lg"
-            aria-label={`Other ${primary.groupId ?? "options"}`}
-          >
-            <ChevronDown className="h-4 w-4" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" sideOffset={4} className="min-w-[220px]">
-          {members.map((member, idx) => {
-            const MemberIcon = member.icon
-            const isPrimary = idx === 0
-            return (
-              <DropdownMenuItem
-                key={member.id}
-                className={cn("gap-2 cursor-pointer", isPrimary && "font-medium")}
-                onSelect={() => {
-                  onClose()
-                  member.action?.(context)
-                }}
-              >
-                <MemberIcon className="h-4 w-4 text-muted-foreground" />
-                <span>{resolveActionLabel(member, context)}</span>
-              </DropdownMenuItem>
-            )
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -1,10 +1,7 @@
-import type { ComponentType } from "react"
 import {
   Sparkles,
   MessageSquareReply,
   Quote,
-  FileText,
-  Type,
   Pencil,
   Trash2,
   History,
@@ -26,8 +23,16 @@ import {
   Check,
 } from "lucide-react"
 import { toast } from "sonner"
-import { stripMarkdown } from "@/lib/markdown"
 import { buildStreamLink, buildConversationLink } from "@/lib/stream-links"
+import {
+  type ActionDefinition,
+  type GroupedAction,
+  copyContentActions,
+  copyToClipboard,
+  filterVisibleActions,
+} from "@/components/actions/action-model"
+
+export { groupVisibleActions, resolveActionLabel } from "@/components/actions/action-model"
 
 /**
  * Actor types whose messages can carry an agent trace. The single source of
@@ -229,99 +234,10 @@ export interface MessageActionContext {
 }
 
 /** A top-level action in the message context menu. */
-export interface MessageAction {
-  id: string
-  /**
-   * Visible menu label. Plain string for static entries; for actions whose
-   * label depends on the message (e.g. "Share to #parent-name"), pass a
-   * function that derives it from the context.
-   */
-  label: string | ((context: MessageActionContext) => string)
-  icon: ComponentType<{ className?: string }>
-  /**
-   * Render a separator before this action in the menu. For grouped entries
-   * (see {@link groupId}), only the group's primary action's `separatorBefore`
-   * is honored — alternatives ride along the group.
-   */
-  separatorBefore?: boolean
-  /** Visual variant — "destructive" renders in red */
-  variant?: "destructive"
-  /**
-   * Group id for split-button grouping. Adjacent visible actions sharing the
-   * same `groupId` collapse into one row: the first action is the primary
-   * (default tap), the rest become alternatives reachable via a chevron-driven
-   * dropdown. A group with only one visible action degrades to a regular row.
-   * `groupVisibleActions` performs the collapse.
-   */
-  groupId?: string
-  /** Controls visibility — evaluated by getVisibleActions */
-  when: (context: MessageActionContext) => boolean
-  /** URL for navigation actions — rendered as <Link> (INV-40) */
-  getHref?: (context: MessageActionContext) => string | undefined
-  /** Handler for mutation actions — rendered as <button> */
-  action?: (context: MessageActionContext) => void | Promise<void>
-}
+export type MessageAction = ActionDefinition<MessageActionContext>
 
-/** Resolve the visible label for an action, handling the string/function variants. */
-export function resolveActionLabel(action: MessageAction, context: MessageActionContext): string {
-  return typeof action.label === "function" ? action.label(context) : action.label
-}
-
-/**
- * A grouped item in the rendered menu.
- *
- * - `single` — an ungrouped action (or a group whose only visible member
- *   degraded to a standalone row). Renders as a normal menu row.
- * - `group` — multiple visible same-`groupId` actions. The renderer shows
- *   `members[0]` as the row's primary tap target and exposes ALL members
- *   (including `members[0]`) in a chevron-driven dropdown so the menu is
- *   a complete list of options rather than "the alternatives". The first
- *   member is always the default — opening the dropdown should feel like
- *   a list with the default option pre-highlighted.
- */
-export type GroupedActionItem = { kind: "single"; action: MessageAction } | { kind: "group"; members: MessageAction[] }
-
-/**
- * Collapse adjacent same-`groupId` actions into split-button groups, leaving
- * ungrouped actions as `single` items. Order is preserved; grouped items
- * appear at the position of their first member. The first member becomes
- * the primary (default tap target); the dropdown lists every member so the
- * UI presents the full set of options rather than "the others".
- *
- * Same-group actions are expected to be defined adjacently in
- * {@link messageActions}; this is enforced by visibility filtering. A group
- * with only one visible member degrades to a `single` item — no chevron.
- */
-export function groupVisibleActions(actions: MessageAction[]): GroupedActionItem[] {
-  const items: GroupedActionItem[] = []
-  let i = 0
-  while (i < actions.length) {
-    const action = actions[i]
-    if (!action.groupId) {
-      items.push({ kind: "single", action })
-      i++
-      continue
-    }
-
-    const members: MessageAction[] = [action]
-    let j = i + 1
-    while (j < actions.length && actions[j].groupId === action.groupId) {
-      members.push(actions[j])
-      j++
-    }
-    if (members.length === 1) {
-      items.push({ kind: "single", action })
-    } else {
-      items.push({ kind: "group", members })
-    }
-    i = j
-  }
-  return items
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  await navigator.clipboard.writeText(text)
-}
+/** A rendered menu item — an action, or a split-button group of them. */
+export type GroupedActionItem = GroupedAction<MessageActionContext>
 
 export const messageActions: MessageAction[] = [
   {
@@ -570,37 +486,10 @@ export const messageActions: MessageAction[] = [
     when: (ctx) => !!ctx.onMarkUnread,
     action: (ctx) => ctx.onMarkUnread?.(),
   },
-  {
-    id: "copy-as-markdown",
-    label: "Copy as Markdown",
-    icon: FileText,
+  ...copyContentActions<MessageActionContext>({
+    getMarkdown: (ctx) => ctx.contentMarkdown,
     separatorBefore: true,
-    groupId: "copy",
-    when: () => true,
-    action: async (ctx) => {
-      try {
-        await copyToClipboard(ctx.contentMarkdown)
-        toast.success("Copied as Markdown") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
-      } catch {
-        toast.error("Failed to copy")
-      }
-    },
-  },
-  {
-    id: "copy-as-plain-text",
-    label: "Copy as Plain text",
-    icon: Type,
-    groupId: "copy",
-    when: () => true,
-    action: async (ctx) => {
-      try {
-        await copyToClipboard(stripMarkdown(ctx.contentMarkdown))
-        toast.success("Copied as plain text") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
-      } catch {
-        toast.error("Failed to copy")
-      }
-    },
-  },
+  }),
   {
     id: "copy-link",
     label: "Copy link to message",
@@ -636,5 +525,5 @@ export const messageActions: MessageAction[] = [
 ]
 /** Filter actions that should be shown for a given message context. */
 export function getVisibleActions(context: MessageActionContext): MessageAction[] {
-  return messageActions.filter((a) => a.when(context))
+  return filterVisibleActions(messageActions, context)
 }

--- a/apps/frontend/src/components/timeline/message-context-menu.tsx
+++ b/apps/frontend/src/components/timeline/message-context-menu.tsx
@@ -1,26 +1,9 @@
 import { useMemo, useState } from "react"
-import { Link } from "react-router-dom"
-import { ChevronDown, EllipsisVertical } from "lucide-react"
+import { EllipsisVertical } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { cn } from "@/lib/utils"
-import {
-  type GroupedActionItem,
-  type MessageAction,
-  type MessageActionContext,
-  getVisibleActions,
-  groupVisibleActions,
-  resolveActionLabel,
-} from "./message-actions"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { ActionDropdownItems } from "@/components/actions/action-dropdown-items"
+import { type MessageActionContext, getVisibleActions, groupVisibleActions } from "./message-actions"
 
 interface MessageContextMenuProps {
   context: MessageActionContext
@@ -62,138 +45,8 @@ export function MessageContextMenu({ context, open: openProp, onOpenChange }: Me
         // then Radix's cleanup steals focus back to the trigger button.
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
-        {groupedActions.map((item) => (
-          <GroupedItem
-            key={item.kind === "single" ? item.action.id : item.members[0].id}
-            item={item}
-            context={context}
-            onClose={() => setOpen(false)}
-          />
-        ))}
+        <ActionDropdownItems items={groupedActions} context={context} onClose={() => setOpen(false)} />
       </DropdownMenuContent>
     </DropdownMenu>
-  )
-}
-
-function GroupedItem({
-  item,
-  context,
-  onClose,
-}: {
-  item: GroupedActionItem
-  context: MessageActionContext
-  onClose: () => void
-}) {
-  if (item.kind === "single") {
-    return <SingleAction action={item.action} context={context} onClose={onClose} showSeparatorBefore />
-  }
-
-  // Split-button group: render the primary as a normal item, then a chevron
-  // sub-trigger that opens a sub-menu listing ALL group members (primary
-  // first, then the rest). Radix positions the sub-menu next to the trigger
-  // (side/align are not configurable on `DropdownMenuSubContent`); we nudge
-  // it with `sideOffset` / `alignOffset` for visual breathing room. Same
-  // data model as the mobile drawer (driven by `groupVisibleActions`).
-  const { members } = item
-  const primary = members[0]
-  const PrimaryIcon = primary.icon
-  const isDestructive = primary.variant === "destructive"
-
-  return (
-    <>
-      {primary.separatorBefore && <DropdownMenuSeparator />}
-      <div className="flex items-stretch group/split">
-        <DropdownMenuItem
-          className={cn(
-            "flex-1 gap-2 cursor-pointer rounded-r-none",
-            isDestructive && "text-destructive focus:text-destructive"
-          )}
-          onSelect={() => {
-            onClose()
-            primary.action?.(context)
-          }}
-        >
-          <PrimaryIcon className={cn("h-4 w-4", isDestructive ? "" : "text-muted-foreground")} />
-          {resolveActionLabel(primary, context)}
-        </DropdownMenuItem>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger
-            className="px-2 cursor-pointer rounded-l-none border-l border-border/50 [&>svg.lucide-chevron-right]:hidden"
-            aria-label={`Other ${primary.groupId ?? "options"}`}
-          >
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent sideOffset={4} alignOffset={-4}>
-            {members.map((member, idx) => {
-              const MemberIcon = member.icon
-              const isPrimary = idx === 0
-              return (
-                <DropdownMenuItem
-                  key={member.id}
-                  className={cn("gap-2 cursor-pointer", isPrimary && "font-medium")}
-                  onSelect={() => {
-                    onClose()
-                    member.action?.(context)
-                  }}
-                >
-                  <MemberIcon className="h-4 w-4 text-muted-foreground" />
-                  {resolveActionLabel(member, context)}
-                </DropdownMenuItem>
-              )
-            })}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      </div>
-    </>
-  )
-}
-
-function SingleAction({
-  action,
-  context,
-  onClose,
-  showSeparatorBefore,
-}: {
-  action: MessageAction
-  context: MessageActionContext
-  onClose: () => void
-  showSeparatorBefore?: boolean
-}) {
-  const Icon = action.icon
-  const href = action.getHref?.(context)
-  const separator = showSeparatorBefore && action.separatorBefore ? <DropdownMenuSeparator /> : null
-
-  if (href) {
-    return (
-      <>
-        {separator}
-        <DropdownMenuItem asChild className="gap-2 cursor-pointer">
-          <Link to={href} onClick={onClose}>
-            <Icon className="h-4 w-4 text-muted-foreground" />
-            {resolveActionLabel(action, context)}
-          </Link>
-        </DropdownMenuItem>
-      </>
-    )
-  }
-
-  const isDestructive = action.variant === "destructive"
-
-  return (
-    <>
-      {separator}
-      <DropdownMenuItem
-        className={
-          isDestructive ? "gap-2 cursor-pointer text-destructive focus:text-destructive" : "gap-2 cursor-pointer"
-        }
-        onSelect={() => {
-          onClose()
-          action.action?.(context)
-        }}
-      >
-        <Icon className={isDestructive ? "h-4 w-4" : "h-4 w-4 text-muted-foreground"} />
-        {resolveActionLabel(action, context)}
-      </DropdownMenuItem>
-    </>
   )
 }

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -592,6 +592,8 @@ describe("streamIdsWithLoadedDraft", () => {
       streamId: "stream_1",
       displayName: "General",
       preview: "hello",
+      contentMarkdown: "hello",
+      contentStatus: "ready" as const,
       attachmentCount: 0,
       updatedAt: 1000,
       href: "/w/ws_1/s/stream_1",

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -17,10 +17,15 @@ import { isDraftId } from "./use-draft-scratchpads"
 import { purgeScopeDrafts } from "./use-draft-message"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
-import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
+import { draftInlineText, draftMarkdown, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { conversationOriginLabel, subtopicOriginLabel, threadOriginLabel } from "@/lib/drafts/origin-label"
-import { useDecryptedDraftPreviews, type DraftPreview, type DraftPreviewInput } from "./use-decrypted-draft-previews"
+import {
+  useDecryptedDraftPreviews,
+  type DraftPreview,
+  type DraftPreviewInput,
+  type DraftPreviewStatus,
+} from "./use-decrypted-draft-previews"
 
 export type DraftType = "scratchpad" | "channel" | "dm" | "thread"
 
@@ -41,6 +46,18 @@ export interface UnifiedDraft {
   displayName: string
   /** Preview of the draft content (truncated) */
   preview: string
+  /**
+   * The full markdown body, for copy-to-clipboard; "" when the body is empty or
+   * not readable (see {@link UnifiedDraft.contentStatus}).
+   */
+  contentMarkdown: string
+  /**
+   * Readability of {@link UnifiedDraft.contentMarkdown}. A sealed draft is
+   * "locked" / "decrypting" / "failed" until its body decrypts, so copy is
+   * disabled rather than putting an empty string or a status label on the
+   * clipboard.
+   */
+  contentStatus: DraftPreviewStatus
   /** Number of attachments */
   attachmentCount: number
   /** Last updated timestamp for sorting */
@@ -118,6 +135,22 @@ function draftPreviewLabel(draft: CachedDraft, previewMap: Map<string, DraftPrev
   if (!preview) return "Encrypted draft"
   if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
   return truncatePreview(preview.text) || "Encrypted draft"
+}
+
+/**
+ * The copy source for a draft row: the full markdown plus how readable it is.
+ * Reads the same decrypted-preview entry the row's label does, so a sealed row
+ * can never show "Decrypting…" while a copy action hands out that label (or an
+ * empty body) as content.
+ */
+function draftCopySource(
+  draft: CachedDraft,
+  previewMap: Map<string, DraftPreview>
+): { contentMarkdown: string; contentStatus: DraftPreviewStatus } {
+  if (draft.ciphertext == null) return { contentMarkdown: draftMarkdown(draft.contentJson), contentStatus: "ready" }
+  const preview = previewMap.get(draft.id)
+  if (!preview) return { contentMarkdown: "", contentStatus: "locked" }
+  return { contentMarkdown: preview.markdown, contentStatus: preview.status }
 }
 
 /** The encrypted root whose SSK seals a draft's body, for decrypt-on-read previews. */
@@ -472,6 +505,7 @@ export function useAllDrafts(workspaceId: string) {
           streamId: scratchpad.id,
           displayName,
           preview: draftPreviewLabel(loadedDraft, previewMap),
+          ...draftCopySource(loadedDraft, previewMap),
           attachmentCount: loadedDraft?.attachments?.length ?? 0,
           updatedAt: loadedDraft?.clientUpdatedAt ?? scratchpad.createdAt,
           href: `/w/${workspaceId}/s/${scratchpad.id}`,
@@ -534,6 +568,7 @@ export function useAllDrafts(workspaceId: string) {
         streamId: resolved.streamId,
         displayName: resolved.displayName,
         preview: draftPreviewLabel(draft, previewMap),
+        ...draftCopySource(draft, previewMap),
         attachmentCount: draft.attachments?.length ?? 0,
         updatedAt: draft.clientUpdatedAt,
         href,

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
@@ -71,21 +71,21 @@ describe("useDecryptedDraftPreviews", () => {
   it("returns plaintext previews straight from contentJson", () => {
     const draft = plaintextDraft("draft_p", "hello plain")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId: undefined }]))
-    expect(result.current.get("draft_p")).toEqual({ text: "hello plain", status: "ready" })
+    expect(result.current.get("draft_p")).toEqual({ text: "hello plain", markdown: "hello plain", status: "ready" })
   })
 
   it("returns the decrypted body for a sealed draft already in the shared cache", () => {
     const draft = sealedDraft("draft_e")
     seedDecryption("draft_e", { contentMarkdown: "secret body", contentJson: makeDoc("secret body") })
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "secret body", status: "ready" })
+    expect(result.current.get("draft_e")).toEqual({ text: "secret body", markdown: "secret body", status: "ready" })
   })
 
   it("reports a sealed draft as locked while the session is locked (no decrypt attempted)", () => {
     vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(locked)
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", status: "locked" })
+    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "locked" })
   })
 
   it("reports decrypting for an unlocked sealed draft whose body hasn't landed yet", () => {
@@ -93,7 +93,7 @@ describe("useDecryptedDraftPreviews", () => {
     vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockReturnValue(new Promise(() => {}))
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", status: "decrypting" })
+    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "decrypting" })
   })
 
   it("reports failed when the decrypt returns null", async () => {
@@ -105,7 +105,7 @@ describe("useDecryptedDraftPreviews", () => {
     )
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    await waitFor(() => expect(result.current.get("draft_e")).toEqual({ text: "", status: "failed" }))
+    await waitFor(() => expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "failed" }))
   })
 
   it("resolves each id independently across a mixed batch in one render", async () => {
@@ -127,10 +127,14 @@ describe("useDecryptedDraftPreviews", () => {
     ]
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, inputs))
 
-    await waitFor(() => expect(result.current.get("draft_fail")).toEqual({ text: "", status: "failed" }))
-    expect(result.current.get("draft_plain")).toEqual({ text: "plain body", status: "ready" })
-    expect(result.current.get("draft_seeded")).toEqual({ text: "seeded body", status: "ready" })
-    expect(result.current.get("draft_hang")).toEqual({ text: "", status: "decrypting" })
+    await waitFor(() => expect(result.current.get("draft_fail")).toEqual({ text: "", markdown: "", status: "failed" }))
+    expect(result.current.get("draft_plain")).toEqual({ text: "plain body", markdown: "plain body", status: "ready" })
+    expect(result.current.get("draft_seeded")).toEqual({
+      text: "seeded body",
+      markdown: "seeded body",
+      status: "ready",
+    })
+    expect(result.current.get("draft_hang")).toEqual({ text: "", markdown: "", status: "decrypting" })
     expect(result.current.size).toBe(4)
   })
 })

--- a/apps/frontend/src/hooks/use-long-press.ts
+++ b/apps/frontend/src/hooks/use-long-press.ts
@@ -5,6 +5,12 @@ interface UseLongPressOptions {
   threshold?: number
   /** Called when long press is detected */
   onLongPress: () => void
+  /**
+   * Wait until the held touch ends before calling `onLongPress`. Use when the
+   * callback mounts a gesture-aware overlay: mounting it under the initiating
+   * finger lets that same touch-end briefly dismiss or drag the new surface.
+   */
+  triggerOnTouchEnd?: boolean
   /** Disable the hook (e.g., on desktop) */
   enabled?: boolean
   /**
@@ -43,6 +49,7 @@ interface UseLongPressReturn {
 export function useLongPress({
   threshold = 500,
   onLongPress,
+  triggerOnTouchEnd = false,
   enabled = true,
   deferToNativeLinks = false,
   deferToInteractiveElements = false,
@@ -103,15 +110,17 @@ export function useLongPress({
         } catch {
           // Ignore
         }
-        onLongPressRef.current()
+        if (!triggerOnTouchEnd) onLongPressRef.current()
       }, threshold)
     },
-    [enabled, threshold, deferToNativeLinks, deferToInteractiveElements]
+    [enabled, threshold, triggerOnTouchEnd, deferToNativeLinks, deferToInteractiveElements]
   )
 
   const onTouchEnd = useCallback(() => {
+    const shouldTrigger = triggerOnTouchEnd && firedRef.current && enabledRef.current
     clear()
-  }, [clear])
+    if (shouldTrigger) onLongPressRef.current()
+  }, [clear, triggerOnTouchEnd])
 
   // `touchcancel` fires (instead of `touchend`) when the browser/OS steals the
   // gesture; clear the pending timer and pressed state so neither gets stuck.
@@ -144,10 +153,10 @@ export function useLongPress({
     (e: React.MouseEvent) => {
       if (enabled && (timerRef.current !== null || firedRef.current)) {
         e.preventDefault()
-        firedRef.current = false
+        if (!triggerOnTouchEnd) firedRef.current = false
       }
     },
-    [enabled]
+    [enabled, triggerOnTouchEnd]
   )
 
   // Cancel pending timer on unmount to avoid firing on stale closures.

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -143,6 +143,13 @@ export type DraftPreviewStatus = "ready" | "decrypting" | "locked" | "failed"
 export interface DraftPreview {
   /** Inline, markdown-stripped body text; "" when empty or unavailable. */
   text: string
+  /**
+   * The full markdown body — what a copy action puts on the clipboard; "" when
+   * empty or unavailable. Kept beside `text` (rather than re-serialized per
+   * surface) so a sealed draft's copyability is decided by the same decrypt
+   * state that decides its preview.
+   */
+  markdown: string
   status: DraftPreviewStatus
 }
 
@@ -152,14 +159,24 @@ export function draftInlineText(contentJson: JSONContent | null | undefined): st
   return stripMarkdownToInline(serializeToMarkdown(contentJson)).trim()
 }
 
+/** Full markdown for a draft body; "" when empty. */
+export function draftMarkdown(contentJson: JSONContent | null | undefined): string {
+  if (!contentJson || isEmptyContent(contentJson)) return ""
+  return serializeToMarkdown(contentJson).trim()
+}
+
 /** Project a decrypt state onto the list-preview shape. */
 export function draftDecryptionToPreview(decryption: DraftDecryption): DraftPreview {
   if (decryption.status === "plaintext" || decryption.status === "decrypted") {
-    return { text: draftInlineText(decryption.contentJson), status: "ready" }
+    return {
+      text: draftInlineText(decryption.contentJson),
+      markdown: draftMarkdown(decryption.contentJson),
+      status: "ready",
+    }
   }
-  if (decryption.status === "failed") return { text: "", status: "failed" }
-  if (decryption.status === "locked") return { text: "", status: "locked" }
-  return { text: "", status: "decrypting" } // pending / none
+  if (decryption.status === "failed") return { text: "", markdown: "", status: "failed" }
+  if (decryption.status === "locked") return { text: "", markdown: "", status: "locked" }
+  return { text: "", markdown: "", status: "decrypting" } // pending / none
 }
 
 /** User-facing label for a non-ready preview status. */

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -1,7 +1,8 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom"
-import { describe, expect, it, vi, beforeEach } from "vitest"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
 import { toast } from "sonner"
-import { render, screen, userEvent, within, waitFor } from "@/test"
+import { act, fireEvent, render, screen, userEvent, within, waitFor } from "@/test"
+import * as touchCapableModule from "@/hooks/use-touch-capable"
 import { DraftsPage } from "./drafts"
 import { SidebarProvider } from "@/contexts"
 import * as hooksModule from "@/hooks"
@@ -41,6 +42,9 @@ function renderPage() {
       <MemoryRouter initialEntries={[`/w/${WS}/drafts`]}>
         <Routes>
           <Route path="/w/:workspaceId/drafts" element={<DraftsPage />} />
+          {/* Any navigation away renders this, so a test can assert a click did
+              NOT route without reaching for a navigate spy. */}
+          <Route path="*" element={<div data-testid="navigated-away" />} />
         </Routes>
       </MemoryRouter>
     </SidebarProvider>
@@ -292,5 +296,40 @@ describe("DraftsPage row context menu", () => {
     renderPage()
 
     expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute("href", `/w/${WS}/s/stream_a`)
+  })
+})
+
+describe("DraftsPage touch long-press", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockDrafts([draft({ id: "a", displayName: "Alpha" })])
+    vi.spyOn(touchCapableModule, "useTouchCapable").mockReturnValue(true)
+  })
+  afterEach(() => vi.useRealTimers())
+
+  // The row IS an <a href>, so a defer-to-interactive-elements guard would match
+  // the row itself via closest() and refuse every touch — the whole mobile half
+  // of this surface would be dead with nothing failing.
+  it("opens the action drawer from a long press on a row that navigates", () => {
+    vi.useFakeTimers()
+    renderPage()
+
+    const row = screen.getByRole("option", { name: /Alpha/i })
+    fireEvent.touchStart(row, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(screen.getByRole("button", { name: /Copy as Markdown/i })).toBeInTheDocument()
+  })
+
+  it("does not navigate on the click that follows the hold", () => {
+    vi.useFakeTimers()
+    renderPage()
+
+    const row = screen.getByRole("option", { name: /Alpha/i })
+    fireEvent.touchStart(row, { touches: [{ clientX: 10, clientY: 10 }] })
+    act(() => vi.advanceTimersByTime(600))
+    fireEvent.click(row)
+
+    expect(screen.queryByTestId("navigated-away")).toBeNull()
   })
 })

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -318,6 +318,8 @@ describe("DraftsPage touch long-press", () => {
     fireEvent.touchStart(row, { touches: [{ clientX: 10, clientY: 10 }] })
     act(() => vi.advanceTimersByTime(600))
 
+    expect(screen.queryByRole("button", { name: /Copy as Markdown/i })).toBeNull()
+    fireEvent.touchEnd(row)
     expect(screen.getByRole("button", { name: /Copy as Markdown/i })).toBeInTheDocument()
   })
 
@@ -328,6 +330,7 @@ describe("DraftsPage touch long-press", () => {
     const row = screen.getByRole("option", { name: /Alpha/i })
     fireEvent.touchStart(row, { touches: [{ clientX: 10, clientY: 10 }] })
     act(() => vi.advanceTimersByTime(600))
+    fireEvent.touchEnd(row)
     fireEvent.click(row)
 
     expect(screen.queryByTestId("navigated-away")).toBeNull()

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -14,6 +14,8 @@ function draft(overrides: Partial<UnifiedDraft> & { id: string; displayName: str
     type: "channel",
     streamId: `stream_${overrides.id}`,
     preview: "some text",
+    contentMarkdown: "some text",
+    contentStatus: "ready" as const,
     attachmentCount: 0,
     updatedAt: 0,
     href: `/w/${WS}/s/stream_${overrides.id}`,
@@ -201,5 +203,94 @@ describe("DraftsPage batch delete", () => {
 
     expect(screen.getByRole("button", { name: "Select drafts" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Cancel selection" })).not.toBeInTheDocument()
+  })
+})
+
+describe("DraftsPage row context menu", () => {
+  const writeText = vi.fn(async () => {})
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    deleteDraft.mockReset()
+    deleteDraft.mockResolvedValue(undefined)
+    writeText.mockClear()
+    Object.assign(navigator, { clipboard: { writeText } })
+  })
+
+  async function openMenu(name: RegExp) {
+    await userEvent.click(screen.getByRole("button", { name }))
+  }
+
+  it("exposes copy, open and delete for a readable draft", async () => {
+    mockDrafts([draft({ id: "a", displayName: "Alpha", contentMarkdown: "**bold** body" })])
+    renderPage()
+
+    await openMenu(/Draft actions: Alpha/)
+
+    expect(await screen.findByRole("menuitem", { name: "Open draft" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Copy as Markdown" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Delete draft" })).toBeInTheDocument()
+  })
+
+  it("copies the draft's markdown", async () => {
+    mockDrafts([draft({ id: "a", displayName: "Alpha", contentMarkdown: "**bold** body" })])
+    renderPage()
+
+    await openMenu(/Draft actions: Alpha/)
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Copy as Markdown" }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("**bold** body"))
+  })
+
+  it("copies the draft as plain text", async () => {
+    mockDrafts([draft({ id: "a", displayName: "Alpha", contentMarkdown: "**bold** body" })])
+    renderPage()
+
+    await openMenu(/Draft actions: Alpha/)
+    // The copy pair is a split group: the alternatives live behind the chevron.
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Other copy" }))
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Copy as Plain text" }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("bold body"))
+  })
+
+  it("disables copy for a sealed draft that has not decrypted", async () => {
+    mockDrafts([
+      draft({
+        id: "a",
+        displayName: "Alpha",
+        preview: "Decrypting…",
+        contentMarkdown: "",
+        contentStatus: "decrypting",
+      }),
+    ])
+    renderPage()
+
+    await openMenu(/Draft actions: Alpha/)
+
+    expect(await screen.findByRole("menuitem", { name: "Copy as Markdown" })).toHaveAttribute("aria-disabled", "true")
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy as Markdown" }))
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it("routes Delete through the confirm dialog", async () => {
+    mockDrafts([draft({ id: "a", displayName: "Alpha" })])
+    renderPage()
+
+    await openMenu(/Draft actions: Alpha/)
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Delete draft" }))
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument()
+    expect(deleteDraft).not.toHaveBeenCalled()
+
+    await userEvent.click(within(screen.getByRole("alertdialog")).getByRole("button", { name: /delete/i }))
+    await waitFor(() => expect(deleteDraft).toHaveBeenCalledWith("a"))
+  })
+
+  it("keeps the row's own open path", async () => {
+    mockDrafts([draft({ id: "a", displayName: "Alpha" })])
+    renderPage()
+
+    expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute("href", `/w/${WS}/s/stream_a`)
   })
 })

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -16,6 +16,9 @@ import { toast } from "sonner"
 import { CompanionModes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { DeleteDraftConfirmDialog } from "@/components/drafts/delete-draft-confirm-dialog"
+import { DraftContextMenu } from "@/components/drafts/draft-context-menu"
+import { DraftActionDrawer } from "@/components/drafts/draft-action-drawer"
+import type { DraftActionContext } from "@/components/drafts/draft-actions"
 import { ItemList, type QuickSwitcherItem } from "@/components/quick-switcher"
 import { SidebarToggle } from "@/components/layout"
 import { cn } from "@/lib/utils"
@@ -34,6 +37,10 @@ export function DraftsPage() {
   const { drafts, deleteDraft } = useAllDrafts(workspaceId ?? "")
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [draftToDelete, setDraftToDelete] = useState<UnifiedDraft | null>(null)
+  // Long-press target: one drawer for the whole list, holding the row that was
+  // pressed. Read back out of `drafts` so a synced edit/delete can't leave the
+  // sheet acting on a stale copy.
+  const [drawerDraftId, setDrawerDraftId] = useState<string | null>(null)
 
   // Batch-select mode: the whole list becomes tappable toggles (desktop + mobile)
   // with a single bulk-delete action, mirroring the message timeline's selection.
@@ -141,6 +148,17 @@ export function DraftsPage() {
   // rows surface a small bookmark icon inline (in front of the preview) so
   // they're distinguishable at a glance without stealing the stream's own
   // icon from the section header.
+  const draftActionContext = useCallback(
+    (draft: UnifiedDraft): DraftActionContext => ({
+      contentMarkdown: draft.contentMarkdown,
+      contentStatus: draft.contentStatus,
+      href: draft.href ?? undefined,
+      isStashed: draft.isStashed,
+      onDelete: () => handleDeleteClick(draft),
+    }),
+    [handleDeleteClick]
+  )
+
   const items: QuickSwitcherItem[] = useMemo(() => {
     return drafts.map((draft) => {
       let description = draft.preview
@@ -167,12 +185,11 @@ export function DraftsPage() {
         href: draft.href ?? undefined,
         group: draft.groupLabel,
         onSelect: () => handleSelectDraft(draft.href),
-        onAction: () => handleDeleteClick(draft),
-        actionIcon: Trash2,
-        actionLabel: "Delete draft",
+        contextMenu: <DraftContextMenu context={draftActionContext(draft)} label={label} />,
+        onLongPress: () => setDrawerDraftId(draft.id),
       }
     })
-  }, [drafts, handleSelectDraft, handleDeleteClick])
+  }, [drafts, handleSelectDraft, draftActionContext])
 
   const handleSelectItem = useCallback((item: QuickSwitcherItem, withModifier: boolean) => {
     if (withModifier && item.href) {
@@ -181,6 +198,8 @@ export function DraftsPage() {
       item.onSelect()
     }
   }, [])
+
+  const drawerDraft = drafts.find((draft) => draft.id === drawerDraftId) ?? null
 
   if (!workspaceId) {
     return null
@@ -310,6 +329,16 @@ export function DraftsPage() {
           />
         </main>
       </div>
+
+      {drawerDraft && (
+        <DraftActionDrawer
+          open={drawerDraftId !== null}
+          onOpenChange={(open) => !open && setDrawerDraftId(null)}
+          context={draftActionContext(drawerDraft)}
+          label={drawerDraft.isStashed ? drawerDraft.groupLabel : drawerDraft.displayName}
+          preview={drawerDraft.preview || undefined}
+        />
+      )}
 
       <DeleteDraftConfirmDialog
         open={!!draftToDelete}

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -147,12 +147,13 @@ test.describe("Drafts Page", () => {
     await page.locator('a[href*="/drafts"]').click()
     await expect(page).toHaveURL(/\/drafts$/, { timeout: 2000 })
 
-    // Hover over draft item to reveal delete button
+    // Hover over draft item to reveal the row's actions menu
     const draftItem = page.getByRole("option").first()
     await draftItem.hover()
 
-    // Click delete button (the action button within the draft item)
-    await draftItem.getByRole("button", { name: /delete/i }).click()
+    // Delete lives in the row's actions dropdown now, not a bare button
+    await draftItem.getByRole("button", { name: /draft actions/i }).click()
+    await page.getByRole("menuitem", { name: "Delete draft" }).click()
 
     // Confirmation dialog should appear
     const dialog = page.getByRole("alertdialog")
@@ -184,10 +185,11 @@ test.describe("Drafts Page", () => {
     await page.locator('a[href*="/drafts"]').click()
     await expect(page).toHaveURL(/\/drafts$/, { timeout: 2000 })
 
-    // Hover and click delete
+    // Hover and delete via the row's actions dropdown
     const draftItem = page.getByRole("option").first()
     await draftItem.hover()
-    await draftItem.getByRole("button", { name: /delete/i }).click()
+    await draftItem.getByRole("button", { name: /draft actions/i }).click()
+    await page.getByRole("menuitem", { name: "Delete draft" }).click()
 
     // Cancel the confirmation
     await page.getByRole("button", { name: /cancel/i }).click()


### PR DESCRIPTION
## Problem

Drafts-page rows carried a single inline trash button. There was no way to get a draft's text out — the product owner's ask was a copy action "like the one we have for messages, which supports markdown and plain text" — and no room to add one without the row becoming a button bar.

## Solution

Rows move to a context menu: **dropdown on desktop, long-press drawer on touch**, carrying open/restore, copy-as-Markdown, copy-as-plain-text, and delete (still behind the existing confirm dialog).

**The message surfaces' machinery is extracted, not copied.** The action model is now generic over its context (`components/actions/`), so the drafts page and the message surfaces share one definition of the copy pair — ids, labels, ordering, the split-button chevron, and the documented `INV-63-allow:` clipboard exception — plus one dropdown body and one drawer row list. `message-actions.ts` re-exports the generic helpers, so no existing importer changed.

**Copy can never put the wrong thing on the clipboard.** It is disabled while a draft is sealed, decrypting, or decrypt-failed, and for an attachment-only draft with no body — reading the same `previewMap` entry the row's own label reads, rather than re-deriving decrypt state. The disabled item stays mounted, so the menu does not reshape as decryption resolves (INV-21).

### Two findings from review, both fixed

- **The long press never fired — the whole mobile half was dead.** It was wired with `deferToInteractiveElements` while its handlers sit on the row's own `<a href>`; that option's `closest()` test matches the element *itself*, so every touch on the row was refused. No timer started, so the `contextmenu` handler never `preventDefault()`ed either, and a hold surfaced the browser's native link sheet. Nothing failed, because nothing covered it. The menu button is now kept from arming the gesture by stopping `touchstart` at its wrapper, which is where that concern belongs.
- **And the click after the hold still navigated**, so the drawer would have opened while the row routed away underneath it. Suppressed with a timestamp window rather than a boolean — platforms don't always send that synthetic click, and a latch would then swallow the user's next real tap. Same shape as `useSidebarItemDrawer` and `ledger-row`, which solved this before.

Both were confirmed red before the fix: re-adding the defer flag reds both new tests.

### Known issues

- `DraftContextMenu` omits the `onCloseAutoFocus` guard `MessageContextMenu` carries. The AlertDialog's focus trap wins in practice, but it is a deliberate divergence from the surface being mirrored.
- The real touch gesture and the drawer's visual fit are unverified — jsdom drives the handlers, not a finger. The Playwright pass over the stack covers the rendering half.
- A raw emoji copies as the emoji from a draft and as `:+1:` from a message, because the backend additionally normalises. Cosmetic.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/actions/action-model.ts` | **new** — generic action model + `copyContentActions` |
| `apps/frontend/src/components/actions/action-dropdown-items.tsx` | **new** — the desktop menu body, moved out of `message-context-menu` |
| `apps/frontend/src/components/actions/action-drawer-list.tsx` | **new** — the drawer rows, moved out of `message-action-drawer` |
| `apps/frontend/src/components/drafts/{draft-actions.ts,draft-context-menu.tsx,draft-action-drawer.tsx}` | **new** — the drafts-side definitions and shells |
| `apps/frontend/src/components/timeline/{message-actions.ts,message-context-menu.tsx,message-action-drawer.tsx}` | Now compose the shared pieces; behaviour unchanged |
| `apps/frontend/src/components/quick-switcher/item-list.tsx` | Row owns the gesture and the click-suppression window |
| `apps/frontend/src/hooks/use-all-drafts.ts`, `lib/drafts/decryption.ts` | `contentMarkdown` + `contentStatus` per row from the existing preview projection |
| `apps/frontend/src/pages/drafts.tsx` | Menu replaces the inline trash button |

## Test plan

- [x] `pages/drafts`, `draft-action-drawer`, `message-actions`, `message-context-menu`, `quick-switcher.integration`, `ledger-row` — 6 files, **189 pass**
- [x] `bunx tsc --noEmit -p apps/frontend` — clean
- [x] Falsification: re-adding `deferToInteractiveElements` reds both long-press tests; neutralising the copy-disabled predicate reds only the sealed case
- [ ] The touch gesture itself is driven through jsdom handlers, not a real finger; the drawer's visual fit at 390px is unverified until the stack's Playwright pass

<details>
<summary>📋 Full implementation plan</summary>

https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-3cd745/ — chunk 6 of 0-6, the last. Chunks 0-5 built the double-editor fix, the landing-site resolver, the pile, the durable composer target, adopt-vs-move, and the picker's origin and tier seam.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788586428&installation_model_id=20758&pr_number=1779&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1779&signature=d335135c6731b84ea26782f4194306b9de16967664f3cd34787eb6ae9e304c12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->