### PR TITLE
feat(delegations): make claim leases recoverable

### DIFF
--- a/apps/backend/src/features/access-log/operations.ts
+++ b/apps/backend/src/features/access-log/operations.ts
@@ -211,6 +211,7 @@ export const ACCESS_LOG_OPERATIONS = [
   "agent_outcomes.list",
   "delegations.list",
   "delegations.get",
+  "delegations.requeue",
   "delegations.cancel",
   "delegations.mark_done",
   "bot_access_requests.approve",

--- a/apps/backend/src/features/delegations/config.ts
+++ b/apps/backend/src/features/delegations/config.ts
@@ -8,13 +8,12 @@
 export { DELEGATION_TITLE_MAX_CHARS, DELEGATION_BRIEF_MAX_CHARS, DELEGATION_CONTEXT_REFS_MAX } from "@threa/types"
 
 /**
- * How long a claim holds without a heartbeat before the expiry sweep flips the
- * delegation to `expired`. Local agents heartbeat well inside this (the 5.3
- * endpoints renew on every progress report); 15 minutes tolerates a laptop
- * napping through a poll cycle without letting a dead claim wedge the task for
- * long.
+ * How long a claim holds without a heartbeat before the expiry sweep reopens
+ * the delegation. Local agents heartbeat well inside this (the 5.3 endpoints
+ * renew on every progress report); 15 minutes tolerates a laptop napping
+ * through a poll cycle without letting a dead claim wedge the task for long.
  */
 export const DELEGATION_CLAIM_TTL_SECONDS = 15 * 60
 
-/** Expiry-sweep cadence. Lapsed claims are reaped within a minute of the TTL passing. */
+/** Expiry-sweep cadence. Lapsed claims reopen within a minute of the TTL passing. */
 export const DELEGATION_EXPIRY_SWEEP_INTERVAL_MS = 60_000

--- a/apps/backend/src/features/delegations/expiry-sweep.ts
+++ b/apps/backend/src/features/delegations/expiry-sweep.ts
@@ -12,8 +12,8 @@ export interface DelegationExpirySweep {
  * 5.1; same `setInterval` shape as `createOrphanSessionCleanup`). A local agent
  * that crashes or loses its network never completes/fails its claim — without
  * this the card would show "claimed" forever. The sweep CASes every lapsed
- * claim to `expired` and appends the card's status event in the same
- * transaction, so viewers see the expiry without a refresh.
+ * claim back to `open` and appends the card's status event in the same
+ * transaction, so another executor can claim it.
  */
 export function createDelegationExpirySweep(
   delegationService: DelegationService,
@@ -25,7 +25,7 @@ export function createDelegationExpirySweep(
 
   const sweep = async () => {
     try {
-      await delegationService.expireLapsedClaims()
+      await delegationService.reopenLapsedClaims()
     } catch (err) {
       logger.error({ err }, "Error during delegation expiry sweep")
     }
@@ -36,7 +36,7 @@ export function createDelegationExpirySweep(
       if (timer) return
       logger.info({ intervalMs }, "Starting delegation expiry sweep")
       timer = setInterval(sweep, intervalMs)
-      // Run immediately on start to reap claims that lapsed while the server was down.
+      // Run immediately on start to reopen claims that lapsed while the server was down.
       sweep()
     },
 

--- a/apps/backend/src/features/delegations/handlers.test.ts
+++ b/apps/backend/src/features/delegations/handlers.test.ts
@@ -62,6 +62,24 @@ function makeHandlers(delegationService: Partial<DelegationService>) {
   })
 }
 
+describe("delegation requeue handler", () => {
+  afterEach(() => mock.restore())
+
+  it("requeues an accessible delegation and reports a lost race honestly", async () => {
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1" } as never)
+    const requeue = mock(async (): Promise<DelegatedTaskWithEvent | null> => makeDelegation({ status: "open" }))
+    const handlers = makeHandlers({ getById: mock(async () => makeDelegation({ status: "expired" })), requeue })
+    const first = createResponse()
+    await handlers.requeue(makeRequest(), first.res)
+    expect(first.payloads[0]).toEqual({ requeued: true })
+    expect(requeue).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: "ws_1", streamId: "stream_1" }))
+    requeue.mockResolvedValue(null)
+    const second = createResponse()
+    await handlers.requeue(makeRequest(), second.res)
+    expect(second.payloads[0]).toEqual({ requeued: false })
+  })
+})
+
 describe("delegation get handler", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/delegations/handlers.ts
+++ b/apps/backend/src/features/delegations/handlers.ts
@@ -81,6 +81,23 @@ export function createDelegationHandlers({ pool, delegationService }: Dependenci
       res.json(toSummary(delegation))
     },
 
+    async requeue(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const id = req.params.id!
+      const delegation = await delegationService.getById({ workspaceId, id })
+      if (!delegation || !(await checkStreamAccess(pool, delegation.streamId, workspaceId, userId))) {
+        throw new HttpError("Delegation not found", { status: 404, code: "DELEGATION_NOT_FOUND" })
+      }
+      const reopened = await delegationService.requeue({
+        workspaceId,
+        id,
+        streamId: delegation.streamId,
+        requeuedBy: { actorId: userId, actorType: AuthorTypes.USER },
+      })
+      res.json({ requeued: reopened !== null })
+    },
+
     async cancel(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!

--- a/apps/backend/src/features/delegations/repository.test.ts
+++ b/apps/backend/src/features/delegations/repository.test.ts
@@ -212,9 +212,6 @@ describe("DelegatedTaskRepository.reclaimByIdempotencyKey", () => {
     expect(captured.values).toContain("fresh_hash")
     expect(captured.values).toContain(DelegationStatuses.CLAIMED)
     expect(captured.values).toContain(DelegationStatuses.RUNNING)
-    // Deliberately NO claim_expires_at guard: the recovery window includes a
-    // lapsed-but-unswept claim; a swept (expired) row fails the status guard.
-    expect(captured.text).not.toContain("claim_expires_at >")
   })
 
   it("returns null when the key doesn't match the live claim", async () => {
@@ -228,21 +225,6 @@ describe("DelegatedTaskRepository.reclaimByIdempotencyKey", () => {
         ttlSeconds: 900,
       })
     ).toBeNull()
-  })
-})
-
-describe("DelegatedTaskRepository.listOpen since", () => {
-  afterEach(() => mock.restore())
-
-  it("narrows to rows created after the instant when since is given", async () => {
-    const captured: Captured = { text: null, values: null }
-    const db = createQuerier(captured, [])
-    const since = new Date("2026-07-12T10:00:00.000Z")
-
-    await DelegatedTaskRepository.listOpen(db, "ws_1", { since })
-
-    expect(captured.text).toContain("created_at >")
-    expect(captured.values).toContain(since)
   })
 })
 
@@ -391,22 +373,20 @@ describe("DelegatedTaskRepository.findCreatedEventId", () => {
   })
 })
 
-describe("DelegatedTaskRepository.expireLapsedClaims", () => {
+describe("DelegatedTaskRepository.reopenLapsedClaims", () => {
   afterEach(() => mock.restore())
 
-  it("set-based CAS of every lapsed claim to expired (INV-56), returning the rows", async () => {
+  it("set-based CAS of every lapsed claim back to open (INV-56), returning the rows", async () => {
     const captured: Captured = { text: null, values: null }
     const db = createQuerier(captured, [
-      makeRow({ id: "dlg_1", status: DelegationStatuses.EXPIRED }),
-      makeRow({ id: "dlg_2", status: DelegationStatuses.EXPIRED }),
+      makeRow({ id: "dlg_1", status: DelegationStatuses.OPEN }),
+      makeRow({ id: "dlg_2", status: DelegationStatuses.OPEN }),
     ])
 
-    const expired = await DelegatedTaskRepository.expireLapsedClaims(db)
+    const reopened = await DelegatedTaskRepository.reopenLapsedClaims(db)
 
-    expect(captured.text).toContain("claim_expires_at <= NOW()")
-    expect(captured.text).toContain("status_note = NULL")
     expect(captured.values).toContain(DelegationStatuses.CLAIMED)
     expect(captured.values).toContain(DelegationStatuses.RUNNING)
-    expect(expired.map((d) => d.id)).toEqual(["dlg_1", "dlg_2"])
+    expect(reopened.map((d) => d.id)).toEqual(["dlg_1", "dlg_2"])
   })
 })

--- a/apps/backend/src/features/delegations/repository.ts
+++ b/apps/backend/src/features/delegations/repository.ts
@@ -172,14 +172,14 @@ export const DelegatedTaskRepository = {
 
   /**
    * A workspace's open (claimable) delegations, oldest first — the 5.3 list
-   * surface. `since` narrows to rows created after the instant, so a polling
-   * runner that remembers its last sweep doesn't re-download the whole queue.
+   * surface. `since` narrows to rows whose availability changed after the
+   * instant, so reopened old tasks appear in polling deltas.
    */
   async listOpen(db: Querier, workspaceId: string, { since }: { since?: Date } = {}): Promise<DelegatedTask[]> {
     const result = await db.query<DelegatedTaskRow>(sql`
       SELECT ${sql.raw(COLUMNS)} FROM delegated_tasks
       WHERE workspace_id = ${workspaceId} AND status = ${DelegationStatuses.OPEN}
-        AND (${since ?? null}::timestamptz IS NULL OR created_at > ${since ?? null})
+        AND (${since ?? null}::timestamptz IS NULL OR status_changed_at > ${since ?? null})
       ORDER BY created_at ASC
     `)
     return result.rows.map(mapRow)
@@ -236,11 +236,12 @@ export const DelegatedTaskRepository = {
         claim_idempotency_key = ${params.claimIdempotencyKey},
         claim_expires_at = NOW() + (${params.ttlSeconds} || ' seconds')::interval,
         claimed_by_label = ${params.claimedByLabel},
+        status_note = NULL,
         status_changed_at = NOW(),
         updated_at = NOW()
       WHERE id = ${params.id}
         AND workspace_id = ${params.workspaceId}
-        AND status = ${DelegationStatuses.OPEN}
+        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.EXPIRED})
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
@@ -268,6 +269,7 @@ export const DelegatedTaskRepository = {
         AND workspace_id = ${params.workspaceId}
         AND status IN (${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING})
         AND claim_idempotency_key = ${params.claimIdempotencyKey}
+        AND claim_expires_at > NOW()
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
@@ -415,7 +417,7 @@ export const DelegatedTaskRepository = {
       WHERE id = ${params.id}
         AND workspace_id = ${params.workspaceId}
         AND (${params.streamId ?? null}::text IS NULL OR stream_id = ${params.streamId ?? null})
-        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING})
+        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING}, ${DelegationStatuses.EXPIRED})
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
@@ -441,22 +443,60 @@ export const DelegatedTaskRepository = {
       WHERE id = ${params.id}
         AND workspace_id = ${params.workspaceId}
         AND (${params.streamId ?? null}::text IS NULL OR stream_id = ${params.streamId ?? null})
-        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING})
+        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING}, ${DelegationStatuses.EXPIRED})
+      RETURNING ${sql.raw(COLUMNS)}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  async requeue(
+    db: Querier,
+    params: { workspaceId: string; id: string; streamId?: string }
+  ): Promise<DelegatedTask | null> {
+    const result = await db.query<DelegatedTaskRow>(sql`
+      UPDATE delegated_tasks SET
+        status = ${DelegationStatuses.OPEN}, claim_token_hash = NULL, claim_idempotency_key = NULL,
+        claim_expires_at = NULL, claimed_by_label = NULL, status_note = NULL,
+        status_changed_at = NOW(), updated_at = NOW()
+      WHERE id = ${params.id} AND workspace_id = ${params.workspaceId}
+        AND (${params.streamId ?? null}::text IS NULL OR stream_id = ${params.streamId ?? null})
+        AND status = ${DelegationStatuses.EXPIRED}
+      RETURNING ${sql.raw(COLUMNS)}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  async release(
+    db: Querier,
+    params: { workspaceId: string; id: string; claimTokenHash: string }
+  ): Promise<DelegatedTask | null> {
+    const result = await db.query<DelegatedTaskRow>(sql`
+      UPDATE delegated_tasks SET
+        status = ${DelegationStatuses.OPEN}, claim_token_hash = NULL, claim_idempotency_key = NULL,
+        claim_expires_at = NULL, claimed_by_label = NULL, status_note = NULL,
+        status_changed_at = NOW(), updated_at = NOW()
+      WHERE id = ${params.id} AND workspace_id = ${params.workspaceId}
+        AND status IN (${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING})
+        AND claim_token_hash = ${params.claimTokenHash} AND claim_expires_at > NOW()
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
   },
 
   /**
-   * Set-based expiry (INV-56): CAS every lapsed claim to `expired` in one
+   * Set-based reopening (INV-56): CAS every lapsed claim to `open` in one
    * statement and return the affected rows so the sweep can append their
    * timeline events in the same transaction. The status guard makes concurrent
    * sweeps idempotent — the second one matches nothing.
    */
-  async expireLapsedClaims(db: Querier): Promise<DelegatedTask[]> {
+  async reopenLapsedClaims(db: Querier): Promise<DelegatedTask[]> {
     const result = await db.query<DelegatedTaskRow>(sql`
       UPDATE delegated_tasks SET
-        status = ${DelegationStatuses.EXPIRED},
+        status = ${DelegationStatuses.OPEN},
+        claim_token_hash = NULL,
+        claim_idempotency_key = NULL,
+        claim_expires_at = NULL,
+        claimed_by_label = NULL,
         status_note = NULL,
         status_changed_at = NOW(),
         updated_at = NOW()

--- a/apps/backend/src/features/delegations/service.test.ts
+++ b/apps/backend/src/features/delegations/service.test.ts
@@ -436,26 +436,52 @@ describe("DelegationService.complete / fail / markRunning", () => {
   })
 })
 
-describe("DelegationService.expireLapsedClaims", () => {
+describe("DelegationService reopening", () => {
   afterEach(() => mock.restore())
 
-  it("appends an expired patch per reaped row, in the sweep's own transaction", async () => {
+  it("appends an open claim_expired patch per reopened row", async () => {
     stubTransaction()
-    spyOn(DelegatedTaskRepository, "expireLapsedClaims").mockResolvedValue([
-      fakeDelegation({ id: "dlg_1", status: DelegationStatuses.EXPIRED }),
-      fakeDelegation({ id: "dlg_2", status: DelegationStatuses.EXPIRED, streamId: "stream_2" }),
+    spyOn(DelegatedTaskRepository, "reopenLapsedClaims").mockResolvedValue([
+      fakeDelegation({ id: "dlg_1", status: DelegationStatuses.OPEN }),
+      fakeDelegation({ id: "dlg_2", status: DelegationStatuses.OPEN, streamId: "stream_2" }),
     ])
     const { insertEvent } = stubEventAppend()
 
-    const expired = await makeService().expireLapsedClaims()
+    expect(await makeService().reopenLapsedClaims()).toHaveLength(2)
+    expect(insertEvent.mock.calls.map((call) => (call[1] as any).payload)).toEqual([
+      expect.objectContaining({ delegationId: "dlg_1", status: "open", reason: "claim_expired" }),
+      expect.objectContaining({ delegationId: "dlg_2", status: "open", reason: "claim_expired" }),
+    ])
+  })
 
-    expect(expired).toHaveLength(2)
-    const appendedIds = insertEvent.mock.calls.map(
-      (call) => (call[1] as { payload: { delegationId: string } }).payload.delegationId
-    )
-    expect(appendedIds).toEqual(["dlg_1", "dlg_2"])
-    const secondAppend = insertEvent.mock.calls[1]?.[1] as { streamId: string; payload: { status: string } }
-    expect(secondAppend.streamId).toBe("stream_2")
-    expect(secondAppend.payload.status).toBe(DelegationStatuses.EXPIRED)
+  it("appends release and requeue reasons, but no event on lost CAS", async () => {
+    stubTransaction()
+    const release = spyOn(DelegatedTaskRepository, "release").mockResolvedValue(fakeDelegation())
+    const requeue = spyOn(DelegatedTaskRepository, "requeue").mockResolvedValue(fakeDelegation())
+    const { insertEvent } = stubEventAppend()
+
+    await makeService().release({ workspaceId: "ws_1", id: "dlg_1", claimToken: "tok" })
+    await makeService().requeue({
+      workspaceId: "ws_1",
+      id: "dlg_1",
+      requeuedBy: { actorId: "usr_1", actorType: AuthorTypes.USER },
+    })
+    expect(insertEvent.mock.calls.map((call) => (call[1] as any).payload.reason)).toEqual([
+      "claim_released",
+      "requeued",
+    ])
+
+    release.mockResolvedValue(null)
+    requeue.mockResolvedValue(null)
+    insertEvent.mockClear()
+    expect(await makeService().release({ workspaceId: "ws_1", id: "dlg_1", claimToken: "old" })).toBeNull()
+    expect(
+      await makeService().requeue({
+        workspaceId: "ws_1",
+        id: "dlg_1",
+        requeuedBy: { actorId: "usr_1", actorType: AuthorTypes.USER },
+      })
+    ).toBeNull()
+    expect(insertEvent).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/delegations/service.ts
+++ b/apps/backend/src/features/delegations/service.ts
@@ -8,6 +8,7 @@ import {
   AuthorTypes,
   type AuthorType,
   type DelegationCreatedEventPayload,
+  type DelegationReopenReason,
   type DelegationStatusChangedEventPayload,
 } from "@threa/types"
 import { StreamEventRepository, StreamRepository } from "../streams"
@@ -56,8 +57,8 @@ export type ClaimDelegationResult =
  * later transition is a `delegation:status_changed` patch on it, so the card
  * can never sit on stale state.
  *
- * Concurrency model (INV-20): claim CASes on `status = 'open'`, cancel on any
- * non-terminal status, and claim-authenticated transitions guard on the token
+ * Concurrency model (INV-20): claim CASes on `open|expired`, cancel on any
+ * recoverable status, and claim-authenticated transitions guard on the token
  * hash + unexpired TTL — so claim-vs-cancel resolves to exactly one winner and
  * a lapsed claim can act on nothing.
  */
@@ -256,6 +257,33 @@ export class DelegationService {
     return { ok: false, reason: existing ? "not_open" : "not_found" }
   }
 
+  async release(params: { workspaceId: string; id: string; claimToken: string }): Promise<DelegatedTask | null> {
+    return withTransaction(this.pool, async (client) => {
+      const reopened = await DelegatedTaskRepository.release(client, {
+        workspaceId: params.workspaceId,
+        id: params.id,
+        claimTokenHash: hashCallbackToken(params.claimToken),
+      })
+      if (!reopened) return null
+      await this.appendStatusEvent(client, reopened, SYSTEM_ACTOR, { reason: "claim_released" })
+      return reopened
+    })
+  }
+
+  async requeue(params: {
+    workspaceId: string
+    id: string
+    streamId?: string
+    requeuedBy: { actorId: string; actorType: AuthorType }
+  }): Promise<DelegatedTask | null> {
+    return withTransaction(this.pool, async (client) => {
+      const reopened = await DelegatedTaskRepository.requeue(client, params)
+      if (!reopened) return null
+      await this.appendStatusEvent(client, reopened, params.requeuedBy, { reason: "requeued" })
+      return reopened
+    })
+  }
+
   /**
    * Heartbeat: push the claim's expiry forward. No status change, no event —
    * liveness is not card-visible state. Returns the fresh expiry or `null`
@@ -377,23 +405,23 @@ export class DelegationService {
   }
 
   /**
-   * Expiry-sweep entry: CAS every lapsed claim to `expired` (set-based, INV-56)
+   * Expiry-sweep entry: CAS every lapsed claim back to `open` (set-based, INV-56)
    * and append each card's status event in the same transaction. Concurrent
    * sweeps are idempotent — the loser's UPDATE matches nothing.
    */
-  async expireLapsedClaims(): Promise<DelegatedTask[]> {
+  async reopenLapsedClaims(): Promise<DelegatedTask[]> {
     return withTransaction(this.pool, async (client) => {
-      const expired = await DelegatedTaskRepository.expireLapsedClaims(client)
-      for (const delegation of expired) {
-        await this.appendStatusEvent(client, delegation, SYSTEM_ACTOR)
+      const reopened = await DelegatedTaskRepository.reopenLapsedClaims(client)
+      for (const delegation of reopened) {
+        await this.appendStatusEvent(client, delegation, SYSTEM_ACTOR, { reason: "claim_expired" })
       }
-      if (expired.length > 0) {
+      if (reopened.length > 0) {
         logger.info(
-          { count: expired.length, delegationIds: expired.map((d) => d.id) },
-          "delegation claims expired by sweep"
+          { count: reopened.length, delegationIds: reopened.map((d) => d.id) },
+          "delegation claims reopened by sweep"
         )
       }
-      return expired
+      return reopened
     })
   }
 
@@ -406,11 +434,12 @@ export class DelegationService {
     client: PoolClient,
     delegation: DelegatedTask,
     actor: { actorId?: string; actorType: AuthorType },
-    extra: { threadStreamId?: string } = {}
+    extra: { threadStreamId?: string; reason?: DelegationReopenReason } = {}
   ): Promise<void> {
     const payload: DelegationStatusChangedEventPayload = {
       delegationId: delegation.id,
       status: delegation.status,
+      reason: extra.reason,
       claimedByLabel: delegation.claimedByLabel,
       resultMessageId: delegation.resultMessageId,
       threadStreamId: extra.threadStreamId,
@@ -459,7 +488,7 @@ export class DelegationService {
 }
 
 /**
- * Machine transitions (claim/running/complete/fail/expired) act as the system
+ * Machine transitions (claim/running/complete/fail/reopen) act as the system
  * (no actorId, like `memos:captured`): the executing local agent is not a
  * workspace actor — `claimedByLabel` on the payload carries its human-readable
  * identity instead.

--- a/apps/backend/src/features/public-api/delegation-endpoints.test.ts
+++ b/apps/backend/src/features/public-api/delegation-endpoints.test.ts
@@ -110,7 +110,9 @@ describe("delegation public API — key + token gates", () => {
     const bareReq = makeRequest({ userKey: false, botKey: false })
     for (const handler of [
       handlers.listDelegations,
+      handlers.getDelegation,
       handlers.claimDelegation,
+      handlers.releaseDelegation,
       handlers.heartbeatDelegation,
       handlers.reportDelegationStatus,
       handlers.completeDelegation,
@@ -160,6 +162,110 @@ describe("listDelegations", () => {
     expect(getAccessibleStreamIdsForBot).toHaveBeenCalledWith("ws_1", "bot_1")
     const data = (payloads[0] as { data: Array<{ id: string }> }).data
     expect(data.map((d) => d.id)).toEqual(["dlg_granted"])
+  })
+})
+
+describe("get/release delegation", () => {
+  it("returns inspect content without claim secrets", async () => {
+    const row = makeDelegation({
+      claimTokenHash: "secret",
+      claimIdempotencyKey: "secret-key",
+      claimExpiresAt: new Date("2026-07-10T12:15:00Z"),
+    })
+    const handlers = makeHandlers({
+      delegationService: { getById: mock(async () => row) },
+      streamService: { tryAccess: mock(async () => ({ id: "stream_1" }) as never) },
+    })
+    const { res, payloads } = createResponse()
+    await handlers.getDelegation(makeRequest(), res)
+    const data = (payloads[0] as any).data
+    expect(data).toMatchObject({
+      brief: row.brief,
+      contextRefs: row.contextRefs,
+      claimExpiresAt: "2026-07-10T12:15:00.000Z",
+    })
+    expect(data.claimTokenHash).toBeUndefined()
+    expect(data.claimIdempotencyKey).toBeUndefined()
+  })
+
+  it("returns bot-accessible inspect content without claim secrets", async () => {
+    const row = makeDelegation({
+      claimTokenHash: "secret",
+      claimIdempotencyKey: "secret-key",
+      claimExpiresAt: new Date("2026-07-10T12:15:00Z"),
+    })
+    const isStreamAccessibleForBot = mock(async () => true)
+    const handlers = makeHandlers({
+      delegationService: { getById: mock(async () => row) },
+      botChannelService: { isStreamAccessibleForBot },
+    })
+    const { res, payloads } = createResponse()
+
+    await handlers.getDelegation(makeRequest({ userKey: false, botKey: true }), res)
+
+    expect(isStreamAccessibleForBot).toHaveBeenCalledWith("ws_1", "bot_1", "stream_1")
+    const data = (payloads[0] as any).data
+    expect(data).toMatchObject({
+      brief: row.brief,
+      contextRefs: row.contextRefs,
+      claimExpiresAt: "2026-07-10T12:15:00.000Z",
+    })
+    expect(data.claimTokenHash).toBeUndefined()
+    expect(data.claimIdempotencyKey).toBeUndefined()
+  })
+
+  it("404s inspect for inaccessible user and bot keys without revealing existence", async () => {
+    const getById = mock(async () => makeDelegation())
+    const handlers = makeHandlers({
+      delegationService: { getById },
+      streamService: { tryAccess: mock(async () => null) },
+      botChannelService: { isStreamAccessibleForBot: mock(async () => false) },
+    })
+    const { res } = createResponse()
+
+    for (const req of [makeRequest(), makeRequest({ userKey: false, botKey: true })]) {
+      await expect(handlers.getDelegation(req, res)).rejects.toMatchObject({ status: 404, code: "NOT_FOUND" })
+    }
+  })
+
+  it("rejects release without a callback token before mutation", async () => {
+    const release = mock(async (): Promise<DelegatedTask | null> => makeDelegation())
+    const handlers = makeHandlers({ delegationService: { release } })
+    const { res } = createResponse()
+
+    await expect(handlers.releaseDelegation(makeRequest(), res)).rejects.toMatchObject({
+      status: 401,
+      code: "UNAUTHORIZED",
+    })
+    expect(release).not.toHaveBeenCalled()
+  })
+
+  it("404s release after stream access is revoked without mutation", async () => {
+    const release = mock(async (): Promise<DelegatedTask | null> => makeDelegation())
+    const handlers = makeHandlers({
+      delegationService: { getById: mock(async () => makeDelegation()), release },
+      botChannelService: { isStreamAccessibleForBot: mock(async () => false) },
+    })
+    const { res } = createResponse()
+
+    await expect(
+      handlers.releaseDelegation(makeRequest({ userKey: false, botKey: true, token: "tok" }), res)
+    ).rejects.toMatchObject({ status: 404, code: "NOT_FOUND" })
+    expect(release).not.toHaveBeenCalled()
+  })
+
+  it("releases with callback token and 404s a lost claim", async () => {
+    const release = mock(async (): Promise<DelegatedTask | null> => makeDelegation())
+    const handlers = makeHandlers({
+      delegationService: { getById: mock(async () => makeDelegation()), release },
+      streamService: { tryAccess: mock(async () => ({ id: "stream_1" }) as never) },
+    })
+    const { res, payloads } = createResponse()
+    await handlers.releaseDelegation(makeRequest({ token: "tok" }), res)
+    expect(release).toHaveBeenCalledWith({ workspaceId: "ws_1", id: "dlg_1", claimToken: "tok" })
+    expect((payloads[0] as any).data.status).toBe("open")
+    release.mockResolvedValue(null)
+    await expect(handlers.releaseDelegation(makeRequest({ token: "old" }), res)).rejects.toMatchObject({ status: 404 })
   })
 })
 

--- a/apps/backend/src/features/public-api/delegation-handlers.ts
+++ b/apps/backend/src/features/public-api/delegation-handlers.ts
@@ -73,9 +73,8 @@ function serializeDelegation(delegation: DelegatedTask) {
  * at rest via the service); every later transition authenticates with the
  * `X-Threa-Callback-Token` header — the sealed-claim pattern. A lapsed, stolen,
  * or already-terminal claim makes the token-guarded CAS match nothing → 404,
- * mirroring bot-invocation renew/complete. Claiming is CAS `open → claimed`
- * only: an `expired` delegation stays terminal (the sweep's visible transition
- * keeps its meaning) — re-claiming was considered and deliberately left out.
+ * mirroring bot-invocation renew/complete. Direct claiming CASes either `open`
+ * or a historical `expired` row to `claimed`; queue listing remains open-only.
  */
 export function createDelegationPublicApiHandlers({
   pool,
@@ -110,8 +109,8 @@ export function createDelegationPublicApiHandlers({
    * Load a delegation the key may act on, or 404. Every lifecycle op gates on
    * CURRENT stream access, not just claim time: a key that loses access
    * mid-claim (revoked channel grant, removed member) can no longer drive the
-   * card — its status notes stop landing and its heartbeats lapse the claim to
-   * the visible `expired` instead of renewing a zombie it can never finish.
+   * card — its status notes stop landing and its lapsed claim reopens instead
+   * of renewing a zombie it can never finish.
    * 404 (not 403) so a non-member probing ids can't tell an existing
    * delegation from a missing one, mirroring the first-party cancel handler.
    */
@@ -162,8 +161,21 @@ export function createDelegationPublicApiHandlers({
       res.json({ data: open.filter((d) => accessible.has(d.streamId)).map(serializeDelegation) })
     },
 
+    async getDelegation(req: Request, res: Response) {
+      const identity = resolveKeyIdentity(req)
+      const delegation = await resolveAccessibleDelegation(identity, req.workspaceId!, req.params.delegationId!)
+      res.json({
+        data: {
+          ...serializeDelegation(delegation),
+          brief: delegation.brief,
+          contextRefs: delegation.contextRefs,
+          claimExpiresAt: delegation.claimExpiresAt?.toISOString(),
+        },
+      })
+    },
+
     /**
-     * CAS `open → claimed`. Exactly one concurrent claimer wins; a lost race is
+     * CAS `open|expired → claimed`. Exactly one concurrent claimer wins; a lost race is
      * 409 (the delegation exists but is not open), an invisible or missing id
      * is 404. The response is the executor's full working set: the brief, the
      * context refs, and the claim token (cleartext, returned exactly once).
@@ -193,6 +205,19 @@ export function createDelegationPublicApiHandlers({
           claimExpiresAt: result.delegation.claimExpiresAt!.toISOString(),
         },
       })
+    },
+
+    async releaseDelegation(req: Request, res: Response) {
+      const identity = resolveKeyIdentity(req)
+      const claimToken = requireCallbackToken(req)
+      await resolveAccessibleDelegation(identity, req.workspaceId!, req.params.delegationId!)
+      const reopened = await delegationService.release({
+        workspaceId: req.workspaceId!,
+        id: req.params.delegationId!,
+        claimToken,
+      })
+      if (!reopened) throw new HttpError("Delegation claim not found", { status: 404, code: "NOT_FOUND" })
+      res.json({ data: serializeDelegation(reopened) })
     },
 
     /** Push the claim TTL forward. Liveness only — no status change, no card event. */
@@ -234,7 +259,7 @@ export function createDelegationPublicApiHandlers({
     /**
      * Terminal success. When a result is given, the message insert and the
      * `completed` CAS share one transaction, so a lost claim race (cancelled /
-     * expired under us) rolls the message back instead of leaving an orphan —
+     * reopened under us) rolls the message back instead of leaving an orphan —
      * the `completeBotInvocation` shape. The author follows the key kind:
      * user key → the user (with via-API provenance), bot key → the bot.
      */

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -590,6 +590,12 @@ const delegationSchema = z.object({
   statusChangedAt: z.string().datetime(),
 })
 
+const inspectedDelegationSchema = delegationSchema.extend({
+  brief: z.string(),
+  contextRefs: z.array(z.string()),
+  claimExpiresAt: z.string().datetime().optional(),
+})
+
 const claimedDelegationSchema = delegationSchema.extend({
   /** The complete hand-off prompt (markdown) — the executor's working set. */
   brief: z.string(),
@@ -752,7 +758,9 @@ export type OperationId =
   | "completeBotInvocation"
   | "failBotInvocation"
   | "listDelegations"
+  | "getDelegation"
   | "claimDelegation"
+  | "releaseDelegation"
   | "heartbeatDelegation"
   | "reportDelegationStatus"
   | "completeDelegation"
@@ -1141,7 +1149,7 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     operationId: "listDelegations",
     summary: "List open delegations",
     description:
-      "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
+      "List delegated tasks whose current status is open and whose availability changed after `since`, filtered to streams the key can access.",
     tags: ["Delegations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_READ],
     parameters: [workspaceIdParam],
@@ -1150,12 +1158,24 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     responseSchema: dataArrayEnvelope(delegationSchema),
   },
   {
+    method: "get",
+    path: "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}",
+    operationId: "getDelegation",
+    summary: "Get a delegation",
+    description: "Inspect an accessible delegation's brief, context references, status, and current claim expiry.",
+    tags: ["Delegations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_READ],
+    parameters: [workspaceIdParam, delegationIdParam],
+    responseSchema: dataEnvelope(inspectedDelegationSchema),
+    canReturn404: true,
+  },
+  {
     method: "post",
     path: "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/claim",
     operationId: "claimDelegation",
-    summary: "Claim an open delegation",
+    summary: "Claim an open or expired delegation",
     description:
-      "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+      "Atomically claim an open or historical expired delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
     tags: ["Delegations"],
     scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE],
     parameters: [workspaceIdParam, delegationIdParam],
@@ -1164,6 +1184,19 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     responseSchema: dataEnvelope(claimedDelegationSchema),
     canReturn404: true,
     canReturn409: true,
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/release",
+    operationId: "releaseDelegation",
+    summary: "Release a delegation claim",
+    description:
+      "Release a live claim so the delegation is open again. Authenticated with the per-claim callback token.",
+    tags: ["Delegations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.DELEGATIONS_WRITE],
+    parameters: [workspaceIdParam, delegationIdParam, delegationTokenHeaderParam],
+    responseSchema: dataEnvelope(delegationSchema),
+    canReturn404: true,
   },
   {
     method: "post",

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -455,7 +455,7 @@ export const listMyBotsSchema = z.object({
 export const listDelegationsQuerySchema = z.object({
   /** Only the claimable queue is listed today; the enum grows when a real consumer needs more (INV-36). */
   status: z.literal("open").optional().default("open"),
-  /** Only delegations created after this instant — a polling runner's cheap delta. */
+  /** Only delegations whose availability changed after this instant. */
   since: z.string().datetime().optional(),
 })
 

--- a/apps/backend/src/lib/outbox/broadcast-handler.test.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.test.ts
@@ -571,6 +571,47 @@ describe("BroadcastHandler", () => {
     })
   })
 
+  it("re-nudges when a delegation status patch reopens it", async () => {
+    const event = makeEvent(1n, "stream:delegation_status_changed", {
+      workspaceId: "ws_1",
+      streamId: "stream_a",
+      event: {
+        id: "event_1",
+        streamId: "stream_a",
+        eventType: "delegation:status_changed",
+        payload: { delegationId: "dlg_1", status: "open" },
+      },
+    })
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
+    const { handler, emitChains } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+    expect(emitChains).toContainEqual({
+      room: "bot:ws_1",
+      eventType: "delegation:available",
+      payload: { workspaceId: "ws_1", streamId: "stream_a", delegationId: "dlg_1", title: undefined },
+      namespace: "/bot",
+    })
+  })
+
+  it("does not re-nudge for a non-open delegation status patch", async () => {
+    const event = makeEvent(1n, "stream:delegation_status_changed", {
+      workspaceId: "ws_1",
+      streamId: "stream_a",
+      event: {
+        id: "event_1",
+        streamId: "stream_a",
+        eventType: "delegation:status_changed",
+        payload: { delegationId: "dlg_1", status: "claimed" },
+      },
+    })
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
+    const { handler, emitChains } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+    expect(emitChains.some((e) => e.eventType === "delegation:available")).toBe(false)
+  })
+
   it("re-nudges the workspace runtime room when an approved bot_access request carries a delegation (F3)", async () => {
     const event = makeEvent(1n, "stream:bot_access_status_changed", {
       workspaceId: "ws_1",

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -11,6 +11,7 @@ import {
   type BotSessionArchivedOutboxPayload,
   type BotSessionRestoredOutboxPayload,
   type StreamDelegationCreatedOutboxPayload,
+  type StreamDelegationStatusChangedOutboxPayload,
   type StreamBotAccessStatusChangedOutboxPayload,
 } from "./repository"
 import { resolveDeliveryGroups, emitToGroups } from "./delivery-groups"
@@ -18,6 +19,7 @@ import { logger } from "../logger"
 import { SyncLogRepository, type SyncLogEntryInput } from "../../features/sync"
 import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type ProcessResult } from "@threa/backend-common"
 import type { OutboxHandler } from "@threa/backend-common"
+import type { DelegationStatusChangedEventPayload } from "@threa/types"
 import { invalidatePointersForEvent } from "../../features/messaging/sharing"
 import {
   outboxBatchSize,
@@ -236,6 +238,18 @@ export class BroadcastHandler implements OutboxHandler {
         delegationId: created.delegationId,
         title: created.title,
       })
+    }
+
+    if (isOutboxEventType(event, "stream:delegation_status_changed")) {
+      const payload = event.payload as StreamDelegationStatusChangedOutboxPayload
+      const changed = payload.event.payload as DelegationStatusChangedEventPayload
+      if (changed.status === "open" && changed.delegationId) {
+        this.botNamespace.to(`bot:${payload.workspaceId}`).emit("delegation:available", {
+          workspaceId: payload.workspaceId,
+          streamId: payload.streamId,
+          delegationId: changed.delegationId,
+        })
+      }
     }
 
     // An approved access request that carries a delegation re-emits the same

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -1425,6 +1425,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/delegations", ...authed, audit("delegations.list", "read"), delegations.list)
   app.get("/api/workspaces/:workspaceId/delegations/:id", ...authed, audit("delegations.get", "read"), delegations.get)
   app.post(
+    "/api/workspaces/:workspaceId/delegations/:id/requeue",
+    ...authed,
+    audit("delegations.requeue", "write"),
+    delegations.requeue
+  )
+  app.post(
     "/api/workspaces/:workspaceId/delegations/:id/cancel",
     ...authed,
     audit("delegations.cancel", "write"),
@@ -1923,7 +1929,9 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     completeBotInvocation: publicApi.completeBotInvocation,
     failBotInvocation: publicApi.failBotInvocation,
     listDelegations: delegationPublicApi.listDelegations,
+    getDelegation: delegationPublicApi.getDelegation,
     claimDelegation: delegationPublicApi.claimDelegation,
+    releaseDelegation: delegationPublicApi.releaseDelegation,
     heartbeatDelegation: delegationPublicApi.heartbeatDelegation,
     reportDelegationStatus: delegationPublicApi.reportDelegationStatus,
     completeDelegation: delegationPublicApi.completeDelegation,

--- a/apps/backend/tests/integration/delegation-leases.test.ts
+++ b/apps/backend/tests/integration/delegation-leases.test.ts
@@ -1,0 +1,419 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test"
+import type { Pool } from "pg"
+import { DelegationStatuses } from "@threa/types"
+import { DelegatedTaskRepository, type DelegatedTask } from "../../src/features/delegations/repository"
+import { setupIsolatedTestDatabase } from "./setup"
+
+let pool: Pool
+let cleanup: () => Promise<void>
+
+const holderFields = {
+  claimTokenHash: null,
+  claimIdempotencyKey: null,
+  claimExpiresAt: null,
+  claimedByLabel: null,
+  statusNote: null,
+}
+
+async function seed(
+  id: string,
+  status: string,
+  overrides: Record<string, unknown> = {},
+  workspaceId = "ws_leases"
+): Promise<DelegatedTask> {
+  const fields = {
+    claim_token_hash: null,
+    claim_idempotency_key: null,
+    claim_expires_at: null,
+    claimed_by_label: null,
+    status_note: null,
+    ...overrides,
+  }
+  await pool.query(
+    `INSERT INTO delegated_tasks
+      (id, workspace_id, stream_id, created_by_kind, created_by_id, title, brief, status,
+       claim_token_hash, claim_idempotency_key, claim_expires_at, claimed_by_label, status_note,
+       created_at, updated_at, status_changed_at)
+     VALUES ($1, $2, 'stream_leases', 'persona', 'persona_1', $1, 'brief', $3,
+       $4, $5, $6, $7, $8, NOW() - interval '2 days', NOW() - interval '1 day', NOW() - interval '1 day')`,
+    [
+      id,
+      workspaceId,
+      status,
+      fields.claim_token_hash,
+      fields.claim_idempotency_key,
+      fields.claim_expires_at,
+      fields.claimed_by_label,
+      fields.status_note,
+    ]
+  )
+  return (await DelegatedTaskRepository.findById(pool, workspaceId, id))!
+}
+
+function claim(id: string, token = `${id}_token`, key: string | null = null, workspaceId = "ws_leases") {
+  return DelegatedTaskRepository.claim(pool, {
+    workspaceId,
+    id,
+    claimTokenHash: token,
+    claimIdempotencyKey: key,
+    claimedByLabel: "runner",
+    ttlSeconds: 900,
+  })
+}
+
+async function expectRow(id: string, expected: Partial<DelegatedTask>, workspaceId = "ws_leases") {
+  expect(await DelegatedTaskRepository.findById(pool, workspaceId, id)).toMatchObject(expected)
+}
+
+async function raceTransactions<T, U>(
+  left: (client: import("pg").PoolClient) => Promise<T>,
+  right: (client: import("pg").PoolClient) => Promise<U>
+): Promise<[T | null, U | null]> {
+  const clients = await Promise.all([pool.connect(), pool.connect()])
+  try {
+    await Promise.all(clients.map((client) => client.query("BEGIN ISOLATION LEVEL SERIALIZABLE")))
+    const results = await Promise.allSettled([
+      left(clients[0]).then(async (value) => (await clients[0].query("COMMIT"), value)),
+      right(clients[1]).then(async (value) => (await clients[1].query("COMMIT"), value)),
+    ])
+    return results.map((result) => {
+      if (result.status === "fulfilled") return result.value
+      if (
+        typeof result.reason === "object" &&
+        result.reason !== null &&
+        "code" in result.reason &&
+        result.reason.code === "40001"
+      ) {
+        return null
+      }
+      throw result.reason
+    }) as [T | null, U | null]
+  } finally {
+    await Promise.allSettled(clients.map((client) => client.query("ROLLBACK")))
+    clients.forEach((client) => client.release())
+  }
+}
+
+beforeAll(async () => ({ pool, cleanup } = await setupIsolatedTestDatabase("delegation_leases")), 120_000)
+afterAll(async () => cleanup(), 120_000)
+
+describe("delegation lease recovery SQL", () => {
+  it("sweeps lapsed claimed and running rows only, clearing holder fields and advancing DB timestamps", async () => {
+    const claimedBefore = await seed("dlg_sweep_claimed", "claimed", {
+      claim_token_hash: "a",
+      claim_idempotency_key: "key-a",
+      claim_expires_at: new Date(0),
+      claimed_by_label: "a",
+      status_note: "working",
+    })
+    const runningBefore = await seed("dlg_sweep_running", "running", {
+      claim_token_hash: "b",
+      claim_idempotency_key: "key-b",
+      claim_expires_at: new Date(0),
+      claimed_by_label: "b",
+      status_note: "working",
+    })
+    await seed("dlg_sweep_live", "claimed", { claim_token_hash: "live", claim_expires_at: new Date("2099-01-01") })
+    await seed("dlg_sweep_expired", "expired", { claim_token_hash: "historical" })
+    await seed("dlg_sweep_open", "open")
+    await seed(
+      "dlg_sweep_other",
+      "claimed",
+      {
+        claim_token_hash: "other",
+        claim_idempotency_key: "key-other",
+        claim_expires_at: new Date(0),
+        claimed_by_label: "other-runner",
+        status_note: "working",
+      },
+      "ws_other"
+    )
+
+    const reopened = await DelegatedTaskRepository.reopenLapsedClaims(pool)
+    const changed = reopened.filter((row) => row.id.startsWith("dlg_sweep_"))
+    expect(changed.map((row) => row.id).sort()).toEqual(["dlg_sweep_claimed", "dlg_sweep_other", "dlg_sweep_running"])
+    expect(
+      changed.map((row) => ({
+        workspaceId: row.workspaceId,
+        status: row.status,
+        claimTokenHash: row.claimTokenHash,
+        claimIdempotencyKey: row.claimIdempotencyKey,
+        claimExpiresAt: row.claimExpiresAt,
+        claimedByLabel: row.claimedByLabel,
+        statusNote: row.statusNote,
+      }))
+    ).toEqual([
+      { workspaceId: "ws_leases", status: "open", ...holderFields },
+      { workspaceId: "ws_leases", status: "open", ...holderFields },
+      { workspaceId: "ws_other", status: "open", ...holderFields },
+    ])
+    expect(changed.find((row) => row.id === claimedBefore.id)!.statusChangedAt.getTime()).toBeGreaterThan(
+      claimedBefore.statusChangedAt.getTime()
+    )
+    expect(changed.find((row) => row.id === runningBefore.id)!.statusChangedAt.getTime()).toBeGreaterThan(
+      runningBefore.statusChangedAt.getTime()
+    )
+    await expectRow("dlg_sweep_live", { status: "claimed", claimTokenHash: "live" })
+    await expectRow("dlg_sweep_expired", { status: "expired", claimTokenHash: "historical" })
+    await expectRow("dlg_sweep_open", { status: "open" })
+    await expectRow("dlg_sweep_other", { status: "open" }, "ws_other")
+  })
+
+  it("releases claimed and running live holders, but rejects lapsed, mismatched, and cross-workspace holders", async () => {
+    for (const status of ["claimed", "running"]) {
+      const id = `dlg_release_${status}`
+      await seed(id, status, {
+        claim_token_hash: "token",
+        claim_idempotency_key: "key",
+        claim_expires_at: new Date("2099-01-01"),
+        claimed_by_label: "runner",
+        status_note: "work",
+      })
+      expect(
+        await DelegatedTaskRepository.release(pool, { workspaceId: "ws_leases", id, claimTokenHash: "token" })
+      ).toMatchObject({ status: "open", ...holderFields })
+    }
+    await seed("dlg_release_lapsed", "claimed", { claim_token_hash: "token", claim_expires_at: new Date(0) })
+    await seed("dlg_release_mismatch", "running", {
+      claim_token_hash: "token",
+      claim_expires_at: new Date("2099-01-01"),
+    })
+    expect(
+      await DelegatedTaskRepository.release(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_release_lapsed",
+        claimTokenHash: "token",
+      })
+    ).toBeNull()
+    expect(
+      await DelegatedTaskRepository.release(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_release_mismatch",
+        claimTokenHash: "wrong",
+      })
+    ).toBeNull()
+    expect(
+      await DelegatedTaskRepository.release(pool, {
+        workspaceId: "ws_other",
+        id: "dlg_release_mismatch",
+        claimTokenHash: "token",
+      })
+    ).toBeNull()
+  })
+
+  it("direct claim accepts open and expired but rejects settled and currently held rows", async () => {
+    for (const status of ["open", "expired"]) {
+      const id = `dlg_claim_yes_${status}`
+      await seed(id, status, { status_note: "stale" })
+      expect(await claim(id)).toMatchObject({ status: "claimed", statusNote: null })
+    }
+    for (const status of ["completed", "failed", "cancelled", "claimed", "running"]) {
+      const id = `dlg_claim_no_${status}`
+      await seed(
+        id,
+        status,
+        status === "claimed" || status === "running"
+          ? { claim_token_hash: "held", claim_expires_at: new Date("2099-01-01") }
+          : {}
+      )
+      expect(await claim(id)).toBeNull()
+    }
+    await seed("dlg_claim_other", "open", {}, "ws_other")
+    expect(await claim("dlg_claim_other")).toBeNull()
+  })
+
+  it("mark done and cancel accept historical expired rows", async () => {
+    await seed("dlg_expired_done", "expired")
+    await seed("dlg_expired_cancel", "expired")
+    expect(
+      await DelegatedTaskRepository.markDone(pool, { workspaceId: "ws_leases", id: "dlg_expired_done" })
+    ).toMatchObject({ status: "completed" })
+    expect(
+      await DelegatedTaskRepository.markCancelled(pool, { workspaceId: "ws_leases", id: "dlg_expired_cancel" })
+    ).toMatchObject({ status: "cancelled" })
+  })
+
+  it("since includes reopened old work and excludes unchanged old open work", async () => {
+    await seed("dlg_since_reopened", "running", { claim_token_hash: "old", claim_expires_at: new Date(0) })
+    await seed("dlg_since_unchanged", "open")
+    const cursor = (await pool.query<{ now: Date }>("SELECT NOW() AS now")).rows[0].now
+    await DelegatedTaskRepository.reopenLapsedClaims(pool)
+    const delta = await DelegatedTaskRepository.listOpen(pool, "ws_leases", { since: cursor })
+    expect(delta.map((row) => row.id)).toContain("dlg_since_reopened")
+    expect(delta.map((row) => row.id)).not.toContain("dlg_since_unchanged")
+  })
+
+  it("does not re-key a lapsed claim; after sweep the same key can claim and a competing claimant loses", async () => {
+    await seed("dlg_rekey", "claimed", {
+      claim_token_hash: "old",
+      claim_idempotency_key: "runner-key",
+      claim_expires_at: new Date(0),
+    })
+    expect(
+      await DelegatedTaskRepository.reclaimByIdempotencyKey(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_rekey",
+        claimIdempotencyKey: "runner-key",
+        claimTokenHash: "new",
+        ttlSeconds: 900,
+      })
+    ).toBeNull()
+    await DelegatedTaskRepository.reopenLapsedClaims(pool)
+    const [sameKey, competitor] = await Promise.all([
+      claim("dlg_rekey", "same-key-token", "runner-key"),
+      claim("dlg_rekey", "competitor"),
+    ])
+    expect([sameKey, competitor].filter(Boolean)).toHaveLength(1)
+    const winner = sameKey ?? competitor!
+    await expectRow("dlg_rekey", { status: "claimed", claimTokenHash: winner.claimTokenHash })
+  })
+
+  it("allows only the sweep when a lapsed claim races a heartbeat", async () => {
+    await seed("dlg_lapsed_heartbeat", "claimed", { claim_token_hash: "token", claim_expires_at: new Date(0) })
+    const [swept, heartbeat] = await raceTransactions(
+      (client) => DelegatedTaskRepository.reopenLapsedClaims(client),
+      (client) =>
+        DelegatedTaskRepository.renewClaim(client, {
+          workspaceId: "ws_leases",
+          id: "dlg_lapsed_heartbeat",
+          claimTokenHash: "token",
+          ttlSeconds: 900,
+        })
+    )
+    expect(swept?.some((row) => row.id === "dlg_lapsed_heartbeat")).toBe(true)
+    expect(heartbeat).toBeNull()
+    await expectRow("dlg_lapsed_heartbeat", { status: "open", ...holderFields })
+  })
+
+  it("allows only the heartbeat when a live claim races a sweep", async () => {
+    await seed("dlg_live_heartbeat", "claimed", {
+      claim_token_hash: "token",
+      claim_expires_at: new Date("2099-01-01"),
+    })
+    const [swept, heartbeat] = await raceTransactions(
+      (client) => DelegatedTaskRepository.reopenLapsedClaims(client),
+      (client) =>
+        DelegatedTaskRepository.renewClaim(client, {
+          workspaceId: "ws_leases",
+          id: "dlg_live_heartbeat",
+          claimTokenHash: "token",
+          ttlSeconds: 900,
+        })
+    )
+    expect(swept?.some((row) => row.id === "dlg_live_heartbeat") ?? false).toBe(false)
+    expect(heartbeat).toMatchObject({ status: "claimed", claimTokenHash: "token" })
+    await expectRow("dlg_live_heartbeat", {
+      status: "claimed",
+      claimTokenHash: "token",
+      claimExpiresAt: heartbeat!.claimExpiresAt,
+    })
+  })
+
+  it("allows exactly one release or competing terminal transition", async () => {
+    const competitors = [
+      [
+        "complete",
+        (id: string, db: import("pg").PoolClient) =>
+          DelegatedTaskRepository.complete(db, {
+            workspaceId: "ws_leases",
+            id,
+            claimTokenHash: "token",
+            resultMessageId: null,
+          }),
+      ],
+      [
+        "fail",
+        (id: string, db: import("pg").PoolClient) =>
+          DelegatedTaskRepository.fail(db, {
+            workspaceId: "ws_leases",
+            id,
+            claimTokenHash: "token",
+            statusNote: "failed",
+          }),
+      ],
+      [
+        "cancel",
+        (id: string, db: import("pg").PoolClient) =>
+          DelegatedTaskRepository.markCancelled(db, { workspaceId: "ws_leases", id }),
+      ],
+    ] as const
+    for (const [name, transition] of competitors) {
+      const id = `dlg_release_race_${name}`
+      await seed(id, "running", { claim_token_hash: "token", claim_expires_at: new Date("2099-01-01") })
+      const [released, settled] = await raceTransactions(
+        (client) => DelegatedTaskRepository.release(client, { workspaceId: "ws_leases", id, claimTokenHash: "token" }),
+        (client) => transition(id, client)
+      )
+      expect([released, settled].filter(Boolean)).toHaveLength(1)
+      await expectRow(id, { status: released ? "open" : settled!.status })
+    }
+
+    await seed("dlg_release_race_sweep", "running", { claim_token_hash: "token", claim_expires_at: new Date(0) })
+    const [released, swept] = await Promise.all([
+      DelegatedTaskRepository.release(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_release_race_sweep",
+        claimTokenHash: "token",
+      }),
+      DelegatedTaskRepository.reopenLapsedClaims(pool),
+    ])
+    expect(Number(released !== null) + Number(swept.some((row) => row.id === "dlg_release_race_sweep"))).toBe(1)
+    await expectRow("dlg_release_race_sweep", { status: "open", ...holderFields })
+  })
+
+  it("serializes requeue against direct claim", async () => {
+    await seed("dlg_requeue_claim_race", "expired", { status_note: "stale" })
+    const [requeued, claimed] = await raceTransactions(
+      (client) => DelegatedTaskRepository.requeue(client, { workspaceId: "ws_leases", id: "dlg_requeue_claim_race" }),
+      (client) =>
+        DelegatedTaskRepository.claim(client, {
+          workspaceId: "ws_leases",
+          id: "dlg_requeue_claim_race",
+          claimTokenHash: "new-owner",
+          claimIdempotencyKey: null,
+          claimedByLabel: "runner",
+          ttlSeconds: 900,
+        })
+    )
+    expect([requeued, claimed].filter(Boolean)).toHaveLength(1)
+    await expectRow(
+      "dlg_requeue_claim_race",
+      requeued ? { status: "open", ...holderFields } : { status: "claimed", claimTokenHash: "new-owner" }
+    )
+  })
+
+  it("rejects every old-token operation after replacement claim", async () => {
+    await seed("dlg_old_token", "claimed", { claim_token_hash: "old", claim_expires_at: new Date("2099-01-01") })
+    expect(
+      await DelegatedTaskRepository.release(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_old_token",
+        claimTokenHash: "old",
+      })
+    ).toMatchObject({ status: "open" })
+    expect(await claim("dlg_old_token", "replacement")).toMatchObject({ status: "claimed" })
+    const results = await Promise.all([
+      DelegatedTaskRepository.renewClaim(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_old_token",
+        claimTokenHash: "old",
+        ttlSeconds: 900,
+      }),
+      DelegatedTaskRepository.release(pool, { workspaceId: "ws_leases", id: "dlg_old_token", claimTokenHash: "old" }),
+      DelegatedTaskRepository.complete(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_old_token",
+        claimTokenHash: "old",
+        resultMessageId: null,
+      }),
+      DelegatedTaskRepository.fail(pool, {
+        workspaceId: "ws_leases",
+        id: "dlg_old_token",
+        claimTokenHash: "old",
+        statusNote: "old",
+      }),
+    ])
+    expect(results).toEqual([null, null, null, null])
+    await expectRow("dlg_old_token", { status: "claimed", claimTokenHash: "replacement" })
+  })
+})

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -3259,7 +3259,7 @@
         "operationId": "listDelegations",
         "summary": "List open delegations",
         "tags": ["Delegations"],
-        "description": "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
+        "description": "List delegated tasks whose current status is open and whose availability changed after `since`, filtered to streams the key can access.",
         "security": [{ "apiKey": ["delegations:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3347,12 +3347,115 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}": {
+      "get": {
+        "operationId": "getDelegation",
+        "summary": "Get a delegation",
+        "tags": ["Delegations"],
+        "description": "Inspect an accessible delegation's brief, context references, status, and current claim expiry.",
+        "security": [{ "apiKey": ["delegations:read"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" },
+                        "brief": { "type": "string" },
+                        "contextRefs": { "type": "array", "items": { "type": "string" } },
+                        "claimExpiresAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": [
+                        "id",
+                        "streamId",
+                        "title",
+                        "status",
+                        "createdAt",
+                        "statusChangedAt",
+                        "brief",
+                        "contextRefs"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/claim": {
       "post": {
         "operationId": "claimDelegation",
-        "summary": "Claim an open delegation",
+        "summary": "Claim an open or expired delegation",
         "tags": ["Delegations"],
-        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+        "description": "Atomically claim an open or historical expired delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3492,6 +3595,104 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/release": {
+      "post": {
+        "operationId": "releaseDelegation",
+        "summary": "Release a delegation claim",
+        "tags": ["Delegations"],
+        "description": "Release a live claim so the delegation is open again. Authenticated with the per-claim callback token.",
+        "security": [{ "apiKey": ["delegations:write"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim token from the delegation claim response (binds the caller to its claim)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": ["id", "streamId", "title", "status", "createdAt", "statusChangedAt"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
         }
       }
     },

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -3017,7 +3017,7 @@
         "operationId": "listDelegations",
         "summary": "List open delegations",
         "tags": ["Delegations"],
-        "description": "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
+        "description": "List delegated tasks whose current status is open and whose availability changed after `since`, filtered to streams the key can access.",
         "security": [{ "apiKey": ["delegations:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3105,12 +3105,115 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}": {
+      "get": {
+        "operationId": "getDelegation",
+        "summary": "Get a delegation",
+        "tags": ["Delegations"],
+        "description": "Inspect an accessible delegation's brief, context references, status, and current claim expiry.",
+        "security": [{ "apiKey": ["delegations:read"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" },
+                        "brief": { "type": "string" },
+                        "contextRefs": { "type": "array", "items": { "type": "string" } },
+                        "claimExpiresAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": [
+                        "id",
+                        "streamId",
+                        "title",
+                        "status",
+                        "createdAt",
+                        "statusChangedAt",
+                        "brief",
+                        "contextRefs"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/claim": {
       "post": {
         "operationId": "claimDelegation",
-        "summary": "Claim an open delegation",
+        "summary": "Claim an open or expired delegation",
         "tags": ["Delegations"],
-        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+        "description": "Atomically claim an open or historical expired delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3250,6 +3353,104 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/release": {
+      "post": {
+        "operationId": "releaseDelegation",
+        "summary": "Release a delegation claim",
+        "tags": ["Delegations"],
+        "description": "Release a live claim so the delegation is open again. Authenticated with the per-claim callback token.",
+        "security": [{ "apiKey": ["delegations:write"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim token from the delegation claim response (binds the caller to its claim)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": ["id", "streamId", "title", "status", "createdAt", "statusChangedAt"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
         }
       }
     },

--- a/docs/public-api/versions/2026-07-22.json
+++ b/docs/public-api/versions/2026-07-22.json
@@ -3017,7 +3017,7 @@
         "operationId": "listDelegations",
         "summary": "List open delegations",
         "tags": ["Delegations"],
-        "description": "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
+        "description": "List delegated tasks whose current status is open and whose availability changed after `since`, filtered to streams the key can access.",
         "security": [{ "apiKey": ["delegations:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3105,12 +3105,115 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}": {
+      "get": {
+        "operationId": "getDelegation",
+        "summary": "Get a delegation",
+        "tags": ["Delegations"],
+        "description": "Inspect an accessible delegation's brief, context references, status, and current claim expiry.",
+        "security": [{ "apiKey": ["delegations:read"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" },
+                        "brief": { "type": "string" },
+                        "contextRefs": { "type": "array", "items": { "type": "string" } },
+                        "claimExpiresAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": [
+                        "id",
+                        "streamId",
+                        "title",
+                        "status",
+                        "createdAt",
+                        "statusChangedAt",
+                        "brief",
+                        "contextRefs"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/claim": {
       "post": {
         "operationId": "claimDelegation",
-        "summary": "Claim an open delegation",
+        "summary": "Claim an open or expired delegation",
         "tags": ["Delegations"],
-        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+        "description": "Atomically claim an open or historical expired delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3250,6 +3353,104 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/release": {
+      "post": {
+        "operationId": "releaseDelegation",
+        "summary": "Release a delegation claim",
+        "tags": ["Delegations"],
+        "description": "Release a live claim so the delegation is open again. Authenticated with the per-claim callback token.",
+        "security": [{ "apiKey": ["delegations:write"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim token from the delegation claim response (binds the caller to its claim)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": ["id", "streamId", "title", "status", "createdAt", "statusChangedAt"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
         }
       }
     },

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -3259,7 +3259,7 @@
         "operationId": "listDelegations",
         "summary": "List open delegations",
         "tags": ["Delegations"],
-        "description": "List delegated tasks that are open to claim, filtered to what the key can access: a user-scoped key sees streams its user can access, a workspace key sees the bot's channel grants.",
+        "description": "List delegated tasks whose current status is open and whose availability changed after `since`, filtered to streams the key can access.",
         "security": [{ "apiKey": ["delegations:read"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3347,12 +3347,115 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}": {
+      "get": {
+        "operationId": "getDelegation",
+        "summary": "Get a delegation",
+        "tags": ["Delegations"],
+        "description": "Inspect an accessible delegation's brief, context references, status, and current claim expiry.",
+        "security": [{ "apiKey": ["delegations:read"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" },
+                        "brief": { "type": "string" },
+                        "contextRefs": { "type": "array", "items": { "type": "string" } },
+                        "claimExpiresAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": [
+                        "id",
+                        "streamId",
+                        "title",
+                        "status",
+                        "createdAt",
+                        "statusChangedAt",
+                        "brief",
+                        "contextRefs"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/claim": {
       "post": {
         "operationId": "claimDelegation",
-        "summary": "Claim an open delegation",
+        "summary": "Claim an open or expired delegation",
         "tags": ["Delegations"],
-        "description": "Atomically claim an open delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
+        "description": "Atomically claim an open or historical expired delegation. Returns the brief, context refs, and the claim token (cleartext, exactly once; send it as X-Threa-Callback-Token on every later lifecycle call). A delegation that is no longer open returns 409.",
         "security": [{ "apiKey": ["delegations:write"] }],
         "parameters": [
           { "$ref": "#/components/parameters/ThreaVersion" },
@@ -3492,6 +3595,104 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/delegations/{delegationId}/release": {
+      "post": {
+        "operationId": "releaseDelegation",
+        "summary": "Release a delegation claim",
+        "tags": ["Delegations"],
+        "description": "Release a live claim so the delegation is open again. Authenticated with the per-claim callback token.",
+        "security": [{ "apiKey": ["delegations:write"] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/ThreaVersion" },
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "delegationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Delegation ID (prefixed ULID)"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim token from the delegation claim response (binds the caller to its claim)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "streamId": { "type": "string" },
+                        "title": { "type": "string" },
+                        "status": {
+                          "type": "string",
+                          "enum": ["open", "claimed", "running", "completed", "failed", "cancelled", "expired"]
+                        },
+                        "claimedByLabel": { "type": "string" },
+                        "statusNote": { "type": "string" },
+                        "resultMessageId": { "type": "string" },
+                        "sourceConversationId": { "type": "string" },
+                        "createdAt": { "type": "string", "format": "date-time" },
+                        "statusChangedAt": { "type": "string", "format": "date-time" }
+                      },
+                      "required": ["id", "streamId", "title", "status", "createdAt", "statusChangedAt"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "code": {
+                      "description": "Machine-readable error code, e.g. INVALID_API_VERSION",
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
         }
       }
     },

--- a/eslint/threa-plugin.js
+++ b/eslint/threa-plugin.js
@@ -554,7 +554,7 @@ export const sqlTextAssertionAllowlist = {
   "apps/backend/src/features/bot-runtimes/repository.test.ts": 64,
   "apps/backend/src/features/bot-runtimes/service.test.ts": 2,
   "apps/backend/src/features/calls/repository.test.ts": 64,
-  "apps/backend/src/features/delegations/repository.test.ts": 23,
+  "apps/backend/src/features/delegations/repository.test.ts": 19,
   "apps/backend/src/features/drafts/repository.test.ts": 39,
   "apps/backend/src/features/e2e-streams/actor-repository.test.ts": 9,
   "apps/backend/src/features/e2e-streams/key-wrap-repository.test.ts": 11,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -18,6 +18,7 @@ import type {
   AgentStepType,
   KnowledgeType,
   DelegationStatus,
+  DelegationReopenReason,
 } from "./constants"
 import type { WorkspaceInvitableRole } from "./workspace-permissions"
 import type { ContextBag, ContextIntent, ContextRefKind } from "./context-bag"
@@ -1324,6 +1325,8 @@ export interface DelegationCreatedEventPayload {
 export interface DelegationStatusChangedEventPayload {
   delegationId: string
   status: DelegationStatus
+  /** Why a delegation became open again. */
+  reason?: DelegationReopenReason
   /** Free-text label for the claiming agent, e.g. "Kris's MacBook / Claude Code". */
   claimedByLabel?: string | null
   /** The stream message the completing agent posted its result as. */

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -769,6 +769,9 @@ export const DelegationStatuses = {
   EXPIRED: "expired",
 } as const satisfies Record<string, DelegationStatus>
 
+export const DELEGATION_REOPEN_REASONS = ["claim_expired", "claim_released", "requeued"] as const
+export type DelegationReopenReason = (typeof DELEGATION_REOPEN_REASONS)[number]
+
 /** Terminal delegation statuses — no further transitions (and no expiry sweep interest). */
 export const DELEGATION_TERMINAL_STATUSES = [
   "completed",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -151,6 +151,8 @@ export {
   DELEGATION_STATUSES,
   type DelegationStatus,
   DelegationStatuses,
+  DELEGATION_REOPEN_REASONS,
+  type DelegationReopenReason,
   DELEGATION_TERMINAL_STATUSES,
   // Bot access-request lifecycle (F3)
   BOT_ACCESS_REQUEST_STATUSES,


### PR DESCRIPTION
## Problem

Delegation claims currently combine task status with a 15-minute execution lease. A lapsed claim becomes terminal `expired`, so the original executor, a replacement, and the delegator cannot recover the same task. Agents must also claim before the public API reveals the full brief and context.

## Solution

- Add access-gated public inspection without claiming, plus token-authenticated claim release and first-party requeue.
- Reopen lapsed claims atomically, revoke all holder state, append a structured status patch, and re-notify runtime consumers.
- Let direct claim-by-id recover historical expired rows while leaving them out of the automatic queue; Mark done and Cancel also accept them.
- Change polling deltas to `status_changed_at` so reopened old work is visible.
- Keep stale tokens and lapsed idempotency rekeys inert through token, status, and DB-time CAS predicates.

Handover/claim transfer, generic clients, and frontend recovery controls are intentionally owned by later stack layers.

## Verification

- [x] Real PostgreSQL lease integration tests: 11 passed
- [x] Delegation/public API/outbox unit tests: 114 passed
- [x] Full monorepo lint and typecheck
- [x] OpenAPI drift and 254 migration checks

<details>
<summary>📋 Full implementation plan</summary>

# Binding plan: recoverable agent delegations

## Scope and stack

Four PRs, merged as one GitHub Stack with `gh stack`. Planning base: `origin/main` at `b05f17dcb09d3442d7a26854fcf9f948203c3fc4`; refresh `origin/main` before creating PR 1. No open delegation-related PR was found during planning.

This stack changes the generic delegation protocol. Threa harnessd, Pi, Claude Code, and any particular executor are not protocol requirements. The existing `@threa/remote-session` runner remains an optional SDK convenience.

Deferred and prohibited throughout the stack:

- No handover or claim-transfer protocol.
- No automatic requeue of rows already stored with `status = 'expired'`.
- No queue listing of `expired` rows.
- No executor-specific requirement, hidden automatic heartbeat requirement, or dependence on Socket.IO for correctness.
- No new delegation index without an `EXPLAIN`-backed need. Reuse `idx_delegated_tasks_workspace_status_changed` and the existing open partial index.
- No schema migration unless implementation proves a schema change is unavoidable. The planned behavior needs none; append-only migration rules still apply if that conclusion changes.
- No transfer aliases, deprecated endpoint aliases, compatibility shims, or unrelated delegation refactors.

## Binding protocol decisions

### State transitions

| Operation | CAS source | Target | Claim fields | Event reason |
| --- | --- | --- | --- | --- |
| Automatic lease sweep | `claimed|running`, `claim_expires_at <= NOW()` | `open` | Clear token hash, idempotency key, expiry, claimant label, progress note | `claim_expired` |
| Explicit release | `claimed|running`, matching token hash, unexpired lease | `open` | Clear the same five fields | `claim_released` |
| First-party Requeue | `expired` only | `open` | Clear the same five fields | `requeued` |
| Direct claim by id | `open|expired` | `claimed` | Set new token hash, optional idempotency key, expiry, claimant label; clear stale progress note | none; append normal `claimed` patch |
| Mark done | `open|claimed|running|expired` | `completed` | Existing terminal behavior | none |
| Cancel | `open|claimed|running|expired` | `cancelled` | Existing terminal behavior | none |

`completed`, `failed`, and `cancelled` remain settled. `expired` remains a wire status but becomes recoverable and belongs to the outstanding outcome group. A historical expired row changes only through direct claim, Requeue, Mark done, or Cancel.

Every status-changing write and its `delegation:status_changed` stream event/outbox row commit in one service-owned transaction (INV-4/6/7). Reopen patches carry a typed optional reason, not display prose (INV-33/46). The frontend maps `claim_expired`, `claim_released`, and `requeued` to copy.

Release, complete, fail, cancel, and the lease sweep use status/token/lease CAS predicates so one transition wins (INV-20). A replacement claim has a new token hash; a stale token cannot release, heartbeat, complete, or fail it. Idempotency re-keying is limited to an unexpired current claim. After automatic reopen, the old idempotency field is null, so the same caller-supplied key may win a fresh claim; a different winner makes the retry return 409.

### Read and availability contract

- Add public `GET /api/v1/workspaces/{workspaceId}/delegations/{delegationId}` under `delegations:read`.
- Return the normal delegation summary plus immutable `brief` and `contextRefs`. Never serialize `claimTokenHash`, `claimToken`, or `claimIdempotencyKey`.
- Apply the same user-stream or bot-grant access resolution as list/claim. Missing or inaccessible ids both return 404.
- Keep public manual heartbeat unchanged and documented.
- `GET /delegations?since=` continues to return only `open` rows, but `since` filters `status_changed_at`, meaning “availability changed after this timestamp.” Ordering remains oldest-created first.
- A `delegation:status_changed` patch with `status: open` re-emits workspace runtime `delegation:available` with workspace, stream, and delegation id. Title remains optional. Polling remains authoritative if nudges are missed.

### Rollout

No data migration or deployment backfill runs. Existing expired rows remain expired. The startup sweep may reopen only rows still stored as `claimed|running` whose lease has lapsed.

An old backend replica can still write `expired` during a mixed-version rollout. Drain old replicas before relying on automatic reopen. Any row moved to `expired` by an old binary during that window remains explicitly recoverable; do not add an automatic cleanup that would also requeue historical rows.

The new GET/release routes, optional event reason, and SDK methods are additive. Do not add a public API version date. Regenerate canonical and all dated OpenAPI specs because the generator checks each file; pinned versions may call the additive routes and retain their existing response downgrades.

---

## PR 1: server protocol, CAS recovery, and public endpoints

- Branch: `feat/delegation-recovery-01-protocol`
- Base ref: `origin/main`

### Deliverables and owned surfaces

1. Shared structured contract
   - Add a centralized reopen-reason constant/type and export it through `packages/types/src/constants.ts` and `packages/types/src/index.ts`.
   - Add optional `reason` to `DelegationStatusChangedEventPayload` in `packages/types/src/api.ts`.
   - Do not yet change `DELEGATION_TERMINAL_STATUSES`; PR 3 changes outcome/UI semantics together.

2. Repository and service lifecycle
   - Update `apps/backend/src/features/delegations/repository.ts` and `service.ts` to implement the transition table above.
   - Replace `expireLapsedClaims` semantics with set-based reopen semantics; a method rename such as `reopenLapsedClaims` is expected, while the existing timer/file may retain “expiry sweep” naming because it sweeps expired leases.
   - Keep the set-based row update (INV-56), then append one status patch/outbox row per returned delegation inside the same transaction.
   - Add token-authenticated release service flow and expired-only first-party requeue flow.
   - Keep claim token hashing and one-time cleartext return unchanged. Restrict idempotent re-keying to an unexpired claim.
   - Update `expiry-sweep.ts` comments/logging and existing wiring without adding a deploy-time expired-row sweep.

3. First-party recovery actions
   - Add access-checked `POST /api/workspaces/:workspaceId/delegations/:id/requeue` in `features/delegations/handlers.ts` and `apps/backend/src/routes.ts`.
   - Allow existing Mark done and Cancel handlers to win from `expired`.
   - Preserve 404 existence hiding and stream scoping (INV-8/62).

4. Public inspect and release
   - Add public GET-by-id and `POST .../{delegationId}/release` in `features/public-api/delegation-handlers.ts`, schemas/route registry, operation-id registry, and route mounting.
   - GET uses `delegations:read`; release uses `delegations:write` and `X-Threa-Callback-Token`.
   - Release returns the reopened delegation summary. A stale, lapsed, inaccessible, missing, or replaced claim returns privacy-safe 404.
   - Keep claim-by-id access checks and extend its CAS to `open|expired`; list remains open-only.

5. Availability delivery
   - Change `listOpen` delta filtering from `created_at` to `status_changed_at`.
   - Extend `apps/backend/src/lib/outbox/broadcast-handler.ts` so an open status patch emits `delegation:available`; do not emit for other status patches.
   - Preserve event/outbox transactionality. Socket delivery is only an optimization over polling.

6. Generated API contract
   - Add schemas/descriptions for inspect and release in `features/public-api/routes.ts`.
   - Regenerate `docs/public-api/openapi.json` and every `docs/public-api/versions/*.json` so PR 1 passes drift checks. PR 4 may revise prose and regenerate again.

### Enumerated tests

1. Add `apps/backend/tests/integration/delegation-leases.test.ts` against real PostgreSQL (INV-68):
   - lapsed claimed/running rows reopen set-wise; live rows and historical expired rows remain unchanged;
   - every reopened row has the five holder/progress fields cleared and a fresh `status_changed_at`;
   - release of a live token reopens and clears fields;
   - release racing complete, fail, cancel, or sweep has exactly one winner;
   - an old token cannot affect a replacement claim;
   - direct claim accepts open and historical expired rows but not completed/failed/cancelled/claimed rows;
   - same idempotency key may claim after automatic reopen, while a concurrent winner yields the losing CAS;
   - a lapsed-but-unswept claim cannot be revived through idempotency re-key;
   - `since` finds a reopened row created before the cursor and excludes unchanged older open rows;
   - workspace/id predicates prevent cross-workspace mutation.
2. Replace changed-method SQL-text assertions in `features/delegations/repository.test.ts` with behavior coverage above; add no new SQL-text assertions. Keep unit tests only for mapping or service orchestration not exercised by PostgreSQL.
3. Extend `features/delegations/service.test.ts` to assert exact status-patch content/reason and matching outbox type for expiry, release, and requeue; assert no event on a lost CAS (INV-23/24).
4. Extend `features/delegations/handlers.test.ts` for expired Mark done/Cancel/Requeue, requeue lost race, access hiding, and stream binding.
5. Extend `features/public-api/delegation-endpoints.test.ts` for GET full brief/context, omitted secrets, user/bot access, inaccessible 404, release token requirements, release 404 outcomes, and expired direct claim.
6. Extend public route/mount/schema tests for methods, scopes, parameters, operation ids, and generated response schemas.
7. Extend `broadcast-handler.test.ts` for open-patch re-nudge by id/title-optional and non-open no-nudge.
8. Assert the existing general `workspace/status_changed_at` index exists through migration/schema checks; add no index-shape test unless query evidence changes the decision.

### Gates

- `bun run test:db:start`
- `bun run --cwd apps/backend test:integration`
- Targeted delegation/public API/outbox unit tests, then `bun run --cwd apps/backend test:unit`
- `bun run --cwd packages/types test`
- `bun run --cwd packages/types typecheck`
- `bun run --cwd apps/backend typecheck`
- `bun run --cwd apps/backend lint`
- `bun run generate:api-docs:check`
- `bun run check:migrations`

### Exclusions

- No CLI, MCP, SDK runner, or frontend changes beyond compile fallout from the additive event type.
- No outcome grouping change yet.
- No user-facing prose sweep beyond accurate provisional route descriptions.
- No migration, backfill, transfer, or handover.

### Compatibility and rollout notes

- Safe for old clients: they ignore optional event `reason`; reopened rows look like ordinary open rows.
- Deploy backend before PR 2 clients are distributed. New clients must treat route absence on an older backend as unsupported, not emulate release with fail.
- Old replicas must be drained as described in the stack rollout section.

### Cross-PR dependencies

- Foundation for all later PRs.
- PR 2 consumes GET/release and reopen behavior.
- PR 3 consumes reason values and first-party requeue.
- PR 4 finalizes all public wording and generated docs.

---

## PR 2: generic CLI/MCP/SDK clients and recoverable runner shutdown

- Branch: `feat/delegation-recovery-02-clients`
- Base ref: `feat/delegation-recovery-01-protocol`

### Deliverables and owned surfaces

1. CLI operations and token storage
   - Add `getDelegation` and `releaseDelegation` in `packages/cli/src/ops.ts`.
   - Add `threa delegations get <id>` and `threa delegations release <id> [--claim-token t]` in `commands/delegations.ts`.
   - GET works before claim and prints/returns brief plus context refs without a token.
   - Successful release deletes the workspace/delegation token from `TokenStore`. Do not delete on an ambiguous transport/server failure.
   - Keep `delegations update` as the explicit manual heartbeat/progress surface.

2. MCP tools
   - Add `get_delegation` and `release_delegation` in `packages/cli/src/tools/delegations.ts` and register/update server guidance in `packages/cli/src/server.ts`.
   - Describe the generic loop as inspect, claim, optional manual heartbeat/progress, then complete/fail/release.
   - Do not imply that a runner or automatic heartbeat is required.

3. SDK client
   - Add `DelegationClient.get(id)` and `DelegationClient.release(id, claimToken)` in `extensions/remote-session/src/delegation-client.ts`; export any new wire types from `index.ts`.
   - Keep `heartbeat` public and independent of `DelegationRunner`.

4. Optional `DelegationRunner` convenience
   - Add an `AbortSignal` to `DelegationExecutorContext` as cooperative best-effort cancellation.
   - On controlled `stop()`, abort active execution and release any held live claim instead of reporting a fabricated failure. A claim that arrives after stop also uses release.
   - An executor exception while the runner is not stopping still calls `/fail` with the real error.
   - Treat claim-authenticated 404 from heartbeat or progress as a known-lost claim: mark it lost, abort the executor, and do not attempt complete/fail/release with that token. Non-404 heartbeat transport errors remain logged and execution continues; server CAS remains authoritative.
   - Preserve strict-stop error propagation for a failed release and non-strict best-effort shutdown.
   - Update the reference `extensions/claude-code-remote/src/channel-server.ts` only as needed to observe the SDK abort signal and remove false “fail on shutdown” behavior. This adapter is compatibility work, not protocol semantics.

### Enumerated tests

1. CLI command tests:
   - `get` calls GET, exposes full brief/context, and never writes token state;
   - `release` sends the stored or explicit callback token and clears stored state only after success;
   - missing token is a usage/tool error; failed/ambiguous release preserves state;
   - list help says `since` means availability/status change, not creation.
2. MCP tests:
   - `get_delegation` and `release_delegation` schemas and paths;
   - successful release clears shared CLI/MCP token state;
   - tool descriptions retain manual heartbeat and inspect-before-claim ordering.
3. Add focused `delegation-client.test.ts` for GET, release header/path, secret-free inspect shape, and structured 404 propagation.
4. Extend `delegation-runner.test.ts`:
   - stop before/after claim response releases and never fails;
   - stop during execution aborts cooperatively and releases;
   - executor error without stop still fails;
   - heartbeat/status 404 aborts and suppresses terminal writes;
   - heartbeat 5xx/network error does not invent claim loss;
   - replacement/stale-token 404 is handled as lost;
   - strict release failure propagates, normal shutdown logs and resolves;
   - existing one-at-a-time drain, nudge, poll, access-request, and heartbeat tests remain green.
5. Extend Claude channel-server tests only for the SDK integration seam: shutdown/reconnect releases and an abort settles the open delegation promise without a false failure.

### Gates

- `bun run --cwd packages/cli test`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd extensions/remote-session test`
- `bun run --cwd extensions/remote-session typecheck`
- `bun run --cwd extensions/claude-code-remote test`
- `bun run --cwd extensions/claude-code-remote typecheck`
- `bun run typecheck`

### Exclusions

- No automatic heartbeat in the CLI or MCP server.
- No claim-token transfer between machines beyond existing explicit token override/state file behavior.
- No changes to bot invocation lifecycle, `RemoteSession` invocation claims, Pi, harnessd, or delegation creation.
- No docs/README final copy; PR 4 owns it.

### Compatibility and rollout notes

- New CLI/MCP commands require PR 1 backend routes.
- `DelegationExecutorContext.signal` is additive for TypeScript callers. Existing executors may ignore it; cancellation remains best effort and the server token CAS prevents stale completion.
- The SDK runner's changed shutdown outcome is intentional: controlled stop means release/open, while execution failure still means failed.

### Cross-PR dependencies

- Depends on PR 1 endpoints and CAS behavior.
- PR 4 documents these exact commands/tools and SDK semantics.

---

## PR 3: recoverable frontend states and outcome grouping

- Branch: `feat/delegation-recovery-03-ui`
- Base ref: `feat/delegation-recovery-02-clients`

### Deliverables and owned surfaces

1. Settled/outstanding contract
   - Remove `expired` from `DELEGATION_TERMINAL_STATUSES` and update its shared comment/tests in `packages/types`.
   - Update backend agent-outcome grouping so expired delegations appear under Outstanding, not Settled; `all` remains status-agnostic.
   - Keep failed/cancelled/completed settled.

2. Frontend display ownership
   - Add frontend mappings for reopen reasons in `apps/frontend/src/lib/delegation-display.ts`.
   - Render `claim_expired`, `claim_released`, and `requeued` as clear availability text on timeline cards without backend display strings (INV-46).
   - Present legacy `expired` as recoverable, not struck through or inert. Use a distinct “claim expired” state so it is not confused with an automatically reopened open task.

3. Recovery actions
   - Add `delegationsApi.requeue` and a Requeue action for expired cards and expired delegation outcome details.
   - Keep Mark done and Cancel available for expired rows.
   - Requeue success optimistically shows open/requeued until the authoritative patch arrives; lost-race responses do not lie about state.
   - Invalidate delegation/outcome queries through existing keys; rely on stream status events for timeline authority.

4. Copy prompt technical update
   - Change `buildDelegationPrompt` and its visible hint to be executor-neutral.
   - Put inspect-before-claim first: GET the delegation, review brief/context, then claim only when accepting the work.
   - Include release as the controlled-stop path and retain manual heartbeat as optional liveness.
   - Remove claims that context refs are “resolved” by claim if the wire only returns pointers.
   - PR 4 performs the final prose gate and may make prose-only edits here.

5. Secondary surfaces
   - Update outcome item capability flags (`canRequeue`, Mark done/Cancel on expired), outcome detail actions, timeline card action menus/mobile drawer, status pills, and relevant stream-context/board expectations.
   - Reopened open rows without a loaded reason still render honestly as Open; do not add a database column or status-patch join solely for display.

### Enumerated tests

1. Shared constants tests assert expired is a valid delegation status but not terminal/settled.
2. Backend outcome service/integration tests assert expired is Outstanding, completed/failed/cancelled are Settled, counts match, and access scoping remains intact.
3. `delegation-display` tests cover all reason-to-copy mappings and status pill exhaustiveness.
4. Timeline integration/component tests cover:
   - automatic expiry patch renders open again with expiry reason and active actions;
   - release and manual requeue reasons render distinct frontend-owned text;
   - legacy expired renders recoverable and offers Requeue, Mark done, Cancel on desktop and mobile action surfaces;
   - requeue success/lost race/error behavior;
   - last status patch still wins after expired then open then claimed;
   - Copy prompt orders GET before claim, mentions release/manual heartbeat accurately, and contains no executor-specific requirement.
5. Outcome tests cover expired in Outstanding, recovery buttons, query invalidation, and action race messages.
6. Stream-context/board tests verify expired/reopened labels and styling without treating expired as settled.
7. Throwaway Playwright visual pass after implementation at 1440px and 390px for open-again and legacy-expired cards, including opened action menus/drawers and inner-container scrolling; inspect screenshots and delete the temporary spec.

### Gates

- Targeted package-types, agent-outcomes, delegation timeline, outcomes, stream-context, and board tests
- `bun run --cwd packages/types test`
- `bun run --cwd apps/backend test:unit`
- `bun run --cwd apps/backend test:integration`
- `bun run --cwd apps/frontend test`
- `bun run --cwd apps/frontend typecheck`
- `bun run --cwd apps/frontend lint`
- Playwright visual verification at both widths

### Exclusions

- No public first-party claim UI.
- No status rename or deletion of `expired`.
- No persistence of display text or reopen reason in `delegated_tasks`.
- No new notification/toast success path, transfer, or handover.

### Compatibility and rollout notes

- Old events have no reason and continue to render from status alone.
- Historical expired rows become actionable only after the PR 1 backend is present.
- Frontend reason strings are presentation only; API clients branch on status/reason constants.

### Cross-PR dependencies

- Depends on PR 1 reason payload and requeue endpoint.
- Independent of the optional runner behavior in PR 2 except for Copy prompt documentation.
- PR 4 runs the final prose review over all new UI strings.

---

## PR 4: public docs, roadmap ruling, help, and final prose gate

- Branch: `docs/delegation-recovery-04-contract`
- Base ref: `feat/delegation-recovery-03-ui`

### Deliverables and owned surfaces

1. Public API and developer docs
   - Finalize delegation route summaries/descriptions in `features/public-api/routes.ts` and regenerate canonical/all dated OpenAPI files.
   - Update `apps/public-site/src/pages/developers/recipes.astro` with inspect-before-claim, release, automatic reopen, `since=status_changed_at`, direct legacy-expired claim, and manual heartbeat semantics.
   - Update `apps/public-site/src/pages/developers/cli.astro`, `docs/public-api/mcp-server.md`, and relevant API changelog/version prose only where generated/current behavior requires it.
   - Correct existing completion-anchor wording to the current card-thread contract while in the touched delegation recipe; do not broaden into unrelated doc cleanup.

2. CLI/MCP/SDK docs
   - Update `packages/cli/README.md`, command help, MCP tool descriptions/server instructions, and `extensions/remote-session/README.md`.
   - Document `delegations get`, `get_delegation`, release commands/tools, token clearing on successful release, manual heartbeat, and optional runner auto-heartbeat.
   - State that executor errors fail; controlled shutdown releases; known-lost claims abort best effort.

3. Agent skill
   - Update `.agents/skills/threa-cli/SKILL.md` description and delegation loop. Required order: whoami, inspect, claim, heartbeat/progress as needed, complete/fail/release.
   - Explain reopened polling semantics and explicit recovery for legacy expired tasks.

4. Product/roadmap ruling
   - Update `docs/plans/ariadne-collaborator-roadmap.md` to supersede the old “expired stays terminal” ruling with this stack's final behavior.
   - Record that handover/transfer remains deferred until inspect-before-claim is dogfooded.
   - Update Copy prompt wording from PR 3 if the prose gate accepts improvements.

5. Final prose gate, in this exact order
   - Assemble every changed user-facing string from route descriptions, OpenAPI, CLI/MCP help, READMEs, public-site docs, skill, roadmap ruling, Copy prompt, and UI labels.
   - First make the draft technically accurate against implemented code/tests.
   - Send only the prose and audience/context to Kimi K2.5 through OpenRouter with reasoning explicitly disabled. Ask for prose direction only; do not ask it to decide protocol behavior and do not include credentials or production data.
   - Record each suggestion in `.tmp` as Accept or Reject with a technical/editorial reason. Suggestions are advisory.
   - Apply accepted revisions conservatively.
   - Run the `deslopify` skill in edit mode over all changed user-facing files, then its `eval.md` self-check. Run mechanical checks for em dashes, formulaic accent markup, bold-first bullets, clichés/openers, and accidental executor-specific claims. Existing unrelated copy is out of scope.
   - Reverify every endpoint, status, scope, token, TTL, `since`, release, event, and completion claim against code, generated OpenAPI, and executable help/tests after prose edits. Technical accuracy overrides model/style suggestions.

### Enumerated tests and gates

1. CLI help snapshot/behavior tests include get/release and correct `since`/heartbeat wording.
2. MCP registration tests include get/release and lifecycle guidance.
3. `bun run generate:api-docs` followed by `bun run generate:api-docs:check` produces no drift.
4. `bun run --cwd apps/public-site typecheck`
5. `bun run --cwd apps/public-site lint`
6. `bun run --cwd apps/public-site build`
7. `bun run --cwd packages/cli test` and typecheck after help changes.
8. `bun run --cwd extensions/remote-session test` and typecheck after README-adjacent contract verification.
9. Mechanical deslopify checks and completed `eval.md` self-check recorded in `.tmp`, not committed.
10. Final grep verifies no docs still say expired is terminal, `since` means created time, shutdown fails work, or claim must precede inspection.

### Exclusions

- No code behavior changes except prose-only corrections and generated OpenAPI output. A discovered behavior bug returns to the owning PR instead of being hidden in docs.
- No new API version, marketing expansion, unrelated public-site restyling, handover, or transfer design.
- Do not commit Kimi prompts/responses or `.tmp` review artifacts.

### Compatibility and rollout notes

- Publish docs only with the complete stack so commands and endpoints are live when described.
- Generated dated specs include additive routes; existing version-specific response transformations remain unchanged.

### Cross-PR dependencies

- Depends on the final code and UI vocabulary from PRs 1–3.
- Any technical mismatch found by the prose gate is fixed in the PR that owns it, followed by stack rebase, affected gates, and another technical-claim check. Do not run another broad prose/model pass.

---

## Final whole-stack verification

1. Stack hygiene
   - Fetch `origin/main`; run `gh stack sync --prune` if main moved.
   - Confirm `gh stack view --json` contains all four branches/PRs in one Stack and each base is the preceding ref.
   - Confirm every CI check is green before whole-stack review.

2. Whole-stack adversarial checks
   - Review `origin/main...<tip>` for every transition in the binding table, access hiding, workspace scoping (INV-8), transactionality (INV-4/7), CAS races (INV-20), set-based sweep (INV-56), structured reason copy (INV-46), and real-Postgres coverage (INV-68).
   - Walk mixed races explicitly: sweep/release/complete/fail/cancel; old token/replacement claim; idempotency retry/reopen/new winner; GET/access revocation; requeue/direct claim; open re-nudge/poll delta.
   - Verify every planned route, CLI command, MCP tool, SDK method, UI action, docs surface, and final prose gate exists. Verify no handover or transfer code entered the diff.
   - Disposition every review/CodeRabbit finding and fold fixes into the owning branch before rebasing up-stack.

3. Full gates
   - `bun run test:db:start`
   - `bun run lint`
   - `bun run typecheck`
   - `bun run --cwd apps/backend test:unit`
   - `bun run --cwd apps/backend test:integration`
   - `bun run --cwd apps/backend test:e2e`
   - `bun run --cwd apps/frontend test`
   - `bun run --cwd packages/cli test`
   - `bun run --cwd extensions/remote-session test`
   - `bun run --cwd extensions/claude-code-remote test`
   - `bun run --cwd apps/public-site build`
   - `bun run generate:api-docs:check`
   - `bun run check:migrations`
   - Repeat the 1440px/390px Playwright screenshot inspection after final UI/prose fixes.

4. Rollout verification before dogfood
   - Confirm all regional backends run the new sweep before waiting for a deliberate lapse.
   - Query/inspect a known historical expired delegation and verify deployment did not change it.
   - Check logs/metrics for sweep errors and unexpected `expired` writes from an old replica; explicitly recover any rollout-window test row.

## Production dogfood checklist

Use a dedicated production test stream and approved write-capable user/bot keys from secure environment storage. Never print keys or claim tokens; do not use the read-only production key for writes. Record only delegation ids, timestamps, statuses, and outcomes.

1. Inspect before claim
   - Create a harmless delegation.
   - Raw API GET it before claiming; verify full brief/context, no claim token/hash/idempotency field, and inaccessible key gets indistinguishable 404.
   - Run `threa delegations get` and MCP `get_delegation`; compare the same task.
   - Only then claim it.

2. Manual long claim and release
   - Claim through raw API with a persisted idempotency key.
   - Keep it alive beyond 15 minutes using manual raw heartbeat calls; verify the lease/status remains held without relying on a runner.
   - Release with the token; verify the card shows released/open, the old token can no longer act, the CLI token store clears on CLI release, and an open-list delta using a timestamp from before release returns the task.

3. Deliberate lapse and reclaim
   - Claim a fresh task and send no heartbeat.
   - After TTL plus sweep interval, verify GET/card reports open again with `claim_expired`, queue delta finds it despite old `createdAt`, and `delegation:available` is re-emitted if a raw Socket.IO listener is connected.
   - Reclaim with the same idempotency key; verify the old token cannot release/complete/fail the replacement claim.
   - Complete the replacement claim and confirm the result thread/message and final card state.

4. Legacy expired recovery
   - On a harmless existing/test expired row, verify it stayed expired after deploy and is absent from queue listing.
   - Inspect it, then exercise one explicit recovery path. Prefer Requeue for UI proof; separately cover direct claim-by-id in staging/integration if production cleanup policy allows only one outcome.
   - Verify expired offers Requeue, Mark done, and Cancel and appears under Outstanding until resolved.

5. Missing-access bot flow
   - Connect a minimal raw `/bot` Socket.IO listener for a bot with no grant to the test stream; create a delegation and capture its `delegation:available` id.
   - Verify bot GET/claim returns privacy-safe 404, then request access with raw API or CLI.
   - Approve from the first-party card; verify a second `delegation:available` nudge for the same id.
   - Inspect with the now-authorized bot before claim, claim it, manually heartbeat if needed, and complete it.
   - Confirm result authorship/access, card transition, and no duplicate access request or completion.

6. Cleanup and acceptance
   - Complete, cancel, or requeue every dogfood task into an intentional final state; leave no live claim.
   - Confirm no historical expired row outside the selected test task changed.
   - Dogfood is accepted only after inspect-before-claim, long manual heartbeat, explicit release, lapse/reopen/delta/reclaim, stale-token rejection, legacy explicit recovery, and missing-access request/approve/re-nudge/claim/complete all pass.


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788695987&installation_model_id=20758&pr_number=1797&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1797&signature=949d522424d455ddf76583468bd080699cfe31f12c5c9e3c827af0220fce50d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->