### PR TITLE
feat(drafts): stash is durable and synced — stashed_at on the draft row

### DIFF
--- a/apps/backend/src/db/migrations/20260806150000_drafts_stashed_at.sql
+++ b/apps/backend/src/db/migrations/20260806150000_drafts_stashed_at.sql
@@ -1,0 +1,5 @@
+-- Stash becomes a durable, synced statement (draft-sharing v2 chunk 4): a
+-- stashed draft must not be advertised or auto-restored by any surface on any
+-- device until the user takes it back out. Nullable, no default, no index —
+-- read paths filter client-side.
+ALTER TABLE drafts ADD COLUMN stashed_at TIMESTAMPTZ;

--- a/apps/backend/src/features/drafts/handlers.ts
+++ b/apps/backend/src/features/drafts/handlers.ts
@@ -39,6 +39,10 @@ const upsertSchema = z
     ciphertext: z.string().min(1).nullable().optional(),
     envelope: z.unknown().optional(),
     e2eVersion: z.number().int().nullable().optional(),
+    // Absent means PRESERVE: a client that predates this field (or a stale PWA
+    // bundle) must not erase a stash set elsewhere with its next autosave. New
+    // clients always send the value — explicit null clears, a timestamp sets.
+    stashedAt: z.string().datetime().nullable().optional(),
   })
   .refine((d) => !(d.contentJson && d.ciphertext), {
     message: "A draft carries either plaintext contentJson or an E2E ciphertext, not both",
@@ -54,6 +58,12 @@ const resolveSchema = z.object({
 const deleteSchema = z.object({
   supersededWriteIds: z.array(writeIdSchema).max(64).optional(),
 })
+
+/** undefined = absent on the wire (preserve), null = clear, string = set. */
+function parseStashedAt(value: string | null | undefined): Date | null | undefined {
+  if (value === undefined) return undefined
+  return value ? new Date(value) : null
+}
 
 interface Dependencies {
   draftsService: DraftsService
@@ -93,6 +103,7 @@ export function createDraftsHandlers({ draftsService }: Dependencies) {
         writeId: data.writeId,
         priorWriteIds: data.priorWriteIds ?? [],
         clientUpdatedAt: new Date(data.clientUpdatedAt),
+        stashedAt: parseStashedAt(data.stashedAt),
         contentJson,
         contentMarkdown: contentJson ? deriveContentMarkdown(contentJson) : null,
         attachmentIds: data.attachmentIds ?? [],

--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -60,6 +60,7 @@ const INSERT_PARAMS = {
   e2eVersion: null,
   clientUpdatedAt: NOW,
   lastClientWriteId: "write_1",
+  stashedAt: null,
 }
 
 describe("DraftsRepository.insertIfAbsent", () => {
@@ -131,6 +132,7 @@ describe("DraftsRepository.casUpdate", () => {
       e2eVersion: null,
       clientUpdatedAt: NOW,
       lastClientWriteId: "write_2",
+      stashedAt: null,
     })
 
     expect(captured.text).toContain("UPDATE drafts SET")
@@ -168,6 +170,7 @@ describe("DraftsRepository.casUpdate", () => {
       e2eVersion: null,
       clientUpdatedAt: NOW,
       lastClientWriteId: "write_3",
+      stashedAt: null,
     })
 
     expect(result).toBeNull()

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -20,6 +20,7 @@ interface DraftRow {
   last_client_write_id: string | null
   superseded_write_ids: string[] | null
   client_updated_at: Date
+  stashed_at: Date | null
   created_at: Date
   updated_at: Date
   deleted_at: Date | null
@@ -60,6 +61,8 @@ export interface Draft {
    */
   supersededWriteIds: string[] | null
   clientUpdatedAt: Date
+  /** Set while the draft is stashed; null = active. Synced verbatim, cleared on restore. */
+  stashedAt: Date | null
   createdAt: Date
   updatedAt: Date
   deletedAt: Date | null
@@ -81,6 +84,7 @@ export interface InsertDraftParams {
   envelope: unknown | null
   e2eVersion: number | null
   clientUpdatedAt: Date
+  stashedAt: Date | null
   lastClientWriteId: string
 }
 
@@ -108,11 +112,13 @@ export interface CasUpdateDraftParams {
   envelope: unknown | null
   e2eVersion: number | null
   clientUpdatedAt: Date
+  /** undefined = preserve the row's current value (field absent on the wire — legacy client). */
+  stashedAt: Date | null | undefined
   lastClientWriteId: string
 }
 
 const COLUMNS =
-  "id, workspace_id, user_id, scope, root_stream_id, content_json, content_markdown, attachment_ids, command, context_refs, ciphertext, envelope, e2e_version, version, last_client_write_id, superseded_write_ids, client_updated_at, created_at, updated_at, deleted_at"
+  "id, workspace_id, user_id, scope, root_stream_id, content_json, content_markdown, attachment_ids, command, context_refs, ciphertext, envelope, e2e_version, version, last_client_write_id, superseded_write_ids, client_updated_at, stashed_at, created_at, updated_at, deleted_at"
 
 function mapRow(row: DraftRow): Draft {
   return {
@@ -133,6 +139,7 @@ function mapRow(row: DraftRow): Draft {
     lastClientWriteId: row.last_client_write_id,
     supersededWriteIds: Array.isArray(row.superseded_write_ids) ? row.superseded_write_ids : null,
     clientUpdatedAt: row.client_updated_at,
+    stashedAt: row.stashed_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     deletedAt: row.deleted_at,
@@ -156,7 +163,7 @@ export const DraftsRepository = {
         id, workspace_id, user_id, scope, root_stream_id,
         content_json, content_markdown, attachment_ids, command, context_refs,
         ciphertext, envelope, e2e_version, version, last_client_write_id,
-        client_updated_at
+        client_updated_at, stashed_at
       )
       VALUES (
         ${params.id},
@@ -174,7 +181,8 @@ export const DraftsRepository = {
         ${params.e2eVersion},
         1,
         ${params.lastClientWriteId},
-        ${params.clientUpdatedAt}
+        ${params.clientUpdatedAt},
+        ${params.stashedAt}
       )
       ON CONFLICT (id) DO NOTHING
       RETURNING ${sql.raw(COLUMNS)}
@@ -226,6 +234,7 @@ export const DraftsRepository = {
         e2e_version = ${params.e2eVersion},
         last_client_write_id = ${params.lastClientWriteId},
         client_updated_at = ${params.clientUpdatedAt},
+        stashed_at = CASE WHEN ${params.stashedAt === undefined} THEN stashed_at ELSE ${params.stashedAt ?? null} END,
         updated_at = NOW(),
         version = version + 1
       WHERE id = ${params.id}

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -27,6 +27,7 @@ function fakeDraft(overrides: Partial<Draft> = {}): Draft {
     e2eVersion: null,
     version: 1,
     lastClientWriteId: "write_1",
+    stashedAt: null,
     supersededWriteIds: null,
     clientUpdatedAt: NOW,
     createdAt: NOW,
@@ -38,6 +39,7 @@ function fakeDraft(overrides: Partial<Draft> = {}): Draft {
 
 function baseUpsertParams() {
   return {
+    stashedAt: null,
     workspaceId: WORKSPACE_ID,
     userId: USER_ID,
     id: DRAFT_ID,

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -26,6 +26,8 @@ export interface UpsertDraftParams {
    */
   priorWriteIds: string[]
   clientUpdatedAt: Date
+  /** undefined = field absent on the wire (legacy client) → preserve the row's current value. */
+  stashedAt: Date | null | undefined
   contentJson: JSONContent | null
   contentMarkdown: string | null
   attachmentIds: string[]
@@ -122,6 +124,7 @@ export class DraftsService {
         envelope: params.envelope,
         e2eVersion: params.e2eVersion,
         clientUpdatedAt: params.clientUpdatedAt,
+        stashedAt: params.stashedAt ?? null,
         lastClientWriteId: params.writeId,
       }
 
@@ -183,6 +186,7 @@ export class DraftsService {
           envelope: params.envelope,
           e2eVersion: params.e2eVersion,
           clientUpdatedAt: params.clientUpdatedAt,
+          stashedAt: params.stashedAt,
           lastClientWriteId: params.writeId,
         })
         if (updated) {

--- a/apps/backend/src/features/drafts/view.ts
+++ b/apps/backend/src/features/drafts/view.ts
@@ -26,6 +26,7 @@ export function toDraftView(row: Draft): DraftView {
     e2eVersion: row.e2eVersion,
     version: row.version,
     clientUpdatedAt: row.clientUpdatedAt.toISOString(),
+    stashedAt: row.stashedAt ? row.stashedAt.toISOString() : null,
     lastClientWriteId: row.lastClientWriteId,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),

--- a/apps/backend/tests/integration/draft-stashed-at.test.ts
+++ b/apps/backend/tests/integration/draft-stashed-at.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, addTestMember, setupTestDatabase } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { DraftsService } from "../../src/features/drafts/service"
+import { DraftsRepository } from "../../src/features/drafts/repository"
+import { userId, workspaceId, draftId } from "../../src/lib/id"
+import type { JSONContent } from "@threa/types"
+
+// INV-68: `stashed_at` is verified against the real schema — the column exists,
+// the insert and CAS-update statements actually run, and the value round-trips
+// through the repository (µs-precision TIMESTAMPTZ vs JS ms is exactly the class
+// of drift a text assertion can't see).
+describe("drafts.stashed_at round-trip", () => {
+  let pool: Pool
+  let testUserId: string
+  let testWorkspaceId: string
+  let service: DraftsService
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    testUserId = userId()
+    testWorkspaceId = workspaceId()
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Test Workspace",
+        slug: `test-ws-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+    })
+    service = new DraftsService({ pool })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  type ServiceUpsertParams = Parameters<DraftsService["upsert"]>[0]
+
+  function upsertParams(id: string, overrides: Partial<ServiceUpsertParams> = {}): ServiceUpsertParams {
+    return {
+      workspaceId: testWorkspaceId,
+      userId: testUserId,
+      id,
+      scope: "stream:stream_it",
+      rootStreamId: null,
+      expectedVersion: 0,
+      writeId: `write_${id}_1`,
+      priorWriteIds: [],
+      clientUpdatedAt: new Date("2026-08-06T10:00:00.000Z"),
+      stashedAt: null,
+      contentJson: { type: "doc", content: [] } as JSONContent,
+      contentMarkdown: "body",
+      attachmentIds: [],
+      command: null,
+      contextRefs: null,
+      ciphertext: null,
+      envelope: null,
+      e2eVersion: null,
+      ...overrides,
+    }
+  }
+
+  test("insert persists stashed_at and the view reads it back", async () => {
+    const id = draftId()
+    const stashedAt = new Date("2026-08-06T11:22:33.000Z")
+    const created = await service.upsert(upsertParams(id, { stashedAt }))
+
+    expect(created.split).toBe(false)
+    expect(created.draft.stashedAt).toBe(stashedAt.toISOString())
+
+    const row = await DraftsRepository.findByIdForUpdate(pool, testWorkspaceId, testUserId, id)
+    expect(row?.stashedAt?.toISOString()).toBe(stashedAt.toISOString())
+  })
+
+  test("CAS update sets and clears stashed_at in place", async () => {
+    const id = draftId()
+    const created = await service.upsert(upsertParams(id))
+    expect(created.draft.stashedAt).toBeNull()
+
+    const stashedAt = new Date("2026-08-06T12:00:00.000Z")
+    const stashed = await service.upsert(
+      upsertParams(id, { stashedAt, expectedVersion: created.draft.version, writeId: `write_${id}_2` })
+    )
+    expect(stashed.split).toBe(false)
+    expect(stashed.draft.stashedAt).toBe(stashedAt.toISOString())
+
+    const restored = await service.upsert(
+      upsertParams(id, { stashedAt: null, expectedVersion: stashed.draft.version, writeId: `write_${id}_3` })
+    )
+    expect(restored.split).toBe(false)
+    expect(restored.draft.stashedAt).toBeNull()
+  })
+
+  test("an ABSENT stashedAt preserves the row's current value — a legacy client's autosave cannot erase a stash", async () => {
+    const id = draftId()
+    const created = await service.upsert(upsertParams(id))
+    const stashedAt = new Date("2026-08-06T14:00:00.000Z")
+    const stashed = await service.upsert(
+      upsertParams(id, { stashedAt, expectedVersion: created.draft.version, writeId: `write_${id}_2` })
+    )
+    expect(stashed.draft.stashedAt).toBe(stashedAt.toISOString())
+
+    // The old-bundle client: no stashedAt field at all on its push.
+    const legacy = await service.upsert(
+      upsertParams(id, { stashedAt: undefined, expectedVersion: stashed.draft.version, writeId: `write_${id}_3` })
+    )
+    expect(legacy.split).toBe(false)
+    expect(legacy.draft.stashedAt).toBe(stashedAt.toISOString())
+  })
+
+  test("a version-mismatch split carries the INCOMING stashedAt onto the fresh row", async () => {
+    const id = draftId()
+    const created = await service.upsert(upsertParams(id))
+
+    const stashedAt = new Date("2026-08-06T13:00:00.000Z")
+    // Wrong expectedVersion + a foreign write lineage → genuine drift → split.
+    const split = await service.upsert(
+      upsertParams(id, {
+        stashedAt,
+        expectedVersion: created.draft.version + 5,
+        writeId: `write_${id}_other`,
+      })
+    )
+
+    expect(split.split).toBe(true)
+    expect(split.draft.id).not.toBe(id)
+    expect(split.draft.stashedAt).toBe(stashedAt.toISOString())
+    // The untouched original keeps its own (null) flag.
+    const original = await DraftsRepository.findByIdForUpdate(pool, testWorkspaceId, testUserId, id)
+    expect(original?.stashedAt).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -307,13 +307,12 @@ function MessageInputComponent({
   // stream's own draft. The typed draft is NOT moved — its scope IS its target,
   // so it stays a draft of that conversation and keeps its filing.
   //
-  // It must also stop being CHECKED OUT here. Piles now offer loaded rows too
-  // (v2 take-over), but the drafts EXPLORER still keys `isStashed` on the
-  // pointer and offers a `?stash=` deep link only to detached rows — so without
-  // this detach the disarmed draft would carry no link there and "it stays
-  // reachable" would be weaker than promised. Detaching the pointer turns it
-  // into a real stash entry. Unless another composer is already mounted on the
-  // scope: then it is showing the draft and owns it.
+  // It must also stop being CHECKED OUT here — a pure DETACH (`putAway:
+  // false`): the drafts explorer keys its `?stash=` deep link on the pointer,
+  // so the detach is what keeps the disarmed draft reachable there, while the
+  // conversation's own board button and auto-restore keep advertising it (the
+  // user dismissed the ARM, not the draft). Unless another composer is already
+  // mounted on the scope: then it is showing the draft and owns it.
   //
   // ONE disarm, for every path that drops the target: clearing the target alone
   // strands the gesture latch, and a stranded latch makes the NEXT arm read as a
@@ -336,7 +335,11 @@ function MessageInputComponent({
       console.error("[composer] flush before disarm failed", err)
     }
     try {
-      await stashLoadedDraft(workspaceId, vacated)
+      // A disarm is MECHANICAL — "stop replying to that conversation here", not
+      // "put the draft away". Detach only: the draft keeps its board button,
+      // auto-restore and explorer link (putAway would hide all three on every
+      // device).
+      await stashLoadedDraft(workspaceId, vacated, { putAway: false })
     } catch (err) {
       console.error("[composer] could not release the disarmed draft", err)
     }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -527,6 +527,13 @@ export interface CachedDraft {
   /** Authoring-device clock (ms); drives recency ordering. */
   clientUpdatedAt: number
   /**
+   * Epoch ms while the draft is stashed ("put away"): no surface advertises or
+   * auto-restores it until a restore clears the flag. Synced via the draft row;
+   * null/absent = active. Plain field, deliberately unindexed (no Dexie
+   * version bump) — every read path filters in code.
+   */
+  stashedAt?: number | null
+  /**
    * Server attachment ids for this draft (Stage 3 sync). The wire `Draft`
    * carries only attachment ids, not the `DraftAttachment` display metadata
    * (filename/mime/size), so a draft arriving from another device keeps its ids

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -77,6 +77,7 @@ export {
 export {
   useScopeDraftPreview,
   useBoardSubtopicDraftIndex,
+  useBoardDraftPayloadScopes,
   useBoardScopeDraftIndex,
   useBoardDraftsReady,
   type ScopeDraftPreview,

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -588,6 +588,7 @@ describe("streamIdsWithLoadedDraft", () => {
   function unifiedDraft(overrides: Partial<UnifiedDraft> = {}): UnifiedDraft {
     return {
       id: "draft_1",
+      putAway: false,
       type: "channel" as DraftType,
       streamId: "stream_1",
       displayName: "General",

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -78,6 +78,13 @@ export interface UnifiedDraft {
    */
   isStashed: boolean
   /**
+   * True only for a draft the user DELIBERATELY put away (`stashedAt` on the
+   * synced row — chunk 4). Strictly narrower than `isStashed`, which is the
+   * device-local "no composer here holds it" and is also true for rows merely
+   * roamed from another device. Drives the explorer's "Stashed" annotation.
+   */
+  putAway: boolean
+  /**
    * Scratchpad-only: the companion mode the draft was created with (locked at
    * Quick Switcher choice). Lets the drafts explorer distinguish "Quick Note"
    * (off) from "Scratchpad" (on) at a glance.
@@ -512,6 +519,7 @@ export function useAllDrafts(workspaceId: string) {
           href: `/w/${workspaceId}/s/${scratchpad.id}`,
           groupLabel: displayName,
           isStashed: false,
+          putAway: false,
           companionMode: scratchpad.companionMode,
         })
       }
@@ -575,6 +583,7 @@ export function useAllDrafts(workspaceId: string) {
         href,
         groupLabel: resolved.groupLabel,
         isStashed,
+        putAway: draft.stashedAt != null,
       })
     }
 

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -192,6 +192,7 @@ export async function upsertLoadedDraft(
         attachments: [],
         clientUpdatedAt: Date.now(),
         baseVersion: existing?.baseVersion,
+        stashedAt: existing?.stashedAt,
         ciphertext: sealed.ciphertext,
         envelope: sealed.envelope,
         e2eVersion: sealed.e2eVersion,
@@ -213,6 +214,7 @@ export async function upsertLoadedDraft(
         // server would SPLIT it into a duplicate — once per keystroke after the
         // first sync. Preserve it so the push CAS-updates in place instead.
         baseVersion: existing?.baseVersion,
+        stashedAt: existing?.stashedAt,
         attachmentIds: existing?.attachmentIds,
       }
     }
@@ -256,8 +258,13 @@ export async function upsertLoadedDraft(
         // between our read and this txn, and writing the stale value back would
         // make the next push CAS against an old version and split.
         row = seal
-          ? { ...row, baseVersion: liveRow.baseVersion }
-          : { ...row, baseVersion: liveRow.baseVersion, attachmentIds: liveRow.attachmentIds }
+          ? { ...row, baseVersion: liveRow.baseVersion, stashedAt: liveRow.stashedAt }
+          : {
+              ...row,
+              baseVersion: liveRow.baseVersion,
+              stashedAt: liveRow.stashedAt,
+              attachmentIds: liveRow.attachmentIds,
+            }
         await db.drafts.put(row)
       } else {
         await db.drafts.put(row)
@@ -524,13 +531,30 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
  * first (so unsaved keystrokes survive) and reset the editor afterward.
  */
 export async function stashLoadedDraft(workspaceId: string, scope: string): Promise<string | null> {
-  const draftId = (await db.composerLoaded.get(scope))?.draftId ?? null
-  if (!draftId) return null
   // The caller flushed the live editor into the row before stashing, so the
   // staged buffer is now redundant; drop it so a reload doesn't recover the
   // stashed body back into the (now draft-less) composer as a new loaded draft.
   clearStagedDraft(workspaceId, scope)
-  await db.composerLoaded.delete(scope)
+  // Stash is a durable, SYNCED statement (chunk 4): `stashedAt` rides the row
+  // so no surface on any device advertises or auto-restores it until a restore
+  // clears the flag. Marker + pointer detach + push enqueue in one txn, so the
+  // stashed row is never visible without its dirty bit. `clientUpdatedAt` is
+  // deliberately NOT bumped — putting a draft away must not reorder the pile.
+  let stashed: CachedDraft | null = null
+  const draftId = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+    const id = (await db.composerLoaded.get(scope))?.draftId ?? null
+    if (!id) return null
+    const row = await db.drafts.get(id)
+    if (row && row.stashedAt == null) {
+      stashed = { ...row, stashedAt: Date.now() }
+      await db.drafts.put(stashed)
+      await enqueueDraftUpsert(workspaceId, id)
+    }
+    await db.composerLoaded.delete(scope)
+    return id
+  })
+  if (!draftId) return null
+  if (stashed) upsertDraftInCache(workspaceId, stashed)
   setComposerLoadedInCache(workspaceId, scope, null)
   return draftId
 }
@@ -558,7 +582,8 @@ export async function restoreStashedDraftToComposer(
   // just restored — corrupting it. The restored draft re-stages on its first edit.
   clearStagedDraft(workspaceId, scope)
   let pointedId = draftId
-  const detached = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+  let unstashed: CachedDraft | null = null
+  const detached = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
     // The id is re-validated INSIDE the txn (INV-20): a split ack can re-key the
     // row (`migrateLocalDraftId`) between the caller's read and here — the
     // caller's flush is an IDB write sitting in exactly that window — and
@@ -573,9 +598,19 @@ export async function restoreStashedDraftToComposer(
     const others = holders.filter((row) => row.draftId === pointedId && row.scope !== scope)
     for (const row of others) await db.composerLoaded.delete(row.scope)
     await db.composerLoaded.put({ scope, workspaceId, draftId: pointedId })
+    // Restoring UN-stashes (chunk 4): the durable "put away" flag clears the
+    // moment a composer takes the draft back, and the clear rides the same push
+    // machinery so every device's resting affordances resume advertising it.
+    const row = await db.drafts.get(pointedId)
+    if (row && row.stashedAt != null) {
+      unstashed = { ...row, stashedAt: null }
+      await db.drafts.put(unstashed)
+      await enqueueDraftUpsert(workspaceId, pointedId)
+    }
     return others.map((row) => row.scope)
   })
   if (detached === null) return false
+  if (unstashed) upsertDraftInCache(workspaceId, unstashed)
   for (const detachedScope of detached) {
     // Same teardown a stash does for the scope it detaches: the staging buffer's
     // keystrokes belong to the draft just taken, and a reload's reconcile would

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -530,7 +530,20 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
  * `null` when nothing was loaded. Callers flush the live editor content into the row
  * first (so unsaved keystrokes survive) and reset the editor afterward.
  */
-export async function stashLoadedDraft(workspaceId: string, scope: string): Promise<string | null> {
+export async function stashLoadedDraft(
+  workspaceId: string,
+  scope: string,
+  /**
+   * `putAway: false` is a MECHANICAL detach — a disarm dropping a conversation
+   * arm, a relocate displacing the target's loaded draft. The pointer clears but
+   * the draft stays fully advertised (board button, auto-restore, fork
+   * indicators): the user never said "put it away", so no surface may act as if
+   * they did. Only the deliberate stash gesture (Cmd+S / "Save current") writes
+   * the durable marker.
+   */
+  opts?: { putAway?: boolean }
+): Promise<string | null> {
+  const putAway = opts?.putAway ?? true
   // The caller flushed the live editor into the row before stashing, so the
   // staged buffer is now redundant; drop it so a reload doesn't recover the
   // stashed body back into the (now draft-less) composer as a new loaded draft.
@@ -545,7 +558,7 @@ export async function stashLoadedDraft(workspaceId: string, scope: string): Prom
     const id = (await db.composerLoaded.get(scope))?.draftId ?? null
     if (!id) return null
     const row = await db.drafts.get(id)
-    if (row && row.stashedAt == null) {
+    if (putAway && row && row.stashedAt == null) {
       stashed = { ...row, stashedAt: Date.now() }
       await db.drafts.put(stashed)
       await enqueueDraftUpsert(workspaceId, id)

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -210,3 +210,36 @@ describe("membership vs advertising (payloadScopes)", () => {
     expect(advertise.result.current.has("board:reply:conv_2")).toBe(true)
   })
 })
+
+describe("sub-topic indicator is membership, not advertising", () => {
+  it("keeps the fork-message entry for a put-away sub-topic draft while the reply button drops its preview", async () => {
+    const subScope = "board:subtopic:stream_9:msg_fork"
+    await db.drafts.add({
+      id: "d_sub_stashed",
+      workspaceId,
+      scope: subScope,
+      contentJson: doc("forked thought"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+    // Control on the same snapshot: a conversation-reply scope with a put-away
+    // row loses its ADVERTISING preview — that filter is real and untouched.
+    await db.drafts.add({
+      id: "d_conv_stashed",
+      workspaceId,
+      scope,
+      contentJson: doc("stashed reply"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+
+    const subtopics = renderHook(() => useBoardSubtopicDraftIndex(workspaceId))
+    const preview = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() => expect(subtopics.result.current.get("msg_fork")?.draftId).toBe("d_sub_stashed"))
+    expect(preview.result.current).toBeNull()
+    subtopics.unmount()
+    preview.unmount()
+  })
+})

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -4,6 +4,8 @@ import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
 import {
   useScopeDraftPreview,
+  useBoardDraftPayloadScopes,
+  useBoardScopeDraftIndex,
   useBoardSubtopicDraftIndex,
   useBoardCheckedOutDraftScopes,
   useBoardDraftsReady,
@@ -144,5 +146,67 @@ describe("useBoardCheckedOutDraftScopes", () => {
     const ready = renderHook(() => useBoardDraftsReady(workspaceId))
     await waitFor(() => expect(ready.result.current).toBe(true))
     expect([...result.current]).toEqual([])
+  })
+})
+
+describe("stashed rows (durable stash, chunk 4)", () => {
+  it("never advertises a stashed row — the resting button rests instead of un-doing the stash", async () => {
+    await db.drafts.add({
+      id: "d_stashed",
+      workspaceId,
+      scope,
+      contentJson: doc("put away"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+    // Control: an OLDER roamed (non-stashed) sibling is what gets advertised —
+    // proving the filter picked by flag, not by recency accident.
+    await seed("d_roamed", scope, "roamed body", 1000)
+
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() => expect(result.current?.draftId).toBe("d_roamed"))
+  })
+
+  it("returns null when every payload row is stashed", async () => {
+    await db.drafts.add({
+      id: "d_only_stashed",
+      workspaceId,
+      scope,
+      contentJson: doc("put away"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+    // Control on the same snapshot: a sibling scope with a live row still
+    // advertises, so the null is the flag's doing, not an empty snapshot.
+    await seed("d_live", "board:reply:conv_2", "live", 1000)
+
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    const control = renderHook(() => useScopeDraftPreview(workspaceId, "board:reply:conv_2"))
+    await waitFor(() => expect(control.result.current?.draftId).toBe("d_live"))
+    expect(result.current).toBeNull()
+  })
+})
+
+describe("membership vs advertising (payloadScopes)", () => {
+  it("keeps a stashed-only scope in the membership set while the advertise index drops it", async () => {
+    await db.drafts.add({
+      id: "d_member",
+      workspaceId,
+      scope,
+      contentJson: doc("stashed away"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+    await seed("d_other", "board:reply:conv_2", "live", 1000)
+
+    const membership = renderHook(() => useBoardDraftPayloadScopes(workspaceId))
+    const advertise = renderHook(() => useBoardScopeDraftIndex(workspaceId))
+    await waitFor(() => expect(membership.result.current.has(scope)).toBe(true))
+    expect(membership.result.current.has("board:reply:conv_2")).toBe(true)
+    expect(advertise.result.current.has(scope)).toBe(false)
+    expect(advertise.result.current.has("board:reply:conv_2")).toBe(true)
   })
 })

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -108,17 +108,26 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
     if (loadedDraftId !== null && scopeRows.some((row) => row.id === loadedDraftId)) checkedOutScopes.add(scope)
     if (scopeRows.some(hasPayload)) payloadScopes.add(scope)
     const best = bestRow(scopeRows, loadedDraftId)
-    if (!best) continue
-    const preview = toPreview(best, loadedDraftId)
-    previewByScope.set(scope, preview)
+    if (best) previewByScope.set(scope, toPreview(best, loadedDraftId))
     const parsed = parseBoardDraftKey(scope)
     if (parsed?.kind === "subtopic") {
-      subtopicByMessageId.set(parsed.messageId, {
-        ...preview,
-        scope,
-        streamId: parsed.streamId,
-        messageId: parsed.messageId,
-      })
+      // The fork indicator is MEMBERSHIP, not advertising: it marks "an unsent
+      // sub-topic draft exists here" and its tap is an explicit open — the
+      // in-situ equivalent of a pile row — so a put-away draft keeps it (the
+      // required presentation per Kris's 2026-07-13 ruling). Only the
+      // auto-restoring resting affordances read the stash-filtered preview.
+      const withPayload = scopeRows.filter(hasPayload)
+      const member =
+        withPayload.find((row) => row.id === loadedDraftId) ??
+        (withPayload.length > 0 ? withPayload.reduce((a, b) => (b.clientUpdatedAt > a.clientUpdatedAt ? b : a)) : null)
+      if (member) {
+        subtopicByMessageId.set(parsed.messageId, {
+          ...toPreview(member, loadedDraftId),
+          scope,
+          streamId: parsed.streamId,
+          messageId: parsed.messageId,
+        })
+      }
     }
   }
   return { previewByScope, subtopicByMessageId, checkedOutScopes, payloadScopes }

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -38,15 +38,25 @@ function toPreview(best: CachedDraft, loadedDraftId: string | null): ScopeDraftP
   }
 }
 
-/** The checked-out row when there is one, else the newest — what a resting
- *  affordance should advertise. */
+/**
+ * The checked-out row when there is one, else the newest NON-STASHED row — what
+ * a resting affordance should advertise. A stashed row (`stashedAt` set) is the
+ * user's durable "put away": advertising it — and the open-time auto-restore
+ * that follows the advertisement — would un-do the stash on the next tap, which
+ * is exactly the v1 board bug. A ROAMED row (no pointer here, not stashed)
+ * keeps the zero-tap continue. Checked-out wins even over the stash flag: a
+ * row can be BOTH on a second device (another device stashes while this one
+ * has it checked out — pointers are device-local, and the flag rides
+ * last-writer-wins content), and a composer that visibly holds the draft must
+ * keep advertising what it holds.
+ */
 function bestRow(rows: CachedDraft[], loadedDraftId: string | null): CachedDraft | null {
   const withPayload = rows.filter(hasPayload)
-  if (withPayload.length === 0) return null
-  return (
-    withPayload.find((row) => row.id === loadedDraftId) ??
-    withPayload.reduce((a, b) => (b.clientUpdatedAt > a.clientUpdatedAt ? b : a))
-  )
+  const checkedOut = withPayload.find((row) => row.id === loadedDraftId)
+  if (checkedOut) return checkedOut
+  const advertisable = withPayload.filter((row) => row.stashedAt == null)
+  if (advertisable.length === 0) return null
+  return advertisable.reduce((a, b) => (b.clientUpdatedAt > a.clientUpdatedAt ? b : a))
 }
 
 interface BoardDraftsSnapshot {
@@ -55,12 +65,21 @@ interface BoardDraftsSnapshot {
   /** Scopes whose row is checked out into this device's composer, payload or
    *  not — an empty checked-out row is a composer mid-edit, not a resolved one. */
   checkedOutScopes: Set<string>
+  /**
+   * Every scope with at least one PAYLOAD row, stashed or not — the MEMBERSHIP
+   * set. Advertising (`previewByScope`) filters stashed rows out, but a stashed
+   * draft still exists: the board's `?drafts=true` narrowing and other
+   * membership surfaces must keep its conversation, or a stash makes the draft
+   * unreachable from the very view named after drafts.
+   */
+  payloadScopes: Set<string>
 }
 
 const EMPTY_SNAPSHOT: BoardDraftsSnapshot = {
   previewByScope: new Map(),
   subtopicByMessageId: new Map(),
   checkedOutScopes: new Set(),
+  payloadScopes: new Set(),
 }
 
 interface BoardDraftsEntry {
@@ -83,9 +102,11 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
   const previewByScope = new Map<string, ScopeDraftPreview>()
   const subtopicByMessageId = new Map<string, SubtopicDraftEntry>()
   const checkedOutScopes = new Set<string>()
+  const payloadScopes = new Set<string>()
   for (const [scope, scopeRows] of byScope) {
     const loadedDraftId = loadedByScope.get(scope) ?? null
     if (loadedDraftId !== null && scopeRows.some((row) => row.id === loadedDraftId)) checkedOutScopes.add(scope)
+    if (scopeRows.some(hasPayload)) payloadScopes.add(scope)
     const best = bestRow(scopeRows, loadedDraftId)
     if (!best) continue
     const preview = toPreview(best, loadedDraftId)
@@ -100,7 +121,7 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
       })
     }
   }
-  return { previewByScope, subtopicByMessageId, checkedOutScopes }
+  return { previewByScope, subtopicByMessageId, checkedOutScopes, payloadScopes }
 }
 
 // INV-9 exception: one shared board-drafts liveQuery per workspace, ref-counted
@@ -228,6 +249,22 @@ export function useBoardCheckedOutDraftScopes(workspaceId: string): ReadonlySet<
   const subscribe = useBoardDraftsSubscription(workspaceId)
   const getSnapshot = useCallback(
     () => boardDraftsRegistry.get(workspaceId)?.snapshot.checkedOutScopes ?? EMPTY_SNAPSHOT.checkedOutScopes,
+    [workspaceId]
+  )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
+ * Board scopes holding at least one payload draft row, STASHED INCLUDED — the
+ * membership set for surfaces that answer "does this conversation have a
+ * draft?" (the board's `?drafts=true` narrowing). Deliberately wider than
+ * {@link useBoardScopeDraftIndex}, which is the ADVERTISE set and hides
+ * stashed rows so resting buttons don't un-do a stash.
+ */
+export function useBoardDraftPayloadScopes(workspaceId: string): ReadonlySet<string> {
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(
+    () => boardDraftsRegistry.get(workspaceId)?.snapshot.payloadScopes ?? EMPTY_SNAPSHOT.payloadScopes,
     [workspaceId]
   )
   return useSyncExternalStore(subscribe, getSnapshot)

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -185,9 +185,11 @@ export function useStashComposer(
     await composer.flushDraft()
     const stashedId = await stashLoadedDraft(workspaceId, scope)
     if (!stashedId) return
+    // The durable stash marker rides the row (chunk 4) — drain it promptly.
+    syncEngine?.kickOperationQueue()
     // Re-init the (now draft-less) composer so the editor blanks out.
     composer.markNeedsRehydrate()
-  }, [composer, workspaceId, scope])
+  }, [composer, workspaceId, scope, syncEngine])
 
   const { canHostForeignDraft, describeScope } = stashedDrafts
 
@@ -275,6 +277,8 @@ export function useStashComposer(
           if (!(await restoreStashedDraftToComposer(workspaceId, plan.targetScope, id))) {
             return refuse("missing", `draft ${id} vanished (or re-keyed away) before its adopt could land`)
           }
+          // The restore may have cleared a durable stash marker — drain the push.
+          syncEngine?.kickOperationQueue()
           // Through the host's own disarm, never a bare `clearComposerTarget`: the
           // gesture latch has to be cleared with the target or a later adopt reads
           // as a fresh gesture and redirects to the panel, wiping the target the
@@ -320,6 +324,8 @@ export function useStashComposer(
         if (!(await restoreStashedDraftToComposer(workspaceId, scope, id))) {
           return refuse("missing", `draft ${id} vanished (or re-keyed away) before its restore could land`)
         }
+        // The restore may have cleared a durable stash marker — drain the push.
+        syncEngine?.kickOperationQueue()
         // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
         composer.markNeedsRehydrate()
         return { ok: true }

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -34,7 +34,57 @@ describe("stashLoadedDraft (pointer-move stash)", () => {
     // Pointer cleared; the row is preserved (not deleted) so it stays a stash entry
     // and keeps roaming — no plaintext snapshot into a new row.
     expect(await db.composerLoaded.get(scope)).toBeUndefined()
-    expect(await db.drafts.get(loaded.id)).toBeDefined()
+    const row = await db.drafts.get(loaded.id)
+    expect(row).toBeDefined()
+    // Durable stash (chunk 4): the marker is set WITHOUT bumping recency, and a
+    // push is enqueued so it roams to every device.
+    expect(row?.stashedAt).toEqual(expect.any(Number))
+    expect(row?.clientUpdatedAt).toBe(loaded.clientUpdatedAt)
+  })
+
+  // The setup above coalesces onto the create's own op, which made an "op
+  // exists" assertion vacuous (it existed before the stash). This seeds a
+  // CLEAN, fully-synced row — baseVersion set, queue empty — so the op can only
+  // come from the stash itself; without the enqueue the marker never leaves
+  // this device.
+  it("enqueues the marker push even for a clean, already-synced row", async () => {
+    await db.drafts.put({
+      id: "draft_clean",
+      workspaceId,
+      scope,
+      contentJson: makeDoc("synced body"),
+      attachments: [],
+      baseVersion: 3,
+      clientUpdatedAt: 1000,
+    })
+    await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_clean" })
+    expect(await db.pendingOperations.count()).toBe(0)
+
+    await stashLoadedDraft(workspaceId, scope)
+
+    expect((await db.drafts.get("draft_clean"))?.stashedAt).toEqual(expect.any(Number))
+    const ops = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    expect(ops.some((op) => (op.payload as { draftId?: string }).draftId === "draft_clean")).toBe(true)
+  })
+
+  it("restore enqueues the un-stash push for a clean, already-synced stashed row", async () => {
+    await db.drafts.put({
+      id: "draft_clean_stashed",
+      workspaceId,
+      scope,
+      contentJson: makeDoc("synced body"),
+      attachments: [],
+      baseVersion: 5,
+      clientUpdatedAt: 1000,
+      stashedAt: 900,
+    })
+    expect(await db.pendingOperations.count()).toBe(0)
+
+    await restoreStashedDraftToComposer(workspaceId, scope, "draft_clean_stashed")
+
+    expect((await db.drafts.get("draft_clean_stashed"))?.stashedAt).toBeNull()
+    const ops = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    expect(ops.some((op) => (op.payload as { draftId?: string }).draftId === "draft_clean_stashed")).toBe(true)
   })
 
   it("no-ops when nothing is loaded", async () => {
@@ -79,6 +129,9 @@ describe("restoreStashedDraftToComposer (pointer-move restore)", () => {
     // Both rows survive (nothing deleted) — `second` is now the stash entry.
     expect(await db.drafts.get(first.id)).toBeDefined()
     expect(await db.drafts.get(second.id)).toBeDefined()
+    // Restoring UN-stashes: the durable marker set by the stash clears and the
+    // clear is pushed (chunk 4).
+    expect((await db.drafts.get(first.id))?.stashedAt).toBeNull()
   })
 })
 

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -87,6 +87,18 @@ describe("stashLoadedDraft (pointer-move stash)", () => {
     expect(ops.some((op) => (op.payload as { draftId?: string }).draftId === "draft_clean_stashed")).toBe(true)
   })
 
+  it("a MECHANICAL detach (putAway: false) clears the pointer without the durable marker", async () => {
+    const loaded = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("armed reply"), attachments: [] })
+
+    const stashedId = await stashLoadedDraft(workspaceId, scope, { putAway: false })
+
+    expect(stashedId).toBe(loaded.id)
+    expect(await db.composerLoaded.get(scope)).toBeUndefined()
+    // No marker: a disarm is "stop replying here", not "put the draft away" —
+    // the board button and auto-restore must keep advertising it everywhere.
+    expect((await db.drafts.get(loaded.id))?.stashedAt ?? null).toBeNull()
+  })
+
   it("no-ops when nothing is loaded", async () => {
     expect(await stashLoadedDraft(workspaceId, scope)).toBeNull()
   })

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -34,7 +34,7 @@ import {
 import {
   useBoardDraftsReady,
   useBoardCheckedOutDraftScopes,
-  useBoardScopeDraftIndex,
+  useBoardDraftPayloadScopes,
   useBoardSubtopicDraftIndex,
 } from "@/hooks/use-scope-draft-preview"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
@@ -330,34 +330,39 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // drafts are written, no refetch. No fail-open gate: the board's reveal holds
   // first paint on `useBoardDraftsReady`, so the snapshot is settled by then.
   const draftsOnly = searchParams.get(BOARD_DRAFTS_PARAM) === BOARD_DRAFTS_ON
-  const scopeDraftIndex = useBoardScopeDraftIndex(workspaceId)
   const subtopicDraftIndex = useBoardSubtopicDraftIndex(workspaceId)
   // A scope checked out into a composer counts as a draft even with no payload:
   // select-all + Backspace mid-rewrite must not yank the card out from under the
   // focused composer. The row is deleted on send/discard — that is when it sheds.
   const checkedOutDraftScopes = useBoardCheckedOutDraftScopes(workspaceId)
+  // Membership, not advertising: a STASHED draft's conversation must stay in
+  // the ?drafts=true narrowing even though no resting button advertises it —
+  // otherwise stashing makes the draft unreachable from the drafts view.
+  const payloadDraftScopes = useBoardDraftPayloadScopes(workspaceId)
   // Signature-memoized like `archivedRootSignature`: the draft indexes get a new
   // Map identity on every keystroke, and these sets feed the feed filter.
   const draftConversationSignature = useMemo(() => {
     const ids = new Set<string>()
-    for (const scope of [...scopeDraftIndex.keys(), ...checkedOutDraftScopes]) {
+    for (const scope of [...payloadDraftScopes, ...checkedOutDraftScopes]) {
       const parsed = parseBoardDraftKey(scope)
       if (parsed && (parsed.kind === "reply" || parsed.kind === "branch-reply")) ids.add(parsed.conversationId)
     }
     return [...ids].sort().join(",")
-  }, [scopeDraftIndex, checkedOutDraftScopes])
+  }, [payloadDraftScopes, checkedOutDraftScopes])
   const draftConversationIds = useMemo(
     () => new Set<string>(draftConversationSignature ? draftConversationSignature.split(",") : []),
     [draftConversationSignature]
   )
   const subtopicMessageSignature = useMemo(() => {
     const ids = new Set<string>(subtopicDraftIndex.keys())
-    for (const scope of checkedOutDraftScopes) {
+    // Same membership-vs-advertising split as conversations: a stashed
+    // sub-topic draft shows no pill but keeps its message in the drafts view.
+    for (const scope of [...payloadDraftScopes, ...checkedOutDraftScopes]) {
       const parsed = parseBoardDraftKey(scope)
       if (parsed?.kind === "subtopic") ids.add(parsed.messageId)
     }
     return [...ids].sort().join(",")
-  }, [subtopicDraftIndex, checkedOutDraftScopes])
+  }, [subtopicDraftIndex, payloadDraftScopes, checkedOutDraftScopes])
   const subtopicDraftMessageIds = useMemo(
     () => new Set<string>(subtopicMessageSignature ? subtopicMessageSignature.split(",") : []),
     [subtopicMessageSignature]

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -22,6 +22,7 @@ function draft(overrides: Partial<UnifiedDraft> & { id: string; displayName: str
     href: `/w/${WS}/s/stream_${overrides.id}`,
     groupLabel: overrides.displayName,
     isStashed: false,
+    putAway: false,
     ...overrides,
   }
 }
@@ -334,5 +335,27 @@ describe("DraftsPage touch long-press", () => {
     fireEvent.click(row)
 
     expect(screen.queryByTestId("navigated-away")).toBeNull()
+  })
+})
+
+describe("put-away annotation (durable stash, chunk 4)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    deleteDraft.mockReset()
+    deleteDraft.mockResolvedValue(undefined)
+  })
+
+  it("labels a deliberately put-away row 'Stashed' and leaves a merely-roamed row unlabeled", () => {
+    mockDrafts([
+      draft({ id: "a", displayName: "Alpha", isStashed: true, putAway: true, preview: "put away body" }),
+      draft({ id: "b", displayName: "Bravo", isStashed: true, putAway: false, preview: "roamed body" }),
+    ])
+    renderPage()
+
+    // The put-away row carries the annotation; the roamed control row does not
+    // — the two device-local/durable notions must not be conflated.
+    expect(screen.getByText("Stashed")).toBeInTheDocument()
+    const roamedRow = screen.getByText("roamed body").closest("a, button, li")
+    expect(roamedRow?.textContent).not.toContain("Stashed")
   })
 })

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -358,4 +358,18 @@ describe("put-away annotation (durable stash, chunk 4)", () => {
     const roamedRow = screen.getByText("roamed body").closest("a, button, li")
     expect(roamedRow?.textContent).not.toContain("Stashed")
   })
+
+  it("keeps the active preview when a durable marker remains on a locally loaded row", () => {
+    mockDrafts([
+      draft({ id: "c", displayName: "Charlie", isStashed: false, putAway: true, preview: "active-looking body" }),
+    ])
+    renderPage()
+
+    // A cross-device marker can coexist briefly with this device's pointer. The
+    // local loaded state wins: hiding this preview would leave an apparently
+    // active-looking row with a "Stashed" caption (and its preview discarded)
+    // until another sync transition happens.
+    expect(screen.getByText("active-looking body")).toBeInTheDocument()
+    expect(screen.queryByText("Stashed")).not.toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -31,6 +31,11 @@ const TYPE_ICONS: Record<DraftType, React.ComponentType<{ className?: string }>>
   thread: MessageSquare,
 }
 
+/** The put-away annotation ("Stashed"); null for active and merely-roamed rows. */
+function stashedRowDescription(draft: UnifiedDraft): string | null {
+  return draft.putAway ? "Stashed" : null
+}
+
 export function DraftsPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const navigate = useNavigate()
@@ -180,7 +185,9 @@ export function DraftsPage() {
       return {
         id: draft.id,
         label,
-        description: draft.isStashed ? undefined : description,
+        // A put-away row says so (INV-46: structured flag, formatted here) — a
+        // merely-roamed row shows nothing, exactly like before.
+        description: stashedRowDescription(draft) ?? (draft.isStashed ? undefined : description),
         icon,
         href: draft.href ?? undefined,
         group: draft.groupLabel,

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -31,9 +31,15 @@ const TYPE_ICONS: Record<DraftType, React.ComponentType<{ className?: string }>>
   thread: MessageSquare,
 }
 
-/** The put-away annotation ("Stashed"); null for active and merely-roamed rows. */
+/**
+ * The put-away annotation ("Stashed"). Gated on BOTH flags: `putAway` alone can
+ * coexist with a locally checked-out row (another device stashed while this one
+ * holds the composer pointer — the board resolves that in favor of checked-out),
+ * and annotating an active-looking row "Stashed" while its preview is discarded
+ * reads as a contradiction. Only a row that is put away AND detached here says so.
+ */
 function stashedRowDescription(draft: UnifiedDraft): string | null {
-  return draft.putAway ? "Stashed" : null
+  return draft.putAway && draft.isStashed ? "Stashed" : null
 }
 
 export function DraftsPage() {

--- a/apps/frontend/src/sync/draft-e2e-roam.test.ts
+++ b/apps/frontend/src/sync/draft-e2e-roam.test.ts
@@ -82,6 +82,7 @@ describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
       e2eVersion: sealed.e2eVersion,
       version: 1,
       clientUpdatedAt: new Date().toISOString(),
+      stashedAt: null,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
@@ -138,6 +139,7 @@ describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
       workspaceId,
       userId,
       scope,
+      stashedAt: null,
       rootStreamId: streamId,
       contentJson: null,
       contentMarkdown: null,

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -50,6 +50,7 @@ function wireDraft(overrides: Partial<Draft> = {}): Draft {
     e2eVersion: null,
     version: 1,
     clientUpdatedAt: new Date(1000).toISOString(),
+    stashedAt: null,
     createdAt: new Date(1000).toISOString(),
     updatedAt: new Date(1000).toISOString(),
     ...overrides,
@@ -95,6 +96,13 @@ describe("cachedDraftFromWire", () => {
   it("drops empty contextRefs to undefined", () => {
     expect(cachedDraftFromWire(wireDraft({ contextRefs: [] })).contextRefs).toBeUndefined()
     expect(cachedDraftFromWire(wireDraft({ contextRefs: [{ kind: "x" }] })).contextRefs).toEqual([{ kind: "x" }])
+  })
+
+  it("round-trips stashedAt as epoch ms (null stays null)", () => {
+    expect(cachedDraftFromWire(wireDraft({ stashedAt: "2026-08-06T12:00:00.000Z" })).stashedAt).toBe(
+      Date.parse("2026-08-06T12:00:00.000Z")
+    )
+    expect(cachedDraftFromWire(wireDraft({ stashedAt: null })).stashedAt).toBeNull()
   })
 
   it("maps the E2E triple and uses the placeholder body for a sealed row", () => {

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -85,6 +85,7 @@ export function cachedDraftFromWire(draft: Draft): CachedDraft {
     attachmentIds: draft.attachmentIds,
     baseVersion: draft.version,
     clientUpdatedAt: Number.isNaN(clientUpdatedAt) ? Date.now() : clientUpdatedAt,
+    stashedAt: draft.stashedAt ? Date.parse(draft.stashedAt) : null,
     ...(draft.ciphertext != null
       ? { ciphertext: draft.ciphertext, envelope: draft.envelope, e2eVersion: draft.e2eVersion ?? undefined }
       : {}),
@@ -865,6 +866,9 @@ export async function executeDraftUpsert(
     ciphertext: isE2e ? row.ciphertext : null,
     envelope: isE2e ? row.envelope : null,
     e2eVersion: isE2e ? (row.e2eVersion ?? null) : null,
+    // The current value rides every push (absent means null server-side), so a
+    // stash set while offline still roams once the queue drains.
+    stashedAt: row.stashedAt ? new Date(row.stashedAt).toISOString() : null,
   }
 
   const res = await service.upsert(workspaceId, draftId, input)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -2507,6 +2507,12 @@ export interface Draft {
   version: number
   /** Authoring device's wall clock for the last edit; drives recency ordering. */
   clientUpdatedAt: string
+  /**
+   * Set while the draft is stashed ("put away"): no surface on any device may
+   * advertise or auto-restore it — it lives in piles and the drafts explorer
+   * until the user restores it, which clears the flag. Null = active.
+   */
+  stashedAt: string | null
   /** Last accepted write id; lets the authoring device suppress its own sent-write echoes. */
   lastClientWriteId?: string | null
   createdAt: string
@@ -2545,6 +2551,11 @@ export interface UpsertDraftInput {
   ciphertext?: string | null
   envelope?: unknown | null
   e2eVersion?: number | null
+  /**
+   * Absent means PRESERVE the server's current value (legacy clients omit it);
+   * new clients send it on every push — explicit null clears, a timestamp sets.
+   */
+  stashedAt?: string | null
 }
 
 /**


### PR DESCRIPTION
## Problem

Stash is an unmarked, device-local pointer detach — indistinguishable from a draft roamed from another
device, which is exactly what the board's resting button advertises and auto-restores. So stashing on the
board un-does itself on the next open (Kris's staging complaint 3), and no other device ever learns the
draft was put away. Chunk 4 of https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-v2-13fec2/.

## Solution

`stashed_at TIMESTAMPTZ` on `drafts` (append-only migration), synced with the row.

- **Backend:** repo/service/handlers/view thread it through; on a version-mismatch split the fresh row takes
  the INCOMING value. **Absent means preserve** — a legacy client (stale PWA bundle) whose autosave omits the
  field cannot erase a stash set elsewhere; explicit null clears, a timestamp sets (`CASE` in the CAS SQL).
  Verified against the real schema (INV-68): insert, CAS set/clear, absent-preserves, split — 4 integration
  cases, no type-waiving casts.
- **Frontend:** `stashLoadedDraft` marks + detaches + enqueues in one txn, deliberately NOT bumping
  `clientUpdatedAt` (putting a draft away must not reorder the pile); the take-over restore clears the flag
  and pushes the clear; ordinary saves carry it (`baseVersion`-style in-txn preserve). No Dexie version bump
  — plain unindexed field.
- **Board:** `bestRow` never advertises a stashed row (checked-out wins defensively — on a second device the
  two states can coexist, and a composer visibly holding a draft keeps advertising it); the open-time
  auto-restore inherits the filter. Membership is split from advertising: a new `payloadScopes` set keeps a
  stashed-only conversation (and sub-topic) inside the `?drafts=true` narrowing.
- **Drafts explorer:** rows deliberately put away carry a "Stashed" annotation via a new `putAway` flag —
  strictly narrower than the device-local `isStashed`, which is also true for merely-roamed rows.

**Semantics note (accepted, not a bug):** the flag is PRESERVED through ordinary saves (the baseVersion-style in-txn carry), so typing on another device does NOT un-stash — only a restore clears it. A device that ignored the stash echo while dirty keeps stashedAt null locally and its next push writes null (last-writer-wins), which is the one window where concurrent editing drops a stash.

Deploy: frontend-before-backend leaves stash local-only until the backend lands (old Zod strips the key);
backend-before-frontend is inert. Mixed-version clients cannot erase stashes (the absent-preserves rule).

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/db/migrations/20260806150000_drafts_stashed_at.sql` | **new** column |
| `apps/backend/src/features/drafts/{repository,service,handlers,view}.ts` | plumbing + absent-preserves CAS |
| `apps/backend/tests/integration/draft-stashed-at.test.ts` | **new** real-schema round-trip (INV-68) |
| `packages/types/src/api.ts` | wire fields |
| `apps/frontend/src/hooks/use-draft-message.ts` | stash marks+enqueues, restore clears, saves preserve |
| `apps/frontend/src/sync/draft-sync.ts` | wire mapping both directions |
| `apps/frontend/src/hooks/use-scope-draft-preview.ts` | advertise filter + `payloadScopes` membership |
| `apps/frontend/src/pages/board.tsx` | membership set drives `?drafts=` narrowing |
| `apps/frontend/src/{hooks/use-all-drafts.ts,pages/drafts.tsx}` | `putAway` + "Stashed" annotation |

## Test plan

- [x] Backend: tsc, feature tests 27/27, integration 4/4 against real Postgres; `check:migrations` clean.
- [x] Frontend: vitest 250/250 across 9 suites; tsc; lint (monorepo pre-commit) green.
- [x] Neutralisations: view emit, stash marker, restore clear, `bestRow` filter, both clean-row enqueues,
  membership guard — each inverted → red → restored.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788617459&installation_model_id=20758&pr_number=1783&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1783&signature=d9e6d40241396cbf38aff00e3ab92a2a142c358125a3d90f3f98b7e0d2185851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
