### PR TITLE
feat(drafts): the pile shows every member draft, loaded or not

### DIFF
--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { CornerDownRight, X } from "lucide-react"
 import { toast } from "sonner"
+import { RESTORE_REFUSAL_MESSAGE } from "@/lib/drafts/restore-refusal"
 import {
   MessageComposer,
   FloatingComposerShell,
@@ -221,11 +222,15 @@ export function InlineComposerForm({
     if (!id || !composer.isLoaded) return
     restoreOnMountRef.current = null
     // A refusal here is rare (only a row deleted mid-open survives v2's
-    // take-over) but must not vanish silently (INV-11): the resting button
-    // advertised this draft, so an empty composer needs an explanation in the log.
+    // take-over) but the user TAPPED the resting button that advertised this
+    // draft — an unexplained empty composer is a silent failure, so it toasts
+    // like the picker and the deep link do (INV-11, INV-63).
     stash.handleRestoreStashed(id).then(
       (result) => {
-        if (!result.ok) console.error(`[board] mount restore of ${id} refused: ${result.reason}`)
+        if (!result.ok) {
+          console.error(`[board] mount restore of ${id} refused: ${result.reason}`)
+          toast.error(RESTORE_REFUSAL_MESSAGE[result.reason])
+        }
       },
       (err) => console.error(`[board] mount restore of ${id} threw`, err)
     )
@@ -257,7 +262,10 @@ export function InlineComposerForm({
     const stashId = restoreOnSignal.stashId
     stash.handleRestoreStashed(stashId).then(
       (result) => {
-        if (!result.ok) console.error(`[board] signal restore of ${stashId} refused: ${result.reason}`)
+        if (!result.ok) {
+          console.error(`[board] signal restore of ${stashId} refused: ${result.reason}`)
+          toast.error(RESTORE_REFUSAL_MESSAGE[result.reason])
+        }
       },
       (err) => console.error(`[board] signal restore of ${stashId} threw`, err)
     )

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -274,8 +274,12 @@ describe("StashedDraftsPicker", () => {
 
   describe("origin and the own/borrowed seam", () => {
     const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
-    const own: StashedDraftRowOrigin = { tier: "own", label: "#general" }
-    const borrowed = (label: string): StashedDraftRowOrigin => ({ tier: "borrowed", label })
+    const own: StashedDraftRowOrigin = { tier: "own", label: "#general", checkedOutElsewhere: false }
+    const borrowed = (label: string, checkedOutElsewhere = false): StashedDraftRowOrigin => ({
+      tier: "borrowed",
+      label,
+      checkedOutElsewhere,
+    })
     const rows = [makeDraft("draft_own", "mine"), makeDraft("draft_borrowed", "theirs")]
 
     it("draws the seam between the last own row and the first borrowed one", async () => {
@@ -292,6 +296,24 @@ describe("StashedDraftsPicker", () => {
       expect(items[0]).toContain("mine")
       expect(items[1]).toContain("From elsewhere")
       expect(items[2]).toContain("theirs")
+    })
+
+    it("hints a row checked out by another composer, without gating it", async () => {
+      renderPicker({
+        drafts: rows,
+        originById: new Map([
+          ["draft_own", own],
+          ["draft_borrowed", borrowed("Reply in Pizza plans", true)],
+        ]),
+      })
+      await open()
+
+      const items = Array.from(screen.getByRole("list").children).map((el) => el.textContent)
+      // Control: the un-checked-out row carries no hint.
+      expect(items[0]).not.toContain("open elsewhere")
+      expect(items[2]).toContain("open elsewhere")
+      // Still a live action, not a disabled row.
+      expect(screen.getByText("theirs").closest("button")).not.toBeDisabled()
     })
 
     it("renders no seam when every row is own", async () => {

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -378,14 +378,18 @@ export function StashedDraftsPicker({
                           // target), so it says the part that is true either way
                           // rather than guessing — and does it in the accessible
                           // name and the tooltip, which cost no layout (INV-21).
+                          // `aria-label` REPLACES the content-derived name, so
+                          // the "open elsewhere" hint must ride inside it too —
+                          // as a visible-only span it would be dropped from the
+                          // accessible name on exactly the rows that carry it.
                           title={
                             isBorrowed
-                              ? `From ${origin.label}. Picking it changes where this composer files.`
+                              ? `From ${origin.label}.${origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""} Picking it changes where this composer files.`
                               : undefined
                           }
                           aria-label={
                             isBorrowed
-                              ? `${preview} — from ${origin.label}. Picking it changes where this composer files.`
+                              ? `${preview} — from ${origin.label}.${origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""} Picking it changes where this composer files.`
                               : undefined
                           }
                           className="flex-1 min-w-0 text-left focus:outline-none"
@@ -422,6 +426,15 @@ export function StashedDraftsPicker({
                               {formatRelativeTime(new Date(draft.clientUpdatedAt), now, undefined, { terse: true })}
                               {attachmentCount > 0 && <span className="ml-1.5">· {attachmentCount} 📎</span>}
                             </span>
+                            {/* Quiet hint on the shared meta line (no layout
+                                shift, INV-21): the row is still fully loadable —
+                                a tap takes the draft over — this just says the
+                                take-over will detach another composer. */}
+                            {origin?.checkedOutElsewhere && (
+                              <span data-draft-open-elsewhere className="shrink-0 truncate">
+                                · open elsewhere
+                              </span>
+                            )}
                           </p>
                         </button>
                         <Button

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -307,13 +307,13 @@ function MessageInputComponent({
   // stream's own draft. The typed draft is NOT moved — its scope IS its target,
   // so it stays a draft of that conversation and keeps its filing.
   //
-  // It must also stop being CHECKED OUT here. A draft loaded under a scope no
-  // composer is showing is excluded from every pile on the device (the
-  // checked-out-anywhere rule) and carries no `?stash=` link in the explorer, so
-  // "it stays reachable" would be false — the only way back would be to open that
-  // conversation. Detaching the pointer turns it into a real stash entry, which
-  // is what makes that sentence true. Unless another composer is already mounted
-  // on the scope: then it is showing the draft and owns it.
+  // It must also stop being CHECKED OUT here. Piles now offer loaded rows too
+  // (v2 take-over), but the drafts EXPLORER still keys `isStashed` on the
+  // pointer and offers a `?stash=` deep link only to detached rows — so without
+  // this detach the disarmed draft would carry no link there and "it stays
+  // reachable" would be weaker than promised. Detaching the pointer turns it
+  // into a real stash entry. Unless another composer is already mounted on the
+  // scope: then it is showing the draft and owns it.
   //
   // ONE disarm, for every path that drops the target: clearing the target alone
   // strands the gesture latch, and a stranded latch makes the NEXT arm read as a

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -404,9 +404,10 @@ export function useAllDrafts(workspaceId: string) {
     return map
   }, [composerLoaded])
 
-  // A draft is "stashed" when no composer on this device holds it — keyed by
-  // draft id, the same checked-out-anywhere rule the stash pile excludes on, so
-  // the explorer can never offer a `?stash=` deep link the destination refuses.
+  // A draft is "stashed" when no composer on this device holds it — the
+  // explorer's own rule for which rows carry a `?stash=` deep link. (The stash
+  // PILE no longer excludes on it — v2 offers loaded rows and a restore takes
+  // them over — so this is deliberately the stricter of the two, not a mirror.)
   // Every writer of `composerLoaded` keeps pointer-scope == row-scope (adopt
   // checks the row out under its own scope; move rewrites the scope first), so
   // an id-keyed and a scope-keyed rule agree on every reachable state; id-keyed

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -428,14 +428,8 @@ export function useDraftComposer({
   // cannot cross-write into Y) and then re-run init against Y. Rehydration happens
   // whether or not the user is engaged: the repoint is this same user's own action
   // on this device, so the new draft is what they asked to see.
-  // Pointer transitions are handled STRICTLY IN ORDER through a promise chain:
-  // a transition that persists content (an async save) must fully resolve before
-  // the next transition's handler reads the editor state, or a second repoint
-  // landing inside the save's in-flight window (a programmatic double-restore,
-  // a catch-up burst) reads half-updated refs and flushes the wrong content into
-  // the wrong row. `prevLoadedIdRef` still advances synchronously so each queued
-  // handler gets its own (prev, next) pair; everything else is read at RUN time,
-  // after the previous handler settled.
+  // Serialization (why and how) is documented once, on the chain effect below.
+  //
   // NOT async: a transition with no persistence work completes synchronously
   // (returns null) so its resets and ref updates land in the same tick the
   // pointer changed — the pre-chain semantics every hydrate effect depends on.

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -544,3 +544,71 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
     expect(await db.drafts.get("draft_other")).toBeDefined()
   })
 })
+
+describe("restoreDraftHere — re-plan on mid-restore drift", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    __clearBoardDraftContextRegistry()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.composerTarget.clear()
+    await db.pendingOperations.clear()
+    await db.streams.clear()
+    await db.conversations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    __clearBoardDraftContextRegistry()
+  })
+
+  // The plan (adopt vs move) is made from the row's scope BEFORE the flush; the
+  // flush is the drift window. A row re-homed into a conversation during it must
+  // be ADOPTED by the re-plan — executing the stale move would rewrite its scope
+  // and destroy the filing with no undo.
+  it("re-plans a move into an adopt when the row is re-homed during the flush", async () => {
+    await seedAoStream()
+    await seedAoConversation()
+    const subtopicScope = `board:subtopic:${aoStreamId}:msg_1`
+    await db.drafts.put(aoDraft("draft_drift", subtopicScope))
+    await seedDraftCacheFromIdb(aoWorkspaceId)
+
+    function useDriftHarness() {
+      const composer = useDraftComposer({ workspaceId: aoWorkspaceId, draftKey: aoHostScope, scopeId: aoHostScope })
+      // The drift lands inside the flush window: another surface re-homes the
+      // row into the conversation between the plan and the move txn.
+      const wrapped = {
+        ...composer,
+        flushDraft: async () => {
+          const live = await db.drafts.get("draft_drift")
+          if (live && live.scope === subtopicScope) {
+            const { migrateLocalDraftScope } = await import("@/sync/draft-sync")
+            await migrateLocalDraftScope(aoWorkspaceId, subtopicScope, { ...live, scope: aoConversationScope })
+          }
+        },
+      }
+      const stash = useStashComposer(wrapped as never, aoWorkspaceId, aoHostScope, {
+        targetHost: aoHostScope,
+        disarmTarget: () => clearComposerTarget(aoHostScope),
+      })
+      return { stash }
+    }
+
+    const { result } = renderHook(() => useDriftHarness(), { wrapper })
+    await waitFor(() => expect(result.current.stash.drafts.map((d) => d.id)).toContain("draft_drift"))
+
+    await act(async () => {
+      expect(await result.current.stash.handleRestoreStashed("draft_drift")).toEqual({ ok: true })
+    })
+
+    // Re-planned: adopted where it now lives — filing KEPT, host armed at the
+    // conversation; never moved onto the host scope.
+    expect((await db.drafts.get("draft_drift"))?.scope).toBe(aoConversationScope)
+    expect((await db.composerTarget.get(aoHostScope))?.scope).toBe(aoConversationScope)
+    expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_drift")
+  })
+})

--- a/apps/frontend/src/hooks/use-stashed-draft-origins.ts
+++ b/apps/frontend/src/hooks/use-stashed-draft-origins.ts
@@ -9,6 +9,8 @@ export interface StashedDraftRowOrigin {
   tier: "own" | "borrowed"
   /** Always a displayable string — an unresolved place degrades to the explorer's wording. */
   label: string
+  /** Another scope's composer holds this draft; a tap takes it over (quiet hint, never a gate). */
+  checkedOutElsewhere: boolean
 }
 
 /**
@@ -52,7 +54,9 @@ export function useStashedDraftOrigins(
       }
     }
     const map = new Map<string, StashedDraftRowOrigin>()
-    for (const [draftId, origin] of originByDraftId) map.set(draftId, { tier: origin.tier, label: label(origin) })
+    for (const [draftId, origin] of originByDraftId) {
+      map.set(draftId, { tier: origin.tier, label: label(origin), checkedOutElsewhere: origin.checkedOutElsewhere })
+    }
     return map
   }, [originByDraftId, streams, users, dmPeers])
 }

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -207,6 +207,7 @@ describe("useStashedDrafts — pile membership", () => {
       kind: "conversation",
       conversationId: "conv_lone",
       tier: "borrowed",
+      checkedOutElsewhere: false,
       title: null,
       // No topic summary yet — the label falls back to this stream's name rather
       // than a generic phrase, the same rung the drafts explorer uses.
@@ -357,18 +358,47 @@ describe("useStashedDrafts — pile membership", () => {
     ])
   })
 
-  it("excludes a draft checked out into ANY scope's composer on this device", async () => {
+  it("offers a draft checked out under ANOTHER scope, marked checkedOutElsewhere; hides only this host's own loaded one", async () => {
     await seedStream("stream_s")
     await seedConversation("conv_1", "stream_s")
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_stream", scope: "stream:stream_s" }),
       draftRow({ id: "draft_conv", scope: "board:reply:conv_1" }),
     ])
-    // Live-typed in the timeline composer: the conversation's picker must not
-    // offer it, or a move would vacate it under a live editor.
+    // Loaded under the timeline scope — v1 hid this row from every other pile,
+    // which (pointers never detaching on navigation) meant nothing ever shared
+    // without an explicit stash. v2 offers it; a tap takes it over (chunk 2).
     await db.composerLoaded.put({ scope: "stream:stream_s", workspaceId: pileWorkspaceId, draftId: "draft_stream" })
 
-    await expectPile("board:reply:conv_1", ["draft_conv"])
+    const { result, unmount } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_conv", "draft_stream"]))
+    expect(result.current.originByDraftId.get("draft_stream")?.checkedOutElsewhere).toBe(true)
+    expect(result.current.originByDraftId.get("draft_conv")?.checkedOutElsewhere).toBe(false)
+    // The deep-link claim set includes the loaded-elsewhere row too (take-over).
+    expect(result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_conv"])
+    unmount()
+
+    // Control: the host whose OWN composer holds the draft does not see it in
+    // its pile (it is already on screen) — the exclusion that remains.
+    const host = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() => expect(host.result.current.drafts.map((d) => d.id)).toEqual(["draft_conv"]))
+    expect(host.result.current.claimableDrafts.map((d) => d.id)).toEqual([])
+    host.unmount()
+  })
+
+  it("a stream draft with a live pointer appears in a same-root conversation pile without any stash step", async () => {
+    await seedStream("stream_s")
+    await seedConversation("conv_1", "stream_s")
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_typed", scope: "stream:stream_s" }),
+      // Control row proving the pile is not just "everything": a draft under a
+      // different root stays out even while the widened rule admits the typed one.
+      draftRow({ id: "draft_other_root", scope: "stream:stream_other" }),
+    ])
+    await seedStream("stream_other")
+    await db.composerLoaded.put({ scope: "stream:stream_s", workspaceId: pileWorkspaceId, draftId: "draft_typed" })
+
+    await expectPile("board:reply:conv_1", ["draft_typed"])
   })
 
   it("excludes an empty borrowed draft, an archived home, an E2E host, and an uncached conversation", async () => {
@@ -426,11 +456,19 @@ describe("useStashedDrafts — pile membership", () => {
     const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
     await waitFor(() => expect(result.current.originByDraftId.size).toBe(4))
     expect(Object.fromEntries(result.current.originByDraftId)).toEqual({
-      draft_stream: { kind: "stream", streamId: "stream_s", tier: "own", title: null, anchorStreamId: "stream_s" },
+      draft_stream: {
+        kind: "stream",
+        streamId: "stream_s",
+        tier: "own",
+        checkedOutElsewhere: false,
+        title: null,
+        anchorStreamId: "stream_s",
+      },
       draft_conv: {
         kind: "conversation",
         conversationId: "conv_1",
         tier: "borrowed",
+        checkedOutElsewhere: false,
         title: "Pizza plans",
         anchorStreamId: "stream_s",
       },
@@ -439,6 +477,7 @@ describe("useStashedDrafts — pile membership", () => {
         anchorId: "msg_9",
         streamId: "stream_s",
         tier: "borrowed",
+        checkedOutElsewhere: false,
         title: null,
         anchorStreamId: "stream_s",
       },
@@ -448,6 +487,7 @@ describe("useStashedDrafts — pile membership", () => {
         messageId: "msg_1",
         anchorStreamId: "stream_s",
         tier: "borrowed",
+        checkedOutElsewhere: false,
         title: "Pizza plans",
       },
     })
@@ -489,21 +529,43 @@ describe("useStashedDrafts — pile membership", () => {
     expect(result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_conv"])
   })
 
-  it("never offers or claims a row already checked out by another scope on this device", async () => {
+  // Every `composerLoaded` writer keeps pointer-scope == row-scope (adopt checks
+  // a row out under its OWN scope; move rewrites the scope first), so "checked
+  // out elsewhere" always means: a borrowed row loaded in its own composer on
+  // another surface. That also means a host's claim set never meets a foreign
+  // pointer on its own rows — dropping the old checked-out-anywhere claim filter
+  // is behavior-preserving, and the exclusion that remains (the host's own
+  // loaded draft) is asserted here with live rows on both sides.
+  it("offers a borrowed row loaded in its own composer elsewhere; a host never claims its own loaded draft", async () => {
     await seedStream("stream_s")
     await seedConversation("conv_1", "stream_s")
     await db.drafts.bulkAdd([
       draftRow({ id: "draft_shared", scope: "board:reply:conv_1" }),
       draftRow({ id: "draft_sibling", scope: "board:reply:conv_1", clientUpdatedAt: 900 }),
     ])
-    // Restored into the timeline composer from the drafts explorer: the row's own
-    // scope still says `board:reply:conv_1`, so a scope-exact claimable list would
-    // hand the same row to a second composer.
-    await db.composerLoaded.put({ scope: "stream:stream_s", workspaceId: pileWorkspaceId, draftId: "draft_shared" })
+    // The conversation's docked composer holds draft_shared (reachable shape:
+    // pointer under the row's own scope). v1 hid it from the stream's pile; v2
+    // offers it there — a tap takes it over (chunk 2).
+    await db.composerLoaded.put({
+      scope: "board:reply:conv_1",
+      workspaceId: pileWorkspaceId,
+      draftId: "draft_shared",
+    })
 
-    const { result } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_1"))
-    await waitFor(() => expect(result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_sibling"]))
-    expect(result.current.drafts.map((d) => d.id)).toEqual(["draft_sibling"])
+    const stream = renderHook(() => useStashedDrafts(pileWorkspaceId, "stream:stream_s"))
+    await waitFor(() =>
+      expect(stream.result.current.drafts.map((d) => d.id).sort()).toEqual(["draft_shared", "draft_sibling"])
+    )
+    expect(stream.result.current.originByDraftId.get("draft_shared")?.checkedOutElsewhere).toBe(true)
+    expect(stream.result.current.originByDraftId.get("draft_sibling")?.checkedOutElsewhere).toBe(false)
+    stream.unmount()
+
+    // The conversation host itself: its loaded draft is on screen, so neither
+    // pile nor claim set offers it; the detached sibling stays claimable.
+    const conv = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(conv.result.current.claimableDrafts.map((d) => d.id)).toEqual(["draft_sibling"]))
+    expect(conv.result.current.drafts.map((d) => d.id)).toEqual(["draft_sibling"])
+    conv.unmount()
   })
 
   // The scope-exact branch deliberately applies NO payload filter. A draft can

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -34,6 +34,12 @@ export type StashedDraftSource =
  */
 export type StashedDraftOrigin = StashedDraftSource & {
   tier: "own" | "borrowed"
+  /**
+   * A DIFFERENT scope's composer pointer currently references this draft.
+   * Restoring still works — it takes the draft over (chunk 2) — but the picker
+   * shows a quiet hint so the take-over is informed rather than surprising.
+   */
+  checkedOutElsewhere: boolean
   /** The owning conversation's topic summary, when it has one. */
   title: string | null
   /**
@@ -48,13 +54,13 @@ export type StashedDraftOrigin = StashedDraftSource & {
 }
 
 export interface UseStashedDraftsResult {
-  /** The pile the picker renders: every draft that could have been written under this host's root stream, minus the loaded ones. Own rows first, then borrowed; each group newest first. */
+  /** The pile the picker renders: every draft that could have been written under this host's root stream, minus only THIS host's loaded one (already on screen). Own rows first, then borrowed; each group newest first. */
   drafts: CachedDraft[]
   /**
-   * The subset this host may restore: its own scope's rows, minus any row already
-   * checked out by a composer on this device. A row checked out under one scope is
-   * neither offered nor claimable under another — two scopes holding one row make
-   * their debounced saves fight over its `scope` and body.
+   * The subset the `?stash=` deep link may claim: this scope's rows minus the
+   * host's own loaded one. A row checked out under another scope stays claimable
+   * — the restore takes it over (chunk 2), the identity-addressed write path
+   * makes the displaced editor split rather than fight.
    */
   claimableDrafts: CachedDraft[]
   /** Where each pile row came from, and its tier, keyed by draft id. */
@@ -133,8 +139,12 @@ function isHostHomeEligible(
 
 /**
  * The stashed drafts a composer offers — every draft the user could plausibly
- * have written from here, except the ones checked out into a composer on this
- * device.
+ * have written from here, loaded elsewhere or not; the only exclusion is this
+ * host's own loaded draft, which is already on screen. A row checked out under
+ * another scope is offered with `checkedOutElsewhere` set and a tap TAKES it
+ * (chunk 2) — hiding it was v1's mistake: pointers never detach on navigation,
+ * so "loaded somewhere" described almost every draft and the pile shared
+ * nothing.
  *
  * "Could have written here" is {@link isDraftInHostPile}: one root stream, then
  * own scope / same conversation / a top-level draft / a top-level host offering
@@ -162,12 +172,13 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
   const cachedStreams = useWorkspaceStreamsRaw(workspaceId)
 
   const loadedId = scope ? (loaded.find((row) => row.scope === scope)?.draftId ?? null) : null
-  // Loaded in ANY scope on this device, not just this host's: a draft the user is
-  // live-typing in another composer must never be offered here.
-  const loadedAnywhere = useMemo(() => {
-    const ids = new Set<string>()
-    for (const row of loaded) if (row.draftId) ids.add(row.draftId)
-    return ids
+  // Where each draft is checked out, if anywhere. Being loaded somewhere no
+  // longer HIDES a row (v2: a visible row is loadable — restoring takes it
+  // over, chunk 2); it only annotates the origin so the take-over is informed.
+  const pointerScopeByDraftId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const row of loaded) if (row.draftId) map.set(row.draftId, row.scope)
+    return map
   }, [loaded])
 
   const streamMap = useMemo(() => {
@@ -182,10 +193,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     return ids
   }, [cachedStreams])
 
-  const candidates = useMemo(
-    () => allDrafts.filter((draft) => !loadedAnywhere.has(draft.id) && draftHasPayload(draft)),
-    [allDrafts, loadedAnywhere]
-  )
+  const candidates = useMemo(() => allDrafts.filter(draftHasPayload), [allDrafts])
 
   const pileScopes = useMemo(() => {
     const scopes = candidates.map((draft) => draft.scope)
@@ -266,12 +274,13 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
         // (seeded by "Discuss with Ariadne") has an empty body and no attachments,
         // and the explorer already skips it — the scope's own picker is the last
         // surface that can reach it, so filtering here would strand it while it
-        // keeps syncing. `loadedAnywhere` is not optional: a row checked out under
-        // any scope on this device must be claimable from none.
-        .filter((draft) => draft.scope === scope && !loadedAnywhere.has(draft.id))
+        // keeps syncing. The only exclusion is this host's own loaded draft (it's
+        // already on screen); a row checked out ELSEWHERE stays claimable — the
+        // restore takes it over (v2).
+        .filter((draft) => draft.scope === scope && draft.id !== loadedId)
         .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
     )
-  }, [allDrafts, workspaceId, scope, loadedAnywhere])
+  }, [allDrafts, workspaceId, scope, loadedId])
 
   const comparePile = useCallback(
     (a: CachedDraft, b: CachedDraft) => {
@@ -314,17 +323,19 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     const rows = new Map<string, CachedDraft>()
     for (const id of latchedIdsRef.current) {
       const row = draftsById.get(id)
-      // A row that was deleted, emptied or checked out into a composer still goes
-      // — the latch holds membership against a moving home stream, not the row.
-      // "Emptied" applies to borrowed rows only; an own row carrying just context
-      // refs is legitimately body-less (see `scopeExact`).
-      if (!row || loadedAnywhere.has(row.id)) continue
+      // A row that was deleted, emptied, or that became THIS host's loaded draft
+      // still goes — the latch holds membership against a moving home stream, not
+      // the row. Checked out elsewhere is no longer a drop-out (v2: the row stays
+      // offered and a tap takes it over). "Emptied" applies to borrowed rows
+      // only; an own row carrying just context refs is legitimately body-less
+      // (see `scopeExact`).
+      if (!row || row.id === loadedId) continue
       if (row.scope !== scope && !draftHasPayload(row)) continue
       rows.set(id, row)
     }
     for (const row of livePile) rows.set(row.id, row)
     return [...rows.values()].sort(comparePile)
-  }, [pileOpen, livePile, draftsById, loadedAnywhere, comparePile, scope])
+  }, [pileOpen, livePile, draftsById, loadedId, comparePile, scope])
 
   const originByDraftId = useMemo(() => {
     const topicSummary = (source: StashedDraftSource): string | null => {
@@ -349,15 +360,17 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     for (const draft of drafts) {
       const source = draftSource(draft.scope, streamByAnchorId)
       if (!source) continue
+      const pointerScope = pointerScopeByDraftId.get(draft.id)
       map.set(draft.id, {
         ...source,
         tier: draft.scope === scope ? "own" : "borrowed",
+        checkedOutElsewhere: pointerScope !== undefined && pointerScope !== scope,
         title: topicSummary(source),
         anchorStreamId: anchorStream(source),
       })
     }
     return map
-  }, [drafts, scope, streamByAnchorId, boardPostMap, hostPostByMessageId])
+  }, [drafts, scope, streamByAnchorId, boardPostMap, hostPostByMessageId, pointerScopeByDraftId])
 
   const canHostForeignDraft = useCallback(
     () => !!workspaceId && !!scope && isHostHomeEligible(scope, pileContext, streamMap, archivedStreamIds),


### PR DESCRIPTION
## Problem

v1's pile excluded any draft "loaded anywhere" — and since `composerLoaded` pointers never detach on
navigation, that described almost every active draft. Only explicitly stashed rows ever shared, reducing the
feature to the ritual Kris rejected ("drafts should not have to be stashed to be made visible in their other
scopes"). Chunk 3 of https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-v2-13fec2/, standing on #1781's
take-over restore.

## Solution

- `useStashedDrafts` candidates drop the `loadedAnywhere` exclusion; the only per-host exclusion left is the
  host's own on-screen draft. The picker-open latch drops a row only when it becomes this host's loaded one.
- Claim set (`?stash=`) simplified to the same rule — behavior-preserving, and documented as such: every
  `composerLoaded` writer keeps pointer-scope == row-scope, so the old id-keyed filter and the new one agree
  on every reachable state (the "deep link to a draft loaded under a different scope" case is unreachable;
  the fixtures that seeded it are rewritten to the reachable shape).
- Origins carry `checkedOutElsewhere` (a different scope's pointer holds the row); the picker hints those
  rows on the meta line AND inside the `aria-label`/tooltip (an `aria-label` replaces the content-derived
  name, so a visible-only span would be dropped for screen readers on exactly the rows that carry it). The
  hint never gates — a tap takes the draft over.
- #1781 review folds: board mount/signal auto-restore refusals now `toast.error` like the picker (the user
  tapped a button advertising the draft — INV-63); the duplicated serialization paragraph deduplicated; the
  mid-restore drift re-plan finally has a test (a flush-window re-home into a conversation is ADOPTED, filing
  kept — the one irreversible-operation guard, neutralised red→restored).
- Two comments still describing the deleted checked-out-anywhere rule corrected (`message-input.tsx`
  disarm rationale, `use-all-drafts.ts` explorer rule — the two rules are now deliberately different and say
  so).

**Known issue (deferred to chunk 5, which owns the navigate/focus pattern):** adopting a draft whose target
scope has a MOUNTED composer (the open conversation panel's docked footer) arms the timeline, whose
yield-to-panel effect immediately disarms it — net silent no-op. The right behavior is to focus/navigate to
the panel composer that already shows the draft; chunk 5 implements it.

**Accepted trade-off (from #1781's review, restated here):** the take-over wipes a detached scope's staging
buffer; keystrokes typed within the 500 ms debounce window before navigating away AND taken over before the
next reload are unrecoverable. The alternative resurrects a duplicate row on reload; the code documents the
chosen side.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-stashed-drafts.ts` | exclusion removal, `checkedOutElsewhere`, latch rule |
| `apps/frontend/src/hooks/use-stashed-draft-origins.ts` | hint threading |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | meta-line + aria hint |
| `apps/frontend/src/components/board/board-inline-composer.tsx` | refusal toasts |
| `apps/frontend/src/hooks/use-draft-composer.ts` | comment dedup |
| `apps/frontend/src/hooks/use-stash-composer.test.ts` | drift re-plan test |
| tests (3 more files) | widened-pile cases with positive control rows |

## Test plan

- [x] vitest 256/256 across the 8 affected suites; tsc clean.
- [x] Neutralisations: pile widening, `checkedOutElsewhere`, picker hint, drift re-plan guard — each
  inverted → red → restored.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788615432&installation_model_id=20758&pr_number=1782&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1782&signature=2d2ee6685894c56e3ff70d16ec82363961fd2199447aacd9ccf6825d1600da59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->