### PR TITLE
fix: keep reminder menus above thread previews

### DIFF
--- a/apps/frontend/src/components/ui/hover-card.test.tsx
+++ b/apps/frontend/src/components/ui/hover-card.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card"
+
+describe("HoverCardContent", () => {
+  it("portals content outside its trigger's stacking context", () => {
+    render(
+      <div data-testid="stacking-context">
+        <HoverCard open>
+          <HoverCardTrigger>Open</HoverCardTrigger>
+          <HoverCardContent>Reminder options</HoverCardContent>
+        </HoverCard>
+      </div>
+    )
+
+    const stackingContext = screen.getByTestId("stacking-context")
+    const content = screen.getByText("Reminder options")
+
+    expect(stackingContext).not.toContainElement(content)
+    expect(document.body).toContainElement(content)
+  })
+})

--- a/apps/frontend/src/components/ui/hover-card.tsx
+++ b/apps/frontend/src/components/ui/hover-card.tsx
@@ -11,16 +11,18 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
-      className
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ))
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
 

--- a/tests/browser/thread-replies.spec.ts
+++ b/tests/browser/thread-replies.spec.ts
@@ -101,6 +101,40 @@ test.describe("Thread Replies", () => {
     await expect(parentInStream.getByRole("link", { name: /1 reply/i })).toBeVisible({ timeout: 45000 })
   })
 
+  test("keeps reminder controls above a thread preview", async ({ page }) => {
+    const channelName = `thread-reminder-${testId}`
+    await createChannel(page, channelName)
+
+    const editor = page.locator("[contenteditable='true']")
+    await editor.click()
+    const parentMessage = `Parent with reminder ${testId}`
+    await page.keyboard.type(parentMessage)
+    await page.keyboard.press("Meta+Enter")
+
+    const parentInStream = page.getByRole("main").locator(".message-item").filter({ hasText: parentMessage }).first()
+    await expect(parentInStream).toBeVisible({ timeout: 5000 })
+    await clickReplyInThread(parentInStream)
+    await expect(page.getByText(/Start a new thread/)).toBeVisible({ timeout: 3000 })
+
+    await sendPanelReply(page, `Thread reply for reminder ${testId}`)
+    await waitForRealThreadPanel(page)
+
+    const returnToChannel = page.getByRole("button", { name: `Return to #${channelName}` })
+    await returnToChannel.click()
+    await expect(page).not.toHaveURL(/panel=/)
+    await expect(parentInStream.getByRole("link", { name: /1 reply/i })).toBeVisible({ timeout: 10000 })
+
+    await parentInStream.hover()
+    await parentInStream.getByRole("button", { name: "Save for later" }).hover()
+
+    const reminderContent = page.locator("[data-state='open']").filter({ hasText: "In 15 minutes" })
+    await expect(reminderContent).toBeVisible()
+    expect(await reminderContent.evaluate((element) => element.closest(".message-item"))).toBeNull()
+
+    await reminderContent.getByRole("button", { name: "In 15 minutes" }).click()
+    await expect(parentInStream.getByText("Saved", { exact: true })).toBeVisible()
+  })
+
   test("should send multiple replies in a thread", async ({ page }) => {
     // Create a channel
     const channelName = `multi-reply-${testId}`


### PR DESCRIPTION
## Problem

`HoverCardContent` rendered inline inside the message hover toolbar. In Brave, that left the reminder menu in the message row's stacking context, allowing the thread preview to paint through the menu and leaving both surfaces visually colliding.

## Solution

Portal shared hover-card content to `document.body`, matching the existing popover/dropdown primitives. The menu now escapes message-row stacking and remains wholly above the thread preview. Reminder mutations, scheduling presets, thread navigation, and card layout are unchanged.

Added two regressions:
- Primitive coverage requires hover-card content to mount outside its trigger's stacking context.
- Browser coverage creates a thread preview, opens the message reminder menu, verifies it escaped `.message-item`, schedules a 15-minute reminder, and confirms the saved state.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/ui/hover-card.tsx` | Portal hover-card content. |
| `apps/frontend/src/components/ui/hover-card.test.tsx` | Assert portal placement. |
| `tests/browser/thread-replies.spec.ts` | Cover thread-preview layering and reminder scheduling. |

## Test plan

- [x] Targeted frontend tests — 24 passed
- [x] Browser regression — Brave 151, Chrome 151, Firefox 148
- [x] Monorepo lint, typecheck, OpenAPI, Dockerfile, and migration checks

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788686377&installation_model_id=20758&pr_number=1794&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1794&signature=e4f2a83d101b3ff6afdaddceeed99656abf72d529ef5c211ceb4d8fa76236d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->