### PR TITLE
feat(composer): add mobile inline attachment option

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -239,6 +239,15 @@ describe("updatePreferencesSchema board ledger settings", () => {
   })
 })
 
+describe("updatePreferencesSchema mobileInlineAttachments", () => {
+  it("accepts booleans and rejects other values", () => {
+    expect(updatePreferencesSchema.parse({ mobileInlineAttachments: true })).toEqual({
+      mobileInlineAttachments: true,
+    })
+    expect(updatePreferencesSchema.safeParse({ mobileInlineAttachments: "yes" }).success).toBe(false)
+  })
+})
+
 describe("updatePreferencesSchema accessibility.composerActionSide", () => {
   it("accepts both sides", () => {
     expect(updatePreferencesSchema.parse({ accessibility: { composerActionSide: "left" } }).accessibility).toEqual({

--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -244,6 +244,9 @@ describe("updatePreferencesSchema mobileInlineAttachments", () => {
     expect(updatePreferencesSchema.parse({ mobileInlineAttachments: true })).toEqual({
       mobileInlineAttachments: true,
     })
+    expect(updatePreferencesSchema.parse({ mobileInlineAttachments: false })).toEqual({
+      mobileInlineAttachments: false,
+    })
     expect(updatePreferencesSchema.safeParse({ mobileInlineAttachments: "yes" }).success).toBe(false)
   })
 })

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -55,6 +55,7 @@ const updatePreferencesSchema = z.object({
   notificationLevel: z.enum(PREF_NOTIFICATION_LEVEL_OPTIONS).optional(),
   sidebarCollapsed: z.boolean().optional(),
   messageSendMode: z.enum(MESSAGE_SEND_MODE_OPTIONS).optional(),
+  mobileInlineAttachments: z.boolean().optional(),
   linkPreviewDefault: z.enum(LINK_PREVIEW_DEFAULT_OPTIONS).optional(),
   labelRemoveOnMove: z.enum(LABEL_REMOVE_ON_MOVE_OPTIONS).optional(),
   unreadOpenPosition: z.enum(UNREAD_OPEN_POSITION_OPTIONS).optional(),

--- a/apps/backend/src/features/user-preferences/service.test.ts
+++ b/apps/backend/src/features/user-preferences/service.test.ts
@@ -76,6 +76,27 @@ describe("UserPreferencesService.updatePreferences defaultCompanionPersonaId", (
   })
 })
 
+describe("UserPreferencesService.updatePreferences mobile inline attachments", () => {
+  afterEach(() => mock.restore())
+
+  it("stores the enabled override", async () => {
+    setupTransaction()
+    const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
+    const bulkDelete = spyOn(UserPreferencesRepository, "bulkDeleteOverrides").mockResolvedValue(undefined as any)
+    spyOn(UserPreferencesRepository, "findOverrides").mockResolvedValue([
+      { key: "mobileInlineAttachments", value: true },
+    ])
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    const service = new UserPreferencesService({} as any)
+
+    const prefs = await service.updatePreferences(WORKSPACE_ID, USER_ID, { mobileInlineAttachments: true })
+
+    expect(bulkSet).toHaveBeenCalledWith({}, USER_ID, [{ key: "mobileInlineAttachments", value: true }])
+    expect(bulkDelete).not.toHaveBeenCalled()
+    expect(prefs.mobileInlineAttachments).toBe(true)
+  })
+})
+
 describe("UserPreferencesService.updatePreferences board ledger settings", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/user-preferences/service.test.ts
+++ b/apps/backend/src/features/user-preferences/service.test.ts
@@ -79,21 +79,21 @@ describe("UserPreferencesService.updatePreferences defaultCompanionPersonaId", (
 describe("UserPreferencesService.updatePreferences mobile inline attachments", () => {
   afterEach(() => mock.restore())
 
-  it("stores the enabled override", async () => {
+  it("stores the disabled override", async () => {
     setupTransaction()
     const bulkSet = spyOn(UserPreferencesRepository, "bulkSetOverrides").mockResolvedValue(undefined as any)
     const bulkDelete = spyOn(UserPreferencesRepository, "bulkDeleteOverrides").mockResolvedValue(undefined as any)
     spyOn(UserPreferencesRepository, "findOverrides").mockResolvedValue([
-      { key: "mobileInlineAttachments", value: true },
+      { key: "mobileInlineAttachments", value: false },
     ])
     spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
     const service = new UserPreferencesService({} as any)
 
-    const prefs = await service.updatePreferences(WORKSPACE_ID, USER_ID, { mobileInlineAttachments: true })
+    const prefs = await service.updatePreferences(WORKSPACE_ID, USER_ID, { mobileInlineAttachments: false })
 
-    expect(bulkSet).toHaveBeenCalledWith({}, USER_ID, [{ key: "mobileInlineAttachments", value: true }])
+    expect(bulkSet).toHaveBeenCalledWith({}, USER_ID, [{ key: "mobileInlineAttachments", value: false }])
     expect(bulkDelete).not.toHaveBeenCalled()
-    expect(prefs.mobileInlineAttachments).toBe(true)
+    expect(prefs.mobileInlineAttachments).toBe(false)
   })
 })
 

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -69,6 +69,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "notificationLevel",
     "sidebarCollapsed",
     "messageSendMode",
+    "mobileInlineAttachments",
     "linkPreviewDefault",
     "labelRemoveOnMove",
     "unreadOpenPosition",

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -374,10 +374,10 @@ describe("MessageComposer", () => {
       expect(screen.queryByText(/\.txt$/)).not.toBeInTheDocument()
     })
 
-    it("inserts picked files at the editor selection when enabled on mobile", async () => {
+    it("inserts picked files at the editor selection by default on mobile", async () => {
       isMobileMockValue = true
       vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
-        preferences: { mobileInlineAttachments: true },
+        preferences: {},
       } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
       const onFileSelect = vi.fn()
       const { container } = render(<MessageComposer {...defaultProps} onFileSelect={onFileSelect} />)

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -400,8 +400,10 @@ describe("MessageComposer", () => {
 
       await userEvent.upload(container.querySelector('input[type="file"]') as HTMLInputElement, file)
 
-      expect(onFileSelect).toHaveBeenCalledOnce()
-      expect(mockInsertFiles).not.toHaveBeenCalled()
+      expect({
+        selectedFiles: Array.from(onFileSelect.mock.calls[0]?.[0].target.files ?? []),
+        inlineInsertCalls: mockInsertFiles.mock.calls,
+      }).toEqual({ selectedFiles: [file], inlineInsertCalls: [] })
     })
   })
 

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -15,6 +15,7 @@ import { queueComposerCommandRequest } from "@/stores/composer-command-request-s
 
 let isMobileMockValue = false
 const mockRichEditorFocus = vi.fn()
+const mockInsertFiles = vi.fn(() => true)
 
 type MockEditorInstance = {
   id: string
@@ -31,6 +32,7 @@ const MockRichEditor = forwardRef<
     insertSlash: () => void
     insertEmoji: () => void
     openSnippetEditor: () => void
+    insertFiles: (files: File[]) => boolean
     getEditor: () => MockEditorInstance | null
   },
   {
@@ -69,6 +71,7 @@ const MockRichEditor = forwardRef<
       insertSlash: () => undefined,
       insertEmoji: () => undefined,
       openSnippetEditor: () => undefined,
+      insertFiles: mockInsertFiles,
       getEditor: () => editorInstance,
     }),
     [editorInstance]
@@ -142,6 +145,7 @@ describe("MessageComposer", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     mockRichEditorFocus.mockClear()
+    mockInsertFiles.mockClear()
     isMobileMockValue = false
     vi.useRealTimers()
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileMockValue)
@@ -368,6 +372,36 @@ describe("MessageComposer", () => {
       render(<MessageComposer {...defaultProps} pendingAttachments={[]} />)
 
       expect(screen.queryByText(/\.txt$/)).not.toBeInTheDocument()
+    })
+
+    it("inserts picked files at the editor selection when enabled on mobile", async () => {
+      isMobileMockValue = true
+      vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
+        preferences: { mobileInlineAttachments: true },
+      } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+      const onFileSelect = vi.fn()
+      const { container } = render(<MessageComposer {...defaultProps} onFileSelect={onFileSelect} />)
+      const file = new File(["notes"], "notes.txt", { type: "text/plain" })
+
+      await userEvent.upload(container.querySelector('input[type="file"]') as HTMLInputElement, file)
+
+      expect(mockInsertFiles).toHaveBeenCalledWith([file])
+      expect(onFileSelect).not.toHaveBeenCalled()
+    })
+
+    it("keeps the attachment-row flow when inline insertion is disabled", async () => {
+      isMobileMockValue = true
+      vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
+        preferences: { mobileInlineAttachments: false },
+      } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+      const onFileSelect = vi.fn()
+      const { container } = render(<MessageComposer {...defaultProps} onFileSelect={onFileSelect} />)
+      const file = new File(["notes"], "notes.txt", { type: "text/plain" })
+
+      await userEvent.upload(container.querySelector('input[type="file"]') as HTMLInputElement, file)
+
+      expect(onFileSelect).toHaveBeenCalledOnce()
+      expect(mockInsertFiles).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -19,6 +19,7 @@ import { usePreferencesOptional } from "@/contexts"
 import { getEffectiveKeyBinding, matchesKeyBinding } from "@/lib/keyboard-shortcuts"
 import { RichEditor, EditorToolbar, EditorActionBar } from "@/components/editor"
 import type { RichEditorHandle } from "@/components/editor"
+import { handleMobileInlineAttachmentPicker } from "@/components/editor/mobile-inline-attachment-picker"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
@@ -575,14 +576,14 @@ export function MessageComposer({
 
   const handleFileInputChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const files = Array.from(event.target.files ?? [])
-      const mobileInlineAttachments =
-        preferencesCtx?.preferences?.mobileInlineAttachments ?? DEFAULT_USER_PREFERENCES.mobileInlineAttachments
-      if (!isMobile || !mobileInlineAttachments || files.length === 0 || !richEditorRef.current?.insertFiles(files)) {
-        onFileSelect(event)
-        return
-      }
-      event.target.value = ""
+      handleMobileInlineAttachmentPicker({
+        event,
+        isMobile,
+        inlineEnabled:
+          preferencesCtx?.preferences?.mobileInlineAttachments ?? DEFAULT_USER_PREFERENCES.mobileInlineAttachments,
+        insertFiles: (files) => richEditorRef.current?.insertFiles(files) ?? false,
+        fallback: onFileSelect,
+      })
     },
     [isMobile, onFileSelect, preferencesCtx?.preferences?.mobileInlineAttachments]
   )

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -35,7 +35,7 @@ import { COLLAPSED_COMPOSER_ROW, COLLAPSED_COMPOSER_SHADOW } from "@/components/
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { collapsedComposerPreview } from "@/lib/drafts/collapsed-composer-preview"
 import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
-import type { MessageSendMode, JSONContent } from "@threa/types"
+import { DEFAULT_USER_PREFERENCES, type MessageSendMode, type JSONContent } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import type { Editor } from "@tiptap/react"
 import { consumeComposerCommandRequest, subscribeComposerCommandRequest } from "@/stores/composer-command-request-store"
@@ -576,8 +576,9 @@ export function MessageComposer({
   const handleFileInputChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const files = Array.from(event.target.files ?? [])
-      const insertInline = isMobile && preferencesCtx?.preferences?.mobileInlineAttachments === true
-      if (!insertInline || files.length === 0 || !richEditorRef.current?.insertFiles(files)) {
+      const mobileInlineAttachments =
+        preferencesCtx?.preferences?.mobileInlineAttachments ?? DEFAULT_USER_PREFERENCES.mobileInlineAttachments
+      if (!isMobile || !mobileInlineAttachments || files.length === 0 || !richEditorRef.current?.insertFiles(files)) {
         onFileSelect(event)
         return
       }

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -313,6 +313,7 @@ export function MessageComposer({
   const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobile()
   const actionSide = useComposerActionSide()
+  const preferencesCtx = usePreferencesOptional()
   const mirrored = actionSide === "left"
   // Selection toolbar is a hover/mouse affordance, so it keys off the active
   // input mode (a finger suppresses it) rather than viewport width — a mouse on
@@ -572,6 +573,19 @@ export function MessageComposer({
     fileInputRef.current?.click()
   }, [fileInputRef])
 
+  const handleFileInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? [])
+      const insertInline = isMobile && preferencesCtx?.preferences?.mobileInlineAttachments === true
+      if (!insertInline || files.length === 0 || !richEditorRef.current?.insertFiles(files)) {
+        onFileSelect(event)
+        return
+      }
+      event.target.value = ""
+    },
+    [isMobile, onFileSelect, preferencesCtx?.preferences?.mobileInlineAttachments]
+  )
+
   // Stable wrappers that read the editor handle at call time (not render time),
   // so they stay fresh whether invoked from an inline toolbar button or a
   // folded "+" overflow menu item.
@@ -653,7 +667,6 @@ export function MessageComposer({
   // scopes the shortcut to whichever composer actually received focus — if
   // main + thread are both mounted, only the focused one fires. Registered
   // via `SHORTCUT_ACTIONS`, so the user can remap it in settings.
-  const preferencesCtx = usePreferencesOptional()
   const stashBinding = getEffectiveKeyBinding("draftStash", preferencesCtx?.preferences?.keyboardShortcuts ?? {})
 
   // Cmd/Ctrl+S with nothing to stash flips to "show me my drafts": open the
@@ -854,7 +867,7 @@ export function MessageComposer({
               type="file"
               multiple
               className="hidden"
-              onChange={onFileSelect}
+              onChange={handleFileInputChange}
               disabled={controlsDisabled}
             />
 
@@ -1135,7 +1148,7 @@ export function MessageComposer({
             type="file"
             multiple
             className="hidden"
-            onChange={onFileSelect}
+            onChange={handleFileInputChange}
             disabled={controlsDisabled}
           />
 

--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -78,6 +78,59 @@ function pasteHtml(editor: Editor, html: string): Slice {
 }
 
 describe("attachment reference insertion", () => {
+  it.each([
+    ["Hello", "Hello "],
+    ["Hello ", "Hello "],
+    ["Hello:   ", "Hello:   "],
+    ["", ""],
+  ])("normalizes spacing before a chip inserted after %j", (input, expectedBeforeChip) => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph", content: input ? [{ type: "text", text: input }] : undefined }],
+      },
+    })
+    openEditors.push(editor)
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, input.length + 1)))
+
+    editor.commands.insertAttachmentReference(CHIP_ATTRS)
+
+    const at = chipPos(editor)
+    expect({
+      beforeChip: editor.state.doc.textBetween(0, at),
+      afterChip: editor.state.doc.textBetween(at + 1, at + 2),
+    }).toEqual({ beforeChip: expectedBeforeChip, afterChip: " " })
+  })
+
+  it("does not add a leading space after a hard break", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Hello" }, { type: "hardBreak" }],
+          },
+        ],
+      },
+    })
+    openEditors.push(editor)
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 7)))
+
+    editor.commands.insertAttachmentReference(CHIP_ATTRS)
+
+    expect(editor.getJSON().content?.[0]?.content).toEqual([
+      { type: "text", text: "Hello" },
+      { type: "hardBreak" },
+      { type: "attachmentReference", attrs: CHIP_ATTRS },
+      { type: "text", text: " " },
+    ])
+  })
+
   it("inserts the chip at the current text selection", () => {
     const editor = new Editor({
       element: document.createElement("div"),

--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { Editor } from "@tiptap/core"
 import { DOMParser as PMDOMParser, DOMSerializer, type Slice } from "@tiptap/pm/model"
-import { NodeSelection } from "@tiptap/pm/state"
+import { NodeSelection, TextSelection } from "@tiptap/pm/state"
 import { createEditorExtensions } from "./editor-extensions"
 import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
 
@@ -76,6 +76,34 @@ function pasteHtml(editor: Editor, html: string): Slice {
   wrapper.innerHTML = html
   return PMDOMParser.fromSchema(editor.schema).parseSlice(wrapper)
 }
+
+describe("attachment reference insertion", () => {
+  it("inserts the chip at the current text selection", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+      content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "before after" }] }] },
+    })
+    openEditors.push(editor)
+    editor.view.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 8)))
+
+    editor.commands.insertAttachmentReference(CHIP_ATTRS)
+
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "before " },
+            { type: "attachmentReference", attrs: CHIP_ATTRS },
+            { type: "text", text: " after" },
+          ],
+        },
+      ],
+    })
+  })
+})
 
 describe("attachment reference clipboard roundtrip", () => {
   it("serializes a chip selected on its own and parses it back with its attributes", () => {

--- a/apps/frontend/src/components/editor/attachment-reference-extension.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.ts
@@ -137,9 +137,16 @@ export const AttachmentReferenceExtension = Node.create({
             type: mark.type.name,
             attrs: mark.attrs,
           }))
+          const nodeBefore = $from.nodeBefore
+          const isLineStart = $from.parentOffset === 0 || nodeBefore?.type.name === "hardBreak"
+          let charBefore = ""
+          if (nodeBefore?.isText) charBefore = nodeBefore.text?.slice(-1) ?? ""
+          else if (nodeBefore) charBefore = "\uFFFC"
+          const needsLeadingSpace = !isLineStart && charBefore !== "" && !/\s/u.test(charBefore)
 
           return chain()
             .insertContent([
+              ...(needsLeadingSpace ? [{ type: "text", text: " ", marks }] : []),
               { type: "attachmentReference", attrs, marks },
               { type: "text", text: " ", marks },
             ])

--- a/apps/frontend/src/components/editor/editor-action-bar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.test.tsx
@@ -12,6 +12,7 @@ function renderBar(props: Partial<React.ComponentProps<typeof EditorActionBar>> 
     insertSlash: vi.fn(),
     insertEmoji: vi.fn(),
     openSnippetEditor: vi.fn(),
+    insertFiles: vi.fn(() => true),
     insertTranscribedText: vi.fn(),
     setDictationInterim: vi.fn(),
     insertDictationChunk: vi.fn(),

--- a/apps/frontend/src/components/editor/mobile-inline-attachment-picker.test.ts
+++ b/apps/frontend/src/components/editor/mobile-inline-attachment-picker.test.ts
@@ -1,0 +1,46 @@
+import type { ChangeEvent } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { handleMobileInlineAttachmentPicker } from "./mobile-inline-attachment-picker"
+
+function pickerEvent(files: File[]): ChangeEvent<HTMLInputElement> {
+  return {
+    target: { files, value: "selected" },
+  } as unknown as ChangeEvent<HTMLInputElement>
+}
+
+describe("handleMobileInlineAttachmentPicker", () => {
+  it("inserts selected files inline and resets the picker", () => {
+    const file = new File(["notes"], "notes.txt", { type: "text/plain" })
+    const event = pickerEvent([file])
+    const insertFiles = vi.fn((_files: File[]) => true)
+    const fallback = vi.fn()
+
+    handleMobileInlineAttachmentPicker({ event, isMobile: true, inlineEnabled: true, insertFiles, fallback })
+
+    expect({
+      insertedFiles: insertFiles.mock.calls[0]?.[0],
+      fallbackCalls: fallback.mock.calls,
+      inputValue: event.target.value,
+    }).toEqual({ insertedFiles: [file], fallbackCalls: [], inputValue: "" })
+  })
+
+  it.each([
+    ["desktop", false, true, true],
+    ["disabled", true, false, true],
+    ["editor unavailable", true, true, false],
+  ])("uses the attachment-row fallback when inline insertion is %s", (_case, isMobile, inlineEnabled, inserted) => {
+    const file = new File(["notes"], "notes.txt", { type: "text/plain" })
+    const event = pickerEvent([file])
+    const fallback = vi.fn()
+
+    handleMobileInlineAttachmentPicker({
+      event,
+      isMobile,
+      inlineEnabled,
+      insertFiles: () => inserted,
+      fallback,
+    })
+
+    expect(fallback).toHaveBeenCalledWith(event)
+  })
+})

--- a/apps/frontend/src/components/editor/mobile-inline-attachment-picker.ts
+++ b/apps/frontend/src/components/editor/mobile-inline-attachment-picker.ts
@@ -1,0 +1,24 @@
+import type { ChangeEvent } from "react"
+
+interface HandleMobileInlineAttachmentPickerOptions {
+  event: ChangeEvent<HTMLInputElement>
+  isMobile: boolean
+  inlineEnabled: boolean
+  insertFiles: (files: File[]) => boolean
+  fallback: (event: ChangeEvent<HTMLInputElement>) => void
+}
+
+export function handleMobileInlineAttachmentPicker({
+  event,
+  isMobile,
+  inlineEnabled,
+  insertFiles,
+  fallback,
+}: HandleMobileInlineAttachmentPickerOptions): void {
+  const files = Array.from(event.target.files ?? [])
+  if (!isMobile || !inlineEnabled || files.length === 0 || !insertFiles(files)) {
+    fallback(event)
+    return
+  }
+  event.target.value = ""
+}

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -71,6 +71,8 @@ export interface RichEditorHandle {
   insertEmoji(): void
   /** Open the snippet editor with an empty draft anchored at the caret. */
   openSnippetEditor(): void
+  /** Upload files and insert their reference chips at the current selection. */
+  insertFiles(files: File[]): boolean
   /** Append a committed dictation span at the caret. */
   insertTranscribedText(text: string): void
   /** Show the live (uncommitted) dictation hypothesis as a caret ghost; empty string clears it. */
@@ -557,6 +559,16 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       })
     }
   }, [])
+
+  const insertFiles = useCallback(
+    (files: File[]): boolean => {
+      const editorInstance = editorRef.current
+      if (!editorInstance || editorInstance.isDestroyed || !onFileUploadRef.current) return false
+      for (const file of files) void handleFileInsert(file, editorInstance)
+      return true
+    },
+    [handleFileInsert]
+  )
 
   // Save the snippet editor's contents as a text attachment, inserting the chip
   // back at the caret position the paste happened at. Reuses the same
@@ -1159,6 +1171,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       insertSlash: handleSlashClick,
       insertEmoji: handleEmojiClick,
       openSnippetEditor,
+      insertFiles,
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,
@@ -1175,6 +1188,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       handleSlashClick,
       handleEmojiClick,
       openSnippetEditor,
+      insertFiles,
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.test.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.test.tsx
@@ -1,0 +1,94 @@
+import { forwardRef } from "react"
+import { fireEvent, render } from "@testing-library/react"
+import type { ScheduledMessageView } from "@threa/types"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { spyOnExport } from "@/test/spy"
+import * as contextsModule from "@/contexts"
+import * as hooksModule from "@/hooks"
+import * as useAttachmentsModule from "@/hooks/use-attachments"
+import * as useInputModeModule from "@/hooks/use-input-mode"
+import * as useMentionablesModule from "@/hooks/use-mentionables"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as editorModule from "@/components/editor"
+import { ScheduledEditDialog } from "./scheduled-edit-dialog"
+
+const MockRichEditor = forwardRef(function MockRichEditor() {
+  return <div data-testid="scheduled-rich-editor" />
+})
+
+const SCHEDULED_MESSAGE: ScheduledMessageView = {
+  id: "sched_local_test",
+  workspaceId: "workspace-1",
+  userId: "user-1",
+  streamId: "stream-1",
+  parentMessageId: null,
+  contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+  contentMarkdown: "",
+  attachmentIds: [],
+  metadata: null,
+  scheduledFor: new Date(Date.now() + 60_000).toISOString(),
+  status: "pending",
+  sentMessageId: null,
+  lastError: null,
+  editActiveUntil: null,
+  clientMessageId: "client-1",
+  version: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  statusChangedAt: new Date().toISOString(),
+}
+
+describe("ScheduledEditDialog attachments", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("uses the attachment-row fallback when mobile inline insertion is disabled", () => {
+    const handleFileSelect = vi.fn()
+    const attachments = {
+      pendingAttachments: [],
+      getPendingAttachmentsSnapshot: () => [],
+      fileInputRef: { current: null },
+      handleFileSelect,
+      uploadFile: vi.fn(),
+      removeAttachment: vi.fn(),
+      cancelUpload: vi.fn(),
+      uploadedIds: [],
+      isUploading: false,
+      isReserving: false,
+      hasFailed: false,
+      clear: vi.fn(),
+      restore: vi.fn(),
+      imageCount: 0,
+    } as unknown as ReturnType<typeof useAttachmentsModule.useAttachments>
+    const mutation = {
+      isPending: false,
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+    }
+
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    vi.spyOn(useInputModeModule, "useInputMode").mockReturnValue("touch")
+    vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+      preferences: { mobileInlineAttachments: false },
+    } as ReturnType<typeof contextsModule.usePreferences>)
+    vi.spyOn(useAttachmentsModule, "useAttachments").mockReturnValue(attachments)
+    vi.spyOn(useMentionablesModule, "useMentionStreamContext").mockReturnValue(undefined)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([])
+    vi.spyOn(hooksModule, "useUpdateScheduled").mockReturnValue(mutation as never)
+    vi.spyOn(hooksModule, "useLockScheduledForEdit").mockReturnValue(mutation as never)
+    vi.spyOn(hooksModule, "useReleaseScheduledEditLock").mockReturnValue(mutation as never)
+    vi.spyOn(hooksModule, "useSendScheduledNow").mockReturnValue(mutation as never)
+    vi.spyOn(hooksModule, "useCancelScheduled").mockReturnValue(mutation as never)
+    spyOnExport(editorModule, "RichEditor").mockReturnValue(MockRichEditor as unknown as typeof editorModule.RichEditor)
+    spyOnExport(editorModule, "EditorActionBar").mockReturnValue((() => null) as never)
+    spyOnExport(editorModule, "EditorToolbar").mockReturnValue((() => null) as never)
+
+    render(<ScheduledEditDialog workspaceId="workspace-1" scheduled={SCHEDULED_MESSAGE} onClose={vi.fn()} />)
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["notes"], "notes.txt", { type: "text/plain" })
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(Array.from(handleFileSelect.mock.calls[0]?.[0].target.files ?? [])).toEqual([file])
+  })
+})

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Loader2, Send, Trash2 } from "lucide-react"
 import type { Editor } from "@tiptap/react"
-import { type JSONContent, type ScheduledMessageView } from "@threa/types"
+import { DEFAULT_USER_PREFERENCES, type JSONContent, type ScheduledMessageView } from "@threa/types"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { Button } from "@/components/ui/button"
 import { RichEditor, EditorActionBar, EditorToolbar } from "@/components/editor"
 import type { RichEditorHandle } from "@/components/editor"
+import { handleMobileInlineAttachmentPicker } from "@/components/editor/mobile-inline-attachment-picker"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
 import { DateTimeField } from "@/components/forms/date-time-field"
 import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/dates"
@@ -22,6 +23,7 @@ import {
 } from "@/hooks"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
 import { useAttachments } from "@/hooks/use-attachments"
+import { usePreferences } from "@/contexts"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { materializePendingAttachmentReferences } from "@/components/timeline/message-input"
 import { toast } from "sonner"
@@ -52,6 +54,7 @@ interface ScheduledEditDialogProps {
  */
 export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: ScheduledEditDialogProps) {
   const isMobile = useIsMobile()
+  const { preferences } = usePreferences()
   // Selection toolbar is a hover/mouse affordance, so it keys off the active
   // input mode (a finger suppresses it) rather than viewport width — a mouse on
   // a touchscreen laptop still gets it.
@@ -188,6 +191,19 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
     const next = handle?.getEditor() ?? null
     setToolbarEditor((cur) => (cur === next ? cur : next))
   }, [])
+
+  const handleFileInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      handleMobileInlineAttachmentPicker({
+        event,
+        isMobile,
+        inlineEnabled: preferences?.mobileInlineAttachments ?? DEFAULT_USER_PREFERENCES.mobileInlineAttachments,
+        insertFiles: (files) => editorRef.current?.insertFiles(files) ?? false,
+        fallback: attachmentsHook.handleFileSelect,
+      })
+    },
+    [attachmentsHook.handleFileSelect, isMobile, preferences?.mobileInlineAttachments]
+  )
 
   // Snapshot the live editor content + materialized attachments — shared by
   // Save and Send now so both ship exactly what the user currently sees.
@@ -347,7 +363,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       type="file"
       multiple
       className="hidden"
-      onChange={attachmentsHook.handleFileSelect}
+      onChange={handleFileInputChange}
       disabled={isSaving}
     />
   )

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -8,7 +8,7 @@ import * as contextsModule from "@/contexts"
 const mockPreferences = {
   keyboardShortcuts: {} as Record<string, string>,
   messageSendMode: "enter" as const,
-  mobileInlineAttachments: false,
+  mobileInlineAttachments: true,
 }
 
 const updatePreference = vi.fn()
@@ -22,7 +22,7 @@ describe("KeyboardSettings", () => {
     resetKeyboardShortcut.mockReset()
     resetAllKeyboardShortcuts.mockReset()
     mockPreferences.keyboardShortcuts = {}
-    mockPreferences.mobileInlineAttachments = false
+    mockPreferences.mobileInlineAttachments = true
 
     vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
       preferences: mockPreferences,
@@ -36,11 +36,11 @@ describe("KeyboardSettings", () => {
     render(<KeyboardSettings />)
 
     const toggle = screen.getByRole("switch", { name: "Insert files at the cursor" })
-    expect(toggle).not.toBeChecked()
+    expect(toggle).toBeChecked()
 
     await userEvent.click(toggle)
 
-    expect(updatePreference).toHaveBeenCalledWith("mobileInlineAttachments", true)
+    expect(updatePreference).toHaveBeenCalledWith("mobileInlineAttachments", false)
   })
 
   it("saves conflict overrides as a single keyboardShortcuts update", async () => {

--- a/apps/frontend/src/components/settings/keyboard-settings.test.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.test.tsx
@@ -8,6 +8,7 @@ import * as contextsModule from "@/contexts"
 const mockPreferences = {
   keyboardShortcuts: {} as Record<string, string>,
   messageSendMode: "enter" as const,
+  mobileInlineAttachments: false,
 }
 
 const updatePreference = vi.fn()
@@ -21,6 +22,7 @@ describe("KeyboardSettings", () => {
     resetKeyboardShortcut.mockReset()
     resetAllKeyboardShortcuts.mockReset()
     mockPreferences.keyboardShortcuts = {}
+    mockPreferences.mobileInlineAttachments = false
 
     vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
       preferences: mockPreferences,
@@ -28,6 +30,17 @@ describe("KeyboardSettings", () => {
       resetKeyboardShortcut,
       resetAllKeyboardShortcuts,
     } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  })
+
+  it("updates mobile inline attachment behavior", async () => {
+    render(<KeyboardSettings />)
+
+    const toggle = screen.getByRole("switch", { name: "Insert files at the cursor" })
+    expect(toggle).not.toBeChecked()
+
+    await userEvent.click(toggle)
+
+    expect(updatePreference).toHaveBeenCalledWith("mobileInlineAttachments", true)
   })
 
   it("saves conflict overrides as a single keyboardShortcuts update", async () => {

--- a/apps/frontend/src/components/settings/keyboard-settings.tsx
+++ b/apps/frontend/src/components/settings/keyboard-settings.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { RotateCcw } from "lucide-react"
 import { usePreferences } from "@/contexts"
@@ -19,7 +20,7 @@ import {
   resolveShortcutBindingUpdate,
   type ShortcutAction,
 } from "@/lib/keyboard-shortcuts"
-import { MESSAGE_SEND_MODE_OPTIONS, type MessageSendMode } from "@threa/types"
+import { DEFAULT_USER_PREFERENCES, MESSAGE_SEND_MODE_OPTIONS, type MessageSendMode } from "@threa/types"
 
 const SEND_MODE_CONFIG: Record<MessageSendMode, { label: string; description: string }> = {
   enter: {
@@ -293,6 +294,8 @@ export function KeyboardSettings({ onCaptureStateChange }: KeyboardSettingsProps
   const hasConflicts = conflicts.size > 0
   const hasCustomBindings = Object.keys(customBindings).length > 0
   const messageSendMode = preferences?.messageSendMode ?? "enter"
+  const mobileInlineAttachments =
+    preferences?.mobileInlineAttachments ?? DEFAULT_USER_PREFERENCES.mobileInlineAttachments
 
   const [capturingId, setCapturingId] = useState<string | null>(null)
 
@@ -388,6 +391,28 @@ export function KeyboardSettings({ onCaptureStateChange }: KeyboardSettingsProps
             </div>
           ))}
         </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">File attachments</h3>
+          <p className="text-sm text-muted-foreground">Control how picked files appear in the mobile composer</p>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="mobile-inline-attachments">Insert files at the cursor</Label>
+            <p className="text-sm text-muted-foreground">
+              Adds a file chip to the message. Removing the chip keeps the file attached.
+            </p>
+          </div>
+          <Switch
+            id="mobile-inline-attachments"
+            checked={mobileInlineAttachments}
+            onCheckedChange={(checked) => updatePreference("mobileInlineAttachments", checked)}
+          />
+        </div>
       </section>
 
       {shortcuts.navigation.length > 0 && (

--- a/apps/frontend/src/components/settings/tab-config.ts
+++ b/apps/frontend/src/components/settings/tab-config.ts
@@ -54,9 +54,9 @@ export const SETTINGS_TAB_CONFIG: Record<SettingsTab, SettingsTabConfig> = {
     keywords: ["push", "alerts", "mute", "mentions", "enable notifications"],
   },
   keyboard: {
-    label: "Keyboard",
-    description: "Shortcuts and send behavior",
-    keywords: ["shortcuts", "hotkeys", "bindings", "enter", "send"],
+    label: "Composer",
+    description: "Sending, attachments, and shortcuts",
+    keywords: ["keyboard", "shortcuts", "hotkeys", "bindings", "enter", "send", "attachments", "files", "mobile"],
   },
   diagnostics: {
     label: "Diagnostics",

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -70,6 +70,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       language: "en",
       notificationLevel: "all",
       sidebarCollapsed: false,
+      mobileInlineAttachments: false,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
       unreadOpenPosition: "latest",

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -70,7 +70,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       language: "en",
       notificationLevel: "all",
       sidebarCollapsed: false,
-      mobileInlineAttachments: false,
+      mobileInlineAttachments: true,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
       unreadOpenPosition: "latest",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -94,6 +94,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       language: "en",
       notificationLevel: "all",
       sidebarCollapsed: false,
+      mobileInlineAttachments: false,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
       unreadOpenPosition: "latest",

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -94,7 +94,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       language: "en",
       notificationLevel: "all",
       sidebarCollapsed: false,
-      mobileInlineAttachments: false,
+      mobileInlineAttachments: true,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
       unreadOpenPosition: "latest",

--- a/packages/types/src/preferences.test.ts
+++ b/packages/types/src/preferences.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test"
 import { DEFAULT_BOARD_MASS_BADGE, DEFAULT_USER_PREFERENCES, normalizeBoardMassBadge } from "./preferences"
 
 describe("user preference defaults", () => {
-  it("keeps mobile file picking out of the message body until enabled", () => {
-    expect(DEFAULT_USER_PREFERENCES.mobileInlineAttachments).toBe(false)
+  it("inserts mobile-picked files into the message body by default", () => {
+    expect(DEFAULT_USER_PREFERENCES.mobileInlineAttachments).toBe(true)
   })
 })
 

--- a/packages/types/src/preferences.test.ts
+++ b/packages/types/src/preferences.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test"
 import { DEFAULT_BOARD_MASS_BADGE, DEFAULT_USER_PREFERENCES, normalizeBoardMassBadge } from "./preferences"
 
+describe("user preference defaults", () => {
+  it("keeps mobile file picking out of the message body until enabled", () => {
+    expect(DEFAULT_USER_PREFERENCES.mobileInlineAttachments).toBe(false)
+  })
+})
+
 describe("normalizeBoardMassBadge", () => {
   it("keeps a mode that still exists", () => {
     expect(normalizeBoardMassBadge("count")).toBe("count")

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -320,6 +320,8 @@ export interface UserPreferences {
   notificationLevel: PrefNotificationLevel
   sidebarCollapsed: boolean
   messageSendMode: MessageSendMode
+  /** Whether files picked on mobile are also inserted into the message body at the caret. */
+  mobileInlineAttachments: boolean
   linkPreviewDefault: LinkPreviewDefault
   /**
    * What dragging a labeled stream out of its sidebar label section does to that
@@ -444,6 +446,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   notificationLevel: "all",
   sidebarCollapsed: false,
   messageSendMode: "enter",
+  mobileInlineAttachments: false,
   linkPreviewDefault: "open",
   labelRemoveOnMove: "ask",
   unreadOpenPosition: "latest",
@@ -489,6 +492,7 @@ export interface UpdateUserPreferencesInput {
   notificationLevel?: PrefNotificationLevel
   sidebarCollapsed?: boolean
   messageSendMode?: MessageSendMode
+  mobileInlineAttachments?: boolean
   linkPreviewDefault?: LinkPreviewDefault
   labelRemoveOnMove?: LabelRemoveOnMove
   unreadOpenPosition?: UnreadOpenPosition

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -446,7 +446,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   notificationLevel: "all",
   sidebarCollapsed: false,
   messageSendMode: "enter",
-  mobileInlineAttachments: false,
+  mobileInlineAttachments: true,
   linkPreviewDefault: "open",
   labelRemoveOnMove: "ask",
   unreadOpenPosition: "latest",

--- a/tests/browser/message-send-mode.spec.ts
+++ b/tests/browser/message-send-mode.spec.ts
@@ -31,16 +31,11 @@ test.describe("Message Send Mode", () => {
     await openSettings(page)
     const dialog = page.getByRole("dialog")
 
-    // Settings now use sidebar buttons on desktop but older flows used tabs.
-    const composerSidebarButton = dialog.getByRole("button", { name: /composer/i })
-    if (await composerSidebarButton.isVisible().catch(() => false)) {
-      await composerSidebarButton.click()
-    } else {
-      const composerTab = dialog.getByRole("tab", { name: /composer/i })
-      if (await composerTab.isVisible().catch(() => false)) {
-        await composerTab.click()
-      }
-    }
+    // Wait for the responsive nav to mount before selecting Composer; checking
+    // visibility immediately races the dialog's deferred content render.
+    const composerSidebarButton = dialog.getByRole("button", { name: /^Composer\b/ })
+    await expect(composerSidebarButton).toBeVisible({ timeout: 5000 })
+    await composerSidebarButton.click()
 
     await expect(dialog.getByRole("radio", { name: "Enter to send", exact: true })).toBeVisible({ timeout: 5000 })
 

--- a/tests/browser/message-send-mode.spec.ts
+++ b/tests/browser/message-send-mode.spec.ts
@@ -32,13 +32,13 @@ test.describe("Message Send Mode", () => {
     const dialog = page.getByRole("dialog")
 
     // Settings now use sidebar buttons on desktop but older flows used tabs.
-    const keyboardSidebarButton = dialog.getByRole("button", { name: /keyboard/i })
-    if (await keyboardSidebarButton.isVisible().catch(() => false)) {
-      await keyboardSidebarButton.click()
+    const composerSidebarButton = dialog.getByRole("button", { name: /composer/i })
+    if (await composerSidebarButton.isVisible().catch(() => false)) {
+      await composerSidebarButton.click()
     } else {
-      const keyboardTab = dialog.getByRole("tab", { name: /keyboard/i })
-      if (await keyboardTab.isVisible().catch(() => false)) {
-        await keyboardTab.click()
+      const composerTab = dialog.getByRole("tab", { name: /composer/i })
+      if (await composerTab.isVisible().catch(() => false)) {
+        await composerTab.click()
       }
     }
 


### PR DESCRIPTION
## Problem

Files selected from the mobile composer only appear in the attachment row. Pasted and dropped files can already insert a reference chip at the current editor selection, but the file picker cannot use that path. Users also need to choose whether picked files alter the message body.

## Solution

Add a configurable `mobileInlineAttachments` user preference and route mobile file-picker selections through the editor's existing attachment insertion path when enabled.

- `RichEditor.insertFiles` reuses `handleFileInsert`, preserving the current selection, upload placeholders, E2E upload handling, image numbering, and reservation updates. A shared picker router applies the behavior consistently in regular, board, and scheduled-message composers. Attachment chips gain one leading space only when adjacent non-whitespace content precedes the caret, and retain their existing trailing space.
- `MessageComposer` applies the preference only on mobile; disabled and desktop flows continue using the attachment row handler.
- The upload remains in draft attachment state independently of the inline node, so deleting the chip does not remove the attachment.
- User settings now present this under **Composer → File attachments**. The setting defaults to on; users can disable it to keep files out of the message body.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/preferences.ts` | Defines the preference and default. |
| `apps/backend/src/features/user-preferences/` | Validates and persists the override. |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Exposes picker-driven insertion through the existing upload-and-chip path. |
| `apps/frontend/src/components/composer/message-composer.tsx` | Selects inline or attachment-row behavior by device and preference. |
| `apps/frontend/src/components/settings/keyboard-settings.tsx` | Adds the Composer setting. |

## Test plan

- [x] Frontend focused suites — 253 tests passed
- [x] User-preferences backend suites — 42 tests passed
- [x] Preferences package suite — 5 tests passed
- [x] Monorepo typecheck
- [x] Commit gates — lint, migration checks, Dockerfile checks, and API docs check

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Insert mobile-picked files as inline attachment chips at the caret by default without coupling chip deletion to attachment deletion.

## What Was Built

1. Add `mobileInlineAttachments` to shared preference contracts, defaulting to `true`.
2. Validate, persist, merge, and broadcast the preference through the existing user-preferences service.
3. Expose a Composer settings switch with copy explaining chip deletion behavior.
4. Add an imperative editor method that sends selected files through the same `handleFileInsert` path used by paste and drop.
5. Route mobile picker changes through that method only when enabled; retain the existing fallback everywhere else.
6. Normalize chip spacing at the caret: preserve existing whitespace, add one leading space after adjacent content, omit it at line starts, and keep the existing trailing space.
7. Cover preference persistence, settings interaction, device gating, fallback behavior, caret spacing, and insertion at the current text selection.

## Design Decisions

- Reuse `handleFileInsert` rather than duplicate attachment node construction, upload state, or scope guards.
- Keep the preference on by default so mobile file picking matches paste behavior; users can turn it off.
- Keep attachment state in the existing draft sidecar; the inline chip remains removable editor content.

## What's NOT Included

- Paste and drop behavior is unchanged.
- Desktop file-picker behavior is unchanged.
- No schema migration is needed because user preferences are stored as key/value overrides.

## Status

- [x] Preference contract and persistence
- [x] Composer setting
- [x] Mobile picker insertion
- [x] Focused tests and repository gates

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788694732&installation_model_id=20758&pr_number=1796&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1796&signature=581763b991ad5ce8206b9dd9bf894957199b2f8303072eab2b9b707a09528888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



