### PR TITLE
feat: make scratchpad stream titles canonical

### DIFF
--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -267,6 +267,7 @@ export {
   GENERAL_RESEARCH_TOOL_POLICY,
 } from "./general-researcher"
 
+export { findThreadAnchorContext, serializeThreadAnchorCard } from "./thread-anchor-context"
 export { ToolGuardianService } from "./guardian/service"
 export type { ToolGuardianServiceDeps, ToolGuardianTurn } from "./guardian/service"
 export {

--- a/apps/backend/src/features/agents/thread-anchor-context.ts
+++ b/apps/backend/src/features/agents/thread-anchor-context.ts
@@ -11,7 +11,7 @@ function textDoc(text: string): JSONContent {
 }
 
 /** Render a threadable card event as the terse markdown the agent needs to know what the thread is about. */
-function serializeCardAnchor(eventType: string, payload: unknown): string | null {
+export function serializeThreadAnchorCard(eventType: string, payload: unknown): string | null {
   if (eventType === "delegation:created") {
     const p = payload as DelegationCreatedEventPayload
     const brief = p.brief.length > MAX_BRIEF_CHARS ? `${p.brief.slice(0, MAX_BRIEF_CHARS)}…` : p.brief
@@ -40,7 +40,7 @@ export async function findThreadAnchorContext(db: Querier, stream: Stream): Prom
 
   const event = await StreamEventRepository.findById(db, anchorId)
   if (!event) return null
-  const text = serializeCardAnchor(event.eventType, event.payload)
+  const text = serializeThreadAnchorCard(event.eventType, event.payload)
   if (!text) return null
 
   return {

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -367,7 +367,6 @@ export class BoundaryExtractionService {
           }
         : {
             assignments: [{ conversationId: null, isPrimary: true }],
-            newTopic: stream.displayName ?? "Scratchpad",
             confidence: 1.0,
             reassignments: [],
             validUpdateTargets: new Set(),

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -8,6 +8,7 @@ import { setAuditSubjects } from "../access-log"
 import {
   CONVERSATION_STATUSES,
   ConversationStatuses,
+  StreamTypes,
   MAX_CONVERSATION_TOPIC_LENGTH,
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
@@ -422,7 +423,13 @@ export function createConversationHandlers({
       }
 
       // validateStreamAccess handles public visibility + thread root membership
-      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+      const stream = await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+      if (stream.type === StreamTypes.SCRATCHPAD) {
+        throw new HttpError("Scratchpad conversations cannot be split", {
+          status: 400,
+          code: "SCRATCHPAD_CONVERSATION_TITLE_OWNED_BY_STREAM",
+        })
+      }
 
       const proposal = await boundaryExtractionService.proposeSplit(conversationId, workspaceId)
       res.json(proposal)

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -779,6 +779,13 @@ export class ConversationService {
         throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
       }
       if (topicSummary !== undefined) {
+        const ownerStream = await StreamRepository.findById(client, updated.streamId)
+        if (ownerStream?.type === StreamTypes.SCRATCHPAD) {
+          throw new HttpError("Rename the scratchpad instead", {
+            status: 400,
+            code: "SCRATCHPAD_TITLE_OWNED_BY_STREAM",
+          })
+        }
         updated = await ConversationRepository.updateTopicSummary(client, {
           workspaceId,
           conversationId,
@@ -1308,6 +1315,13 @@ export class ConversationService {
         throw new HttpError("Conversation is not in this stream", {
           status: 400,
           code: "CONVERSATION_NOT_IN_STREAM",
+        })
+      }
+      const ownerStream = await StreamRepository.findById(client, source.streamId)
+      if (ownerStream?.type === StreamTypes.SCRATCHPAD) {
+        throw new HttpError("Scratchpad conversations cannot be split", {
+          status: 400,
+          code: "SCRATCHPAD_CONVERSATION_TITLE_OWNED_BY_STREAM",
         })
       }
 

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -264,6 +264,7 @@ describe("LinkPreviewService.resolveInAppLink", () => {
     expect(result).toEqual({
       kind: "conversation",
       accessTier: "full",
+      streamId: "stream_1",
       topicSummary: "Auth redesign",
       summary: "Deciding how auth flows through the router.",
       status: "resolved",
@@ -271,6 +272,40 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       participantIds: ["user_a", "user_b"],
       streamName: "eng",
       streamType: "channel",
+    })
+  })
+
+  test("never returns historical plaintext streamName for an E2E conversation link", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({ contentType: "conversation_link", targetStreamId: null, targetConversationId: "conv_1" })
+    )
+    spyOn(ConversationRepository, "findById").mockResolvedValue(makeConversation())
+    const service = makeService(
+      {
+        tryAccess: async () =>
+          makeStream({
+            type: "scratchpad",
+            e2eEnabled: true,
+            displayName: "Historical private title",
+            slug: "historical-private-title",
+          }),
+      },
+      {}
+    )
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toEqual({
+      kind: "conversation",
+      accessTier: "full",
+      streamId: "stream_1",
+      topicSummary: undefined,
+      summary: "Deciding how auth flows through the router.",
+      status: "active",
+      messageCount: 3,
+      participantIds: ["user_a", "user_b"],
+      streamName: undefined,
+      streamType: "scratchpad",
     })
   })
 

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -12,7 +12,7 @@ import type {
   MessageLinkPreviewData,
   JSONContent,
 } from "@threa/types"
-import { getAvatarUrl, isInAppLinkContentType, stripMarkdownToInline } from "@threa/types"
+import { getAvatarUrl, isInAppLinkContentType, stripMarkdownToInline, StreamTypes } from "@threa/types"
 import { LinkPreviewRepository, type LinkPreview, type UpdateLinkPreviewParams } from "./repository"
 import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
@@ -561,7 +561,7 @@ export class LinkPreviewService {
       authorName,
       authorAvatarUrl,
       contentPreview,
-      streamName: stream.displayName ?? stream.slug ?? undefined,
+      streamName: stream.e2eEnabled ? undefined : (stream.displayName ?? stream.slug ?? undefined),
       streamType: stream.type,
       recipientName,
       authorId: message.authorId,
@@ -591,7 +591,7 @@ export class LinkPreviewService {
     return {
       kind: "stream",
       accessTier: "full",
-      streamName: stream.displayName ?? stream.slug ?? undefined,
+      streamName: stream.e2eEnabled ? undefined : (stream.displayName ?? stream.slug ?? undefined),
       streamType: stream.type,
       visibility: stream.visibility,
       description,
@@ -669,16 +669,21 @@ export class LinkPreviewService {
     }
 
     const summary = conversation.summary ? buildPreviewSnippet(conversation.summary) : undefined
+    let topicSummary = conversation.topicSummary ?? undefined
+    if (stream.type === StreamTypes.SCRATCHPAD) {
+      topicSummary = stream.e2eEnabled ? undefined : (stream.displayName ?? undefined)
+    }
 
     return {
       kind: "conversation",
       accessTier: "full",
-      topicSummary: conversation.topicSummary ?? undefined,
+      streamId: conversation.streamId,
+      topicSummary,
       summary,
       status: conversation.status,
       messageCount: conversation.messageIds.length,
       participantIds: conversation.participantIds,
-      streamName: stream.displayName ?? stream.slug ?? undefined,
+      streamName: stream.e2eEnabled ? undefined : (stream.displayName ?? stream.slug ?? undefined),
       streamType: stream.type,
     }
   }

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -57,6 +57,7 @@ import {
   BotInvocationCapabilities,
   BotInvocationTriggers,
   MemoryModes,
+  StreamTypes,
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
   THREA_CALLBACK_TOKEN_HEADER,
   sentViaApiKey,
@@ -222,12 +223,17 @@ function serializeMessage(
   }
 }
 
-function serializeConversation(conversation: Conversation, rootStreamId: string): WireConversation {
+function serializeConversation(conversation: Conversation, stream: Stream | undefined): WireConversation {
+  const rootStreamId = stream?.rootStreamId ?? stream?.id ?? conversation.streamId
+  let topicSummary = conversation.topicSummary
+  if (stream?.type === StreamTypes.SCRATCHPAD) {
+    topicSummary = stream.e2eEnabled ? null : stream.displayName
+  }
   return {
     id: conversation.id,
     streamId: conversation.streamId,
     rootStreamId,
-    topicSummary: conversation.topicSummary,
+    topicSummary,
     summary: conversation.summary,
     status: conversation.status,
     messageCount: conversation.messageIds.length,
@@ -242,11 +248,11 @@ function serializeConversation(conversation: Conversation, rootStreamId: string)
  * Map each conversation's anchor stream to its effective root
  * (`COALESCE(root_stream_id, id)`, INV-62) for the wire `rootStreamId`.
  */
-async function resolveConversationRoots(pool: Pool, conversations: Conversation[]): Promise<Map<string, string>> {
+async function resolveConversationStreams(pool: Pool, conversations: Conversation[]): Promise<Map<string, Stream>> {
   const streamIds = [...new Set(conversations.map((c) => c.streamId))]
   if (streamIds.length === 0) return new Map()
   const streams = await StreamRepository.findByIds(pool, streamIds)
-  return new Map(streams.map((s) => [s.id, s.rootStreamId ?? s.id]))
+  return new Map(streams.map((stream) => [stream.id, stream]))
 }
 
 // Label domain dates are already ISO strings on the wire shape; the only
@@ -2318,11 +2324,11 @@ export function createPublicApiHandlers({
 
       const hasMore = rows.length > limit
       const page = hasMore ? rows.slice(0, limit) : rows
-      const rootByStream = await resolveConversationRoots(pool, page)
+      const streamsById = await resolveConversationStreams(pool, page)
       const last = page[page.length - 1]
 
       res.json({
-        data: page.map((c) => serializeConversation(c, rootByStream.get(c.streamId) ?? c.streamId)),
+        data: page.map((conversation) => serializeConversation(conversation, streamsById.get(conversation.streamId))),
         hasMore,
         cursor: last ? encodeCursor(last.lastActivityAt, last.id) : null,
       })
@@ -2330,9 +2336,9 @@ export function createPublicApiHandlers({
 
     async getConversation(req: Request, res: Response) {
       const conversation = await resolveAccessibleConversation(req, req.params.conversationId)
-      const rootByStream = await resolveConversationRoots(pool, [conversation])
+      const streamsById = await resolveConversationStreams(pool, [conversation])
       res.json({
-        data: serializeConversation(conversation, rootByStream.get(conversation.streamId) ?? conversation.streamId),
+        data: serializeConversation(conversation, streamsById.get(conversation.streamId)),
       })
     },
 

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -21,6 +21,7 @@ export {
 
 export { StreamNamingService } from "./naming-service"
 export type { GenerateNameResult } from "./naming-service"
+export { prependThreadNamingAnchor, renderNamingEventAnchor } from "./naming-context"
 export { StubStreamNamingService } from "./naming-service.stub"
 export { createNamingWorker } from "./naming-worker"
 export type { StreamNamingServiceLike, NamingWorkerDeps } from "./naming-worker"

--- a/apps/backend/src/features/streams/naming-context.test.ts
+++ b/apps/backend/src/features/streams/naming-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { MessageRepository } from "../messaging"
+import { prependThreadNamingAnchor, renderNamingEventAnchor } from "./naming-context"
+
+const db = {} as never
+const stream = { parentAnchorId: "msg_root" } as never
+const message = (id: string, contentMarkdown: string) => ({ id, contentMarkdown }) as never
+
+describe("thread naming context", () => {
+  test("prepends the canonical message anchor", async () => {
+    const findRoot = spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(message("msg_root", "Anchor"))
+    await expect(prependThreadNamingAnchor(db, stream, [message("msg_reply", "Reply")])).resolves.toEqual([
+      message("msg_root", "Anchor"),
+      message("msg_reply", "Reply"),
+    ])
+    findRoot.mockRestore()
+  })
+
+  test("returns replies when no anchor resolves", async () => {
+    const findRoot = spyOn(MessageRepository, "findThreadRoot").mockResolvedValue(null)
+    await expect(prependThreadNamingAnchor(db, stream, [message("msg_reply", "Reply")])).resolves.toEqual([
+      message("msg_reply", "Reply"),
+    ])
+    findRoot.mockRestore()
+  })
+
+  test("allowlists structured event fields without dumping payload JSON", () => {
+    expect(
+      renderNamingEventAnchor("delegation:created", {
+        title: "Audit",
+        brief: "Check access",
+        assigneeActorId: "bot_1",
+        assigneeActorType: "bot",
+        secret: "do not leak",
+      })
+    ).toBe("Delegation: Audit\n\nCheck access")
+    expect(renderNamingEventAnchor("delegation:completed", { title: "Audit", summary: "Done" })).toBeNull()
+    expect(renderNamingEventAnchor("unknown", { title: "Audit", secret: "do not leak" })).toBeNull()
+    expect(renderNamingEventAnchor("call_started", { mode: "audio_only", secret: "do not leak" })).toBe(
+      "Call started (audio)"
+    )
+  })
+})

--- a/apps/backend/src/features/streams/naming-context.ts
+++ b/apps/backend/src/features/streams/naming-context.ts
@@ -1,0 +1,11 @@
+import type { Querier } from "../../db"
+import { findThreadAnchorContext, serializeThreadAnchorCard } from "../agents"
+import type { Message } from "../messaging"
+import type { Stream } from "./repository"
+
+export const renderNamingEventAnchor = serializeThreadAnchorCard
+
+export async function prependThreadNamingAnchor(db: Querier, stream: Stream, replies: Message[]): Promise<Message[]> {
+  const anchor = await findThreadAnchorContext(db, stream)
+  return anchor ? [anchor, ...replies.filter((message) => message.id !== anchor.id)] : replies
+}

--- a/apps/backend/src/features/streams/naming-service.ts
+++ b/apps/backend/src/features/streams/naming-service.ts
@@ -15,6 +15,7 @@ import { MessageFormatter } from "../../lib/ai/message-formatter"
 import { awaitAttachmentProcessing } from "../attachments"
 import { awaitLinkPreviewProcessing, enrichMessagesWithLinkPreviewMap } from "../link-previews"
 import { MAX_MESSAGES_FOR_NAMING, MAX_EXISTING_NAMES, buildNamingSystemPrompt } from "./naming-config"
+import { prependThreadNamingAnchor } from "./naming-context"
 
 export interface GenerateNameResult {
   name: string | null
@@ -102,9 +103,10 @@ export class StreamNamingService {
         return { stream: null, messages: [], otherStreams: [], attachmentIds: [] }
       }
 
-      const messages = await MessageRepository.list(client, streamId, {
+      const replies = await MessageRepository.list(client, streamId, {
         limit: MAX_MESSAGES_FOR_NAMING,
       })
+      const messages = await prependThreadNamingAnchor(client, stream, replies)
 
       if (messages.length === 0) {
         return { stream: null, messages: [], otherStreams: [], attachmentIds: [] }

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -360,7 +360,9 @@ export const StreamRepository = {
 
   async findByIds(db: Querier, ids: string[]): Promise<Stream[]> {
     if (ids.length === 0) return []
-    const result = await db.query<StreamRow>(sql`SELECT ${sql.raw(SELECT_FIELDS)} FROM streams WHERE id = ANY(${ids})`)
+    const result = await db.query<StreamRow>(
+      sql`SELECT ${sql.raw(SELECT_FIELDS_WITH_E2E)} FROM ${sql.raw(FROM_STREAMS_WITH_E2E)} WHERE s.id = ANY(${ids})`
+    )
     return result.rows.map(mapRowToStream)
   },
 

--- a/apps/backend/tests/integration/boundary-extraction-service.test.ts
+++ b/apps/backend/tests/integration/boundary-extraction-service.test.ts
@@ -1087,7 +1087,7 @@ describe("BoundaryExtractionService", () => {
       expect(result2?.messageIds).toContain(msg2Id)
     })
 
-    test("uses stream display name as conversation topic", async () => {
+    test("leaves the conversation topic null when the scratchpad stream has a title", async () => {
       const localStreamId = streamId()
       const msgId = messageId()
 
@@ -1114,10 +1114,12 @@ describe("BoundaryExtractionService", () => {
 
       const result = await service.processMessage(msgId, localStreamId, testWorkspaceId)
 
-      expect(result?.topicSummary).toBe("Project Ideas")
+      // The scratchpad stream is the sole title owner. Copying its title here
+      // creates a second, independently mutable source of truth.
+      expect(result?.topicSummary).toBeNull()
     })
 
-    test("falls back to 'Scratchpad' when stream has no display name", async () => {
+    test("leaves the conversation topic null when the scratchpad stream is unnamed", async () => {
       const localStreamId = streamId()
       const msgId = messageId()
 
@@ -1144,7 +1146,9 @@ describe("BoundaryExtractionService", () => {
 
       const result = await service.processMessage(msgId, localStreamId, testWorkspaceId)
 
-      expect(result?.topicSummary).toBe("Scratchpad")
+      // Generic UI fallback text is derived at read time, never persisted as
+      // an independently owned conversation title.
+      expect(result?.topicSummary).toBeNull()
     })
   })
 })

--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -135,7 +135,6 @@ beforeEach(() => {
       lastReadEventId: "evt_old",
     },
   ] as never)
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -172,7 +172,6 @@ beforeEach(async () => {
   await db.events.clear()
   await db.streams.clear()
   await db.conversations.clear()
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -189,7 +189,6 @@ beforeEach(async () => {
   await db.streams.clear()
   await db.conversations.clear()
   await db.streams.put(cachedStream(STREAM, StreamTypes.CHANNEL))
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.mass-badge.test.tsx
+++ b/apps/frontend/src/components/board/board-card.mass-badge.test.tsx
@@ -187,7 +187,6 @@ beforeEach(async () => {
   await db.conversations.clear()
   await db.streams.put(cachedStream(STREAM))
   await db.conversations.put(post())
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
@@ -146,7 +146,6 @@ beforeEach(async () => {
   await db.events.clear()
   await db.streams.clear()
   await db.conversations.clear()
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.split.test.tsx
+++ b/apps/frontend/src/components/board/board-card.split.test.tsx
@@ -184,7 +184,6 @@ beforeEach(async () => {
   await db.events.clear()
   await db.streams.clear()
   await db.conversations.clear()
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -210,7 +210,6 @@ beforeEach(async () => {
   __resetConversationMessageSnapshots()
   await db.conversations.clear()
   await db.streams.clear()
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -61,6 +61,7 @@ import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { useSplitThread } from "@/hooks/use-conversations"
 import { applySettlingAll, useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { useConversationBackfill } from "@/hooks/use-conversation-backfill"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
 import { LedgerRow } from "@/components/board/ledger-row"
@@ -139,6 +140,7 @@ export function BoardCard({
   onClearUnread,
 }: BoardCardProps) {
   const { conversation } = post
+  const conversationTitle = useConversationTitle(workspaceId, conversation)
   const flash = useBoardFlash(conversation.id)
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
@@ -1061,7 +1063,7 @@ export function BoardCard({
         workspaceId={workspaceId}
         conversationId={conversation.id}
         streamId={conversation.streamId}
-        topicSummary={conversation.topicSummary}
+        topicSummary={conversationTitle}
         status={conversation.status}
         triggerClassName="shrink-0"
       />
@@ -1151,7 +1153,7 @@ export function BoardCard({
                 to a small line beneath it. A message-led card (no topic) keeps the
                 locator AS the lead so it never grows a fake title. A resolved topic
                 reads muted with a marker; it also drops out of the Active lens. */}
-            {conversation.topicSummary ? (
+            {conversationTitle ? (
               <>
                 <div className="flex items-center gap-1.5">
                   {chevronToggle}
@@ -1164,7 +1166,7 @@ export function BoardCard({
                       conversation.status === "resolved" ? "font-medium text-muted-foreground" : "font-semibold"
                     )}
                   >
-                    {conversation.topicSummary}
+                    {conversationTitle}
                   </span>
                   {runningChip}
                   {massBadge}
@@ -1210,7 +1212,7 @@ export function BoardCard({
               </button>
             )}
           </div>
-          {conversation.topicSummary && (
+          {conversationTitle && (
             <div data-board-card-context-spacer aria-hidden className={cn("h-0 sm:hidden", headerStuck && "h-6")} />
           )}
 
@@ -1286,7 +1288,7 @@ export function BoardCard({
                 post={post}
                 hostStreamType={streamType}
                 openReplySignal={openReplySignal}
-                contextChip={conversation.topicSummary ?? contextLabel}
+                contextChip={conversationTitle ?? contextLabel}
                 // The conversation's most-recently-active stream — the latest displayed
                 // reply's own stream (a thread under the root), INCLUDING the viewer's own
                 // pending reply and any expand-backfilled rows, so a continuation follows

--- a/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
+++ b/apps/frontend/src/components/board/board-card.unread-divider.test.tsx
@@ -200,7 +200,6 @@ beforeEach(async () => {
     ...REPLY_IDS.map((id, i) => messageEvent(id, 10 + i, `Reply ${i + 1}.`)),
   ])
   await db.conversations.put(post())
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -146,7 +146,6 @@ beforeEach(() => {
   vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("mouse")
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({ preferences: undefined } as never)
   vi.spyOn(mentionablesModule, "useMentionStreamContext").mockReturnValue(undefined as never)
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue(undefined as never)
@@ -619,7 +618,6 @@ describe("InlineComposerForm compose trace", () => {
   it("measures against the streamId prop even when the host is absent from the workspace cache", async () => {
     // A thread host never appears in the workspace streams cache — resolving the
     // horizon there is what left branch and panel replies unmeasured.
-    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     composerStub.canSend = true
     render(<Capturing>{form({ onSubmit })}</Capturing>)

--- a/apps/frontend/src/components/board/board-removed-card.test.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.test.tsx
@@ -90,7 +90,6 @@ beforeEach(async () => {
   await db.events.clear()
   await db.conversations.clear()
   await db.streams.clear()
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-removed-card.test.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.test.tsx
@@ -127,7 +127,7 @@ afterEach(() => vi.restoreAllMocks())
 
 describe("BoardRemovedCard", () => {
   it("keeps the retained card's content and links into the successor", () => {
-    renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
+    renderCard({ conversationId: "conv_successor", streamId: "stream_1", topicSummary: "Deploy plan" })
 
     // The retained body still renders — the row holds its footprint.
     expect(screen.getByText("Opening body.")).toBeTruthy()
@@ -136,7 +136,11 @@ describe("BoardRemovedCard", () => {
   })
 
   it("offers no interactive affordance but the successor link", () => {
-    const { container } = renderCard({ conversationId: "conv_successor", topicSummary: "Deploy plan" })
+    const { container } = renderCard({
+      conversationId: "conv_successor",
+      streamId: "stream_1",
+      topicSummary: "Deploy plan",
+    })
 
     // The card underneath is `inert` — out of the a11y tree AND the tab order
     // (aria-hidden alone would satisfy role queries while leaving every button

--- a/apps/frontend/src/components/board/board-removed-card.tsx
+++ b/apps/frontend/src/components/board/board-removed-card.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom"
 import { BoardCard } from "@/components/board/board-card"
 import { usePanel, createConversationPanelId } from "@/contexts"
 import type { BoardViewPost, RemovedSuccessor } from "@/hooks/use-stable-board-view"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 
 interface BoardRemovedCardProps {
   workspaceId: string
@@ -35,6 +36,7 @@ export function BoardRemovedCard({
   emptyLabel = "No longer on your board.",
 }: BoardRemovedCardProps) {
   const { getPanelUrl } = usePanel()
+  const successorTitle = useConversationTitle(workspaceId, successor ?? { streamId: "", topicSummary: null })
 
   return (
     <div className="relative">
@@ -57,7 +59,7 @@ export function BoardRemovedCard({
                 to={getPanelUrl(createConversationPanelId(successor.conversationId))}
                 className="font-medium text-foreground underline-offset-2 hover:underline"
               >
-                {successor.topicSummary ?? "another conversation"}
+                {successorTitle ?? "another conversation"}
               </Link>
             </span>
           ) : (

--- a/apps/frontend/src/components/board/ledger-row.test.tsx
+++ b/apps/frontend/src/components/board/ledger-row.test.tsx
@@ -80,7 +80,6 @@ function renderRow(overrides: Partial<Parameters<typeof LedgerRow>[0]> = {}) {
 }
 
 beforeEach(() => {
-  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.test.tsx
@@ -21,11 +21,11 @@ const index = {
   threadsByAnchorId: new Map([["msg_fork_b", { id: "stream_thread_1" }]]),
 } as unknown as StreamStructuralIndex
 
-function makeGraph(): ConversationGraph {
+function makeGraph(topicSummary?: string): ConversationGraph {
   const branchPost = {
     id: "conv_branch",
     workspaceId,
-    conversation: { id: "conv_branch", streamId: "stream_thread_1", messageIds: ["msg_branch_1"] },
+    conversation: { id: "conv_branch", streamId: "stream_thread_1", messageIds: ["msg_branch_1"], topicSummary },
   }
   return {
     conversationByAnchorStreamId: new Map([["stream_thread_1", branchPost]]),
@@ -349,6 +349,29 @@ describe("useInlineBranchComposer panel arming (onArmBranchReply)", () => {
     )
     // Armed, not opened inline — the docked footer owns the editor.
     expect(result.current.openComposer).toBeNull()
+  })
+
+  it("arms a stashed branch with its effective inline title", async () => {
+    const draftId = await seedDraft("board:branch-reply:conv_branch")
+    renderHook(
+      () =>
+        useInlineBranchComposer({
+          workspaceId,
+          conversationId: PARENT_ID,
+          memberMessageIds: ["msg_fork", "msg_fork_b"],
+          index,
+          graph: makeGraph("[Auth redesign](https://example.com)"),
+          onArmBranchReply: onArmBranchReply as never,
+        }),
+      { wrapper: wrapperWithStash(draftId) }
+    )
+
+    await waitFor(() =>
+      expect(onArmBranchReply).toHaveBeenCalledWith(
+        { conversationId: "conv_branch", threadStreamId: "stream_thread_1", title: "Auth redesign" },
+        draftId
+      )
+    )
   })
 
   it("queueExistingBranchReply routes an existing-conversation directive into the branch thread", async () => {

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -6,6 +6,7 @@ import { useBoardSubtopicDraftIndex, useScopeDraftPreview, useStashParamDraftRow
 import type { SubtopicDraftEntry } from "@/hooks"
 import { rescopeScopeDrafts } from "@/hooks/use-draft-message"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { CollapsedComposerBar } from "@/components/composer/collapsed-composer-bar"
 import { createDraftPanelId } from "@/contexts"
 import { collectBranchThreadStreamIds } from "@/hooks/use-conversation-graph"
@@ -246,7 +247,11 @@ export function useInlineBranchComposer(params: {
           {
             conversationId: parsed.conversationId,
             threadStreamId,
-            title: branchPost?.conversation.topicSummary ?? "sub-topic",
+            title:
+              effectiveConversationTitle(
+                branchPost.conversation,
+                [...index.threadsByAnchorId.values()].find((stream) => stream.id === threadStreamId)
+              ) ?? "sub-topic",
           },
           stashTarget.draftId
         )

--- a/apps/frontend/src/components/board/use-move-to-subtopic.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.tsx
@@ -5,6 +5,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { useReassignConversationMessage } from "@/hooks/use-conversations"
 import { useBoardPosts } from "@/stores/board-store"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
 
 interface MoveTarget {
   conversationId: string
@@ -54,6 +56,15 @@ export function useMoveToSubtopic(params: {
     settling: boolean
   } | null>(null)
   const reassign = useReassignConversationMessage(workspaceId, conversation.streamId)
+  const streams = useWorkspaceStreams(workspaceId)
+  const titleFor = useCallback(
+    (item: { streamId: string; topicSummary: string | null }) =>
+      effectiveConversationTitle(
+        item,
+        streams.find((stream) => stream.id === item.streamId)
+      ),
+    [streams]
+  )
 
   // Every branch at any depth (sub-topics nest to depth 2 — a grandchild is as
   // valid a target as its parent; the server's one-root rule resolves any depth
@@ -95,10 +106,10 @@ export function useMoveToSubtopic(params: {
       .slice(0, SETTLING_SIBLING_TARGET_CAP)
       .map((post) => ({
         conversationId: post.conversation.id,
-        title: post.conversation.topicSummary ?? "Untitled topic",
+        title: titleFor(post.conversation) ?? "Untitled topic",
         kind: "main" as const,
       }))
-  }, [boardPosts, conversation.streamId, conversation.id])
+  }, [boardPosts, conversation.streamId, conversation.id, titleFor])
 
   const targetsFor = useCallback(
     (currentConversationId: string, settling = false): MoveTarget[] => {
@@ -107,7 +118,7 @@ export function useMoveToSubtopic(params: {
           ? [
               {
                 conversationId: conversation.id,
-                title: conversation.topicSummary ?? "Main topic",
+                title: titleFor(conversation) ?? "Main topic",
                 kind: "main" as const,
               },
             ]
@@ -120,7 +131,7 @@ export function useMoveToSubtopic(params: {
       const seen = new Set([currentConversationId, ...targets.map((t) => t.conversationId)])
       return [...targets, ...siblings.filter((s) => !seen.has(s.conversationId))]
     },
-    [conversation.id, conversation.topicSummary, branches, siblings]
+    [conversation, branches, siblings, titleFor]
   )
 
   // Ignore opens and picks while a move is already in flight (mirrors the

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { CircleCheck, Eye, EyeOff, EllipsisVertical, Pencil, RotateCcw, Sparkles } from "lucide-react"
-import { ConversationStatuses, MAX_CONVERSATION_TOPIC_LENGTH } from "@threa/types"
+import { ConversationStatuses, MAX_CONVERSATION_TOPIC_LENGTH, StreamTypes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -21,6 +21,9 @@ import {
 import { cn } from "@/lib/utils"
 import { useUpdateConversation, useHideConversation, useUnhideConversation } from "@/hooks/use-conversations"
 import { ConversationSplitDialog } from "./conversation-split-dialog"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
+import { useRenameStream } from "@/hooks/use-rename-stream"
 
 interface ConversationActionsMenuProps {
   workspaceId: string
@@ -59,6 +62,10 @@ export function ConversationActionsMenu({
   const [renameOpen, setRenameOpen] = useState(false)
   const [splitOpen, setSplitOpen] = useState(false)
   const update = useUpdateConversation(workspaceId)
+  const streams = useWorkspaceStreams(workspaceId)
+  const stream = streams.find((item) => item.id === streamId)
+  const isScratchpad = stream?.type === StreamTypes.SCRATCHPAD
+  const effectiveTitle = effectiveConversationTitle({ streamId: streamId ?? "", topicSummary }, stream)
   const hide = useHideConversation(workspaceId)
   const unhide = useUnhideConversation(workspaceId)
   const resolved = status === ConversationStatuses.RESOLVED
@@ -77,20 +84,27 @@ export function ConversationActionsMenu({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onSelect={(event) => {
-              // Close the menu explicitly and open the dialog. `preventDefault`
-              // stops Radix's own select-close (which returns focus to the
-              // trigger and can race the dialog); we drive the close via state so
-              // the menu can't linger open behind a dialog that doesn't steal focus.
-              event.preventDefault()
-              setMenuOpen(false)
-              setRenameOpen(true)
-            }}
-          >
-            <Pencil className="h-4 w-4" />
-            Rename topic…
-          </DropdownMenuItem>
+          {isScratchpad && streamId ? (
+            <ScratchpadRenameMenuItem
+              workspaceId={workspaceId}
+              streamId={streamId}
+              onSelect={() => {
+                setMenuOpen(false)
+                setRenameOpen(true)
+              }}
+            />
+          ) : (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault()
+                setMenuOpen(false)
+                setRenameOpen(true)
+              }}
+            >
+              <Pencil className="h-4 w-4" />
+              Rename topic…
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             onSelect={() =>
               update.mutate({
@@ -102,7 +116,7 @@ export function ConversationActionsMenu({
             {resolved ? <RotateCcw className="h-4 w-4" /> : <CircleCheck className="h-4 w-4" />}
             {resolved ? "Reopen" : "Mark resolved"}
           </DropdownMenuItem>
-          {streamId && (
+          {streamId && !isScratchpad && (
             <DropdownMenuItem
               onSelect={(event) => {
                 event.preventDefault()
@@ -121,13 +135,24 @@ export function ConversationActionsMenu({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <RenameConversationDialog
-        open={renameOpen}
-        onOpenChange={setRenameOpen}
-        initialTopic={topicSummary ?? ""}
-        onSave={(next) => update.mutate({ conversationId, topicSummary: next })}
-      />
-      {streamId && (
+      {isScratchpad && streamId ? (
+        <ScratchpadRenameDialog
+          workspaceId={workspaceId}
+          streamId={streamId}
+          open={renameOpen}
+          onOpenChange={setRenameOpen}
+          initialTopic={effectiveTitle ?? ""}
+        />
+      ) : (
+        <RenameConversationDialog
+          open={renameOpen}
+          onOpenChange={setRenameOpen}
+          initialTopic={effectiveTitle ?? ""}
+          title="Rename topic"
+          onSave={(next) => update.mutateAsync({ conversationId, topicSummary: next }).then(() => undefined)}
+        />
+      )}
+      {streamId && !isScratchpad && (
         <ConversationSplitDialog
           workspaceId={workspaceId}
           streamId={streamId}
@@ -140,15 +165,53 @@ export function ConversationActionsMenu({
   )
 }
 
+function ScratchpadRenameMenuItem(props: { workspaceId: string; streamId: string; onSelect: () => void }) {
+  const renameStream = useRenameStream(props.workspaceId, props.streamId)
+  return (
+    <DropdownMenuItem
+      disabled={!renameStream.canRename}
+      onSelect={(event) => {
+        event.preventDefault()
+        props.onSelect()
+      }}
+    >
+      <Pencil className="h-4 w-4" />
+      Rename scratchpad…
+    </DropdownMenuItem>
+  )
+}
+
+function ScratchpadRenameDialog(props: {
+  workspaceId: string
+  streamId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialTopic: string
+}) {
+  const renameStream = useRenameStream(props.workspaceId, props.streamId)
+  return (
+    <RenameConversationDialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      initialTopic={props.initialTopic}
+      title="Rename scratchpad"
+      onSave={renameStream.rename}
+    />
+  )
+}
+
 interface RenameConversationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   initialTopic: string
-  onSave: (topic: string) => void
+  onSave: (topic: string) => Promise<void>
+  title: string
 }
 
-function RenameConversationDialog({ open, onOpenChange, initialTopic, onSave }: RenameConversationDialogProps) {
+function RenameConversationDialog({ open, onOpenChange, initialTopic, onSave, title }: RenameConversationDialogProps) {
   const [value, setValue] = useState(initialTopic)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   // Re-seed only on an open transition (a different card, or a re-open after
   // cancel) — NOT whenever `initialTopic` changes, so a concurrent rename landing
   // via the live query while you're typing doesn't wipe your in-progress input.
@@ -161,17 +224,25 @@ function RenameConversationDialog({ open, onOpenChange, initialTopic, onSave }: 
   const trimmed = value.trim()
   const canSave = trimmed.length > 0 && trimmed !== initialTopic.trim()
 
-  const save = () => {
-    if (!canSave) return
-    onSave(trimmed)
-    onOpenChange(false)
+  const save = async () => {
+    if (!canSave || isSaving) return
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await onSave(trimmed)
+      onOpenChange(false)
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Failed to rename")
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   return (
     <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
       <ResponsiveDialogContent>
         <ResponsiveDialogHeader>
-          <ResponsiveDialogTitle>Rename topic</ResponsiveDialogTitle>
+          <ResponsiveDialogTitle>{title}</ResponsiveDialogTitle>
         </ResponsiveDialogHeader>
         <ResponsiveDialogBody>
           <Input
@@ -182,18 +253,19 @@ function RenameConversationDialog({ open, onOpenChange, initialTopic, onSave }: 
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault()
-                save()
+                void save()
               }
             }}
             placeholder="Topic name"
           />
+          {saveError && <p className="text-sm text-destructive">{saveError}</p>}
         </ResponsiveDialogBody>
         <ResponsiveDialogFooter>
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={save} disabled={!canSave}>
-            Save
+          <Button onClick={() => void save()} disabled={!canSave || isSaving}>
+            {isSaving ? "Saving…" : "Save"}
           </Button>
         </ResponsiveDialogFooter>
       </ResponsiveDialogContent>

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -10,6 +10,7 @@ import { RelativeTime } from "@/components/relative-time"
 import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { useActors } from "@/hooks"
 import { conversationKeys } from "@/hooks/use-conversations"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import type { AuthorType, ConversationWithStaleness, Message } from "@threa/types"
 
 interface ConversationItemProps {
@@ -29,7 +30,8 @@ export function ConversationItem({
   onMessageClick,
   className,
 }: ConversationItemProps) {
-  const { topicSummary, messageIds, lastActivityAt } = conversation
+  const { messageIds, lastActivityAt } = conversation
+  const title = useConversationTitle(workspaceId, conversation)
   const { openPanel } = usePanel()
 
   return (
@@ -51,7 +53,7 @@ export function ConversationItem({
                     <ChevronRight className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
                   )}
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{topicSummary || "Untitled conversation"}</p>
+                    <p className="text-sm font-medium truncate">{title || "Untitled conversation"}</p>
                     <span className="mt-1 block text-xs text-muted-foreground">
                       {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
                     </span>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -73,6 +73,7 @@ import { useStashedDrafts } from "@/hooks/use-stashed-drafts"
 import { boardReplyDraftKey, boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import { usePanel, parseConversationPanel, useSidebar, useCoordinatedPhase, type CoordinatedPhase } from "@/contexts"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { consumeConversationReplyOpen, subscribeConversationReplyOpen } from "@/stores/conversation-reply-open-store"
@@ -185,6 +186,7 @@ function ConversationPanelHeader({
   onClose,
 }: ConversationPanelHeaderProps) {
   const ContextGlyph = (hostStreamType && TYPE_GLYPH[hostStreamType]) || MessageSquareText
+  const effectiveTitle = useConversationTitle(workspaceId, post?.conversation ?? { streamId: "", topicSummary: null })
   const revealed = phase === "ready" && post !== null
   return (
     <SidePanelHeader>
@@ -207,7 +209,7 @@ function ConversationPanelHeader({
             {/* The topic is the conversation's identity — show it when set, falling
                 back to the stream locator (the pre-topic behavior). */}
             <span className={cn("truncate", post.conversation.status === "resolved" && "text-muted-foreground")}>
-              {post.conversation.topicSummary ?? locator}
+              {effectiveTitle ?? locator}
             </span>
             <RelativeTime
               date={post.conversation.lastActivityAt}
@@ -227,7 +229,7 @@ function ConversationPanelHeader({
           workspaceId={workspaceId}
           conversationId={post.conversation.id}
           streamId={post.conversation.streamId}
-          topicSummary={post.conversation.topicSummary}
+          topicSummary={effectiveTitle}
           status={post.conversation.status}
           isHidden={isHidden}
           triggerClassName="shrink-0"

--- a/apps/frontend/src/components/editor/conversation-chip-label.test.ts
+++ b/apps/frontend/src/components/editor/conversation-chip-label.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { conversationChipLabel } from "./conversation-chip-label"
+
+describe("conversationChipLabel", () => {
+  it.each([
+    [true, "Loading encrypted conversation"],
+    [false, "Encrypted conversation"],
+  ])("never falls back to legacy attrs.name for an E2E link (pending=%s)", (pending, expected) => {
+    expect(
+      conversationChipLabel({
+        accessTier: "full",
+        resolvedName: null,
+        isE2e: true,
+        pending,
+      })
+    ).toBe(expected)
+  })
+
+  it("uses a generic label until a privacy-safe non-E2E title resolves", () => {
+    expect(
+      conversationChipLabel({
+        accessTier: "full",
+        resolvedName: null,
+        isE2e: false,
+        pending: false,
+      })
+    ).toBe("Conversation")
+  })
+})

--- a/apps/frontend/src/components/editor/conversation-chip-label.ts
+++ b/apps/frontend/src/components/editor/conversation-chip-label.ts
@@ -1,0 +1,16 @@
+interface ConversationChipLabelInput {
+  accessTier: "full" | "private" | "cross_workspace" | null | undefined
+  resolvedName: string | null
+  isE2e: boolean
+  pending: boolean
+}
+
+export function conversationChipLabel(input: ConversationChipLabelInput): string {
+  if (input.accessTier === "cross_workspace") return "Another workspace"
+  if (input.accessTier === "private") return "Private conversation"
+  if (input.resolvedName) return input.resolvedName
+  if (input.accessTier === "full" && input.isE2e) {
+    return input.pending ? "Loading encrypted conversation" : "Encrypted conversation"
+  }
+  return "Conversation"
+}

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -5,8 +5,9 @@ import { useParams } from "react-router-dom"
 import { InAppLinkChip } from "@/components/in-app-link/in-app-link-chip"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
-import { useConversationTitle } from "@/hooks/use-conversation-title"
+import { useConversationTitleDetails } from "@/hooks/use-conversation-title"
 import type { InAppLinkAttrs } from "./in-app-link-extension"
+import { conversationChipLabel } from "./conversation-chip-label"
 
 /**
  * In-composer chip for an in-app link (TipTap NodeView). A conversation link has
@@ -89,11 +90,11 @@ function ConversationChipView({
 }) {
   const { data } = useResolvedInAppLink(workspaceId, undefined, attrs.url, true)
   const conversation = data?.kind === "conversation" ? data : null
-  const effectiveTitle = useConversationTitle(workspaceId, {
+  const titleDetails = useConversationTitleDetails(workspaceId, {
     streamId: conversation?.streamId ?? "",
     topicSummary: conversation?.topicSummary ?? null,
   })
-  const resolvedName = conversation?.accessTier === "full" ? effectiveTitle : null
+  const resolvedName = conversation?.accessTier === "full" ? titleDetails.title : null
 
   useEffect(() => {
     if (resolvedName && !attrs.name) {
@@ -102,16 +103,14 @@ function ConversationChipView({
   }, [resolvedName, attrs.name, updateAttributes])
 
   let icon = MessagesSquare
-  let label = attrs.name || "Conversation"
-  if (data?.accessTier === "cross_workspace") {
-    icon = Globe
-    label = "Another workspace"
-  } else if (data?.accessTier === "private") {
-    icon = Lock
-    label = "Private conversation"
-  } else if (resolvedName) {
-    label = resolvedName
-  }
+  if (data?.accessTier === "cross_workspace") icon = Globe
+  else if (data?.accessTier === "private" || (conversation?.accessTier === "full" && titleDetails.isE2e)) icon = Lock
+  const label = conversationChipLabel({
+    accessTier: data?.accessTier,
+    resolvedName,
+    isE2e: titleDetails.isE2e,
+    pending: titleDetails.pending,
+  })
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom"
 import { InAppLinkChip } from "@/components/in-app-link/in-app-link-chip"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import type { InAppLinkAttrs } from "./in-app-link-extension"
 
 /**
@@ -87,8 +88,12 @@ function ConversationChipView({
   updateAttributes: (attrs: Record<string, unknown>) => void
 }) {
   const { data } = useResolvedInAppLink(workspaceId, undefined, attrs.url, true)
-
-  const resolvedName = data?.kind === "conversation" && data.accessTier === "full" ? (data.topicSummary ?? null) : null
+  const conversation = data?.kind === "conversation" ? data : null
+  const effectiveTitle = useConversationTitle(workspaceId, {
+    streamId: conversation?.streamId ?? "",
+    topicSummary: conversation?.topicSummary ?? null,
+  })
+  const resolvedName = conversation?.accessTier === "full" ? effectiveTitle : null
 
   useEffect(() => {
     if (resolvedName && !attrs.name) {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -5,6 +5,8 @@ import { resolveInternalAppPath } from "@/lib/internal-url"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import { InAppLinkChip } from "./in-app-link-chip"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
 
 /**
  * Posted-message rendering of an in-app stream/message link: the same chip the
@@ -68,6 +70,7 @@ export function InAppLinkInline({
 export function ConversationLinkInline({ href, workspaceId }: { href: string; workspaceId: string }) {
   const navigate = useNavigate()
   const { data } = useResolvedInAppLink(workspaceId, undefined, href, true)
+  const streams = useWorkspaceStreams(workspaceId)
 
   if (data?.accessTier === "cross_workspace") {
     return <InAppLinkChip icon={Globe} label="Another workspace" />
@@ -76,7 +79,13 @@ export function ConversationLinkInline({ href, workspaceId }: { href: string; wo
     return <InAppLinkChip icon={Lock} label="Private conversation" />
   }
 
-  const label = (data?.kind === "conversation" && data.topicSummary) || "Conversation"
+  const label =
+    data?.kind === "conversation"
+      ? effectiveConversationTitle(
+          { streamId: data.streamId ?? "", topicSummary: data.topicSummary ?? null },
+          streams.find((stream) => stream.id === data.streamId)
+        ) || "Conversation"
+      : "Conversation"
   const chip = <InAppLinkChip icon={MessagesSquare} label={label} />
 
   const internalPath = resolveInternalAppPath(href)

--- a/apps/frontend/src/components/stream-settings/general-tab.rename.test.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.rename.test.tsx
@@ -102,7 +102,7 @@ describe("GeneralTab display-name rename (stream settings surface)", () => {
     const stream = encryptedScratchpad()
     const update = vi.fn().mockResolvedValue({ ...stream, displayName: null, sealedNameCiphertext: "Y3Q=" })
 
-    renderTab(stream, update)
+    const view = renderTab(stream, update)
 
     await userEvent.type(screen.getByPlaceholderText("Scratchpad name"), "Therapy notes")
     await userEvent.click(screen.getByRole("button", { name: /save/i }))
@@ -116,6 +116,7 @@ describe("GeneralTab display-name rename (stream settings surface)", () => {
     expect(update.mock.calls[0]![2]).not.toHaveProperty("displayName")
     // The new name is immediately resolvable on this device (no re-decrypt flicker).
     expect(getCachedStreamName(streamNameCacheKey(WS, stream.id, "Y3Q="))).toBe("Therapy notes")
+    view.unmount()
   })
 
   it("makes the field read-only and never updates while the session is locked", async () => {
@@ -124,7 +125,7 @@ describe("GeneralTab display-name rename (stream settings surface)", () => {
     const sealSpy = vi.spyOn(messageEnvelope, "sealStreamName")
 
     const update = vi.fn()
-    renderTab(encryptedScratchpad(), update)
+    const view = renderTab(encryptedScratchpad(), update)
 
     const input = screen.getByPlaceholderText("Scratchpad name")
     expect(input).toBeDisabled()
@@ -132,5 +133,6 @@ describe("GeneralTab display-name rename (stream settings surface)", () => {
     expect(screen.queryByRole("button", { name: /save/i })).not.toBeInTheDocument()
     expect(update).not.toHaveBeenCalled()
     expect(sealSpy).not.toHaveBeenCalled()
+    view.unmount()
   })
 })

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -20,9 +20,7 @@ import { ChannelSlugInput } from "./channel-slug-input"
 import { DescriptionSection } from "./description-section"
 import { getStreamName } from "@/lib/streams"
 import { useUpdateStream, useArchiveStream, useUnarchiveStream, useSetNotificationLevel } from "@/hooks"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useE2eSession } from "@/stores/e2e-session-store"
-import { sealStreamRename } from "@/lib/crypto/stream-rename"
+import { useRenameStream } from "@/hooks/use-rename-stream"
 import {
   StreamTypes,
   Visibilities,
@@ -334,29 +332,17 @@ function SlugSection({ workspaceId, stream }: { workspaceId: string; stream: Str
 
 function DisplayNameSection({ workspaceId, stream }: { workspaceId: string; stream: Stream }) {
   const [name, setName] = useState(stream.displayName ?? "")
-  const updateMutation = useUpdateStream(workspaceId, stream.id)
+  const renameStream = useRenameStream(workspaceId, stream.id, stream)
   const hasChanged = name !== (stream.displayName ?? "")
-
-  // An E2E scratchpad's name is sealed-only — renaming seals the new name under
-  // the stream key and never writes plaintext (INV-E1), so it needs an unlocked
-  // session. While locked the field is read-only and points the user at unlock.
-  const isEncrypted = !!stream.e2eEnabled
-  const currentUserId = useWorkspaceUserId(workspaceId)
-  const e2eUnlocked = useE2eSession(workspaceId, currentUserId ?? "").status === "unlocked"
-  const locked = isEncrypted && !e2eUnlocked
+  const locked = !renameStream.canRename
 
   const handleSave = async () => {
     const trimmed = name.trim()
     if (!trimmed || !hasChanged || locked) return
     try {
-      const data = isEncrypted
-        ? await sealStreamRename({ workspaceId, streamId: stream.id, userId: currentUserId ?? "", name: trimmed })
-        : { displayName: trimmed }
-      updateMutation.mutate(data, {
-        onError: () => toast.error("Failed to update name"),
-      })
-    } catch {
-      toast.error("Unlock this scratchpad to rename it")
+      await renameStream.rename(trimmed)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update name")
     }
   }
 
@@ -372,8 +358,8 @@ function DisplayNameSection({ workspaceId, stream }: { workspaceId: string; stre
       />
       {locked && <p className="text-xs text-muted-foreground">Unlock this scratchpad to rename it.</p>}
       {hasChanged && !locked && (
-        <Button size="sm" onClick={handleSave} disabled={!name.trim() || updateMutation.isPending}>
-          {updateMutation.isPending ? "Saving..." : "Save"}
+        <Button size="sm" onClick={() => void handleSave()} disabled={!name.trim() || renameStream.isPending}>
+          {renameStream.isPending ? "Saving..." : "Save"}
         </Button>
       )}
     </div>

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -21,6 +21,8 @@ import {
   type ConversationRowAnnotation,
 } from "./model"
 import { ConversationOverlayRowProvider } from "./row-context"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
 
 /**
  * Floating panel listing the conversations that currently have message rows
@@ -53,6 +55,12 @@ export function ConversationOverlayPanel({
   topBarOpen?: boolean
 }) {
   const isMobile = useIsMobile()
+  const streams = useWorkspaceStreams(workspaceId)
+  const titleFor = (conversation: ConversationWithStaleness) =>
+    effectiveConversationTitle(
+      conversation,
+      streams.find((stream) => stream.id === conversation.streamId)
+    )
   // Collapsed by default on mobile; the user's explicit choice wins once made.
   const [userCollapsed, setUserCollapsed] = useState<boolean | null>(null)
   const collapsed = userCollapsed ?? isMobile
@@ -136,7 +144,7 @@ export function ConversationOverlayPanel({
                       type="button"
                       onClick={() => onToggleFocus(conversation.id)}
                       aria-pressed={isFocused}
-                      title={conversation.topicSummary ?? undefined}
+                      title={titleFor(conversation) ?? undefined}
                       className={cn(
                         "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
                         isFocused && "font-medium"
@@ -148,7 +156,7 @@ export function ConversationOverlayPanel({
                         style={{ backgroundColor: conversationColor(colorIndex) }}
                       />
                       <span className="min-w-0 flex-1 truncate">
-                        {conversation.topicSummary || "Untitled conversation"}
+                        {titleFor(conversation) || "Untitled conversation"}
                       </span>
                       <span className="shrink-0 tabular-nums text-muted-foreground">
                         {conversation.messageIds.length}
@@ -228,6 +236,7 @@ export function ConversationOverlayRow({
   annotation,
   messageId,
   messageCreatedAt,
+  workspaceId = "",
   selectionActive = false,
   children,
 }: {
@@ -235,12 +244,19 @@ export function ConversationOverlayRow({
   annotation: ConversationRowAnnotation
   messageId: string
   messageCreatedAt: string
+  workspaceId?: string
   /** While a split selection is active the row is a selection toggle; the
    *  single-message correction swatch is hidden so it can't intercept the tap. */
   selectionActive?: boolean
   children: ReactNode
 }) {
   const { model, focusedConversationId, onReassignMessage, pendingMessageIds, observeRow } = overlay
+  const streams = useWorkspaceStreams(workspaceId)
+  const titleFor = (item: ConversationWithStaleness) =>
+    effectiveConversationTitle(
+      item,
+      streams.find((stream) => stream.id === item.streamId)
+    )
   const conversation = annotation.conversationId ? model.conversationsById.get(annotation.conversationId) : undefined
   const conversationId = conversation?.id ?? null
   const colorIndex = conversation ? (model.colorIndexById.get(conversation.id) ?? 0) : null
@@ -293,7 +309,7 @@ export function ConversationOverlayRow({
           // panel already carry the grouping.
           <span
             data-testid="conversation-block-chip"
-            title={conversation.topicSummary ?? undefined}
+            title={titleFor(conversation) ?? undefined}
             className={cn(
               "pointer-events-none absolute right-4 top-1.5 z-[5]",
               "hidden max-w-[40%] items-center gap-1.5 rounded-full border px-2 py-0.5 min-[1120px]:inline-flex",
@@ -310,7 +326,7 @@ export function ConversationOverlayRow({
               className="h-1.5 w-1.5 shrink-0 rounded-full"
               style={{ backgroundColor: conversationColor(colorIndex) }}
             />
-            <span className="truncate">{conversation.topicSummary || "Untitled conversation"}</span>
+            <span className="truncate">{titleFor(conversation) || "Untitled conversation"}</span>
           </span>
         )}
         {!selectionActive && (
@@ -359,7 +375,7 @@ export function ConversationOverlayRow({
                       className="h-2 w-2 shrink-0 rounded-full"
                       style={{ backgroundColor: conversationColor(candidateColorIndex) }}
                     />
-                    <span className="flex-1 truncate">{candidate.topicSummary || "Untitled conversation"}</span>
+                    <span className="flex-1 truncate">{titleFor(candidate) || "Untitled conversation"}</span>
                     <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                       {candidate.messageIds.length}
                     </span>
@@ -397,6 +413,7 @@ export function ConversationPickerDrawer({
   annotation,
   messageId,
   messageCreatedAt,
+  workspaceId = "",
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -404,7 +421,14 @@ export function ConversationPickerDrawer({
   annotation: ConversationRowAnnotation
   messageId: string
   messageCreatedAt: string
+  workspaceId?: string
 }) {
+  const streams = useWorkspaceStreams(workspaceId)
+  const titleFor = (item: ConversationWithStaleness) =>
+    effectiveConversationTitle(
+      item,
+      streams.find((stream) => stream.id === item.streamId)
+    )
   const { model, onReassignMessage, pendingMessageIds } = overlay
   // Mirror the rail swatch menu: ignore picks while this message's
   // reassignment is already in flight, so rapid taps can't enqueue
@@ -442,7 +466,7 @@ export function ConversationPickerDrawer({
                   className="h-2.5 w-2.5 shrink-0 rounded-full"
                   style={{ backgroundColor: conversationColor(colorIndex) }}
                 />
-                <span className="min-w-0 flex-1 truncate">{candidate.topicSummary || "Untitled conversation"}</span>
+                <span className="min-w-0 flex-1 truncate">{titleFor(candidate) || "Untitled conversation"}</span>
                 <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                   {candidate.messageIds.length}
                 </span>

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -277,7 +277,12 @@ describe("annotateConversationRevivals", () => {
     expect(revivals(items, membership)).toEqual([
       null,
       null,
-      { conversationId: "conv_a", topicSummary: "Pizza", previousActivityAt: "2026-06-01T00:00:00.000Z" },
+      {
+        conversationId: "conv_a",
+        streamId: "stream_123",
+        topicSummary: "Pizza",
+        previousActivityAt: "2026-06-01T00:00:00.000Z",
+      },
     ])
   })
 
@@ -322,6 +327,7 @@ describe("annotateConversationRevivals", () => {
     expect(result[3]).toBeNull()
     expect(result[4]).toEqual({
       conversationId: "conv_a",
+      streamId: "stream_123",
       topicSummary: "Pizza",
       previousActivityAt: "2026-06-01T00:00:00.000Z",
     })

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -116,6 +116,7 @@ export function buildMessageConversationMap(conversations: ConversationWithStale
 export interface ConversationRevival {
   /** Conversation to open when the chip is tapped (`conv:<id>` panel). */
   conversationId: string
+  streamId: string
   /** Topic label for the chip; null falls back to a generic label. */
   topicSummary: string | null
   /**

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -401,13 +401,24 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(items[2])).toEqual({
       conversationId: "conv_x",
+      streamId: "",
       topicSummary: null,
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
     // Every block start chips now — A and B each open their conversation for
     // the first time locally, so both chip too, just with no time to show.
-    expect(revivalOf(items[0])).toEqual({ conversationId: "conv_x", topicSummary: null, previousActivityAt: undefined })
-    expect(revivalOf(items[1])).toEqual({ conversationId: "conv_y", topicSummary: null, previousActivityAt: undefined })
+    expect(revivalOf(items[0])).toEqual({
+      conversationId: "conv_x",
+      streamId: "",
+      topicSummary: null,
+      previousActivityAt: undefined,
+    })
+    expect(revivalOf(items[1])).toEqual({
+      conversationId: "conv_y",
+      streamId: "",
+      topicSummary: null,
+      previousActivityAt: undefined,
+    })
   })
 
   it("resolves the topic label from the conversation list when it has loaded", () => {
@@ -437,6 +448,7 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(items[2])).toEqual({
       conversationId: "conv_x",
+      streamId: "",
       topicSummary: "Pizza",
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
@@ -465,6 +477,7 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(items[2])).toEqual({
       conversationId: "conv_successor",
+      streamId: "",
       topicSummary: "Pizza",
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
@@ -501,6 +514,7 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(annotated[1])).toEqual({
       conversationId: "conv_x",
+      streamId: "",
       topicSummary: null,
       previousActivityAt: undefined,
     })
@@ -511,6 +525,7 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(annotated[2])).toEqual({
       conversationId: "conv_x",
+      streamId: "",
       topicSummary: null,
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
@@ -535,6 +550,7 @@ describe("annotateConversationRevivals", () => {
 
     expect(revivalOf(annotated[0])).toEqual({
       conversationId: "conv_x",
+      streamId: "",
       topicSummary: null,
       previousActivityAt: undefined,
     })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -300,6 +300,7 @@ export function annotateConversationRevivals(
       if (blockStart && (isDeclared || seen.has(conversationId))) {
         revival = {
           conversationId,
+          streamId: conversationsById.get(conversationId)?.streamId ?? "",
           topicSummary: conversationsById.get(conversationId)?.topicSummary ?? null,
           previousActivityAt: lastActivityByConversation.get(conversationId),
         }
@@ -844,6 +845,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
           annotation={item.conversationRow}
           messageId={overlayMessageId}
           messageCreatedAt={item.event.createdAt}
+          workspaceId={ctx.workspaceId}
           // Split-select keeps the overlay mounted for its coloring, but the row
           // is a selection toggle then — hide the single-message correction swatch
           // so it can't steal the tap (it renders outside the row's `inert` slot).

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -21,6 +21,7 @@ import { actorTypeFromId } from "@/hooks/use-actors"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import { DELEGATION_STATUS_LABEL, delegationStatusPillClass } from "@/lib/delegation-display"
 import { AccentGlow } from "./link-preview-primitives"
 import { linkPreviewsApi } from "@/api"
@@ -449,6 +450,10 @@ function ConversationLinkCard({
   reserve: boolean
   onDismiss?: () => void
 }) {
+  const effectiveTitle = useConversationTitle(workspaceId, {
+    streamId: data.streamId ?? "",
+    topicSummary: data.topicSummary ?? null,
+  })
   if (data.accessTier === "cross_workspace") {
     return (
       <MinimalCard
@@ -491,7 +496,7 @@ function ConversationLinkCard({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <h4 className="truncate text-sm font-semibold leading-snug text-foreground">
-              {data.topicSummary ?? "Conversation"}
+              {effectiveTitle ?? "Conversation"}
             </h4>
             {conversationStatusBadge(data.status)}
           </div>

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -203,6 +203,7 @@ describe("MessageEvent", () => {
           streamId={streamId}
           revival={{
             conversationId: "conv_a",
+            streamId: "stream_1",
             topicSummary: "Pizza",
             previousActivityAt: "2026-06-01T00:00:00.000Z",
           }}
@@ -233,6 +234,7 @@ describe("MessageEvent", () => {
           groupContinuation
           revival={{
             conversationId: "conv_a",
+            streamId: "stream_1",
             topicSummary: "Pizza",
             previousActivityAt: "2026-06-01T00:00:00.000Z",
           }}
@@ -251,7 +253,12 @@ describe("MessageEvent", () => {
           event={event}
           workspaceId={workspaceId}
           streamId={streamId}
-          revival={{ conversationId: "conv_a", topicSummary: "Pizza", previousActivityAt: undefined }}
+          revival={{
+            conversationId: "conv_a",
+            streamId: "stream_1",
+            topicSummary: "Pizza",
+            previousActivityAt: undefined,
+          }}
         />,
         { wrapper: Wrapper }
       )

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -43,6 +43,7 @@ import { Link, useLocation, useNavigate } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { useLongPress } from "@/hooks/use-long-press"
 import { AttachmentList } from "./attachment-list"
@@ -291,10 +292,10 @@ function MessageLinkPreviews({
  * not Ariadne's structural gold line. The topic label mirrors the overlay's
  * `topicSummary || fallback` rendering.
  */
-function ConversationProvenanceChip({ revival }: { revival: ConversationRevival }) {
+function ConversationProvenanceChip({ revival, workspaceId }: { revival: ConversationRevival; workspaceId: string }) {
   const { getPanelUrl } = usePanel()
   const href = getPanelUrl(createConversationPanelId(revival.conversationId))
-  const topic = revival.topicSummary || "an earlier conversation"
+  const topic = useConversationTitle(workspaceId, revival) || "an earlier conversation"
   return (
     <Link
       to={href}
@@ -1299,7 +1300,7 @@ function SentMessageEvent({
   } else {
     footerContent = (
       <>
-        {revival && <ConversationProvenanceChip revival={revival} />}
+        {revival && <ConversationProvenanceChip revival={revival} workspaceId={workspaceId} />}
         {payload.reactions && Object.keys(payload.reactions).length > 0 && (
           <MessageReactions
             reactions={payload.reactions}
@@ -1569,6 +1570,7 @@ function SentMessageEvent({
           annotation={conversationOverlayRow.annotation}
           messageId={payload.messageId}
           messageCreatedAt={event.createdAt}
+          workspaceId={workspaceId}
         />
       )}
     </>

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -42,6 +42,7 @@ import { useComposerCommandSend } from "@/components/composer/use-composer-comma
 import type { JSONContent } from "@threa/types"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { ComposerEncryptionNotice } from "@/components/encryption/stream-encryption-affordance"
+import { useConversationTitle } from "@/hooks/use-conversation-title"
 
 interface MessageInputProps {
   workspaceId: string
@@ -327,7 +328,10 @@ function MessageInputComponent({
     workspaceId,
     conversationReply?.conversationId ?? null
   )
-  const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
+  const conversationReplyTopic = useConversationTitle(
+    workspaceId,
+    conversationReplyPost?.conversation ?? { streamId: "", topicSummary: null }
+  )
   const conversationReplyLastActiveStreamId = conversationReplyPost
     ? boardPostLastActiveStreamId(conversationReplyPost)
     : null

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -46,6 +46,7 @@ import {
   useWorkspaceStreamReadStates,
 } from "@/stores/workspace-store"
 import { resolveFrontierEventId, resolveFrontierSequence } from "@/lib/read-frontier"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { useUser } from "@/auth"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"
@@ -2524,6 +2525,7 @@ export function StreamContent({
                       (batchIntent === "splitConversation" ? (
                         <SplitSelectionBar
                           count={selectedMessageIds.size}
+                          workspaceId={workspaceId}
                           conversations={conversationOverlay?.model.conversations ?? streamConversations}
                           colorIndexById={conversationOverlay?.model.colorIndexById}
                           busy={isSplitting}
@@ -3475,6 +3477,7 @@ function BatchSelectionBar({ count, onCancel }: { count: number; onCancel: () =>
  */
 function SplitSelectionBar({
   count,
+  workspaceId,
   conversations,
   colorIndexById,
   busy,
@@ -3483,6 +3486,7 @@ function SplitSelectionBar({
   onCancel,
 }: {
   count: number
+  workspaceId: string
   conversations: ConversationWithStaleness[]
   colorIndexById?: ReadonlyMap<string, number>
   busy: boolean
@@ -3491,6 +3495,7 @@ function SplitSelectionBar({
   onCancel: () => void
 }) {
   const disabled = count === 0 || busy
+  const streams = useWorkspaceStreams(workspaceId)
 
   return (
     <div
@@ -3551,7 +3556,12 @@ function SplitSelectionBar({
                   className="h-2.5 w-2.5 shrink-0 rounded-full"
                   style={{ backgroundColor: conversationColor(colorIndexById?.get(conversation.id) ?? 0) }}
                 />
-                <span className="min-w-0 flex-1 truncate">{conversation.topicSummary || "Untitled conversation"}</span>
+                <span className="min-w-0 flex-1 truncate">
+                  {effectiveConversationTitle(
+                    conversation,
+                    streams.find((stream) => stream.id === conversation.streamId)
+                  ) || "Untitled conversation"}
+                </span>
                 <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                   {conversation.messageIds.length}
                 </span>

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -18,6 +18,7 @@ import { purgeScopeDrafts } from "./use-draft-message"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { useDecryptedDraftPreviews, type DraftPreview, type DraftPreviewInput } from "./use-decrypted-draft-previews"
 
 export type DraftType = "scratchpad" | "channel" | "dm" | "thread"
@@ -255,7 +256,8 @@ function resolveBoardDraftLocation(
   if (parsed.kind === "subtopic") {
     const host = subtopicHostByMessageId.get(parsed.messageId)
     const stream = streamMap.get(parsed.streamId)
-    const context = host?.conversation.topicSummary ?? (stream ? streamLabel(stream, "sidebar") : null)
+    let context = stream ? streamLabel(stream, "sidebar") : null
+    if (host) context = effectiveConversationTitle(host.conversation, streamMap.get(host.conversation.streamId))
     const displayName = context ? `New sub-topic in ${context}` : "New sub-topic"
     return {
       draftType: streamDraftType(stream),
@@ -272,7 +274,8 @@ function resolveBoardDraftLocation(
   const post = boardPostMap.get(parsed.conversationId)
   const anchorStreamId = post?.conversation.streamId ?? null
   const stream = anchorStreamId ? streamMap.get(anchorStreamId) : undefined
-  const target = post?.conversation.topicSummary ?? (stream ? streamLabel(stream, "sidebar") : null)
+  let target = stream ? streamLabel(stream, "sidebar") : null
+  if (post) target = effectiveConversationTitle(post.conversation, streamMap.get(post.conversation.streamId))
   const displayName = target ? `Reply in ${target}` : "Conversation reply"
   const shared = { draftType: streamDraftType(stream), streamId: anchorStreamId, displayName, groupLabel: displayName }
 

--- a/apps/frontend/src/hooks/use-conversation-graph.test.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.test.ts
@@ -177,7 +177,7 @@ describe("useStreamStructuralIndex — anchor-keyed thread map", () => {
       // Card anchor — a board branch never forks off a card, so it's excluded.
       threadStream("t_card", { parentAnchorId: "event_c", parentMessageId: null }),
     ]
-    vi.spyOn(workspaceStore, "useWorkspaceStreamsRaw").mockReturnValue(streams)
+    vi.spyOn(workspaceStore, "useWorkspaceStreams").mockReturnValue(streams)
 
     const { result } = renderHook(() => useStreamStructuralIndex("ws_1"))
     const map = result.current.threadsByAnchorId

--- a/apps/frontend/src/hooks/use-conversation-graph.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.ts
@@ -2,9 +2,9 @@ import { useCallback, useSyncExternalStore } from "react"
 import { liveQuery, type Subscription } from "dexie"
 import { StreamTypes } from "@threa/types"
 import { db, type CachedBoardPost, type CachedStream } from "@/db"
-import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { streamLabel } from "@/lib/streams"
-import { stripMarkdownToInline } from "@/lib/markdown/strip"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
 import type { RenderableMessage } from "@/components/message/message-item"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 import { applySettlingAll } from "@/hooks/use-board-card-messages"
@@ -168,7 +168,7 @@ function computeStructuralIndex(streams: CachedStream[]): StreamStructuralIndex 
 }
 
 export function useStreamStructuralIndex(workspaceId: string): StreamStructuralIndex {
-  const streams = useWorkspaceStreamsRaw(workspaceId)
+  const streams = useWorkspaceStreams(workspaceId)
   return computeStructuralIndex(streams)
 }
 
@@ -289,7 +289,7 @@ export function deriveBranchConversations(params: {
       const markedMessages = settlingMessageIds.length
         ? applySettlingAll(messages, new Set(settlingMessageIds))
         : messages
-      const title = stripMarkdownToInline(childPost.conversation.topicSummary ?? "") || streamLabel(thread, "generic")
+      const title = effectiveConversationTitle(childPost.conversation, thread) || streamLabel(thread, "generic")
       const children = depth < maxDepth ? walk(childMemberIds, depth + 1, nextSeen) : []
       const overflow = depth >= maxDepth && hasDeeperBranch(childMemberIds, index, graph, nextSeen)
       out.push({
@@ -358,7 +358,7 @@ export function deriveBranchProvenance(params: {
   const parentPost = params.graph.conversationById.get(parentId)!
   const parentAnchor = params.index.streamsById.get(parentPost.conversation.streamId)
   const title =
-    stripMarkdownToInline(parentPost.conversation.topicSummary ?? "") ||
+    effectiveConversationTitle(parentPost.conversation, parentAnchor) ||
     (parentAnchor ? streamLabel(parentAnchor, "generic") : "conversation")
   return { parentConversationId: parentId, title }
 }

--- a/apps/frontend/src/hooks/use-conversation-title.test.tsx
+++ b/apps/frontend/src/hooks/use-conversation-title.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import * as streamStore from "@/stores/stream-store"
+import { clearStreamNameCache, primeStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
+import { useConversationTitle } from "./use-conversation-title"
+
+const workspaceId = "workspace_1"
+const stream = {
+  id: "stream_1",
+  workspaceId,
+  type: "scratchpad" as const,
+  displayName: "Legacy plaintext",
+  e2eEnabled: true,
+  sealedNameCiphertext: "ciphertext_1",
+}
+
+afterEach(() => {
+  clearStreamNameCache()
+  vi.restoreAllMocks()
+})
+
+describe("useConversationTitle", () => {
+  it("is null while an E2E title is locked, then synchronously reads the decrypted cache", () => {
+    vi.spyOn(streamStore, "useStreamFromStore").mockReturnValue(stream as never)
+    const key = streamNameCacheKey(workspaceId, stream.id, stream.sealedNameCiphertext)
+    const reader = renderHook(() =>
+      useConversationTitle(workspaceId, { streamId: stream.id, topicSummary: "Persisted topic" })
+    )
+
+    expect(reader.result.current).toBeNull()
+    act(() => primeStreamName(key, "Decrypted title"))
+    expect(reader.result.current).toBe("Decrypted title")
+  })
+
+  it("does not rerender when another stream title changes", () => {
+    vi.spyOn(streamStore, "useStreamFromStore").mockReturnValue(stream as never)
+    let renders = 0
+    renderHook(() => {
+      renders += 1
+      return useConversationTitle(workspaceId, { streamId: stream.id, topicSummary: null })
+    })
+    const before = renders
+
+    act(() => primeStreamName(streamNameCacheKey(workspaceId, "stream_other", "ciphertext_2"), "Other title"))
+
+    expect(renders).toBe(before)
+  })
+})

--- a/apps/frontend/src/hooks/use-conversation-title.test.tsx
+++ b/apps/frontend/src/hooks/use-conversation-title.test.tsx
@@ -30,12 +30,13 @@ describe("useConversationTitle", () => {
     expect(reader.result.current).toBeNull()
     act(() => primeStreamName(key, "Decrypted title"))
     expect(reader.result.current).toBe("Decrypted title")
+    reader.unmount()
   })
 
   it("does not rerender when another stream title changes", () => {
     vi.spyOn(streamStore, "useStreamFromStore").mockReturnValue(stream as never)
     let renders = 0
-    renderHook(() => {
+    const reader = renderHook(() => {
       renders += 1
       return useConversationTitle(workspaceId, { streamId: stream.id, topicSummary: null })
     })
@@ -44,5 +45,6 @@ describe("useConversationTitle", () => {
     act(() => primeStreamName(streamNameCacheKey(workspaceId, "stream_other", "ciphertext_2"), "Other title"))
 
     expect(renders).toBe(before)
+    reader.unmount()
   })
 })

--- a/apps/frontend/src/hooks/use-conversation-title.ts
+++ b/apps/frontend/src/hooks/use-conversation-title.ts
@@ -1,14 +1,46 @@
+import { useCallback, useSyncExternalStore } from "react"
 import type { Conversation } from "@threa/types"
-import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useStreamFromStore } from "@/stores/stream-store"
+import {
+  getCachedStreamName,
+  isStreamNamePending,
+  streamNameCacheKey,
+  subscribeStreamName,
+} from "@/lib/crypto/stream-name-cache"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
+
+interface ConversationTitleDetails {
+  title: string | null
+  isE2e: boolean
+  pending: boolean
+}
+
+export function useConversationTitleDetails(
+  workspaceId: string,
+  conversation: Pick<Conversation, "streamId" | "topicSummary">
+): ConversationTitleDetails {
+  const stream = useStreamFromStore(conversation.streamId)
+  const nameKey =
+    stream?.e2eEnabled && stream.sealedNameCiphertext
+      ? streamNameCacheKey(workspaceId, stream.id, stream.sealedNameCiphertext)
+      : null
+  const subscribe = useCallback(
+    (listener: () => void) => (nameKey ? subscribeStreamName(nameKey, listener) : () => {}),
+    [nameKey]
+  )
+  const readName = useCallback(() => (nameKey ? getCachedStreamName(nameKey) : null), [nameKey])
+  const decryptedTitle = useSyncExternalStore(subscribe, readName, readName)
+
+  return {
+    title: effectiveConversationTitle(conversation, stream, decryptedTitle),
+    isE2e: stream?.e2eEnabled === true,
+    pending: nameKey ? isStreamNamePending(nameKey) : false,
+  }
+}
 
 export function useConversationTitle(
   workspaceId: string,
   conversation: Pick<Conversation, "streamId" | "topicSummary">
 ): string | null {
-  const streams = useWorkspaceStreams(workspaceId)
-  return effectiveConversationTitle(
-    conversation,
-    streams.find((stream) => stream.id === conversation.streamId)
-  )
+  return useConversationTitleDetails(workspaceId, conversation).title
 }

--- a/apps/frontend/src/hooks/use-conversation-title.ts
+++ b/apps/frontend/src/hooks/use-conversation-title.ts
@@ -1,0 +1,14 @@
+import type { Conversation } from "@threa/types"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { effectiveConversationTitle } from "@/lib/conversations/title"
+
+export function useConversationTitle(
+  workspaceId: string,
+  conversation: Pick<Conversation, "streamId" | "topicSummary">
+): string | null {
+  const streams = useWorkspaceStreams(workspaceId)
+  return effectiveConversationTitle(
+    conversation,
+    streams.find((stream) => stream.id === conversation.streamId)
+  )
+}

--- a/apps/frontend/src/hooks/use-rename-stream.ts
+++ b/apps/frontend/src/hooks/use-rename-stream.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import type { Stream } from "@threa/types"
+import { useStreamService } from "@/contexts"
+import { sealStreamRename } from "@/lib/crypto/stream-rename"
+import { mergeStreamByTitleRevision, persistStreamByTitleRevision } from "@/lib/title-merge"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useWorkspaceUserId } from "./use-workspaces"
+import { streamKeys } from "./use-streams"
+import { workspaceKeys } from "./use-workspaces"
+
+export function useRenameStream(workspaceId: string, streamId: string, streamOverride?: Stream) {
+  const queryClient = useQueryClient()
+  const service = useStreamService()
+  const streams = useWorkspaceStreams(workspaceId)
+  const stream = streamOverride ?? streams.find((item) => item.id === streamId)
+  const userId = useWorkspaceUserId(workspaceId) ?? ""
+  const session = useE2eSession(workspaceId, userId)
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const canRename = !stream?.e2eEnabled || session.status === "unlocked"
+
+  const rename = useCallback(
+    async (name: string) => {
+      if (!canRename) {
+        const lockedError = new Error("Unlock this scratchpad to rename it")
+        setError(lockedError)
+        throw lockedError
+      }
+      setIsPending(true)
+      setError(null)
+      try {
+        const input = stream?.e2eEnabled
+          ? await sealStreamRename({ workspaceId, streamId, userId, name })
+          : { displayName: name }
+        const updated = await service.update(workspaceId, streamId, input)
+        await persistStreamByTitleRevision(updated)
+        queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), (old) =>
+          old ? mergeStreamByTitleRevision(old, updated) : updated
+        )
+        queryClient.setQueriesData<{ stream?: Stream }>(
+          { queryKey: streamKeys.bootstrap(workspaceId, streamId) },
+          (old) =>
+            old ? { ...old, stream: old.stream ? mergeStreamByTitleRevision(old.stream, updated) : updated } : old
+        )
+        queryClient.setQueryData<{ streams?: Stream[] }>(workspaceKeys.bootstrap(workspaceId), (old) =>
+          old?.streams
+            ? {
+                ...old,
+                streams: old.streams.map((item) =>
+                  item.id === streamId ? mergeStreamByTitleRevision(item, updated) : item
+                ),
+              }
+            : old
+        )
+      } catch (cause) {
+        const nextError = cause instanceof Error ? cause : new Error("Failed to update name")
+        setError(nextError)
+        throw nextError
+      } finally {
+        setIsPending(false)
+      }
+    },
+    [canRename, queryClient, service, stream, streamId, userId, workspaceId]
+  )
+
+  return { rename, canRename, isPending, error }
+}

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -345,6 +345,7 @@ export function reconcileStableView(
 /** The conversation a merged-away card's opening message now belongs to. */
 export interface RemovedSuccessor {
   conversationId: string
+  streamId: string
   topicSummary: string | null
 }
 
@@ -662,7 +663,11 @@ export function useStableBoardView(
         successorById.set(
           postId(post),
           successor
-            ? { conversationId: successor.conversation.id, topicSummary: successor.conversation.topicSummary ?? null }
+            ? {
+                conversationId: successor.conversation.id,
+                streamId: successor.conversation.streamId,
+                topicSummary: successor.conversation.topicSummary ?? null,
+              }
             : null
         )
       }

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -639,14 +639,16 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
   })
 
   it("seals the new name and persists a sealed-only update (no plaintext) for an encrypted scratchpad", async () => {
-    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue({
+    const unlockedSession = {
       status: "unlocked",
       keyId: "e2ek_alice",
       publicKey: null,
       privateKey: {} as CryptoKey,
       deviceTrusted: true,
       error: null,
-    } as never)
+    } as never
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(unlockedSession)
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(unlockedSession)
     vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({
       key: new Uint8Array(32),
       keyGeneration: 0,
@@ -684,7 +686,10 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
       wrapper: createWrapper(queryClient, { streamService: { update } }),
     })
 
-    await waitFor(() => expect(result.current.stream?.e2eEnabled).toBe(true))
+    await waitFor(() => {
+      expect(result.current.stream?.e2eEnabled).toBe(true)
+      expect(result.current.canRename).toBe(true)
+    })
 
     await act(async () => {
       await result.current.rename("Therapy notes")

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -682,7 +682,7 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
     }))
 
     const queryClient = new QueryClient()
-    const { result } = renderHook(() => useStreamOrDraft("ws_1", streamId), {
+    const { result, unmount } = renderHook(() => useStreamOrDraft("ws_1", streamId), {
       wrapper: createWrapper(queryClient, { streamService: { update } }),
     })
 
@@ -708,6 +708,10 @@ describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
 
     const persisted = await db.streams.get(streamId)
     expect(persisted).toMatchObject({ sealedNameCiphertext: "Y3Q=", displayName: null })
+
+    // This hook subscribes to the E2E session store. Unmount it before afterEach
+    // restores the mocked hook implementation and clears its title cache.
+    unmount()
   })
 
   it("renames a plaintext scratchpad by writing displayName directly (no sealing)", async () => {

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -7,7 +7,6 @@ import { useUser } from "@/auth"
 import { type SealStreamMessageResult } from "@/lib/crypto/message-envelope"
 import { reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { sealOutgoingMessage } from "@/lib/crypto/seal-send"
-import { sealStreamRename } from "@/lib/crypto/stream-rename"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
@@ -37,7 +36,7 @@ import type {
 } from "@threa/types"
 import { StreamTypes, Visibilities, CompanionModes } from "@threa/types"
 import { nextOptimisticSequence } from "@/lib/optimistic-sequence"
-import { mergeStreamByTitleRevision, persistStreamByTitleRevision } from "@/lib/title-merge"
+import { useRenameStream } from "./use-rename-stream"
 
 const DM_DRAFT_PREFIX = "draft_dm_"
 
@@ -165,6 +164,9 @@ export interface UseStreamOrDraftReturn {
   error: Error | null
 
   rename: (newName: string) => Promise<void>
+  canRename: boolean
+  renamePending: boolean
+  renameError: Error | null
   archive: () => Promise<void>
   unarchive?: () => Promise<void>
   sendMessage: (input: SendMessageInput) => Promise<{ navigateTo?: string; replace?: boolean }>
@@ -253,6 +255,9 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
     isDraft: true,
     error: null,
     rename,
+    canRename: true,
+    renamePending: false,
+    renameError: null,
     archive,
     sendMessage,
     currentUserId,
@@ -457,6 +462,9 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
     isDraft: true,
     error: null,
     rename,
+    canRename: true,
+    renamePending: false,
+    renameError: null,
     archive,
     sendMessage,
     currentUserId,
@@ -485,6 +493,8 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
     enabled: enabled && !idbStream,
   })
   const baseStream = idbStream ?? bootstrap?.stream
+  const renameStream = useRenameStream(workspaceId, streamId, baseStream)
+  const { rename } = renameStream
   const displayName =
     baseStream?.type === StreamTypes.DM
       ? resolveRealDmDisplayName(baseStream.id, baseStream.displayName, idbStreams, idbUsers, idbDmPeers)
@@ -509,48 +519,6 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         sealedNameEnvelope: baseStream.sealedNameEnvelope ?? null,
       }
     : undefined
-
-  const rename = useCallback(
-    async (newName: string) => {
-      // An E2E stream's name is sealed-only: we persist the tamper-evident
-      // ciphertext and NEVER the plaintext, so the server can't read it (the
-      // server scrubs `display_name` to null when a sealed name is set). Sealing
-      // needs the SSK, so it throws when the session is locked — the rename
-      // affordance is disabled in that state, and this is the backstop that
-      // keeps a rename from ever falling back to writing plaintext.
-      const updateInput = baseStream?.e2eEnabled
-        ? await sealStreamRename({ workspaceId, streamId, userId: currentUserId ?? "", name: newName })
-        : { displayName: newName }
-
-      const updatedStream = await streamService.update(workspaceId, streamId, updateInput)
-      await persistStreamByTitleRevision(updatedStream)
-
-      queryClient.setQueryData<Stream>(streamKeys.detail(workspaceId, streamId), (old) =>
-        old ? mergeStreamByTitleRevision(old, updatedStream) : updatedStream
-      )
-      queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
-        if (!old || typeof old !== "object") return old
-        const bootstrap = old as { stream?: Stream }
-        return {
-          ...bootstrap,
-          stream: bootstrap.stream ? mergeStreamByTitleRevision(bootstrap.stream, updatedStream) : updatedStream,
-        }
-      })
-
-      queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), (old: unknown) => {
-        if (!old || typeof old !== "object") return old
-        const wsBootstrap = old as { streams?: Stream[] }
-        if (!wsBootstrap.streams) return old
-        return {
-          ...wsBootstrap,
-          streams: wsBootstrap.streams.map((stream) =>
-            stream.id === streamId ? mergeStreamByTitleRevision(stream, updatedStream) : stream
-          ),
-        }
-      })
-    },
-    [streamId, workspaceId, streamService, queryClient, idbStream, baseStream?.e2eEnabled, currentUserId]
-  )
 
   const archive = useCallback(async () => {
     await streamService.archive(workspaceId, streamId)
@@ -723,6 +691,9 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
     isDraft: false,
     error: stream ? null : (error ?? null),
     rename,
+    canRename: renameStream.canRename,
+    renamePending: renameStream.isPending,
+    renameError: renameStream.error,
     archive,
     unarchive,
     sendMessage,

--- a/apps/frontend/src/lib/conversations/title.test.ts
+++ b/apps/frontend/src/lib/conversations/title.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest"
+import { effectiveConversationTitle } from "./title"
+
+const conversation = { streamId: "stream_1", topicSummary: "**Legacy topic**" }
+
+describe("effectiveConversationTitle", () => {
+  test("uses the current scratchpad stream overlay and strips preview markdown", () => {
+    expect(
+      effectiveConversationTitle(conversation, {
+        id: "stream_1",
+        type: "scratchpad",
+        displayName: "**Decrypted name**",
+      })
+    ).toBe("Decrypted name")
+  })
+
+  test("ignores a scratchpad stream that is not the conversation root", () => {
+    expect(
+      effectiveConversationTitle(conversation, { id: "stream_other", type: "scratchpad", displayName: "Other" })
+    ).toBe("Legacy topic")
+  })
+
+  test("preserves non-scratchpad conversation ownership", () => {
+    expect(effectiveConversationTitle(conversation, { id: "stream_1", type: "channel", displayName: "Channel" })).toBe(
+      "Legacy topic"
+    )
+  })
+})

--- a/apps/frontend/src/lib/conversations/title.test.ts
+++ b/apps/frontend/src/lib/conversations/title.test.ts
@@ -1,17 +1,41 @@
-import { describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test } from "vitest"
+import {
+  applyDecryptedNameOverlay,
+  clearStreamNameCache,
+  primeStreamName,
+  streamNameCacheKey,
+} from "@/lib/crypto/stream-name-cache"
 import { effectiveConversationTitle } from "./title"
 
 const conversation = { streamId: "stream_1", topicSummary: "**Legacy topic**" }
 
+afterEach(clearStreamNameCache)
+
 describe("effectiveConversationTitle", () => {
-  test("uses the current scratchpad stream overlay and strips preview markdown", () => {
+  test("uses a plaintext scratchpad title and strips preview markdown", () => {
     expect(
       effectiveConversationTitle(conversation, {
         id: "stream_1",
         type: "scratchpad",
-        displayName: "**Decrypted name**",
+        displayName: "**Scratchpad name**",
+        e2eEnabled: false,
       })
-    ).toBe("Decrypted name")
+    ).toBe("Scratchpad name")
+  })
+
+  test("uses only the memory-only decrypted title for an E2E scratchpad", () => {
+    const stream = {
+      id: "stream_1",
+      type: "scratchpad" as const,
+      displayName: "Legacy plaintext title",
+      e2eEnabled: true,
+    }
+    expect(effectiveConversationTitle(conversation, stream)).toBeNull()
+    expect(effectiveConversationTitle(conversation, stream, "**Decrypted name**")).toBe("Decrypted name")
+    const sealedStream = { ...stream, sealedNameCiphertext: "ciphertext" }
+    primeStreamName(streamNameCacheKey("workspace_1", stream.id, "ciphertext"), "**Overlaid decrypted name**")
+    const [overlaid] = applyDecryptedNameOverlay("workspace_1", [sealedStream])
+    expect(effectiveConversationTitle(conversation, overlaid)).toBe("Overlaid decrypted name")
   })
 
   test("ignores a scratchpad stream that is not the conversation root", () => {

--- a/apps/frontend/src/lib/conversations/title.ts
+++ b/apps/frontend/src/lib/conversations/title.ts
@@ -1,16 +1,20 @@
 import { StreamTypes, type Conversation, type Stream } from "@threa/types"
 import { stripMarkdownToInline } from "@/lib/markdown/strip"
+import { isDecryptedStreamNameOverlay } from "@/lib/crypto/stream-name-cache"
 
 type ConversationTitle = Pick<Conversation, "streamId" | "topicSummary">
-type TitleStream = Pick<Stream, "id" | "type" | "displayName">
+type TitleStream = Pick<Stream, "id" | "type" | "displayName"> & Partial<Pick<Stream, "e2eEnabled">>
 
 export function effectiveConversationTitle(
   conversation: ConversationTitle,
-  stream: TitleStream | null | undefined
+  stream: TitleStream | null | undefined,
+  decryptedStreamTitle?: string | null
 ): string | null {
-  const title =
-    stream?.type === StreamTypes.SCRATCHPAD && stream.id === conversation.streamId
-      ? stream.displayName
-      : conversation.topicSummary
+  const isRootScratchpad = stream?.type === StreamTypes.SCRATCHPAD && stream.id === conversation.streamId
+  let title = conversation.topicSummary
+  if (isRootScratchpad) {
+    const memoryOnlyTitle = decryptedStreamTitle ?? (isDecryptedStreamNameOverlay(stream) ? stream.displayName : null)
+    title = stream.e2eEnabled ? memoryOnlyTitle : stream.displayName
+  }
   return title ? stripMarkdownToInline(title) : null
 }

--- a/apps/frontend/src/lib/conversations/title.ts
+++ b/apps/frontend/src/lib/conversations/title.ts
@@ -1,0 +1,16 @@
+import { StreamTypes, type Conversation, type Stream } from "@threa/types"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
+
+type ConversationTitle = Pick<Conversation, "streamId" | "topicSummary">
+type TitleStream = Pick<Stream, "id" | "type" | "displayName">
+
+export function effectiveConversationTitle(
+  conversation: ConversationTitle,
+  stream: TitleStream | null | undefined
+): string | null {
+  const title =
+    stream?.type === StreamTypes.SCRATCHPAD && stream.id === conversation.streamId
+      ? stream.displayName
+      : conversation.topicSummary
+  return title ? stripMarkdownToInline(title) : null
+}

--- a/apps/frontend/src/lib/crypto/stream-name-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-name-cache.ts
@@ -2,16 +2,16 @@ import { tryOpenStreamName, type DecryptMessageOpts } from "./message-envelope"
 import { createDecryptedCache, type DecryptStatus } from "./decrypted-cache"
 
 /**
- * In-memory cache for decrypted E2E stream names — a global-subscription instance
+ * In-memory cache for decrypted E2E stream names — a keyed-subscription instance
  * of the shared {@link createDecryptedCache} primitive (which owns the
  * inflight-dedup, lock-epoch guard, version signal, and lock-clear registration).
  *
  * The enclave seals a scratchpad's auto-title (and a manual rename re-seals it)
  * under the stream's SSK, AAD-bound to the stream. The ciphertext lives at rest
  * in `db.streams` (`sealedNameCiphertext`/`sealedNameEnvelope`); the decrypted
- * plaintext is held ONLY here and is never persisted. A single global version
- * counter drives re-renders: the store-read overlay (`useWorkspaceStreams`) and
- * the open-stream header subscribe once and re-read when any name lands. Keyed by
+ * plaintext is held ONLY here and is never persisted. Keyed title readers wake
+ * only for their stream; the collection overlay can still subscribe globally.
+ * Keyed by
  * `${workspaceId}:${streamId}:${ciphertext}` so a rename (fresh ciphertext)
  * supersedes the prior plaintext without a manual purge, and a never-decrypted key
  * reads `null` rather than a stale value.
@@ -22,6 +22,12 @@ import { createDecryptedCache, type DecryptStatus } from "./decrypted-cache"
  * fired by `clearAllDecrypted` on lock) drops everything.
  */
 
+const decryptedNameOverlays = new WeakSet<object>()
+
+export function isDecryptedStreamNameOverlay(stream: object): boolean {
+  return decryptedNameOverlays.has(stream)
+}
+
 interface NameEntry {
   status: DecryptStatus
   /** The decrypted name; null while pending or after a failed/locked open. */
@@ -29,7 +35,7 @@ interface NameEntry {
 }
 
 const cache = createDecryptedCache<NameEntry>({
-  subscription: "global",
+  subscription: "per-key",
   // A null open is transient (locked, or a wrap that becomes resolvable later),
   // so a later request must retry rather than pin the placeholder forever.
   retryFailed: true,
@@ -45,6 +51,10 @@ export function streamNameCacheKey(workspaceId: string, streamId: string, cipher
 
 export function subscribeStreamNameCache(listener: () => void): () => void {
   return cache.subscribe(null, listener)
+}
+
+export function subscribeStreamName(key: string, listener: () => void): () => void {
+  return cache.subscribe(key, listener)
 }
 
 export function getStreamNameCacheVersion(): number {
@@ -119,7 +129,9 @@ export function applyDecryptedNameOverlay<
     const decrypted = getCachedStreamName(streamNameCacheKey(workspaceId, stream.id, stream.sealedNameCiphertext))
     if (decrypted == null || decrypted === stream.displayName) return stream
     changed = true
-    return { ...stream, displayName: decrypted }
+    const overlaid = { ...stream, displayName: decrypted }
+    decryptedNameOverlays.add(overlaid)
+    return overlaid
   })
   return changed ? next : streams
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react"
+import { toast } from "sonner"
 import { useParams, useSearchParams, useNavigate } from "react-router-dom"
 import {
   ListChecks,
@@ -52,10 +53,8 @@ import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-enc
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
 import { useDecryptedStreamName, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
 import { Skeleton } from "@/components/ui/skeleton"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { CallStartMenu, RejoinBar } from "@/components/call"
-import { useE2eSession } from "@/stores/e2e-session-store"
 import { ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle, StreamTitlePreview, panelTakeoverClasses } from "@/components/layout"
 import { PanelHost } from "@/components/layout/panel-host"
@@ -76,7 +75,8 @@ export function StreamPage() {
   const { workspaceId, streamId } = useParams<{ workspaceId: string; streamId: string }>()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
-  const { stream, isDraft, error, rename, archive, unarchive } = useStreamOrDraft(workspaceId!, streamId!)
+  const { stream, isDraft, error, rename, canRename, renamePending, renameError, archive, unarchive } =
+    useStreamOrDraft(workspaceId!, streamId!)
   const { isMobile } = useSidebar()
   const { panelId, isPanelOpen, closePanel, setFocusedPane } = usePanel()
   const {
@@ -219,11 +219,9 @@ export function StreamPage() {
   // but the decrypt hasn't landed) so the header shows a loader instead of
   // flashing the "unnamed" placeholder on cold load.
   const nameDecrypting = useStreamNameDecrypting(workspaceId ?? "", stream)
-  // Renaming an E2E stream seals the new name under its key, so it requires an
-  // unlocked session — the affordance is omitted while locked (the stream is in
-  // its locked/unlock state then anyway).
-  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
-  const e2eUnlocked = useE2eSession(workspaceId ?? "", currentUserId ?? "").status === "unlocked"
+  useEffect(() => {
+    if (renameError) toast.error(renameError.message)
+  }, [renameError])
   // An external agent (e.g. a Pi remote bot runtime) attached to this
   // scratchpad. Drives the "External" pill state and its connection dot.
   // Called here (above the early returns below) to keep hook order stable.
@@ -293,7 +291,7 @@ export function StreamPage() {
   // a non-encrypted scratchpad can always be renamed. Gate every rename affordance
   // (header title click and menu item) on this so a locked session can't open the
   // editor only for `rename()` to reject on seal.
-  const canRenameScratchpad = !isEncryptedScratchpad || e2eUnlocked
+  const canRenameScratchpad = canRename
 
   const handleStartRename = () => {
     if (!canRenameScratchpad) return
@@ -595,6 +593,7 @@ export function StreamPage() {
         className="h-8 max-w-xs font-semibold"
         placeholder="Scratchpad name"
         autoFocus
+        disabled={renamePending}
       />
     )
   } else if (isThread && stream) {

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1665,6 +1665,8 @@ export interface MemoLinkPreviewData {
 export interface ConversationLinkPreviewData {
   kind: "conversation"
   accessTier: InAppLinkAccessTier
+  /** Anchor stream id used for live effective-title resolution (full tier only). */
+  streamId?: string
   /** LLM-generated 2–5 word title (full tier only) */
   topicSummary?: string
   /** Rolling prose summary of the conversation (full tier only) */


### PR DESCRIPTION
## Problem

Scratchpad conversations could retain a second title owner in `conversations.topic_summary`, so stream renames and conversation labels could diverge across app, public API, and E2E views. Thread naming also omitted the canonical parent anchor context needed to name a branch from its root message or supported event card.

## Solution

Make the scratchpad stream the only title authority. New scratchpad conversations store no topic; direct title edits and split title writers are rejected with structured errors, while status updates remain valid. `effectiveConversationTitle` and `useConversationTitle` derive every scratchpad label from the live stream title, including decrypted memory-only E2E overlays, while preserving non-scratchpad topics and markdown stripping. `useRenameStream` now owns plaintext and sealed rename capability, writes, errors, and revision-aware cache updates for stream settings, headers, and conversation actions.

Public plaintext scratchpad reads derive `topicSummary` during serialization only; E2E reads and link previews suppress historical plaintext. Thread naming prepends the typed canonical message or allowlisted event anchor, reusing existing attachment, link-preview, and card formatting without changing scheduling or `requireName` behavior.

## Files

| Area | Change |
| ---- | ------ |
| `apps/backend/src/features/{conversations,public-api,link-previews}/**` | Enforce scratchpad ownership and privacy-safe derived reads. |
| `apps/backend/src/features/streams/naming-context.ts` | Add canonical anchor-first thread naming context. |
| `apps/frontend/src/lib/conversations/title.ts`, `hooks/use-{conversation-title,rename-stream}.ts` | Centralize effective titles and stream rename behavior. |
| `apps/frontend/src/{components,hooks,pages}/**` | Route board, panel, overlay, draft, graph, action, and link labels through canonical titles. |

## Test plan

- [x] `bun run --cwd apps/backend test:unit -- src/features/conversations src/features/public-api src/features/streams src/features/link-previews/service.test.ts` - 350 passed
- [x] `bun run --cwd apps/frontend test -- src/lib/conversations/title.test.ts src/components/board/board-card.test.tsx src/components/conversations/conversation-actions-menu.test.tsx src/components/conversations/conversation-panel.test.tsx src/components/timeline/conversation-overlay` - 137 passed
- [x] `bun run --cwd apps/frontend test -- src/components/timeline/conversation-overlay/model.test.ts` - 16 passed
- [x] `bun run --cwd apps/backend test:integration -- tests/integration/stream-naming.test.ts tests/integration/conversation-repository.test.ts` - 58 passed
- [x] `bun run typecheck`; `bun run lint`; `git diff --check` - passed
- [ ] Browser test not run; deterministic component/integration coverage was added. Whole-stack UI pass remains required.

## Exclusions

No checkpoint state, structured evaluator, repeated naming, conversation refinement, regenerate action, or E2E checkpoint protocol. Existing scratchpad shadow topics remain stored but ignored; channel, DM, and thread conversation ownership is unchanged.

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Deliver PR2 of the [Seer dynamic naming plan](https://seer.build/ws_vbyzjvdg6g/b/dynamic-naming-plan-5d5b5b/): establish one scratchpad title owner across backend reads/writes and all current frontend title surfaces, then add canonical thread-anchor context for later dynamic naming.

## What Was Built

### Scratchpad ownership and API projections

- New scratchpad conversations persist `topic_summary = NULL`; existing conversations are reused without invoking a conversation title writer.
- App API title edits and split title-producing paths reject scratchpad roots with structured `HttpError`; status-only updates remain valid under inherited stream-root access.
- Public plaintext reads derive the current stream title during serialization. E2E public and in-app link projections return no backend scratchpad plaintext.

### Effective frontend titles and rename ownership

- `effectiveConversationTitle` selects the matching scratchpad root stream title and otherwise preserves `conversation.topicSummary`; all output keeps inline markdown stripping.
- `useConversationTitle` resolves against reactive workspace streams, including decrypted E2E overlays.
- Board cards, removed cards, conversation list/panel/actions, timeline overlays and provenance, reply/split labels, drafts, graph labels, and in-app links use the shared resolver.
- `useRenameStream` is the single plaintext/E2E rename path. It owns unlocked capability, sealing, pending/error state, one stream update, persistence, and revision-aware cache merges; no E2E plaintext fallback exists.

### Thread naming context

- `naming-context.ts` prepends `parentAnchorId` context before thread-local replies.
- Message anchors reuse content, attachment, and link-preview enrichment.
- Event anchors reuse the typed thread-anchor formatter for supported `delegation:created` and `call_started` card fields; arbitrary payload JSON is never rendered.
- Existing naming scheduling and `requireName` behavior are unchanged.

## Design Decisions

- Derive scratchpad titles at read/render time instead of copying them into conversation rows, preventing competing owners and preserving legacy rows without destructive cleanup.
- Reuse live stream overlays instead of backend conversation projections so decrypted E2E names remain memory-only and reactive.
- Reuse one rename hook and one typed event-anchor formatter to prevent crypto, cache, capability, and card-format drift.

## What's NOT Included

Checkpoint persistence, evaluator decisions, repeated renaming, non-scratchpad conversation refinement, regenerate controls, E2E checkpoint protocol, and deletion of legacy scratchpad topics remain in later stack layers.

## Status

- [x] Scratchpad conversation title writers blocked
- [x] Plaintext and E2E derived-read privacy enforced
- [x] Current frontend title and rename surfaces unified
- [x] Canonical thread-anchor naming context added
- [x] Unit, real-schema integration, typecheck, lint, and diff gates passed
- [ ] Whole-stack browser pass

</details>

---

🤖 _PR by Codex_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788653860&installation_model_id=20758&pr_number=1787&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1787&signature=6f8c57920739418d9251a92b1c0ff8dcc9ecf861c8cd965fa1b7d8ab2e9f5cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->