### PR TITLE
feat(drafts): restore is an atomic take-over — refusals reduced to "row is gone"

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -106,7 +106,7 @@ function stashComposerStub() {
     claimableDrafts: [],
     originByDraftId: new Map(),
     handleStashDraft: vi.fn().mockResolvedValue(undefined),
-    handleRestoreStashed: vi.fn().mockResolvedValue(undefined),
+    handleRestoreStashed: vi.fn().mockResolvedValue({ ok: true }),
     handleDeleteStashed: vi.fn().mockResolvedValue(undefined),
   }
 }

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -220,7 +220,15 @@ export function InlineComposerForm({
     const id = restoreOnMountRef.current
     if (!id || !composer.isLoaded) return
     restoreOnMountRef.current = null
-    void stash.handleRestoreStashed(id)
+    // A refusal here is rare (only a row deleted mid-open survives v2's
+    // take-over) but must not vanish silently (INV-11): the resting button
+    // advertised this draft, so an empty composer needs an explanation in the log.
+    stash.handleRestoreStashed(id).then(
+      (result) => {
+        if (!result.ok) console.error(`[board] mount restore of ${id} refused: ${result.reason}`)
+      },
+      (err) => console.error(`[board] mount restore of ${id} threw`, err)
+    )
   }, [composer.isLoaded, stash])
 
   // Focus-on-signal for always-mounted hosts (skip the mount value — focus on
@@ -246,7 +254,13 @@ export function InlineComposerForm({
     }
     if (!composer.isLoaded) return
     lastRestoreSignalRef.current = restoreOnSignal.signal
-    void stash.handleRestoreStashed(restoreOnSignal.stashId)
+    const stashId = restoreOnSignal.stashId
+    stash.handleRestoreStashed(stashId).then(
+      (result) => {
+        if (!result.ok) console.error(`[board] signal restore of ${stashId} refused: ${result.reason}`)
+      },
+      (err) => console.error(`[board] signal restore of ${stashId} threw`, err)
+    )
   }, [restoreOnSignal, composer.isLoaded, stash])
 
   const composerControlRef = useRef<ComposerControlHandle | null>(null)

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -128,7 +128,6 @@ describe("StashedDraftsPicker", () => {
     // happened. Every reason gets its own message.
     it.each([
       ["missing", "no longer there"],
-      ["checked-out", "open in another composer"],
       ["host-ineligible", "can't hold that draft"],
       ["raced", "moved before it could be restored"],
     ] as const)("says why a %s restore did nothing and keeps the picker open", async (reason, message) => {

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -916,18 +916,22 @@ describe("useDraftComposer", () => {
       expect(mockSaveDraft).not.toHaveBeenCalled()
     })
 
-    it("flushes typed content to its OWN row before rehydrating from the new one", () => {
+    it("flushes typed content to its OWN row before rehydrating from the new one", async () => {
       mockDraftIsLoaded = true
       mockDraftLoadedId = "draft_x"
       mockDraftContentJson = makeDoc("X body")
-      mockSaveDraft.mockResolvedValue(undefined)
+      // The flush must report a PERSISTED row: the reset is gated on it, so a
+      // gated save (null) deliberately leaves the editor untouched instead.
+      mockSaveDraft.mockResolvedValue({ id: "draft_x" })
       const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
 
       act(() => {
         result.current.handleContentChange(makeDoc("X body and typing"))
       })
 
-      act(() => {
+      // The rehydrate happens once the flush RESOLVES (persist-gated), so the
+      // pointer change and the settled flush need an async act.
+      await act(async () => {
         mockDraftLoadedId = "draft_y"
         mockDraftContentJson = makeDoc("Y body")
         rerender()
@@ -936,6 +940,71 @@ describe("useDraftComposer", () => {
       // Identity-addressed: the typed body is written to draft_x, never to draft_y.
       expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("X body and typing"), [], "draft_x")
       expect(result.current.content).toEqual(makeDoc("Y body"))
+    })
+
+    it("keeps the typed content on screen when the repoint flush cannot persist", async () => {
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("X body")
+      // A gated save (locked E2E): the content reached no disk, so blanking the
+      // editor would destroy it — the composer must keep it and its identity.
+      mockSaveDraft.mockResolvedValue(null)
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("X body and typing"))
+      })
+
+      await act(async () => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+
+      expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("X body and typing"), [], "draft_x")
+      expect(result.current.content).toEqual(makeDoc("X body and typing"))
+    })
+
+    it("serializes overlapping repoints — a second pointer change waits for the in-flight flush", async () => {
+      mockDraftIsLoaded = true
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("X body")
+      // A flush the test controls: X→Y arrives while typed content is engaged,
+      // and Y→Z lands BEFORE the X-flush resolves. The Z transition must queue
+      // behind it — running it immediately would read half-updated refs and
+      // flush the fragment into Y's real row.
+      let resolveFlush!: (row: { id: string }) => void
+      mockSaveDraft.mockImplementationOnce(() => new Promise<{ id: string }>((resolve) => (resolveFlush = resolve)))
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.handleContentChange(makeDoc("X body and typing"))
+      })
+      act(() => {
+        mockDraftLoadedId = "draft_y"
+        mockDraftContentJson = makeDoc("Y body")
+        rerender()
+      })
+      // The X-flush is in flight; a second repoint lands.
+      act(() => {
+        mockDraftLoadedId = "draft_z"
+        mockDraftContentJson = makeDoc("Z body")
+        rerender()
+      })
+
+      // Only the X flush has run — the Z transition is queued, so no save was
+      // fired against Y (that would be the fragment landing in Y's row).
+      expect(mockSaveDraft).toHaveBeenCalledTimes(1)
+      expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("X body and typing"), [], "draft_x")
+
+      await act(async () => {
+        resolveFlush({ id: "draft_x" })
+      })
+
+      // The queued Z transition ran after the flush settled: the editor shows Z
+      // and still only one save ever fired.
+      expect(mockSaveDraft).toHaveBeenCalledTimes(1)
+      expect(result.current.content).toEqual(makeDoc("Z body"))
     })
 
     it("follows an id migration without flushing or blanking the editor", () => {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -4,7 +4,7 @@ import { useAttachments, type PendingAttachment, type UploadResult } from "./use
 import type { JSONContent } from "@threa/types"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import type { DraftContextRef } from "@/lib/context-bag/types"
-import { generateLocalDraftId, type DraftAttachment } from "@/db"
+import { generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
 import { resolveMigratedDraftId, wasDraftResolvedLocally } from "@/sync/draft-resolution-guard"
 
 // Mounted composers per draft scope, in mount order. More than one live composer
@@ -267,7 +267,7 @@ export function useDraftComposer({
   const savedAttachmentsRef = useRef(savedAttachments)
   savedAttachmentsRef.current = savedAttachments
 
-  const scopeRegistryKey = `${workspaceId} ${draftKey}`
+  const scopeRegistryKey = `${workspaceId} ${draftKey}`
   const composerTokenRef = useRef<string | null>(null)
   if (composerTokenRef.current === null) composerTokenRef.current = `composer_${++composerTokenSeq}`
   const composerToken = composerTokenRef.current
@@ -428,108 +428,149 @@ export function useDraftComposer({
   // cannot cross-write into Y) and then re-run init against Y. Rehydration happens
   // whether or not the user is engaged: the repoint is this same user's own action
   // on this device, so the new draft is what they asked to see.
-  useEffect(() => {
-    const prev = prevLoadedIdRef.current
-    prevLoadedIdRef.current = loadedDraftId ?? null
-    if (loadedDraftId && prev !== loadedDraftId) {
-      if (!prev) {
-        // First pointer for this composer (null → X). With the editor idle — or
-        // when the editor's content already belongs to this very row, i.e. the
-        // pointer merely flickered null and came back — adopt its identity and
-        // hydrate from it as usual.
-        // The pointer merely flickered null and came back to the row the editor's
-        // content already belongs to — nothing to reconcile.
-        if (contentDraftIdRef.current === loadedDraftId) return
-        if (!userEngagedRef.current) {
-          contentDraftIdRef.current = loadedDraftId
-          return
+  // Pointer transitions are handled STRICTLY IN ORDER through a promise chain:
+  // a transition that persists content (an async save) must fully resolve before
+  // the next transition's handler reads the editor state, or a second repoint
+  // landing inside the save's in-flight window (a programmatic double-restore,
+  // a catch-up burst) reads half-updated refs and flushes the wrong content into
+  // the wrong row. `prevLoadedIdRef` still advances synchronously so each queued
+  // handler gets its own (prev, next) pair; everything else is read at RUN time,
+  // after the previous handler settled.
+  // NOT async: a transition with no persistence work completes synchronously
+  // (returns null) so its resets and ref updates land in the same tick the
+  // pointer changed — the pre-chain semantics every hydrate effect depends on.
+  // Only the flush leg returns a promise, and only THAT marks the chain busy.
+  const handlePointerTransition = useCallback(
+    (prev: string | null, next: string | null): Promise<void> | null => {
+      if (!next) {
+        if (!prev) return null
+        // The row can move scopes before its host target catches up. The mounted
+        // editor still owns this identity, so the old pointer going null is not
+        // a removal.
+        if (contentDraftScope && contentDraftScope !== draftKey) return null
+        if (userEngagedRef.current && hasDocContent(contentRef.current)) {
+          // With another composer live on this scope, the vanishing pointer can be
+          // THAT editor's send resolving the shared row while this one holds newer
+          // unsent text that exists only in React state — persist it rather than
+          // merely declining to blank. Both conditions are load-bearing: alone on
+          // the scope the null is a deliberate teardown (relocate/stash/clear/
+          // purge), and only a local resolve-on-send marks the id, so a remote
+          // `draft:deleted` reads false and stays deleted instead of being
+          // resurrected by whichever device happens to hold the composer open.
+          if (mountedComposerCount(scopeRegistryKey) > 1 && wasDraftResolvedLocally(prev)) {
+            return saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot())).then(
+              () => undefined,
+              (err) => {
+                console.error("Failed to persist draft rescued from a resolved row", err)
+              }
+            )
+          }
+          return null
         }
-        if (!hasDocContent(contentRef.current)) {
-          // Engaged but empty (typed, then deleted back to nothing). There is
-          // nothing to preserve, but the debounce is still armed with an EMPTY_DOC
-          // save whose expected id is null — pointer-addressed, it would fire into
-          // the arriving draft and delete it. Drop it without persisting, then
-          // hydrate from the arriving draft like an idle composer would.
-          cancelPendingSave()
-          resetForReinit()
-          contentDraftIdRef.current = loadedDraftId
-          return
-        }
-        // The user typed into a pointer-less scope and a draft was checked into
-        // it underneath them. Their fragment has no identity yet, so the armed
-        // pointer-addressed save would land in the arriving draft and destroy its
-        // body. Persist the fragment as its OWN detached row first (an expected
-        // id no row holds takes the create path, and the occupied pointer is
-        // never stolen); `saveDraft` also clears the armed debounce. Only once it
-        // actually persisted may the editor be blanked — on a locked E2E scope the
-        // save is gated and returns null, and resetting would erase the fragment
-        // from screen and disk both, so the focused composer keeps its content.
-        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot()), generateLocalDraftId())
-          .then((saved) => {
-            if (!saved) return
-            resetForReinit()
-            contentDraftIdRef.current = loadedDraftId
-          })
-          .catch((err) => {
-            console.error("Failed to persist draft content displaced by a first pointer", err)
-          })
-        return
+        userEngagedRef.current = false
+        contentDraftIdRef.current = null
+        setContent(initialContent)
+        clearAttachments()
+        return null
       }
-      if (resolveMigratedDraftId(prev) === loadedDraftId) {
+      // The pointer flickered away and back to the row the editor's content
+      // already belongs to — nothing to reconcile.
+      if (contentDraftIdRef.current === next) return null
+      if (prev && resolveMigratedDraftId(prev) === next) {
         // Not a repoint: the SAME draft was re-keyed underneath the composer (a
         // split ack / remote-delete preserve). The editor's content still belongs
         // to this row, so nothing is flushed and nothing is reset — the id is
         // simply followed. Any armed save captured the old id and is redirected
         // by the migration map on the write path.
-        contentDraftIdRef.current = loadedDraftId
-        return
+        contentDraftIdRef.current = next
+        return null
       }
-      if (userEngagedRef.current && hasDocContent(contentRef.current)) {
-        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot()), prev).catch((err) => {
+      if (!userEngagedRef.current) {
+        // Idle. A first pointer (null → X) adopts and lets init/late-hydrate
+        // fill; a repoint re-runs init against the new draft.
+        if (prev) resetForReinit()
+        contentDraftIdRef.current = next
+        return null
+      }
+      if (!hasDocContent(contentRef.current)) {
+        // Engaged but empty (typed, then deleted back to nothing). Nothing to
+        // preserve, but the debounce may still be armed with an EMPTY_DOC save —
+        // fired later it would delete whatever row it resolves to. Drop it
+        // without persisting, then hydrate from the arriving draft.
+        cancelPendingSave()
+        resetForReinit()
+        contentDraftIdRef.current = next
+        return null
+      }
+      // Engaged with content. If the content belongs to a row (an ordinary
+      // repoint), flush it there; if it has no identity — typing that outran
+      // hydration, or a fragment kept on screen by an earlier gated save — it
+      // must NOT touch any existing row, so it detaches into its own fresh one
+      // (a never-existing expected id takes the create path without stealing
+      // the pointer). Only once the save actually persisted may the editor be
+      // blanked: on a locked E2E scope it returns null, and resetting would
+      // erase the content from screen and disk both, so the focused composer
+      // keeps it (and its identity) until it can be saved.
+      const owner = contentDraftIdRef.current
+      return saveDraft(
+        contentRef.current,
+        persistableAttachments(getPendingAttachmentsSnapshot()),
+        owner ?? generateLocalDraftId()
+      ).then(
+        (saved: CachedDraft | null) => {
+          if (!saved) return
+          resetForReinit()
+          contentDraftIdRef.current = next
+        },
+        (err) => {
           console.error("Failed to persist draft content displaced by a repoint", err)
-        })
-      }
-      resetForReinit()
-      contentDraftIdRef.current = loadedDraftId
+        }
+      )
+    },
+    [
+      saveDraft,
+      cancelPendingSave,
+      resetForReinit,
+      initialContent,
+      clearAttachments,
+      scopeRegistryKey,
+      getPendingAttachmentsSnapshot,
+      contentDraftScope,
+      draftKey,
+    ]
+  )
+
+  // Transitions are handled STRICTLY IN ORDER: a transition whose handler
+  // persists content (returns a promise) marks the chain busy, and any
+  // transition arriving before it settles queues behind it — a second repoint
+  // landing inside the save's in-flight window (a programmatic double-restore,
+  // a catch-up burst) must not read half-updated refs and flush the wrong
+  // content into the wrong row. `prevLoadedIdRef` advances synchronously so
+  // each queued handler gets its own (prev, next) pair; everything else is read
+  // at run time, after the previous handler settled.
+  const pointerTransitionTailRef = useRef<Promise<void> | null>(null)
+  useEffect(() => {
+    const prev = prevLoadedIdRef.current
+    const next = loadedDraftId ?? null
+    prevLoadedIdRef.current = next
+    if (prev === next) return
+    const pending = pointerTransitionTailRef.current
+    if (!pending) {
+      const run = handlePointerTransition(prev, next)
+      if (!run) return
+      const tail: Promise<void> = run.then(() => {
+        if (pointerTransitionTailRef.current === tail) pointerTransitionTailRef.current = null
+      })
+      pointerTransitionTailRef.current = tail
       return
     }
-    if (!prev || loadedDraftId) return
-    // A filing-only move can publish the row's new scope before the host target
-    // catches up. The editor still owns this identity, so the old pointer going
-    // null is not a removal.
-    if (contentDraftScope && contentDraftScope !== draftKey) return
-    if (userEngagedRef.current && hasDocContent(contentRef.current)) {
-      // With another composer live on this scope, the vanishing pointer can be
-      // THAT editor's send resolving the shared row while this one holds newer
-      // unsent text that exists only in React state — persist it rather than
-      // merely declining to blank. Both conditions are load-bearing: alone on the
-      // scope the null is a deliberate teardown (relocate/stash/clear/purge), and
-      // only a local resolve-on-send marks the id, so a remote `draft:deleted`
-      // reads false and stays deleted instead of being resurrected by whichever
-      // device happens to hold the composer open.
-      if (mountedComposerCount(scopeRegistryKey) > 1 && wasDraftResolvedLocally(prev)) {
-        saveDraft(contentRef.current, persistableAttachments(getPendingAttachmentsSnapshot())).catch((err) => {
-          console.error("Failed to persist draft rescued from a resolved row", err)
-        })
-      }
-      return
-    }
-    userEngagedRef.current = false
-    contentDraftIdRef.current = null
-    setContent(initialContent)
-    clearAttachments()
-  }, [
-    loadedDraftId,
-    initialContent,
-    clearAttachments,
-    saveDraft,
-    scopeRegistryKey,
-    getPendingAttachmentsSnapshot,
-    resetForReinit,
-    cancelPendingSave,
-    contentDraftScope,
-    draftKey,
-  ])
+    const tail: Promise<void> = pending
+      .then(() => handlePointerTransition(prev, next) ?? undefined)
+      .then(() => {
+        if (pointerTransitionTailRef.current === tail) pointerTransitionTailRef.current = null
+      })
+    pointerTransitionTailRef.current = tail
+  }, [loadedDraftId, handlePointerTransition])
 
   // When attachments change, persist to draft storage. Reserved-but-still-
   // uploading attachments persist too: their id is already real, and a draft

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./use-draft-message"
 import { readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
 import { getScopeResolveSeq, resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
+import { migrateLocalDraftScope } from "@/sync/draft-sync"
 import { ContextRefKinds, type JSONContent } from "@threa/types"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import { db } from "@/db"
@@ -1432,7 +1433,7 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
   })
 })
 
-describe("take-over (chunk 2) — a restore detaches every other holder; a stale save splits", () => {
+describe("take-over (chunk 2) — a restore detaches every other holder; only divergent edits split", () => {
   beforeEach(async () => {
     vi.restoreAllMocks()
     resetDraftStoreCache()
@@ -1469,7 +1470,36 @@ describe("take-over (chunk 2) — a restore detaches every other holder; a stale
     expect((await db.drafts.get("draft_T"))?.contentJson).toEqual(makeDoc("taken body"))
   })
 
-  it("an identity-addressed save for a row another scope now holds SPLITS instead of writing it", async () => {
+  it("drops an identical late save after the row moves instead of creating a duplicate", async () => {
+    await db.drafts.put({
+      id: "draft_T",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("same body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_T" })
+    await seedDraftCacheFromIdb(workspaceId)
+    const row = await db.drafts.get("draft_T")
+    await migrateLocalDraftScope(workspaceId, draftKey, { ...row!, scope: otherScope })
+
+    const saved = await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("same body"), attachments: [] },
+      undefined,
+      { expectedDraftId: "draft_T" }
+    )
+
+    expect(saved?.id).toBe("draft_T")
+    expect(await db.drafts.get("draft_T")).toMatchObject({ scope: otherScope, contentJson: makeDoc("same body") })
+    expect((await db.drafts.toArray()).map((draft) => draft.id)).toEqual(["draft_T"])
+    expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
+    expect((await db.composerLoaded.get(otherScope))?.draftId).toBe("draft_T")
+  })
+
+  it("splits a divergent identity-addressed save for a row another scope now holds", async () => {
     await db.drafts.put({
       id: "draft_T",
       workspaceId,

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -1431,3 +1431,144 @@ describe("upsertLoadedDraft — identity-addressed saves (repoint safety)", () =
     expect((await db.drafts.get(pointerId!))?.contentJson).toEqual(makeDoc("first words"))
   })
 })
+
+describe("take-over (chunk 2) — a restore detaches every other holder; a stale save splits", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const otherScope = "board:reply:conv_take"
+
+  it("restoreStashedDraftToComposer detaches every other scope's pointer at the draft", async () => {
+    await db.drafts.put({
+      id: "draft_T",
+      workspaceId,
+      scope: otherScope,
+      contentJson: makeDoc("taken body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: otherScope, workspaceId, draftId: "draft_T" })
+    await seedDraftCacheFromIdb(workspaceId)
+
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_T")
+
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_T")
+    expect(await db.composerLoaded.get(otherScope)).toBeUndefined()
+    expect((await db.drafts.get("draft_T"))?.contentJson).toEqual(makeDoc("taken body"))
+  })
+
+  it("an identity-addressed save for a row another scope now holds SPLITS instead of writing it", async () => {
+    await db.drafts.put({
+      id: "draft_T",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("original body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_T" })
+    await seedDraftCacheFromIdb(workspaceId)
+    // Another surface takes the draft (pointer moves to its scope, ours detached).
+    await restoreStashedDraftToComposer(workspaceId, otherScope, "draft_T")
+
+    const saved = await upsertLoadedDraft(
+      workspaceId,
+      draftKey,
+      { contentJson: makeDoc("displaced keystrokes"), attachments: [] },
+      undefined,
+      { expectedDraftId: "draft_T" }
+    )
+
+    // Fresh row under the old scope; the taken row's body is untouched and the
+    // taker's pointer still references it.
+    expect(saved.id).not.toBe("draft_T")
+    expect(saved.scope).toBe(draftKey)
+    expect((await db.drafts.get(saved.id))?.contentJson).toEqual(makeDoc("displaced keystrokes"))
+    expect((await db.drafts.get("draft_T"))?.contentJson).toEqual(makeDoc("original body"))
+    expect((await db.composerLoaded.get(otherScope))?.draftId).toBe("draft_T")
+    // Our scope's pointer was freed by the take-over, so the split claims it.
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(saved.id)
+  })
+})
+
+describe("take-over aftermath — the displaced composer can neither delete nor overwrite the taken draft", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const otherScope = "board:reply:conv_aftermath"
+
+  it("an empty identity save after a take-over leaves the taken row alone (delete-path foreign guard)", async () => {
+    await db.drafts.put({
+      id: "draft_D",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("taken body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_D" })
+    await seedDraftCacheFromIdb(workspaceId)
+    // Another surface takes D; the victim scope's pointer is detached.
+    await restoreStashedDraftToComposer(workspaceId, otherScope, "draft_D")
+
+    // The victim composer empties its editor; its armed save still speaks for D.
+    await clearLoadedDraft(workspaceId, draftKey, "draft_D")
+
+    expect((await db.drafts.get("draft_D"))?.contentJson).toEqual(makeDoc("taken body"))
+    expect((await db.composerLoaded.get(otherScope))?.draftId).toBe("draft_D")
+    expect(await db.pendingOperations.where("workspaceId").equals(workspaceId).count()).toBe(0)
+  })
+
+  it("a null-identity save under a foreign pointer detaches to a fresh row instead of writing the pointed-at draft", async () => {
+    await db.drafts.put({
+      id: "draft_Y",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("Y body"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_Y" })
+    await seedDraftCacheFromIdb(workspaceId)
+
+    // A composer with an identity ref (strict protocol) whose content never
+    // hydrated from Y — the ref is null while the pointer references Y.
+    const contentDraftIdRef = { current: null as string | null }
+    const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+    let saved: Awaited<ReturnType<typeof result.current.saveDraft>> = null
+    await act(async () => {
+      saved = await result.current.saveDraft(makeDoc("orphan fragment"))
+    })
+
+    expect(saved).not.toBeNull()
+    expect(saved!.id).not.toBe("draft_Y")
+    expect((await db.drafts.get("draft_Y"))?.contentJson).toEqual(makeDoc("Y body"))
+    expect((await db.drafts.get(saved!.id))?.contentJson).toEqual(makeDoc("orphan fragment"))
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_Y")
+  })
+})

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -127,11 +127,16 @@ export async function upsertLoadedDraft(
   // plaintext scopes, the staging buffer) until the next keystroke re-saves.
   let row!: CachedDraft
   const expectedId = opts?.expectedDraftId ?? null
+  // Set when the expected row turned out to be owned by ANOTHER scope's composer
+  // (a take-over moved it): this save must SPLIT into a fresh row here rather
+  // than write a draft someone else is now editing — the same-device mirror of
+  // the cross-device split protection.
+  let forceCreate = false
   for (let attempt = 0; attempt < 3; attempt++) {
     // Identity-addressed when the caller named a row; pointer-addressed otherwise.
-    let loadedId = expectedId ?? (await getLoadedDraftId(scope))
+    let loadedId = forceCreate ? null : (expectedId ?? (await getLoadedDraftId(scope)))
     let existing = loadedId ? await db.drafts.get(loadedId) : undefined
-    if (expectedId && !existing) {
+    if (expectedId && !existing && !forceCreate) {
       // The expected row may have been RE-KEYED rather than deleted (a split ack
       // or a remote-delete preserve runs `migrateLocalDraftId`). Follow the
       // migration before concluding the row is gone: creating a fresh row here
@@ -221,6 +226,13 @@ export async function upsertLoadedDraft(
       if (existing) {
         const liveRow = await db.drafts.get(id)
         if (!liveRow) return "conflict"
+        // A pointer in ANOTHER scope means a take-over moved this row while the
+        // save was in flight: someone else's composer owns it now, and writing it
+        // would put this editor's body into their draft. Split instead.
+        if (expectedId) {
+          const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
+          if (holders.some((p) => p.draftId === id && p.scope !== scope)) return "foreign"
+        }
         // Freshest sync bookkeeping wins: a push ack can advance baseVersion
         // between our read and this txn, and writing the stale value back would
         // make the next push CAS against an old version and split.
@@ -244,6 +256,10 @@ export async function upsertLoadedDraft(
       return "persisted"
     })
 
+    if (outcome === "foreign") {
+      forceCreate = true
+      continue
+    }
     if (outcome === "conflict") continue
     if (outcome === "dropped") return row
     if (wrotePointer) {
@@ -332,6 +348,10 @@ export async function clearLoadedDraft(
     const targetId = (await db.drafts.get(expectedDraftId)) ? expectedDraftId : resolveMigratedDraftId(expectedDraftId)
     const pointer = (await db.composerLoaded.get(scope))?.draftId ?? null
     if (pointer !== targetId) {
+      // The delete-path twin of the write path's foreign-holder split, enforced
+      // INSIDE `removeDraftRowById`'s transaction (INV-20): a pointer anywhere
+      // referencing the row — the calling scope's pointer returning to it, or a
+      // take-over having given it to another composer — makes the delete a no-op.
       await removeDraftRowById(workspaceId, targetId, (id, baseVersion) =>
         syncDraftRemoval(workspaceId, id, baseVersion)
       )
@@ -360,6 +380,14 @@ async function removeDraftRowById(
   const removed = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
     const row = await db.drafts.get(draftId)
     if (!row) return false
+    // Re-validated INSIDE the txn (INV-20): a pointer ANYWHERE referencing this
+    // row means a composer owns it — either the pointer returned to the calling
+    // scope in the check-act gap (deleting would leave it dangling and wedge the
+    // scope), or a take-over gave the row to another scope's composer (deleting
+    // would destroy it out from under them and mirror the delete to every
+    // device). Both mean: not ours to delete, do nothing.
+    const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
+    if (holders.some((p) => p.draftId === draftId)) return false
     await db.drafts.delete(draftId)
     await mirror(draftId, row.baseVersion)
     return true
@@ -472,12 +500,16 @@ export async function stashLoadedDraft(workspaceId: string, scope: string): Prom
 }
 
 /**
- * Restore stash entry `draftId` into the composer for `scope` by pointing the
- * scope at it. Whatever was loaded becomes a stash entry automatically (the scope
- * points at exactly one draft), so this is a swap that never loses work. The row's
- * body — plaintext or sealed — is untouched; the composer decrypts on read. Like
- * stash, it is a pure pointer move: no snapshot, no server round-trip (the row was
- * already pushed when it was last edited).
+ * Restore draft `draftId` into the composer for `scope` by pointing the scope at
+ * it — a TAKE-OVER: any other scope's pointer at this draft is detached in the
+ * same transaction, so the draft is never live in two composers at once and a
+ * visible pile row is always loadable (no "checked out elsewhere" refusal). The
+ * detached composers react through the pointer-null path (blank, or split their
+ * engaged content into a fresh row — the same protection a cross-device send
+ * already exercises). Whatever this scope held becomes a stash entry
+ * automatically (a scope points at exactly one draft), so the swap never loses
+ * work. The row's body — plaintext or sealed — is untouched; the composer
+ * decrypts on read. No snapshot, no server round-trip.
  */
 export async function restoreStashedDraftToComposer(
   workspaceId: string,
@@ -489,7 +521,21 @@ export async function restoreStashedDraftToComposer(
   // reload before the next keystroke recover that stale body over the draft we
   // just restored — corrupting it. The restored draft re-stages on its first edit.
   clearStagedDraft(workspaceId, scope)
-  await db.composerLoaded.put({ scope, workspaceId, draftId })
+  const detached = await db.transaction("rw", db.composerLoaded, async () => {
+    const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
+    const others = holders.filter((row) => row.draftId === draftId && row.scope !== scope)
+    for (const row of others) await db.composerLoaded.delete(row.scope)
+    await db.composerLoaded.put({ scope, workspaceId, draftId })
+    return others.map((row) => row.scope)
+  })
+  for (const detachedScope of detached) {
+    // Same teardown a stash does for the scope it detaches: the staging buffer's
+    // keystrokes belong to the draft just taken, and a reload's reconcile would
+    // otherwise "recover" them into a brand-new duplicate row under the old
+    // scope (and claim its pointer).
+    clearStagedDraft(workspaceId, detachedScope)
+    setComposerLoadedInCache(workspaceId, detachedScope, null)
+  }
   setComposerLoadedInCache(workspaceId, scope, draftId)
 }
 
@@ -601,6 +647,12 @@ export function useDraftMessage(
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fallbackContentDraftIdRef = useRef<string | null>(null)
   const contentDraftId = contentDraftIdRef ?? fallbackContentDraftIdRef
+  // Only a caller that supplied a real identity ref gets the strict
+  // null-identity re-route below: for it, "null while the pointer holds a
+  // draft" provably means the editor never hydrated that draft. A ref-less
+  // caller has no hydration protocol, so null just means "address the pointer"
+  // — the historical contract.
+  const strictIdentity = contentDraftIdRef !== undefined
 
   // Seal needs the viewer's workspace user id and unlocked UIK. Read here (not
   // threaded from the call site) so the composer reacts when the session unlocks
@@ -685,6 +737,20 @@ export function useDraftMessage(
         if (contentDraftId.current === targetId) contentDraftId.current = next
       }
 
+      // A null identity while the scope's pointer references a draft means the
+      // editor's content was NEVER hydrated from the pointed-at row (a detach
+      // that could not persist, or typing that outran hydration). Falling back
+      // to the pointer would write — or delete — a draft this composer does not
+      // own, so the save re-routes: non-empty content detaches into its own
+      // fresh row (a never-existing expected id takes `upsertLoadedDraft`'s
+      // create path without stealing the pointer), and an empty save is a no-op
+      // (there is nothing of ours to delete).
+      let effectiveTarget = targetId
+      if (strictIdentity && targetId === null && (await getLoadedDraftId(draftKey)) !== null) {
+        if (isEmptyContent(contentJson) && (attachments?.length ?? 0) === 0) return null
+        effectiveTarget = generateLocalDraftId()
+      }
+
       // The scope's resolve sequence as this save begins. If a resolve-on-send
       // advances it before the create below runs, this save is a stale echo of
       // the just-sent content and `upsertLoadedDraft` drops its create.
@@ -700,10 +766,10 @@ export function useDraftMessage(
         // preserve them, exactly as the plaintext path preserves them below. The
         // sealed row holds no plaintext attachments at rest, so they're read back
         // from the in-memory decrypt cache (the plaintext authority).
-        const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+        const currentLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
         const finalAttachments = attachments ?? (currentLoadedId ? cachedDraftAttachments(currentLoadedId) : [])
         if (!options?.keepEmpty && isEmptyContent(contentJson) && finalAttachments.length === 0) {
-          await clearLoadedDraft(workspaceId, draftKey, targetId)
+          await clearLoadedDraft(workspaceId, draftKey, effectiveTarget)
           advanceIdentity(null)
           syncEngine?.kickOperationQueue()
           return null
@@ -714,7 +780,7 @@ export function useDraftMessage(
             draftKey,
             { contentJson, attachments: finalAttachments },
             { senderId: gate.senderId, streamId: gate.streamId },
-            { observedResolveSeq, expectedDraftId: targetId }
+            { observedResolveSeq, expectedDraftId: effectiveTarget }
           )
           advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
@@ -731,7 +797,7 @@ export function useDraftMessage(
       // sidecar must survive a content-only save (e.g. user typing into a
       // bag-attached scratchpad) — without this preservation the chip would
       // vanish from the composer the moment the first keystroke fires.
-      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+      const currentLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const finalAttachments = attachments ?? currentDraft?.attachments ?? []
       const finalContextRefs = currentDraft?.contextRefs ?? []
@@ -743,7 +809,7 @@ export function useDraftMessage(
         finalAttachments.length === 0 &&
         finalContextRefs.length === 0
       ) {
-        await clearLoadedDraft(workspaceId, draftKey, targetId)
+        await clearLoadedDraft(workspaceId, draftKey, effectiveTarget)
         advanceIdentity(null)
         syncEngine?.kickOperationQueue()
         return null
@@ -754,7 +820,7 @@ export function useDraftMessage(
         draftKey,
         { contentJson, attachments: finalAttachments, contextRefs: finalContextRefs },
         undefined,
-        { observedResolveSeq, expectedDraftId: targetId }
+        { observedResolveSeq, expectedDraftId: effectiveTarget }
       )
       advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()
@@ -809,6 +875,14 @@ export function useDraftMessage(
       const advanceIdentity = (next: string | null) => {
         if (contentDraftId.current === targetId) contentDraftId.current = next
       }
+      // Same null-identity rule as `saveDraft`: no identity + a foreign pointer
+      // means this composer never hydrated the pointed-at draft, so the
+      // attachment must not be sealed/written into it — it detaches to a fresh
+      // row instead.
+      let effectiveTarget = targetId
+      if (strictIdentity && targetId === null && (await getLoadedDraftId(draftKey)) !== null) {
+        effectiveTarget = generateLocalDraftId()
+      }
       if (e2eEnabled) {
         // E2EE-4: re-seal the draft with the added attachment. The body + current
         // attachments are the decrypted copy in memory (the row holds only
@@ -817,7 +891,7 @@ export function useDraftMessage(
         // attachment stays in the composer session, like a typed body would.
         const gate = e2eGateRef.current
         if (!gate.unlocked || !gate.senderId || !gate.streamId) return
-        const sealedLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+        const sealedLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
         const currentSealed = sealedLoadedId ? cachedDraftAttachments(sealedLoadedId) : []
         if (currentSealed.some((a) => a.id === attachment.id)) return
         const body = (sealedLoadedId ? cachedDraftBody(sealedLoadedId) : null) ?? EMPTY_DOC
@@ -827,7 +901,7 @@ export function useDraftMessage(
             draftKey,
             { contentJson: body, attachments: [...currentSealed, attachment] },
             { senderId: gate.senderId, streamId: gate.streamId },
-            { expectedDraftId: targetId }
+            { expectedDraftId: effectiveTarget }
           )
           advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
@@ -836,7 +910,7 @@ export function useDraftMessage(
         }
         return
       }
-      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+      const currentLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const currentAttachments = currentDraft?.attachments ?? []
 
@@ -855,7 +929,7 @@ export function useDraftMessage(
           contextRefs: currentDraft?.contextRefs,
         },
         undefined,
-        { expectedDraftId: targetId }
+        { expectedDraftId: effectiveTarget }
       )
       advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()
@@ -877,18 +951,25 @@ export function useDraftMessage(
       const advanceIdentity = (next: string | null) => {
         if (contentDraftId.current === targetId) contentDraftId.current = next
       }
+      // Null-identity rule (see `saveDraft`): never operate on a pointed-at
+      // draft this composer did not hydrate. A fresh id resolves to no row, so
+      // every branch below self-no-ops.
+      let effectiveTarget = targetId
+      if (strictIdentity && targetId === null && (await getLoadedDraftId(draftKey)) !== null) {
+        effectiveTarget = generateLocalDraftId()
+      }
       if (e2eEnabled) {
         // E2EE-4: re-seal without the removed attachment (or clear when the draft
         // is left empty). Reads body + attachments from the in-memory decrypt
         // cache for the same reason `addAttachment` does. Locked → no-op.
         const gate = e2eGateRef.current
         if (!gate.unlocked || !gate.senderId || !gate.streamId) return
-        const sealedLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+        const sealedLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
         if (!sealedLoadedId) return
         const remaining = cachedDraftAttachments(sealedLoadedId).filter((a) => a.id !== attachmentId)
         const body = cachedDraftBody(sealedLoadedId) ?? EMPTY_DOC
         if (isEmptyContent(body) && remaining.length === 0) {
-          await clearLoadedDraft(workspaceId, draftKey, targetId)
+          await clearLoadedDraft(workspaceId, draftKey, effectiveTarget)
           advanceIdentity(null)
           syncEngine?.kickOperationQueue()
           return
@@ -899,7 +980,7 @@ export function useDraftMessage(
             draftKey,
             { contentJson: body, attachments: remaining },
             { senderId: gate.senderId, streamId: gate.streamId },
-            { expectedDraftId: targetId }
+            { expectedDraftId: effectiveTarget }
           )
           advanceIdentity(saved.id)
           syncEngine?.kickOperationQueue()
@@ -908,7 +989,7 @@ export function useDraftMessage(
         }
         return
       }
-      const currentLoadedId = targetId ?? (await getLoadedDraftId(draftKey))
+      const currentLoadedId = effectiveTarget ?? (await getLoadedDraftId(draftKey))
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       if (!currentDraft) return
 
@@ -916,7 +997,7 @@ export function useDraftMessage(
 
       // Delete draft if both content and attachments are empty
       if (isEmptyContent(currentDraft.contentJson) && remainingAttachments.length === 0) {
-        await clearLoadedDraft(workspaceId, draftKey, targetId)
+        await clearLoadedDraft(workspaceId, draftKey, effectiveTarget)
         advanceIdentity(null)
         syncEngine?.kickOperationQueue()
         return
@@ -931,7 +1012,7 @@ export function useDraftMessage(
           contextRefs: currentDraft.contextRefs,
         },
         undefined,
-        { expectedDraftId: targetId }
+        { expectedDraftId: effectiveTarget }
       )
       advanceIdentity(saved.id)
       syncEngine?.kickOperationQueue()

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -60,6 +60,17 @@ export interface DraftFields {
   contextRefs?: DraftContextRef[]
 }
 
+function sameDraftPayload(row: CachedDraft, fields: DraftFields): boolean {
+  const contentJson = row.ciphertext ? cachedDraftBody(row.id) : row.contentJson
+  if (!contentJson) return false
+  const attachments = row.ciphertext ? cachedDraftAttachments(row.id) : row.attachments
+  return (
+    JSON.stringify(contentJson) === JSON.stringify(fields.contentJson) &&
+    JSON.stringify(attachments) === JSON.stringify(fields.attachments) &&
+    JSON.stringify(row.contextRefs ?? []) === JSON.stringify(fields.contextRefs ?? [])
+  )
+}
+
 /**
  * E2E seal context for a draft write — present only for encrypted streams.
  * `streamId` is the encrypted root whose current SSK seals the body.
@@ -128,10 +139,11 @@ export async function upsertLoadedDraft(
   let row!: CachedDraft
   const expectedId = opts?.expectedDraftId ?? null
   // Set when the expected row turned out to be owned by ANOTHER scope's composer
-  // (a take-over moved it): this save must SPLIT into a fresh row here rather
-  // than write a draft someone else is now editing — the same-device mirror of
-  // the cross-device split protection.
+  // and this editor has genuinely different content. An identical late save is
+  // only the old surface finishing the same-device hand-off; splitting that
+  // creates the duplicate row the move was meant to avoid.
   let forceCreate = false
+  let unchangedForeignRow: CachedDraft | null = null
   for (let attempt = 0; attempt < 3; attempt++) {
     // Identity-addressed when the caller named a row; pointer-addressed otherwise.
     let loadedId = forceCreate ? null : (expectedId ?? (await getLoadedDraftId(scope)))
@@ -227,11 +239,18 @@ export async function upsertLoadedDraft(
         const liveRow = await db.drafts.get(id)
         if (!liveRow) return "conflict"
         // A pointer in ANOTHER scope means a take-over moved this row while the
-        // save was in flight: someone else's composer owns it now, and writing it
-        // would put this editor's body into their draft. Split instead.
+        // save was in flight. The common mobile hand-off leaves an identical
+        // debounce behind; that is already the moved row, not concurrent work,
+        // so it is a no-op. Only divergent content earns a split.
         if (expectedId) {
           const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
-          if (holders.some((p) => p.draftId === id && p.scope !== scope)) return "foreign"
+          if (holders.some((p) => p.draftId === id && p.scope !== scope)) {
+            if (sameDraftPayload(liveRow, fields)) {
+              unchangedForeignRow = liveRow
+              return "unchanged-foreign"
+            }
+            return "foreign"
+          }
         }
         // Freshest sync bookkeeping wins: a push ack can advance baseVersion
         // between our read and this txn, and writing the stale value back would
@@ -260,6 +279,7 @@ export async function upsertLoadedDraft(
       forceCreate = true
       continue
     }
+    if (outcome === "unchanged-foreign") return unchangedForeignRow!
     if (outcome === "conflict") continue
     if (outcome === "dropped") return row
     if (wrotePointer) {

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -306,11 +306,20 @@ export async function upsertLoadedDraft(
 async function removeLoadedDraftLocally(
   workspaceId: string,
   scope: string,
-  mirror: (loadedId: string, baseVersion: number | undefined) => Promise<void>
+  mirror: (loadedId: string, baseVersion: number | undefined) => Promise<void>,
+  /**
+   * When set, the pointer is re-asserted INSIDE the txn to still name this row
+   * (INV-20): an identity-addressed empty save read the pointer outside, and a
+   * restore repointing the scope in that gap must make the delete a no-op — not
+   * destroy whatever the pointer now holds (and mirror the delete everywhere).
+   * The pointer-addressed callers ("whatever is loaded") pass nothing.
+   */
+  expectedDraftId?: string | null
 ): Promise<void> {
   let removedId: string | null = null
   await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
     const loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
+    if (expectedDraftId && loadedId !== expectedDraftId) return
     let version: number | undefined
     if (loadedId) {
       const row = await db.drafts.get(loadedId)
@@ -342,10 +351,11 @@ export async function clearLoadedDraft(
    */
   expectedDraftId?: string | null
 ): Promise<void> {
+  let targetId: string | null = null
   if (expectedDraftId) {
     // Follow a re-key (`migrateLocalDraftId`) so an empty save for the pre-split
     // id clears the row that id became, not nothing at all.
-    const targetId = (await db.drafts.get(expectedDraftId)) ? expectedDraftId : resolveMigratedDraftId(expectedDraftId)
+    targetId = (await db.drafts.get(expectedDraftId)) ? expectedDraftId : resolveMigratedDraftId(expectedDraftId)
     const pointer = (await db.composerLoaded.get(scope))?.draftId ?? null
     if (pointer !== targetId) {
       // The delete-path twin of the write path's foreign-holder split, enforced
@@ -361,8 +371,14 @@ export async function clearLoadedDraft(
   // Drop the staging buffer first (synchronous) so a racing flush or a reload
   // can't recover the discarded content back into the composer.
   clearStagedDraft(workspaceId, scope)
-  await removeLoadedDraftLocally(workspaceId, scope, (loadedId, baseVersion) =>
-    syncDraftRemoval(workspaceId, loadedId, baseVersion)
+  await removeLoadedDraftLocally(
+    workspaceId,
+    scope,
+    (loadedId, baseVersion) => syncDraftRemoval(workspaceId, loadedId, baseVersion),
+    // The RESOLVED id: the in-txn re-assertion must track a re-key the same way
+    // the branch above did, or a mid-clear migration turns the guard into a
+    // spurious no-op.
+    targetId
   )
 }
 
@@ -515,19 +531,31 @@ export async function restoreStashedDraftToComposer(
   workspaceId: string,
   scope: string,
   draftId: string
-): Promise<void> {
+): Promise<boolean> {
   // Drop the staging buffer: it holds the keystrokes for the draft being swapped
   // OUT (already flushed to its own row by the caller), so leaving it would let a
   // reload before the next keystroke recover that stale body over the draft we
   // just restored — corrupting it. The restored draft re-stages on its first edit.
   clearStagedDraft(workspaceId, scope)
-  const detached = await db.transaction("rw", db.composerLoaded, async () => {
+  let pointedId = draftId
+  const detached = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+    // The id is re-validated INSIDE the txn (INV-20): a split ack can re-key the
+    // row (`migrateLocalDraftId`) between the caller's read and here — the
+    // caller's flush is an IDB write sitting in exactly that window — and
+    // pointing the scope at a retired id renders an empty composer over an
+    // orphaned row. Follow the migration; a genuinely-gone row restores nothing.
+    if (!(await db.drafts.get(pointedId))) {
+      const migrated = resolveMigratedDraftId(pointedId)
+      if (migrated === pointedId || !(await db.drafts.get(migrated))) return null
+      pointedId = migrated
+    }
     const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
-    const others = holders.filter((row) => row.draftId === draftId && row.scope !== scope)
+    const others = holders.filter((row) => row.draftId === pointedId && row.scope !== scope)
     for (const row of others) await db.composerLoaded.delete(row.scope)
-    await db.composerLoaded.put({ scope, workspaceId, draftId })
+    await db.composerLoaded.put({ scope, workspaceId, draftId: pointedId })
     return others.map((row) => row.scope)
   })
+  if (detached === null) return false
   for (const detachedScope of detached) {
     // Same teardown a stash does for the scope it detaches: the staging buffer's
     // keystrokes belong to the draft just taken, and a reload's reconcile would
@@ -536,7 +564,8 @@ export async function restoreStashedDraftToComposer(
     clearStagedDraft(workspaceId, detachedScope)
     setComposerLoadedInCache(workspaceId, detachedScope, null)
   }
-  setComposerLoadedInCache(workspaceId, scope, draftId)
+  setComposerLoadedInCache(workspaceId, scope, pointedId)
+  return true
 }
 
 /**

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -434,26 +434,32 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
     expect(await db.drafts.get("draft_host")).toBeDefined()
   })
 
-  it("leaves both drafts untouched when the row is checked out under another scope", async () => {
+  // Move-shaped: the detach here rides `migrateLocalDraftScope` (which re-points
+  // the source pointer as part of the move) — what this case pins is the REMOVAL
+  // of the checked-out refusal. The take-over transaction's own detach is pinned
+  // by the adopt-shaped case below and by use-draft-message's take-over tests.
+  it("takes over a row checked out under another scope — never a refusal (v2)", async () => {
     await db.drafts.bulkAdd([aoDraft("draft_stream", aoHostScope), aoDraft("draft_host", aoConversationScope)])
     await db.composerLoaded.put({ scope: aoConversationScope, workspaceId: aoWorkspaceId, draftId: "draft_host" })
     await seedDraftCacheFromIdb(aoWorkspaceId)
 
     const { result } = renderHook(() => useAoHarness(aoConversationScope), { wrapper })
     await waitFor(() => expect(result.current.stash.drafts.map((d) => d.id)).toContain("draft_stream"))
-    // Another composer checks it out between the pile render and the click.
+    // Another composer checks it out between the pile render and the click. The
+    // rendered row is a promise: the restore takes the draft anyway, exactly as a
+    // send on the phone clears the laptop's composer.
     await db.composerLoaded.put({ scope: aoHostScope, workspaceId: aoWorkspaceId, draftId: "draft_stream" })
 
     await act(async () => {
-      expect(await result.current.stash.handleRestoreStashed("draft_stream")).toEqual({
-        ok: false,
-        reason: "checked-out",
-      })
+      expect(await result.current.stash.handleRestoreStashed("draft_stream")).toEqual({ ok: true })
     })
 
-    expect((await db.drafts.get("draft_stream"))?.scope).toBe(aoHostScope)
-    expect(await upsertOpsFor("draft_stream")).toHaveLength(0)
-    expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_host")
+    // Moved here, taken here; the old holder's pointer is detached, and nothing
+    // was deleted anywhere.
+    expect((await db.drafts.get("draft_stream"))?.scope).toBe(aoConversationScope)
+    expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_stream")
+    expect(await db.composerLoaded.get(aoHostScope)).toBeUndefined()
+    expect(await db.drafts.get("draft_host")).toBeDefined()
   })
 
   it("leaves both drafts untouched when the row is gone by the time the click lands", async () => {
@@ -506,13 +512,11 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
     expect((await db.drafts.get("draft_conv"))?.scope).toBe(aoConversationScope)
   })
 
-  // The pre-checks prove the RESTORED ROW is checked out nowhere; they say nothing
-  // about the scope being pointed at. A conversation can hold one draft in its own
-  // composer and have another stashed — repointing would leave that composer
-  // rendering its old body against our draft's id (its loaded id changes value
-  // rather than going null, so nothing blanks it) and its next save would write
-  // that body into the row we adopted.
-  it("refuses to adopt into a conversation scope that already holds a different draft", async () => {
+  // The target scope holding a different draft is no obstacle: the pointer
+  // overwrite displaces it into a stash entry (row intact), and a composer
+  // mounted there rehydrates through the repoint path — its typed content, if
+  // any, flushes to its own row first (identity-addressed saves, chunk 1).
+  it("adopts into a conversation scope that already holds a different draft, displacing it to the stash", async () => {
     await db.drafts.bulkAdd([
       aoDraft("draft_conv", aoConversationScope),
       aoDraft("draft_other", aoConversationScope),
@@ -528,15 +532,15 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
     await waitFor(() => expect(result.current.stash.drafts.map((d) => d.id)).toContain("draft_conv"))
 
     await act(async () => {
-      expect(await result.current.stash.handleRestoreStashed("draft_conv")).toEqual({
-        ok: false,
-        reason: "target-busy",
-      })
+      expect(await result.current.stash.handleRestoreStashed("draft_conv")).toEqual({ ok: true })
     })
 
-    // The other composer keeps its draft, and ours was not adopted.
-    expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_other")
-    expect(await db.composerTarget.get(aoHostScope)).toBeUndefined()
+    // Adopted: the conversation's composer now points at our row (which kept its
+    // filing — scope unchanged), the host is armed at the conversation, and the
+    // displaced draft survives as a stash entry.
+    expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_conv")
+    expect((await db.composerTarget.get(aoHostScope))?.scope).toBe(aoConversationScope)
     expect((await db.drafts.get("draft_conv"))?.scope).toBe(aoConversationScope)
+    expect(await db.drafts.get("draft_other")).toBeDefined()
   })
 })

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -74,12 +74,6 @@ export function planDraftRestore(input: {
   return { action: "move", fromScope: draftScope, toScope: hostScope }
 }
 
-/** Every scope holding a device-local pointer at this draft. */
-async function loadedScopesForDraft(draftId: string): Promise<string[]> {
-  const pointers = await db.composerLoaded.toArray()
-  return pointers.filter((row) => row.draftId === draftId).map((row) => row.scope)
-}
-
 /**
  * What a host tells the pile about itself beyond its scope. Only the timeline's
  * top-level composer has one; a thread panel and a board composer restore by
@@ -200,9 +194,10 @@ export function useStashComposer(
   /**
    * Bring pile row `id` into this host. Everything is revalidated HERE, against
    * IDB, not against the pile computed a render ago: by the time the user clicks,
-   * the row may have been deleted or checked out elsewhere and the host may have
-   * resolved encrypted or archived. On any failure nothing happens at all — no
-   * partial move, both drafts intact — and the reason comes back to the caller,
+   * the row may have been deleted and the host may have resolved encrypted or
+   * archived. A row checked out elsewhere is TAKEN, never refused (v2). On any
+   * failure nothing happens at all — no partial move, both drafts intact — and
+   * the reason comes back to the caller,
    * which owes the user a message: the picker closes and the caret lands in the
    * composer either way, so a silent refusal looks exactly like a success
    * (INV-11, INV-63).
@@ -214,104 +209,118 @@ export function useStashComposer(
       if (!row || row.workspaceId !== workspaceId) {
         return refuse("missing", `refusing restore of missing draft ${id}`)
       }
-      // Checked out anywhere on this device — including under its own scope — is
-      // not restorable: two scopes holding one row make their debounced saves
-      // fight over its `scope` and body.
-      const checkedOut = await loadedScopesForDraft(id)
-      if (checkedOut.length > 0) {
-        return refuse("checked-out", `refusing restore of ${id}: checked out in ${checkedOut.join(", ")}`)
-      }
+      // A draft checked out elsewhere — any scope, any surface — is TAKEN, never
+      // refused: `restoreStashedDraftToComposer` detaches every other pointer in
+      // its own transaction, and a composer that loses its pointer mid-edit
+      // splits its content into a fresh row (`upsertLoadedDraft`'s foreign-holder
+      // guard). Same semantics as continuing a draft on your phone while the
+      // laptop still has it open.
 
-      const plan = planDraftRestore({
-        hostScope: scope,
-        targetHost,
-        draftScope: row.scope,
-        draftSource: describeScope(row.scope),
-      })
-      if (plan.action === "refuse") {
-        return refuse(plan.reason, `refusing restore of ${id} into ${scope}: ${plan.reason}`)
-      }
-      // Leaving the row's own scope needs a host that can hold it: an encrypted
-      // or archived home means the pile should never have offered it, and for an
-      // adopt a late `e2eEnabled` resolve would let `purgePlaintextScopeDrafts`
-      // delete the draft we just targeted.
-      if (plan.action !== "same-scope" && !canHostForeignDraft()) {
-        return refuse("host-ineligible", `refusing restore of ${id} into ${scope}: host is not eligible`)
-      }
-
-      // Swap semantics: flush whatever the composer holds into its row first so
-      // switching drafts never silently destroys work — it stays as a stash entry
-      // once the pointer moves off it. `flushDraft` only persists a non-empty
-      // editor, so a restore fired while the composer is still mid-hydration
-      // (transiently empty) can NEVER delete the currently-loaded draft. A thrown
-      // flush (e.g. IDB quota, or a seal that raced a lock) is swallowed: losing a
-      // recent auto-save is a smaller harm than aborting the deliberate restore.
-      try {
-        await composer.flushDraft()
-      } catch (err) {
-        console.error("Failed to flush current content before restoring", err)
-      }
-
-      if (plan.action === "adopt") {
-        // The pre-checks proved the RESTORED ROW is checked out nowhere; they say
-        // nothing about the scope we are about to point at. A conversation can
-        // hold one draft in its own composer and have another stashed, and that
-        // stashed one is in this pile. Repointing the target scope would leave
-        // that composer rendering its old body against our draft's id — its
-        // loaded id changes value rather than going null, so nothing blanks or
-        // rehydrates it — and its next debounced save would write that body into
-        // the row we just adopted. We cannot flush an editor we do not own, so
-        // refuse and let the user deal with it where it lives.
-        const targetPointer = await db.composerLoaded.get(plan.targetScope)
-        if (targetPointer?.draftId && targetPointer.draftId !== id) {
-          return refuse("target-busy", `refusing adopt of ${id}: ${plan.targetScope} holds ${targetPointer.draftId}`)
+      // Two attempts: the plan (adopt vs move) is made from the row's scope, and
+      // the flush below (an IDB write, possibly a seal) sits between that read
+      // and the execute. A concurrent re-home in that window must produce a NEW
+      // plan, not execute the stale one — a move planned against a `stream:`
+      // filing must become an adopt if the row just became conversation-filed,
+      // because executing the stale move rewrites the scope and destroys the
+      // filing with no undo. The move txn detects the drift and retries once.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const live = attempt === 0 ? row : await db.drafts.get(id)
+        if (!live || live.workspaceId !== workspaceId) {
+          return refuse("missing", `refusing restore of missing draft ${id}`)
         }
-        // The row stays exactly where it is — it keeps its filing, which is the
-        // whole point. Check it out under its OWN scope first, then point the
-        // host at it, so the composer never renders the target scope for a frame
-        // with no draft loaded under it. Targeting the host's own scope IS the
-        // disarm, so it clears rather than stores.
-        await restoreStashedDraftToComposer(workspaceId, plan.targetScope, id)
-        // Through the host's own disarm, never a bare `clearComposerTarget`: the
-        // gesture latch has to be cleared with the target or a later adopt reads
-        // as a fresh gesture and redirects to the panel, wiping the target the
-        // adopt just set.
-        if (plan.targetScope === plan.targetHost) {
-          if (!disarmTarget) throw new Error(`[stash] host ${plan.targetHost} can retarget but has no disarm`)
-          await disarmTarget()
-        } else await setComposerTarget(workspaceId, plan.targetHost, plan.targetScope)
+        const plan = planDraftRestore({
+          hostScope: scope,
+          targetHost,
+          draftScope: live.scope,
+          draftSource: describeScope(live.scope),
+        })
+        if (plan.action === "refuse") {
+          return refuse(plan.reason, `refusing restore of ${id} into ${scope}: ${plan.reason}`)
+        }
+        // Leaving the row's own scope needs a host that can hold it: an encrypted
+        // or archived home means the pile should never have offered it, and for an
+        // adopt a late `e2eEnabled` resolve would let `purgePlaintextScopeDrafts`
+        // delete the draft we just targeted.
+        if (plan.action !== "same-scope" && !canHostForeignDraft()) {
+          return refuse("host-ineligible", `refusing restore of ${id} into ${scope}: host is not eligible`)
+        }
+
+        // Swap semantics: flush whatever the composer holds into its row first so
+        // switching drafts never silently destroys work — it stays as a stash entry
+        // once the pointer moves off it. `flushDraft` only persists a non-empty
+        // editor, so a restore fired while the composer is still mid-hydration
+        // (transiently empty) can NEVER delete the currently-loaded draft. A thrown
+        // flush (e.g. IDB quota, or a seal that raced a lock) is swallowed: losing a
+        // recent auto-save is a smaller harm than aborting the deliberate restore.
+        // Once only — the retry re-plans, it does not re-flush.
+        if (attempt === 0) {
+          try {
+            await composer.flushDraft()
+          } catch (err) {
+            console.error("Failed to flush current content before restoring", err)
+          }
+        }
+
+        if (plan.action === "adopt") {
+          // Whatever the target scope held is simply displaced: the pointer
+          // overwrite detaches it into a stash entry, and a composer mounted there
+          // rehydrates to the adopted draft through the repoint path (chunk 1) —
+          // its own typed content, if any, is flushed to its own row first. No
+          // refusal: the row the user tapped is the row they get (v2 principle).
+          // The row stays exactly where it is — it keeps its filing, which is the
+          // whole point. Check it out under its OWN scope first, then point the
+          // host at it, so the composer never renders the target scope for a frame
+          // with no draft loaded under it. Targeting the host's own scope IS the
+          // disarm, so it clears rather than stores.
+          await restoreStashedDraftToComposer(workspaceId, plan.targetScope, id)
+          // Through the host's own disarm, never a bare `clearComposerTarget`: the
+          // gesture latch has to be cleared with the target or a later adopt reads
+          // as a fresh gesture and redirects to the panel, wiping the target the
+          // adopt just set.
+          if (plan.targetScope === plan.targetHost) {
+            if (!disarmTarget) throw new Error(`[stash] host ${plan.targetHost} can retarget but has no disarm`)
+            await disarmTarget()
+          } else await setComposerTarget(workspaceId, plan.targetHost, plan.targetScope)
+          composer.markNeedsRehydrate()
+          return { ok: true }
+        }
+
+        if (plan.action === "move") {
+          // Row-preserving: same id, same `baseVersion`, `scope` rewritten. NOT
+          // `relocateLoadedDraft` (it rebuilds the row through `upsertLoadedDraft`
+          // with no seal context, writing plaintext at rest on an encrypted stream)
+          // and NOT a plain coalescing enqueue (a push snapshotted before the move
+          // may be in flight with its claim not yet visible; coalescing onto it
+          // loses the scope change server-side forever). Move + enqueue share one
+          // transaction so the re-scoped row is never visible without its dirty bit.
+          // The scope is re-checked INSIDE the txn: drift since planning means the
+          // plan may be the wrong ACTION now, so it goes back around for a fresh
+          // plan instead of moving from wherever the row happens to live.
+          const moved = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+            const inTxn = await db.drafts.get(id)
+            if (!inTxn) return "missing"
+            if (inTxn.scope === plan.toScope) return "done"
+            if (inTxn.scope !== plan.fromScope) return "replan"
+            await migrateLocalDraftScope(workspaceId, plan.fromScope, { ...inTxn, scope: plan.toScope })
+            await enqueueDraftUpsert(workspaceId, id, { forceNewOp: true })
+            return "done"
+          })
+          if (moved === "missing") {
+            return refuse("missing", `draft ${id} vanished before its move could run`)
+          }
+          if (moved === "replan") continue
+          syncEngine?.kickOperationQueue()
+        }
+
+        // The host's pointer takes the restored row. Whatever it held is detached
+        // by that same write and becomes a stash entry — a scope points at exactly
+        // one draft, so the swap never clobbers (it was already flushed above).
+        await restoreStashedDraftToComposer(workspaceId, scope, id)
+        // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
         composer.markNeedsRehydrate()
         return { ok: true }
       }
-
-      if (plan.action === "move") {
-        // Row-preserving: same id, same `baseVersion`, `scope` rewritten. NOT
-        // `relocateLoadedDraft` (it rebuilds the row through `upsertLoadedDraft`
-        // with no seal context, writing plaintext at rest on an encrypted stream)
-        // and NOT a plain coalescing enqueue (a push snapshotted before the move
-        // may be in flight with its claim not yet visible; coalescing onto it
-        // loses the scope change server-side forever). Move + enqueue share one
-        // transaction so the re-scoped row is never visible without its dirty bit.
-        const moved = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
-          const live = await db.drafts.get(id)
-          if (!live || live.scope !== plan.fromScope) return false
-          await migrateLocalDraftScope(workspaceId, plan.fromScope, { ...live, scope: plan.toScope })
-          await enqueueDraftUpsert(workspaceId, id, { forceNewOp: true })
-          return true
-        })
-        if (!moved) {
-          return refuse("raced", `draft ${id} moved out of ${plan.fromScope} before its restore could run`)
-        }
-        syncEngine?.kickOperationQueue()
-      }
-
-      // The host's pointer takes the restored row. Whatever it held is detached
-      // by that same write and becomes a stash entry — a scope points at exactly
-      // one draft, so the swap never clobbers (it was already flushed above).
-      await restoreStashedDraftToComposer(workspaceId, scope, id)
-      // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
-      composer.markNeedsRehydrate()
-      return { ok: true }
+      return refuse("raced", `draft ${id} kept moving while being restored`)
     },
     [composer, workspaceId, scope, targetHost, disarmTarget, canHostForeignDraft, describeScope, syncEngine]
   )

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -272,7 +272,9 @@ export function useStashComposer(
           // host at it, so the composer never renders the target scope for a frame
           // with no draft loaded under it. Targeting the host's own scope IS the
           // disarm, so it clears rather than stores.
-          await restoreStashedDraftToComposer(workspaceId, plan.targetScope, id)
+          if (!(await restoreStashedDraftToComposer(workspaceId, plan.targetScope, id))) {
+            return refuse("missing", `draft ${id} vanished (or re-keyed away) before its adopt could land`)
+          }
           // Through the host's own disarm, never a bare `clearComposerTarget`: the
           // gesture latch has to be cleared with the target or a later adopt reads
           // as a fresh gesture and redirects to the panel, wiping the target the
@@ -315,7 +317,9 @@ export function useStashComposer(
         // The host's pointer takes the restored row. Whatever it held is detached
         // by that same write and becomes a stash entry — a scope points at exactly
         // one draft, so the swap never clobbers (it was already flushed above).
-        await restoreStashedDraftToComposer(workspaceId, scope, id)
+        if (!(await restoreStashedDraftToComposer(workspaceId, scope, id))) {
+          return refuse("missing", `draft ${id} vanished (or re-keyed away) before its restore could land`)
+        }
         // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
         composer.markNeedsRehydrate()
         return { ok: true }

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -592,3 +592,28 @@ describe("useStashedDrafts — the worked example: two conversations in one chan
     expect(result.current.drafts.map((d) => d.id)).not.toContain("draft_b_thread")
   })
 })
+
+describe("restoreStashedDraftToComposer — id validated in the txn (INV-20)", () => {
+  it("follows a re-key that landed mid-restore instead of pointing at the retired id", async () => {
+    const { migrateLocalDraftId } = await import("@/sync/draft-sync")
+    const { resetDraftResolutionGuard } = await import("@/sync/draft-resolution-guard")
+    resetDraftResolutionGuard()
+    const first = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("body"), attachments: [] })
+    await stashLoadedDraft(workspaceId, scope)
+    // A split ack re-keys the row between the caller's read and the restore txn.
+    const live = await db.drafts.get(first.id)
+    await migrateLocalDraftId(workspaceId, first.id, { ...live!, id: "draft_rekeyed", baseVersion: 4 })
+
+    expect(await restoreStashedDraftToComposer(workspaceId, scope, first.id)).toBe(true)
+
+    // The pointer follows the migration — never the retired id, which would
+    // render an empty composer over an orphaned row.
+    expect((await db.composerLoaded.get(scope))?.draftId).toBe("draft_rekeyed")
+    expect(await db.drafts.get(first.id)).toBeUndefined()
+  })
+
+  it("returns false for a row that is genuinely gone, and points at nothing", async () => {
+    expect(await restoreStashedDraftToComposer(workspaceId, scope, "draft_never")).toBe(false)
+    expect(await db.composerLoaded.get(scope)).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/lib/drafts/restore-refusal.ts
+++ b/apps/frontend/src/lib/drafts/restore-refusal.ts
@@ -1,11 +1,5 @@
 /** Why a restore did not happen. Every guard returns one; none is silent (INV-11). */
-export type DraftRestoreRefusal =
-  | "missing"
-  | "checked-out"
-  | "target-busy"
-  | "host-ineligible"
-  | "branch-elsewhere"
-  | "raced"
+export type DraftRestoreRefusal = "missing" | "host-ineligible" | "branch-elsewhere" | "raced"
 
 export type DraftRestoreResult = { ok: true } | { ok: false; reason: DraftRestoreRefusal }
 
@@ -18,8 +12,6 @@ export type DraftRestoreResult = { ok: true } | { ok: false; reason: DraftRestor
  */
 export const RESTORE_REFUSAL_MESSAGE: Record<DraftRestoreRefusal, string> = {
   missing: "That draft is no longer there.",
-  "checked-out": "That draft is open in another composer.",
-  "target-busy": "That conversation already has a different draft open.",
   "host-ineligible": "This stream can't hold that draft — it stays where it is.",
   "branch-elsewhere": "Open the conversation to continue that branch reply.",
   raced: "That draft moved before it could be restored.",


### PR DESCRIPTION
## Problem

v1's restore refused what its own picker offered: `checked-out` (draft loaded under any scope on the device)
and `target-busy` (adopt target's pointer holding another draft) surfaced invisible, device-local pointer
state as user-facing errors — the staging failure Kris rejected. Chunk 1 (#1780) made the substrate safe;
this chunk removes the refusals. Chunk 2 of https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-v2-13fec2/.

## Solution

- `restoreStashedDraftToComposer` is now a take-over: one txn detaches every other scope's pointer at the
  draft and points the target; staging buffers of detached scopes are cleared (a reload would otherwise
  resurrect a duplicate). Detached composers react via the chunk-1 pointer paths.
- `upsertLoadedDraft`: an identity-addressed save whose row another scope now holds returns `foreign` and
  splits into a fresh row (same-device mirror of the cross-device split). `removeDraftRowById` re-validates
  INSIDE its txn (INV-20) that no pointer anywhere holds the row before deleting — a displaced composer's
  empty save can no longer delete (or server-mirror-delete) the taken draft.
- `restoreDraftHere`: refusals reduced to `missing` (+ internal `host-ineligible`, `raced` after two re-plan
  attempts). The move txn re-checks the row's scope and goes back around for a fresh plan on drift — a stale
  move plan must not destroy a filing that just became conversation-owned.
- `checked-out`/`target-busy` copy deleted (INV-38); board mount/signal auto-restores log refusals and
  rejections instead of `void`ing them (INV-11).

**#1780's four review findings are fixed here, not on #1780** — same files, unmerged stack, and hunk-splitting
shared files across two branches is how work got destroyed once already today: persist-gated resets (a gated
save keeps the fragment on screen), strict null-identity re-route (`strictIdentity`: a composer's null identity
under a foreign pointer detaches to a fresh row / no-ops the delete — never falls back to fire-time pointer
addressing), serialized pointer transitions (sync-completing handler + promise chain, with an
overlapping-repoints test), and the INV-20 in-txn pointer revalidation above.

Also: a NUL byte inside `scopeRegistryKey`'s template literal (introduced during chunk-1 agent runs, committed
in aea87b75) made composer registrations invisible to `useMountedComposerCount`, silently disabling the
cross-surface double-editor rescue. Normalized to the space every other key site uses.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | take-over txn, `foreign` split, in-txn delete guard, `strictIdentity` re-route |
| `apps/frontend/src/hooks/use-stash-composer.ts` | refusals removed, re-plan loop, dead helper deleted |
| `apps/frontend/src/hooks/use-draft-composer.ts` | serialized transitions, persist-gated resets, NUL fix |
| `apps/frontend/src/lib/drafts/restore-refusal.ts` | `checked-out`/`target-busy` pruned |
| `apps/frontend/src/components/board/board-inline-composer.tsx` | restore results logged, rejection handlers |
| tests (5 files) | take-over, foreign split, delete guard, overlapping repoints, persist gates |

## Test plan

- [x] vitest 316/316 across the 10 affected suites; tsc clean.
- [x] 6 verify findings (Opus/high) + 4 `/code-review` findings from #1780, every fix's guard neutralised
  red → restored.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788614169&installation_model_id=20758&pr_number=1781&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1781&signature=7db0d1f68e566323d6670c627a725f672032ef8301378f5dae2920ddc2965fdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->