### PR TITLE
feat(drafts): identity-addressed saves — a composer writes the row it hydrated from

### DIFF
--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -119,6 +119,7 @@ describe("DraftsRepository.casUpdate", () => {
       id: "draft_01",
       expectedVersion: 3,
       ownWriteIds: ["write_2", "write_prior"],
+      scope: "stream:stream_2",
       rootStreamId: "stream_1",
       contentJson: { type: "doc", content: [] },
       contentMarkdown: "edited",
@@ -133,6 +134,7 @@ describe("DraftsRepository.casUpdate", () => {
     })
 
     expect(captured.text).toContain("UPDATE drafts SET")
+    expect(captured.values).toContain("stream:stream_2")
     expect(captured.text).toContain("version = version + 1")
     expect(captured.text).toContain("deleted_at IS NULL")
     expect(captured.text).toContain("version =")
@@ -154,6 +156,7 @@ describe("DraftsRepository.casUpdate", () => {
       id: "draft_01",
       expectedVersion: 99,
       ownWriteIds: ["write_3"],
+      scope: "stream:stream_2",
       rootStreamId: null,
       contentJson: { type: "doc", content: [] },
       contentMarkdown: "x",

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -97,6 +97,7 @@ export interface CasUpdateDraftParams {
    * `expectedVersion` trails (the ack of the prior write was lost).
    */
   ownWriteIds: string[]
+  scope: string
   rootStreamId: string | null
   contentJson: JSONContent | null
   contentMarkdown: string | null
@@ -213,6 +214,7 @@ export const DraftsRepository = {
     const ownWriteIds = params.ownWriteIds
     const result = await db.query<DraftRow>(sql`
       UPDATE drafts SET
+        scope = ${params.scope},
         root_stream_id = ${params.rootStreamId},
         content_json = ${jsonbOrNull(params.contentJson)}::jsonb,
         content_markdown = ${params.contentMarkdown},

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -126,7 +126,7 @@ describe("DraftsService.upsert", () => {
     expect(result.split).toBe(false)
     expect(casUpdate).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ ownWriteIds: ["write_next", "write_prior"] })
+      expect.objectContaining({ scope: "stream:stream_1", ownWriteIds: ["write_next", "write_prior"] })
     )
   })
 

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -172,6 +172,7 @@ export class DraftsService {
           id: params.id,
           expectedVersion: params.expectedVersion,
           ownWriteIds,
+          scope: params.scope,
           rootStreamId: params.rootStreamId,
           contentJson: params.contentJson,
           contentMarkdown: params.contentMarkdown,

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -311,8 +311,8 @@ describe("InlineComposerForm armed reply-target strip", () => {
     expect(screen.getByRole("button", { name: "Cancel reply in conversation" })).toBeTruthy()
   })
 
-  it("× relocates the draft (live content included) to the root scope, then disarms", async () => {
-    const relocateSpy = vi.fn().mockResolvedValue(undefined)
+  it("× flushes and moves the stable draft to the root scope before disarming", async () => {
+    const relocateSpy = vi.fn().mockResolvedValue(null)
     spyOnExport(draftMessageModule, "relocateLoadedDraft").mockReturnValue(relocateSpy as never)
     const onCancel = vi.fn()
     render(
@@ -327,15 +327,9 @@ describe("InlineComposerForm armed reply-target strip", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel reply in conversation" }))
 
-    expect(relocateSpy).toHaveBeenCalledWith(
-      "ws_1",
-      "board:branch-reply:conv_b",
-      "board:reply:conv_root",
-      expect.anything()
-    )
-    // Flush must precede the relocate: it clears the armed typing debounce
-    // (bound to the branch scope) that would otherwise fire after the move and
-    // mint a fresh draft under the vacated scope.
+    expect(relocateSpy).toHaveBeenCalledWith("ws_1", "board:branch-reply:conv_b", "board:reply:conv_root")
+    // Flush must precede the metadata move so the stable row carries the latest
+    // editor payload into its new filing scope.
     expect(flushDraft).toHaveBeenCalled()
     expect(flushDraft.mock.invocationCallOrder[0]).toBeLessThan(relocateSpy.mock.invocationCallOrder[0])
     await waitFor(() => expect(onCancel).toHaveBeenCalled())

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -586,26 +586,19 @@ export function InlineComposerForm({
     </div>
   ) : null
 
-  // Cancel the armed sub-conversation target: relocate the draft (live editor
-  // content wins) into the root reply scope, then disarm. `relocateLoadedDraft`
-  // deletes the source rather than re-scoping the row — an in-flight push
-  // snapshotted under the branch scope would otherwise land last and reinstate
-  // it server-side; the delete's tombstone suppresses exactly that. The content
-  // re-reads under root via the scope-change rehydrate once `onCancel` flips
-  // the draft key.
+  // Cancel the armed sub-conversation target: flush the editor, move that same
+  // draft row into the root reply scope, then disarm. The stable identity lets
+  // the mounted composer keep its live content and attachments through the
+  // filing-only scope change.
   const handleCancelReplyTarget = useCallback(async () => {
     if (!replyTarget) return
-    // Flush FIRST: `saveDraft` clears the armed typing debounce, whose closure
-    // is bound to the branch scope — the composer never unmounts on cancel
-    // (only its draftKey flips), so an unfired timer would otherwise outlive
-    // the relocate and mint a fresh draft under the vacated scope. In-flight
-    // saves past the timer are dropped by the resolve-seq bump inside
-    // `relocateLoadedDraft`.
-    await composerRef.current.flushDraft()
-    await relocateLoadedDraft(workspaceId, draftKey, replyTarget.moveDraftToKey, composer.content)
+    // Flush first so the row carries the editor's latest payload before its
+    // filing metadata changes.
+    await composerRef.current.flushDraft({ keepEmpty: true })
+    await relocateLoadedDraft(workspaceId, draftKey, replyTarget.moveDraftToKey)
     syncEngine?.kickOperationQueue()
     replyTarget.onCancel()
-  }, [replyTarget, workspaceId, draftKey, syncEngine, composer.content])
+  }, [replyTarget, workspaceId, draftKey, syncEngine])
 
   // Armed reply-target strip — the send's only signal that it files into a
   // sub-conversation, matching the timeline's dismissible strip. Replaces the

--- a/apps/frontend/src/components/composer/conversation-reply-strip.tsx
+++ b/apps/frontend/src/components/composer/conversation-reply-strip.tsx
@@ -36,3 +36,16 @@ export function ConversationReplyStrip({ title, onCancel }: ConversationReplyStr
     </div>
   )
 }
+
+/** Preserve the strip's line box while the focused mobile compose session ends. */
+export function ConversationReplyStripPlaceholder() {
+  return (
+    <div
+      data-testid="conversation-reply-strip-placeholder"
+      aria-hidden="true"
+      className={`${CONVERSATION_REPLY_STRIP_CLASS_NAME} invisible pointer-events-none`}
+    >
+      <span>&nbsp;</span>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/composer/index.ts
+++ b/apps/frontend/src/components/composer/index.ts
@@ -13,7 +13,7 @@ export { MessageContextBadge } from "./message-context-badge"
 export { StreamTargetPicker, type StreamTargetPickerProps } from "./stream-target-picker"
 export { StreamSortToggle } from "./stream-sort-toggle"
 export { OverlayComposerShell, type OverlayComposerShellProps } from "./overlay-composer-shell"
-export { ConversationReplyStrip } from "./conversation-reply-strip"
+export { ConversationReplyStrip, ConversationReplyStripPlaceholder } from "./conversation-reply-strip"
 export {
   ComposerDisabledNotice,
   CONVERSATION_ARCHIVED_REASON,

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -480,6 +480,22 @@ describe("MessageComposer", () => {
       expect(screen.getByText("/steer focus on tests")).toBeInTheDocument()
     })
 
+    it("reports chrome closure after focus leaves", () => {
+      isMobileMockValue = true
+      vi.useFakeTimers()
+      const onMobileChromeOpenChange = vi.fn()
+
+      render(<MessageComposer {...defaultProps} onMobileChromeOpenChange={onMobileChromeOpenChange} />)
+      expect(onMobileChromeOpenChange).toHaveBeenLastCalledWith(false)
+
+      fireEvent.click(screen.getByTestId("rich-editor-wrapper"))
+      expect(onMobileChromeOpenChange).toHaveBeenLastCalledWith(true)
+
+      fireEvent.blur(screen.getByTestId("rich-editor"))
+      act(() => vi.advanceTimersByTime(200))
+      expect(onMobileChromeOpenChange).toHaveBeenLastCalledWith(false)
+    })
+
     it("renders editor in preview mode when mobile unfocused with content", () => {
       isMobileMockValue = true
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -155,6 +155,8 @@ export interface MessageComposerProps {
    * Default false (the timeline/thread composers rest compacted on mobile).
    */
   initialMobileChromeOpen?: boolean
+  /** Reports mobile focus/chrome changes so hosts can retire temporary layout slots after the keyboard closes. */
+  onMobileChromeOpenChange?: (open: boolean) => void
 
   /** Scope identifier — when it changes, re-focus the editor (if autoFocus) */
   scopeId?: string
@@ -262,6 +264,7 @@ export function MessageComposer({
   messageSendMode = "enter",
   autoFocus = false,
   initialMobileChromeOpen = false,
+  onMobileChromeOpenChange,
   scopeId,
   onEditLastMessage,
   onEscapeBlur,
@@ -331,6 +334,9 @@ export function MessageComposer({
   const mobileChromeOpen = mobileFocused || voiceActive
   const mobileChromeOpenRef = useRef(mobileChromeOpen)
   mobileChromeOpenRef.current = mobileChromeOpen
+  useEffect(() => {
+    if (isMobile) onMobileChromeOpenChange?.(mobileChromeOpen)
+  }, [isMobile, mobileChromeOpen, onMobileChromeOpenChange])
 
   // Defer the mobile chrome expansion until the keyboard's viewport resize
   // lands. Expanding on focus alone ran ~100ms ahead of the keyboard, so the

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -57,6 +57,7 @@ let loadFailed = false
 let lastActiveStreamId = streamId
 let e2eEnabled = false
 let openPanelSpy = vi.fn()
+let renderedBodies: string[] = []
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
@@ -76,6 +77,7 @@ beforeEach(async () => {
   lastActiveStreamId = streamId
   e2eEnabled = false
   openPanelSpy = vi.fn()
+  renderedBodies = []
 
   vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
   vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
@@ -189,6 +191,7 @@ beforeEach(async () => {
     onContentChange: (value: JSONContent) => void
     composerRef?: { current: unknown }
   }) => {
+    renderedBodies.push(docText(content))
     if (composerRef) {
       composerRef.current = {
         focus: vi.fn(),
@@ -201,6 +204,7 @@ beforeEach(async () => {
       <div>
         <span data-testid="editor-body">{docText(content)}</span>
         <button onClick={() => onContentChange(makeDoc("typed here"))}>type</button>
+        <button onClick={() => onContentChange({ type: "doc", content: [{ type: "paragraph" }] })}>clear</button>
       </div>
     )
   }) as unknown as typeof composerModule.MessageComposer)
@@ -275,6 +279,33 @@ describe("the timeline composer's durable target", () => {
     expect(await bodyOf(hostScope)).toBe("stream body")
   })
 
+  it("re-files the current composer content across conversations with one stable draft", async () => {
+    await seedDrafts()
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("stream body"))
+    const stableDraftId = (await db.composerLoaded.get(hostScope))?.draftId
+
+    await userEvent.click(screen.getByRole("button", { name: "type" }))
+    await waitFor(async () => expect(await bodyOf(hostScope)).toBe("typed here"))
+    await act(async () => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+    await waitFor(async () => expect((await db.composerTarget.get(hostScope))?.scope).toBe(boardScope))
+    expect((await db.composerLoaded.get(boardScope))?.draftId).toBe(stableDraftId)
+
+    const secondScope = "board:reply:conv_2"
+    renderedBodies = []
+    await act(async () => registeredConversationReplyHandler?.({ conversationId: "conv_2" }))
+    await waitFor(async () => expect((await db.composerTarget.get(hostScope))?.scope).toBe(secondScope))
+
+    expect((await db.composerLoaded.get(secondScope))?.draftId).toBe(stableDraftId)
+    expect(await db.drafts.get(stableDraftId!)).toMatchObject({
+      id: stableDraftId,
+      scope: secondScope,
+      contentJson: makeDoc("typed here"),
+    })
+    expect(screen.getByTestId("editor-body")).toHaveTextContent("typed here")
+    expect(renderedBodies).not.toContain("")
+  })
+
   it("survives a reload — a fresh mount reads the stored target", async () => {
     await seedDrafts()
     await setComposerTarget(workspaceId, hostScope, boardScope)
@@ -291,6 +322,57 @@ describe("the timeline composer's durable target", () => {
     mount()
     await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
     expect(screen.getByTestId("conversation-reply-strip")).toHaveTextContent("Replying in Pizza plans")
+  })
+
+  it("removes conversation filing without changing the live draft identity or payload", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+    const stableDraftId = (await db.composerLoaded.get(boardScope))?.draftId
+    expect(stableDraftId).toBeDefined()
+
+    await userEvent.click(screen.getByRole("button", { name: "type" }))
+    await waitFor(async () => expect(await bodyOf(boardScope)).toBe("typed here"))
+    renderedBodies = []
+    await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
+
+    await waitFor(async () => expect(await db.composerTarget.get(hostScope)).toBeUndefined())
+    await waitFor(() => expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument())
+    expect(screen.getByTestId("editor-body")).toHaveTextContent("typed here")
+    expect(renderedBodies).not.toContain("")
+    expect((await db.composerLoaded.get(hostScope))?.draftId).toBe(stableDraftId)
+    expect(await db.drafts.get(stableDraftId!)).toMatchObject({
+      id: stableDraftId,
+      scope: hostScope,
+      contentJson: makeDoc("typed here"),
+    })
+    // The stream draft that was loaded before arming remains as a pile sibling.
+    expect(await bodyOf(hostScope)).toBe("stream body|typed here")
+    expect(await bodyOf(boardScope)).toBe("")
+  })
+
+  it("keeps a deliberately cleared composer empty while removing its filing", async () => {
+    await seedDrafts()
+    await setComposerTarget(workspaceId, hostScope, boardScope)
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("board body"))
+    const stableDraftId = (await db.composerLoaded.get(boardScope))?.draftId
+
+    await userEvent.click(screen.getByRole("button", { name: "clear" }))
+    renderedBodies = []
+    await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
+
+    await waitFor(async () => expect(await db.composerTarget.get(hostScope)).toBeUndefined())
+    expect(screen.getByTestId("editor-body").textContent).toBe("")
+    expect(renderedBodies).not.toContain("stream body")
+    expect((await db.composerLoaded.get(hostScope))?.draftId).toBe(stableDraftId)
+    expect(await db.drafts.get(stableDraftId!)).toMatchObject({
+      id: stableDraftId,
+      scope: hostScope,
+      contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+    })
   })
 
   it("falls back to the stream scope when the target's conversation is gone", async () => {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -14,16 +14,17 @@ import {
   useMentionStreamContext,
   useComposerTarget,
   useMountedComposerCount,
-  setComposerTarget,
   clearComposerTarget,
 } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { stashLoadedDraft } from "@/hooks/use-draft-message"
+import { relocateLoadedDraft, stashLoadedDraft } from "@/hooks/use-draft-message"
+import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useComposeTrace } from "@/lib/compose-trace"
 import { usePreferences } from "@/contexts"
 import { useConnectionState } from "@/components/layout/connection-status"
 import {
   ConversationReplyStrip,
+  ConversationReplyStripPlaceholder,
   FloatingComposerShell,
   ComposerDisabledNotice,
   MessageComposer,
@@ -256,6 +257,7 @@ function MessageInputComponent({
   // through their root channel for access grants — handled inside the hook.
   const streamContext = useMentionStreamContext(workspaceId, stream)
 
+  const isMobile = useIsMobile()
   const e2eEnabled = stream?.e2eEnabled === true
   // The encrypted root holds the SSK + wraps (a thread shares its root's key), so
   // both sealing and the repair notice key off the root, not the (maybe-thread) id.
@@ -365,6 +367,7 @@ function MessageInputComponent({
   // `scopeId` (`use-draft-composer.ts`), so a mismatched pair renders one draft
   // while every save targets another.
   const draftKey = effectiveTarget ?? hostScope
+  const syncEngine = useOptionalSyncEngine()
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
@@ -403,6 +406,10 @@ function MessageInputComponent({
   // Use a ref so the handler always reads fresh composer state without
   // re-registering on every render (composer object is not memoized).
   const composerRef = useRef(composer)
+  const armConversationPendingRef = useRef(false)
+  const removeConversationFilingPendingRef = useRef(false)
+  const mobileChromeOpenRef = useRef(false)
+  const [preserveConversationStripSpace, setPreserveConversationStripSpace] = useState(false)
   composerRef.current = composer
 
   // Imperative handle for programmatic focus from outside (e.g. quote reply insertion)
@@ -426,21 +433,63 @@ function MessageInputComponent({
     })
   }, [quoteReplyCtx])
 
-  // "Reply in conversation" (Mechanism C): arming points this host at the
-  // conversation's draft scope. The send reads the same target for its `existing`
-  // directive — nothing is inserted into the body.
+  // "Reply in conversation" changes the filing of the content already in this
+  // mounted editor. Flush it, move that same draft row, and update the durable
+  // target in one local-first transaction. An empty composer with no row simply
+  // opens the destination's existing draft, if any.
   const conversationReplyCtx = useConversationReply()
   const { openPanel } = usePanel()
   useEffect(() => {
     if (!conversationReplyCtx) return
-    // Arm only. Focus is deferred to the resolve effect below: focusing the
-    // channel composer here would pop the mobile keyboard on it a beat before a
-    // thread-follow reply redirects to the conversation panel.
     return conversationReplyCtx.registerHandler((data: ConversationReplyData) => {
+      if (armConversationPendingRef.current) return
+      armConversationPendingRef.current = true
       gestureArmedIdRef.current = { host: hostScope, conversationId: data.conversationId }
-      void setComposerTarget(workspaceId, hostScope, boardReplyDraftKey(data.conversationId))
+      const targetScope = boardReplyDraftKey(data.conversationId)
+      void (async () => {
+        try {
+          await composerRef.current.flushDraft({ keepEmpty: true })
+          await relocateLoadedDraft(workspaceId, draftKey, targetScope, { targetHost: hostScope })
+          syncEngine?.kickOperationQueue()
+        } catch (err) {
+          gestureArmedIdRef.current = null
+          console.error("[composer] could not change the conversation filing", err)
+        } finally {
+          armConversationPendingRef.current = false
+        }
+      })()
     })
-  }, [conversationReplyCtx, workspaceId, hostScope])
+  }, [conversationReplyCtx, workspaceId, hostScope, draftKey, syncEngine])
+
+  const removeConversationFiling = useCallback(async () => {
+    const vacated = effectiveTarget
+    if (!vacated || removeConversationFilingPendingRef.current) return
+    removeConversationFilingPendingRef.current = true
+    try {
+      // The editor owns the payload. Persist it, then move that same row's filing
+      // metadata and durable target together; no identity hand-off occurs.
+      await composerRef.current.flushDraft({ keepEmpty: true })
+      await relocateLoadedDraft(workspaceId, vacated, hostScope, { targetHost: hostScope })
+      gestureArmedIdRef.current = null
+      syncEngine?.kickOperationQueue()
+    } catch (err) {
+      setPreserveConversationStripSpace(false)
+      console.error("[composer] could not remove the conversation filing", err)
+    } finally {
+      removeConversationFilingPendingRef.current = false
+    }
+  }, [effectiveTarget, workspaceId, hostScope, syncEngine])
+
+  const dismissConversationFiling = useCallback(() => {
+    // Keep the focused mobile shell still until its keyboard/chrome session ends.
+    setPreserveConversationStripSpace(isMobile && mobileChromeOpenRef.current)
+    void removeConversationFiling()
+  }, [isMobile, removeConversationFiling])
+
+  const handleMobileChromeOpenChange = useCallback((open: boolean) => {
+    mobileChromeOpenRef.current = open
+    if (!open) setPreserveConversationStripSpace(false)
+  }, [])
 
   useEffect(() => {
     if (stashParamWantsHostScope) disarm()
@@ -639,7 +688,6 @@ function MessageInputComponent({
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
   const messageSendMode = preferences?.messageSendMode ?? "enter"
-  const isMobile = useIsMobile()
   const connectionState = useConnectionState()
   const isOffline = connectionState === "offline"
 
@@ -652,6 +700,7 @@ function MessageInputComponent({
   useEffect(() => {
     setError(null)
     setExpanded(false)
+    setPreserveConversationStripSpace(false)
   }, [streamId])
 
   // Collapse the fullscreen overlay when the viewport crosses to mobile (expand is
@@ -887,6 +936,7 @@ function MessageInputComponent({
     placeholder: composerPlaceholder,
     messageSendMode,
     onComposerFocus,
+    onMobileChromeOpenChange: handleMobileChromeOpenChange,
     scopeId: streamId,
     onEditLastMessage: triggerEditLast
       ? () => {
@@ -964,11 +1014,18 @@ function MessageInputComponent({
     ),
   } as const
 
-  // The filing strip is informational here. Dismissing it required relocating
-  // a live synced draft solely to preserve an uncommon inline undo action.
-  const conversationReplyStrip = armedConversationId ? (
-    <ConversationReplyStrip title={conversationReplyTopic ?? "this conversation"} />
-  ) : null
+  // Removing the filing changes metadata on the same draft. On mobile, retain
+  // the strip's line box until the focused chrome session closes so neither the
+  // composer nor keyboard moves during the action.
+  let conversationReplyStrip = preserveConversationStripSpace ? <ConversationReplyStripPlaceholder /> : null
+  if (armedConversationId) {
+    conversationReplyStrip = (
+      <ConversationReplyStrip
+        title={conversationReplyTopic ?? "this conversation"}
+        onCancel={dismissConversationFiling}
+      />
+    )
+  }
 
   const StreamGlyph = stream ? STREAM_ICONS[stream.type] : null
 

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -4,6 +4,7 @@ import { useDraftComposer } from "./use-draft-composer"
 import type { JSONContent } from "@threa/types"
 import * as useDraftMessageModule from "./use-draft-message"
 import * as useAttachmentsModule from "./use-attachments"
+import { markDraftMigrated, resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const makeDoc = (text: string): JSONContent => ({
@@ -18,6 +19,10 @@ const mockAddDraftAttachment = vi.fn()
 const mockRemoveDraftAttachment = vi.fn()
 const mockClearDraft = vi.fn()
 const mockResolveDraft = vi.fn()
+const mockCancelPendingSave = vi.fn()
+
+/** What `saveDraft` resolves to when it actually persisted (see its contract). */
+const persistedRow = (id: string) => ({ id }) as unknown as import("@/db").CachedDraft
 
 interface MockDraftState {
   isLoaded: boolean
@@ -64,12 +69,14 @@ describe("useDraftComposer", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks()
+    resetDraftResolutionGuard()
     mockSaveDraft.mockReset()
     mockSaveDraftDebounced.mockReset()
     mockAddDraftAttachment.mockReset()
     mockRemoveDraftAttachment.mockReset()
     mockClearDraft.mockReset()
     mockResolveDraft.mockReset()
+    mockCancelPendingSave.mockReset()
     mockHandleFileSelect.mockReset()
     mockRemoveAttachment.mockReset()
     mockClearAttachments.mockReset()
@@ -98,6 +105,7 @@ describe("useDraftComposer", () => {
           loadedDraftId: mockDraftLoadedId,
           saveDraft: mockSaveDraft,
           saveDraftDebounced: mockSaveDraftDebounced,
+          cancelPendingSave: mockCancelPendingSave,
           addAttachment: mockAddDraftAttachment,
           removeAttachment: mockRemoveDraftAttachment,
           clearDraft: mockClearDraft,
@@ -854,6 +862,159 @@ describe("useDraftComposer", () => {
       rerender()
 
       expect(result.current.content).toEqual(makeDoc("saved body and more"))
+    })
+  })
+
+  describe("repoint (loaded pointer changes value)", () => {
+    it("rehydrates an idle composer from the newly-pointed draft", () => {
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("X body")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("X body"))
+
+      act(() => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      expect(result.current.content).toEqual(makeDoc("Y body"))
+      // An idle editor holds only the hydrated body, so nothing needs flushing.
+      expect(mockSaveDraft).not.toHaveBeenCalled()
+    })
+
+    it("flushes typed content to its OWN row before rehydrating from the new one", () => {
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("X body")
+      mockSaveDraft.mockResolvedValue(undefined)
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("X body and typing"))
+      })
+
+      act(() => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      // Identity-addressed: the typed body is written to draft_x, never to draft_y.
+      expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("X body and typing"), [], "draft_x")
+      expect(result.current.content).toEqual(makeDoc("Y body"))
+    })
+
+    it("follows an id migration without flushing or blanking the editor", () => {
+      // A split ack / remote-delete preserve re-keys the SAME draft underneath the
+      // composer. The pointer changes value, but the editor's content still belongs
+      // to that row — treating it as a repoint would flush to the deleted id and
+      // `resetForReinit` mid-typing.
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("X body")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("X body and typing"))
+      })
+
+      act(() => {
+        markDraftMigrated("draft_x", "draft_x2")
+        mockDraftLoadedId = "draft_x2"
+        rerender()
+      })
+
+      expect(result.current.content).toEqual(makeDoc("X body and typing"))
+      expect(mockSaveDraft).not.toHaveBeenCalled()
+
+      // Engagement survived: a stale saved body arriving now must not re-fill.
+      act(() => {
+        mockDraftContentJson = makeDoc("stale saved body")
+        rerender()
+      })
+      expect(result.current.content).toEqual(makeDoc("X body and typing"))
+    })
+
+    it("detaches a typed fragment to its own row when a first pointer arrives under an engaged editor", async () => {
+      // null → Y with the user mid-typing: the fragment has no identity, so the
+      // armed pointer-addressed save would land in Y and destroy its body.
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = null
+      mockDraftContentJson = EMPTY_DOC
+      mockSaveDraft.mockResolvedValue(persistedRow("draft_detached"))
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("fragment"))
+      })
+
+      await act(async () => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      expect(mockSaveDraft).toHaveBeenCalledTimes(1)
+      const [flushedContent, , detachedId] = mockSaveDraft.mock.calls[0]
+      expect(flushedContent).toEqual(makeDoc("fragment"))
+      // A row id of its own — never Y's, and never the pointer-addressed null.
+      expect(typeof detachedId).toBe("string")
+      expect(detachedId).not.toBe("draft_y")
+      // Y rehydrates intact.
+      expect(result.current.content).toEqual(makeDoc("Y body"))
+    })
+
+    it("keeps the typed fragment on screen when the detached save could not persist", async () => {
+      // Locked E2E scope: `saveDraft` is gated and persists nothing (resolves
+      // null). Blanking the editor then would lose the fragment from screen AND
+      // disk, so the focused composer keeps it and does not adopt Y.
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = null
+      mockDraftContentJson = EMPTY_DOC
+      mockSaveDraft.mockResolvedValue(null)
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("fragment"))
+      })
+
+      await act(async () => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      expect(result.current.content).toEqual(makeDoc("fragment"))
+      expect(mockClearAttachments).not.toHaveBeenCalled()
+    })
+
+    it("drops the armed save without persisting when an engaged editor is empty as the first pointer arrives", async () => {
+      // Typed, then deleted back to empty: the debounce is re-armed with an empty
+      // doc and a null expected id, so firing it would delete the arriving draft.
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = null
+      mockDraftContentJson = EMPTY_DOC
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("fragment"))
+      })
+      act(() => {
+        result.current.handleContentChange(EMPTY_DOC)
+      })
+
+      await act(async () => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      expect(mockCancelPendingSave).toHaveBeenCalledTimes(1)
+      expect(mockSaveDraft).not.toHaveBeenCalled()
+      // Y is adopted and hydrated into the (empty) editor.
+      expect(result.current.content).toEqual(makeDoc("Y body"))
     })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -199,6 +199,26 @@ describe("useDraftComposer", () => {
   })
 
   describe("scope change", () => {
+    it("keeps live content and attachments when the same draft identity changes filing scope", () => {
+      const sourceKey = "board:reply:conv_1"
+      const targetKey = "stream:stream_1"
+      mockDraftLoadedId = "draft_stable"
+      mockDraftStateByKey[sourceKey] = { isLoaded: true, contentJson: makeDoc("saved"), attachments: [] }
+      mockDraftStateByKey[targetKey] = { isLoaded: true, contentJson: makeDoc("saved"), attachments: [] }
+
+      const { result, rerender } = renderHook(
+        ({ currentKey }) => useDraftComposer({ workspaceId, draftKey: currentKey, scopeId: currentKey }),
+        { initialProps: { currentKey: sourceKey } }
+      )
+      act(() => result.current.handleContentChange(makeDoc("typed here")))
+      mockClearAttachments.mockClear()
+
+      rerender({ currentKey: targetKey })
+
+      expect(result.current.content).toEqual(makeDoc("typed here"))
+      expect(mockClearAttachments).not.toHaveBeenCalled()
+    })
+
     it("should reset content when scopeId changes", () => {
       const { result, rerender } = renderHook(({ scopeId }) => useDraftComposer({ workspaceId, draftKey, scopeId }), {
         initialProps: { scopeId: "stream_1" },
@@ -211,7 +231,8 @@ describe("useDraftComposer", () => {
       })
       expect(result.current.content).toEqual(newContent)
 
-      // Change scope
+      // Change to a scope that points at another identity.
+      mockDraftLoadedId = null
       rerender({ scopeId: "stream_2" })
 
       expect(result.current.content).toEqual(EMPTY_DOC)
@@ -222,7 +243,8 @@ describe("useDraftComposer", () => {
         initialProps: { scopeId: "stream_1" },
       })
 
-      // Change scope
+      // Change to a scope that points at another identity.
+      mockDraftLoadedId = null
       rerender({ scopeId: "stream_2" })
 
       expect(mockClearAttachments).toHaveBeenCalled()
@@ -694,6 +716,16 @@ describe("useDraftComposer", () => {
       })
 
       expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("unsaved keystrokes"))
+    })
+
+    it("persists an existing empty row when a filing-only move requests it", async () => {
+      const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      await act(async () => {
+        await result.current.flushDraft({ keepEmpty: true })
+      })
+
+      expect(mockSaveDraft).toHaveBeenCalledWith(EMPTY_DOC, [], undefined, { keepEmpty: true })
     })
 
     it("no-ops on an empty editor so a restore mid-hydration can't delete the loaded draft", async () => {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -4,8 +4,8 @@ import { useAttachments, type PendingAttachment, type UploadResult } from "./use
 import type { JSONContent } from "@threa/types"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import type { DraftContextRef } from "@/lib/context-bag/types"
-import type { DraftAttachment } from "@/db"
-import { wasDraftResolvedLocally } from "@/sync/draft-resolution-guard"
+import { generateLocalDraftId, type DraftAttachment } from "@/db"
+import { resolveMigratedDraftId, wasDraftResolvedLocally } from "@/sync/draft-resolution-guard"
 
 // Mounted composers per draft scope, in mount order. More than one live composer
 // on a scope is a precondition for the rescue below: with only this one, a
@@ -180,6 +180,14 @@ export function useDraftComposer({
   initialContent = EMPTY_DOC,
   e2eStreamId,
 }: UseDraftComposerOptions): DraftComposerState {
+  // Which draft row the editor's current content came from (hydrated, or created
+  // by the first save). Every save path addresses THIS row instead of re-reading
+  // the scope's pointer, so a repoint between hydration and a debounced save can
+  // never write this content into the newly-pointed draft. Set wherever the
+  // content is (re)filled from a loaded draft below; advanced by `useDraftMessage`
+  // itself after a create.
+  const contentDraftIdRef = useRef<string | null>(null)
+
   // Draft message persistence
   const {
     isLoaded: isDraftLoaded,
@@ -191,11 +199,12 @@ export function useDraftComposer({
     contextRefs: savedContextRefs = [] as DraftContextRef[],
     saveDraft,
     saveDraftDebounced,
+    cancelPendingSave,
     addAttachment: addDraftAttachment,
     removeAttachment: removeDraftAttachment,
     clearDraft,
     resolveDraft,
-  } = useDraftMessage(workspaceId, draftKey, e2eStreamId)
+  } = useDraftMessage(workspaceId, draftKey, e2eStreamId, contentDraftIdRef)
 
   // Attachment handling
   const {
@@ -326,9 +335,10 @@ export function useDraftComposer({
         restoreAttachments(savedAttachments)
       }
       restoredAttachmentIdsRef.current = new Set(savedAttachments.map((attachment: { id: string }) => attachment.id))
+      contentDraftIdRef.current = loadedDraftId ?? null
       hasInitialized.current = true
     }
-  }, [scopeId, isDraftLoaded, savedDraft, savedAttachments, restoreAttachments, resetForReinit])
+  }, [scopeId, isDraftLoaded, savedDraft, savedAttachments, restoreAttachments, resetForReinit, loadedDraftId])
 
   // Restore the loaded draft's (decrypted) attachments alongside its body when the
   // body late-hydrates. A sealed E2E draft's attachments become readable only once
@@ -377,14 +387,16 @@ export function useDraftComposer({
     if (awaitingRehydrateRef.current) {
       if (savedBodyAvailable) setContent(savedDraft)
       hydrateAttachments()
+      contentDraftIdRef.current = loadedDraftId ?? null
       awaitingRehydrateRef.current = false
       return
     }
     if (becameAvailable && !hasDocContent(content)) {
       if (savedBodyAvailable) setContent(savedDraft)
       hydrateAttachments()
+      contentDraftIdRef.current = loadedDraftId ?? null
     }
-  }, [isDraftLoaded, savedDraft, savedAttachmentIds, content, hydrateAttachments])
+  }, [isDraftLoaded, savedDraft, savedAttachmentIds, content, hydrateAttachments, loadedDraftId])
 
   // Blank the editor the moment the loaded draft is removed underneath the
   // composer: sent/resolved here, or discarded/resolved on another device (its
@@ -399,9 +411,78 @@ export function useDraftComposer({
   // wiped the in-progress edits and, on the pointer's return, the late-hydrate
   // rising edge re-filled the stale last-saved body — the keystrokes were lost.
   // A clean (unedited) loaded draft still clears: that is the cross-device case.
+  //
+  // A pointer that changes VALUE (X → Y) is a repoint: another surface — or a
+  // restore — checked a different draft into this scope. The editor is still
+  // rendering X, so persist X's content to X's own row (identity-addressed, so it
+  // cannot cross-write into Y) and then re-run init against Y. Rehydration happens
+  // whether or not the user is engaged: the repoint is this same user's own action
+  // on this device, so the new draft is what they asked to see.
   useEffect(() => {
     const prev = prevLoadedIdRef.current
     prevLoadedIdRef.current = loadedDraftId ?? null
+    if (loadedDraftId && prev !== loadedDraftId) {
+      if (!prev) {
+        // First pointer for this composer (null → X). With the editor idle — or
+        // when the editor's content already belongs to this very row, i.e. the
+        // pointer merely flickered null and came back — adopt its identity and
+        // hydrate from it as usual.
+        // The pointer merely flickered null and came back to the row the editor's
+        // content already belongs to — nothing to reconcile.
+        if (contentDraftIdRef.current === loadedDraftId) return
+        if (!userEngagedRef.current) {
+          contentDraftIdRef.current = loadedDraftId
+          return
+        }
+        if (!hasDocContent(contentRef.current)) {
+          // Engaged but empty (typed, then deleted back to nothing). There is
+          // nothing to preserve, but the debounce is still armed with an EMPTY_DOC
+          // save whose expected id is null — pointer-addressed, it would fire into
+          // the arriving draft and delete it. Drop it without persisting, then
+          // hydrate from the arriving draft like an idle composer would.
+          cancelPendingSave()
+          resetForReinit()
+          contentDraftIdRef.current = loadedDraftId
+          return
+        }
+        // The user typed into a pointer-less scope and a draft was checked into
+        // it underneath them. Their fragment has no identity yet, so the armed
+        // pointer-addressed save would land in the arriving draft and destroy its
+        // body. Persist the fragment as its OWN detached row first (an expected
+        // id no row holds takes the create path, and the occupied pointer is
+        // never stolen); `saveDraft` also clears the armed debounce. Only once it
+        // actually persisted may the editor be blanked — on a locked E2E scope the
+        // save is gated and returns null, and resetting would erase the fragment
+        // from screen and disk both, so the focused composer keeps its content.
+        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot()), generateLocalDraftId())
+          .then((saved) => {
+            if (!saved) return
+            resetForReinit()
+            contentDraftIdRef.current = loadedDraftId
+          })
+          .catch((err) => {
+            console.error("Failed to persist draft content displaced by a first pointer", err)
+          })
+        return
+      }
+      if (resolveMigratedDraftId(prev) === loadedDraftId) {
+        // Not a repoint: the SAME draft was re-keyed underneath the composer (a
+        // split ack / remote-delete preserve). The editor's content still belongs
+        // to this row, so nothing is flushed and nothing is reset — the id is
+        // simply followed. Any armed save captured the old id and is redirected
+        // by the migration map on the write path.
+        contentDraftIdRef.current = loadedDraftId
+        return
+      }
+      if (userEngagedRef.current && hasDocContent(contentRef.current)) {
+        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot()), prev).catch((err) => {
+          console.error("Failed to persist draft content displaced by a repoint", err)
+        })
+      }
+      resetForReinit()
+      contentDraftIdRef.current = loadedDraftId
+      return
+    }
     if (!prev || loadedDraftId) return
     if (userEngagedRef.current && hasDocContent(contentRef.current)) {
       // With another composer live on this scope, the vanishing pointer can be
@@ -420,9 +501,19 @@ export function useDraftComposer({
       return
     }
     userEngagedRef.current = false
+    contentDraftIdRef.current = null
     setContent(initialContent)
     clearAttachments()
-  }, [loadedDraftId, initialContent, clearAttachments, saveDraft, scopeRegistryKey, getPendingAttachmentsSnapshot])
+  }, [
+    loadedDraftId,
+    initialContent,
+    clearAttachments,
+    saveDraft,
+    scopeRegistryKey,
+    getPendingAttachmentsSnapshot,
+    resetForReinit,
+    cancelPendingSave,
+  ])
 
   // When attachments change, persist to draft storage. Reserved-but-still-
   // uploading attachments persist too: their id is already real, and a draft

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -133,13 +133,11 @@ export interface DraftComposerState {
   setIsSending: (sending: boolean) => void
 
   /**
-   * Persist the live editor content into the loaded draft row immediately
-   * (bypassing the debounce, sealing it for E2E) — but only when it is non-empty,
-   * so it never takes the empty→delete path. Used by stash/restore to preserve
-   * unsaved keystrokes before the loaded draft is detached or swapped, without
-   * risking deletion of a draft whose editor is still mid-hydration.
+   * Persist the live editor payload immediately, bypassing the debounce. Normal
+   * stash/restore calls avoid the empty→delete path; filing-only scope moves may
+   * preserve an existing row after the user deliberately cleared its body.
    */
-  flushDraft: () => Promise<void>
+  flushDraft: (options?: { keepEmpty?: boolean }) => Promise<void>
   /**
    * Re-run the composer's init from whatever draft is now loaded for the scope.
    * Called after a stash/restore pointer move so the editor re-reads (and, for
@@ -194,6 +192,7 @@ export function useDraftComposer({
     isDecrypting,
     decryptFailed,
     loadedDraftId,
+    contentDraftScope,
     contentJson: savedDraft,
     attachments: savedAttachments,
     contextRefs: savedContextRefs = [] as DraftContextRef[],
@@ -280,9 +279,19 @@ export function useDraftComposer({
   // while the editor is still mid-hydration (transiently empty) — taking the
   // empty→delete path then would silently destroy the loaded draft. An
   // intentional clear is handled by the debounced save, never here.
-  const flushDraft = useCallback(async () => {
-    if (hasDocContent(contentRef.current)) await saveDraft(contentRef.current)
-  }, [saveDraft])
+  const flushDraft = useCallback(
+    async (options?: { keepEmpty?: boolean }) => {
+      const attachments = persistableAttachments(getPendingAttachmentsSnapshot())
+      if (options?.keepEmpty) {
+        await saveDraft(contentRef.current, attachments, undefined, options)
+      } else if (hasDocContent(contentRef.current)) {
+        await saveDraft(contentRef.current)
+      } else if (attachments.length > 0) {
+        await saveDraft(contentRef.current, attachments)
+      }
+    },
+    [getPendingAttachmentsSnapshot, saveDraft]
+  )
 
   // Blank the composer to an un-initialized state so the init effect below
   // re-hydrates it from whatever draft is now loaded for the scope. Used on both
@@ -307,7 +316,8 @@ export function useDraftComposer({
   useEffect(() => {
     const isScopeChange = prevScopeIdRef.current !== null && prevScopeIdRef.current !== scopeId
 
-    if (isScopeChange) resetForReinit()
+    const followsSameDraft = loadedDraftId !== null && contentDraftIdRef.current === loadedDraftId
+    if (isScopeChange && !followsSameDraft) resetForReinit()
 
     // Track scope changes
     if (prevScopeIdRef.current !== scopeId) {
@@ -484,6 +494,10 @@ export function useDraftComposer({
       return
     }
     if (!prev || loadedDraftId) return
+    // A filing-only move can publish the row's new scope before the host target
+    // catches up. The editor still owns this identity, so the old pointer going
+    // null is not a removal.
+    if (contentDraftScope && contentDraftScope !== draftKey) return
     if (userEngagedRef.current && hasDocContent(contentRef.current)) {
       // With another composer live on this scope, the vanishing pointer can be
       // THAT editor's send resolving the shared row while this one holds newer
@@ -513,6 +527,8 @@ export function useDraftComposer({
     getPendingAttachmentsSnapshot,
     resetForReinit,
     cancelPendingSave,
+    contentDraftScope,
+    draftKey,
   ])
 
   // When attachments change, persist to draft storage. Reserved-but-still-

--- a/apps/frontend/src/hooks/use-draft-message-sync.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message-sync.test.ts
@@ -7,7 +7,6 @@ import {
   upsertLoadedDraft,
 } from "./use-draft-message"
 import { readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
-import { getScopeResolveSeq } from "@/sync/draft-resolution-guard"
 import { hasPendingDraftUpsert } from "@/sync/draft-sync"
 import { db, type CachedDraft } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
@@ -151,53 +150,43 @@ describe("draft write helpers — Stage 3 sync wiring", () => {
     expect(readStagedDraft(workspaceId, toScope)?.contentJson).toEqual(makeDoc("moving"))
   })
 
-  it("relocateLoadedDraft mints a fresh target draft, tombstones the source, and stashes an existing target draft", async () => {
+  it("relocateLoadedDraft keeps one identity while displacing an existing target draft", async () => {
     const fromScope = "board:branch-reply:conv_move"
     const toScope = "board:reply:conv_move_root"
     const sourceRow = await upsertLoadedDraft(workspaceId, fromScope, {
-      contentJson: makeDoc("stale persisted"),
+      contentJson: makeDoc("live keystrokes"),
       attachments: [],
     })
     const existingTarget = await upsertLoadedDraft(workspaceId, toScope, {
       contentJson: makeDoc("root already had this"),
       attachments: [],
     })
+    const sourceOp = (await db.pendingOperations.where("type").equals("upsert_draft").toArray()).find(
+      (op) => op.payload.draftId === sourceRow.id
+    )
 
-    await relocateLoadedDraft(workspaceId, fromScope, toScope, makeDoc("live keystrokes"))
+    const moved = await relocateLoadedDraft(workspaceId, fromScope, toScope)
 
-    // Source: row deleted, pointer gone, delete queued (tombstone suppresses in-flight pushes).
-    expect(await db.drafts.get(sourceRow.id)).toBeUndefined()
+    expect(moved?.id).toBe(sourceRow.id)
     expect((await db.composerLoaded.get(fromScope))?.draftId).toBeUndefined()
-    expect(await pendingDeletes(sourceRow.id)).toBe(1)
-    // Target: a FRESH loaded draft carrying the live editor content, not the stale body.
-    const targetLoadedId = (await db.composerLoaded.get(toScope))?.draftId
-    expect(targetLoadedId).toBeDefined()
-    expect(targetLoadedId).not.toBe(sourceRow.id)
-    expect((await db.drafts.get(targetLoadedId!))?.contentJson).toEqual(makeDoc("live keystrokes"))
-    // The target's previous loaded draft survives as a stash sibling (no-loss).
-    expect((await db.drafts.get(existingTarget.id))?.scope).toBe(toScope)
-    expect((await db.drafts.get(existingTarget.id))?.contentJson).toEqual(makeDoc("root already had this"))
-  })
-
-  it("relocateLoadedDraft drops an in-flight debounced save for the vacated scope (resolve-seq bump)", async () => {
-    // A debounced typing save that began BEFORE the relocate captured the
-    // pre-bump resolve sequence; letting its create land would resurrect the
-    // scope the user just moved out of (the review's phantom-draft finding).
-    const fromScope = "board:branch-reply:conv_seq"
-    const toScope = "board:reply:conv_seq_root"
-    await upsertLoadedDraft(workspaceId, fromScope, { contentJson: makeDoc("typed"), attachments: [] })
-    const observedResolveSeq = getScopeResolveSeq(fromScope)
-
-    await relocateLoadedDraft(workspaceId, fromScope, toScope, makeDoc("typed"))
-
-    // Simulates the stale save's create firing after the relocate.
-    await upsertLoadedDraft(workspaceId, fromScope, { contentJson: makeDoc("typed"), attachments: [] }, undefined, {
-      observedResolveSeq,
+    expect((await db.composerLoaded.get(toScope))?.draftId).toBe(sourceRow.id)
+    expect(await db.drafts.get(sourceRow.id)).toMatchObject({
+      id: sourceRow.id,
+      scope: toScope,
+      contentJson: makeDoc("live keystrokes"),
     })
-
-    const fromRows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, fromScope]).toArray()
-    expect(fromRows).toHaveLength(0)
-    expect((await db.composerLoaded.get(fromScope))?.draftId).toBeUndefined()
+    expect(await pendingDeletes(sourceRow.id)).toBe(0)
+    expect(await pendingUpserts(sourceRow.id)).toBe(1)
+    const movedOp = (await db.pendingOperations.where("type").equals("upsert_draft").toArray()).find(
+      (op) => op.payload.draftId === sourceRow.id
+    )
+    expect(movedOp?.id).not.toBe(sourceOp?.id)
+    expect(movedOp?.payload.priorWriteIds).toContain(sourceOp?.payload.writeId)
+    // The target's previous loaded draft survives as a pile sibling (no-loss).
+    expect(await db.drafts.get(existingTarget.id)).toMatchObject({
+      scope: toScope,
+      contentJson: makeDoc("root already had this"),
+    })
   })
 
   it("rescopeScopeDrafts supersedes a queued push with a fresh op carrying its writeId lineage", async () => {

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -198,6 +198,22 @@ describe("useDraftMessage", () => {
       expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
     })
 
+    it("can keep an existing empty row alive for a filing-only scope move", async () => {
+      const row = await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: makeDoc("something"),
+        attachments: [],
+      })
+      const identity = { current: row.id }
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, identity))
+
+      await act(async () => {
+        await result.current.saveDraft(EMPTY_DOC, [], undefined, { keepEmpty: true })
+      })
+
+      expect(await loadedDraft(draftKey)).toMatchObject({ id: row.id, contentJson: EMPTY_DOC })
+      expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(row.id)
+    })
+
     it("should preserve existing attachments when saving content", async () => {
       const existingAttachments = [{ id: "attach_1", filename: "file.txt", mimeType: "text/plain", sizeBytes: 50 }]
       await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("x"), attachments: existingAttachments })

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -1171,11 +1171,11 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
       await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
       contentDraftIdRef.current = "draft_Y"
     })
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 700))
+    // Poll for the debounced write instead of sleeping a fixed margin — a slow
+    // runner firing the 500 ms timer late must not race the assertion.
+    await vi.waitFor(async () => {
+      expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("typed into X"))
     })
-
-    expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("typed into X"))
     expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
     expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
     // The stale save spoke for a superseded row, so it must not repoint the ref.
@@ -1194,11 +1194,9 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
       await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
       contentDraftIdRef.current = "draft_Y"
     })
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 700))
+    await vi.waitFor(async () => {
+      expect(await db.drafts.get("draft_X")).toBeUndefined()
     })
-
-    expect(await db.drafts.get("draft_X")).toBeUndefined()
     expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
     expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
     expect(contentDraftIdRef.current).toBe("draft_Y")
@@ -1238,11 +1236,9 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
       await migrateLocalDraftId(workspaceId, "draft_X", { ...live!, id: "draft_X2", baseVersion: 9 })
       contentDraftIdRef.current = "draft_X2"
     })
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 700))
+    await vi.waitFor(async () => {
+      expect((await db.drafts.get("draft_X2"))?.contentJson).toEqual(makeDoc("typed into X"))
     })
-
-    expect((await db.drafts.get("draft_X2"))?.contentJson).toEqual(makeDoc("typed into X"))
     expect(await db.drafts.get("draft_X")).toBeUndefined()
     // X2 and Y only — a forked third row is the bug this closes.
     expect((await db.drafts.toArray()).map((row) => row.id).sort()).toEqual(["draft_X2", "draft_Y"])
@@ -1364,6 +1360,9 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
       result.current.cancelPendingSave()
     })
     await act(async () => {
+      // A NEGATIVE outcome (the cancelled timer must not fire) has nothing to
+      // poll for; the bounded wait can only weaken with runner slowness, never
+      // false-fail — the assertion below holds whether or not more time passes.
       await new Promise((r) => setTimeout(r, 700))
     })
 

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -1045,3 +1045,374 @@ describe("upsertLoadedDraft — save races the sync engine (in-transaction reval
     expect((await db.drafts.get("draft_x"))?.baseVersion).toBe(7)
   })
 })
+
+describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /** Two drafts on one scope, the pointer parked on X. */
+  async function seedXY() {
+    await db.drafts.put({
+      id: "draft_X",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("X body"),
+      attachments: [],
+      baseVersion: 3,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.drafts.put({
+      id: "draft_Y",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("Y body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_X" })
+    await seedDraftCacheFromIdb(workspaceId)
+  }
+
+  it("writes the expected row (not the pointer's) when the pointer moved off it", async () => {
+    await seedXY()
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+
+    await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("late keystrokes"), attachments: [] },
+      undefined,
+      { expectedDraftId: "draft_X" }
+    )
+
+    expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("late keystrokes"))
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+  })
+
+  it("carries the expected row's baseVersion forward (no split on the next push)", async () => {
+    await seedXY()
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("more"), attachments: [] }, undefined, {
+      expectedDraftId: "draft_X",
+    })
+
+    expect((await db.drafts.get("draft_X"))?.baseVersion).toBe(3)
+  })
+
+  it("creates a fresh row without stealing the pointer when the expected row was deleted", async () => {
+    await seedXY()
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+    await db.drafts.delete("draft_X")
+
+    const created = await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("orphaned keystrokes"), attachments: [] },
+      undefined,
+      { expectedDraftId: "draft_X" }
+    )
+
+    expect(created.id).not.toBe("draft_X")
+    expect(await db.drafts.get("draft_X")).toBeUndefined()
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+  })
+
+  it("claims the pointer on the create fallback when the scope has none", async () => {
+    await seedXY()
+    await db.drafts.delete("draft_X")
+    await db.composerLoaded.delete(draftKey)
+
+    const created = await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("recreated"), attachments: [] },
+      undefined,
+      { expectedDraftId: "draft_X" }
+    )
+
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(created.id)
+  })
+
+  it("clearLoadedDraft deletes the expected row by id and leaves a moved-on pointer alone", async () => {
+    await seedXY()
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+
+    await clearLoadedDraft(workspaceId, draftKey, "draft_X")
+
+    expect(await db.drafts.get("draft_X")).toBeUndefined()
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+  })
+
+  it("a debounced save landing after a repoint writes its own row, not the new pointer's", async () => {
+    await seedXY()
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    act(() => {
+      result.current.saveDraftDebounced(makeDoc("typed into X"))
+    })
+    await act(async () => {
+      await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+      contentDraftIdRef.current = "draft_Y"
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700))
+    })
+
+    expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("typed into X"))
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+    // The stale save spoke for a superseded row, so it must not repoint the ref.
+    expect(contentDraftIdRef.current).toBe("draft_Y")
+  })
+
+  it("an empty debounced save landing after a repoint deletes its own row, not the new pointer's", async () => {
+    await seedXY()
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    act(() => {
+      result.current.saveDraftDebounced(EMPTY_DOC)
+    })
+    await act(async () => {
+      await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_Y")
+      contentDraftIdRef.current = "draft_Y"
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700))
+    })
+
+    expect(await db.drafts.get("draft_X")).toBeUndefined()
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+    expect(contentDraftIdRef.current).toBe("draft_Y")
+  })
+
+  it("does not drag the identity ref back when a flush for a superseded row resolves", async () => {
+    // The composer's repoint branch flushes X's content while the ref still reads
+    // X, then advances the ref to Y. The resolving flush must not pull it back —
+    // the next keystroke would write Y's body into X's row.
+    await seedXY()
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    await act(async () => {
+      const flushed = result.current.saveDraft(makeDoc("X body and typing"), undefined, "draft_X")
+      contentDraftIdRef.current = "draft_Y"
+      await flushed
+    })
+
+    expect(contentDraftIdRef.current).toBe("draft_Y")
+    expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("X body and typing"))
+  })
+
+  it("a debounced save follows an id migration instead of forking the draft", async () => {
+    // A split ack re-keys X → X2 while the debounce is armed with X. The save
+    // must land on X2 (the same draft, new id), not create a third row.
+    await seedXY()
+    const { migrateLocalDraftId } = await import("@/sync/draft-sync")
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    act(() => {
+      result.current.saveDraftDebounced(makeDoc("typed into X"))
+    })
+    await act(async () => {
+      const live = await db.drafts.get("draft_X")
+      await migrateLocalDraftId(workspaceId, "draft_X", { ...live!, id: "draft_X2", baseVersion: 9 })
+      contentDraftIdRef.current = "draft_X2"
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700))
+    })
+
+    expect((await db.drafts.get("draft_X2"))?.contentJson).toEqual(makeDoc("typed into X"))
+    expect(await db.drafts.get("draft_X")).toBeUndefined()
+    // X2 and Y only — a forked third row is the bug this closes.
+    expect((await db.drafts.toArray()).map((row) => row.id).sort()).toEqual(["draft_X2", "draft_Y"])
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_X2")
+  })
+
+  it("seals into the expected row when the pointer moved off it (E2E path)", async () => {
+    await db.drafts.put({
+      id: "draft_X",
+      workspaceId,
+      scope: draftKey,
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_X_old",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      baseVersion: 4,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.drafts.put({
+      id: "draft_Y",
+      workspaceId,
+      scope: draftKey,
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_Y",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_Y" })
+    await seedDraftCacheFromIdb(workspaceId)
+    vi.spyOn(sealDraft, "sealDraftContent").mockResolvedValue({
+      ciphertext: "ct_X_new",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      contentMarkdown: "late sealed keystrokes",
+      attachmentRefs: [],
+    } as unknown as Awaited<ReturnType<typeof sealDraft.sealDraftContent>>)
+
+    await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("late sealed keystrokes"), attachments: [] },
+      { senderId: "user_1", streamId: "stream_e2e_root" },
+      { expectedDraftId: "draft_X" }
+    )
+
+    expect(await db.drafts.get("draft_X")).toMatchObject({ ciphertext: "ct_X_new", baseVersion: 4 })
+    expect((await db.drafts.get("draft_Y"))?.ciphertext).toBe("ct_Y")
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+  })
+
+  it("does not drag the identity ref back when an addAttachment for a superseded row resolves", async () => {
+    // Same shape as the flush case above, through the attachment path: the ref
+    // moves X → Y while the upsert is in flight; the resolving call must not
+    // pull it back onto X.
+    await seedXY()
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    await act(async () => {
+      const added = result.current.addAttachment({
+        id: "attach_1",
+        filename: "a.txt",
+        mimeType: "text/plain",
+        sizeBytes: 10,
+      })
+      contentDraftIdRef.current = "draft_Y"
+      await added
+    })
+
+    expect(contentDraftIdRef.current).toBe("draft_Y")
+    expect((await db.drafts.get("draft_X"))?.attachments.map((a) => a.id)).toEqual(["attach_1"])
+  })
+
+  it("does not drag the identity ref back when a removeAttachment for a superseded row empties it", async () => {
+    await db.drafts.put({
+      id: "draft_X",
+      workspaceId,
+      scope: draftKey,
+      contentJson: EMPTY_DOC,
+      attachments: [{ id: "attach_1", filename: "a.txt", mimeType: "text/plain", sizeBytes: 10 }],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.drafts.put({
+      id: "draft_Y",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("Y body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_Y" })
+    await seedDraftCacheFromIdb(workspaceId)
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    await act(async () => {
+      const removed = result.current.removeAttachment("attach_1")
+      contentDraftIdRef.current = "draft_Y"
+      await removed
+    })
+
+    // X emptied out and went away; the ref still speaks for Y, not null.
+    expect(await db.drafts.get("draft_X")).toBeUndefined()
+    expect(contentDraftIdRef.current).toBe("draft_Y")
+  })
+
+  it("cancelPendingSave drops an armed debounce without persisting it", async () => {
+    await seedXY()
+    const contentDraftIdRef = { current: null as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    act(() => {
+      result.current.saveDraftDebounced(EMPTY_DOC)
+    })
+    act(() => {
+      result.current.cancelPendingSave()
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 700))
+    })
+
+    // The armed empty save was pointer-addressed (null identity): had it fired it
+    // would have cleared the scope's loaded row.
+    expect((await db.drafts.get("draft_X"))?.contentJson).toEqual(makeDoc("X body"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_X")
+  })
+
+  it("saveDraft reports null when the E2E gate refused to persist", async () => {
+    // Locked session on an encrypted scope: nothing reaches disk, so the caller
+    // must not blank the editor.
+    await seedDraftCacheFromIdb(workspaceId)
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, "stream_e2e_root"))
+
+    let saved: unknown = "unset"
+    await act(async () => {
+      saved = await result.current.saveDraft(makeDoc("typed while locked"))
+    })
+
+    expect(saved).toBeNull()
+    expect(await db.drafts.toArray()).toEqual([])
+  })
+
+  it("saveDraft reports the persisted row on a plaintext save", async () => {
+    await seedXY()
+    const contentDraftIdRef = { current: "draft_X" as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    const saved: unknown[] = []
+    await act(async () => {
+      saved.push(await result.current.saveDraft(makeDoc("more X")))
+    })
+
+    expect(saved[0]).toMatchObject({ id: "draft_X", contentJson: makeDoc("more X") })
+  })
+
+  it("records the created id on the create path (empty scope, no identity yet)", async () => {
+    await seedDraftCacheFromIdb(workspaceId)
+    const contentDraftIdRef = { current: null as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    await act(async () => {
+      await result.current.saveDraft(makeDoc("first words"))
+    })
+
+    const pointerId = (await db.composerLoaded.get(draftKey))?.draftId
+    expect(pointerId).toBeDefined()
+    expect(contentDraftIdRef.current).toBe(pointerId)
+    expect((await db.drafts.get(pointerId!))?.contentJson).toEqual(makeDoc("first words"))
+  })
+})

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -12,7 +12,12 @@ import {
 } from "@/stores/draft-store"
 import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
 import { clearStagedDraft, readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
-import { getScopeResolveSeq, markDraftResolved, recordScopeResolved } from "@/sync/draft-resolution-guard"
+import {
+  getScopeResolveSeq,
+  markDraftResolved,
+  recordScopeResolved,
+  resolveMigratedDraftId,
+} from "@/sync/draft-resolution-guard"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
 import { serializeToMarkdown } from "@threa/prosemirror"
@@ -90,14 +95,27 @@ export async function upsertLoadedDraft(
   scope: string,
   fields: DraftFields,
   seal?: DraftSealContext,
-  /**
-   * The scope's resolve sequence observed when this save began. Passed only by
-   * the debounced typing save: if a resolve-on-send advanced the sequence while
-   * the save was in flight, creating a draft here would resurrect the just-sent
-   * content into the composer, so the create is dropped. Other create paths pass
-   * nothing and are never affected.
-   */
-  opts?: { observedResolveSeq?: number }
+  opts?: {
+    /**
+     * The scope's resolve sequence observed when this save began. Passed only by
+     * the debounced typing save: if a resolve-on-send advanced the sequence while
+     * the save was in flight, creating a draft here would resurrect the just-sent
+     * content into the composer, so the create is dropped. Other create paths pass
+     * nothing and are never affected.
+     */
+    observedResolveSeq?: number
+    /**
+     * The draft row this content belongs to — the id the composer's live content
+     * hydrated from (or was created as). When set, the save is addressed by ROW
+     * identity, not by the scope's `composerLoaded` pointer: a save landing after
+     * the pointer was repointed at another draft still writes its own row instead
+     * of overwriting the newly-pointed one. The pointer is never written in this
+     * branch (a stashed row taking late keystrokes stays stashed). When the row
+     * has been deleted underneath, the save falls back to the create path and
+     * claims the pointer only if the scope has none.
+     */
+    expectedDraftId?: string | null
+  }
 ): Promise<CachedDraft> {
   // The save's target identity is re-validated INSIDE the write transaction:
   // a split ack can migrate the loaded draft's id (and a push ack can advance
@@ -108,9 +126,24 @@ export async function upsertLoadedDraft(
   // still conflicts is dropped — the content stands in the editor (and, for
   // plaintext scopes, the staging buffer) until the next keystroke re-saves.
   let row!: CachedDraft
+  const expectedId = opts?.expectedDraftId ?? null
   for (let attempt = 0; attempt < 3; attempt++) {
-    const loadedId = await getLoadedDraftId(scope)
-    const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+    // Identity-addressed when the caller named a row; pointer-addressed otherwise.
+    let loadedId = expectedId ?? (await getLoadedDraftId(scope))
+    let existing = loadedId ? await db.drafts.get(loadedId) : undefined
+    if (expectedId && !existing) {
+      // The expected row may have been RE-KEYED rather than deleted (a split ack
+      // or a remote-delete preserve runs `migrateLocalDraftId`). Follow the
+      // migration before concluding the row is gone: creating a fresh row here
+      // would fork the draft the user is still typing into. Only a genuinely
+      // unmigrated missing row falls through to the create path below.
+      const migratedId = resolveMigratedDraftId(expectedId)
+      const migratedRow = migratedId === expectedId ? undefined : await db.drafts.get(migratedId)
+      if (migratedRow) {
+        loadedId = migratedId
+        existing = migratedRow
+      }
+    }
     // The draft id binds the seal AAD (in the message-id slot), so resolve it
     // before sealing — a re-seal of the same draft reuses the id.
     const id = existing?.id ?? generateLocalDraftId()
@@ -178,10 +211,13 @@ export async function upsertLoadedDraft(
     // sent message into the composer. `recordScopeResolved` runs before the
     // resolve clears the pointer, so by the time the cleared pointer routes a
     // stale save into the create branch the bumped seq is visible.
+    let wrotePointer = false
     const outcome = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
       if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return "dropped"
       const livePointer = (await db.composerLoaded.get(scope))?.draftId ?? null
-      if (livePointer !== loadedId) return "conflict"
+      // Pointer-addressed saves revalidate the pointer; identity-addressed ones
+      // revalidate the ROW below, so a repoint can't route them onto another draft.
+      if (!expectedId && livePointer !== loadedId) return "conflict"
       if (existing) {
         const liveRow = await db.drafts.get(id)
         if (!liveRow) return "conflict"
@@ -194,7 +230,13 @@ export async function upsertLoadedDraft(
         await db.drafts.put(row)
       } else {
         await db.drafts.put(row)
-        await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+        // Claim the pointer only when the scope has none. An identity-addressed
+        // save whose row was deleted underneath lands here; stealing a pointer
+        // that now references another draft would detach that draft instead.
+        if (livePointer === null) {
+          await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+          wrotePointer = true
+        }
       }
       // Mirror to the backend: a coalesced push that retries silently. The
       // caller kicks the queue so it drains promptly.
@@ -204,10 +246,10 @@ export async function upsertLoadedDraft(
 
     if (outcome === "conflict") continue
     if (outcome === "dropped") return row
-    if (existing) {
-      upsertDraftInCache(workspaceId, row)
-    } else {
+    if (wrotePointer) {
       upsertLoadedDraftInCache(workspaceId, row, scope)
+    } else {
+      upsertDraftInCache(workspaceId, row)
     }
 
     if (seal) {
@@ -272,13 +314,57 @@ async function removeLoadedDraftLocally(
  * The backend mirror is an UNCONDITIONAL delete — the user threw it away, so
  * drift doesn't matter.
  */
-export async function clearLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+export async function clearLoadedDraft(
+  workspaceId: string,
+  scope: string,
+  /**
+   * The row the caller means to discard (see `upsertLoadedDraft`'s
+   * `expectedDraftId`). When the scope's pointer has since moved off it — an
+   * empty debounced save landing after a repoint — the row is deleted BY ID and
+   * the pointer (and the staging buffer, which now belongs to the new draft) is
+   * left alone. Omitted by the discard/send paths, which mean "whatever is loaded".
+   */
+  expectedDraftId?: string | null
+): Promise<void> {
+  if (expectedDraftId) {
+    // Follow a re-key (`migrateLocalDraftId`) so an empty save for the pre-split
+    // id clears the row that id became, not nothing at all.
+    const targetId = (await db.drafts.get(expectedDraftId)) ? expectedDraftId : resolveMigratedDraftId(expectedDraftId)
+    const pointer = (await db.composerLoaded.get(scope))?.draftId ?? null
+    if (pointer !== targetId) {
+      await removeDraftRowById(workspaceId, targetId, (id, baseVersion) =>
+        syncDraftRemoval(workspaceId, id, baseVersion)
+      )
+      return
+    }
+  }
   // Drop the staging buffer first (synchronous) so a racing flush or a reload
   // can't recover the discarded content back into the composer.
   clearStagedDraft(workspaceId, scope)
   await removeLoadedDraftLocally(workspaceId, scope, (loadedId, baseVersion) =>
     syncDraftRemoval(workspaceId, loadedId, baseVersion)
   )
+}
+
+/**
+ * Delete draft row `draftId` and mirror the removal, leaving every scope pointer
+ * untouched. The identity-addressed counterpart of `removeLoadedDraftLocally`:
+ * used when an empty save arrives for a row the scope no longer points at. Same
+ * one-transaction shape (read version, delete, enqueue) for the same reasons.
+ */
+async function removeDraftRowById(
+  workspaceId: string,
+  draftId: string,
+  mirror: (draftId: string, baseVersion: number | undefined) => Promise<void>
+): Promise<void> {
+  const removed = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+    const row = await db.drafts.get(draftId)
+    if (!row) return false
+    await db.drafts.delete(draftId)
+    await mirror(draftId, row.baseVersion)
+    return true
+  })
+  if (removed) deleteDraftFromCache(workspaceId, draftId)
 }
 
 /**
@@ -499,9 +585,24 @@ export async function relocateLoadedDraft(
  *   waits on disk. Attachments roam sealed inside the body's ciphertext (Stage 4d);
  *   context refs on E2E drafts stay session-local (deferred).
  */
-export function useDraftMessage(workspaceId: string, draftKey: string, e2eStreamId?: string | null) {
+export function useDraftMessage(
+  workspaceId: string,
+  draftKey: string,
+  e2eStreamId?: string | null,
+  /**
+   * Owned by the composer: the id of the draft row the live editor content
+   * hydrated from (or was created as). Every save path here addresses THAT row
+   * rather than re-reading the scope's pointer, so a pointer repointed between
+   * hydration and a debounced save can't route the write onto another draft.
+   * `null` means "no identity yet" and keeps the historical pointer-addressed
+   * behaviour (a fresh composer that has not yet read a draft).
+   */
+  contentDraftIdRef?: { current: string | null }
+) {
   const e2eEnabled = !!e2eStreamId
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const fallbackContentDraftIdRef = useRef<string | null>(null)
+  const contentDraftId = contentDraftIdRef ?? fallbackContentDraftIdRef
 
   // Seal needs the viewer's workspace user id and unlocked UIK. Read here (not
   // threaded from the call site) so the composer reacts when the session unlocks
@@ -548,12 +649,38 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     void purgePlaintextScopeDrafts(workspaceId, draftKey)
   }, [e2eEnabled, draftKey, workspaceId])
 
+  /**
+   * Persist the composer content for this scope.
+   *
+   * Returns the row that was written, or `null` when nothing was persisted:
+   * the E2E gate refused (locked / no sender / no stream), the seal threw, the
+   * save was a deletion (empty content and no attachments), or a resolve-on-send
+   * advanced the scope's sequence and the create was dropped. Callers that
+   * discard the editor after a save MUST branch on this: on `null` the content
+   * exists only on screen, so blanking it loses it.
+   */
   const saveDraft = useCallback(
-    async (contentJson: JSONContent, attachments?: DraftAttachment[]) => {
+    async (
+      contentJson: JSONContent,
+      attachments?: DraftAttachment[],
+      expectedDraftId?: string | null
+    ): Promise<CachedDraft | null> => {
       // Clear any pending debounced save
       if (debounceRef.current) {
         clearTimeout(debounceRef.current)
         debounceRef.current = null
+      }
+
+      // The row this content belongs to. An explicit argument (the debounced
+      // save's arm-time capture, or a repoint flush) wins over the live ref,
+      // which may already have moved on to another draft.
+      const targetId = expectedDraftId ?? contentDraftId.current
+      // Whether this save still speaks for the composer's current content is
+      // decided at ASSIGNMENT time, never captured here: the ref can move on
+      // (a repoint) during the awaits below, and a stale capture would drag it
+      // back to the superseded row.
+      const advanceIdentity = (next: string | null) => {
+        if (contentDraftId.current === targetId) contentDraftId.current = next
       }
 
       // The scope's resolve sequence as this save begins. If a resolve-on-send
@@ -565,62 +692,68 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       if (gate.enabled) {
         // E2EE-4: seal before disk, and only while unlocked. Locked → keep the
         // content in the composer for the session; nothing persists.
-        if (!gate.unlocked || !gate.senderId || !gate.streamId) return
+        if (!gate.unlocked || !gate.senderId || !gate.streamId) return null
         // Resolve the attachment set: an explicit arg, else the draft's current
         // (decrypted) attachments — a content-only save (a keystroke) must
         // preserve them, exactly as the plaintext path preserves them below. The
         // sealed row holds no plaintext attachments at rest, so they're read back
         // from the in-memory decrypt cache (the plaintext authority).
-        const currentLoadedId = await getLoadedDraftId(draftKey)
+        const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
         const finalAttachments = attachments ?? (currentLoadedId ? cachedDraftAttachments(currentLoadedId) : [])
         if (isEmptyContent(contentJson) && finalAttachments.length === 0) {
-          await clearLoadedDraft(workspaceId, draftKey)
+          await clearLoadedDraft(workspaceId, draftKey, targetId)
+          advanceIdentity(null)
           syncEngine?.kickOperationQueue()
-          return
+          return null
         }
         try {
-          await upsertLoadedDraft(
+          const saved = await upsertLoadedDraft(
             workspaceId,
             draftKey,
             { contentJson, attachments: finalAttachments },
             { senderId: gate.senderId, streamId: gate.streamId },
-            { observedResolveSeq }
+            { observedResolveSeq, expectedDraftId: targetId }
           )
+          advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
+          return isStaleObservedResolve(draftKey, observedResolveSeq) ? null : saved
         } catch (err) {
           // A failed seal (e.g. the session locked between the gate check and the
           // seal) must never interrupt the user — the content stands in the composer.
           console.error("Failed to seal draft; kept in composer", err)
         }
-        return
+        return null
       }
 
       // Get current attachments + contextRefs if not provided. The contextRefs
       // sidecar must survive a content-only save (e.g. user typing into a
       // bag-attached scratchpad) — without this preservation the chip would
       // vanish from the composer the moment the first keystroke fires.
-      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const finalAttachments = attachments ?? currentDraft?.attachments ?? []
       const finalContextRefs = currentDraft?.contextRefs ?? []
 
       // Delete draft only when content + attachments + contextRefs are all empty.
       if (isEmptyContent(contentJson) && finalAttachments.length === 0 && finalContextRefs.length === 0) {
-        await clearLoadedDraft(workspaceId, draftKey)
+        await clearLoadedDraft(workspaceId, draftKey, targetId)
+        advanceIdentity(null)
         syncEngine?.kickOperationQueue()
-        return
+        return null
       }
 
-      await upsertLoadedDraft(
+      const saved = await upsertLoadedDraft(
         workspaceId,
         draftKey,
         { contentJson, attachments: finalAttachments, contextRefs: finalContextRefs },
         undefined,
-        { observedResolveSeq }
+        { observedResolveSeq, expectedDraftId: targetId }
       )
+      advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()
+      return isStaleObservedResolve(draftKey, observedResolveSeq) ? null : saved
     },
-    [draftKey, workspaceId, syncEngine]
+    [draftKey, workspaceId, syncEngine, contentDraftId]
   )
 
   const saveDraftDebounced = useCallback(
@@ -639,15 +772,19 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       // encrypted never stages a plaintext keystroke. (The seal at timer-fire still
       // reads the ref, the right source for that deferred point.)
       if (!e2eEnabled) stageDraftContent(workspaceId, draftKey, contentJson)
+      // Capture the target row at ARM time, not at fire time: the keystrokes in
+      // `contentJson` belong to the draft loaded now, and the scope's pointer (and
+      // with it the composer's identity) may be repointed before the timer fires.
+      const expectedDraftId = contentDraftId.current
       // `saveDraft` reads the live E2E gate when the timer fires, so a value typed
       // while the stream was plaintext is sealed (or dropped) — never written as
       // plaintext — if the stream became encrypted in the meantime (E2EE-4).
       debounceRef.current = setTimeout(() => {
         debounceRef.current = null
-        void saveDraft(contentJson)
+        void saveDraft(contentJson, undefined, expectedDraftId)
       }, DEBOUNCE_MS)
     },
-    [saveDraft, workspaceId, draftKey, e2eEnabled]
+    [saveDraft, workspaceId, draftKey, e2eEnabled, contentDraftId]
   )
 
   /**
@@ -655,6 +792,16 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
    */
   const addAttachment = useCallback(
     async (attachment: DraftAttachment) => {
+      // The row this attachment operation belongs to, captured ONCE: the ref can
+      // move on (a repoint) across the awaits below, and reading it twice would
+      // source the content from one draft and address the write to another.
+      const targetId = contentDraftId.current
+      // Same assignment-time recheck `saveDraft` uses: the ref may have been
+      // repointed during the awaits below, and writing the captured target back
+      // would drag the composer's identity onto the superseded row.
+      const advanceIdentity = (next: string | null) => {
+        if (contentDraftId.current === targetId) contentDraftId.current = next
+      }
       if (e2eEnabled) {
         // E2EE-4: re-seal the draft with the added attachment. The body + current
         // attachments are the decrypted copy in memory (the row holds only
@@ -663,24 +810,26 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
         // attachment stays in the composer session, like a typed body would.
         const gate = e2eGateRef.current
         if (!gate.unlocked || !gate.senderId || !gate.streamId) return
-        const sealedLoadedId = await getLoadedDraftId(draftKey)
+        const sealedLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
         const currentSealed = sealedLoadedId ? cachedDraftAttachments(sealedLoadedId) : []
         if (currentSealed.some((a) => a.id === attachment.id)) return
         const body = (sealedLoadedId ? cachedDraftBody(sealedLoadedId) : null) ?? EMPTY_DOC
         try {
-          await upsertLoadedDraft(
+          const saved = await upsertLoadedDraft(
             workspaceId,
             draftKey,
             { contentJson: body, attachments: [...currentSealed, attachment] },
-            { senderId: gate.senderId, streamId: gate.streamId }
+            { senderId: gate.senderId, streamId: gate.streamId },
+            { expectedDraftId: targetId }
           )
+          advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
         } catch (err) {
           console.error("Failed to seal draft attachment; kept in composer", err)
         }
         return
       }
-      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const currentAttachments = currentDraft?.attachments ?? []
 
@@ -689,15 +838,22 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
         return
       }
 
-      await upsertLoadedDraft(workspaceId, draftKey, {
-        contentJson: currentDraft?.contentJson ?? EMPTY_DOC,
-        attachments: [...currentAttachments, attachment],
-        // Preserve sidecar so a paste/upload doesn't wipe an attached chip.
-        contextRefs: currentDraft?.contextRefs,
-      })
+      const saved = await upsertLoadedDraft(
+        workspaceId,
+        draftKey,
+        {
+          contentJson: currentDraft?.contentJson ?? EMPTY_DOC,
+          attachments: [...currentAttachments, attachment],
+          // Preserve sidecar so a paste/upload doesn't wipe an attached chip.
+          contextRefs: currentDraft?.contextRefs,
+        },
+        undefined,
+        { expectedDraftId: targetId }
+      )
+      advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()
     },
-    [draftKey, workspaceId, e2eEnabled, syncEngine]
+    [draftKey, workspaceId, e2eEnabled, syncEngine, contentDraftId]
   )
 
   /**
@@ -706,35 +862,46 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
    */
   const removeAttachment = useCallback(
     async (attachmentId: string) => {
+      // The row this attachment operation belongs to, captured ONCE: the ref can
+      // move on (a repoint) across the awaits below, and reading it twice would
+      // source the content from one draft and address the write to another.
+      const targetId = contentDraftId.current
+      // Assignment-time recheck, as in `addAttachment`/`saveDraft`.
+      const advanceIdentity = (next: string | null) => {
+        if (contentDraftId.current === targetId) contentDraftId.current = next
+      }
       if (e2eEnabled) {
         // E2EE-4: re-seal without the removed attachment (or clear when the draft
         // is left empty). Reads body + attachments from the in-memory decrypt
         // cache for the same reason `addAttachment` does. Locked → no-op.
         const gate = e2eGateRef.current
         if (!gate.unlocked || !gate.senderId || !gate.streamId) return
-        const sealedLoadedId = await getLoadedDraftId(draftKey)
+        const sealedLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
         if (!sealedLoadedId) return
         const remaining = cachedDraftAttachments(sealedLoadedId).filter((a) => a.id !== attachmentId)
         const body = cachedDraftBody(sealedLoadedId) ?? EMPTY_DOC
         if (isEmptyContent(body) && remaining.length === 0) {
-          await clearLoadedDraft(workspaceId, draftKey)
+          await clearLoadedDraft(workspaceId, draftKey, targetId)
+          advanceIdentity(null)
           syncEngine?.kickOperationQueue()
           return
         }
         try {
-          await upsertLoadedDraft(
+          const saved = await upsertLoadedDraft(
             workspaceId,
             draftKey,
             { contentJson: body, attachments: remaining },
-            { senderId: gate.senderId, streamId: gate.streamId }
+            { senderId: gate.senderId, streamId: gate.streamId },
+            { expectedDraftId: targetId }
           )
+          advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
         } catch (err) {
           console.error("Failed to re-seal draft after attachment removal; kept in composer", err)
         }
         return
       }
-      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       if (!currentDraft) return
 
@@ -742,20 +909,42 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
 
       // Delete draft if both content and attachments are empty
       if (isEmptyContent(currentDraft.contentJson) && remainingAttachments.length === 0) {
-        await clearLoadedDraft(workspaceId, draftKey)
+        await clearLoadedDraft(workspaceId, draftKey, targetId)
+        advanceIdentity(null)
         syncEngine?.kickOperationQueue()
         return
       }
 
-      await upsertLoadedDraft(workspaceId, draftKey, {
-        contentJson: currentDraft.contentJson,
-        attachments: remainingAttachments,
-        contextRefs: currentDraft.contextRefs,
-      })
+      const saved = await upsertLoadedDraft(
+        workspaceId,
+        draftKey,
+        {
+          contentJson: currentDraft.contentJson,
+          attachments: remainingAttachments,
+          contextRefs: currentDraft.contextRefs,
+        },
+        undefined,
+        { expectedDraftId: targetId }
+      )
+      advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()
     },
-    [draftKey, workspaceId, e2eEnabled, syncEngine]
+    [draftKey, workspaceId, e2eEnabled, syncEngine, contentDraftId]
   )
+
+  /**
+   * Drop an armed debounced save WITHOUT persisting it. For the case where the
+   * pending keystrokes are known to be moot (the editor is empty and about to be
+   * re-hydrated from an arriving draft): letting the timer fire would run a
+   * pointer-addressed save with a stale expected id and delete or overwrite the
+   * draft that just arrived. `saveDraft` is not a substitute — it persists.
+   */
+  const cancelPendingSave = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+  }, [])
 
   const clearDraft = useCallback(async () => {
     // Clear any pending debounced save
@@ -765,8 +954,9 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     }
 
     await clearLoadedDraft(workspaceId, draftKey)
+    contentDraftId.current = null
     syncEngine?.kickOperationQueue()
-  }, [draftKey, workspaceId, syncEngine])
+  }, [draftKey, workspaceId, syncEngine, contentDraftId])
 
   /**
    * Clear the loaded draft because its message was sent (resolve-on-send). Same
@@ -782,8 +972,9 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     }
 
     await resolveLoadedDraft(workspaceId, draftKey)
+    contentDraftId.current = null
     syncEngine?.kickOperationQueue()
-  }, [draftKey, workspaceId, syncEngine])
+  }, [draftKey, workspaceId, syncEngine, contentDraftId])
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -822,6 +1013,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     contextRefs: (resolvedDraft?.contextRefs ?? []) as DraftContextRef[],
     saveDraft,
     saveDraftDebounced,
+    cancelPendingSave,
     addAttachment,
     removeAttachment,
     clearDraft,

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -534,44 +534,42 @@ export async function rescopeScopeDrafts(workspaceId: string, fromScope: string,
 }
 
 /**
- * Move the loaded draft's content out of `fromScope` into a FRESH loaded draft
- * under `toScope`, deleting the source draft. The race-proof alternative to
- * `rescopeScopeDrafts` for a scope a LIVE editor is leaving: an in-flight push
- * snapshotted before a row-move can land after it and reinstate the old scope
- * server-side (last write wins) — no enqueue-layer ordering can prevent that.
- * Deleting the source instead rides the delete machinery's tombstone
- * (`supersededWriteIds`), which is designed to suppress exactly those late
- * pushes; the target row is brand-new, so it has no version history to fight.
+ * Move the loaded draft from `fromScope` to `toScope` without changing its id or
+ * payload. The composer flushes first, then this changes only filing metadata.
+ * An existing loaded draft at the destination is displaced into that scope's
+ * pile rather than overwritten.
  *
- * `liveContent` is the editor's current document (keystrokes may not have
- * flushed); it wins over the persisted body. An existing loaded draft under
- * `toScope` is stashed first, never clobbered (cardinal no-loss rule). Stash
- * siblings under `fromScope` stay put — they were deliberately stashed against
- * that target. No-op (source still cleared) when there is nothing to move.
+ * Scope move + pointer move + forced sync op commit atomically. The forced op
+ * carries any in-flight write lineage, so an old-scope push is followed by an
+ * idempotent push of the new scope.
  */
 export async function relocateLoadedDraft(
   workspaceId: string,
   fromScope: string,
   toScope: string,
-  liveContent?: JSONContent
-): Promise<void> {
-  // Bump the source scope's resolve sequence BEFORE the teardown (mirroring
-  // `resolveLoadedDraft`): a debounced typing save already in flight captured
-  // the pre-bump sequence, so `isStaleObservedResolve` drops its create instead
-  // of letting it resurrect the scope we're vacating. The caller must separately
-  // clear any ARMED-but-unfired debounce (its save would capture the post-bump
-  // sequence) — flushing the composer before calling this does that.
-  recordScopeResolved(fromScope)
-  const loadedId = (await db.composerLoaded.get(fromScope))?.draftId ?? null
-  const row = loadedId ? await db.drafts.get(loadedId) : null
-  const contentJson = liveContent && !isEmptyContent(liveContent) ? liveContent : (row?.contentJson ?? EMPTY_DOC)
-  const attachments = row?.attachments ?? []
+  opts?: { targetHost?: string }
+): Promise<CachedDraft | null> {
+  let moved: CachedDraft | null = null
+  await db.transaction("rw", db.drafts, db.composerLoaded, db.composerTarget, db.pendingOperations, async () => {
+    const loadedId = (await db.composerLoaded.get(fromScope))?.draftId ?? null
+    const live = loadedId ? await db.drafts.get(loadedId) : null
+    if (live && live.scope === fromScope) {
+      moved = { ...live, scope: toScope }
+      await migrateLocalDraftScope(workspaceId, fromScope, moved)
+      await enqueueDraftUpsert(workspaceId, live.id, { forceNewOp: true })
+    }
+    if (opts?.targetHost) {
+      if (toScope === opts.targetHost) await db.composerTarget.delete(opts.targetHost)
+      else await db.composerTarget.put({ host: opts.targetHost, workspaceId, scope: toScope })
+    }
+  })
 
-  if (!isEmptyContent(contentJson) || attachments.length > 0) {
-    await stashLoadedDraft(workspaceId, toScope)
-    await upsertLoadedDraft(workspaceId, toScope, { contentJson, attachments })
+  const staged = readStagedDraft(workspaceId, fromScope)
+  if (staged) {
+    stageDraftContent(workspaceId, toScope, staged.contentJson)
+    clearStagedDraft(workspaceId, fromScope)
   }
-  await clearLoadedDraft(workspaceId, fromScope)
+  return moved
 }
 
 /**
@@ -663,7 +661,8 @@ export function useDraftMessage(
     async (
       contentJson: JSONContent,
       attachments?: DraftAttachment[],
-      expectedDraftId?: string | null
+      expectedDraftId?: string | null,
+      options?: { keepEmpty?: boolean }
     ): Promise<CachedDraft | null> => {
       // Clear any pending debounced save
       if (debounceRef.current) {
@@ -675,6 +674,9 @@ export function useDraftMessage(
       // save's arm-time capture, or a repoint flush) wins over the live ref,
       // which may already have moved on to another draft.
       const targetId = expectedDraftId ?? contentDraftId.current
+      // Filing can preserve an existing row after the user deliberately cleared
+      // it, but must never mint an empty draft before this editor owns an id.
+      if (options?.keepEmpty && targetId === null) return null
       // Whether this save still speaks for the composer's current content is
       // decided at ASSIGNMENT time, never captured here: the ref can move on
       // (a repoint) during the awaits below, and a stale capture would drag it
@@ -700,7 +702,7 @@ export function useDraftMessage(
         // from the in-memory decrypt cache (the plaintext authority).
         const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
         const finalAttachments = attachments ?? (currentLoadedId ? cachedDraftAttachments(currentLoadedId) : [])
-        if (isEmptyContent(contentJson) && finalAttachments.length === 0) {
+        if (!options?.keepEmpty && isEmptyContent(contentJson) && finalAttachments.length === 0) {
           await clearLoadedDraft(workspaceId, draftKey, targetId)
           advanceIdentity(null)
           syncEngine?.kickOperationQueue()
@@ -735,7 +737,12 @@ export function useDraftMessage(
       const finalContextRefs = currentDraft?.contextRefs ?? []
 
       // Delete draft only when content + attachments + contextRefs are all empty.
-      if (isEmptyContent(contentJson) && finalAttachments.length === 0 && finalContextRefs.length === 0) {
+      if (
+        !options?.keepEmpty &&
+        isEmptyContent(contentJson) &&
+        finalAttachments.length === 0 &&
+        finalContextRefs.length === 0
+      ) {
         await clearLoadedDraft(workspaceId, draftKey, targetId)
         advanceIdentity(null)
         syncEngine?.kickOperationQueue()
@@ -989,6 +996,9 @@ export function useDraftMessage(
   // content, or the empty placeholder while locked/decrypting/failed/absent (the
   // shared core returns null contentJson for those states).
   const contentJson = decryptedContent.contentJson ?? EMPTY_DOC
+  const contentDraftScope = contentDraftId.current
+    ? (drafts.find((draft) => draft.id === contentDraftId.current)?.scope ?? null)
+    : null
 
   return {
     /** True once Dexie has loaded and (for an E2E draft) the read has settled (not mid-decrypt). */
@@ -1004,6 +1014,8 @@ export function useDraftMessage(
      * clear the editor so a gone draft doesn't linger.
      */
     loadedDraftId: loadedId,
+    /** Current scope of the row whose payload the live editor owns, even while its pointer is moving. */
+    contentDraftScope,
     contentJson,
     // Attachments come from the shared read path: a plaintext draft's own
     // `attachments`, or — for a sealed draft — the metadata recovered from the

--- a/apps/frontend/src/hooks/use-external-thread-draft-promotion.test.ts
+++ b/apps/frontend/src/hooks/use-external-thread-draft-promotion.test.ts
@@ -16,7 +16,7 @@ describe("useExternalThreadDraftPromotion", () => {
     setIsSending.mockReset()
     onPromoted.mockReset()
     kickOperationQueue.mockReset()
-    vi.spyOn(draftMessageModule, "relocateLoadedDraft").mockResolvedValue(undefined)
+    vi.spyOn(draftMessageModule, "relocateLoadedDraft").mockResolvedValue(null)
     vi.spyOn(draftMessageModule, "rescopeScopeDrafts").mockResolvedValue(undefined)
     vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue({
       kickOperationQueue,

--- a/apps/frontend/src/hooks/use-external-thread-draft-promotion.ts
+++ b/apps/frontend/src/hooks/use-external-thread-draft-promotion.ts
@@ -8,15 +8,15 @@ interface ExternalThreadDraftPromotionOptions {
   isDraft: boolean
   anchorId: string | null | undefined
   externalThreadId: string | null | undefined
-  flushDraft: () => Promise<void>
+  flushDraft: (options?: { keepEmpty?: boolean }) => Promise<void>
   setIsSending: (sending: boolean) => void
   onPromoted: (threadId: string) => void
 }
 
 /**
  * Preserve a live draft when another actor materializes its thread first.
- * The loaded row uses the tombstone-safe relocation path; stash siblings can
- * then move normally once no live editor write can resurrect the old scope.
+ * The loaded row keeps its identity while its scope and pointer move; stash
+ * siblings then follow through the same lineage-safe scope update.
  */
 export function useExternalThreadDraftPromotion({
   workspaceId,
@@ -38,7 +38,7 @@ export function useExternalThreadDraftPromotion({
     void (async () => {
       try {
         // Flush also cancels the composer's armed debounce before relocation.
-        await flushDraft()
+        await flushDraft({ keepEmpty: true })
         const fromScope = draftThreadScope(anchorId)
         const toScope = draftStreamScope(externalThreadId)
         await relocateLoadedDraft(workspaceId, fromScope, toScope)

--- a/apps/frontend/src/sync/draft-resolution-guard.ts
+++ b/apps/frontend/src/sync/draft-resolution-guard.ts
@@ -51,7 +51,7 @@ export function markDraftResolved(draftId: string, version: number): void {
  * True when THIS device resolved-on-send the draft that just disappeared. The
  * discriminator a composer needs when its loaded pointer goes null: only a local
  * send marks an id here, so a null that is a remote `draft:deleted` or a
- * deliberate teardown (discard, stash, relocate, purge) reads false and must not
+ * deliberate teardown (discard, stash, purge) reads false and must not
  * be treated as "another editor sent the row out from under me".
  */
 export function wasDraftResolvedLocally(draftId: string): boolean {

--- a/apps/frontend/src/sync/draft-resolution-guard.ts
+++ b/apps/frontend/src/sync/draft-resolution-guard.ts
@@ -79,8 +79,42 @@ export function isResolvedDraftEcho(draftId: string, version: number): boolean {
   return version <= rec.version
 }
 
+/**
+ * 3. **Id migration — a device-local forwarding map.** A draft can be re-keyed
+ *    underneath a live composer (`migrateLocalDraftId`: a server split ack, a
+ *    remote-delete preserve). Anything holding the OLD id — an armed debounced
+ *    save, an in-flight identity-addressed write — must land on the new row, not
+ *    create an orphan copy of it. The migration is recorded synchronously so a
+ *    save that captured the pre-migration id can follow it forward. Chains are
+ *    followed (X → X′ → X″); the map is device-local and unbounded only in the
+ *    number of migrations a session performs.
+ */
+const migratedDraftIds = new Map<string, string>()
+
+/** Record that draft `oldId` was re-keyed to `newId`. */
+export function markDraftMigrated(oldId: string, newId: string): void {
+  if (oldId === newId) return
+  migratedDraftIds.set(oldId, newId)
+}
+
+/**
+ * Follow a draft id through any migrations recorded for it, returning the id the
+ * row lives under now (the input itself when it never migrated). A cycle would
+ * be a bug, so the walk is bounded by the map size rather than trusting it.
+ */
+export function resolveMigratedDraftId(draftId: string): string {
+  let current = draftId
+  for (let hops = 0; hops <= migratedDraftIds.size; hops++) {
+    const next = migratedDraftIds.get(current)
+    if (next === undefined) return current
+    current = next
+  }
+  return current
+}
+
 /** Test-only reset of the in-memory guards between cases. */
 export function resetDraftResolutionGuard(): void {
   scopeResolveSeq.clear()
   draftResolvedVersion.clear()
+  migratedDraftIds.clear()
 }

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -22,7 +22,7 @@ import {
 } from "@threa/types"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { clearStagedDraft, listStagedDrafts, type StagedDraft } from "@/lib/drafts/draft-staging"
-import { isResolvedDraftEcho } from "./draft-resolution-guard"
+import { isResolvedDraftEcho, markDraftMigrated } from "./draft-resolution-guard"
 
 /**
  * Stage 3 draft sync — wires the local-first draft store (Stage 2) to the
@@ -212,6 +212,10 @@ export async function migrateLocalDraftScope(
  * `baseVersion`) come from `toRow`; content is whatever is live at commit time.
  */
 export async function migrateLocalDraftId(workspaceId: string, fromId: string, toRow: CachedDraft): Promise<void> {
+  // Recorded BEFORE the transaction so anything already holding `fromId` — an
+  // armed debounced save, an in-flight identity-addressed write — follows the row
+  // forward instead of re-creating it as an orphan under the retired id.
+  markDraftMigrated(fromId, toRow.id)
   let repointedScope: string | null = null
   let finalRow: CachedDraft = toRow
   await db.transaction("rw", db.drafts, db.composerLoaded, async () => {


### PR DESCRIPTION
## Problem

Draft saves are pointer-addressed: `upsertLoadedDraft` resolves "which row do I write" by reading
`db.composerLoaded.get(scope)` at save time, and `useDraftComposer` only reacts to its pointer going *null*,
never to it changing value. Repoint a scope's pointer between hydration and a debounced save and the old
editor's body is written into the newly-pointed draft. This is the substrate flaw behind the v1 restore
refusals (`checked-out`, `target-busy`) that staging rejected — the guards existed because the write path
couldn't tolerate a take-over. Chunk 1 of the v2 repair plan (https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-v2-13fec2/).

## Solution

The composer records which draft id its content hydrated from (`contentDraftIdRef`); every save path addresses
that row, and the pointer's only write-path job left is the create case.

- `upsertLoadedDraft` gains `opts.expectedDraftId`: the txn revalidates the ROW, not the pointer; no pointer
  write on the update branch (a stashed row taking late keystrokes stays stashed); create claims the pointer
  only when the scope has none. `baseVersion` carry-forward and the resolve-seq guard are unchanged.
- Debounce captures the target id at ARM time — the keystrokes belong to the draft loaded then, not to whatever
  the pointer says when the timer fires.
- Pointer value-change (X→Y) under the composer: flush typed content to X by id, rehydrate to Y. An id
  MIGRATION (split ack, remote-delete preserve — old row deleted) is distinguished via a synchronous
  `markDraftMigrated`/`resolveMigratedDraftId` marker in `draft-resolution-guard`: the composer adopts the new
  id with no reset (typing continues seamlessly), and a save addressed to a migrated id is redirected to its
  successor instead of forking an orphan.
- null→Y under an engaged editor: typed fragment detaches to its own pointer-less row, then the editor
  rehydrates to Y; on a locked E2E scope (where nothing can persist) the fragment stays on screen —
  `saveDraft` now reports whether it persisted. Engaged-but-empty cancels the armed debounce without saving so
  a stale empty save can't delete Y.
- Identity advances only via assignment-time rechecks (`advanceIdentity`), so a flush for a superseded row
  resolving late can't drag the ref back — on the typing path and both attachment paths.
- `clearLoadedDraft(scope, expectedDraftId)` deletes by id when the pointer moved on, leaving the new pointer
  and its staging buffer alone.

Adversarial verify (Opus/high) found 3 bugs in the first cut — the late-flush identity revert, the
migration-vs-repoint confusion, the null→Y engaged edge — plus 2 more on the targeted recheck (attachment-path
revert, locked-E2E fragment loss). All five fixed in-branch; every new assertion was neutralised red before
restore.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | `expectedDraftId` plumbing, migration redirect, by-id clear, `saveDraft` persisted-row contract, `cancelPendingSave` |
| `apps/frontend/src/hooks/use-draft-composer.ts` | `contentDraftIdRef`, repoint/migration/first-pointer branches |
| `apps/frontend/src/sync/draft-resolution-guard.ts` | `markDraftMigrated` / `resolveMigratedDraftId` (chain-following) |
| `apps/frontend/src/sync/draft-sync.ts` | `migrateLocalDraftId` records the migration before its txn |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | +15 identity/migration/E2E cases |
| `apps/frontend/src/hooks/use-draft-composer.test.ts` | +6 repoint/migration/detach cases |

## Test plan

- [x] vitest 254/254 across the 8 affected suites (draft-message, draft-composer, double-editor,
  stash-composer, draft-message-sync, draft-sync, message-input.composer-target, stashed-drafts); tsc clean.
  One single-occurrence timing flake under parallel load, not reproducible ×3 — the debounce tests use real
  700 ms timers; flagged as a CI flake risk.
- [x] 13 assertion neutralisations logged across implement + both fix batches (each inverted → red → restored).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788611945&installation_model_id=20758&pr_number=1780&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1780&signature=c28b2c091ef50d46a34305c18cdb7cae2447ce4babf639e984ee0a3c85aa3d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->