### PR TITLE
fix: recover remote polling after transport loss

### DIFF
--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -384,22 +384,33 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
     }
   })
 
-  it("redials after a server-initiated disconnect (Socket.IO won't reconnect on its own)", async () => {
+  it("reports a ready-socket loss and redials after a server-initiated disconnect", async () => {
     const fake = makeFakeSocket()
     const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
     try {
       stubHintFetch()
-      const transport = makeSelfHealTransport(3 * 60 * 1000)
+      const disconnected = mock(() => {})
+      const transport = new BotRuntimeTransport({
+        baseUrl: "https://app.example.test",
+        workspaceId: "ws_1",
+        apiKey: "threa_bk_test",
+        hello: HELLO,
+        staleSocketRedialMs: 3 * 60 * 1000,
+        callbacks: { onDisconnected: disconnected },
+      })
       await transport.connect()
       fake.handlers.connect!()
       expect(transport.socketConnected).toBe(true)
 
       fake.handlers.disconnect!("io server disconnect")
       expect(transport.socketConnected).toBe(false)
+      expect(disconnected).toHaveBeenCalledTimes(1)
       expect(fake.connect).toHaveBeenCalledTimes(1)
 
-      // Client-side drops are left to Socket.IO's own retry loop.
+      // Duplicate disconnect events while already unavailable neither notify
+      // again nor force a client-side reconnect.
       fake.handlers.disconnect!("transport close")
+      expect(disconnected).toHaveBeenCalledTimes(1)
       expect(fake.connect).toHaveBeenCalledTimes(1)
     } finally {
       ioSpy.mockRestore()

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -146,10 +146,12 @@ export class BotRuntimeTransport {
       this.sendHello()
     })
     socket.on("disconnect", (reason: string) => {
+      const wasReady = this.socketConnected
       this.connected = false
       this.helloReady = false
       this.helloInFlight = false
       this.disconnectedAt ??= Date.now()
+      if (wasReady) this.callbacks.onDisconnected?.()
       // Socket.IO's auto-reconnect covers every disconnect reason EXCEPT a
       // server-initiated one (deploy drain, kick) — there the client stays down
       // until someone calls connect(). Redial immediately; a flap lands on the
@@ -157,10 +159,12 @@ export class BotRuntimeTransport {
       if (reason === "io server disconnect") socket.connect()
     })
     socket.on("connect_error", (error: unknown) => {
+      const wasReady = this.socketConnected
       this.connected = false
       this.helloReady = false
       this.helloInFlight = false
       this.disconnectedAt ??= Date.now()
+      if (wasReady) this.callbacks.onDisconnected?.()
       this.logFn(`socket connect_error: ${summarize(error)}`)
     })
     socket.on("bot_invocation:available", () => this.callbacks.onInvocationAvailable?.())
@@ -228,10 +232,12 @@ export class BotRuntimeTransport {
 
   /** Drop the current socket without stopping the transport — the next `connect()` dials fresh. */
   private teardownSocket(): void {
+    const wasReady = this.socketConnected
     this.connected = false
     this.helloReady = false
     this.helloInFlight = false
     this.disconnectedAt = undefined
+    if (wasReady) this.callbacks.onDisconnected?.()
     const socket = this.socket
     this.socket = undefined
     if (socket) {

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -79,6 +79,8 @@ export interface BotRuntimeTransportCallbacks {
   onSessionRestored?: (payload: unknown) => void
   /** The `bot:hello` ack landed; carries the bootstrap snapshot. */
   onBootstrap?: (bootstrap: BotHelloBootstrap) => void
+  /** A hello-ready socket became unavailable; wake any HTTP delivery backstop parked on the healthy-socket cadence. */
+  onDisconnected?: () => void
 }
 
 export interface BotRuntimeTransportOptions {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -523,6 +523,30 @@ describe("Pi remote trace safety", () => {
     // socket push is the real delivery path. See the constant's comment.
     expect(__testing.WS_BACKSTOP_POLL_MS).toBe(15 * 60 * 1000)
   })
+
+  test("pulls polling back to the fast cadence when a ready socket drops", () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      pollMs: 3000,
+    })
+    expect(__testing.nextQuietPollMs()).toBe(3000)
+    expect(__testing.nextQuietPollMs()).toBe(6000)
+
+    const delays: number[] = []
+    __testing.handleTransportDisconnected((delayMs) => delays.push(delayMs), 7, 7)
+
+    // The current run's poll owns the next timer and will observe the socketless
+    // state itself; scheduling here would create a second poll loop.
+    expect(delays).toEqual([])
+    expect(__testing.nextQuietPollMs()).toBe(3000)
+
+    // A poll left over from a canceled run cannot schedule for the active run,
+    // so it must not suppress the disconnect wakeup.
+    __testing.handleTransportDisconnected((delayMs) => delays.push(delayMs), 6, 7)
+    expect(delays).toEqual([3000])
+  })
 })
 
 describe("sanitizeInstanceIdSegment", () => {
@@ -1756,6 +1780,72 @@ describe("session-scoped lifecycle isolation", () => {
 })
 
 describe("reload claim continuity", () => {
+  test("starts transport and polling even when the session-start heartbeat fails", async () => {
+    const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
+    const pi = {
+      registerCommand: () => {},
+      on: (event: string, handler: (event: unknown, ctx: any) => Promise<void>) => handlers.set(event, handler),
+      sendUserMessage: () => {},
+    }
+    threaRemote(pi as never)
+
+    const runtimeSessionId = "runtime_heartbeat_failure"
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      pollMs: 10,
+      linkedSessions: {
+        [runtimeSessionId]: {
+          enabled: true,
+          instanceId: "pi-heartbeat-failure",
+          runtimeSessionId,
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => runtimeSessionId, getBranch: () => [] },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        setStatus: () => {},
+        notify: () => {},
+        theme: { fg: (_tone: string, text: string) => text },
+      },
+    }
+    const requests: string[] = []
+    let failPresence = true
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      const url = String(input)
+      requests.push(url)
+      if (url.endsWith("/bot-runtime/presence") && failPresence) {
+        failPresence = false
+        return new Response(JSON.stringify({ error: "temporary" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      const data = url.endsWith("/bot-invocations/claim") ? null : {}
+      return new Response(JSON.stringify(url.includes("/api/workspaces/") ? {} : { data }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+
+    try {
+      await handlers.get("session_start")!({ reason: "reload" }, ctx)
+      await Bun.sleep(30)
+
+      expect(requests.some((url) => url.includes("/api/workspaces/ws_123/config"))).toBe(true)
+      expect(requests.some((url) => url.endsWith("/bot-invocations/claim"))).toBe(true)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("restores, renews, and completes the in-flight claim after the extension cache is cleared", async () => {
     const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
     const pi = {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -891,6 +891,7 @@ function ensureTransport(pi: ExtensionAPI, ctx: ExtensionContext): BotRuntimeTra
           void claimIfIdle(pi, ctx).catch(() => undefined)
         }
       },
+      onDisconnected: () => handleTransportDisconnected(),
       onSessionArchived: (payload) => handleArchivePush(ctx, payload),
       onSessionRestored: (payload) => handleRestorePush(ctx, payload),
     },
@@ -1943,6 +1944,16 @@ function handleRestorePush(ctx: ExtensionContext, payload: unknown): void {
   if (!isObject(payload) || sessionTearingDown) return
   if (typeof payload.runtimeSessionId === "string" && payload.runtimeSessionId !== getRuntimeSessionId(ctx)) return
   void ensureArchiveController(ctx).restored()
+}
+
+function handleTransportDisconnected(
+  schedule: typeof rearmPoll = rearmPoll,
+  inFlightRunId = pollInFlightRunId,
+  activeRunId = pollingRunId
+): void {
+  if (sessionTearingDown) return
+  consecutiveQuietPolls = 0
+  if (inFlightRunId !== activeRunId) schedule?.(basePollMs())
 }
 
 function basePollMs(): number {
@@ -4229,6 +4240,7 @@ export const __testing = {
   resetQuietPollsForTesting: () => {
     consecutiveQuietPolls = 0
   },
+  handleTransportDisconnected,
 }
 
 export default function (pi: ExtensionAPI): void {
@@ -4396,7 +4408,9 @@ export default function (pi: ExtensionAPI): void {
     } else {
       clearPendingSnapshot(ctx)
     }
-    await heartbeat(pending ? "busy" : "available", pending ? "Working on Threa invocation…" : undefined, ctx)
+    await heartbeat(pending ? "busy" : "available", pending ? "Working on Threa invocation…" : undefined, ctx).catch(
+      (error) => emitPollDebug(ctx, `session startup heartbeat failed; continuing: ${summarizeError(error)}`)
+    )
     await ensureTransport(pi, ctx)?.connect()
     startPolling(pi, ctx)
     if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -1658,6 +1658,37 @@ describe("claimDrain intercept routing", () => {
 })
 
 describe("no-socket poll backoff", () => {
+  test("pulls a parked socket backstop forward when the shared transport disconnects", () => {
+    const { client } = makeFakeClient()
+    const session = new RemoteSession({
+      config: makeConfig(),
+      client,
+      delegate: { deliverTurn: async () => {} },
+      runtime: RUNTIME,
+    })
+    const internal = session as unknown as {
+      emptyNoSocketPolls: number
+      pollTimer: ReturnType<typeof setTimeout> | undefined
+      stopped: boolean
+      transport: {
+        callbacks: { onDisconnected?: () => void }
+        disconnect: () => void
+      }
+    }
+    internal.emptyNoSocketPolls = 5
+    const parkedTimer = setTimeout(() => {}, 15 * 60 * 1000)
+    internal.pollTimer = parkedTimer
+
+    internal.transport.callbacks.onDisconnected?.()
+
+    expect(internal.emptyNoSocketPolls).toBe(0)
+    expect(internal.pollTimer).toBeDefined()
+    expect(internal.pollTimer).not.toBe(parkedTimer)
+    if (internal.pollTimer) clearTimeout(internal.pollTimer)
+    internal.stopped = true
+    internal.transport.disconnect()
+  })
+
   test("doubles empty socketless ticks to the cap; claim, socket, or reconnect resets", () => {
     const { client } = makeFakeClient()
     const { transport } = makeFakeTransport()

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -402,6 +402,7 @@ export class RemoteSession {
             void this.probeArchiveBackstop()
             if (bootstrap.availableInvocations.length > 0 || bootstrap.ownedClaims.length > 0) void this.claimDrain()
           },
+          onDisconnected: () => this.handleTransportDisconnected(),
           onSessionArchived: (payload) => void this.handleSessionArchived(payload),
           onSessionRestored: (payload) => void this.handleSessionRestored(payload),
         },
@@ -1697,6 +1698,11 @@ export class RemoteSession {
   }
 
   private startPoll(): void {
+    this.reschedulePoll(this.config.pollMs)
+  }
+
+  private handleTransportDisconnected(): void {
+    this.emptyNoSocketPolls = 0
     this.reschedulePoll(this.config.pollMs)
   }
 


### PR DESCRIPTION
## Problem

Pi can finish a reload without restarting remote delivery when the startup presence heartbeat fails: `session_start` exits before reconnecting the bot transport or starting HTTP polling. Separately, Pi and Claude park HTTP polling for 15 minutes while the bot socket is healthy, but a later socket loss does not pull that backstop forward. Queued invocations can therefore wait until another reload or the long backstop expires.

## Solution

Keep startup and transport-loss recovery independent of presence/socket availability:

- Treat Pi's initial session heartbeat as best-effort, then always reconnect the transport and start polling.
- Add `onDisconnected` to `BotRuntimeTransport`, emitted once when a hello-ready socket becomes unavailable.
- Rearm Pi and shared `RemoteSession` polling at the configured fast cadence after socket loss.
- Preserve one poll-timer owner in Pi: the current in-flight generation schedules its own next tick; stale generations cannot suppress the active generation's wakeup.
- Keep shutdown safe through existing teardown/stopped guards.

## Files

| File | Change |
| ---- | ------ |
| `extensions/bot-runtime-client/src/{types,transport}.ts` | Expose and emit the ready-socket disconnect callback. |
| `extensions/pi-remote/src/threa-remote.ts` | Continue reload startup after heartbeat failure and rearm generation-safe polling. |
| `extensions/remote-session/src/session.ts` | Pull Claude/shared runtime polling forward after socket loss. |
| Corresponding `*.test.ts` files | Cover disconnect emission, heartbeat failure, timer ownership, and Claude polling rearm. |

## Test plan

- [x] Extension suites — 503 passed across bot-runtime-client, pi-remote, remote-session, and claude-code-remote
- [x] Root lint, typecheck, migration checks, Dockerfile checks, and generated API docs check — commit hooks passed
- [x] Two adversarial local review passes; both timer-generation findings fixed

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788676097&installation_model_id=20758&pr_number=1790&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1790&signature=8faeebfe2329e4963f57ded5b2d81256247386c2b374093975e098119809e090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->