### PR TITLE
fix(composer): keep collapsed previews aligned with editor content

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -527,14 +527,20 @@ The composer is **TipTap (ProseMirror)** wrapped by:
 - `PendingAttachments` — upload status row.
 - `AttachmentPill`, `MessageContextBadge`, `ScheduledMessagesPicker`, `StashedDraftsPicker`, `FloatingComposerShell`.
 
-### 9.1 Custom node types in flight
+### 9.1 Composer document nodes
 
-From the editor's content-walk helpers in `message-composer.tsx`:
+`editor/editor-extensions.ts` defines the composer schema:
 
-- `text`, `mention` (with `attrs.label`), `emoji` (with `attrs.emoji`/`attrs.shortcode`), `hardBreak`.
-- `quoteReply` — inline replied-to bubble, `attrs.authorName`.
-- `sharedMessage` — embedded cross-stream message card, `attrs.authorName`.
-- `paragraph`, `heading`, `bulletList`, `orderedList`, `codeBlock`.
+- Text structure: `doc`, `paragraph`, `text`, `hardBreak`, `heading`, `blockquote`, `horizontalRule`, and `codeBlock`.
+- Lists and tables: `bulletList`, `orderedList`, `listItem`, `table`, `tableRow`, `tableHeader`, and `tableCell`.
+- Inline atoms: `mention` (`attrs.slug`), `channelLink` (`attrs.slug`), `slashCommand` (`attrs.name`), `emoji`, `attachmentReference`, `memoEmbed`, `inAppLink`, and `giphyEmbed`.
+- Block atoms: `quoteReply` and `sharedMessage`.
+
+The mobile collapsed bar and board draft affordances both use
+`lib/drafts/collapsed-composer-preview.ts`. It gives each schema node a one-line
+semantic projection. Its test compares the preview fixture matrix with the node
+extensions returned by `createEditorExtensions`, so adding a node without a
+preview fixture fails the frontend suite.
 
 ### 9.2 Editor styles
 

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -395,6 +395,30 @@ describe("MessageComposer", () => {
   })
 
   describe("mobile state handling", () => {
+    it("shows a slash command in the collapsed preview", () => {
+      isMobileMockValue = true
+
+      render(
+        <MessageComposer
+          {...defaultProps}
+          content={{
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "slashCommand", attrs: { name: "steer", clientActionId: null } },
+                  { type: "text", text: " focus on tests" },
+                ],
+              },
+            ],
+          }}
+        />
+      )
+
+      expect(screen.getByText("/steer focus on tests")).toBeInTheDocument()
+    })
+
     it("renders editor in preview mode when mobile unfocused with content", () => {
       isMobileMockValue = true
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -33,6 +33,7 @@ import type { DraftContextRef } from "@/lib/context-bag/types"
 import { cn } from "@/lib/utils"
 import { COLLAPSED_COMPOSER_ROW, COLLAPSED_COMPOSER_SHADOW } from "@/components/composer/collapsed-composer-bar"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { collapsedComposerPreview } from "@/lib/drafts/collapsed-composer-preview"
 import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
 import type { MessageSendMode, JSONContent } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
@@ -61,88 +62,6 @@ function prependComposerCommand(content: JSONContent, command: string): JSONCont
     ...content,
     content: [{ type: "paragraph", content: [{ type: "text", text: command }] }, ...(content.content ?? [])],
   }
-}
-
-/** Check whether the document has content beyond a single line. */
-function isMultiLine(doc: JSONContent): boolean {
-  const blocks = doc.content
-  if (!blocks?.length) return false
-
-  // Filter out empty trailing paragraphs (TipTap always appends one)
-  const nonEmpty = blocks.filter((b) => b.type !== "paragraph" || (b.content?.length ?? 0) > 0)
-  if (nonEmpty.length > 1) return true
-
-  const first = nonEmpty[0]
-  if (!first) return false
-
-  if ((first.type === "bulletList" || first.type === "orderedList") && (first.content?.length ?? 0) > 1) return true
-  if (first.type === "codeBlock") {
-    const text = (first.content ?? []).map((c) => c.text ?? "").join("")
-    return text.includes("\n")
-  }
-  if (first.content?.some((c) => c.type === "hardBreak")) return true
-
-  return false
-}
-
-/** Extract the first line of plain text from editor content for the mobile preview bar. */
-function getPreviewText(doc: JSONContent): string {
-  function walk(node: JSONContent): string | null {
-    if (node.type === "text") return node.text ?? ""
-    if (node.type === "mention") return `@${node.attrs?.label ?? ""}`
-    if (node.type === "emoji") return String(node.attrs?.emoji ?? node.attrs?.shortcode ?? "")
-    if (node.type === "hardBreak") return null
-    // Atom node: no child text, so surface its baked label or it reads as empty.
-    if (node.type === "inAppLink")
-      return typeof node.attrs?.name === "string" && node.attrs.name ? node.attrs.name : "Link"
-
-    if (node.type === "quoteReply") {
-      const author = typeof node.attrs?.authorName === "string" ? node.attrs.authorName : ""
-      return `Replying to ${author}`
-    }
-
-    if (node.type === "sharedMessage") {
-      const author = typeof node.attrs?.authorName === "string" ? node.attrs.authorName : ""
-      return author ? `Sharing message from ${author}` : "Sharing a message"
-    }
-
-    if (node.type === "memoEmbed") {
-      const title = typeof node.attrs?.title === "string" ? node.attrs.title : ""
-      return title ? `Memo: ${title}` : "Memo"
-    }
-
-    if (node.type === "giphyEmbed") {
-      const title = typeof node.attrs?.title === "string" ? node.attrs.title : ""
-      return title ? `GIF: ${title}` : "GIF"
-    }
-
-    if (node.type === "codeBlock") {
-      const text = (node.content ?? []).map((c) => c.text ?? "").join("")
-      return text.split("\n")[0] ?? ""
-    }
-
-    if (!node.content?.length) return null
-
-    if (node.type === "paragraph" || node.type === "heading") {
-      const parts: string[] = []
-      for (const child of node.content) {
-        const t = walk(child)
-        if (t === null) break
-        parts.push(t)
-      }
-      return parts.join("") || null
-    }
-
-    for (const child of node.content) {
-      const t = walk(child)
-      if (t) return t
-    }
-    return null
-  }
-
-  const firstLine = walk(doc)?.trim() ?? ""
-  if (!firstLine) return ""
-  return isMultiLine(doc) ? `${firstLine}…` : firstLine
 }
 
 /** Platform-appropriate modifier key symbol (⌘ on Mac, Ctrl+ elsewhere) */
@@ -647,7 +566,7 @@ export function MessageComposer({
   }, [effectiveSendMode, expanded])
 
   // Plain-text first line for the mobile collapsed preview bar
-  const previewText = useMemo(() => getPreviewText(content), [content])
+  const previewText = useMemo(() => collapsedComposerPreview(content), [content])
 
   const handleAttachClick = useCallback(() => {
     fileInputRef.current?.click()

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -138,48 +138,20 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
     // Tracks ranges of polished dictation chunks so the session toggle can
     // swap them back to raw transcript; inert unless chunks are added.
     DictationChunkExtension,
+
+    // Schema nodes stay mounted even when their picker is disabled. Their
+    // extensions provide inert default suggestions, so every RichEditor parses
+    // the same document shape and the preview audit can inspect one factory call.
+    config.mentionSuggestion ? MentionExtension.configure({ suggestion: config.mentionSuggestion }) : MentionExtension,
+    config.channelSuggestion ? ChannelExtension.configure({ suggestion: config.channelSuggestion }) : ChannelExtension,
+    config.commandSuggestion ? CommandExtension.configure({ suggestion: config.commandSuggestion }) : CommandExtension,
+    config.emojiSuggestion && config.toEmoji
+      ? EmojiExtension.configure({ suggestion: config.emojiSuggestion, toEmoji: config.toEmoji })
+      : EmojiExtension,
+    config.memoSearchSuggestion
+      ? MemoSearchExtension.configure({ suggestion: config.memoSearchSuggestion })
+      : MemoSearchExtension,
   ]
-
-  if (config.mentionSuggestion) {
-    extensions.push(
-      MentionExtension.configure({
-        suggestion: config.mentionSuggestion,
-      })
-    )
-  }
-
-  if (config.channelSuggestion) {
-    extensions.push(
-      ChannelExtension.configure({
-        suggestion: config.channelSuggestion,
-      })
-    )
-  }
-
-  if (config.commandSuggestion) {
-    extensions.push(
-      CommandExtension.configure({
-        suggestion: config.commandSuggestion,
-      })
-    )
-  }
-
-  if (config.emojiSuggestion && config.toEmoji) {
-    extensions.push(
-      EmojiExtension.configure({
-        suggestion: config.emojiSuggestion,
-        toEmoji: config.toEmoji,
-      })
-    )
-  }
-
-  if (config.memoSearchSuggestion) {
-    extensions.push(
-      MemoSearchExtension.configure({
-        suggestion: config.memoSearchSuggestion,
-      })
-    )
-  }
 
   return extensions
 }

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -18,8 +18,12 @@ const doc = (text: string): JSONContent => ({
   content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
 })
 
+async function seedContent(id: string, draftScope: string, contentJson: JSONContent, clientUpdatedAt: number) {
+  await db.drafts.add({ id, workspaceId, scope: draftScope, contentJson, attachments: [], clientUpdatedAt })
+}
+
 async function seed(id: string, draftScope: string, text: string, clientUpdatedAt: number) {
-  await db.drafts.add({ id, workspaceId, scope: draftScope, contentJson: doc(text), attachments: [], clientUpdatedAt })
+  await seedContent(id, draftScope, doc(text), clientUpdatedAt)
 }
 
 beforeEach(async () => {
@@ -55,6 +59,29 @@ describe("useScopeDraftPreview", () => {
     await waitFor(() =>
       expect(result.current).toMatchObject({ draftId: "draft_new", preview: "newest roamed body", isCheckedOut: false })
     )
+  })
+
+  it("uses the shared collapsed-composer projection for structural draft content", async () => {
+    await seedContent(
+      "draft_command",
+      scope,
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "slashCommand", attrs: { name: "steer", clientActionId: null } },
+              { type: "text", text: " focus on tests" },
+            ],
+          },
+        ],
+      },
+      1000
+    )
+
+    const { result } = renderHook(() => useScopeDraftPreview(workspaceId, scope))
+    await waitFor(() => expect(result.current?.preview).toBe("/steer focus on tests"))
   })
 
   it("throws on a non-board scope — the shared snapshot only covers board:* rows", () => {

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -1,7 +1,7 @@
 import { useCallback, useSyncExternalStore } from "react"
 import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedDraft } from "@/db"
-import { draftInlineText } from "@/lib/drafts/decryption"
+import { collapsedComposerPreview } from "@/lib/drafts/collapsed-composer-preview"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { parseBoardDraftKey, BOARD_DRAFT_SCOPE_PREFIX } from "@/lib/board/draft-keys"
 
@@ -32,7 +32,7 @@ function hasPayload(draft: CachedDraft): boolean {
 function toPreview(best: CachedDraft, loadedDraftId: string | null): ScopeDraftPreview {
   return {
     draftId: best.id,
-    preview: draftInlineText(best.contentJson),
+    preview: collapsedComposerPreview(best.contentJson),
     attachmentCount: best.attachments?.length ?? 0,
     isCheckedOut: best.id === loadedDraftId,
   }

--- a/apps/frontend/src/lib/drafts/collapsed-composer-preview.test.ts
+++ b/apps/frontend/src/lib/drafts/collapsed-composer-preview.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest"
+import type { JSONContent } from "@threa/types"
+import { createEditorExtensions } from "@/components/editor/editor-extensions"
+import { collapsedComposerPreview } from "./collapsed-composer-preview"
+
+const text = (value: string): JSONContent => ({ type: "text", text: value })
+const paragraph = (...content: JSONContent[]): JSONContent => ({ type: "paragraph", content })
+const listItem = (value: string): JSONContent => ({ type: "listItem", content: [paragraph(text(value))] })
+const cell = (type: "tableHeader" | "tableCell", value: string): JSONContent => ({
+  type,
+  content: [paragraph(text(value))],
+})
+const doc = (...content: JSONContent[]): JSONContent => ({ type: "doc", content })
+
+const hardBreakDoc = doc(paragraph(text("Before"), { type: "hardBreak" }, text("After")))
+
+const NODE_CASES: Record<string, { content: JSONContent; expected: string }> = {
+  doc: { content: doc(paragraph(text("Message"))), expected: "Message" },
+  paragraph: { content: doc(paragraph(text("Message"))), expected: "Message" },
+  text: { content: doc(paragraph(text("Message"))), expected: "Message" },
+  hardBreak: { content: hardBreakDoc, expected: "Before…" },
+  heading: { content: doc({ type: "heading", attrs: { level: 2 }, content: [text("Heading")] }), expected: "Heading" },
+  bulletList: {
+    content: doc({ type: "bulletList", content: [listItem("First"), listItem("Second")] }),
+    expected: "First…",
+  },
+  orderedList: {
+    content: doc({ type: "orderedList", content: [listItem("First"), listItem("Second")] }),
+    expected: "First…",
+  },
+  listItem: {
+    content: doc({ type: "listItem", content: [paragraph(text("First")), paragraph(text("Second"))] }),
+    expected: "First…",
+  },
+  blockquote: {
+    content: doc({ type: "blockquote", content: [paragraph(text("Quoted")), paragraph(text("More"))] }),
+    expected: "Quoted…",
+  },
+  horizontalRule: { content: doc({ type: "horizontalRule" }), expected: "Divider" },
+  codeBlock: {
+    content: doc({
+      type: "codeBlock",
+      attrs: { language: "ts" },
+      content: [text("const first = 1\nconst second = 2")],
+    }),
+    expected: "const first = 1…",
+  },
+  table: {
+    content: doc({
+      type: "table",
+      content: [
+        { type: "tableRow", content: [cell("tableHeader", "Name"), cell("tableHeader", "Owner")] },
+        { type: "tableRow", content: [cell("tableCell", "Composer"), cell("tableCell", "Ada")] },
+      ],
+    }),
+    expected: "Table: Name…",
+  },
+  tableRow: {
+    content: doc({ type: "tableRow", content: [cell("tableCell", "Name"), cell("tableCell", "Owner")] }),
+    expected: "Name…",
+  },
+  tableHeader: {
+    content: doc({ type: "tableHeader", content: [paragraph(text("Name")), paragraph(text("Details"))] }),
+    expected: "Name…",
+  },
+  tableCell: {
+    content: doc({ type: "tableCell", content: [paragraph(text("Name")), paragraph(text("Details"))] }),
+    expected: "Name…",
+  },
+  attachmentReference: {
+    content: doc(
+      paragraph({
+        type: "attachmentReference",
+        attrs: {
+          id: "att_1",
+          filename: "spec.pdf",
+          mimeType: "application/pdf",
+          status: "uploaded",
+          imageIndex: null,
+        },
+      })
+    ),
+    expected: "spec.pdf",
+  },
+  quoteReply: {
+    content: doc({ type: "quoteReply", attrs: { authorName: "Ada", snippet: "Original" } }),
+    expected: "Replying to Ada",
+  },
+  sharedMessage: {
+    content: doc({ type: "sharedMessage", attrs: { authorName: "Bob" } }),
+    expected: "Sharing message from Bob",
+  },
+  memoEmbed: {
+    content: doc(paragraph({ type: "memoEmbed", attrs: { memoId: "memo_1", title: "Auth plan" } })),
+    expected: "Memo: Auth plan",
+  },
+  inAppLink: {
+    content: doc(paragraph({ type: "inAppLink", attrs: { name: "Design", url: "/w/ws/s/stream_1" } })),
+    expected: "Design",
+  },
+  giphyEmbed: {
+    content: doc(paragraph({ type: "giphyEmbed", attrs: { title: "happy cat", giphyUrl: "https://giphy.test/cat" } })),
+    expected: "GIF: happy cat",
+  },
+  mention: {
+    content: doc(paragraph({ type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } })),
+    expected: "@alice",
+  },
+  channelLink: {
+    content: doc(paragraph({ type: "channelLink", attrs: { id: "stream_1", slug: "general" } })),
+    expected: "#general",
+  },
+  slashCommand: {
+    content: doc(paragraph({ type: "slashCommand", attrs: { name: "steer", clientActionId: null } }, text(" focus"))),
+    expected: "/steer focus",
+  },
+  emoji: {
+    content: doc(paragraph({ type: "emoji", attrs: { shortcode: "rocket", emoji: "🚀" } })),
+    expected: "🚀",
+  },
+}
+
+function containsNodeType(node: JSONContent, type: string): boolean {
+  return node.type === type || (node.content ?? []).some((child) => containsNodeType(child, type))
+}
+
+describe("collapsedComposerPreview", () => {
+  it.each(Object.entries(NODE_CASES))("projects the %s editor node", (_type, testCase) => {
+    expect(collapsedComposerPreview(testCase.content)).toBe(testCase.expected)
+  })
+
+  it("uses a real fixture for every matrix entry", () => {
+    for (const [type, testCase] of Object.entries(NODE_CASES)) {
+      expect(containsNodeType(testCase.content, type), `${type} fixture`).toBe(true)
+    }
+  })
+
+  it("keeps the preview matrix aligned with every node in the composer schema", () => {
+    const schemaNodeTypes = createEditorExtensions({ placeholder: "" })
+      .filter((extension) => extension.type === "node")
+      .map((extension) => extension.name)
+
+    expect(new Set(schemaNodeTypes).size).toBe(schemaNodeTypes.length)
+    expect(Object.keys(NODE_CASES).sort()).toEqual(schemaNodeTypes.sort())
+  })
+
+  it("skips empty leading lines without hiding later content", () => {
+    expect(
+      collapsedComposerPreview(
+        doc(paragraph(text("  ")), paragraph({ type: "slashCommand", attrs: { name: "steer" } }), paragraph(text(" ")))
+      )
+    ).toBe("/steer")
+    expect(collapsedComposerPreview(doc(paragraph({ type: "hardBreak" }, text("After"))))).toBe("After…")
+    expect(collapsedComposerPreview(doc({ type: "codeBlock", content: [text("\nconst after = true")] }))).toBe(
+      "const after = true…"
+    )
+  })
+
+  it("names an unknown leaf instead of making a non-empty draft look empty", () => {
+    expect(collapsedComposerPreview(doc({ type: "pollEmbed" }))).toBe("Poll embed")
+  })
+})

--- a/apps/frontend/src/lib/drafts/collapsed-composer-preview.ts
+++ b/apps/frontend/src/lib/drafts/collapsed-composer-preview.ts
@@ -1,0 +1,178 @@
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+import { stripMarkdownToInline } from "@/lib/markdown"
+
+function stringAttr(node: JSONContent, name: string): string {
+  const value = node.attrs?.[name]
+  return typeof value === "string" ? value : ""
+}
+
+function humanizeNodeType(type: string | undefined): string {
+  if (!type) return "Content"
+  const words = type.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[-_]+/g, " ")
+  return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase()
+}
+
+function serializedPreview(node: JSONContent): string {
+  return stripMarkdownToInline(serializeToMarkdown({ type: "doc", content: [node] })).trim()
+}
+
+function attachmentPreview(node: JSONContent): string {
+  const filename = stringAttr(node, "filename")
+  const status = stringAttr(node, "status")
+  if (status === "uploading") return filename ? `Uploading ${filename}…` : "Uploading attachment…"
+  if (status === "error") return filename ? `${filename} upload failed` : "Attachment upload failed"
+  if (filename) return filename
+
+  const imageIndex = node.attrs?.imageIndex
+  return typeof imageIndex === "number" ? `Image #${imageIndex}` : "Attachment"
+}
+
+function previewTable(node: JSONContent): string {
+  const firstCell = node.content?.flatMap((row) => row.content ?? []).find((cell) => previewNode(cell).trim() !== "")
+  const cellPreview = firstCell ? previewNode(firstCell) : ""
+  return cellPreview ? `Table: ${cellPreview}` : "Table"
+}
+
+function previewChildren(node: JSONContent): string {
+  const parts: string[] = []
+  for (const child of node.content ?? []) {
+    if (child.type === "hardBreak") {
+      if (parts.join("").trim() !== "") break
+      parts.length = 0
+      continue
+    }
+    const preview = previewNode(child)
+    if (preview) parts.push(preview)
+  }
+  return parts.join("")
+}
+
+function previewFirstChild(node: JSONContent): string {
+  for (const child of node.content ?? []) {
+    const preview = previewNode(child)
+    if (preview.trim() !== "") return preview
+  }
+  return ""
+}
+
+function previewNode(node: JSONContent): string {
+  if (node.type === "text") return node.text ?? ""
+  if (node.type === "hardBreak") return ""
+
+  if (node.type === "mention") {
+    const label = stringAttr(node, "slug") || stringAttr(node, "label")
+    return label ? `@${label}` : "Mention"
+  }
+  if (node.type === "channelLink") {
+    const slug = stringAttr(node, "slug")
+    return slug ? `#${slug}` : "Channel"
+  }
+  if (node.type === "slashCommand") {
+    const name = stringAttr(node, "name")
+    return name ? `/${name}` : "Command"
+  }
+  if (node.type === "emoji") {
+    const emoji = stringAttr(node, "emoji")
+    if (emoji) return emoji
+    const shortcode = stringAttr(node, "shortcode")
+    return shortcode ? `:${shortcode}:` : "Emoji"
+  }
+  if (node.type === "attachmentReference") return attachmentPreview(node)
+  if (node.type === "inAppLink") return stringAttr(node, "name") || "Link"
+
+  if (node.type === "quoteReply") {
+    const author = stringAttr(node, "authorName")
+    return author ? `Replying to ${author}` : "Quoted reply"
+  }
+  if (node.type === "sharedMessage") {
+    const author = stringAttr(node, "authorName")
+    return author ? `Sharing message from ${author}` : "Sharing a message"
+  }
+  if (node.type === "memoEmbed") {
+    const title = stringAttr(node, "title")
+    return title ? `Memo: ${title}` : "Memo"
+  }
+  if (node.type === "giphyEmbed") {
+    const title = stringAttr(node, "title")
+    return title ? `GIF: ${title}` : "GIF"
+  }
+  if (node.type === "horizontalRule") return "Divider"
+  if (node.type === "table") return previewTable(node)
+  if (node.type === "codeBlock") {
+    const lines = (node.content ?? [])
+      .map((child) => child.text ?? "")
+      .join("")
+      .split("\n")
+    return lines.find((line) => line.trim() !== "") ?? ""
+  }
+
+  if (node.type === "paragraph" || node.type === "heading") {
+    return previewChildren(node)
+  }
+  if (
+    node.type === "doc" ||
+    node.type === "bulletList" ||
+    node.type === "orderedList" ||
+    node.type === "listItem" ||
+    node.type === "blockquote" ||
+    node.type === "tableRow" ||
+    node.type === "tableHeader" ||
+    node.type === "tableCell"
+  ) {
+    return previewFirstChild(node)
+  }
+
+  const childPreview = previewFirstChild(node)
+  if (childPreview) return childPreview
+
+  const canonicalPreview = serializedPreview(node)
+  return canonicalPreview || humanizeNodeType(node.type)
+}
+
+function hasMultipleMeaningfulChildren(node: JSONContent): boolean {
+  let meaningful = 0
+  for (const child of node.content ?? []) {
+    if (previewNode(child).trim() === "") continue
+    meaningful += 1
+    if (meaningful > 1) return true
+  }
+  return false
+}
+
+function isMultiline(node: JSONContent): boolean {
+  if (node.type === "codeBlock") {
+    return (node.content ?? []).some((child) => (child.text ?? "").includes("\n"))
+  }
+  if (node.type === "table") return true
+  if (node.type === "paragraph" || node.type === "heading") {
+    return (node.content ?? []).some((child) => child.type === "hardBreak")
+  }
+  if (
+    node.type === "doc" ||
+    node.type === "bulletList" ||
+    node.type === "orderedList" ||
+    node.type === "listItem" ||
+    node.type === "blockquote" ||
+    node.type === "tableRow" ||
+    node.type === "tableHeader" ||
+    node.type === "tableCell"
+  ) {
+    if (hasMultipleMeaningfulChildren(node)) return true
+    const first = (node.content ?? []).find((child) => previewNode(child).trim() !== "")
+    return first ? isMultiline(first) : false
+  }
+  return false
+}
+
+/**
+ * One-line semantic projection of a composer document for collapsed mobile
+ * chrome. Known atoms keep concise labels; canonical markdown serialization is
+ * the fallback for new sendable nodes, and an unknown leaf still names itself
+ * instead of making a non-empty draft look empty.
+ */
+export function collapsedComposerPreview(content: JSONContent): string {
+  const preview = previewNode(content).trim()
+  if (!preview) return ""
+  return isMultiline(content) ? `${preview}…` : preview
+}


### PR DESCRIPTION
## Problem

The collapsed mobile composer used a private node walker while board draft affordances serialized drafts separately. The implementations had drifted: `/steer`, channel links, mentions, dividers, and tables could disappear or render misleading text when the composer collapsed.

## Solution

Both surfaces now call `collapsedComposerPreview()` for one-line semantic projections.

- Every current TipTap node has an expected preview, including slash commands, mentions, channel links, attachments, tables, quotes, embeds, and multiline structures.
- Canonical markdown serialization handles new sendable nodes; unknown leaves still show a generated label instead of the empty-composer placeholder.
- `createEditorExtensions()` always mounts the full document schema; disabled pickers use inert suggestions. Adding a composer node without a preview fixture fails tests.
- Whitespace-only blocks are ignored, multiline table cells stop at the first meaningful block, and real additional content adds an ellipsis.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/drafts/collapsed-composer-preview.ts` | Shared semantic projection (**new**) |
| `apps/frontend/src/components/composer/message-composer.tsx` | Uses the shared projection for collapsed mobile chrome |
| `apps/frontend/src/hooks/use-scope-draft-preview.ts` | Uses the same projection for board draft affordances |
| `apps/frontend/src/components/editor/editor-extensions.ts` | Keeps document nodes unconditional while picker behavior remains configurable |
| `apps/frontend/src/**/*preview*.test.ts` | Node matrix, drift guard, and surface integration coverage |
| `DESIGN.md` | Corrects the composer-node inventory and documents the guard |

## Test plan

- [x] Frontend suite: 6,245 passed
- [x] Focused composer/board preview tests: 70 passed
- [x] Repository lint, typecheck, migration checks, Dockerfile checks, and generated API docs check
- [x] Two GPT-5.6 Sol/high adversarial passes; 4 findings fixed and targeted rechecks clean

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Show every composer content type when mobile chrome collapses, keep board and panel previews identical, and make future schema drift fail CI.

## What Was Built

### Shared projection

`collapsedComposerPreview()` walks the ProseMirror document once and returns a compact first meaningful line. Known atoms use explicit labels. Multiline structures add an ellipsis. Whitespace-only blocks do not hide later content.

### Shared consumers

`MessageComposer` and `useScopeDraftPreview` now call the same helper. This covers the docked conversation panel, stream composer, board card reply drafts, branch drafts, and sub-topic drafts.

### Drift prevention

The test fixture matrix covers every node name returned by `createEditorExtensions()`. Schema nodes are unconditional; disabling a picker swaps in inert suggestion behavior instead of removing its node. A new node therefore changes the audited set automatically.

### Review fixes

The local and PR reviews found four gaps and all were fixed:

- Conditional node configuration could evade the original test setup. The editor factory now owns a registry consumed by the audit.
- Whitespace-only blocks could hide later content or add false ellipses. Meaningful-child checks now trim before selection and counting.
- Multi-block table cells could concatenate text. Cells now project their first meaningful block and mark overflow.
- A later conditional non-trigger node could still evade the registry-based audit. Composer schema nodes are now unconditional, and configuration only controls picker behavior.

## Design Decisions

### Textual proxies in the collapsed bar

The bar remains one line. Attachments, references, links, embeds, and structural blocks get semantic text rather than mounting heavy cards inside the 30px surface. Existing sidecar chips remain visible.

### Visible fallback

Canonical serialization is the first fallback for new sendable nodes. An unknown leaf falls back to a humanized node name, so non-empty content never looks discarded while CI identifies the missing fixture.

## What's NOT Included

No changes to expanded composer rendering, send behavior, draft persistence, or sidecar chip layout.

## Status

- [x] Implement shared projection
- [x] Wire both collapsed preview paths
- [x] Add schema-aligned coverage
- [x] Run full frontend tests and repository checks
- [x] Complete adversarial review and targeted recheck

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
