### PR TITLE
feat: track title provenance and revisions

### DIFF
--- a/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
+++ b/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
@@ -22,3 +22,60 @@ WHERE s.display_name IS NOT NULL
 UPDATE conversations
 SET topic_summary_source = 'legacy'
 WHERE topic_summary IS NOT NULL;
+
+-- Sealed E2E titles are authoritative. Remove the historical plaintext copy
+-- after provenance is captured so no later projection can expose it.
+UPDATE streams s
+SET display_name = NULL
+WHERE EXISTS (
+  SELECT 1 FROM e2e_streams e
+  WHERE e.workspace_id = s.workspace_id
+    AND e.stream_id = s.id
+    AND e.name_ciphertext IS NOT NULL
+);
+
+-- One rollout-window compatibility fence: a pre-migration replica updates only
+-- the old title column. Conservatively classify such writes as explicit and
+-- advance the revision; new writers advance the revision themselves and pass
+-- through unchanged. PR8 removes these after fleet soak.
+CREATE FUNCTION preserve_legacy_stream_title_intent() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.display_name IS NOT NULL AND NEW.display_name_source IS NULL THEN
+      NEW.display_name_source := 'explicit';
+      NEW.display_name_revision := GREATEST(NEW.display_name_revision, 1);
+    END IF;
+  ELSIF NEW.display_name IS DISTINCT FROM OLD.display_name
+    AND NEW.display_name_revision = OLD.display_name_revision THEN
+    NEW.display_name_source := 'explicit';
+    NEW.display_name_revision := OLD.display_name_revision + 1;
+    NEW.display_name_updated_by_user_id := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER preserve_legacy_stream_title_intent_trigger
+BEFORE INSERT OR UPDATE OF display_name ON streams
+FOR EACH ROW EXECUTE FUNCTION preserve_legacy_stream_title_intent();
+
+CREATE FUNCTION preserve_legacy_conversation_title_intent() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.topic_summary IS NOT NULL AND NEW.topic_summary_source IS NULL THEN
+      NEW.topic_summary_source := 'explicit';
+      NEW.topic_summary_revision := GREATEST(NEW.topic_summary_revision, 1);
+    END IF;
+  ELSIF NEW.topic_summary IS DISTINCT FROM OLD.topic_summary
+    AND NEW.topic_summary_revision = OLD.topic_summary_revision THEN
+    NEW.topic_summary_source := 'explicit';
+    NEW.topic_summary_revision := OLD.topic_summary_revision + 1;
+    NEW.topic_summary_updated_by_user_id := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER preserve_legacy_conversation_title_intent_trigger
+BEFORE INSERT OR UPDATE OF topic_summary ON conversations
+FOR EACH ROW EXECUTE FUNCTION preserve_legacy_conversation_title_intent();

--- a/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
+++ b/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
@@ -79,3 +79,28 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER preserve_legacy_conversation_title_intent_trigger
 BEFORE INSERT OR UPDATE OF topic_summary ON conversations
 FOR EACH ROW EXECUTE FUNCTION preserve_legacy_conversation_title_intent();
+
+-- Old replicas write sealed title bytes directly on e2e_streams and cannot
+-- advance the new streams provenance columns. Treat those rollout-window writes
+-- as explicit. New repository writes set a statement-local guard and coordinate
+-- provenance themselves in the same transaction.
+CREATE FUNCTION preserve_legacy_e2e_title_intent() RETURNS TRIGGER AS $$
+BEGIN
+  IF current_setting('threa.coordinated_title_write', true) = '1' THEN
+    RETURN NEW;
+  END IF;
+  IF (TG_OP = 'INSERT' AND NEW.name_ciphertext IS NOT NULL)
+    OR (TG_OP = 'UPDATE' AND NEW.name_ciphertext IS DISTINCT FROM OLD.name_ciphertext) THEN
+    UPDATE streams
+    SET display_name_source = 'explicit',
+        display_name_revision = display_name_revision + 1,
+        display_name_updated_by_user_id = NULL
+    WHERE workspace_id = NEW.workspace_id AND id = NEW.stream_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER preserve_legacy_e2e_title_intent_trigger
+AFTER INSERT OR UPDATE OF name_ciphertext ON e2e_streams
+FOR EACH ROW EXECUTE FUNCTION preserve_legacy_e2e_title_intent();

--- a/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
+++ b/apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql
@@ -1,0 +1,24 @@
+-- Add title provenance and monotonic revisions for rollout-safe naming writes.
+ALTER TABLE streams
+  ADD COLUMN display_name_source TEXT,
+  ADD COLUMN display_name_revision INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN display_name_updated_by_user_id TEXT;
+
+ALTER TABLE conversations
+  ADD COLUMN topic_summary_source TEXT,
+  ADD COLUMN topic_summary_revision INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN topic_summary_updated_by_user_id TEXT;
+
+UPDATE streams s
+SET display_name_source = 'legacy'
+WHERE s.display_name IS NOT NULL
+   OR EXISTS (
+     SELECT 1 FROM e2e_streams e
+     WHERE e.workspace_id = s.workspace_id
+       AND e.stream_id = s.id
+       AND e.name_ciphertext IS NOT NULL
+   );
+
+UPDATE conversations
+SET topic_summary_source = 'legacy'
+WHERE topic_summary IS NOT NULL;

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -26,7 +26,13 @@ import { resolveConversationDelivery } from "./conversation-delivery"
 import { emitAssignmentEvents } from "./assignment-events"
 import { isClusteredAuthorType, isClusteredStreamType } from "./extraction-eligibility"
 import { conversationId } from "../../lib/id"
-import { ConversationStatuses, LinkPreviewStatuses, StreamTypes, THREAD_ANCHORABLE_EVENT_TYPES } from "@threa/types"
+import {
+  ConversationStatuses,
+  LinkPreviewStatuses,
+  StreamTypes,
+  THREAD_ANCHORABLE_EVENT_TYPES,
+  TitleSources,
+} from "@threa/types"
 import { logger } from "../../lib/logger"
 
 const MESSAGES_BEFORE = 5
@@ -426,6 +432,7 @@ export class BoundaryExtractionService {
               streamId,
               workspaceId,
               topicSummary: decision.newTopic,
+              topicSummarySource: decision.newTopic === undefined ? undefined : TitleSources.GENERATED,
               summary: decision.newSummary,
               confidence: decision.confidence,
               status: ConversationStatuses.ACTIVE,

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -414,6 +414,7 @@ describe("Conversation Handlers", () => {
         conversationId: "conv_1",
         topicSummary: "New topic",
         status: undefined,
+        actorUserId: "usr_1",
       })
       expect((res as unknown as { body: unknown }).body).toEqual({
         conversation: { id: "conv_1", topicSummary: "Renamed", status: "active" },

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -481,7 +481,13 @@ export function createConversationHandlers({
       // validateStreamAccess handles public visibility + thread root membership
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
-      const result = await conversationService.updateConversation({ workspaceId, conversationId, topicSummary, status })
+      const result = await conversationService.updateConversation({
+        workspaceId,
+        conversationId,
+        topicSummary,
+        status,
+        actorUserId: userId,
+      })
       res.json(result)
     },
 

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -688,9 +688,6 @@ export const ConversationRepository = {
   },
 
   async insert(db: Querier, params: InsertConversationParams): Promise<Conversation> {
-    if (params.topicSummary !== undefined && params.topicSummarySource === undefined) {
-      throw new Error("Titled conversation inserts require topicSummarySource")
-    }
     const result = await db.query<ConversationRow>(sql`
       INSERT INTO conversations (
         id, stream_id, workspace_id,
@@ -701,7 +698,7 @@ export const ConversationRepository = {
         ${params.streamId},
         ${params.workspaceId},
         ${params.topicSummary ?? null},
-        ${params.topicSummarySource ?? null},
+        ${params.topicSummary === undefined ? null : (params.topicSummarySource ?? TitleSources.EXPLICIT)},
         ${params.topicSummary === undefined ? 0 : 1},
         ${params.topicSummaryUpdatedByUserId ?? null},
         ${params.summary ?? null},

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -6,6 +6,8 @@ import {
   LabelableResourceTypes,
   type ConversationStatus,
   type BoardLens,
+  type TitleSource,
+  TitleSources,
 } from "@threa/types"
 
 /**
@@ -202,6 +204,9 @@ interface ConversationRow {
   stream_id: string
   workspace_id: string
   topic_summary: string | null
+  topic_summary_source: TitleSource | null
+  topic_summary_revision: number
+  topic_summary_updated_by_user_id: string | null
   summary: string | null
   completeness_score: number
   confidence: number
@@ -236,6 +241,9 @@ export interface Conversation {
   participantIds: string[]
   secondaryMessageIds: string[]
   topicSummary: string | null
+  topicSummarySource?: TitleSource | null
+  topicSummaryRevision?: number
+  topicSummaryUpdatedByUserId?: string | null
   summary: string | null
   completenessScore: number
   confidence: number
@@ -251,6 +259,8 @@ export interface InsertConversationParams {
   streamId: string
   workspaceId: string
   topicSummary?: string
+  topicSummarySource?: TitleSource
+  topicSummaryUpdatedByUserId?: string | null
   summary?: string
   completenessScore?: number
   confidence?: number
@@ -259,7 +269,6 @@ export interface InsertConversationParams {
 }
 
 export interface UpdateConversationParams {
-  topicSummary?: string
   summary?: string
   completenessScore?: number
   confidence?: number
@@ -279,6 +288,9 @@ function mapRowToConversation(row: ConversationRow): Conversation {
     participantIds: row.participant_ids,
     secondaryMessageIds: row.secondary_message_ids,
     topicSummary: row.topic_summary,
+    topicSummarySource: row.topic_summary_source ?? (row.topic_summary !== null ? TitleSources.LEGACY : null),
+    topicSummaryRevision: row.topic_summary_revision,
+    topicSummaryUpdatedByUserId: row.topic_summary_updated_by_user_id,
     summary: row.summary,
     completenessScore: row.completeness_score,
     confidence: row.confidence,
@@ -293,7 +305,7 @@ function mapRowToConversation(row: ConversationRow): Conversation {
 const SELECT_FIELDS = `
   id, stream_id, workspace_id,
   message_ids, participant_ids, secondary_message_ids,
-  topic_summary, summary, completeness_score, confidence, status, parent_conversation_id,
+  topic_summary, topic_summary_source, topic_summary_revision, topic_summary_updated_by_user_id, summary, completeness_score, confidence, status, parent_conversation_id,
   last_activity_at, created_at, updated_at
 `
 
@@ -676,16 +688,22 @@ export const ConversationRepository = {
   },
 
   async insert(db: Querier, params: InsertConversationParams): Promise<Conversation> {
+    if (params.topicSummary !== undefined && params.topicSummarySource === undefined) {
+      throw new Error("Titled conversation inserts require topicSummarySource")
+    }
     const result = await db.query<ConversationRow>(sql`
       INSERT INTO conversations (
         id, stream_id, workspace_id,
-        topic_summary, summary, completeness_score, confidence, status, parent_conversation_id
+        topic_summary, topic_summary_source, topic_summary_revision, topic_summary_updated_by_user_id, summary, completeness_score, confidence, status, parent_conversation_id
       )
       VALUES (
         ${params.id},
         ${params.streamId},
         ${params.workspaceId},
         ${params.topicSummary ?? null},
+        ${params.topicSummarySource ?? null},
+        ${params.topicSummary === undefined ? 0 : 1},
+        ${params.topicSummaryUpdatedByUserId ?? null},
         ${params.summary ?? null},
         ${params.completenessScore ?? 1},
         ${params.confidence ?? 0.5},
@@ -712,10 +730,6 @@ export const ConversationRepository = {
     const values: unknown[] = []
     let paramIndex = 1
 
-    if (params.topicSummary !== undefined) {
-      updates.push(`topic_summary = $${paramIndex++}`)
-      values.push(params.topicSummary)
-    }
     if (params.summary !== undefined) {
       updates.push(`summary = $${paramIndex++}`)
       values.push(params.summary)
@@ -767,6 +781,33 @@ export const ConversationRepository = {
     const result = await db.query<ConversationRow>(query, values)
     if (!result.rows[0]) return null
     return mapRowToConversation(result.rows[0])
+  },
+
+  async updateTopicSummary(
+    db: Querier,
+    params: {
+      workspaceId: string
+      conversationId: string
+      topicSummary: string
+      source: TitleSource
+      updatedByUserId?: string | null
+      expectedRevision?: number
+      expectedSource?: TitleSource | null
+    }
+  ): Promise<Conversation | null> {
+    const result = await db.query<ConversationRow>(sql`
+      UPDATE conversations SET
+        topic_summary = ${params.topicSummary},
+        topic_summary_source = ${params.source},
+        topic_summary_revision = topic_summary_revision + 1,
+        topic_summary_updated_by_user_id = ${params.updatedByUserId ?? null},
+        updated_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.conversationId}
+        AND (${params.expectedRevision === undefined} OR topic_summary_revision = ${params.expectedRevision ?? 0})
+        AND (${params.expectedSource === undefined} OR COALESCE(topic_summary_source, CASE WHEN topic_summary IS NOT NULL THEN ${TitleSources.LEGACY} END) IS NOT DISTINCT FROM ${params.expectedSource ?? null})
+      RETURNING ${sql.raw(SELECT_FIELDS)}
+    `)
+    return result.rows[0] ? mapRowToConversation(result.rows[0]) : null
   },
 
   /**

--- a/apps/backend/src/features/conversations/service.apply-split.test.ts
+++ b/apps/backend/src/features/conversations/service.apply-split.test.ts
@@ -50,6 +50,7 @@ function message(id: string): Message {
 interface Spies {
   insert: ReturnType<typeof spyOn>
   update: ReturnType<typeof spyOn>
+  updateTopicSummary: ReturnType<typeof spyOn>
   removePrimaryMessages: ReturnType<typeof spyOn>
   addPrimaryMessages: ReturnType<typeof spyOn>
   resolveIfEmpty: ReturnType<typeof spyOn>
@@ -116,6 +117,9 @@ function setup(options: { source: Conversation; primaries: Record<string, string
   return {
     insert,
     update: spyOn(ConversationRepository, "update").mockResolvedValue(null as never),
+    updateTopicSummary: spyOn(ConversationRepository, "updateTopicSummary").mockImplementation(async (_db, params) =>
+      makeConversation({ id: params.conversationId, topicSummary: params.topicSummary })
+    ),
     removePrimaryMessages: spyOn(ConversationRepository, "removePrimaryMessages").mockResolvedValue(undefined as never),
     addPrimaryMessages: spyOn(ConversationRepository, "addPrimaryMessages").mockResolvedValue(undefined as never),
     resolveIfEmpty: spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never),
@@ -155,10 +159,14 @@ describe("ConversationService.applySplit", () => {
     ])
 
     // Source re-titled to the kept (first) group; only the moved ids are stripped.
-    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", {
+    expect(spies.updateTopicSummary).toHaveBeenCalledWith(expect.anything(), {
+      workspaceId: WORKSPACE_ID,
+      conversationId: "conv_a",
       topicSummary: "Fable pricing",
-      summary: undefined,
+      source: "explicit",
+      updatedByUserId: ACTOR_ID,
     })
+    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", { summary: undefined })
     expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
       expect.anything(),
       WORKSPACE_ID,
@@ -229,10 +237,14 @@ describe("ConversationService.applySplit", () => {
       { title: "Moved", messageIds: ["m3", "m4"] },
     ])
 
-    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", {
+    expect(spies.updateTopicSummary).toHaveBeenCalledWith(expect.anything(), {
+      workspaceId: WORKSPACE_ID,
+      conversationId: "conv_a",
       topicSummary: "Kept",
-      summary: undefined,
+      source: "explicit",
+      updatedByUserId: ACTOR_ID,
     })
+    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", { summary: undefined })
   })
 
   test("leaves the source title untouched when un-analyzed messages remain", async () => {

--- a/apps/backend/src/features/conversations/service.test.ts
+++ b/apps/backend/src/features/conversations/service.test.ts
@@ -34,11 +34,15 @@ function fakeConversation(over: Partial<Conversation> = {}): Conversation {
 
 describe("ConversationService.updateConversation — user status lock", () => {
   let updateSpy: ReturnType<typeof spyOn>
+  let updateTopicSpy: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, cb: (client: unknown) => unknown) =>
       cb({})) as never)
     updateSpy = spyOn(ConversationRepository, "update").mockResolvedValue(fakeConversation())
+    updateTopicSpy = spyOn(ConversationRepository, "updateTopicSummary").mockResolvedValue(
+      fakeConversation({ topicSummary: "New title", topicSummarySource: "explicit", topicSummaryRevision: 1 })
+    )
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1" } as never)
     spyOn(delivery, "resolveConversationDelivery").mockResolvedValue({
       parentStreamId: null,
@@ -66,9 +70,11 @@ describe("ConversationService.updateConversation — user status lock", () => {
     const service = new ConversationService(POOL)
     await service.updateConversation({ workspaceId: "ws_1", conversationId: "conv_1", topicSummary: "New title" })
 
-    const params = updateSpy.mock.calls[0]![3] as { topicSummary?: string; statusLockedByUser?: boolean }
-    expect(params.topicSummary).toBe("New title")
-    expect(params.statusLockedByUser).toBeUndefined()
+    expect(updateSpy.mock.calls[0]![3]).toEqual(expect.objectContaining({ statusLockedByUser: undefined }))
+    expect(updateTopicSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ topicSummary: "New title", source: "explicit" })
+    )
   })
 })
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -27,6 +27,7 @@ import {
   type ConversationStatus,
   type LinkPreviewSummary,
   type MemoEmbedSummary,
+  TitleSources,
 } from "@threa/types"
 
 export { ConversationWithStaleness }
@@ -763,11 +764,11 @@ export class ConversationService {
     conversationId: string
     topicSummary?: string
     status?: ConversationStatus
+    actorUserId?: string
   }): Promise<{ conversation: ConversationWithStaleness }> {
-    const { workspaceId, conversationId, topicSummary, status } = params
+    const { workspaceId, conversationId, topicSummary, status, actorUserId } = params
     return withTransaction(this.pool, async (client) => {
-      const updated = await ConversationRepository.update(client, workspaceId, conversationId, {
-        topicSummary,
+      let updated = await ConversationRepository.update(client, workspaceId, conversationId, {
         status,
         // A user-set status is authoritative — lock it so the extractor's LLM stops
         // overriding it (user resolution wins over the AI's ruling). Only when the
@@ -776,6 +777,16 @@ export class ConversationService {
       })
       if (!updated) {
         throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      if (topicSummary !== undefined) {
+        updated = await ConversationRepository.updateTopicSummary(client, {
+          workspaceId,
+          conversationId,
+          topicSummary,
+          source: TitleSources.EXPLICIT,
+          updatedByUserId: actorUserId,
+        })
+        if (!updated) throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
       }
       const stream = await StreamRepository.findById(client, updated.streamId)
       const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
@@ -1366,9 +1377,13 @@ export class ConversationService {
         distinctAuthors(remainingSourceIds, memberMessages)
       )
       if (sourceFullyAnalyzed) {
-        await ConversationRepository.update(client, workspaceId, source.id, {
+        await ConversationRepository.update(client, workspaceId, source.id, { summary: keepGroup.summary })
+        await ConversationRepository.updateTopicSummary(client, {
+          workspaceId,
+          conversationId: source.id,
           topicSummary: keepGroup.title,
-          summary: keepGroup.summary,
+          source: TitleSources.EXPLICIT,
+          updatedByUserId: actorUserId,
         })
       }
       await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
@@ -1383,6 +1398,8 @@ export class ConversationService {
           streamId,
           workspaceId,
           topicSummary: g.title,
+          topicSummarySource: TitleSources.EXPLICIT,
+          topicSummaryUpdatedByUserId: actorUserId,
           summary: g.summary,
           confidence: 1,
           status: ConversationStatuses.ACTIVE,

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -145,7 +145,9 @@ export const E2eStreamsRepository = {
       UPDATE e2e_streams
       SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
           name_envelope = ${JSON.stringify(sealed.envelope)}
-      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId} AND name_ciphertext IS NULL
+      WHERE workspace_id = ${workspaceId}
+        AND stream_id = ${streamId}
+        AND name_ciphertext IS NULL
     `)
     return (result.rowCount ?? 0) > 0
   },

--- a/apps/backend/src/features/e2e-streams/repository.ts
+++ b/apps/backend/src/features/e2e-streams/repository.ts
@@ -105,13 +105,20 @@ export const E2eStreamsRepository = {
     if (sealed && Buffer.from(sealed.ciphertext, "base64").toString("base64") !== sealed.ciphertext) {
       throw new Error("updateSealedName: ciphertext is not canonical base64")
     }
-    const result = await db.query(sql`
-      UPDATE e2e_streams
-      SET name_ciphertext = ${sealed ? Buffer.from(sealed.ciphertext, "base64") : null},
-          name_envelope = ${sealed ? JSON.stringify(sealed.envelope) : null}
-      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
+    const result = await db.query<{ updated: boolean }>(sql`
+      WITH rollout_guard AS MATERIALIZED (
+        SELECT set_config('threa.coordinated_title_write', '1', true)
+      ), updated AS (
+        UPDATE e2e_streams
+        SET name_ciphertext = ${sealed ? Buffer.from(sealed.ciphertext, "base64") : null},
+            name_envelope = ${sealed ? JSON.stringify(sealed.envelope) : null}
+        FROM rollout_guard
+        WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
+        RETURNING 1
+      )
+      SELECT EXISTS(SELECT 1 FROM updated) AS updated
     `)
-    return (result.rowCount ?? 0) > 0
+    return result.rows[0]?.updated ?? false
   },
 
   async getByStreamId(db: Querier, workspaceId: string, streamId: string): Promise<E2eStream | null> {
@@ -141,15 +148,22 @@ export const E2eStreamsRepository = {
     if (Buffer.from(sealed.ciphertext, "base64").toString("base64") !== sealed.ciphertext) {
       throw new Error("setSealedNameIfAbsent: ciphertext is not canonical base64")
     }
-    const result = await db.query(sql`
-      UPDATE e2e_streams
-      SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
-          name_envelope = ${JSON.stringify(sealed.envelope)}
-      WHERE workspace_id = ${workspaceId}
-        AND stream_id = ${streamId}
-        AND name_ciphertext IS NULL
+    const result = await db.query<{ updated: boolean }>(sql`
+      WITH rollout_guard AS MATERIALIZED (
+        SELECT set_config('threa.coordinated_title_write', '1', true)
+      ), updated AS (
+        UPDATE e2e_streams
+        SET name_ciphertext = ${Buffer.from(sealed.ciphertext, "base64")},
+            name_envelope = ${JSON.stringify(sealed.envelope)}
+        FROM rollout_guard
+        WHERE workspace_id = ${workspaceId}
+          AND stream_id = ${streamId}
+          AND name_ciphertext IS NULL
+        RETURNING 1
+      )
+      SELECT EXISTS(SELECT 1 FROM updated) AS updated
     `)
-    return (result.rowCount ?? 0) > 0
+    return result.rows[0]?.updated ?? false
   },
 
   /**

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -281,6 +281,13 @@ describe("createEnclaveSessionHandlers.sealedName", () => {
   it("stores the sealed title (first-write-wins) and broadcasts stream:updated", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
+    spyOn(StreamRepository, "findByIdForUpdate").mockResolvedValue({
+      id: "stream_1",
+      workspaceId: "ws_1",
+      displayNameSource: null,
+      displayNameRevision: 0,
+    } as never)
+    spyOn(StreamRepository, "updateDisplayName").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
     spyOn(db, "withTransaction").mockImplementation(((_pool: unknown, cb: (c: unknown) => unknown) => cb({})) as never)
     const setName = spyOn(E2eStreamsRepository, "setSealedNameIfAbsent").mockResolvedValue(true)
     const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
@@ -297,6 +304,12 @@ describe("createEnclaveSessionHandlers.sealedName", () => {
   it("does not broadcast when the scratchpad is already named (no-op)", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
+    spyOn(StreamRepository, "findByIdForUpdate").mockResolvedValue({
+      id: "stream_1",
+      workspaceId: "ws_1",
+      displayNameSource: null,
+      displayNameRevision: 0,
+    } as never)
     spyOn(db, "withTransaction").mockImplementation(((_pool: unknown, cb: (c: unknown) => unknown) => cb({})) as never)
     spyOn(E2eStreamsRepository, "setSealedNameIfAbsent").mockResolvedValue(false)
     const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -281,7 +281,7 @@ describe("createEnclaveSessionHandlers.sealedName", () => {
   it("stores the sealed title (first-write-wins) and broadcasts stream:updated", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
-    spyOn(StreamRepository, "findByIdForUpdate").mockResolvedValue({
+    spyOn(StreamRepository, "findByIdForUpdateBlocking").mockResolvedValue({
       id: "stream_1",
       workspaceId: "ws_1",
       displayNameSource: null,
@@ -304,7 +304,7 @@ describe("createEnclaveSessionHandlers.sealedName", () => {
   it("does not broadcast when the scratchpad is already named (no-op)", async () => {
     spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
     spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
-    spyOn(StreamRepository, "findByIdForUpdate").mockResolvedValue({
+    spyOn(StreamRepository, "findByIdForUpdateBlocking").mockResolvedValue({
       id: "stream_1",
       workspaceId: "ws_1",
       displayNameSource: null,

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -7,6 +7,7 @@ import {
   AuthorTypes,
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
   ENCLAVE_CALLBACK_TOKEN_HEADER,
+  TitleSources,
   type EnclaveMidTurnMessage,
   type EnclaveMidTurnMessagesResponse,
   type EnclaveSessionHeartbeatResponse,
@@ -413,12 +414,23 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
       if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
 
       await withTransaction(pool, async (client) => {
+        const locked = await StreamRepository.findByIdForUpdate(client, session.streamId)
+        if (!locked || locked.workspaceId !== stream.workspaceId || locked.displayNameSource !== null) return
         const set = await E2eStreamsRepository.setSealedNameIfAbsent(client, stream.workspaceId, session.streamId, {
           ciphertext: parsed.data.ciphertext,
           envelope: parsed.data.envelope,
         })
         if (!set) return
-        const updated = (await StreamRepository.findById(client, session.streamId)) ?? stream
+        const titled = await StreamRepository.updateDisplayName(client, {
+          workspaceId: stream.workspaceId,
+          streamId: session.streamId,
+          displayName: null,
+          source: TitleSources.GENERATED,
+          expectedRevision: locked.displayNameRevision,
+          expectedSource: null,
+        })
+        if (!titled) throw new Error("Sealed title metadata update lost its stream lock")
+        const updated = (await StreamRepository.findById(client, session.streamId)) ?? titled
         await OutboxRepository.insert(client, "stream:updated", {
           workspaceId: updated.workspaceId,
           streamId: updated.id,

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -414,7 +414,7 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
       if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
 
       await withTransaction(pool, async (client) => {
-        const locked = await StreamRepository.findByIdForUpdate(client, session.streamId)
+        const locked = await StreamRepository.findByIdForUpdateBlocking(client, session.streamId)
         if (!locked || locked.workspaceId !== stream.workspaceId || locked.displayNameSource !== null) return
         const set = await E2eStreamsRepository.setSealedNameIfAbsent(client, stream.workspaceId, session.streamId, {
           ciphertext: parsed.data.ciphertext,

--- a/apps/backend/src/features/streams/display-name.test.ts
+++ b/apps/backend/src/features/streams/display-name.test.ts
@@ -39,14 +39,14 @@ describe("thread placeholder display names", () => {
 
   test("a generated thread name wins over any placeholder", () => {
     const result = getEffectiveDisplayName(
-      thread({ displayName: "API redesign", displayNameGeneratedAt: new Date() }),
+      thread({ displayName: "API redesign", displayNameSource: "generated", displayNameGeneratedAt: new Date() }),
       { parentStream: { slug: "general", displayName: null } }
     )
     expect(result).toEqual({ displayName: "API redesign", source: "generated" })
   })
 
   test("a name set at creation wins too, without an auto-namer timestamp", () => {
-    const result = getEffectiveDisplayName(thread({ displayName: "Handover" }), {
+    const result = getEffectiveDisplayName(thread({ displayName: "Handover", displayNameSource: "explicit" }), {
       parentStream: { slug: "general", displayName: null },
     })
     expect(result).toEqual({ displayName: "Handover", source: "explicit" })
@@ -73,13 +73,15 @@ describe("scratchpad display names", () => {
   // database — and `needsAutoNaming` (displayName === null) skipped them, so
   // nothing ever set the timestamp either.
   test("a name set at creation renders instead of the placeholder", () => {
-    const result = getEffectiveDisplayName(scratchpad({ displayName: "CC - threa.conversations-match-timeline" }))
+    const result = getEffectiveDisplayName(
+      scratchpad({ displayName: "CC - threa.conversations-match-timeline", displayNameSource: "explicit" })
+    )
     expect(result).toEqual({ displayName: "CC - threa.conversations-match-timeline", source: "explicit" })
   })
 
   test("an auto-generated name still reports itself as generated", () => {
     const result = getEffectiveDisplayName(
-      scratchpad({ displayName: "Board rollup", displayNameGeneratedAt: new Date() })
+      scratchpad({ displayName: "Board rollup", displayNameSource: "generated", displayNameGeneratedAt: new Date() })
     )
     expect(result).toEqual({ displayName: "Board rollup", source: "generated" })
   })

--- a/apps/backend/src/features/streams/display-name.ts
+++ b/apps/backend/src/features/streams/display-name.ts
@@ -1,6 +1,6 @@
 import type { Stream, StreamType } from "./repository"
 
-export type DisplayNameSource = "slug" | "generated" | "explicit" | "participants" | "placeholder"
+export type DisplayNameSource = "slug" | "generated" | "explicit" | "legacy" | "participants" | "placeholder"
 
 /**
  * A stored name is authoritative however it got there.
@@ -19,7 +19,7 @@ function storedDisplayName(stream: Stream): EffectiveDisplayName | undefined {
   // ever replace it.
   const name = stream.displayName?.trim()
   if (!name) return undefined
-  return { displayName: name, source: stream.displayNameGeneratedAt ? "generated" : "explicit" }
+  return { displayName: name, source: stream.displayNameSource ?? "legacy" }
 }
 
 export interface DisplayNameContext {
@@ -80,7 +80,7 @@ export function getEffectiveDisplayName(stream: Stream, context?: DisplayNameCon
     default:
       return {
         displayName: stream.displayName ?? "Unnamed",
-        source: stream.displayNameGeneratedAt ? "generated" : "placeholder",
+        source: stream.displayName ? (stream.displayNameSource ?? "legacy") : "placeholder",
       }
   }
 }

--- a/apps/backend/src/features/streams/naming-service.test.ts
+++ b/apps/backend/src/features/streams/naming-service.test.ts
@@ -72,6 +72,11 @@ describe("StreamNamingService", () => {
     spyOn(StreamRepository, "findByIdForUpdate").mockResolvedValue(mockStream as any)
     spyOn(StreamRepository, "list").mockResolvedValue([])
     spyOn(StreamRepository, "update").mockResolvedValue(undefined as any)
+    spyOn(StreamRepository, "updateDisplayName").mockResolvedValue({
+      ...mockStream,
+      displayNameSource: "generated",
+      displayNameRevision: 1,
+    } as any)
     spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
     spyOn(dbModule, "withClient").mockImplementation((_pool: unknown, fn: any) => fn({}))
     spyOn(dbModule, "withTransaction").mockImplementation((_pool: unknown, fn: any) => fn({}))
@@ -110,10 +115,10 @@ describe("StreamNamingService", () => {
       const result = await service.attemptAutoNaming("stream_123", false)
 
       expect(result).toBe(true)
-      expect(StreamRepository.update).toHaveBeenCalledWith({}, "stream_123", {
-        displayName: "Help Request",
-        displayNameGeneratedAt: expect.any(Date),
-      })
+      expect(StreamRepository.updateDisplayName).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ streamId: "stream_123", displayName: "Help Request", source: "generated" })
+      )
     })
   })
 
@@ -142,7 +147,7 @@ describe("StreamNamingService", () => {
       const result = await service.attemptAutoNaming("stream_123", true)
 
       expect(result).toBe(true)
-      expect(StreamRepository.update).toHaveBeenCalled()
+      expect(StreamRepository.updateDisplayName).toHaveBeenCalled()
     })
   })
 
@@ -232,10 +237,10 @@ describe("StreamNamingService", () => {
 
       await service.attemptAutoNaming("stream_123", false)
 
-      expect(StreamRepository.update).toHaveBeenCalledWith({}, "stream_123", {
-        displayName: "Quoted Title",
-        displayNameGeneratedAt: expect.any(Date),
-      })
+      expect(StreamRepository.updateDisplayName).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ streamId: "stream_123", displayName: "Quoted Title", source: "generated" })
+      )
     })
 
     test("should reject names that are too long", async () => {

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -208,10 +208,15 @@ export class StreamNamingService {
         return false
       }
 
-      await StreamRepository.update(client, streamId, {
+      const namedStream = await StreamRepository.updateDisplayName(client, {
+        workspaceId: currentStream.workspaceId,
+        streamId,
         displayName: cleanName,
-        displayNameGeneratedAt: new Date(),
+        source: "generated",
+        expectedRevision: currentStream.displayNameRevision,
+        expectedSource: currentStream.displayNameSource,
       })
+      if (!namedStream) return false
 
       // The payload's visibility gates workspace-wide fanout in
       // delivery-groups. A thread's own row can hold a stale copied "public"
@@ -229,6 +234,8 @@ export class StreamNamingService {
         streamId,
         displayName: cleanName,
         visibility: fanoutVisibility,
+        source: namedStream.displayNameSource!,
+        revision: namedStream.displayNameRevision!,
       })
 
       logger.info({ streamId, displayName: cleanName, requireName }, "Auto-generated stream display name")

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -10,8 +10,9 @@ import type {
   ThreadSummary,
   E2eActor,
   ThreaDocument,
+  TitleSource,
 } from "@threa/types"
-import { StreamTypes } from "@threa/types"
+import { StreamTypes, TitleSources } from "@threa/types"
 import { parseArchiveStatusFilter, type ArchiveStatus } from "../../lib/sql-filters"
 
 export type { StreamType, Visibility, CompanionMode, MemoryMode, ArchiveStatus }
@@ -21,6 +22,9 @@ interface StreamRow {
   workspace_id: string
   type: string
   display_name: string | null
+  display_name_source: TitleSource | null
+  display_name_revision: number
+  display_name_updated_by_user_id: string | null
   slug: string | null
   description: string | null
   description_json: ThreaDocument | null
@@ -101,6 +105,9 @@ export interface Stream {
   workspaceId: string
   type: StreamType
   displayName: string | null
+  displayNameSource?: TitleSource | null
+  displayNameRevision?: number
+  displayNameUpdatedByUserId?: string | null
   slug: string | null
   description: string | null
   descriptionJson: ThreaDocument | null
@@ -159,6 +166,8 @@ export interface InsertStreamParams {
   workspaceId: string
   type: StreamType
   displayName?: string
+  displayNameSource?: TitleSource
+  displayNameUpdatedByUserId?: string | null
   slug?: string
   description?: string | null
   descriptionJson?: ThreaDocument | null
@@ -177,9 +186,6 @@ export interface InsertStreamParams {
 }
 
 export interface UpdateStreamParams {
-  // `null` scrubs the plaintext name — used by a sealed-only E2E rename, where
-  // the authoritative name lives in `e2e_streams.name_ciphertext`.
-  displayName?: string | null
   slug?: string
   description?: string | null
   descriptionJson?: ThreaDocument | null
@@ -188,7 +194,6 @@ export interface UpdateStreamParams {
   companionPersonaId?: string | null
   memoryMode?: MemoryMode
   archivedAt?: Date | null
-  displayNameGeneratedAt?: Date | null
 }
 
 /** Preview of the last message in a stream for sidebar display */
@@ -216,6 +221,10 @@ function mapRowToStream(row: StreamRow): Stream {
     workspaceId: row.workspace_id,
     type: row.type as StreamType,
     displayName: row.display_name,
+    displayNameSource:
+      row.display_name_source ?? (row.display_name !== null || row.e2e_name_ciphertext ? TitleSources.LEGACY : null),
+    displayNameRevision: row.display_name_revision,
+    displayNameUpdatedByUserId: row.display_name_updated_by_user_id,
     slug: row.slug,
     description: row.description,
     descriptionJson: row.description_json,
@@ -275,7 +284,7 @@ function mapRowToStreamWithPreview(row: StreamWithPreviewRow): StreamWithPreview
 }
 
 const SELECT_FIELDS = `
-  id, workspace_id, type, display_name, slug, description, description_json, visibility,
+  id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, description_json, visibility,
   parent_stream_id, parent_anchor_id, root_stream_id, reply_count, last_reply_at,
   companion_mode, companion_persona_id, memory_mode, purpose,
   created_by, created_at, updated_at, archived_at, display_name_generated_at
@@ -285,7 +294,7 @@ const SELECT_FIELDS = `
 // plaintext rows visible (the `e2e_owner_user_key_id` projection is just
 // NULL for them) so callers don't have to branch on stream type.
 const SELECT_FIELDS_WITH_E2E = `
-  s.id, s.workspace_id, s.type, s.display_name, s.slug, s.description, s.description_json, s.visibility,
+  s.id, s.workspace_id, s.type, s.display_name, s.display_name_source, s.display_name_revision, s.display_name_updated_by_user_id, s.slug, s.description, s.description_json, s.visibility,
   s.parent_stream_id, s.parent_anchor_id, s.root_stream_id, s.reply_count, s.last_reply_at,
   s.companion_mode, s.companion_persona_id, s.memory_mode, s.purpose,
   s.created_by, s.created_at, s.updated_at, s.archived_at, s.display_name_generated_at,
@@ -844,9 +853,12 @@ export const StreamRepository = {
   },
 
   async insert(db: Querier, params: InsertStreamParams): Promise<Stream> {
+    if (params.displayName !== undefined && params.displayNameSource === undefined) {
+      throw new Error("Titled stream inserts require displayNameSource")
+    }
     const result = await db.query<StreamRow>(sql`
       INSERT INTO streams (
-        id, workspace_id, type, display_name, slug, description, description_json, visibility,
+        id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, description_json, visibility,
         parent_stream_id, parent_anchor_id, root_stream_id,
         companion_mode, companion_persona_id, memory_mode, purpose, uniqueness_key, created_by
       ) VALUES (
@@ -854,6 +866,9 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
+        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? 0 : 1},
+        ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},
         ${params.description ?? null},
         ${params.descriptionJson ? JSON.stringify(params.descriptionJson) : null},
@@ -881,9 +896,12 @@ export const StreamRepository = {
     db: Querier,
     params: InsertStreamParams & { uniquenessKey: string }
   ): Promise<{ stream: Stream; created: boolean }> {
+    if (params.displayName !== undefined && params.displayNameSource === undefined) {
+      throw new Error("Titled stream inserts require displayNameSource")
+    }
     const insertResult = await db.query<StreamRow>(sql`
       INSERT INTO streams (
-        id, workspace_id, type, display_name, slug, description, visibility,
+        id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, visibility,
         parent_stream_id, parent_anchor_id, root_stream_id,
         companion_mode, companion_persona_id, memory_mode, uniqueness_key, created_by
       ) VALUES (
@@ -891,6 +909,9 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
+        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? 0 : 1},
+        ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},
         ${params.description ?? null},
         ${params.visibility ?? "private"},
@@ -929,12 +950,15 @@ export const StreamRepository = {
    */
   async insertThreadOrFind(db: Querier, params: InsertStreamParams): Promise<{ stream: Stream; created: boolean }> {
     const anchorId = params.parentAnchorId ?? null
+    if (params.displayName !== undefined && params.displayNameSource === undefined) {
+      throw new Error("Titled stream inserts require displayNameSource")
+    }
     if (!params.parentStreamId || !anchorId) {
       throw new Error("parentStreamId and parentAnchorId are required for thread creation")
     }
     const insertResult = await db.query<StreamRow>(sql`
       INSERT INTO streams (
-        id, workspace_id, type, display_name, slug, description, visibility,
+        id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, visibility,
         parent_stream_id, parent_anchor_id, root_stream_id,
         companion_mode, companion_persona_id, memory_mode, uniqueness_key, created_by
       ) VALUES (
@@ -942,6 +966,9 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
+        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? 0 : 1},
+        ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},
         ${params.description ?? null},
         ${params.visibility ?? "private"},
@@ -974,10 +1001,6 @@ export const StreamRepository = {
     const values: unknown[] = []
     let paramIndex = 1
 
-    if (params.displayName !== undefined) {
-      sets.push(`display_name = $${paramIndex++}`)
-      values.push(params.displayName)
-    }
     if (params.slug !== undefined) {
       sets.push(`slug = $${paramIndex++}`)
       values.push(params.slug)
@@ -1010,10 +1033,6 @@ export const StreamRepository = {
       sets.push(`archived_at = $${paramIndex++}`)
       values.push(params.archivedAt)
     }
-    if (params.displayNameGeneratedAt !== undefined) {
-      sets.push(`display_name_generated_at = $${paramIndex++}`)
-      values.push(params.displayNameGeneratedAt)
-    }
 
     if (sets.length === 0) return this.findById(db, id)
 
@@ -1026,6 +1045,34 @@ export const StreamRepository = {
       RETURNING ${SELECT_FIELDS}
     `
     const result = await db.query<StreamRow>(query, values)
+    return result.rows[0] ? mapRowToStream(result.rows[0]) : null
+  },
+
+  async updateDisplayName(
+    db: Querier,
+    params: {
+      workspaceId: string
+      streamId: string
+      displayName: string | null
+      source: TitleSource
+      updatedByUserId?: string | null
+      expectedRevision?: number
+      expectedSource?: TitleSource | null
+    }
+  ): Promise<Stream | null> {
+    const result = await db.query<StreamRow>(sql`
+      UPDATE streams SET
+        display_name = ${params.displayName},
+        display_name_source = ${params.source},
+        display_name_revision = display_name_revision + 1,
+        display_name_updated_by_user_id = ${params.updatedByUserId ?? null},
+        display_name_generated_at = CASE WHEN ${params.source} = ${TitleSources.GENERATED} THEN NOW() ELSE NULL END,
+        updated_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND id = ${params.streamId}
+        AND (${params.expectedRevision === undefined} OR display_name_revision = ${params.expectedRevision ?? 0})
+        AND (${params.expectedSource === undefined} OR COALESCE(display_name_source, CASE WHEN display_name IS NOT NULL THEN ${TitleSources.LEGACY} END) IS NOT DISTINCT FROM ${params.expectedSource ?? null})
+      RETURNING ${sql.raw(SELECT_FIELDS)}
+    `)
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },
 
@@ -1048,13 +1095,16 @@ export const StreamRepository = {
   ): Promise<Stream> {
     const result = await db.query<StreamRow>(sql`
       INSERT INTO streams (
-        id, workspace_id, type, display_name, visibility,
+        id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, visibility,
         companion_mode, created_by
       ) VALUES (
         ${params.id},
         ${params.workspaceId},
         ${"system"},
         ${"Threa"},
+        ${TitleSources.EXPLICIT},
+        ${1},
+        ${null},
         ${"private"},
         ${"off"},
         ${params.createdBy}

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -342,14 +342,18 @@ export const StreamRepository = {
    */
   async findByIdForUpdate(db: Querier, id: string): Promise<Stream | null> {
     const result = await db.query<StreamRow>(
-      sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams WHERE id = ${id} FOR UPDATE SKIP LOCKED`
+      sql`SELECT ${sql.raw(SELECT_FIELDS)},
+        (SELECT e.name_ciphertext FROM e2e_streams e WHERE e.stream_id = streams.id AND e.workspace_id = streams.workspace_id) AS e2e_name_ciphertext
+        FROM streams WHERE id = ${id} FOR UPDATE SKIP LOCKED`
     )
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },
 
   async findByIdForUpdateBlocking(db: Querier, id: string): Promise<Stream | null> {
     const result = await db.query<StreamRow>(
-      sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams WHERE id = ${id} FOR UPDATE`
+      sql`SELECT ${sql.raw(SELECT_FIELDS)},
+        (SELECT e.name_ciphertext FROM e2e_streams e WHERE e.stream_id = streams.id AND e.workspace_id = streams.workspace_id) AS e2e_name_ciphertext
+        FROM streams WHERE id = ${id} FOR UPDATE`
     )
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -860,9 +860,6 @@ export const StreamRepository = {
   },
 
   async insert(db: Querier, params: InsertStreamParams): Promise<Stream> {
-    if (params.displayName !== undefined && params.displayNameSource === undefined) {
-      throw new Error("Titled stream inserts require displayNameSource")
-    }
     const result = await db.query<StreamRow>(sql`
       INSERT INTO streams (
         id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, description_json, visibility,
@@ -873,7 +870,7 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
-        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? null : (params.displayNameSource ?? TitleSources.EXPLICIT)},
         ${params.displayName === undefined ? 0 : 1},
         ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},
@@ -903,9 +900,6 @@ export const StreamRepository = {
     db: Querier,
     params: InsertStreamParams & { uniquenessKey: string }
   ): Promise<{ stream: Stream; created: boolean }> {
-    if (params.displayName !== undefined && params.displayNameSource === undefined) {
-      throw new Error("Titled stream inserts require displayNameSource")
-    }
     const insertResult = await db.query<StreamRow>(sql`
       INSERT INTO streams (
         id, workspace_id, type, display_name, display_name_source, display_name_revision, display_name_updated_by_user_id, slug, description, visibility,
@@ -916,7 +910,7 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
-        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? null : (params.displayNameSource ?? TitleSources.EXPLICIT)},
         ${params.displayName === undefined ? 0 : 1},
         ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},
@@ -957,9 +951,6 @@ export const StreamRepository = {
    */
   async insertThreadOrFind(db: Querier, params: InsertStreamParams): Promise<{ stream: Stream; created: boolean }> {
     const anchorId = params.parentAnchorId ?? null
-    if (params.displayName !== undefined && params.displayNameSource === undefined) {
-      throw new Error("Titled stream inserts require displayNameSource")
-    }
     if (!params.parentStreamId || !anchorId) {
       throw new Error("parentStreamId and parentAnchorId are required for thread creation")
     }
@@ -973,7 +964,7 @@ export const StreamRepository = {
         ${params.workspaceId},
         ${params.type},
         ${params.displayName ?? null},
-        ${params.displayNameSource ?? null},
+        ${params.displayName === undefined ? null : (params.displayNameSource ?? TitleSources.EXPLICIT)},
         ${params.displayName === undefined ? 0 : 1},
         ${params.displayNameUpdatedByUserId ?? null},
         ${params.slug ?? null},

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -1072,7 +1072,21 @@ export const StreamRepository = {
         updated_at = NOW()
       WHERE workspace_id = ${params.workspaceId} AND id = ${params.streamId}
         AND (${params.expectedRevision === undefined} OR display_name_revision = ${params.expectedRevision ?? 0})
-        AND (${params.expectedSource === undefined} OR COALESCE(display_name_source, CASE WHEN display_name IS NOT NULL THEN ${TitleSources.LEGACY} END) IS NOT DISTINCT FROM ${params.expectedSource ?? null})
+        AND (${params.expectedSource === undefined} OR COALESCE(
+          display_name_source,
+          CASE WHEN display_name IS NOT NULL OR EXISTS (
+            SELECT 1 FROM e2e_streams e
+            WHERE e.workspace_id = streams.workspace_id
+              AND e.stream_id = streams.id
+              AND e.name_ciphertext IS NOT NULL
+          ) THEN ${TitleSources.LEGACY} END
+        ) IS NOT DISTINCT FROM ${params.expectedSource ?? null}
+          OR (
+            current_setting('threa.coordinated_title_write', true) = '1'
+            AND display_name_source IS NULL
+            AND ${params.expectedSource === null}
+          )
+        )
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -347,6 +347,13 @@ export const StreamRepository = {
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },
 
+  async findByIdForUpdateBlocking(db: Querier, id: string): Promise<Stream | null> {
+    const result = await db.query<StreamRow>(
+      sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams WHERE id = ${id} FOR UPDATE`
+    )
+    return result.rows[0] ? mapRowToStream(result.rows[0]) : null
+  },
+
   async findByIds(db: Querier, ids: string[]): Promise<Stream[]> {
     if (ids.length === 0) return []
     const result = await db.query<StreamRow>(sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams WHERE id = ANY(${ids})`)

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -31,6 +31,7 @@ const mockFindMembersByIds = spyOn(UserRepository, "findByIds")
 const mockInsertStream = spyOn(StreamRepository, "insert")
 const mockMarkStreamE2e = spyOn(E2eStreamsRepository, "markStreamE2e")
 const mockUpdate = spyOn(StreamRepository, "update")
+const mockUpdateDisplayName = spyOn(StreamRepository, "updateDisplayName")
 const mockUpdateSealedName = spyOn(E2eStreamsRepository, "updateSealedName")
 // Sparse read overlay pruning/listing runs inside the watermark write paths;
 // stub against the fake `{}` client so unit tests never touch a real DB.
@@ -2013,6 +2014,7 @@ describe("StreamService.updateStream sealed-name handling", () => {
     service = new StreamService({} as never)
     mockFindById.mockReset()
     mockUpdate.mockReset()
+    mockUpdateDisplayName.mockReset()
     mockUpdateSealedName.mockReset()
     mockInsertOutbox.mockReset()
   })
@@ -2020,6 +2022,7 @@ describe("StreamService.updateStream sealed-name handling", () => {
   test("setting a sealed name scrubs the plaintext display_name to null (INV-E1)", async () => {
     const stream = { id: "stream_1", workspaceId: "ws_1", displayName: null } as never
     mockUpdate.mockResolvedValue(stream)
+    mockUpdateDisplayName.mockResolvedValue(stream)
     mockUpdateSealedName.mockResolvedValue(true)
     mockFindById.mockResolvedValue(stream)
 
@@ -2030,7 +2033,10 @@ describe("StreamService.updateStream sealed-name handling", () => {
       sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
     })
 
-    expect(mockUpdate).toHaveBeenCalledWith({}, "stream_1", expect.objectContaining({ displayName: null }))
+    expect(mockUpdateDisplayName).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ streamId: "stream_1", displayName: null, source: "explicit" })
+    )
     expect(mockUpdateSealedName).toHaveBeenCalledWith({}, "ws_1", "stream_1", {
       ciphertext: "Y3Q=",
       envelope: { v: 1 },
@@ -2040,6 +2046,7 @@ describe("StreamService.updateStream sealed-name handling", () => {
   test("setting a sealed name on a non-E2E stream fails loudly and emits no outbox event", async () => {
     const stream = { id: "stream_1", workspaceId: "ws_1", displayName: null } as never
     mockUpdate.mockResolvedValue(stream)
+    mockUpdateDisplayName.mockResolvedValue(stream)
     // No e2e_streams row to update — the stream isn't E2E.
     mockUpdateSealedName.mockResolvedValue(false)
 
@@ -2064,11 +2071,15 @@ describe("StreamService.updateStream sealed-name handling", () => {
   test("a plain (non-sealed) rename writes the plaintext displayName unchanged", async () => {
     const stream = { id: "stream_1", workspaceId: "ws_1", displayName: "New name" } as never
     mockUpdate.mockResolvedValue(stream)
+    mockUpdateDisplayName.mockResolvedValue(stream)
     mockFindById.mockResolvedValue(stream)
 
     await service.updateStream("stream_1", { displayName: "New name" })
 
-    expect(mockUpdate).toHaveBeenCalledWith({}, "stream_1", expect.objectContaining({ displayName: "New name" }))
+    expect(mockUpdateDisplayName).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ streamId: "stream_1", displayName: "New name", source: "explicit" })
+    )
     expect(mockUpdateSealedName).not.toHaveBeenCalled()
   })
 })
@@ -2080,6 +2091,7 @@ describe("StreamService.updateStream description", () => {
     service = new StreamService({} as never)
     mockFindById.mockReset()
     mockUpdate.mockReset()
+    mockUpdateDisplayName.mockReset()
     mockInsertOutbox.mockReset()
     mockInsertEvent.mockReset().mockResolvedValue({ id: "evt_1", streamId: "stream_1" } as never)
   })
@@ -2114,6 +2126,7 @@ describe("StreamService.updateStream description", () => {
   test("leaves the description columns untouched when neither field is supplied", async () => {
     const stream = { id: "stream_1", workspaceId: "ws_1" } as never
     mockUpdate.mockResolvedValue(stream)
+    mockUpdateDisplayName.mockResolvedValue(stream)
     mockFindById.mockResolvedValue(stream)
 
     await service.updateStream("stream_1", { displayName: "Renamed" })

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -55,6 +55,7 @@ import {
   type AuthorType,
   type DescriptionSetEventPayload,
   type StreamReadFrontierSnapshot,
+  TitleSources,
 } from "@threa/types"
 import { ContextBagRepository, PersonaRepository, assertAssignablePersona } from "../agents"
 import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepository } from "../e2e-streams"
@@ -492,6 +493,8 @@ export class StreamService {
       workspaceId: params.workspaceId,
       type: StreamTypes.SCRATCHPAD,
       displayName: params.displayName,
+      displayNameSource: params.displayName === undefined ? undefined : TitleSources.EXPLICIT,
+      displayNameUpdatedByUserId: params.displayName === undefined ? undefined : params.createdBy,
       description: normalizedDescription?.description ?? undefined,
       descriptionJson: normalizedDescription?.descriptionJson ?? undefined,
       visibility: Visibilities.PRIVATE,
@@ -1015,7 +1018,8 @@ export class StreamService {
     }
   ): Promise<Stream | null> {
     const { sealedName, description, descriptionJson, actorId, actorType, ...rest } = data
-    const streamData: UpdateStreamParams = { ...rest }
+    const { displayName, ...nonTitleData } = rest
+    const streamData: UpdateStreamParams = { ...nonTitleData }
     const normalizedDescription = normalizeStreamDescription({ description, descriptionJson })
     if (normalizedDescription) {
       streamData.description = normalizedDescription.description
@@ -1032,8 +1036,7 @@ export class StreamService {
       // along. Trade-off: server-side name search (ILIKE/similarity on
       // display_name) can't see E2E streams — name search for them is
       // client-side over decrypted names.
-      streamData.displayName = null
-    } else if (sealedName === null && streamData.displayName == null) {
+    } else if (sealedName === null && displayName == null) {
       // Clearing a sealed name reverts to a plaintext label, so one must be
       // provided — otherwise the stream loses its name entirely (no ciphertext,
       // no cleartext).
@@ -1065,8 +1068,18 @@ export class StreamService {
           }
         }
 
-        const stream = await StreamRepository.update(client, streamId, streamData)
+        let stream = await StreamRepository.update(client, streamId, streamData)
         if (!stream) return null
+        if (displayName !== undefined || sealedName) {
+          stream = await StreamRepository.updateDisplayName(client, {
+            workspaceId: stream.workspaceId,
+            streamId,
+            displayName: sealedName ? null : (displayName ?? null),
+            source: TitleSources.EXPLICIT,
+            updatedByUserId: actorId,
+          })
+          if (!stream) return null
+        }
 
         // The sealed name lives on a different table; set/clear it in the same
         // transaction. `StreamRepository.update` returns only the plaintext
@@ -1543,11 +1556,17 @@ export class StreamService {
   async updateDisplayName(
     streamId: string,
     displayName: string,
-    markAsGenerated: boolean = false
+    markAsGenerated: boolean = false,
+    updatedByUserId?: string
   ): Promise<Stream | null> {
-    return StreamRepository.update(this.pool, streamId, {
+    const current = await StreamRepository.findById(this.pool, streamId)
+    if (!current) return null
+    return StreamRepository.updateDisplayName(this.pool, {
+      workspaceId: current.workspaceId,
+      streamId,
       displayName,
-      displayNameGeneratedAt: markAsGenerated ? new Date() : undefined,
+      source: markAsGenerated ? TitleSources.GENERATED : TitleSources.EXPLICIT,
+      updatedByUserId,
     })
   }
 

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -313,6 +313,8 @@ export interface ReactionOutboxPayload extends StreamScopedPayload {
 export interface StreamDisplayNameUpdatedPayload extends StreamScopedPayload {
   displayName: string
   visibility: string
+  source: import("@threa/types").TitleSource
+  revision: number
 }
 
 export interface StreamMemberJoinedOutboxPayload extends StreamScopedPayload {

--- a/apps/backend/tests/integration/conversation-repository.test.ts
+++ b/apps/backend/tests/integration/conversation-repository.test.ts
@@ -101,6 +101,7 @@ describe("ConversationRepository", () => {
           streamId: testStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "Discussion about testing",
+          topicSummarySource: "generated",
           completenessScore: 3,
           confidence: 0.85,
           status: ConversationStatuses.ACTIVE,
@@ -131,6 +132,7 @@ describe("ConversationRepository", () => {
           streamId: testStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "Findable conversation",
+          topicSummarySource: "generated",
         })
       })
 
@@ -177,6 +179,7 @@ describe("ConversationRepository", () => {
           streamId: localStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "First conversation",
+          topicSummarySource: "generated",
         })
       })
 
@@ -189,6 +192,7 @@ describe("ConversationRepository", () => {
           streamId: localStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "Second conversation",
+          topicSummarySource: "generated",
         })
       })
 
@@ -336,6 +340,7 @@ describe("ConversationRepository", () => {
           streamId: testStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "Workspace conversation",
+          topicSummarySource: "generated",
         })
       })
 
@@ -682,16 +687,54 @@ describe("ConversationRepository", () => {
           streamId: testStreamId,
           workspaceId: testWorkspaceId,
           topicSummary: "Original topic",
+          topicSummarySource: "generated",
         })
       })
 
       const updated = await withTransaction(pool, async (client) => {
-        return ConversationRepository.update(client, testWorkspaceId, convId, {
+        return ConversationRepository.updateTopicSummary(client, {
+          workspaceId: testWorkspaceId,
+          conversationId: convId,
           topicSummary: "Updated topic",
+          source: "explicit",
         })
       })
 
       expect(updated?.topicSummary).toBe("Updated topic")
+    })
+
+    test("expected revision, source, and workspace mismatches leave the topic unchanged", async () => {
+      const convId = conversationId()
+      const first = await withTransaction(pool, async (client) => {
+        await ConversationRepository.insert(client, {
+          id: convId,
+          streamId: testStreamId,
+          workspaceId: testWorkspaceId,
+          topicSummary: "Current topic",
+          topicSummarySource: "generated",
+        })
+        return ConversationRepository.findById(client, convId)
+      })
+
+      for (const guard of [
+        { workspaceId: testWorkspaceId, expectedRevision: first!.topicSummaryRevision! + 1 },
+        { workspaceId: testWorkspaceId, expectedSource: "explicit" as const },
+        { workspaceId: workspaceId(), expectedRevision: first!.topicSummaryRevision },
+      ]) {
+        expect(
+          await ConversationRepository.updateTopicSummary(pool, {
+            ...guard,
+            conversationId: convId,
+            topicSummary: "Stale topic",
+            source: "generated",
+          })
+        ).toBeNull()
+      }
+      expect(await ConversationRepository.findById(pool, convId)).toMatchObject({
+        topicSummary: "Current topic",
+        topicSummarySource: "generated",
+        topicSummaryRevision: first!.topicSummaryRevision,
+      })
     })
 
     test("returns null for non-existent conversation", async () => {
@@ -918,12 +961,16 @@ describe("ConversationRepository", () => {
           streamId: otherStreamId,
           workspaceId: otherWorkspaceId,
           topicSummary: "Foreign topic",
+          topicSummarySource: "generated",
         })
       })
 
       const result = await withTransaction(pool, async (client) => {
-        return ConversationRepository.update(client, testWorkspaceId, foreignConvId, {
+        return ConversationRepository.updateTopicSummary(client, {
+          workspaceId: testWorkspaceId,
+          conversationId: foreignConvId,
           topicSummary: "Hijacked topic",
+          source: "explicit",
         })
       })
 

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -63,6 +63,29 @@ describe("E2E sealed stream name", () => {
     return { wsId, sId, ownerId }
   }
 
+  test("blocking title lock waits for a contending stream transaction", async () => {
+    const { sId } = await seedStream(true)
+    const holder = await pool.connect()
+    const waiter = await pool.connect()
+    try {
+      await holder.query("BEGIN")
+      await StreamRepository.findByIdForUpdateBlocking(holder, sId)
+      let acquired = false
+      const waiting = StreamRepository.findByIdForUpdateBlocking(waiter, sId).then((stream) => {
+        acquired = true
+        return stream
+      })
+      await new Promise((resolve) => setTimeout(resolve, 30))
+      expect(acquired).toBe(false)
+      await holder.query("COMMIT")
+      expect((await waiting)?.id).toBe(sId)
+    } finally {
+      await holder.query("ROLLBACK").catch(() => undefined)
+      holder.release()
+      waiter.release()
+    }
+  })
+
   test("migration backfills plaintext, sealed, and conversation titles while leaving unnamed rows source-null", async () => {
     const client = await pool.connect()
     try {

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -14,7 +14,10 @@ import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamRepository } from "../../src/features/streams"
 import { E2eStreamsRepository } from "../../src/features/e2e-streams"
-import { userId, workspaceId, streamId } from "../../src/lib/id"
+import { ConversationRepository } from "../../src/features/conversations"
+import { userId, workspaceId, streamId, conversationId } from "../../src/lib/id"
+
+const MIGRATION_PATH = new URL("../../src/db/migrations/20260806220444_dynamic_naming_provenance.sql", import.meta.url)
 
 const ENVELOPE = { v: 2, keyGeneration: 0, iv: "aXYxMjM0NTY3OA==", aad: "c3RyZWFtfG5hbWV8MA==" }
 
@@ -59,6 +62,89 @@ describe("E2E sealed stream name", () => {
     })
     return { wsId, sId, ownerId }
   }
+
+  test("migration backfills plaintext, sealed, and conversation titles while leaving unnamed rows source-null", async () => {
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      const wsId = workspaceId()
+      let ownerId = userId()
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Migration backfill WS",
+        slug: `migration-backfill-${wsId}`,
+        createdBy: ownerId,
+      })
+      ownerId = (await addTestMember(client, wsId, ownerId)).id
+      const plaintextId = streamId()
+      const sealedId = streamId()
+      const unnamedId = streamId()
+      for (const [id, displayName] of [
+        [plaintextId, "Existing title"],
+        [sealedId, undefined],
+        [unnamedId, undefined],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: wsId,
+          type: StreamTypes.SCRATCHPAD,
+          createdBy: ownerId,
+          displayName,
+          displayNameSource: displayName === undefined ? undefined : "explicit",
+        })
+      }
+      await E2eStreamsRepository.markStreamE2e(client, {
+        streamId: sealedId,
+        workspaceId: wsId,
+        ownerUserId: ownerId,
+        ownerUserKeyId: "e2ek_owner",
+      })
+      await E2eStreamsRepository.updateSealedName(client, wsId, sealedId, {
+        ciphertext: Buffer.from("existing-sealed-title").toString("base64"),
+        envelope: ENVELOPE,
+      })
+      const titledConversationId = conversationId()
+      const unnamedConversationId = conversationId()
+      await ConversationRepository.insert(client, {
+        id: titledConversationId,
+        streamId: plaintextId,
+        workspaceId: wsId,
+        topicSummary: "Existing topic",
+        topicSummarySource: "explicit",
+      })
+      await ConversationRepository.insert(client, {
+        id: unnamedConversationId,
+        streamId: unnamedId,
+        workspaceId: wsId,
+      })
+
+      await client.query(
+        "ALTER TABLE streams DROP COLUMN display_name_source, DROP COLUMN display_name_revision, DROP COLUMN display_name_updated_by_user_id"
+      )
+      await client.query(
+        "ALTER TABLE conversations DROP COLUMN topic_summary_source, DROP COLUMN topic_summary_revision, DROP COLUMN topic_summary_updated_by_user_id"
+      )
+      await client.query(await Bun.file(MIGRATION_PATH).text())
+
+      const streamRows = await client.query<{ id: string; display_name_source: string | null }>(
+        "SELECT id, display_name_source FROM streams WHERE id = ANY($1)",
+        [[plaintextId, sealedId, unnamedId]]
+      )
+      const streamSources = Object.fromEntries(streamRows.rows.map((row) => [row.id, row.display_name_source]))
+      const conversationRows = await client.query<{ id: string; topic_summary_source: string | null }>(
+        "SELECT id, topic_summary_source FROM conversations WHERE id = ANY($1)",
+        [[titledConversationId, unnamedConversationId]]
+      )
+      const conversationSources = Object.fromEntries(
+        conversationRows.rows.map((row) => [row.id, row.topic_summary_source])
+      )
+      expect(streamSources).toEqual({ [plaintextId]: "legacy", [sealedId]: "legacy", [unnamedId]: null })
+      expect(conversationSources).toEqual({ [titledConversationId]: "legacy", [unnamedConversationId]: null })
+    } finally {
+      await client.query("ROLLBACK")
+      client.release()
+    }
+  })
 
   test("stores the sealed name and surfaces it (base64 + envelope) on the joined stream", async () => {
     const { wsId, sId } = await seedStream(true)
@@ -107,6 +193,70 @@ describe("E2E sealed stream name", () => {
     const stream = await StreamRepository.findById(pool, sId)
     expect(stream?.sealedNameCiphertext).toBeNull()
     expect(stream?.sealedNameEnvelope).toBeNull()
+  })
+
+  test("first auto-title writes ciphertext and generated revision atomically, then explicit provenance blocks it", async () => {
+    const { wsId, sId, ownerId } = await seedStream(true)
+    const ciphertext = Buffer.from("auto-title").toString("base64")
+
+    await withTransaction(pool, async (client) => {
+      const locked = await StreamRepository.findByIdForUpdate(client, sId)
+      expect(locked?.displayNameSource).toBeNull()
+      expect(
+        await E2eStreamsRepository.setSealedNameIfAbsent(client, wsId, sId, { ciphertext, envelope: ENVELOPE })
+      ).toBe(true)
+      expect(
+        await StreamRepository.updateDisplayName(client, {
+          workspaceId: wsId,
+          streamId: sId,
+          displayName: null,
+          source: "generated",
+          expectedRevision: locked!.displayNameRevision,
+          expectedSource: null,
+        })
+      ).not.toBeNull()
+    })
+
+    let stream = await StreamRepository.findById(pool, sId)
+    expect({
+      ciphertext: stream?.sealedNameCiphertext,
+      source: stream?.displayNameSource,
+      revision: stream?.displayNameRevision,
+      actor: stream?.displayNameUpdatedByUserId,
+    }).toEqual({ ciphertext, source: "generated", revision: 1, actor: null })
+
+    await StreamRepository.updateDisplayName(pool, {
+      workspaceId: wsId,
+      streamId: sId,
+      displayName: null,
+      source: "explicit",
+      updatedByUserId: ownerId,
+    })
+    expect(
+      await E2eStreamsRepository.setSealedNameIfAbsent(pool, wsId, sId, {
+        ciphertext: Buffer.from("late-auto").toString("base64"),
+        envelope: ENVELOPE,
+      })
+    ).toBe(false)
+    stream = await StreamRepository.findById(pool, sId)
+    expect({
+      source: stream?.displayNameSource,
+      revision: stream?.displayNameRevision,
+      actor: stream?.displayNameUpdatedByUserId,
+    }).toEqual({
+      source: "explicit",
+      revision: 2,
+      actor: ownerId,
+    })
+  })
+
+  test("source-null sealed rows map conservatively to legacy", async () => {
+    const { wsId, sId } = await seedStream(true)
+    await E2eStreamsRepository.updateSealedName(pool, wsId, sId, {
+      ciphertext: Buffer.from("old-replica-title").toString("base64"),
+      envelope: ENVELOPE,
+    })
+    expect((await StreamRepository.findByIdForWorkspace(pool, sId, wsId))?.displayNameSource).toBe("legacy")
   })
 
   test("rejects non-canonical base64 instead of storing a corrupt blob", async () => {

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -146,6 +146,8 @@ describe("E2E sealed stream name", () => {
       await client.query("DROP FUNCTION IF EXISTS preserve_legacy_stream_title_intent()")
       await client.query("DROP TRIGGER IF EXISTS preserve_legacy_conversation_title_intent_trigger ON conversations")
       await client.query("DROP FUNCTION IF EXISTS preserve_legacy_conversation_title_intent()")
+      await client.query("DROP TRIGGER IF EXISTS preserve_legacy_e2e_title_intent_trigger ON e2e_streams")
+      await client.query("DROP FUNCTION IF EXISTS preserve_legacy_e2e_title_intent()")
       await client.query(
         "ALTER TABLE streams DROP COLUMN display_name_source, DROP COLUMN display_name_revision, DROP COLUMN display_name_updated_by_user_id"
       )
@@ -201,6 +203,34 @@ describe("E2E sealed stream name", () => {
           ])
         ).rows[0]
       ).toEqual({ topic_summary_source: "explicit", topic_summary_revision: 2 })
+
+      await client.query(
+        "UPDATE streams SET display_name_source = 'generated', display_name_revision = 1 WHERE id = $1",
+        [sealedId]
+      )
+      await client.query("SELECT set_config('threa.coordinated_title_write', '', true)")
+      await client.query("UPDATE e2e_streams SET name_ciphertext = $1 WHERE workspace_id = $2 AND stream_id = $3", [
+        Buffer.from("old-replica-manual-title"),
+        wsId,
+        sealedId,
+      ])
+      expect(
+        (await client.query("SELECT display_name_source, display_name_revision FROM streams WHERE id = $1", [sealedId]))
+          .rows[0]
+      ).toEqual({ display_name_source: "explicit", display_name_revision: 2 })
+
+      await client.query(
+        "UPDATE streams SET display_name_source = 'generated', display_name_revision = 3 WHERE id = $1",
+        [sealedId]
+      )
+      await E2eStreamsRepository.updateSealedName(client, wsId, sealedId, {
+        ciphertext: Buffer.from("coordinated-new-replica-title").toString("base64"),
+        envelope: ENVELOPE,
+      })
+      expect(
+        (await client.query("SELECT display_name_source, display_name_revision FROM streams WHERE id = $1", [sealedId]))
+          .rows[0]
+      ).toEqual({ display_name_source: "generated", display_name_revision: 3 })
     } finally {
       await client.query("ROLLBACK")
       client.release()
@@ -320,6 +350,15 @@ describe("E2E sealed stream name", () => {
     expect((await StreamRepository.findByIdForWorkspace(pool, sId, wsId))?.displayNameSource).toBe("legacy")
     expect((await StreamRepository.findByIdForUpdate(pool, sId))?.displayNameSource).toBe("legacy")
     expect((await StreamRepository.findByIdForUpdateBlocking(pool, sId))?.displayNameSource).toBe("legacy")
+    const updated = await StreamRepository.updateDisplayName(pool, {
+      workspaceId: wsId,
+      streamId: sId,
+      displayName: null,
+      source: "generated",
+      expectedRevision: 0,
+      expectedSource: "legacy",
+    })
+    expect(updated).toMatchObject({ displayNameSource: "generated", displayNameRevision: 1 })
   })
 
   test("rejects non-canonical base64 instead of storing a corrupt blob", async () => {

--- a/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
+++ b/apps/backend/tests/integration/e2e-stream-sealed-name.test.ts
@@ -140,7 +140,12 @@ describe("E2E sealed stream name", () => {
         streamId: unnamedId,
         workspaceId: wsId,
       })
+      await client.query("UPDATE streams SET display_name = 'Leaky plaintext copy' WHERE id = $1", [sealedId])
 
+      await client.query("DROP TRIGGER IF EXISTS preserve_legacy_stream_title_intent_trigger ON streams")
+      await client.query("DROP FUNCTION IF EXISTS preserve_legacy_stream_title_intent()")
+      await client.query("DROP TRIGGER IF EXISTS preserve_legacy_conversation_title_intent_trigger ON conversations")
+      await client.query("DROP FUNCTION IF EXISTS preserve_legacy_conversation_title_intent()")
       await client.query(
         "ALTER TABLE streams DROP COLUMN display_name_source, DROP COLUMN display_name_revision, DROP COLUMN display_name_updated_by_user_id"
       )
@@ -149,10 +154,13 @@ describe("E2E sealed stream name", () => {
       )
       await client.query(await Bun.file(MIGRATION_PATH).text())
 
-      const streamRows = await client.query<{ id: string; display_name_source: string | null }>(
-        "SELECT id, display_name_source FROM streams WHERE id = ANY($1)",
-        [[plaintextId, sealedId, unnamedId]]
-      )
+      const streamRows = await client.query<{
+        id: string
+        display_name: string | null
+        display_name_source: string | null
+      }>("SELECT id, display_name, display_name_source FROM streams WHERE id = ANY($1)", [
+        [plaintextId, sealedId, unnamedId],
+      ])
       const streamSources = Object.fromEntries(streamRows.rows.map((row) => [row.id, row.display_name_source]))
       const conversationRows = await client.query<{ id: string; topic_summary_source: string | null }>(
         "SELECT id, topic_summary_source FROM conversations WHERE id = ANY($1)",
@@ -162,7 +170,37 @@ describe("E2E sealed stream name", () => {
         conversationRows.rows.map((row) => [row.id, row.topic_summary_source])
       )
       expect(streamSources).toEqual({ [plaintextId]: "legacy", [sealedId]: "legacy", [unnamedId]: null })
+      expect(streamRows.rows.find((row) => row.id === sealedId)?.display_name).toBeNull()
       expect(conversationSources).toEqual({ [titledConversationId]: "legacy", [unnamedConversationId]: null })
+
+      // A pre-migration replica updates only the old title column. The rollout
+      // trigger must preserve that human intent over a generated title.
+      await client.query(
+        "UPDATE streams SET display_name = 'Generated', display_name_source = 'generated', display_name_revision = 1 WHERE id = $1",
+        [plaintextId]
+      )
+      await client.query("UPDATE streams SET display_name = 'Human old-replica edit' WHERE id = $1", [plaintextId])
+      await client.query(
+        "UPDATE conversations SET topic_summary = 'Generated', topic_summary_source = 'generated', topic_summary_revision = 1 WHERE id = $1",
+        [titledConversationId]
+      )
+      await client.query("UPDATE conversations SET topic_summary = 'Human old-replica topic' WHERE id = $1", [
+        titledConversationId,
+      ])
+      expect(
+        (
+          await client.query("SELECT display_name_source, display_name_revision FROM streams WHERE id = $1", [
+            plaintextId,
+          ])
+        ).rows[0]
+      ).toEqual({ display_name_source: "explicit", display_name_revision: 2 })
+      expect(
+        (
+          await client.query("SELECT topic_summary_source, topic_summary_revision FROM conversations WHERE id = $1", [
+            titledConversationId,
+          ])
+        ).rows[0]
+      ).toEqual({ topic_summary_source: "explicit", topic_summary_revision: 2 })
     } finally {
       await client.query("ROLLBACK")
       client.release()
@@ -280,6 +318,8 @@ describe("E2E sealed stream name", () => {
       envelope: ENVELOPE,
     })
     expect((await StreamRepository.findByIdForWorkspace(pool, sId, wsId))?.displayNameSource).toBe("legacy")
+    expect((await StreamRepository.findByIdForUpdate(pool, sId))?.displayNameSource).toBe("legacy")
+    expect((await StreamRepository.findByIdForUpdateBlocking(pool, sId))?.displayNameSource).toBe("legacy")
   })
 
   test("rejects non-canonical base64 instead of storing a corrupt blob", async () => {

--- a/apps/backend/tests/integration/stream-naming.test.ts
+++ b/apps/backend/tests/integration/stream-naming.test.ts
@@ -126,6 +126,7 @@ describe("Stream Naming", () => {
         const stream = createMockStream({
           type: "scratchpad",
           displayName: "Project Ideas",
+          displayNameSource: "generated",
           displayNameGeneratedAt: new Date(),
         })
         const result = getEffectiveDisplayName(stream)
@@ -153,6 +154,7 @@ describe("Stream Naming", () => {
         const stream = createMockStream({
           type: "scratchpad",
           displayName: "Manual Name",
+          displayNameSource: "explicit",
           displayNameGeneratedAt: null,
         })
         const result = getEffectiveDisplayName(stream)
@@ -176,6 +178,7 @@ describe("Stream Naming", () => {
         const stream = createMockStream({
           type: "thread",
           displayName: "Discussion about API",
+          displayNameSource: "generated",
           displayNameGeneratedAt: new Date(),
         })
         const result = getEffectiveDisplayName(stream)
@@ -295,6 +298,47 @@ describe("Stream Naming", () => {
 
       expect(updated?.displayName).toBe("AI Generated Title")
       expect(updated?.displayNameGeneratedAt).not.toBeNull()
+    })
+
+    test("expected revision, source, and workspace mismatches leave the title unchanged", async () => {
+      const ownerId = userId()
+      const wsId = workspaceId()
+      await withTestTransaction(pool, async (client) => {
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Stream CAS Workspace",
+          slug: `stream-cas-${wsId}`,
+          createdBy: ownerId,
+        })
+        await addTestMember(client, wsId, ownerId)
+      })
+      const scratchpad = await streamService.createScratchpad({ workspaceId: wsId, createdBy: ownerId })
+      const first = await StreamRepository.updateDisplayName(pool, {
+        workspaceId: wsId,
+        streamId: scratchpad.id,
+        displayName: "Current title",
+        source: "generated",
+      })
+
+      for (const guard of [
+        { workspaceId: wsId, expectedRevision: first!.displayNameRevision + 1 },
+        { workspaceId: wsId, expectedSource: "explicit" as const },
+        { workspaceId: workspaceId(), expectedRevision: first!.displayNameRevision },
+      ]) {
+        expect(
+          await StreamRepository.updateDisplayName(pool, {
+            ...guard,
+            streamId: scratchpad.id,
+            displayName: "Stale title",
+            source: "generated",
+          })
+        ).toBeNull()
+      }
+      expect(await StreamRepository.findById(pool, scratchpad.id)).toMatchObject({
+        displayName: "Current title",
+        displayNameSource: "generated",
+        displayNameRevision: first!.displayNameRevision,
+      })
     })
 
     test("updates display name without marking as generated", async () => {

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -659,10 +659,10 @@ describe("useSettleConversationMessage", () => {
     expect(merge).toHaveBeenCalledWith("conv_1", conversation, ["m_2"])
     expect(queryClient.getQueryData(conversationKeys.list(WORKSPACE_ID, STREAM_ID, {}))).toEqual([
       makeConversation("conv_0"),
-      conversation,
+      { id: "conv_1", topicSummary: "stale" },
     ])
     expect(queryClient.getQueryData(conversationKeys.boardPost("conv_1"))).toEqual({
-      conversation,
+      conversation: { id: "conv_1", topicSummary: "stale" },
       settlingMessageIds: ["m_2"],
       recentMessages: [],
     })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -18,6 +18,7 @@ import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
 import { generateConversationId } from "@/lib/ids"
+import { mergeConversationByTitleRevision } from "@/lib/title-merge"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import type { SplitGroupInput } from "@/api/conversations"
@@ -625,7 +626,9 @@ export function useConversations(workspaceId: string, streamId: string, options?
           if (!exists) {
             return [...old, payload.conversation]
           }
-          return old.map((c) => (c.id === payload.conversationId ? payload.conversation : c))
+          return old.map((c) =>
+            c.id === payload.conversationId ? mergeConversationByTitleRevision(c, payload.conversation) : c
+          )
         }
       )
     }
@@ -710,7 +713,11 @@ export function useReassignConversationMessage(workspaceId: string, streamId: st
       )
       queryClient.setQueryData(
         conversationKeys.list(workspaceId, streamId, {}),
-        (old: ConversationWithStaleness[] | undefined) => old?.map((c) => updatedById.get(c.id) ?? c)
+        (old: ConversationWithStaleness[] | undefined) =>
+          old?.map((c) => {
+            const incoming = updatedById.get(c.id)
+            return incoming ? mergeConversationByTitleRevision(c, incoming) : c
+          })
       )
       // Apply the returned aggregates to the board store now, so the board card /
       // panel re-file on the HTTP response instead of waiting for the socket echo
@@ -744,13 +751,20 @@ export function useSettleConversationMessage(workspaceId: string, streamId: stri
     onSuccess: ({ conversation, settlingMessageIds }) => {
       queryClient.setQueryData(
         conversationKeys.list(workspaceId, streamId, {}),
-        (old: ConversationWithStaleness[] | undefined) => old?.map((c) => (c.id === conversation.id ? conversation : c))
+        (old: ConversationWithStaleness[] | undefined) =>
+          old?.map((c) => (c.id === conversation.id ? mergeConversationByTitleRevision(c, conversation) : c))
       )
       void mergeBoardConversation(conversation.id, conversation, settlingMessageIds)
       const boardPostKey = conversationKeys.boardPost(conversation.id)
       if (queryClient.getQueryData(boardPostKey)) {
         queryClient.setQueryData<BoardPost>(boardPostKey, (prev) =>
-          prev ? { ...prev, conversation, settlingMessageIds } : prev
+          prev
+            ? {
+                ...prev,
+                conversation: mergeConversationByTitleRevision(prev.conversation, conversation),
+                settlingMessageIds,
+              }
+            : prev
         )
       }
     },
@@ -784,7 +798,10 @@ export function useReassignMessagesToConversation(workspaceId: string, streamId:
         conversationKeys.list(workspaceId, streamId, {}),
         (old: ConversationWithStaleness[] | undefined) => {
           if (!old) return old
-          const merged = old.map((c) => updatedById.get(c.id) ?? c)
+          const merged = old.map((c) => {
+            const incoming = updatedById.get(c.id)
+            return incoming ? mergeConversationByTitleRevision(c, incoming) : c
+          })
           // A minted destination isn't in the list yet — append it.
           return old.some((c) => c.id === conversation.id) ? merged : [...merged, conversation]
         }
@@ -828,7 +845,10 @@ export function useApplySplit(workspaceId: string, streamId: string) {
         conversationKeys.list(workspaceId, streamId, {}),
         (old: ConversationWithStaleness[] | undefined) => {
           if (!old) return old
-          const merged = old.map((c) => updatedById.get(c.id) ?? c)
+          const merged = old.map((c) => {
+            const incoming = updatedById.get(c.id)
+            return incoming ? mergeConversationByTitleRevision(c, incoming) : c
+          })
           // Minted conversations aren't in the list yet — append the new ones.
           const present = new Set(old.map((c) => c.id))
           return [...merged, ...newConversations.filter((c) => !present.has(c.id))]
@@ -901,7 +921,9 @@ export function useUpdateConversation(workspaceId: string) {
       void mergeBoardConversation(conversationId, conversation)
       const boardPostKey = conversationKeys.boardPost(conversationId)
       if (queryClient.getQueryData(boardPostKey)) {
-        queryClient.setQueryData<BoardPost>(boardPostKey, (prev) => (prev ? { ...prev, conversation } : prev))
+        queryClient.setQueryData<BoardPost>(boardPostKey, (prev) =>
+          prev ? { ...prev, conversation: mergeConversationByTitleRevision(prev.conversation, conversation) } : prev
+        )
       }
     },
   })

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -742,4 +742,47 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
     expect(update).toHaveBeenCalledWith("ws_1", streamId, { displayName: "Groceries" })
     expect(sealSpy).not.toHaveBeenCalled()
   })
+
+  it("does not let a delayed rename response replace a newer title revision", async () => {
+    const streamId = await seedScratchpad({
+      e2eEnabled: false,
+      displayName: "Newer socket title",
+      displayNameSource: "explicit",
+      displayNameRevision: 2,
+    })
+    const newer = (await db.streams.get(streamId))!
+    const delayed = {
+      ...newer,
+      displayName: "Stale response title",
+      displayNameRevision: 1,
+      _cachedAt: undefined,
+    }
+    const update = vi.fn().mockResolvedValue(delayed)
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(streamKeys.detail("ws_1", streamId), newer)
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", streamId), { stream: newer })
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), { streams: [newer] })
+
+    const { result } = renderHook(() => useStreamOrDraft("ws_1", streamId), {
+      wrapper: createWrapper(queryClient, { streamService: { update } }),
+    })
+    await waitFor(() => expect(result.current.stream?.id).toBe(streamId))
+
+    await act(async () => {
+      await result.current.rename("Attempted rename")
+    })
+
+    expect((await db.streams.get(streamId))?.displayName).toBe("Newer socket title")
+    expect(queryClient.getQueryData<{ displayName: string }>(streamKeys.detail("ws_1", streamId))?.displayName).toBe(
+      "Newer socket title"
+    )
+    expect(
+      queryClient.getQueryData<{ stream: { displayName: string } }>(streamKeys.bootstrap("ws_1", streamId))?.stream
+        .displayName
+    ).toBe("Newer socket title")
+    expect(
+      queryClient.getQueryData<{ streams: Array<{ displayName: string }> }>(workspaceKeys.bootstrap("ws_1"))?.streams[0]
+        ?.displayName
+    ).toBe("Newer socket title")
+  })
 })

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -37,6 +37,7 @@ import type {
 } from "@threa/types"
 import { StreamTypes, Visibilities, CompanionModes } from "@threa/types"
 import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
+import { mergeStreamByTitleRevision, persistStreamByTitleRevision } from "@/lib/title-merge"
 
 const DM_DRAFT_PREFIX = "draft_dm_"
 
@@ -522,20 +523,29 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         : { displayName: newName }
 
       const updatedStream = await streamService.update(workspaceId, streamId, updateInput)
-      await db.streams.put(toCachedStream(updatedStream, idbStream))
+      await persistStreamByTitleRevision(updatedStream)
 
+      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), (old) =>
+        old ? mergeStreamByTitleRevision(old, updatedStream) : updatedStream
+      )
       queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
         if (!old || typeof old !== "object") return old
-        return { ...old, stream: updatedStream }
+        const bootstrap = old as { stream?: Stream }
+        return {
+          ...bootstrap,
+          stream: bootstrap.stream ? mergeStreamByTitleRevision(bootstrap.stream, updatedStream) : updatedStream,
+        }
       })
 
       queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (old: unknown) => {
         if (!old || typeof old !== "object") return old
-        const wsBootstrap = old as { streams?: Array<{ id: string }> }
+        const wsBootstrap = old as { streams?: Stream[] }
         if (!wsBootstrap.streams) return old
         return {
           ...wsBootstrap,
-          streams: wsBootstrap.streams.map((s) => (s.id === streamId ? { ...s, ...updatedStream } : s)),
+          streams: wsBootstrap.streams.map((stream) =>
+            stream.id === streamId ? mergeStreamByTitleRevision(stream, updatedStream) : stream
+          ),
         }
       })
     },

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -20,6 +20,7 @@ import type {
 import type { CreateStreamInput, UpdateStreamInput } from "@/api"
 import { workspaceKeys } from "./use-workspaces"
 import { useSyncEngine } from "@/sync/sync-engine"
+import { mergeStreamByTitleRevision, persistStreamByTitleRevision } from "@/lib/title-merge"
 
 export const streamKeys = {
   all: ["streams"] as const,
@@ -42,10 +43,7 @@ export function useStreams(workspaceId: string, filters?: { type?: StreamType })
     queryFn: async () => {
       const streams = await streamService.list(workspaceId, filters)
 
-      const now = Date.now()
-      await db.streams.bulkPut(streams.map((s) => ({ ...s, _cachedAt: now })))
-
-      return streams
+      return Promise.all(streams.map(persistStreamByTitleRevision))
     },
     enabled: !!workspaceId,
   })
@@ -59,9 +57,7 @@ export function useStream(workspaceId: string, streamId: string) {
     queryFn: async () => {
       const stream = await streamService.get(workspaceId, streamId)
 
-      await db.streams.put({ ...stream, _cachedAt: Date.now() })
-
-      return stream
+      return persistStreamByTitleRevision(stream)
     },
     enabled: !!workspaceId && !!streamId,
   })
@@ -168,7 +164,7 @@ export function useCreateStream(workspaceId: string) {
 
       const now = Date.now()
       await Promise.all([
-        db.streams.put({ ...newStream, _cachedAt: now }),
+        persistStreamByTitleRevision(newStream),
         db.streamMemberships.put({
           id: `${workspaceId}:${newStream.id}`,
           workspaceId,
@@ -189,13 +185,19 @@ export function useUpdateStream(workspaceId: string, streamId: string) {
 
   return useMutation({
     mutationFn: (data: UpdateStreamInput) => streamService.update(workspaceId, streamId, data),
-    onSuccess: (updatedStream) => {
-      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), updatedStream)
+    onSuccess: async (updatedStream) => {
+      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), (old) =>
+        old ? mergeStreamByTitleRevision(old, updatedStream) : updatedStream
+      )
 
       // Update stream-specific bootstrap cache (preserving events, members, etc.)
       queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
         if (!old || typeof old !== "object") return old
-        return { ...old, stream: updatedStream }
+        const bootstrap = old as { stream?: Stream }
+        return {
+          ...bootstrap,
+          stream: bootstrap.stream ? mergeStreamByTitleRevision(bootstrap.stream, updatedStream) : updatedStream,
+        }
       })
 
       // Update workspace bootstrap cache (sidebar uses this)
@@ -205,14 +207,14 @@ export function useUpdateStream(workspaceId: string, streamId: string) {
         if (!bootstrap.streams) return old
         return {
           ...bootstrap,
-          streams: bootstrap.streams.map((s) => (s.id === streamId ? updatedStream : s)),
+          streams: bootstrap.streams.map((s) => (s.id === streamId ? mergeStreamByTitleRevision(s, updatedStream) : s)),
         }
       })
 
       // Invalidate lists as fallback
       queryClient.invalidateQueries({ queryKey: streamKeys.lists() })
 
-      db.streams.put({ ...updatedStream, _cachedAt: Date.now() })
+      await persistStreamByTitleRevision(updatedStream)
     },
   })
 }
@@ -224,12 +226,18 @@ export function useUpdateCompanionMode(workspaceId: string, streamId: string) {
   return useMutation({
     mutationFn: (input: { companionMode: CompanionMode; companionPersonaId?: string | null }) =>
       streamService.updateCompanionMode(workspaceId, streamId, input),
-    onSuccess: (updatedStream) => {
-      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), updatedStream)
+    onSuccess: async (updatedStream) => {
+      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), (old) =>
+        old ? mergeStreamByTitleRevision(old, updatedStream) : updatedStream
+      )
 
       queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
         if (!old || typeof old !== "object") return old
-        return { ...old, stream: updatedStream }
+        const bootstrap = old as { stream?: Stream }
+        return {
+          ...bootstrap,
+          stream: bootstrap.stream ? mergeStreamByTitleRevision(bootstrap.stream, updatedStream) : updatedStream,
+        }
       })
 
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
@@ -237,12 +245,14 @@ export function useUpdateCompanionMode(workspaceId: string, streamId: string) {
         return {
           ...old,
           streams: old.streams.map((s) =>
-            s.id === streamId ? { ...s, ...updatedStream, lastMessagePreview: s.lastMessagePreview } : s
+            s.id === streamId
+              ? { ...mergeStreamByTitleRevision(s, updatedStream), lastMessagePreview: s.lastMessagePreview }
+              : s
           ),
         }
       })
 
-      db.streams.put({ ...updatedStream, _cachedAt: Date.now() })
+      await persistStreamByTitleRevision(updatedStream)
     },
   })
 }

--- a/apps/frontend/src/lib/title-merge.test.ts
+++ b/apps/frontend/src/lib/title-merge.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest"
+import { mergeConversationByTitleRevision, mergeStreamByTitleRevision } from "./title-merge"
+import type { ConversationWithStaleness, Stream } from "@threa/types"
+
+const stream = (revision: number): Stream =>
+  ({
+    id: "stream_1",
+    displayName: `title-${revision}`,
+    displayNameSource: "explicit",
+    displayNameRevision: revision,
+    displayNameUpdatedByUserId: "usr_1",
+    sealedNameCiphertext: `cipher-${revision}`,
+    sealedNameEnvelope: { revision },
+    description: `description-${revision}`,
+  }) as Stream
+
+const conversation = (revision: number): ConversationWithStaleness =>
+  ({
+    id: "conv_1",
+    topicSummary: `topic-${revision}`,
+    topicSummarySource: "explicit",
+    topicSummaryRevision: revision,
+    topicSummaryUpdatedByUserId: "usr_1",
+    summary: `summary-${revision}`,
+  }) as ConversationWithStaleness
+
+describe("revision-guarded title merges", () => {
+  test.each([
+    ["lower", 1],
+    ["missing", undefined],
+  ])("preserves every stream title field for %s revisions while merging non-title fields", (_label, revision) => {
+    const cached = stream(2)
+    const incoming = { ...stream(1), displayNameRevision: revision, description: "new description" }
+    expect(mergeStreamByTitleRevision(cached, incoming)).toMatchObject({
+      displayName: "title-2",
+      displayNameSource: "explicit",
+      displayNameRevision: 2,
+      displayNameUpdatedByUserId: "usr_1",
+      sealedNameCiphertext: "cipher-2",
+      sealedNameEnvelope: { revision: 2 },
+      description: "new description",
+    })
+  })
+
+  test.each([2, 3])("accepts equal/newer stream title revision %s", (revision) => {
+    expect(mergeStreamByTitleRevision(stream(2), stream(revision)).displayName).toBe(`title-${revision}`)
+  })
+
+  test.each([1, undefined])("guards conversation revision %s while accepting summary", (revision) => {
+    const merged = mergeConversationByTitleRevision(conversation(2), {
+      ...conversation(1),
+      topicSummaryRevision: revision,
+      summary: "new summary",
+    })
+    expect({ title: merged.topicSummary, revision: merged.topicSummaryRevision, summary: merged.summary }).toEqual({
+      title: "topic-2",
+      revision: 2,
+      summary: "new summary",
+    })
+  })
+
+  test.each([2, 3])("accepts equal/newer conversation title revision %s", (revision) => {
+    expect(mergeConversationByTitleRevision(conversation(2), conversation(revision)).topicSummary).toBe(
+      `topic-${revision}`
+    )
+  })
+})

--- a/apps/frontend/src/lib/title-merge.test.ts
+++ b/apps/frontend/src/lib/title-merge.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest"
-import { mergeConversationByTitleRevision, mergeStreamByTitleRevision } from "./title-merge"
+import {
+  mergeConversationByTitleRevision,
+  mergeStreamByTitleRevision,
+  persistStreamByTitleRevision,
+} from "./title-merge"
+import { db } from "@/db"
 import type { ConversationWithStaleness, Stream } from "@threa/types"
 
 const stream = (revision: number): Stream =>
@@ -25,6 +30,20 @@ const conversation = (revision: number): ConversationWithStaleness =>
   }) as ConversationWithStaleness
 
 describe("revision-guarded title merges", () => {
+  test("a delayed HTTP mutation preserves a newer socket title in atomic IndexedDB persistence", async () => {
+    await db.streams.clear()
+    await persistStreamByTitleRevision(stream(5))
+
+    await persistStreamByTitleRevision({ ...stream(3), description: "delayed mutation fields" })
+
+    expect(await db.streams.get("stream_1")).toMatchObject({
+      displayName: "title-5",
+      displayNameRevision: 5,
+      sealedNameCiphertext: "cipher-5",
+      description: "delayed mutation fields",
+    })
+  })
+
   test.each([
     ["lower", 1],
     ["missing", undefined],

--- a/apps/frontend/src/lib/title-merge.ts
+++ b/apps/frontend/src/lib/title-merge.ts
@@ -1,0 +1,46 @@
+import type { ConversationWithStaleness, Stream } from "@threa/types"
+
+const streamTitleFields = [
+  "displayName",
+  "displayNameSource",
+  "displayNameRevision",
+  "displayNameUpdatedByUserId",
+  "sealedNameCiphertext",
+  "sealedNameEnvelope",
+] as const
+
+export function mergeStreamByTitleRevision<T extends Partial<Stream>>(cached: T, incoming: Partial<Stream>): T {
+  const cachedRevision = cached.displayNameRevision ?? 0
+  const incomingRevision = incoming.displayNameRevision
+  const stale =
+    (incomingRevision === undefined && cachedRevision > 0) ||
+    (incomingRevision !== undefined && incomingRevision < cachedRevision)
+  if (!stale) return { ...cached, ...incoming } as T
+
+  const merged = { ...cached, ...incoming }
+  for (const field of streamTitleFields) {
+    ;(merged as Record<string, unknown>)[field] = cached[field]
+  }
+  return merged
+}
+
+export function mergeConversationByTitleRevision<T extends ConversationWithStaleness>(cached: T, incoming: T): T {
+  const cachedRevision = cached.topicSummaryRevision ?? 0
+  const incomingRevision = incoming.topicSummaryRevision
+  if (
+    !(
+      (incomingRevision === undefined && cachedRevision > 0) ||
+      (incomingRevision !== undefined && incomingRevision < cachedRevision)
+    )
+  ) {
+    return { ...cached, ...incoming }
+  }
+  return {
+    ...cached,
+    ...incoming,
+    topicSummary: cached.topicSummary,
+    topicSummarySource: cached.topicSummarySource,
+    topicSummaryRevision: cached.topicSummaryRevision,
+    topicSummaryUpdatedByUserId: cached.topicSummaryUpdatedByUserId,
+  }
+}

--- a/apps/frontend/src/lib/title-merge.ts
+++ b/apps/frontend/src/lib/title-merge.ts
@@ -1,3 +1,4 @@
+import { db, type CachedStream } from "@/db"
 import type { ConversationWithStaleness, Stream } from "@threa/types"
 
 const streamTitleFields = [
@@ -22,6 +23,16 @@ export function mergeStreamByTitleRevision<T extends Partial<Stream>>(cached: T,
     ;(merged as Record<string, unknown>)[field] = cached[field]
   }
   return merged
+}
+
+export async function persistStreamByTitleRevision(incoming: Stream): Promise<CachedStream> {
+  return db.transaction("rw", db.streams, async () => {
+    const cached = await db.streams.get(incoming.id)
+    const merged = cached ? mergeStreamByTitleRevision(cached, incoming) : incoming
+    const row = { ...merged, _cachedAt: Date.now() } as CachedStream
+    await db.streams.put(row)
+    return row
+  })
 }
 
 export function mergeConversationByTitleRevision<T extends ConversationWithStaleness>(cached: T, incoming: T): T {

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -98,6 +98,34 @@ describe("seedBoardPosts", () => {
     await seedBoardPosts(WORKSPACE_ID, [makePost("conv_b", "2026-06-21T12:00:00.000Z")])
     expect((await readBoard()).map((p) => p.id)).toEqual(["conv_b", "conv_a"])
   })
+
+  it("keeps a newer socket topic when an older fetched page is ingested later", async () => {
+    const newer = makePost("conv_1", "2026-06-20T12:00:00.000Z")
+    newer.conversation = {
+      ...newer.conversation,
+      topicSummary: "socket topic",
+      topicSummarySource: "explicit",
+      topicSummaryRevision: 4,
+    }
+    await seedBoardPosts(WORKSPACE_ID, [newer])
+    const delayed = makePost("conv_1", "2026-06-21T12:00:00.000Z")
+    delayed.conversation = {
+      ...delayed.conversation,
+      topicSummary: "stale fetched topic",
+      topicSummarySource: "generated",
+      topicSummaryRevision: 2,
+    }
+
+    await seedBoardPosts(WORKSPACE_ID, [delayed])
+
+    expect(await db.conversations.get("conv_1")).toMatchObject({
+      conversation: {
+        lastActivityAt: "2026-06-21T12:00:00.000Z",
+        topicSummary: "socket topic",
+        topicSummaryRevision: 4,
+      },
+    })
+  })
 })
 
 describe("mergeBoardConversation", () => {

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -3,6 +3,7 @@ import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedBoardPost } from "@/db"
 import { deleteConversationMessages, pruneConversationMessagesToMembership } from "./conversation-messages-store"
 import type { AttachmentSummary, BoardPost, BoardScopeStreamType, ConversationWithStaleness } from "@threa/types"
+import { mergeConversationByTitleRevision } from "@/lib/title-merge"
 
 function lastActivityMs(conversation: { lastActivityAt: string }): number {
   const ms = Date.parse(conversation.lastActivityAt)
@@ -294,9 +295,10 @@ export async function mergeBoardConversation(
     // opener — the row stays put meanwhile (no vanish-and-return motion).
     const openingMoved =
       memberIds !== null && existing.openingMessage !== null && !memberIds.has(existing.openingMessage.id)
+    const mergedConversation = mergeConversationByTitleRevision(existing.conversation, conversation)
     await db.conversations.put({
       ...existing,
-      conversation,
+      conversation: mergedConversation,
       recentMessages,
       // A kept cached set is still pruned to the new membership: an event that
       // omits the field but moves a message out must not leave it marked.

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -68,7 +68,17 @@ export function useBoardPost(conversationId: string | null): CachedBoardPost | n
  */
 export async function seedBoardPosts(workspaceId: string, posts: BoardPost[]): Promise<void> {
   if (posts.length === 0) return
-  await db.conversations.bulkPut(posts.map((post) => toCached(workspaceId, post)))
+  await db.transaction("rw", db.conversations, async () => {
+    const incoming = posts.map((post) => toCached(workspaceId, post))
+    const existing = await db.conversations.bulkGet(incoming.map((post) => post.id))
+    await db.conversations.bulkPut(
+      incoming.map((post, index) => {
+        const cached = existing[index]
+        if (!cached) return post
+        return { ...post, conversation: mergeConversationByTitleRevision(cached.conversation, post.conversation) }
+      })
+    )
+  })
 }
 
 /** The known facts about a board post the instant the send returns — enough to

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,4 +1,5 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
+import { mergeStreamByTitleRevision } from "@/lib/title-merge"
 import {
   isEventWriteChunkingEnabled,
   isIndexedMessagePatchEnabled,
@@ -498,27 +499,28 @@ async function writeBootstrapEventsAndStream(
   // after this returns) — same reflect-the-preserved-local-value precedent as
   // `applyReconnectBootstrapBatch`'s sidebarConfig.
   if (preservedReadState) bootstrap.readState = preservedReadState
-  const fullStreamData = {
+  const incomingStreamData = {
     ...stream,
     notificationLevel: bootstrap.membership?.notificationLevel,
-    // Mirror the persisted ContextBag into IDB so the timeline can read it
-    // synchronously on first paint via the `useWorkspaceStreams` cache —
-    // matches how attachments live on the message payload (sync from IDB).
     contextBag: bootstrap.contextBag,
     _cachedAt: now,
   }
+  const cachedStream = await db.streams.get(stream.id)
+  const fullStreamData = cachedStream
+    ? mergeStreamByTitleRevision(cachedStream, incomingStreamData)
+    : incomingStreamData
 
   const isDmWithNullName = stream.type === StreamTypes.DM && stream.displayName == null
   if (isDmWithNullName) {
     const { displayName: _, ...withoutDisplayName } = fullStreamData
-    const updated = await db.streams.update(stream.id, withoutDisplayName)
+    const updated = await db.streams.update(stream.id, withoutDisplayName as never)
     if (updated === 0) {
       await db.streams.put(fullStreamData)
     }
     return preservedReadState
   }
 
-  const updated = await db.streams.update(stream.id, fullStreamData)
+  const updated = await db.streams.update(stream.id, fullStreamData as never)
   if (updated === 0) {
     await db.streams.put(fullStreamData)
   }

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1804,6 +1804,101 @@ describe("registerWorkspaceSocketHandlers", () => {
     subscribeStream: vi.fn(),
   }
 
+  it("revision-orders stream title events and ignores another workspace", async () => {
+    const queryClient = new QueryClient()
+    const current = makeStream("stream_title", {
+      displayName: "revision two",
+      displayNameSource: "explicit",
+      displayNameRevision: 2,
+    })
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ streams: [{ ...current, lastMessagePreview: null }] })
+    )
+    await db.streams.put({ ...current, _cachedAt: Date.now() })
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    const title = () =>
+      queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streams[0]?.displayName
+    emit("stream:display_name_updated", {
+      workspaceId: "ws_1",
+      streamId: current.id,
+      displayName: "lower",
+      source: "generated",
+      revision: 1,
+    })
+    expect(title()).toBe("revision two")
+    emit("stream:display_name_updated", { workspaceId: "ws_1", streamId: current.id, displayName: "missing" })
+    expect(title()).toBe("revision two")
+    emit("stream:display_name_updated", {
+      workspaceId: "ws_other",
+      streamId: current.id,
+      displayName: "foreign",
+      source: "explicit",
+      revision: 3,
+    })
+    expect(title()).toBe("revision two")
+    emit("stream:display_name_updated", {
+      workspaceId: "ws_1",
+      streamId: current.id,
+      displayName: "equal",
+      source: "explicit",
+      revision: 2,
+    })
+    expect(title()).toBe("equal")
+    emit("stream:display_name_updated", {
+      workspaceId: "ws_1",
+      streamId: current.id,
+      displayName: "newer",
+      source: "generated",
+      revision: 3,
+    })
+    expect(title()).toBe("newer")
+    await vi.waitFor(async () => expect((await db.streams.get(current.id))?.displayName).toBe("newer"))
+    cleanup()
+  })
+
+  it("merges a delayed stream:created into cache and IndexedDB without regressing title fields", async () => {
+    const queryClient = new QueryClient()
+    const current = makeStream("stream_delayed_create", {
+      displayName: "new title",
+      displayNameSource: "explicit",
+      displayNameRevision: 4,
+      description: "old description",
+    })
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ streams: [{ ...current, lastMessagePreview: null }] })
+    )
+    await db.streams.put({ ...current, _cachedAt: Date.now() })
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("stream:created", {
+      workspaceId: "ws_1",
+      streamId: current.id,
+      stream: {
+        ...current,
+        displayName: "old title",
+        displayNameSource: "generated",
+        displayNameRevision: 2,
+        description: "new description",
+      },
+    })
+
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streams[0]
+    expect(cached).toMatchObject({ displayName: "new title", displayNameRevision: 4, description: "new description" })
+    await vi.waitFor(async () =>
+      expect(await db.streams.get(current.id)).toMatchObject({
+        displayName: "new title",
+        displayNameRevision: 4,
+        description: "new description",
+      })
+    )
+    cleanup()
+  })
+
   it("does not run the INV-53 saved/scheduled reconnect invalidations on registration", () => {
     // The workspace catch-up cursor replays the missed user-scoped saved/
     // scheduled entries through these same handlers, so registration never

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1899,6 +1899,41 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 
+  it("keeps a newer socket title when an older workspace bootstrap finishes later", async () => {
+    const newer = makeStream("stream_delayed_bootstrap", {
+      displayName: "socket title",
+      displayNameSource: "explicit",
+      displayNameRevision: 3,
+      description: "before fetch",
+    })
+    await db.streams.put({ ...newer, workspaceId: "ws_1", _cachedAt: Date.now() })
+    const stale = makeBootstrap({
+      streams: [
+        {
+          ...newer,
+          displayName: "stale bootstrap title",
+          displayNameSource: "generated",
+          displayNameRevision: 1,
+          description: "from delayed fetch",
+          lastMessagePreview: null,
+        },
+      ],
+    })
+
+    const { bootstrap } = await applyWorkspaceBootstrap("ws_1", stale, Date.now() - 1_000)
+
+    expect(bootstrap.streams[0]).toMatchObject({
+      displayName: "socket title",
+      displayNameRevision: 3,
+      description: "from delayed fetch",
+    })
+    expect(await db.streams.get(newer.id)).toMatchObject({
+      displayName: "socket title",
+      displayNameRevision: 3,
+      description: "from delayed fetch",
+    })
+  })
+
   it("does not run the INV-53 saved/scheduled reconnect invalidations on registration", () => {
     // The workspace catch-up cursor replays the missed user-scoped saved/
     // scheduled entries through these same handlers, so registration never

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2831,14 +2831,13 @@ export async function applyWorkspaceBootstrap(
         ...bootstrap.streams.map((s) => {
           const membership = membershipByStream.get(s.id)
           const existing = existingByStreamId.get(s.id)
-          return {
+          const incoming = {
             ...s,
             notificationLevel: membership?.notificationLevel,
-            // Preserve fields workspace-bootstrap doesn't carry but stream-
-            // bootstrap does (bag mirroring lives in `applyStreamBootstrap`).
             contextBag: existing?.contextBag,
             _cachedAt: now,
           }
+          return existing ? mergeStreamByTitleRevision(existing, incoming) : incoming
         }),
         // Archived roots ship slim (no preview/membership) but must persist so
         // every `useWorkspaceStreams` consumer (drafts, name resolution) keeps
@@ -3132,6 +3131,10 @@ export async function applyWorkspaceBootstrap(
     anyChanged,
     bootstrap: {
       ...bootstrap,
+      streams: bootstrap.streams.map((stream) => {
+        const merged = mergedStreams.find((candidate) => candidate.id === stream.id)
+        return merged ? { ...merged, lastMessagePreview: stream.lastMessagePreview } : stream
+      }),
       streamReadState: effectiveReadStateMap,
       unreadCounts: effectiveUnread.unreadCounts,
       unreadActivities: effectiveUnread.unreadActivities,
@@ -3331,7 +3334,12 @@ export async function applyReconnectBootstrapBatch(
         ? diffSingleton(existingWorkspace, workspaceRow)
         : { write: true, merged: workspaceRow }
       const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
-      const streamsDiff = diffEnabled ? diffRows(byId(existingStreams), streamRows) : writeAllRows(streamRows)
+      const existingByStreamId = byId(existingStreams)
+      const mergedStreamRows = streamRows.map((incoming) => {
+        const existing = existingByStreamId.get(incoming.id)
+        return existing ? mergeStreamByTitleRevision(existing, incoming) : incoming
+      })
+      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, mergedStreamRows) : writeAllRows(mergedStreamRows)
       const membershipsDiff = diffEnabled
         ? diffRows(byId(existingMemberships), membershipRows)
         : writeAllRows(membershipRows)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -13,6 +13,7 @@ import {
   type CachedWorkspaceUser,
 } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
+import { mergeConversationByTitleRevision, mergeStreamByTitleRevision } from "@/lib/title-merge"
 import { resolveFeatureFlags } from "@threa/types"
 import {
   diffRows,
@@ -42,6 +43,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import type {
   Stream,
+  StreamWithPreview,
   StreamBootstrap,
   StreamEvent,
   User,
@@ -277,6 +279,8 @@ interface StreamDisplayNameUpdatedPayload {
   workspaceId: string
   streamId: string
   displayName: string
+  source?: Stream["displayNameSource"]
+  revision?: number
 }
 
 interface UserPreferencesUpdatedPayload {
@@ -784,7 +788,7 @@ export function registerWorkspaceSocketHandlers(
     let shouldAddDmPeer = false
     let currentUserId: string | null = null
     let dmPeerUserId: string | null = null
-    let cachedStream: Stream & { lastMessagePreview?: LastMessagePreview | null } = payload.stream
+    let cachedStream: StreamWithPreview = { ...payload.stream, lastMessagePreview: null }
 
     const applied = updateBootstrapOrInvalidate(queryClient, workspaceId, (old) => {
       const streamExists = old.streams.some((s) => s.id === payload.stream.id)
@@ -799,10 +803,15 @@ export function registerWorkspaceSocketHandlers(
       dmPeerUserId = resolveDmPeerUserId(payload.dmUserIds, currentUserId)
       const dmPeerDisplayName =
         dmPeerUserId != null ? (getWorkspaceUsers(old).find((user) => user.id === dmPeerUserId)?.name ?? null) : null
-      cachedStream =
-        payload.stream.type === StreamTypes.DM && dmPeerDisplayName
-          ? { ...payload.stream, displayName: dmPeerDisplayName }
-          : payload.stream
+      const incomingCachedStream: StreamWithPreview = {
+        ...payload.stream,
+        ...(payload.stream.type === StreamTypes.DM && dmPeerDisplayName ? { displayName: dmPeerDisplayName } : {}),
+        lastMessagePreview: null,
+      }
+      const existingStream = old.streams.find((stream) => stream.id === payload.stream.id)
+      cachedStream = existingStream
+        ? mergeStreamByTitleRevision(existingStream, incomingCachedStream)
+        : incomingCachedStream
       const hasMembership = old.streamMemberships.some((m: StreamMember) => m.streamId === payload.stream.id)
       shouldAddMembership = Boolean(currentUserId && !hasMembership && (isCreator || isDmParticipant))
       shouldAddDmPeer = Boolean(
@@ -821,21 +830,11 @@ export function registerWorkspaceSocketHandlers(
       shouldJoinStreamRoom = hasMembership || shouldAddMembership
       shouldCacheStream = payload.stream.type === StreamTypes.DM ? isDmParticipant : !isPrivate || isCreator
 
-      if (streamExists && !shouldAddMembership && !shouldAddDmPeer) return old
-
       return {
         ...old,
         streams: shouldAddStream
           ? [...old.streams, { ...cachedStream, lastMessagePreview: null }]
-          : old.streams.map((stream) =>
-              stream.id === payload.stream.id
-                ? {
-                    ...stream,
-                    ...cachedStream,
-                    displayName: cachedStream.displayName ?? stream.displayName,
-                  }
-                : stream
-            ),
+          : old.streams.map((stream) => (stream.id === payload.stream.id ? cachedStream : stream)),
         streamMemberships: shouldAddMembership
           ? [
               ...old.streamMemberships,
@@ -864,7 +863,9 @@ export function registerWorkspaceSocketHandlers(
       // Cache to IndexedDB — skip other users' scratchpads to avoid stale
       // entries resurfacing on hydration if the event leaks during a deploy race.
       if (shouldCacheStream) {
-        await db.streams.put({ ...cachedStream, _cachedAt: now })
+        const existingStream = await db.streams.get(payload.stream.id)
+        const mergedStream = existingStream ? mergeStreamByTitleRevision(existingStream, cachedStream) : cachedStream
+        await db.streams.put({ ...mergedStream, _cachedAt: now })
       }
 
       // Persist membership to IDB so sidebar correctly filters public channels.
@@ -898,19 +899,17 @@ export function registerWorkspaceSocketHandlers(
     const isDmWithNullName = payload.stream.type === StreamTypes.DM && payload.stream.displayName == null
 
     queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, payload.stream.id), (old) => {
-      if (isDmWithNullName && old?.displayName) {
-        return { ...payload.stream, displayName: old.displayName }
-      }
-      return payload.stream
+      if (!old) return payload.stream
+      const merged = mergeStreamByTitleRevision(old, payload.stream)
+      return isDmWithNullName && old.displayName ? { ...merged, displayName: old.displayName } : merged
     })
 
     // Update stream bootstrap cache (preserves events, members, etc.)
     queryClient.setQueryData<StreamBootstrap>(streamKeys.bootstrap(workspaceId, payload.stream.id), (old) => {
       if (!old) return old
+      const merged = mergeStreamByTitleRevision(old.stream, payload.stream)
       const stream =
-        isDmWithNullName && old.stream.displayName
-          ? { ...payload.stream, displayName: old.stream.displayName }
-          : payload.stream
+        isDmWithNullName && old.stream.displayName ? { ...merged, displayName: old.stream.displayName } : merged
       return { ...old, stream }
     })
 
@@ -928,14 +927,10 @@ export function registerWorkspaceSocketHandlers(
           ...old,
           streams: old.streams.map((s) =>
             s.id === payload.stream.id
-              ? {
-                  ...s,
-                  ...payload.stream,
-                  displayName:
-                    payload.stream.type === StreamTypes.DM && payload.stream.displayName == null
-                      ? s.displayName
-                      : payload.stream.displayName,
-                }
+              ? (() => {
+                  const merged = mergeStreamByTitleRevision(s, payload.stream)
+                  return isDmWithNullName ? { ...merged, displayName: s.displayName } : merged
+                })()
               : s
           ),
         }
@@ -951,20 +946,23 @@ export function registerWorkspaceSocketHandlers(
     // to preserve cached fields not carried by the Stream payload, notably the
     // last-message preview and notification level. For DMs, also preserve the
     // resolved displayName since the backend sends null.
-    const idbUpdate =
-      payload.stream.type === StreamTypes.DM && payload.stream.displayName == null
-        ? (() => {
-            const { displayName: _, ...rest } = payload.stream
-            return { ...rest, _cachedAt: Date.now() }
-          })()
-        : { ...payload.stream, _cachedAt: Date.now() }
-    db.streams.update(payload.stream.id, idbUpdate)
+    void db.transaction("rw", db.streams, async () => {
+      const old = await db.streams.get(payload.stream.id)
+      if (!old) return
+      const merged = mergeStreamByTitleRevision(old, payload.stream)
+      await db.streams.put({
+        ...merged,
+        ...(isDmWithNullName ? { displayName: old.displayName } : {}),
+        _cachedAt: Date.now(),
+      })
+    })
   }
 
   const handleStreamArchived = (payload: StreamPayload) => {
     queryClient.setQueryData(streamKeys.bootstrap(workspaceId, payload.stream.id), (old: unknown) => {
       if (!old || typeof old !== "object") return old
-      return { ...old, stream: payload.stream }
+      const bootstrap = old as StreamBootstrap
+      return { ...bootstrap, stream: mergeStreamByTitleRevision(bootstrap.stream, payload.stream) }
     })
 
     // Remove from workspace bootstrap cache (sidebar - archived streams don't show)
@@ -990,7 +988,8 @@ export function registerWorkspaceSocketHandlers(
   const handleStreamUnarchived = (payload: StreamPayload) => {
     queryClient.setQueryData(streamKeys.bootstrap(workspaceId, payload.stream.id), (old: unknown) => {
       if (!old || typeof old !== "object") return old
-      return { ...old, stream: payload.stream }
+      const bootstrap = old as StreamBootstrap
+      return { ...bootstrap, stream: mergeStreamByTitleRevision(bootstrap.stream, payload.stream) }
     })
 
     queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (old: unknown) => {
@@ -1001,7 +1000,9 @@ export function registerWorkspaceSocketHandlers(
         // Merge to preserve lastMessagePreview.
         return {
           ...bootstrap,
-          streams: bootstrap.streams.map((s) => (s.id === payload.stream.id ? { ...s, ...payload.stream } : s)),
+          streams: bootstrap.streams.map((s) =>
+            s.id === payload.stream.id ? mergeStreamByTitleRevision(s, payload.stream) : s
+          ),
         }
       }
       return {
@@ -1519,16 +1520,23 @@ export function registerWorkspaceSocketHandlers(
 
   // Handle stream display name updated (from auto-naming service)
   const handleStreamDisplayNameUpdated = (payload: StreamDisplayNameUpdatedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+    const mergeTitle = <T extends Partial<Stream>>(old: T): T =>
+      mergeStreamByTitleRevision(old, {
+        displayName: payload.displayName,
+        displayNameSource: payload.source,
+        displayNameRevision: payload.revision,
+      } as T)
     queryClient.setQueryData(streamKeys.detail(workspaceId, payload.streamId), (old: unknown) => {
       if (!old || typeof old !== "object") return old
-      return { ...old, displayName: payload.displayName }
+      return mergeTitle(old as Stream)
     })
 
     queryClient.setQueryData(streamKeys.bootstrap(workspaceId, payload.streamId), (old: unknown) => {
       if (!old || typeof old !== "object") return old
       const bootstrap = old as { stream?: Stream }
       if (!bootstrap.stream) return old
-      return { ...old, stream: { ...bootstrap.stream, displayName: payload.displayName } }
+      return { ...old, stream: mergeTitle(bootstrap.stream) }
     })
 
     queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (old: unknown) => {
@@ -1537,13 +1545,15 @@ export function registerWorkspaceSocketHandlers(
       if (!bootstrap.streams) return old
       return {
         ...bootstrap,
-        streams: bootstrap.streams.map((s) =>
-          s.id === payload.streamId ? { ...s, displayName: payload.displayName } : s
-        ),
+        streams: bootstrap.streams.map((s) => (s.id === payload.streamId ? mergeTitle(s) : s)),
       }
     })
 
-    db.streams.update(payload.streamId, { displayName: payload.displayName, _cachedAt: Date.now() })
+    void db.transaction("rw", [db.streams], async () => {
+      const old = await db.streams.get(payload.streamId)
+      if (!old) return
+      await db.streams.update(payload.streamId, { ...mergeTitle(old), _cachedAt: Date.now() })
+    })
   }
 
   const handleStreamMemberAdded = (payload: {
@@ -2278,7 +2288,7 @@ export function registerWorkspaceSocketHandlers(
             prev
               ? {
                   ...prev,
-                  conversation: payload.conversation,
+                  conversation: mergeConversationByTitleRevision(prev.conversation, payload.conversation),
                   recentMessages: prev.recentMessages.filter((m) => memberIds.has(m.id)),
                   settlingMessageIds: payload.settlingMessageIds ?? prev.settlingMessageIds,
                 }
@@ -2522,11 +2532,15 @@ export function registerWorkspaceSocketHandlers(
  * archive/unarchive can't silently drop the local row (INV-11: no silent loss).
  */
 async function upsertStreamRow(stream: Stream): Promise<void> {
-  const now = Date.now()
-  const updated = await db.streams.update(stream.id, { ...stream, _cachedAt: now })
-  if (updated === 0) {
-    await db.streams.put({ ...stream, lastMessagePreview: null, _cachedAt: now })
-  }
+  await db.transaction("rw", db.streams, async () => {
+    const now = Date.now()
+    const old = await db.streams.get(stream.id)
+    await db.streams.put(
+      old
+        ? { ...mergeStreamByTitleRevision(old, stream), _cachedAt: now }
+        : { ...stream, lastMessagePreview: null, _cachedAt: now }
+    )
+  })
 }
 
 const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1,3 +1,12 @@
+export const TITLE_SOURCES = ["generated", "explicit", "legacy"] as const
+export type TitleSource = (typeof TITLE_SOURCES)[number]
+
+export const TitleSources = {
+  GENERATED: "generated",
+  EXPLICIT: "explicit",
+  LEGACY: "legacy",
+} as const satisfies Record<string, TitleSource>
+
 export const STREAM_TYPES = ["scratchpad", "channel", "dm", "thread", "system"] as const
 export type StreamType = (typeof STREAM_TYPES)[number]
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -62,6 +62,7 @@ import type {
   BotInvocationTrigger,
   BotInvocationCapability,
   E2eActorKind,
+  TitleSource,
 } from "./constants"
 import type { ThreaDocument } from "./prosemirror"
 
@@ -220,6 +221,9 @@ export interface Stream {
   workspaceId: string
   type: StreamType
   displayName: string | null
+  displayNameSource?: TitleSource | null
+  displayNameRevision?: number
+  displayNameUpdatedByUserId?: string | null
   slug: string | null
   /** Markdown projection of the description (derived from `descriptionJson`). */
   description: string | null
@@ -727,6 +731,9 @@ export interface Conversation {
    */
   secondaryMessageIds: string[]
   topicSummary: string | null
+  topicSummarySource?: TitleSource | null
+  topicSummaryRevision?: number
+  topicSummaryUpdatedByUserId?: string | null
   /**
    * Rolling prose summary of what the conversation covers, maintained by the
    * boundary extractor on every pass that touches the conversation. Richer

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,10 @@ export type { UserId, MemberId, WorkspaceId } from "./ids"
 
 // Constants and their types
 export {
+  // Title provenance
+  TITLE_SOURCES,
+  type TitleSource,
+  TitleSources,
   // Stream types
   STREAM_TYPES,
   type StreamType,


### PR DESCRIPTION
## Problem

Stream and conversation titles had no authoritative provenance or monotonic revision, so generated writes could overwrite user or migrated names and delayed payloads could visually restore stale titles. `display_name_generated_at` could not safely distinguish generated, explicit, and pre-existing titles, including sealed E2E names.

## Solution

This first layer of the dynamic naming stack adds `generated | explicit | legacy` provenance, integer revisions, and nullable user attribution. A migration conservatively marks existing plaintext, sealed, and conversation titles as `legacy`; source-null titled rows also map to `legacy` during mixed-version rollout. Workspace-scoped title methods increment revisions, support revision/source CAS, dual-write `display_name_generated_at`, and keep manual, generated, classifier, split, and sealed writes transactional. Shared frontend merges preserve newer title fields while still accepting non-title updates from stale payloads.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/{constants,domain,index}.ts` | Add shared title sources and additive stream/conversation metadata. |
| `apps/backend/src/db/migrations/20260806220444_dynamic_naming_provenance.sql` | Add columns and backfill existing titles as `legacy`. |
| `apps/backend/src/features/{streams,conversations}/**` | Add dedicated revisioned writers and route existing title creation/rename paths. |
| `apps/backend/src/features/{e2e-streams,enclave-runtimes}/**` | Make sealed generated/manual title updates race-safe and atomic. |
| `apps/backend/src/lib/outbox/repository.ts` | Add source and revision to stream title events. |
| `apps/frontend/src/{lib/title-merge.ts,sync,hooks,stores}/**` | Revision-guard socket, HTTP, bootstrap, and IndexedDB cache merges. |
| `apps/backend/tests/integration/**`, `apps/frontend/src/**/*.test.ts*` | Cover migration, CAS, provenance, sealed races, and stale payloads. |

## Test plan

- [x] `bun run check:migrations` — 255 clean
- [x] `bun run --cwd apps/backend test:integration -- tests/integration/stream-naming.test.ts tests/integration/conversation-repository.test.ts tests/integration/e2e-stream-sealed-name.test.ts` — 66 passed
- [x] `bun run --cwd apps/backend test:unit -- src/features/streams src/features/conversations src/features/enclave-runtimes/session-handlers.test.ts` — 437 passed
- [x] `bun run --cwd apps/frontend test -- src/lib/title-merge.test.ts src/sync/workspace-sync.test.ts src/stores/board-store.test.ts src/hooks/use-conversations.test.tsx` — 181 passed
- [x] `bun run typecheck`; `bun run lint`; `git diff --check` — passed

## Known exclusions

No checkpoint state, evaluator, repeated naming, scratchpad ownership UI, regenerate action, public v1 expansion, or E2E checkpoint protocol. The existing queue, checkpoint behavior, and `display_name_generated_at` remain for compatibility.

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Deliver PR1 of the [Seer dynamic naming plan](https://seer.build/ws_vbyzjvdg6g/b/dynamic-naming-plan-5d5b5b/): establish provenance and revision safety while preserving first-name-only behavior. This is layer 1 of the dynamic naming stack and the base for later ownership, lifecycle, evaluator, E2E parity, and regenerate layers.

## What Was Built

### Schema and contracts

- Added `20260806220444_dynamic_naming_provenance.sql` with nullable source/user columns and revision defaults for streams and conversations.
- Backfilled non-null plaintext stream titles, sealed names, and conversation topics to `legacy`; unnamed rows remain source-null.
- Added shared `TITLE_SOURCES`, `TitleSources`, and `TitleSource`, then exposed additive metadata in domain payloads.

### Revisioned writes

- Added workspace-scoped stream and conversation title mutations that increment revisions and optionally guard expected revision/source.
- Routed explicit creation and manual rename, generated plaintext/classifier naming, confirmed splits, and sealed enclave/manual writes through provenance-aware paths.
- Kept source title mutation, sealed ciphertext, and existing outbox work in service-owned transactions.

### Ordering and rollout safety

- Treat a non-null title or sealed name with null persisted source as effective `legacy`, protecting writes from old replicas.
- Keep `display_name_generated_at` as a compatibility dual-write; source/revision are authoritative.
- Added source/revision to existing title payloads and revision-aware frontend merges across socket events, mutation responses, bootstrap caches, board storage, and IndexedDB.

## Design Decisions

- **Integer CAS over timestamps:** revisions provide monotonic race guards without timestamp equality.
- **Text source columns over DB enums:** shared application constants keep the additive migration rollout-safe.
- **Dedicated writers over generic updates:** non-title changes cannot silently alter provenance or revision.
- **Conservative legacy fallback:** unknown authorship is protected rather than inferred from the old generated timestamp.
- **No new socket channel:** existing stream/conversation delivery paths carry additive metadata.

## Migration

The append-only migration adds no enums or foreign keys. New binaries accept old-replica source-null writes as legacy; old clients ignore additive payload fields, while new clients reject missing/lower title revisions after learning a positive revision.

## What's NOT Included

Checkpoint/progress state, evaluator calls, repeated renaming, scratchpad canonical-owner UI changes, regenerate actions, public v1 changes, and the E2E checkpoint protocol are deferred to later stack layers. The old queue and compatibility timestamp remain intact.

## Status

- [x] Provenance schema, backfill, and shared contracts
- [x] Revisioned stream, conversation, and sealed title writes
- [x] Existing writer routing and explicit-name protection
- [x] Revision-aware realtime and cache merging
- [x] Unit, real-schema integration, migration, typecheck, lint, and diff gates
- [x] PR1 complete; no residual items in scope

</details>

---

🤖 _PR by Codex_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788648874&installation_model_id=20758&pr_number=1786&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1786&signature=4cd0a30ff7be7e08207ac72fb92ba57d0534b7dc70e1cb1b5b742b7a23db3fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->