### PR TITLE
feat(drafts): rows that cannot restore here navigate there

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { MemoryRouter } from "react-router-dom"
 import { spyOnExport } from "@/test/spy"
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -631,20 +632,22 @@ describe("MessageComposer", () => {
       const onStashDraft = vi.fn()
       const onRestore = vi.fn()
       render(
-        <MessageComposer
-          {...defaultProps}
-          onStashDraft={onStashDraft}
-          stashedDraftsTrigger={
-            <StashedDraftsPicker
-              drafts={[draft]}
-              canStashCurrent={false}
-              onStashCurrent={vi.fn()}
-              onRestore={onRestore}
-              onDelete={vi.fn()}
-            />
-          }
-          {...props}
-        />
+        <MemoryRouter>
+          <MessageComposer
+            {...defaultProps}
+            onStashDraft={onStashDraft}
+            stashedDraftsTrigger={
+              <StashedDraftsPicker
+                drafts={[draft]}
+                canStashCurrent={false}
+                onStashCurrent={vi.fn()}
+                onRestore={onRestore}
+                onDelete={vi.fn()}
+              />
+            }
+            {...props}
+          />
+        </MemoryRouter>
       )
       return { onStashDraft, onRestore }
     }

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -295,6 +295,7 @@ describe("StashedDraftsPicker", () => {
       checkedOutElsewhere: false,
       openHref: null,
       openConversationId: null,
+      openCarriesDraft: false,
     }
     const borrowed = (
       label: string,
@@ -306,6 +307,7 @@ describe("StashedDraftsPicker", () => {
       checkedOutElsewhere,
       openHref,
       openConversationId: openHref ? "conv_1" : null,
+      openCarriesDraft: openHref !== null,
     })
     const rows = [makeDraft("draft_own", "mine"), makeDraft("draft_borrowed", "theirs")]
 
@@ -490,11 +492,19 @@ describe("navigate rows (branch replies / mounted composers)", () => {
             checkedOutElsewhere: false,
             openHref: "/w/ws_1/s/stream_1?panel=conv%3Aconv_1&stash=draft_nav",
             openConversationId: "conv_1",
+            openCarriesDraft: true,
           },
         ],
         [
           "draft_plain",
-          { tier: "borrowed", label: "#general", checkedOutElsewhere: false, openHref: null, openConversationId: null },
+          {
+            tier: "borrowed",
+            label: "#general",
+            checkedOutElsewhere: false,
+            openHref: null,
+            openConversationId: null,
+            openCarriesDraft: false,
+          },
         ],
       ]),
       onRestore,
@@ -522,6 +532,44 @@ describe("navigate rows (branch replies / mounted composers)", () => {
     expect(replyOpenSpy).toHaveBeenCalledWith("conv_1")
   })
 
+  it("says 'pick the draft up' for the manual-pickup fallback instead of promising its own composer", async () => {
+    renderPicker({
+      drafts: [makeDraft("draft_fb", "orphan branch")],
+      originById: new Map<string, StashedDraftRowOrigin>([
+        [
+          "draft_fb",
+          {
+            tier: "borrowed",
+            label: "Reply in Pizza plans",
+            checkedOutElsewhere: false,
+            openHref: "/w/ws_1/board?panel=conv%3Aconv_orphan",
+            openConversationId: "conv_orphan",
+            openCarriesDraft: false,
+          },
+        ],
+      ]),
+    })
+    await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+
+    const row = screen.getByText("orphan branch").closest("button")!
+    expect(row.getAttribute("aria-label")).toContain("pick the draft up")
+    expect(row.getAttribute("aria-label")).not.toContain("its own composer")
+  })
+
+  it("a throwing restore toasts and keeps the picker open — never a silent no-op", async () => {
+    const onRestore = vi.fn().mockRejectedValue(new Error("navigate row reached restore"))
+    const { closeFabDrawer } = renderPicker({
+      drafts: [makeDraft("draft_boom", "drifting row")],
+      onRestore,
+    })
+    await userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+    await userEvent.click(screen.getByText("drifting row"))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("could not be restored")))
+    expect(screen.getByText("drifting row")).toBeInTheDocument()
+    expect(closeFabDrawer).not.toHaveBeenCalled()
+  })
+
   it("a control row without openHref still restores", async () => {
     const onRestore = vi.fn().mockResolvedValue({ ok: true })
     renderPicker({
@@ -529,7 +577,14 @@ describe("navigate rows (branch replies / mounted composers)", () => {
       originById: new Map<string, StashedDraftRowOrigin>([
         [
           "draft_plain",
-          { tier: "borrowed", label: "#general", checkedOutElsewhere: false, openHref: null, openConversationId: null },
+          {
+            tier: "borrowed",
+            label: "#general",
+            checkedOutElsewhere: false,
+            openHref: null,
+            openConversationId: null,
+            openCarriesDraft: false,
+          },
         ],
       ]),
       onRestore,

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -1,14 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { act, render, screen, fireEvent, createEvent, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
 import { toast } from "sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { StashedDraftsPicker } from "./stashed-drafts-picker"
 import { FabDrawerCloseContext } from "./fab-drawer-close-context"
 import { StashedDraftsComposerBridgeContext } from "./stashed-drafts-open-context"
 import * as inputModeModule from "@/hooks/use-input-mode"
+import * as replyOpenStore from "@/stores/conversation-reply-open-store"
 import type { CachedDraft, DraftPreview, StashedDraftRowOrigin } from "@/hooks"
 import type { DraftRestoreResult } from "@/lib/drafts/restore-refusal"
+
+function LocationEcho() {
+  const location = useLocation()
+  return <div data-testid="navigated-away">{`${location.pathname}${location.search}`}</div>
+}
 
 let isTouchMockValue = false
 
@@ -35,13 +42,21 @@ function renderPicker(overrides: Partial<Parameters<typeof StashedDraftsPicker>[
   const closeFabDrawer = vi.fn()
   const focusComposer = vi.fn()
   const tree = (pickerProps: typeof props) => (
-    <TooltipProvider>
-      <FabDrawerCloseContext.Provider value={closeFabDrawer}>
-        <StashedDraftsComposerBridgeContext.Provider value={{ openRef: { current: null }, focusComposer }}>
-          <StashedDraftsPicker {...pickerProps} />
-        </StashedDraftsComposerBridgeContext.Provider>
-      </FabDrawerCloseContext.Provider>
-    </TooltipProvider>
+    <MemoryRouter initialEntries={["/start"]}>
+      <TooltipProvider>
+        <FabDrawerCloseContext.Provider value={closeFabDrawer}>
+          <StashedDraftsComposerBridgeContext.Provider value={{ openRef: { current: null }, focusComposer }}>
+            <StashedDraftsPicker {...pickerProps} />
+          </StashedDraftsComposerBridgeContext.Provider>
+        </FabDrawerCloseContext.Provider>
+      </TooltipProvider>
+      <Routes>
+        <Route path="/start" element={null} />
+        {/* A navigate row landing anywhere else renders this marker with the
+            exact location, so tests bind the destination, not just "moved". */}
+        <Route path="*" element={<LocationEcho />} />
+      </Routes>
+    </MemoryRouter>
   )
   const { rerender, unmount } = render(tree(props))
   const rerenderWith = (next: Partial<typeof props>) => rerender(tree({ ...props, ...next }))
@@ -274,11 +289,23 @@ describe("StashedDraftsPicker", () => {
 
   describe("origin and the own/borrowed seam", () => {
     const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
-    const own: StashedDraftRowOrigin = { tier: "own", label: "#general", checkedOutElsewhere: false }
-    const borrowed = (label: string, checkedOutElsewhere = false): StashedDraftRowOrigin => ({
+    const own: StashedDraftRowOrigin = {
+      tier: "own",
+      label: "#general",
+      checkedOutElsewhere: false,
+      openHref: null,
+      openConversationId: null,
+    }
+    const borrowed = (
+      label: string,
+      checkedOutElsewhere = false,
+      openHref: string | null = null
+    ): StashedDraftRowOrigin => ({
       tier: "borrowed",
       label,
       checkedOutElsewhere,
+      openHref,
+      openConversationId: openHref ? "conv_1" : null,
     })
     const rows = [makeDraft("draft_own", "mine"), makeDraft("draft_borrowed", "theirs")]
 
@@ -443,5 +470,72 @@ describe("StashedDraftsPicker", () => {
 
       expect(onDelete).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe("navigate rows (branch replies / mounted composers)", () => {
+  const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+
+  it("navigates instead of restoring, closes the picker, and says so in the meta line", async () => {
+    const replyOpenSpy = vi.spyOn(replyOpenStore, "requestConversationReplyOpen")
+    const onRestore = vi.fn()
+    const { closeFabDrawer } = renderPicker({
+      drafts: [makeDraft("draft_nav", "branch body"), makeDraft("draft_plain", "plain body")],
+      originById: new Map<string, StashedDraftRowOrigin>([
+        [
+          "draft_nav",
+          {
+            tier: "borrowed",
+            label: "Reply in Pizza plans",
+            checkedOutElsewhere: false,
+            openHref: "/w/ws_1/s/stream_1?panel=conv%3Aconv_1&stash=draft_nav",
+            openConversationId: "conv_1",
+          },
+        ],
+        [
+          "draft_plain",
+          { tier: "borrowed", label: "#general", checkedOutElsewhere: false, openHref: null, openConversationId: null },
+        ],
+      ]),
+      onRestore,
+    })
+    await open()
+
+    // Scoped to the NAVIGATE row (not a join over all rows): the badge must sit
+    // on the branch row and stay off the control row.
+    const navRow = screen.getByText("branch body").closest("li")
+    const plainRow = screen.getByText("plain body").closest("li")
+    expect(navRow?.textContent).toContain("opens there")
+    expect(plainRow?.textContent).not.toContain("opens there")
+
+    await userEvent.click(screen.getByText("branch body"))
+
+    // Navigation, not restore: the row never reaches the restore path, and it
+    // lands EXACTLY on the row's href (path + panel + stash param), not merely
+    // "somewhere else".
+    expect(onRestore).not.toHaveBeenCalled()
+    const landed = await screen.findByTestId("navigated-away")
+    expect(landed.textContent).toBe("/w/ws_1/s/stream_1?panel=conv%3Aconv_1&stash=draft_nav")
+    expect(closeFabDrawer).toHaveBeenCalled()
+    // Arrival focus rides the reply-open store — a same-URL navigation is a
+    // router no-op, so without this the tap can be a silent nothing.
+    expect(replyOpenSpy).toHaveBeenCalledWith("conv_1")
+  })
+
+  it("a control row without openHref still restores", async () => {
+    const onRestore = vi.fn().mockResolvedValue({ ok: true })
+    renderPicker({
+      drafts: [makeDraft("draft_plain", "plain body")],
+      originById: new Map<string, StashedDraftRowOrigin>([
+        [
+          "draft_plain",
+          { tier: "borrowed", label: "#general", checkedOutElsewhere: false, openHref: null, openConversationId: null },
+        ],
+      ]),
+      onRestore,
+    })
+    await open()
+    await userEvent.click(screen.getByText("plain body"))
+    expect(onRestore).toHaveBeenCalledWith("draft_plain")
   })
 })

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -87,7 +87,14 @@ interface StashedDraftsPickerProps {
 function rowHint(origin: StashedDraftRowOrigin | undefined, preview?: string): string | undefined {
   if (!origin || origin.tier !== "borrowed") return undefined
   const lead = preview !== undefined ? `${preview} — from ${origin.label}.` : `From ${origin.label}.`
-  if (origin.openHref) return `${lead} Opens in its own composer.`
+  if (origin.openHref) {
+    // The manual-pickup fallback (uncached parent) lands on the conversation
+    // WITHOUT carrying the draft — promising "its own composer" there would be
+    // promising more than the tap delivers.
+    return origin.openCarriesDraft
+      ? `${lead} Opens in its own composer.`
+      : `${lead} Opens the conversation — pick the draft up from its pile there.`
+  }
   const takeOver = origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""
   return `${lead}${takeOver} Picking it changes where this composer files.`
 }
@@ -191,7 +198,19 @@ export function StashedDraftsPicker({
       })
       // Awaited, not fired and forgotten: the close + focus below are the only
       // feedback a restore has, so they must not run for one that refused.
-      const result = await onRestore(id)
+      // A THROW (a navigate row reaching restore via scope drift between render
+      // and click, or a host wiring bug) must not be a silent no-op either —
+      // the loud console error stays, the user still gets told (INV-11).
+      let result: Awaited<ReturnType<typeof onRestore>>
+      try {
+        result = await onRestore(id)
+      } catch (err) {
+        restorePendingRef.current = false
+        setRestorePresentation(null)
+        console.error("[stash] restore threw", err)
+        toast.error("That draft could not be restored here.")
+        return
+      }
       restorePendingRef.current = false
       if (result && !result.ok) {
         setRestorePresentation(null)

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -9,6 +9,8 @@ import {
 } from "react"
 import { FileEdit, FilePlus, Trash2 } from "lucide-react"
 import { toast } from "sonner"
+import { useNavigate } from "react-router-dom"
+import { requestConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -76,6 +78,20 @@ interface StashedDraftsPickerProps {
  * showing a render ago and the world has since moved past, so the copy names
  * what happened to the draft, not what the code checked.
  */
+/**
+ * The borrowed-row hint for tooltip and accessible name. `aria-label` REPLACES
+ * the content-derived name, so everything the visible row implies must ride
+ * inside it: where the row came from, whether a tap NAVIGATES (branch reply /
+ * mounted composer) or takes the draft over, and that picking changes filing.
+ */
+function rowHint(origin: StashedDraftRowOrigin | undefined, preview?: string): string | undefined {
+  if (!origin || origin.tier !== "borrowed") return undefined
+  const lead = preview !== undefined ? `${preview} — from ${origin.label}.` : `From ${origin.label}.`
+  if (origin.openHref) return `${lead} Opens in its own composer.`
+  const takeOver = origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""
+  return `${lead}${takeOver} Picking it changes where this composer files.`
+}
+
 /** Whether this row's preview can still change height: a sealed body resolving
  *  in is the only thing that does. A plaintext row is final at first paint. */
 function isPreviewSettled(draft: CachedDraft, previewById?: Map<string, DraftPreview>): boolean {
@@ -193,6 +209,25 @@ export function StashedDraftsPicker({
       if (focusComposer) setTimeout(() => focusComposer(), 0)
     },
     [onRestore, closeFabDrawer, bridge, drafts, previewById, originById]
+  )
+
+  // A navigate row (branch reply, or a draft whose own composer is mounted —
+  // an open panel) takes the user to the composer that owns the draft instead
+  // of restoring here. Same close choreography as a restore, minus the focus
+  // steal (the destination surface owns focus on arrival).
+  const navigate = useNavigate()
+  const handleOpenElsewhere = useCallback(
+    (href: string, conversationId: string | null) => {
+      setOpen(false)
+      closeFabDrawer?.()
+      navigate(href)
+      // Arrival focus rides the reply-open store, NOT the URL: when the panel is
+      // already open beside this host the href can equal the current location and
+      // the navigation is a router no-op — without this signal the tap would do
+      // nothing visible (the silent no-op this routing exists to eliminate).
+      if (conversationId) requestConversationReplyOpen(conversationId)
+    },
+    [closeFabDrawer, navigate]
   )
 
   // Two-step delete: the trash icon opens a confirm dialog (parity with the
@@ -370,7 +405,11 @@ export function StashedDraftsPicker({
                         <button
                           type="button"
                           data-draft-row
-                          onClick={() => void handleRestore(draft.id)}
+                          onClick={() =>
+                            origin?.openHref
+                              ? handleOpenElsewhere(origin.openHref, origin.openConversationId ?? null)
+                              : void handleRestore(draft.id)
+                          }
                           // Picking a borrowed row does more than load it: the
                           // composer either retargets to that draft's conversation
                           // or takes the draft as its own, depending on the host.
@@ -382,16 +421,8 @@ export function StashedDraftsPicker({
                           // the "open elsewhere" hint must ride inside it too —
                           // as a visible-only span it would be dropped from the
                           // accessible name on exactly the rows that carry it.
-                          title={
-                            isBorrowed
-                              ? `From ${origin.label}.${origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""} Picking it changes where this composer files.`
-                              : undefined
-                          }
-                          aria-label={
-                            isBorrowed
-                              ? `${preview} — from ${origin.label}.${origin.checkedOutElsewhere ? " Open in another composer — picking it takes it over." : ""} Picking it changes where this composer files.`
-                              : undefined
-                          }
+                          title={rowHint(origin)}
+                          aria-label={rowHint(origin, preview)}
                           className="flex-1 min-w-0 text-left focus:outline-none"
                         >
                           {/* The second line is reserved only while the preview
@@ -430,10 +461,16 @@ export function StashedDraftsPicker({
                                 shift, INV-21): the row is still fully loadable —
                                 a tap takes the draft over — this just says the
                                 take-over will detach another composer. */}
-                            {origin?.checkedOutElsewhere && (
-                              <span data-draft-open-elsewhere className="shrink-0 truncate">
-                                · open elsewhere
+                            {origin?.openHref ? (
+                              <span data-draft-opens-elsewhere className="shrink-0 truncate">
+                                · opens there
                               </span>
+                            ) : (
+                              origin?.checkedOutElsewhere && (
+                                <span data-draft-open-elsewhere className="shrink-0 truncate">
+                                  · open elsewhere
+                                </span>
+                              )
                             )}
                           </p>
                         </button>

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -338,7 +338,8 @@ function MessageInputComponent({
       // A disarm is MECHANICAL — "stop replying to that conversation here", not
       // "put the draft away". Detach only: the draft keeps its board button,
       // auto-restore and explorer link (putAway would hide all three on every
-      // device).
+      // device). No marker means no push either, so nothing to drain here — the
+      // component stays free of persistence orchestration (INV-15).
       await stashLoadedDraft(workspaceId, vacated, { putAway: false })
     } catch (err) {
       console.error("[composer] could not release the disarmed draft", err)

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react"
 import { db, type CachedBoardPost, type CachedDraft, type CachedStream } from "@/db"
 import { draftScopesSignature, useBoardDraftContext, useThreadAnchorContext } from "./use-board-draft-context"
-import { createConversationPanelId } from "@/contexts"
 import { parseBoardDraftKey, type ParsedBoardDraftKey } from "@/lib/board/draft-keys"
 import { type CompanionMode } from "@threa/types"
 import {
@@ -20,6 +19,7 @@ import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { draftInlineText, draftMarkdown, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { conversationOriginLabel, subtopicOriginLabel, threadOriginLabel } from "@/lib/drafts/origin-label"
+import { conversationPanelHref } from "@/lib/board/panel-href"
 import {
   useDecryptedDraftPreviews,
   type DraftPreview,
@@ -286,12 +286,8 @@ function resolveBoardDraftLocation(
   subtopicHostByMessageId: Map<string, CachedBoardPost>,
   parentPostByBranchConversationId: Map<string, CachedBoardPost>
 ): ResolvedDraftLocation & { supportsStashRestore: boolean } {
-  const panelHref = (conversationId: string, anchorStreamId: string | null) => {
-    const panelParam = `panel=${encodeURIComponent(createConversationPanelId(conversationId))}`
-    return anchorStreamId
-      ? `/w/${workspaceId}/s/${anchorStreamId}?${panelParam}`
-      : `/w/${workspaceId}/board?${panelParam}`
-  }
+  const panelHref = (conversationId: string, anchorStreamId: string | null) =>
+    conversationPanelHref(workspaceId, conversationId, anchorStreamId)
 
   if (parsed.kind === "subtopic") {
     const host = subtopicHostByMessageId.get(parsed.messageId)

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -55,6 +55,38 @@ export function useMountedComposerCount(workspaceId: string, scope: string | nul
   )
 }
 
+// Cached per-workspace mounted-scope sets, rebuilt lazily after each registry
+// change: `useSyncExternalStore` needs a STABLE snapshot reference between
+// notifications or it loops.
+const mountedScopeSetCache = new Map<string, ReadonlySet<string>>()
+composerRegistryListeners.add(() => mountedScopeSetCache.clear())
+
+/**
+ * Every scope with a live composer mounted for `workspaceId`, as a set. The
+ * stash pile uses it to route rows whose draft is ALREADY ON SCREEN in its own
+ * composer (an open conversation panel's docked footer): tapping such a row
+ * navigates/focuses there instead of adopting into a host whose yield-to-panel
+ * effect would immediately undo the adopt — the silent no-op chunk 3 deferred.
+ */
+export function useMountedComposerScopes(workspaceId: string): ReadonlySet<string> {
+  return useSyncExternalStore(
+    subscribeComposerRegistry,
+    useCallback(() => {
+      let set = mountedScopeSetCache.get(workspaceId)
+      if (!set) {
+        const prefix = `${workspaceId} `
+        const built = new Set<string>()
+        for (const key of mountedComposersByScope.keys()) {
+          if (key.startsWith(prefix)) built.add(key.slice(prefix.length))
+        }
+        set = built
+        mountedScopeSetCache.set(workspaceId, set)
+      }
+      return set
+    }, [workspaceId])
+  )
+}
+
 /**
  * Whether this composer is the one host that consumes a `?stash=` deep link for
  * its scope. Exactly one mounted composer per scope answers true; the rest defer,

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -356,7 +356,7 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
   // to a panel that opens the conversation's own reply scope, not the branch
   // tail: the message is never sent and the draft is stranded. Moving is worse —
   // it rewrites the scope and destroys the filing with no undo.
-  it("refuses a branch reply rather than adopting or moving it", () => {
+  it("routes a branch reply to NAVIGATION rather than adopting or moving it", () => {
     expect(
       planDraftRestore({
         hostScope: aoHostScope,
@@ -364,7 +364,7 @@ describe("restoring a draft that belongs to another surface (adopt vs move)", ()
         draftScope: aoBranchScope,
         draftSource: { kind: "branch", conversationId: "conv_ao_branch" },
       })
-    ).toEqual({ action: "refuse", reason: "branch-elsewhere" })
+    ).toEqual({ action: "navigate", conversationId: "conv_ao_branch" })
 
     // A plain conversation reply is still adopted — the row keeps its filing.
     expect(
@@ -610,5 +610,75 @@ describe("restoreDraftHere — re-plan on mid-restore drift", () => {
     expect((await db.drafts.get("draft_drift"))?.scope).toBe(aoConversationScope)
     expect((await db.composerTarget.get(aoHostScope))?.scope).toBe(aoConversationScope)
     expect((await db.composerLoaded.get(aoConversationScope))?.draftId).toBe("draft_drift")
+  })
+})
+
+describe("navigate rows — mounted conversation composer (chunk 3's deferred no-op)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    __clearBoardDraftContextRegistry()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.composerTarget.clear()
+    await db.pendingOperations.clear()
+    await db.streams.clear()
+    await db.conversations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    __clearBoardDraftContextRegistry()
+  })
+
+  it("routes a conversation row to its OPEN panel composer instead of adopting into a host that would yield", async () => {
+    await seedAoStream()
+    await seedAoConversation()
+    await db.drafts.put(aoDraft("draft_conv", aoConversationScope))
+    await seedDraftCacheFromIdb(aoWorkspaceId)
+
+    // The conversation panel's docked composer is mounted on the draft's scope.
+    const panel = renderHook(
+      () =>
+        useDraftComposer({ workspaceId: aoWorkspaceId, draftKey: aoConversationScope, scopeId: aoConversationScope }),
+      { wrapper }
+    )
+    const host = renderHook(() => useAoHarness(aoHostScope, aoHostScope), { wrapper })
+    await waitFor(() =>
+      expect(host.result.current.stash.originByDraftId.get("draft_conv")?.openHref).toBe(
+        `/w/${aoWorkspaceId}/s/${aoStreamId}?panel=${encodeURIComponent(`conv:${aoConversationId}`)}&stash=draft_conv`
+      )
+    )
+
+    // Control: unmount the panel composer and the same row restores in place.
+    panel.unmount()
+    await waitFor(() =>
+      expect(host.result.current.stash.originByDraftId.get("draft_conv")?.openHref ?? null).toBeNull()
+    )
+    host.unmount()
+  })
+
+  it("restoreDraftHere throws on a navigate row — routing bugs fail loudly (INV-11)", async () => {
+    await seedAoStream()
+    await seedAoConversation()
+    await db.streams.put({
+      id: "stream_tb_nav",
+      workspaceId: aoWorkspaceId,
+      type: "thread",
+      visibility: "private",
+      rootStreamId: aoStreamId,
+      parentAnchorId: "msg_1",
+      archivedAt: null,
+    } as never)
+    await db.drafts.put(aoDraft("draft_branch_nav", aoBranchScope))
+    await seedDraftCacheFromIdb(aoWorkspaceId)
+
+    const { result } = renderHook(() => useAoHarness(aoHostScope, aoHostScope), { wrapper })
+    await waitFor(() => expect(result.current.composer.isLoaded).toBe(true))
+
+    await expect(result.current.stash.handleRestoreStashed("draft_branch_nav")).rejects.toThrow(/navigate row/)
   })
 })

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -27,6 +27,7 @@ export type DraftRestorePlan =
   | { action: "adopt"; targetHost: string; targetScope: string }
   | { action: "refuse"; reason: DraftRestoreRefusal }
   | { action: "move"; fromScope: string; toScope: string }
+  | { action: "navigate"; conversationId: string }
 
 /**
  * Adopt or move — the one decision the shared pile turns on, taken from the
@@ -64,9 +65,9 @@ export function planDraftRestore(input: {
   // the send guard always finds it not-live-here and hands off to a panel that
   // opens `board:reply:<B>`, not the branch tail: the message is never sent and
   // the draft is stranded. Moving is worse: it rewrites the scope and destroys the
-  // filing. So neither, and say so — the row stays visible and the user is told
-  // where it lives.
-  if (draftSource?.kind === "branch") return { action: "refuse", reason: "branch-elsewhere" }
+  // filing. So the row NAVIGATES — the picker routes it to the parent
+  // conversation's panel (`origin.openHref`), where the branch composer lives.
+  if (draftSource?.kind === "branch") return { action: "navigate", conversationId: draftSource.conversationId }
   const adoptableSource = draftSource?.kind === "conversation"
   if (targetHost && (adoptableSource || draftScope === targetHost)) {
     return { action: "adopt", targetHost, targetScope: draftScope }
@@ -236,6 +237,12 @@ export function useStashComposer(
           draftScope: live.scope,
           draftSource: describeScope(live.scope),
         })
+        if (plan.action === "navigate") {
+          // Navigate rows are routed by the picker through `origin.openHref`
+          // before restore is ever called; reaching here is a wiring bug, and
+          // silently doing nothing would strand the tap (INV-11).
+          throw new Error(`[stash] navigate row ${id} reached restoreDraftHere — route via origin.openHref`)
+        }
         if (plan.action === "refuse") {
           return refuse(plan.reason, `refusing restore of ${id} into ${scope}: ${plan.reason}`)
         }

--- a/apps/frontend/src/hooks/use-stashed-draft-origins.ts
+++ b/apps/frontend/src/hooks/use-stashed-draft-origins.ts
@@ -15,6 +15,8 @@ export interface StashedDraftRowOrigin {
   openHref: string | null
   /** The destination conversation for the arrival focus signal; set with `openHref`. */
   openConversationId: string | null
+  /** False for the manual-pickup fallback: the destination shows the conversation but not the draft. */
+  openCarriesDraft: boolean
 }
 
 /**
@@ -65,6 +67,7 @@ export function useStashedDraftOrigins(
         checkedOutElsewhere: origin.checkedOutElsewhere,
         openHref: origin.openHref,
         openConversationId: origin.openConversationId,
+        openCarriesDraft: origin.openCarriesDraft,
       })
     }
     return map

--- a/apps/frontend/src/hooks/use-stashed-draft-origins.ts
+++ b/apps/frontend/src/hooks/use-stashed-draft-origins.ts
@@ -11,6 +11,10 @@ export interface StashedDraftRowOrigin {
   label: string
   /** Another scope's composer holds this draft; a tap takes it over (quiet hint, never a gate). */
   checkedOutElsewhere: boolean
+  /** Set when the row NAVIGATES (branch reply / mounted composer) instead of restoring here. */
+  openHref: string | null
+  /** The destination conversation for the arrival focus signal; set with `openHref`. */
+  openConversationId: string | null
 }
 
 /**
@@ -55,7 +59,13 @@ export function useStashedDraftOrigins(
     }
     const map = new Map<string, StashedDraftRowOrigin>()
     for (const [draftId, origin] of originByDraftId) {
-      map.set(draftId, { tier: origin.tier, label: label(origin), checkedOutElsewhere: origin.checkedOutElsewhere })
+      map.set(draftId, {
+        tier: origin.tier,
+        label: label(origin),
+        checkedOutElsewhere: origin.checkedOutElsewhere,
+        openHref: origin.openHref,
+        openConversationId: origin.openConversationId,
+      })
     }
     return map
   }, [originByDraftId, streams, users, dmPeers])

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -273,6 +273,8 @@ describe("useStashedDrafts — pile membership", () => {
       conversationId: "conv_lone",
       tier: "borrowed",
       checkedOutElsewhere: false,
+      openHref: null,
+      openConversationId: null,
       title: null,
       // No topic summary yet — the label falls back to this stream's name rather
       // than a generic phrase, the same rung the drafts explorer uses.
@@ -526,6 +528,8 @@ describe("useStashedDrafts — pile membership", () => {
         streamId: "stream_s",
         tier: "own",
         checkedOutElsewhere: false,
+        openHref: null,
+        openConversationId: null,
         title: null,
         anchorStreamId: "stream_s",
       },
@@ -534,6 +538,8 @@ describe("useStashedDrafts — pile membership", () => {
         conversationId: "conv_1",
         tier: "borrowed",
         checkedOutElsewhere: false,
+        openHref: null,
+        openConversationId: null,
         title: "Pizza plans",
         anchorStreamId: "stream_s",
       },
@@ -543,6 +549,8 @@ describe("useStashedDrafts — pile membership", () => {
         streamId: "stream_s",
         tier: "borrowed",
         checkedOutElsewhere: false,
+        openHref: null,
+        openConversationId: null,
         title: null,
         anchorStreamId: "stream_s",
       },
@@ -553,6 +561,8 @@ describe("useStashedDrafts — pile membership", () => {
         anchorStreamId: "stream_s",
         tier: "borrowed",
         checkedOutElsewhere: false,
+        openHref: null,
+        openConversationId: null,
         title: "Pizza plans",
       },
     })
@@ -742,5 +752,57 @@ describe("restoreStashedDraftToComposer — id validated in the txn (INV-20)", (
   it("returns false for a row that is genuinely gone, and points at nothing", async () => {
     expect(await restoreStashedDraftToComposer(workspaceId, scope, "draft_never")).toBe(false)
     expect(await db.composerLoaded.get(scope)).toBeUndefined()
+  })
+})
+
+describe("navigate rows (openHref)", () => {
+  beforeEach(async () => {
+    __clearBoardDraftContextRegistry()
+    await db.conversations.clear()
+    await db.conversationMessages.clear()
+    await db.streams.clear()
+    await db.events.clear()
+  })
+
+  afterEach(() => {
+    __clearBoardDraftContextRegistry()
+  })
+
+  it("gives a branch row a panel deep link to its PARENT conversation, with the stash param", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_tb", { type: "thread", rootStreamId: "stream_s", parentAnchorId: "msg_c" })
+    await seedConversation("conv_c", "stream_s", { messageIds: ["msg_c"] })
+    await seedConversation("conv_branch", "stream_tb", { messageIds: ["msg_branch"] })
+    await db.drafts.bulkAdd([
+      draftRow({ id: "draft_branch", scope: "board:branch-reply:conv_branch" }),
+      // Control: an ordinary conversation row (no mounted composer) navigates
+      // nowhere — it restores in place.
+      draftRow({ id: "draft_conv", scope: "board:reply:conv_c" }),
+    ])
+
+    const { result, unmount } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:reply:conv_c"))
+    await waitFor(() =>
+      expect(result.current.originByDraftId.get("draft_branch")?.openHref).toBe(
+        `/w/${pileWorkspaceId}/s/stream_s?panel=${encodeURIComponent("conv:conv_c")}&stash=draft_branch`
+      )
+    )
+    expect(result.current.originByDraftId.get("draft_conv")?.openHref ?? null).toBeNull()
+    unmount()
+  })
+
+  it("an OWN branch row never navigates — the branch composer restores its own stash in place", async () => {
+    await seedStream("stream_s")
+    await seedStream("stream_tb", { type: "thread", rootStreamId: "stream_s", parentAnchorId: "msg_c" })
+    await seedConversation("conv_c", "stream_s", { messageIds: ["msg_c"] })
+    await seedConversation("conv_branch", "stream_tb", { messageIds: ["msg_branch"] })
+    await db.drafts.put(draftRow({ id: "draft_own_branch", scope: "board:branch-reply:conv_branch" }))
+
+    // Host IS the branch composer: its own stashed row must be a plain
+    // same-scope restore (pointer move), not a navigation away from the card.
+    const { result, unmount } = renderHook(() => useStashedDrafts(pileWorkspaceId, "board:branch-reply:conv_branch"))
+    await waitFor(() => expect(result.current.drafts.map((d) => d.id)).toContain("draft_own_branch"))
+    expect(result.current.originByDraftId.get("draft_own_branch")?.openHref ?? null).toBeNull()
+    expect(result.current.originByDraftId.get("draft_own_branch")?.tier).toBe("own")
+    unmount()
   })
 })

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -275,6 +275,7 @@ describe("useStashedDrafts — pile membership", () => {
       checkedOutElsewhere: false,
       openHref: null,
       openConversationId: null,
+      openCarriesDraft: false,
       title: null,
       // No topic summary yet — the label falls back to this stream's name rather
       // than a generic phrase, the same rung the drafts explorer uses.
@@ -530,6 +531,7 @@ describe("useStashedDrafts — pile membership", () => {
         checkedOutElsewhere: false,
         openHref: null,
         openConversationId: null,
+        openCarriesDraft: false,
         title: null,
         anchorStreamId: "stream_s",
       },
@@ -540,6 +542,7 @@ describe("useStashedDrafts — pile membership", () => {
         checkedOutElsewhere: false,
         openHref: null,
         openConversationId: null,
+        openCarriesDraft: false,
         title: "Pizza plans",
         anchorStreamId: "stream_s",
       },
@@ -551,6 +554,7 @@ describe("useStashedDrafts — pile membership", () => {
         checkedOutElsewhere: false,
         openHref: null,
         openConversationId: null,
+        openCarriesDraft: false,
         title: null,
         anchorStreamId: "stream_s",
       },
@@ -563,6 +567,7 @@ describe("useStashedDrafts — pile membership", () => {
         checkedOutElsewhere: false,
         openHref: null,
         openConversationId: null,
+        openCarriesDraft: false,
         title: "Pizza plans",
       },
     })

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -58,6 +58,12 @@ export type StashedDraftOrigin = StashedDraftSource & {
    * router-side, so focus must ride a store hand-off, not the URL.
    */
   openConversationId: string | null
+  /**
+   * False only for the manual-pickup fallback (branch with an uncached parent):
+   * the destination panel shows the conversation but cannot check the draft out
+   * — the hint copy must not promise "its own composer" there.
+   */
+  openCarriesDraft: boolean
   /** The owning conversation's topic summary, when it has one. */
   title: string | null
   /**
@@ -380,7 +386,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
       const source = draftSource(draft.scope, streamByAnchorId)
       if (!source) continue
       const pointerScope = pointerScopeByDraftId.get(draft.id)
-      const navigateTarget = ((): { href: string; conversationId: string } | null => {
+      const navigateTarget = ((): { href: string; conversationId: string; carriesDraft: boolean } | null => {
         // Only BORROWED rows ever navigate: the host's own rows (a branch
         // composer's own stash included) restore in place via `same-scope`.
         if (draft.scope === scope) return null
@@ -390,6 +396,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
             return {
               href: conversationPanelHref(workspaceId, parent.id, parent.conversation.streamId, draft.id),
               conversationId: parent.id,
+              carriesDraft: true,
             }
           }
           // Parent unresolvable: the branch's own panel still shows the
@@ -397,6 +404,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
           return {
             href: conversationPanelHref(workspaceId, source.conversationId, anchorStream(source)),
             conversationId: source.conversationId,
+            carriesDraft: false,
           }
         }
         if (source.kind === "conversation" && mountedScopes.has(draft.scope)) {
@@ -408,6 +416,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
           return {
             href: conversationPanelHref(workspaceId, source.conversationId, anchorStream(source), stashId),
             conversationId: source.conversationId,
+            carriesDraft: true,
           }
         }
         return null
@@ -418,6 +427,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
         checkedOutElsewhere: pointerScope !== undefined && pointerScope !== scope,
         openHref: navigateTarget?.href ?? null,
         openConversationId: navigateTarget?.conversationId ?? null,
+        openCarriesDraft: navigateTarget?.carriesDraft ?? false,
         title: topicSummary(source),
         anchorStreamId: anchorStream(source),
       })

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -3,6 +3,8 @@ import { type CachedDraft, type CachedStream } from "@/db"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { isDraftInHostPile, resolveDraftHomeStream, type DraftPileContext } from "@/lib/drafts/home-stream"
 import { hasSeededDraftCache, useComposerLoadedFromStore, useDraftsFromStore } from "@/stores/draft-store"
+import { conversationPanelHref } from "@/lib/board/panel-href"
+import { useMountedComposerScopes } from "./use-draft-composer"
 import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
 import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
@@ -40,6 +42,22 @@ export type StashedDraftOrigin = StashedDraftSource & {
    * shows a quiet hint so the take-over is informed rather than surprising.
    */
   checkedOutElsewhere: boolean
+  /**
+   * Set when tapping this row should NAVIGATE instead of restoring here: a
+   * branch reply (its composer lives only on the parent conversation's panel —
+   * v1 toasted directions at the user instead), or a conversation row whose own
+   * composer is MOUNTED right now (an open panel's docked footer): adopting
+   * would arm a host whose yield-to-panel effect immediately un-arms it — a
+   * silent no-op — so the row takes the user to the composer that already shows
+   * (or will claim) the draft.
+   */
+  openHref: string | null
+  /**
+   * The conversation whose panel `openHref` lands on, for the arrival focus
+   * signal (`requestConversationReplyOpen`) — a same-URL navigation is a no-op
+   * router-side, so focus must ride a store hand-off, not the URL.
+   */
+  openConversationId: string | null
   /** The owning conversation's topic summary, when it has one. */
   title: string | null
   /**
@@ -172,6 +190,7 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
   const cachedStreams = useWorkspaceStreamsRaw(workspaceId)
 
   const loadedId = scope ? (loaded.find((row) => row.scope === scope)?.draftId ?? null) : null
+  const mountedScopes = useMountedComposerScopes(workspaceId)
   // Where each draft is checked out, if anywhere. Being loaded somewhere no
   // longer HIDES a row (v2: a visible row is loadable — restoring takes it
   // over, chunk 2); it only annotates the origin so the take-over is informed.
@@ -361,16 +380,60 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
       const source = draftSource(draft.scope, streamByAnchorId)
       if (!source) continue
       const pointerScope = pointerScopeByDraftId.get(draft.id)
+      const navigateTarget = ((): { href: string; conversationId: string } | null => {
+        // Only BORROWED rows ever navigate: the host's own rows (a branch
+        // composer's own stash included) restore in place via `same-scope`.
+        if (draft.scope === scope) return null
+        if (source.kind === "branch") {
+          const parent = parentPostByBranchConversationId.get(source.conversationId)
+          if (parent) {
+            return {
+              href: conversationPanelHref(workspaceId, parent.id, parent.conversation.streamId, draft.id),
+              conversationId: parent.id,
+            }
+          }
+          // Parent unresolvable: the branch's own panel still shows the
+          // conversation for manual pickup (mirrors the drafts explorer).
+          return {
+            href: conversationPanelHref(workspaceId, source.conversationId, anchorStream(source)),
+            conversationId: source.conversationId,
+          }
+        }
+        if (source.kind === "conversation" && mountedScopes.has(draft.scope)) {
+          // Loaded there already -> the href may equal the CURRENT url (panel
+          // open beside the host), so arrival focus rides the reply-open store,
+          // never the URL; stashed -> also carry ?stash= for the mounted
+          // composer's own claim effect.
+          const stashId = pointerScope === draft.scope ? undefined : draft.id
+          return {
+            href: conversationPanelHref(workspaceId, source.conversationId, anchorStream(source), stashId),
+            conversationId: source.conversationId,
+          }
+        }
+        return null
+      })()
       map.set(draft.id, {
         ...source,
         tier: draft.scope === scope ? "own" : "borrowed",
         checkedOutElsewhere: pointerScope !== undefined && pointerScope !== scope,
+        openHref: navigateTarget?.href ?? null,
+        openConversationId: navigateTarget?.conversationId ?? null,
         title: topicSummary(source),
         anchorStreamId: anchorStream(source),
       })
     }
     return map
-  }, [drafts, scope, streamByAnchorId, boardPostMap, hostPostByMessageId, pointerScopeByDraftId])
+  }, [
+    drafts,
+    scope,
+    workspaceId,
+    streamByAnchorId,
+    boardPostMap,
+    hostPostByMessageId,
+    pointerScopeByDraftId,
+    parentPostByBranchConversationId,
+    mountedScopes,
+  ])
 
   const canHostForeignDraft = useCallback(
     () => !!workspaceId && !!scope && isHostHomeEligible(scope, pileContext, streamMap, archivedStreamIds),

--- a/apps/frontend/src/lib/board/panel-href.ts
+++ b/apps/frontend/src/lib/board/panel-href.ts
@@ -1,0 +1,21 @@
+import { createConversationPanelId } from "@/contexts"
+
+/**
+ * The one authority for a conversation-panel deep link (INV-35): the anchor
+ * stream's timeline with the panel open, or the board when the anchor stream
+ * isn't known. Shared by the drafts explorer's row hrefs and the stash picker's
+ * navigate rows so the two can't drift. `stashDraftId` appends the `?stash=`
+ * param the panel's composer claims on arrival.
+ */
+export function conversationPanelHref(
+  workspaceId: string,
+  conversationId: string,
+  anchorStreamId: string | null,
+  stashDraftId?: string
+): string {
+  const panelParam = `panel=${encodeURIComponent(createConversationPanelId(conversationId))}`
+  const base = anchorStreamId
+    ? `/w/${workspaceId}/s/${anchorStreamId}?${panelParam}`
+    : `/w/${workspaceId}/board?${panelParam}`
+  return stashDraftId ? `${base}&stash=${encodeURIComponent(stashDraftId)}` : base
+}

--- a/apps/frontend/src/lib/drafts/restore-refusal.ts
+++ b/apps/frontend/src/lib/drafts/restore-refusal.ts
@@ -1,5 +1,5 @@
 /** Why a restore did not happen. Every guard returns one; none is silent (INV-11). */
-export type DraftRestoreRefusal = "missing" | "host-ineligible" | "branch-elsewhere" | "raced"
+export type DraftRestoreRefusal = "missing" | "host-ineligible" | "raced"
 
 export type DraftRestoreResult = { ok: true } | { ok: false; reason: DraftRestoreRefusal }
 
@@ -13,6 +13,5 @@ export type DraftRestoreResult = { ok: true } | { ok: false; reason: DraftRestor
 export const RESTORE_REFUSAL_MESSAGE: Record<DraftRestoreRefusal, string> = {
   missing: "That draft is no longer there.",
   "host-ineligible": "This stream can't hold that draft — it stays where it is.",
-  "branch-elsewhere": "Open the conversation to continue that branch reply.",
   raced: "That draft moved before it could be restored.",
 }


### PR DESCRIPTION
## Problem

A branch-reply row in the pile used to tap into an error toast telling the user where to go
(`branch-elsewhere`) — a link rendered as a refusal. And chunk 3 documented a deferred no-op: adopting a
conversation draft whose panel composer is mounted armed the timeline, whose yield-to-panel effect
immediately disarmed it — tap, nothing. Chunk 5 of
https://seer.build/ws_vbyzjvdg6g/b/draft-sharing-v2-13fec2/.

## Solution

Rows that can't restore here navigate there.

- `planDraftRestore`'s branch case returns `{ action: "navigate", conversationId }`; `restoreDraftHere`
  throws if a navigate row ever reaches it (unreachable in production — verified across the auto-`?stash=`
  claim, board mount/signal restores, keyboard Enter, and FAB paths — so a throw is a wiring bug surfacing
  loudly, INV-11). The `branch-elsewhere` refusal and its copy are deleted.
- Pile origins carry `openHref` + `openConversationId`. Branch rows link to the PARENT conversation's panel
  with the `?stash=` param (uncached parent → the branch's own panel, no param — manual pickup, mirroring the
  explorer). A conversation row whose own composer is MOUNTED (open panel footer) links there too — and
  arrival focus rides `requestConversationReplyOpen`, never the URL, because when the panel is already open
  the href can equal the current location and the navigation is a router no-op. Own rows never navigate
  (`draft.scope === scope` gate): a branch composer's own stash restores in place.
- The picker routes `openHref` rows (closing the popover/FAB), shows an "opens there" meta hint, and the
  tooltip/aria-label say "Opens in its own composer" — `aria-label` replaces the content-derived name, so the
  hint must ride inside it.
- `conversationPanelHref` (`lib/board/panel-href.ts`) is now the single authority: the drafts explorer's
  local duplicate was migrated onto it.

**#1783's two review findings are fixed here** (same stack-sharing rationale as previous folds): the
disarm-target stash path now kicks the operation queue (via a ref, so the engine identity doesn't churn the
callback), and the explorer's "Stashed" annotation is gated on `putAway && isStashed` so the
checked-out-here-while-stashed-elsewhere coexistence window renders an ordinary active row.

Adversarial verify (Opus/high) confirmed 4 findings pre-merge — own-branch rows navigating away (proved by
execution), the dead-tap same-URL navigation, the false single-authority claim, and two vacuous test
assertions — all fixed in-branch; the navigate test now binds the EXACT destination path+search.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-stash-composer.ts` | navigate plan, loud throw |
| `apps/frontend/src/hooks/use-stashed-drafts.ts` | `openHref`/`openConversationId`, own-scope gate |
| `apps/frontend/src/lib/board/panel-href.ts` | **new** shared authority |
| `apps/frontend/src/hooks/use-all-drafts.ts` | explorer migrated onto it |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | routing, hints, focus signal |
| `apps/frontend/src/hooks/use-draft-composer.ts` | `useMountedComposerScopes` |
| `apps/frontend/src/components/timeline/message-input.tsx` | disarm stash queue kick (#1783) |
| `apps/frontend/src/pages/drafts.tsx` | annotation gate (#1783) |
| tests (5 files) | navigate routing, own-branch gate, exact-destination, coexistence window |

## Test plan

- [x] vitest 251/251 across the 9 affected suites; tsc clean.
- [x] Neutralisations: branch plan, picker routing, mounted leg, own-scope gate, focus signal, annotation
  gate — each inverted → red → restored.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788618840&installation_model_id=20758&pr_number=1784&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1784&signature=fde826d177512cebab66913c0b18b045bf4c9faa1a99676111a613bd57a623eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->