### PR TITLE
fix: stabilize dictation polish lifecycle

### DIFF
--- a/apps/backend/src/features/voice-transcription/polish-scheduler.test.ts
+++ b/apps/backend/src/features/voice-transcription/polish-scheduler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, mock } from "bun:test"
+import { PolishScheduler } from "./polish-scheduler"
+import type { PolishOutcome } from "./polish"
+
+function deferred() {
+  let resolve!: (value: PolishOutcome) => void
+  const promise = new Promise<PolishOutcome>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+const success = (markdown: string): PolishOutcome => ({ status: "success", markdown })
+
+describe("PolishScheduler", () => {
+  it("runs one active pass and only the newest pending snapshot", async () => {
+    const first = deferred()
+    const seen: number[] = []
+    const onResult = mock((snapshot: { revision: number }) => seen.push(snapshot.revision))
+    const scheduler = new PolishScheduler(onResult)
+    scheduler.scheduleLive({ revision: 1, run: () => first.promise })
+    scheduler.scheduleLive({ revision: 2, run: async () => success("two") })
+    scheduler.scheduleLive({ revision: 3, run: async () => success("three") })
+    first.resolve(success("one"))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(seen).toEqual([1, 3])
+  })
+
+  it("ignores a late result after cancellation", async () => {
+    const active = deferred()
+    const onResult = mock(() => {})
+    const scheduler = new PolishScheduler(onResult)
+    scheduler.scheduleLive({ revision: 1, run: () => active.promise })
+    scheduler.cancel()
+    active.resolve(success("late"))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(onResult).not.toHaveBeenCalled()
+  })
+
+  it("cancellation releases an authoritative final even when its provider resolves late", async () => {
+    const final = deferred()
+    const scheduler = new PolishScheduler(mock(() => {}))
+    const formatting = scheduler.formatFinal({ revision: 1, run: () => final.promise })
+    scheduler.cancel()
+
+    await expect(formatting).resolves.toEqual({ status: "canceled" })
+    final.resolve(success("late"))
+  })
+
+  it("cancels live work and runs the authoritative final exactly once", async () => {
+    const active = deferred()
+    const onResult = mock(() => {})
+    const finalRun = mock(async () => success("final"))
+    const scheduler = new PolishScheduler(onResult)
+    scheduler.scheduleLive({ revision: 1, run: () => active.promise })
+    const outcome = await scheduler.formatFinal({ revision: 2, run: finalRun })
+    active.resolve(success("late"))
+    await Promise.resolve()
+    expect(outcome).toEqual(success("final"))
+    expect(finalRun).toHaveBeenCalledTimes(1)
+    expect(onResult).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/voice-transcription/polish-scheduler.ts
+++ b/apps/backend/src/features/voice-transcription/polish-scheduler.ts
@@ -1,0 +1,66 @@
+import type { PolishOutcome } from "./polish"
+
+export interface PolishSnapshot {
+  revision: number
+  run: (signal: AbortSignal) => Promise<PolishOutcome>
+}
+
+type ResultHandler = (snapshot: PolishSnapshot, outcome: PolishOutcome) => void
+
+export class PolishScheduler {
+  private generation = 0
+  private active: { controller: AbortController; promise: Promise<void> } | null = null
+  private pending: PolishSnapshot | null = null
+
+  constructor(private readonly onResult: ResultHandler) {}
+
+  scheduleLive(snapshot: PolishSnapshot): void {
+    if (this.active) {
+      this.pending = snapshot
+      return
+    }
+    this.start(snapshot, this.generation)
+  }
+
+  async formatFinal(snapshot: PolishSnapshot): Promise<PolishOutcome> {
+    this.cancel()
+    const generation = this.generation
+    const controller = new AbortController()
+    const outcomePromise = snapshot.run(controller.signal).catch(() => ({ status: "provider_error" }) as PolishOutcome)
+    const promise = outcomePromise.then(() => {})
+    this.active = { controller, promise }
+    const canceled = new Promise<PolishOutcome>((resolve) => {
+      controller.signal.addEventListener("abort", () => resolve({ status: "canceled" }), { once: true })
+    })
+    const outcome = await Promise.race([outcomePromise, canceled])
+    if (this.active?.promise === promise) this.active = null
+    if (generation !== this.generation || controller.signal.aborted) return { status: "canceled" }
+    return outcome
+  }
+
+  cancel(): void {
+    this.generation++
+    this.pending = null
+    this.active?.controller.abort()
+    this.active = null
+  }
+
+  private start(snapshot: PolishSnapshot, generation: number): void {
+    const controller = new AbortController()
+    const promise = snapshot
+      .run(controller.signal)
+      .catch(() => ({ status: "provider_error" }) as PolishOutcome)
+      .then((outcome) => {
+        if (generation === this.generation && !controller.signal.aborted) this.onResult(snapshot, outcome)
+      })
+      .finally(() => {
+        if (this.active?.promise !== promise) return
+        this.active = null
+        if (generation !== this.generation) return
+        const pending = this.pending
+        this.pending = null
+        if (pending) this.start(pending, generation)
+      })
+    this.active = { controller, promise }
+  }
+}

--- a/apps/backend/src/features/voice-transcription/polish.test.ts
+++ b/apps/backend/src/features/voice-transcription/polish.test.ts
@@ -26,7 +26,7 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toBe("Hello, world.")
+    expect(out).toEqual({ status: "success", markdown: "Hello, world." })
     const call = generateText.mock.calls[0][0]
     expect(call.model).toBe(POLISH_MODEL)
     expect(call.telemetry?.functionId).toBe("voice-transcript-polish")
@@ -202,9 +202,7 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).not.toContain("—")
-    expect(out).not.toContain("–")
-    expect(out).toBe("here's what I'm thinking: pie")
+    expect(out).toEqual({ status: "success", markdown: "here's what I'm thinking: pie" })
 
     const sys = generateText.mock.calls[0][0].messages.find((m: { role: string }) => m.role === "system")
     expect(sys?.content).toContain("em dashes")
@@ -224,7 +222,7 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toBe("hello world")
+    expect(out).toEqual({ status: "provider_error" })
   })
 
   it("returns the raw text unchanged when the model returns an empty string", async () => {
@@ -239,7 +237,40 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toBe("non empty")
+    expect(out).toEqual({ status: "invalid_output", reason: "empty" })
+  })
+
+  it("returns canceled when external cancellation aborts the provider", async () => {
+    const generateText = mock(async (args: GenerateTextArgs) => {
+      await new Promise<void>((resolve) => args.abortSignal?.addEventListener("abort", () => resolve(), { once: true }))
+      throw new Error("aborted")
+    })
+    const polish = createPolishTranscript({ ai: fakeAI(generateText) })
+    const controller = new AbortController()
+    const pending = polish({
+      rawTranscript: "hello",
+      level: "minor",
+      workspaceId: "ws_1",
+      userId: "user_1",
+      sessionId: "voicesess_1",
+      signal: controller.signal,
+    })
+    controller.abort()
+    expect(await pending).toEqual({ status: "canceled" })
+  })
+
+  it("rejects length-truncated output", async () => {
+    const generateText = mock(async () => ({ ...textResult("partial"), finishReason: "length" }) as never)
+    const polish = createPolishTranscript({ ai: fakeAI(generateText) })
+    expect(
+      await polish({
+        rawTranscript: "hello",
+        level: "minor",
+        workspaceId: "ws_1",
+        userId: "user_1",
+        sessionId: "voicesess_1",
+      })
+    ).toEqual({ status: "invalid_output", reason: "truncated" })
   })
 
   it("skips the model entirely for whitespace-only input", async () => {
@@ -254,7 +285,7 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toBe("   ")
+    expect(out).toEqual({ status: "empty_input" })
     expect(generateText).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/voice-transcription/polish.ts
+++ b/apps/backend/src/features/voice-transcription/polish.ts
@@ -15,45 +15,51 @@ export interface PolishTranscriptInput {
   workspaceId: string
   userId: string
   sessionId: string
-  /**
-   * Draft text already in the composer around the dictation insertion point,
-   * captured client-side at `voice:start`. Read-only context for the model
-   * (vocabulary, names, sentence continuation) — never part of the output.
-   */
   draftBefore?: string
   draftAfter?: string
-  /**
-   * Spelling reference (product names, custom steering words) the model should
-   * normalize mis-transcriptions to. Reinforces the STT-layer keyterm biasing so
-   * a mis-heard product name is corrected even when the provider couldn't bias it.
-   */
   steeringTerms?: string[]
+  signal?: AbortSignal
 }
 
-export type PolishTranscript = (input: PolishTranscriptInput) => Promise<string>
+export type PolishOutcome =
+  | { status: "success"; markdown: string }
+  | { status: "empty_input" }
+  | { status: "invalid_output"; reason: "empty" | "truncated" | "unparseable" }
+  | { status: "timeout" }
+  | { status: "canceled" }
+  | { status: "provider_error" }
 
-/**
- * Builds the polish entrypoint used by the voice relay. `level` controls rewrite
- * aggressiveness ("minor" vs "opinionated"); "none" short-circuits in the gateway
- * and never reaches here. On timeout or upstream error this never throws: it logs
- * and returns the raw text so dictation always commits something.
- */
+export type PolishTranscript = (input: PolishTranscriptInput) => Promise<PolishOutcome>
+
 export function createPolishTranscript(deps: { ai: AI }): PolishTranscript {
-  return async ({ rawTranscript, level, workspaceId, userId, sessionId, draftBefore, draftAfter, steeringTerms }) => {
+  return async ({
+    rawTranscript,
+    level,
+    workspaceId,
+    userId,
+    sessionId,
+    draftBefore,
+    draftAfter,
+    steeringTerms,
+    signal,
+  }) => {
     const trimmed = rawTranscript.trim()
-    if (!trimmed) return rawTranscript
-    // Defense-in-depth: the gateway short-circuits before reaching here, but an
-    // explicit guard prevents a future caller from silently falling through to
-    // the "minor" branch (INV-11).
-    if (level === "none") return rawTranscript
+    if (!trimmed) return { status: "empty_input" }
+    if (level === "none") return { status: "success", markdown: trimmed }
 
     const systemPrompt = level === "opinionated" ? POLISH_OPINIONATED_SYSTEM_PROMPT : POLISH_MINOR_SYSTEM_PROMPT
     const userMessage = buildPolishUserMessage({ rawTranscript: trimmed, draftBefore, draftAfter, steeringTerms })
-
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), POLISH_TIMEOUT_MS)
+    let timedOut = false
+    const onCancel = () => controller.abort()
+    signal?.addEventListener("abort", onCancel, { once: true })
+    const timer = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, POLISH_TIMEOUT_MS)
 
     try {
+      if (signal?.aborted) return { status: "canceled" }
       const result = await deps.ai.generateText({
         model: POLISH_MODEL,
         messages: [
@@ -75,27 +81,27 @@ export function createPolishTranscript(deps: { ai: AI }): PolishTranscript {
         context: { workspaceId, userId, origin: "user" },
         abortSignal: controller.signal,
       })
-
+      if (signal?.aborted) return { status: "canceled" }
+      if (timedOut) return { status: "timeout" }
+      const finishReason =
+        (result as { finishReason?: string; response?: { finishReason?: string } }).finishReason ??
+        (result as { response?: { finishReason?: string } }).response?.finishReason
+      if (finishReason === "length") return { status: "invalid_output", reason: "truncated" }
       const polished = result.value.trim()
-      if (!polished) return rawTranscript
-      // Providers slip em-dashes through despite the prompt rule; strip them
-      // deterministically so the user never sees one they didn't dictate.
-      return scrubDashes(polished)
+      if (!polished) return { status: "invalid_output", reason: "empty" }
+      return { status: "success", markdown: scrubDashes(polished) }
     } catch (err) {
-      logger.warn({ err, sessionId, workspaceId, level }, "Voice transcript polish failed; falling back to raw")
-      return rawTranscript
+      if (signal?.aborted) return { status: "canceled" }
+      if (timedOut) return { status: "timeout" }
+      logger.warn({ err, sessionId, workspaceId, level }, "Voice transcript polish provider failed")
+      return { status: "provider_error" }
     } finally {
       clearTimeout(timer)
+      signal?.removeEventListener("abort", onCancel)
     }
   }
 }
 
-/**
- * Assembles the polish user message. Draft text around the insertion point is
- * included as labeled read-only sections so the model can match the draft's
- * vocabulary and make the polished text flow with its surroundings; the prompt's
- * hard rules forbid echoing these sections into the output.
- */
 export function buildPolishUserMessage(args: {
   rawTranscript: string
   draftBefore?: string
@@ -106,28 +112,17 @@ export function buildPolishUserMessage(args: {
   const before = args.draftBefore?.trim()
   const after = args.draftAfter?.trim()
   const steeringTerms = args.steeringTerms?.filter((t) => t.trim())
-  if (steeringTerms && steeringTerms.length > 0) {
+  if (steeringTerms?.length)
     sections.push(
       `Spelling reference (normalize mis-transcriptions to these exact spellings):\n${steeringTerms.join(", ")}`
     )
-  }
-  if (before) {
+  if (before)
     sections.push(`Existing draft text before the insertion point (context only, never output it):\n${before}`)
-  }
-  if (after) {
-    sections.push(`Existing draft text after the insertion point (context only, never output it):\n${after}`)
-  }
+  if (after) sections.push(`Existing draft text after the insertion point (context only, never output it):\n${after}`)
   sections.push(`Raw transcript:\n${args.rawTranscript}`)
   return sections.join("\n\n")
 }
 
-/**
- * Replace em/en dashes the model slipped past the prompt rule with natural
- * punctuation:
- *   - " — " / " – " between clauses → ": " (clause expansion / explanation)
- *   - "word—word" / "word–word"     → "word, word" (interruption / list)
- * A regular ASCII hyphen "-" is left alone (legitimate compounds).
- */
 export function scrubDashes(text: string): string {
   return text.replace(/\s+[—–]\s+/g, ": ").replace(/[—–]/g, ", ")
 }

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it, jest, mock } from "bun:test"
+import { afterEach, describe, expect, it, jest, mock, spyOn } from "bun:test"
 import type { Server } from "socket.io"
 import { VOICE_DRAFT_CONTEXT_MAX_CHARS } from "@threa/types"
+import { logger } from "../../lib/logger"
 import { registerVoiceGateway } from "./realtime-gateway"
 import type { TranscriptionSession } from "./transcription/strategy"
 
@@ -218,7 +219,8 @@ describe("registerVoiceGateway voice:start", () => {
     )
   })
 
-  it("keeps polish and per-user steering when the workspace-settings lookup fails", async () => {
+  it("keeps polish and per-user steering while warning when workspace settings fail", async () => {
+    const warn = spyOn(logger, "warn").mockImplementation(() => logger)
     const seenLevels: string[] = []
     const { socket, upstream, transcription } = setup({
       voicePolishLevel: "opinionated",
@@ -243,9 +245,14 @@ describe("registerVoiceGateway voice:start", () => {
     upstream.fireDelta({ text: "hi", isFinal: true })
     await new Promise((r) => setTimeout(r, 0))
     expect(seenLevels).toEqual(["opinionated"])
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws_1" }),
+      "Voice workspace settings lookup failed"
+    )
   })
 
-  it("keeps workspace steering when the user-prefs lookup fails (polish defaults off)", async () => {
+  it("keeps workspace steering while warning when user preferences fail", async () => {
+    const warn = spyOn(logger, "warn").mockImplementation(() => logger)
     const { socket, transcription } = setup({
       workspaceSteeringWords: ["Acme"],
       userPrefsThrows: true,
@@ -260,6 +267,10 @@ describe("registerVoiceGateway voice:start", () => {
     // User prefs failed → polish off + no user terms, but workspace terms still apply.
     expect(transcription.open).toHaveBeenCalledWith(
       expect.objectContaining({ vocabulary: ["Threa", "Ariadne", "Acme"] })
+    )
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws_1" }),
+      "Voice user preferences lookup failed"
     )
   })
 

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test"
+import { afterEach, describe, expect, it, jest, mock } from "bun:test"
 import type { Server } from "socket.io"
 import { VOICE_DRAFT_CONTEXT_MAX_CHARS } from "@threa/types"
 import { registerVoiceGateway } from "./realtime-gateway"
@@ -73,7 +73,8 @@ function setup(overrides?: {
     steeringTerms?: string[]
     draftBefore?: string
     draftAfter?: string
-  }) => Promise<string>
+    signal?: AbortSignal
+  }) => Promise<unknown>
 }) {
   const upstream = fakeUpstream()
   const transcription = { open: mock(overrides?.open ?? (async () => upstream)) }
@@ -138,6 +139,8 @@ function setup(overrides?: {
 
 const START_PAYLOAD = { workspaceId: "ws_1", voiceSessionId: "voicesess_1" }
 
+afterEach(() => jest.useRealTimers())
+
 describe("registerVoiceGateway voice:start", () => {
   it("opens the upstream and relays deltas as voice:transcript:delta tagged with the session id", async () => {
     const { socket, upstream, transcription } = setup()
@@ -145,7 +148,7 @@ describe("registerVoiceGateway voice:start", () => {
 
     await socket.trigger("voice:start", START_PAYLOAD, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: true })
+    expect(cb).toHaveBeenCalledWith({ ok: true, protocolVersion: 2 })
     expect(transcription.open).toHaveBeenCalledWith({
       model: "elevenlabs:scribe-v2-realtime",
       language: undefined,
@@ -161,7 +164,7 @@ describe("registerVoiceGateway voice:start", () => {
 
     expect(socket.emitted).toContainEqual({
       event: "voice:transcript:delta",
-      payload: { voiceSessionId: "voicesess_1", text: "hi", isFinal: true },
+      payload: { voiceSessionId: "voicesess_1", revision: 1, text: "hi", isFinal: true },
     })
     expect(socket.emitted).toContainEqual({
       event: "voice:transcription:error",
@@ -266,7 +269,7 @@ describe("registerVoiceGateway voice:start", () => {
 
     await socket.trigger("voice:start", {}, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "workspaceId and voiceSessionId required" })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "workspaceId and voiceSessionId required", protocolVersion: 2 })
     expect(transcription.open).not.toHaveBeenCalled()
   })
 
@@ -281,7 +284,7 @@ describe("registerVoiceGateway voice:start", () => {
     const cb = mock(() => {})
     await socket.trigger("voice:start", START_PAYLOAD, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session already started" })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session already started", protocolVersion: 2 })
   })
 
   it("tears down the upstream when the socket disconnects mid-start", async () => {
@@ -306,7 +309,7 @@ describe("registerVoiceGateway voice:start", () => {
       sessionId: "voicesess_1",
       totalAudioMs: 0,
     })
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session ended before it started" })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session ended before it started", protocolVersion: 2 })
   })
 
   it("aborts the resolved session when opening the upstream fails", async () => {
@@ -325,7 +328,7 @@ describe("registerVoiceGateway voice:start", () => {
       sessionId: "voicesess_1",
       totalAudioMs: 0,
     })
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Failed to start voice session" })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Failed to start voice session", protocolVersion: 2 })
   })
 })
 
@@ -349,8 +352,35 @@ describe("registerVoiceGateway lifecycle", () => {
       sessionId: "voicesess_1",
       totalAudioMs: 0,
     })
-    expect(socket.emitted).toContainEqual({ event: "voice:stopped", payload: { reason: "stopped" } })
+    expect(socket.emitted).toContainEqual({
+      event: "voice:stopped",
+      payload: { reason: "stopped", revision: 0, outcome: "empty_input" },
+    })
     expect(stopCb).toHaveBeenCalledWith({ ok: true })
+  })
+
+  it("max duration follows the authoritative format path before disconnecting", async () => {
+    jest.useFakeTimers()
+    const { socket, upstream, voiceTranscriptionService } = setup({ voicePolishLevel: "opinionated" })
+    await socket.trigger(
+      "voice:start",
+      START_PAYLOAD,
+      mock(() => {})
+    )
+    upstream.fireDelta({ text: "final words", isFinal: false })
+
+    jest.advanceTimersByTime(10 * 60 * 1_000)
+    jest.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(upstream.flush).toHaveBeenCalledTimes(1)
+    expect(voiceTranscriptionService.finishSession).toHaveBeenCalledTimes(1)
+    expect(voiceTranscriptionService.abortSession).not.toHaveBeenCalled()
+    expect(socket.emitted).toContainEqual({
+      event: "voice:stopped",
+      payload: expect.objectContaining({ reason: "max_duration", outcome: "success" }),
+    })
+    expect(socket.disconnected).toBe(true)
   })
 
   it("disconnect aborts the session without flushing", async () => {
@@ -371,6 +401,109 @@ describe("registerVoiceGateway lifecycle", () => {
       totalAudioMs: 0,
     })
     expect(voiceTranscriptionService.finishSession).not.toHaveBeenCalled()
+  })
+
+  it("a send-as-is upgrade interrupts an in-flight format flush and finishes once", async () => {
+    let releaseFlush!: () => void
+    const flush = new Promise<void>((resolve) => {
+      releaseFlush = resolve
+    })
+    const { socket, upstream, voiceTranscriptionService } = setup()
+    upstream.flush = mock(() => flush)
+    await socket.trigger(
+      "voice:start",
+      START_PAYLOAD,
+      mock(() => {})
+    )
+
+    const formatting = socket.trigger(
+      "voice:stop",
+      { mode: "format" },
+      mock(() => {})
+    ) as Promise<void>
+    await Promise.resolve()
+    const sending = socket.trigger(
+      "voice:stop",
+      { mode: "send_as_is" },
+      mock(() => {})
+    ) as Promise<void>
+    await sending
+
+    expect(upstream.close).toHaveBeenCalledTimes(1)
+    expect(voiceTranscriptionService.finishSession).toHaveBeenCalledTimes(1)
+    expect(voiceTranscriptionService.abortSession).not.toHaveBeenCalled()
+    releaseFlush()
+    await formatting
+  })
+
+  it("abort wins while send-as-is is blocked closing", async () => {
+    let releaseClose!: (result: { totalAudioMs: number }) => void
+    const close = new Promise<{ totalAudioMs: number }>((resolve) => {
+      releaseClose = resolve
+    })
+    const { socket, upstream, voiceTranscriptionService } = setup()
+    upstream.close = mock(() => close)
+    await socket.trigger(
+      "voice:start",
+      START_PAYLOAD,
+      mock(() => {})
+    )
+
+    const sending = socket.trigger(
+      "voice:stop",
+      { mode: "send_as_is" },
+      mock(() => {})
+    ) as Promise<void>
+    await Promise.resolve()
+    const aborting = socket.trigger("disconnect") as Promise<void>
+    releaseClose({ totalAudioMs: 12 })
+    await Promise.all([sending, aborting])
+
+    expect(voiceTranscriptionService.abortSession).toHaveBeenCalledTimes(1)
+    expect(voiceTranscriptionService.finishSession).not.toHaveBeenCalled()
+    expect(socket.emitted.some((event) => event.event === "voice:stopped")).toBe(false)
+  })
+
+  it("send-as-is cancels authoritative formatting without waiting for a late provider", async () => {
+    let startedFinal!: () => void
+    let resolveFinal!: (value: string) => void
+    const finalStarted = new Promise<void>((resolve) => {
+      startedFinal = resolve
+    })
+    const final = new Promise<string>((resolve) => {
+      resolveFinal = resolve
+    })
+    const { socket, upstream, voiceTranscriptionService } = setup({
+      voicePolishLevel: "opinionated",
+      polishTranscript: async ({ signal }) => {
+        if (!signal?.aborted) startedFinal()
+        return final
+      },
+    })
+    await socket.trigger(
+      "voice:start",
+      START_PAYLOAD,
+      mock(() => {})
+    )
+    upstream.fireDelta({ text: "tail", isFinal: false })
+
+    const formatting = socket.trigger(
+      "voice:stop",
+      { mode: "format" },
+      mock(() => {})
+    ) as Promise<void>
+    await finalStarted
+    const sending = socket.trigger(
+      "voice:stop",
+      { mode: "send_as_is" },
+      mock(() => {})
+    ) as Promise<void>
+    await sending
+
+    expect(voiceTranscriptionService.finishSession).toHaveBeenCalledTimes(1)
+    expect(socket.emitted.some((event) => event.event === "voice:transcript:polished")).toBe(false)
+    resolveFinal("late")
+    await formatting
   })
 
   it("pushes decoded audio frames to the upstream", async () => {
@@ -434,7 +567,7 @@ describe("registerVoiceGateway polish", () => {
 
     expect(polishTranscript).not.toHaveBeenCalled()
     const interimDelta = socket.emitted.find((e) => e.event === "voice:transcript:delta")
-    expect(interimDelta?.payload).toEqual({ voiceSessionId: "voicesess_1", text: "hello", isFinal: false })
+    expect(interimDelta?.payload).toEqual({ voiceSessionId: "voicesess_1", revision: 0, text: "hello", isFinal: false })
   })
 
   it("leaves the raw delta in place when polish rejects, with no polished event", async () => {
@@ -476,7 +609,7 @@ describe("registerVoiceGateway polish", () => {
     expect(polishTranscript).not.toHaveBeenCalled()
     expect(socket.emitted).toContainEqual({
       event: "voice:transcript:delta",
-      payload: { voiceSessionId: "voicesess_1", text: "   ", isFinal: true },
+      payload: { voiceSessionId: "voicesess_1", revision: 0, text: "   ", isFinal: true },
     })
   })
 
@@ -523,7 +656,7 @@ describe("registerVoiceGateway polish", () => {
 
     // The error must not have shipped yet — polish hasn't resolved.
     await Promise.resolve()
-    expect(socket.emitted.find((e) => e.event === "voice:transcription:error")).toBeUndefined()
+    expect(socket.emitted.find((e) => e.event === "voice:transcription:error")).toBeDefined()
 
     // Resolve the polish. The drain awaits it, then emits the error.
     resolvePolish!()
@@ -532,8 +665,8 @@ describe("registerVoiceGateway polish", () => {
 
     const errorIdx = socket.emitted.findIndex((e) => e.event === "voice:transcription:error")
     const polishedIdx = socket.emitted.findIndex((e) => e.event === "voice:transcript:polished")
-    expect(polishedIdx).toBeGreaterThanOrEqual(0)
-    expect(errorIdx).toBeGreaterThan(polishedIdx)
+    expect(polishedIdx).toBe(-1)
+    expect(errorIdx).toBeGreaterThanOrEqual(0)
   })
 
   it("forwards the capped draft context from voice:start to every polish pass", async () => {
@@ -622,26 +755,10 @@ describe("registerVoiceGateway polish", () => {
     await new Promise((r) => setTimeout(r, 0))
     await new Promise((r) => setTimeout(r, 0))
 
-    expect(polishTranscript).toHaveBeenCalledTimes(1)
-    expect(polishTranscript).toHaveBeenCalledWith(
-      expect.objectContaining({ rawTranscript: "let me start at nine no sorry eight" })
-    )
-
-    const finalDeltas = socket.emitted.filter(
-      (e) => e.event === "voice:transcript:delta" && (e.payload as { isFinal: boolean }).isFinal
-    )
-    expect(finalDeltas).toHaveLength(1)
-    expect(finalDeltas[0].payload).toMatchObject({
-      voiceSessionId: "voicesess_1",
-      text: "let me start at nine no sorry eight",
-      isFinal: true,
-    })
-    expect((finalDeltas[0].payload as { chunkId?: string }).chunkId).toBeTruthy()
-
-    const polishedIdx = socket.emitted.findIndex((e) => e.event === "voice:transcript:polished")
-    const errorIdx = socket.emitted.findIndex((e) => e.event === "voice:transcription:error")
-    expect(polishedIdx).toBeGreaterThanOrEqual(0)
-    expect(errorIdx).toBeGreaterThan(polishedIdx)
+    expect(polishTranscript).not.toHaveBeenCalled()
+    expect(
+      socket.emitted.filter((e) => e.event === "voice:transcript:delta" && (e.payload as { isFinal: boolean }).isFinal)
+    ).toHaveLength(0)
   })
 
   it("a real final clears the pending interim so the error path doesn't re-emit it", async () => {
@@ -686,16 +803,8 @@ describe("registerVoiceGateway polish", () => {
     await new Promise((r) => setTimeout(r, 0))
 
     expect(polishTranscript).not.toHaveBeenCalled()
-    const finalDeltas = socket.emitted.filter(
-      (e) => e.event === "voice:transcript:delta" && (e.payload as { isFinal: boolean }).isFinal
-    )
-    expect(finalDeltas).toHaveLength(1)
-    expect(finalDeltas[0].payload).toEqual({
-      voiceSessionId: "voicesess_1",
-      text: "halfway through a thought",
-      isFinal: true,
-    })
-    // No chunkId, since polish is off and the client should commit as plain text.
-    expect((finalDeltas[0].payload as { chunkId?: string }).chunkId).toBeUndefined()
+    expect(
+      socket.emitted.filter((e) => e.event === "voice:transcript:delta" && (e.payload as { isFinal: boolean }).isFinal)
+    ).toHaveLength(0)
   })
 })

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.ts
@@ -250,6 +250,16 @@ export function registerVoiceGateway(io: Server, deps: Dependencies) {
             deps.userPreferencesService.getPreferences(workspaceId, row.userId),
             deps.workspaceSettingsService.getSettings(workspaceId),
           ])
+          if (prefs.status === "rejected")
+            logger.warn(
+              { err: prefs.reason, workspaceId, userId: row.userId, voiceSessionId },
+              "Voice user preferences lookup failed"
+            )
+          if (settings.status === "rejected")
+            logger.warn(
+              { err: settings.reason, workspaceId, userId: row.userId, voiceSessionId },
+              "Voice workspace settings lookup failed"
+            )
           const polishLevel = prefs.status === "fulfilled" ? prefs.value.voicePolishLevel : "none"
           const steeringTerms = resolveSteeringTerms(
             settings.status === "fulfilled" ? settings.value.voiceSteeringWords : undefined,

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.ts
@@ -2,27 +2,33 @@ import type { Server } from "socket.io"
 import { ulid } from "ulid"
 import { z } from "zod"
 import type { AuthService } from "@threa/backend-common"
-import { VOICE_DRAFT_CONTEXT_MAX_CHARS, type VoicePolishLevel } from "@threa/types"
+import {
+  VOICE_DRAFT_CONTEXT_MAX_CHARS,
+  VOICE_PROTOCOL_VERSION,
+  type VoicePolishLevel,
+  type VoiceRelayPhase,
+  type VoiceTerminationMode,
+} from "@threa/types"
 import { createSocketAuthMiddleware } from "../../lib/socket-auth"
 import { logger } from "../../lib/logger"
 import { HttpError } from "../../lib/errors"
 import { voiceConfig, resolveSteeringTerms } from "./config"
 import type { VoiceTranscriptionService } from "./service"
 import type { Transcription, TranscriptionSession } from "./transcription/strategy"
-import type { PolishTranscript } from "./polish"
+import type { PolishOutcome, PolishTranscript } from "./polish"
+import { PolishScheduler } from "./polish-scheduler"
 import type { UserPreferencesService } from "../user-preferences"
 import type { WorkspaceSettingsService } from "../workspace-settings"
 
 const startPayloadSchema = z.object({
   workspaceId: z.string().min(1),
   voiceSessionId: z.string().min(1),
-  // Draft around the caret, read-only polish context. The gateway re-caps to
-  // VOICE_DRAFT_CONTEXT_MAX_CHARS below (truncate, don't reject — an oversized
-  // draft must never block dictation from starting).
   draftBefore: z.string().optional(),
   draftAfter: z.string().optional(),
 })
+const stopPayloadSchema = z.object({ mode: z.enum(["format", "send_as_is", "abort"]) })
 
+type StopReason = "stopped" | "max_duration"
 interface Dependencies {
   authService: AuthService
   voiceTranscriptionService: VoiceTranscriptionService
@@ -31,64 +37,28 @@ interface Dependencies {
   workspaceSettingsService: WorkspaceSettingsService
   polishTranscript: PolishTranscript
 }
-
-/**
- * Per-connection relay state. One dictation session is bound to one voice
- * socket: the client opens it with `voice:start`, streams PCM16 frames over
- * `voice:audio`, and ends it with `voice:stop` (or just disconnects, which
- * aborts). The upstream provider socket is opened lazily on `voice:start`.
- */
 interface RelayState {
   workspaceId: string
   userId: string
   voiceSessionId: string
   upstream: TranscriptionSession
   maxDurationTimer: ReturnType<typeof setTimeout>
-  finalized: boolean
-  /**
-   * Resolved once at start. "minor" / "opinionated" trigger a cumulative
-   * re-polish of the whole transcript on every final, letting a later chunk
-   * rewrite an earlier self-correction ("nine, no sorry eight" -> "eight").
-   * "none" ships finals as plain deltas with no chunkId and no tracking.
-   */
+  phase: VoiceRelayPhase
+  terminationMode: VoiceTerminationMode | null
+  terminationPromise: Promise<void> | null
+  interruptFlush: (() => void) | null
+  closePromise: Promise<number> | null
   polishLevel: VoicePolishLevel
-  /**
-   * Resolved once at start (baked-in product terms ∪ the user's steering words).
-   * Reused for every polish pass as the spelling reference; the STT-layer
-   * biasing already consumed it when the upstream session opened.
-   */
   steeringTerms: string[]
-  /**
-   * Stable chunkId for the whole session: every final and polished event
-   * carries it, so the editor extends/replaces a single tracked range.
-   */
   sessionChunkId: string
-  /** Cumulative raw final segments, joined and re-polished on every final. */
   rawFinals: string[]
-  /**
-   * Latest uncommitted interim hypothesis. Promoted to a synthetic final if
-   * the upstream errors before the partial commits — otherwise the client's
-   * flushInterim fallback would ship it as raw, unpolished text (the spurious
-   * ElevenLabs "insufficient funds" close often fires before any final lands).
-   */
   lastInterim: string
-  /**
-   * Draft around the insertion point, forwarded to every polish pass as
-   * read-only context. Already capped to VOICE_DRAFT_CONTEXT_MAX_CHARS.
-   */
-  draftBefore: string | undefined
-  draftAfter: string | undefined
-  /**
-   * Serializes polish work: out-of-order resolves would let an older polished
-   * snapshot land after a newer one and undo incremental corrections.
-   */
-  polishQueue: Promise<void>
+  draftBefore?: string
+  draftAfter?: string
+  revision: number
+  scheduler: PolishScheduler
+  finalOutcome: PolishOutcome["status"]
 }
-
-// Cap on how long an upstream error waits on in-flight polish: long enough for
-// a sub-second polish to land the swap, short enough that a stuck provider
-// can't delay the user-facing error past a heartbeat.
-const POLISH_DRAIN_ON_ERROR_MS = 2000
 
 function toBuffer(frame: unknown): Buffer | null {
   if (Buffer.isBuffer(frame)) return frame
@@ -96,352 +66,288 @@ function toBuffer(frame: unknown): Buffer | null {
   if (ArrayBuffer.isView(frame)) return Buffer.from(frame.buffer, frame.byteOffset, frame.byteLength)
   return null
 }
+const modeRank: Record<VoiceTerminationMode, number> = { format: 0, send_as_is: 1, abort: 2 }
 
-/**
- * The dedicated voice relay. It lives on its own Socket.io namespace (`/voice`)
- * so high-rate audio frames never share the main namespace's room fan-out. The
- * browser never holds the provider key: frames go up, transcript deltas come
- * down, and the upstream provider WebSocket is owned entirely here.
- *
- * INV-4 carve-out: realtime transcript deltas are delivered directly over this
- * socket rather than through the outbox — they are ephemeral and per-connection,
- * with no durable read model to reconstruct.
- */
 export function registerVoiceGateway(io: Server, deps: Dependencies) {
-  const {
-    authService,
-    voiceTranscriptionService,
-    transcription,
-    userPreferencesService,
-    workspaceSettingsService,
-    polishTranscript,
-  } = deps
   const namespace = io.of("/voice")
-
-  // Same session-cookie auth as the main namespace (INV-35: reuse, don't fork).
-  namespace.use(createSocketAuthMiddleware(authService))
-
+  namespace.use(createSocketAuthMiddleware(deps.authService))
   namespace.on("connection", (socket) => {
     const workosUserId = socket.data.workosUserId as string
     let state: RelayState | null = null
-    // `voice:start` yields at several awaits; without these guards a second
-    // start (or a disconnect mid-start) would orphan the upstream socket+timer.
     let starting = false
     let disconnected = false
 
-    async function finalize(reason: "stopped" | "aborted" | "max_duration"): Promise<void> {
-      if (!state || state.finalized) return
-      state.finalized = true
-      clearTimeout(state.maxDurationTimer)
-      const current = state
+    const runPolish = async (
+      current: RelayState,
+      revision: number,
+      rawTranscript: string,
+      signal: AbortSignal
+    ): Promise<PolishOutcome> => {
+      const outcome = await deps.polishTranscript({
+        rawTranscript,
+        level: current.polishLevel,
+        workspaceId: current.workspaceId,
+        userId: current.userId,
+        sessionId: current.voiceSessionId,
+        draftBefore: current.draftBefore,
+        draftAfter: current.draftAfter,
+        steeringTerms: current.steeringTerms,
+        signal,
+      })
+      return typeof outcome === "string" ? { status: "success", markdown: outcome } : outcome
+    }
 
-      let totalAudioMs = 0
-      try {
-        if (reason !== "aborted") await current.upstream.flush()
-      } catch (err) {
-        logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice flush failed")
-      }
-      try {
-        const result = await current.upstream.close()
-        totalAudioMs = result.totalAudioMs
-      } catch (err) {
-        logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice upstream close failed")
-      }
+    function emitPolish(
+      current: RelayState,
+      revision: number,
+      raw: string,
+      outcome: PolishOutcome,
+      authoritative: boolean
+    ) {
+      if (state !== current || current.phase === "closing" || current.phase === "closed") return
+      if (revision !== current.revision || outcome.status !== "success") return
+      socket.emit("voice:transcript:polished", {
+        voiceSessionId: current.voiceSessionId,
+        chunkId: current.sessionChunkId,
+        revision,
+        authoritative,
+        raw,
+        polished: outcome.markdown,
+      })
+    }
 
-      // Drain in-flight polish before responding to voice:stop so a late
-      // `voice:transcript:polished` doesn't race the socket close. On abort
-      // the client is already gone, so skip the wait.
-      if (reason !== "aborted") {
-        try {
-          await current.polishQueue
-        } catch {
-          /* unreachable */
-        }
-      }
-
-      try {
-        if (reason === "aborted") {
-          await voiceTranscriptionService.abortSession({
-            workspaceId: current.workspaceId,
-            userId: current.userId,
-            sessionId: current.voiceSessionId,
-            totalAudioMs,
-          })
-        } else {
-          await voiceTranscriptionService.finishSession({
-            workspaceId: current.workspaceId,
-            userId: current.userId,
-            sessionId: current.voiceSessionId,
-            totalAudioMs,
-          })
-        }
-      } catch (err) {
-        logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice session finalize failed")
+    function commitFinal(current: RelayState, text: string, schedule = true) {
+      const raw = text.trim()
+      if (!raw || (current.phase !== "live" && current.phase !== "formatting")) return
+      current.lastInterim = ""
+      current.rawFinals.push(raw)
+      const revision = ++current.revision
+      socket.emit("voice:transcript:delta", {
+        voiceSessionId: current.voiceSessionId,
+        revision,
+        text: raw,
+        isFinal: true,
+        ...(current.polishLevel === "none" ? {} : { chunkId: current.sessionChunkId }),
+      })
+      if (schedule && current.phase === "live" && current.polishLevel !== "none") {
+        const cumulative = current.rawFinals.join(" ")
+        current.scheduler.scheduleLive({ revision, run: (signal) => runPolish(current, revision, cumulative, signal) })
       }
     }
 
-    socket.on("voice:start", async (payload: unknown, callback?: (result: { ok: boolean; error?: string }) => void) => {
-      if (state || starting) {
-        callback?.({ ok: false, error: "Session already started" })
-        return
+    function closeUpstream(current: RelayState): Promise<number> {
+      if (!current.closePromise) {
+        current.closePromise = current.upstream
+          .close()
+          .then((result) => result.totalAudioMs)
+          .catch((err) => {
+            logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice upstream close failed")
+            return 0
+          })
       }
-      const parsed = startPayloadSchema.safeParse(payload)
-      if (!parsed.success) {
-        callback?.({ ok: false, error: "workspaceId and voiceSessionId required" })
-        return
-      }
-      const { workspaceId, voiceSessionId } = parsed.data
-      // Proximity to the insertion point matters most for polish context, so
-      // keep the END of the before-text and the START of the after-text.
-      const draftBefore = parsed.data.draftBefore?.slice(-VOICE_DRAFT_CONTEXT_MAX_CHARS) || undefined
-      const draftAfter = parsed.data.draftAfter?.slice(0, VOICE_DRAFT_CONTEXT_MAX_CHARS) || undefined
-      starting = true
+      return current.closePromise
+    }
 
-      // Captured once getRelaySession resolves so a later failure (e.g.
-      // upstream open) can abort the DB session instead of leaving it active
-      // until the max-duration sweeper.
-      let resolvedUserId: string | undefined
-
+    async function closeAndRecord(current: RelayState) {
+      const totalAudioMs = await closeUpstream(current)
+      const abort = current.terminationMode === "abort"
       try {
-        const row = await voiceTranscriptionService.getRelaySession({
-          workspaceId,
-          workosUserId,
-          sessionId: voiceSessionId,
-        })
-        resolvedUserId = row.userId
-
-        // Resolve once per session so a mid-session pref change can't shift
-        // behavior for an in-flight take and break the editor's chunk tracker.
-        let polishLevel: VoicePolishLevel = "none"
-        let userTerms: string[] | undefined
-        let workspaceTerms: string[] | undefined
-        // Resolve the two sources independently so one service's failure degrades
-        // only its own output: a workspace-settings outage must not disable a
-        // user's polish or drop their personal steering words, and vice versa.
-        // The baked-in product terms always survive (resolveSteeringTerms prepends
-        // them even when both lists are empty/missing).
-        const [prefsResult, settingsResult] = await Promise.allSettled([
-          userPreferencesService.getPreferences(workspaceId, row.userId),
-          workspaceSettingsService.getSettings(workspaceId),
-        ])
-        if (prefsResult.status === "fulfilled") {
-          polishLevel = prefsResult.value.voicePolishLevel
-          userTerms = prefsResult.value.voiceSteeringWords
-        } else {
-          logger.warn(
-            { err: prefsResult.reason, voiceSessionId, workspaceId },
-            "Voice user-prefs lookup failed; defaulting polish off"
-          )
+        const input = {
+          workspaceId: current.workspaceId,
+          userId: current.userId,
+          sessionId: current.voiceSessionId,
+          totalAudioMs,
         }
-        if (settingsResult.status === "fulfilled") {
-          workspaceTerms = settingsResult.value.voiceSteeringWords
-        } else {
-          logger.warn(
-            { err: settingsResult.reason, voiceSessionId, workspaceId },
-            "Voice workspace-settings lookup failed; skipping shared steering words"
-          )
-        }
-        // base ∪ workspace-shared ∪ per-user (deduped, base/workspace win the spelling).
-        const steeringTerms = resolveSteeringTerms(workspaceTerms, userTerms)
-
-        const upstream = await transcription.open({
-          model: row.model,
-          language: row.language ?? undefined,
-          vocabulary: steeringTerms,
-        })
-
-        // The socket disconnected while we were opening upstream — there is no
-        // longer anyone to relay to, so tear down what we just built.
-        if (disconnected) {
-          try {
-            await upstream.close()
-          } catch (err) {
-            logger.warn({ err, voiceSessionId }, "Voice upstream close after abandoned start failed")
-          }
-          await voiceTranscriptionService
-            .abortSession({ workspaceId, userId: row.userId, sessionId: voiceSessionId, totalAudioMs: 0 })
-            .catch(() => {})
-          callback?.({ ok: false, error: "Session ended before it started" })
-          return
-        }
-
-        const sessionChunkId = ulid()
-
-        // Commit a raw final: buffer it, emit a tagged final delta, and enqueue
-        // a cumulative polish pass. Shared by the normal final path and the
-        // interim-promotion-on-error path so the queue semantics are identical.
-        const commitPolishedFinal = (polishingState: RelayState, raw: string) => {
-          polishingState.rawFinals.push(raw)
-          socket.emit("voice:transcript:delta", {
-            voiceSessionId,
-            text: raw,
-            isFinal: true,
-            chunkId: polishingState.sessionChunkId,
-          })
-          // Each pass re-polishes the FULL transcript so a later chunk can
-          // rewrite an earlier one. The queue keeps emissions in order so a
-          // slow polish N can't clobber a faster polish N+1 already in the editor.
-          polishingState.polishQueue = polishingState.polishQueue.then(async () => {
-            if (state !== polishingState || polishingState.finalized) return
-            const rawTranscript = polishingState.rawFinals.join(" ")
-            try {
-              const polished = await polishTranscript({
-                rawTranscript,
-                level: polishingState.polishLevel,
-                workspaceId: polishingState.workspaceId,
-                userId: polishingState.userId,
-                sessionId: polishingState.voiceSessionId,
-                draftBefore: polishingState.draftBefore,
-                draftAfter: polishingState.draftAfter,
-                steeringTerms: polishingState.steeringTerms,
-              })
-              if (state !== polishingState || polishingState.finalized) return
-              socket.emit("voice:transcript:polished", {
-                voiceSessionId,
-                chunkId: polishingState.sessionChunkId,
-                raw: rawTranscript,
-                polished,
-              })
-            } catch (err) {
-              // Raw text is already in the editor, so skip the polish swap.
-              logger.warn(
-                { err, voiceSessionId, chunkId: polishingState.sessionChunkId },
-                "Voice transcript polish failed; leaving raw text in editor"
-              )
-            }
-          })
-        }
-
-        // Finals are tagged with a session-wide chunkId only when polish is on,
-        // signalling the client to track them as a swappable chunk; with polish
-        // off, no chunkId is sent and the client commits them as plain text.
-        upstream.onDelta((delta) => {
-          if (!state) return
-          if (!delta.isFinal) {
-            // Track the latest interim so the error handler can promote it to
-            // a synthetic final if the upstream dies before the segment commits.
-            state.lastInterim = delta.text ?? ""
-            socket.emit("voice:transcript:delta", { voiceSessionId, ...delta })
-            return
-          }
-          state.lastInterim = ""
-          const raw = delta.text ?? ""
-          if (state.polishLevel === "none" || !raw.trim()) {
-            // Polish off, or an empty terminating final (some providers emit
-            // these) — pass straight through with no chunk tracking.
-            socket.emit("voice:transcript:delta", { voiceSessionId, ...delta })
-            return
-          }
-          commitPolishedFinal(state, raw)
-        })
-        upstream.onError((e) => {
-          // Drain in-flight polish so the polished swap lands BEFORE the client
-          // tears down on this error (ElevenLabs sometimes closes ~10s in even
-          // on healthy sessions). Socket.io preserves order, so emitting the
-          // error after awaiting the polish promise guarantees the client
-          // applies the polish first. Bounded so a hung polish can't stall it.
-          const current = state
-          if (!current || current.finalized) {
-            socket.emit("voice:transcription:error", { voiceSessionId, ...e })
-            return
-          }
-          // Promote the pending interim to a synthetic final so the user
-          // doesn't lose what they just said. ElevenLabs' spurious close fires
-          // before the in-flight segment commits, so without this the speech
-          // since the last committed_transcript exists only as interim text,
-          // which the client's flushInterim() would commit as RAW (unpolished).
-          // Route it through the real-final path so the client tracks it as a
-          // chunk and clears its interim ref (making flushInterim a no-op), and
-          // the drain below waits for the polish. Best-effort: an unfinalized
-          // hypothesis may drift in punctuation, but an approximation beats loss.
-          const pendingInterim = current.lastInterim.trim()
-          if (pendingInterim) {
-            current.lastInterim = ""
-            if (current.polishLevel === "none") {
-              socket.emit("voice:transcript:delta", {
-                voiceSessionId,
-                text: pendingInterim,
-                isFinal: true,
-              })
-            } else {
-              commitPolishedFinal(current, pendingInterim)
-            }
-          }
-          const drain = Promise.race([
-            current.polishQueue,
-            new Promise<void>((resolve) => setTimeout(resolve, POLISH_DRAIN_ON_ERROR_MS)),
-          ])
-          drain
-            .catch(() => {
-              /* polishQueue swallows its own errors */
-            })
-            .then(() => {
-              // A concurrent voice:stop / disconnect may have finalized the
-              // session while we were draining. Skip the error emit so the
-              // client doesn't see a spurious error flash after a clean stop.
-              if (current.finalized) return
-              socket.emit("voice:transcription:error", { voiceSessionId, ...e })
-            })
-        })
-
-        const maxDurationTimer = setTimeout(() => {
-          socket.emit("voice:stopped", { reason: "max_duration" })
-          void finalize("max_duration").finally(() => socket.disconnect(true))
-        }, voiceConfig.maxSessionMs)
-
-        state = {
-          workspaceId,
-          userId: row.userId,
-          voiceSessionId,
-          upstream,
-          maxDurationTimer,
-          finalized: false,
-          polishLevel,
-          steeringTerms,
-          sessionChunkId,
-          rawFinals: [],
-          lastInterim: "",
-          draftBefore,
-          draftAfter,
-          polishQueue: Promise.resolve(),
-        }
-        logger.debug({ voiceSessionId, workspaceId }, "Voice relay started")
-        callback?.({ ok: true })
+        if (abort) await deps.voiceTranscriptionService.abortSession(input)
+        else await deps.voiceTranscriptionService.finishSession(input)
       } catch (err) {
-        // The session row was already resolved/created, so a failure here
-        // leaves it active. Abort it (best-effort) so it doesn't linger.
-        if (resolvedUserId) {
-          await voiceTranscriptionService
-            .abortSession({ workspaceId, userId: resolvedUserId, sessionId: voiceSessionId, totalAudioMs: 0 })
-            .catch(() => {})
-        }
-        if (err instanceof HttpError) {
-          callback?.({ ok: false, error: err.message })
-          return
-        }
-        logger.error({ err, voiceSessionId, workspaceId }, "Failed to start voice relay")
-        callback?.({ ok: false, error: "Failed to start voice session" })
-      } finally {
-        starting = false
+        logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice session finalize failed")
       }
-    })
+      current.phase = "closed"
+    }
+
+    function terminate(requestedMode: VoiceTerminationMode, reason: StopReason): Promise<void> {
+      const current = state
+      if (!current) return Promise.resolve()
+      if (!current.terminationMode || modeRank[requestedMode] > modeRank[current.terminationMode]) {
+        current.terminationMode = requestedMode
+        if (requestedMode !== "format") {
+          current.phase = "closing"
+          current.scheduler.cancel()
+          current.lastInterim = ""
+          current.interruptFlush?.()
+          void closeUpstream(current)
+        }
+      }
+      if (current.terminationPromise) return current.terminationPromise
+      current.terminationPromise = (async () => {
+        clearTimeout(current.maxDurationTimer)
+        if (current.terminationMode === "format") {
+          current.phase = "formatting"
+          current.scheduler.cancel()
+          let interruptFlush!: () => void
+          const interrupted = new Promise<void>((resolve) => {
+            interruptFlush = resolve
+          })
+          current.interruptFlush = interruptFlush
+          try {
+            await Promise.race([current.upstream.flush(), interrupted])
+          } catch (err) {
+            logger.warn({ err, voiceSessionId: current.voiceSessionId }, "Voice flush failed")
+          } finally {
+            current.interruptFlush = null
+          }
+          if (current.terminationMode === "format") {
+            if (current.lastInterim.trim()) commitFinal(current, current.lastInterim, false)
+            const raw = current.rawFinals.join(" ")
+            if (current.polishLevel !== "none") {
+              const revision = current.revision
+              const outcome = await current.scheduler.formatFinal({
+                revision,
+                run: (signal) => runPolish(current, revision, raw, signal),
+              })
+              current.finalOutcome = outcome.status
+              if (current.terminationMode === "format") emitPolish(current, revision, raw, outcome, true)
+            } else current.finalOutcome = raw ? "success" : "empty_input"
+          }
+        }
+        current.phase = "closing"
+        current.scheduler.cancel()
+        await closeAndRecord(current)
+        const mode = current.terminationMode ?? requestedMode
+        if (mode !== "abort")
+          socket.emit("voice:stopped", { reason, revision: current.revision, outcome: current.finalOutcome })
+      })()
+      return current.terminationPromise
+    }
+
+    socket.on(
+      "voice:start",
+      async (
+        payload: unknown,
+        callback?: (result: { ok: boolean; error?: string; protocolVersion: number }) => void
+      ) => {
+        if (state || starting)
+          return callback?.({ ok: false, error: "Session already started", protocolVersion: VOICE_PROTOCOL_VERSION })
+        const parsed = startPayloadSchema.safeParse(payload)
+        if (!parsed.success)
+          return callback?.({
+            ok: false,
+            error: "workspaceId and voiceSessionId required",
+            protocolVersion: VOICE_PROTOCOL_VERSION,
+          })
+        const { workspaceId, voiceSessionId } = parsed.data
+        starting = true
+        let resolvedUserId: string | undefined
+        try {
+          const row = await deps.voiceTranscriptionService.getRelaySession({
+            workspaceId,
+            workosUserId,
+            sessionId: voiceSessionId,
+          })
+          resolvedUserId = row.userId
+          const [prefs, settings] = await Promise.allSettled([
+            deps.userPreferencesService.getPreferences(workspaceId, row.userId),
+            deps.workspaceSettingsService.getSettings(workspaceId),
+          ])
+          const polishLevel = prefs.status === "fulfilled" ? prefs.value.voicePolishLevel : "none"
+          const steeringTerms = resolveSteeringTerms(
+            settings.status === "fulfilled" ? settings.value.voiceSteeringWords : undefined,
+            prefs.status === "fulfilled" ? prefs.value.voiceSteeringWords : undefined
+          )
+          const upstream = await deps.transcription.open({
+            model: row.model,
+            language: row.language ?? undefined,
+            vocabulary: steeringTerms,
+          })
+          if (disconnected) {
+            await upstream.close().catch(() => ({ totalAudioMs: 0 }))
+            await deps.voiceTranscriptionService
+              .abortSession({ workspaceId, userId: row.userId, sessionId: voiceSessionId, totalAudioMs: 0 })
+              .catch(() => {})
+            return callback?.({
+              ok: false,
+              error: "Session ended before it started",
+              protocolVersion: VOICE_PROTOCOL_VERSION,
+            })
+          }
+          const current = {} as RelayState
+          const scheduler = new PolishScheduler((snapshot, outcome) => {
+            emitPolish(current, snapshot.revision, current.rawFinals.join(" "), outcome, false)
+          })
+          Object.assign(current, {
+            workspaceId,
+            userId: row.userId,
+            voiceSessionId,
+            upstream,
+            phase: "live",
+            terminationMode: null,
+            terminationPromise: null,
+            interruptFlush: null,
+            closePromise: null,
+            polishLevel,
+            steeringTerms,
+            sessionChunkId: ulid(),
+            rawFinals: [],
+            lastInterim: "",
+            draftBefore: parsed.data.draftBefore?.slice(-VOICE_DRAFT_CONTEXT_MAX_CHARS) || undefined,
+            draftAfter: parsed.data.draftAfter?.slice(0, VOICE_DRAFT_CONTEXT_MAX_CHARS) || undefined,
+            revision: 0,
+            scheduler,
+            finalOutcome: "empty_input",
+            maxDurationTimer: setTimeout(
+              () => void terminate("format", "max_duration").finally(() => socket.disconnect(true)),
+              voiceConfig.maxSessionMs
+            ),
+          } satisfies Partial<RelayState>)
+          state = current
+          upstream.onDelta((delta) => {
+            if (state !== current || (current.phase !== "live" && current.phase !== "formatting")) return
+            if (!delta.isFinal) {
+              current.lastInterim = delta.text ?? ""
+              socket.emit("voice:transcript:delta", { voiceSessionId, revision: current.revision, ...delta })
+            } else if (delta.text?.trim()) commitFinal(current, delta.text, current.phase === "live")
+            else socket.emit("voice:transcript:delta", { voiceSessionId, revision: current.revision, ...delta })
+          })
+          upstream.onError((error) => {
+            if (state !== current || current.phase !== "live") return
+            socket.emit("voice:transcription:error", { voiceSessionId, ...error })
+            void terminate("abort", "stopped")
+          })
+          callback?.({ ok: true, protocolVersion: VOICE_PROTOCOL_VERSION })
+        } catch (err) {
+          if (resolvedUserId)
+            await deps.voiceTranscriptionService
+              .abortSession({ workspaceId, userId: resolvedUserId, sessionId: voiceSessionId, totalAudioMs: 0 })
+              .catch(() => {})
+          const error = err instanceof HttpError ? err.message : "Failed to start voice session"
+          callback?.({ ok: false, error, protocolVersion: VOICE_PROTOCOL_VERSION })
+        } finally {
+          starting = false
+        }
+      }
+    )
 
     socket.on("voice:audio", (frame: unknown) => {
-      if (!state || state.finalized) return
-      const buf = toBuffer(frame)
-      if (!buf) return
-      state.upstream.pushAudio(buf)
+      if (!state || state.phase !== "live") return
+      const buffer = toBuffer(frame)
+      if (buffer) state.upstream.pushAudio(buffer)
     })
-
-    socket.on("voice:stop", async (callback?: (result: { ok: boolean }) => void) => {
-      await finalize("stopped")
-      socket.emit("voice:stopped", { reason: "stopped" })
+    socket.on("voice:stop", async (payloadOrCallback?: unknown, maybeCallback?: (result: { ok: boolean }) => void) => {
+      const legacy = typeof payloadOrCallback === "function" || payloadOrCallback === undefined
+      const callback = (typeof payloadOrCallback === "function" ? payloadOrCallback : maybeCallback) as
+        | ((result: { ok: boolean }) => void)
+        | undefined
+      const parsed = legacy
+        ? { success: true as const, data: { mode: "format" as const } }
+        : stopPayloadSchema.safeParse(payloadOrCallback)
+      if (!parsed.success) return callback?.({ ok: false })
+      await terminate(parsed.data.mode, "stopped")
       callback?.({ ok: true })
     })
-
     socket.on("disconnect", () => {
       disconnected = true
-      void finalize("aborted")
+      return terminate("abort", "stopped")
     })
   })
 }

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
@@ -165,6 +165,13 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
     expect(elapsed).toBeGreaterThanOrEqual(1400)
   }, 5000)
 
+  test("close releases a pending flush without waiting for its timeout", async () => {
+    const { session } = await openSession()
+    const flushed = session.flush()
+    await session.close()
+    await flushed
+  })
+
   test("a server-initiated close after a successful flush does NOT surface an error", async () => {
     const { session, socket } = await openSession()
     const errors: TranscriptionError[] = []

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.test.ts
@@ -131,7 +131,7 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
     expect(result.totalAudioMs).toBe(1000)
   })
 
-  test("flush sends CloseStream and resolves when the final Results frame arrives", async () => {
+  test("flush ignores a prior final and resolves at the post-CloseStream Metadata boundary", async () => {
     const { session, socket } = await openSession()
     const deltas: TranscriptionDelta[] = []
     session.onDelta((d) => deltas.push(d))
@@ -141,6 +141,19 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
     const msg = JSON.parse(socket.sent.at(-1) as string)
     expect(msg).toEqual({ type: "CloseStream" })
 
+    let resolved = false
+    void flushed.then(() => {
+      resolved = true
+    })
+    socket.dispatch("message", {
+      data: JSON.stringify({
+        type: "Results",
+        is_final: true,
+        channel: { alternatives: [{ transcript: "prior final" }] },
+      }),
+    })
+    await Promise.resolve()
+    expect(resolved).toBe(false)
     socket.dispatch("message", {
       data: JSON.stringify({
         type: "Results",
@@ -148,9 +161,13 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
         channel: { alternatives: [{ transcript: "last word" }] },
       }),
     })
+    socket.dispatch("message", { data: JSON.stringify({ type: "Metadata" }) })
 
     await flushed
-    expect(deltas).toEqual([{ text: "last word", isFinal: true }])
+    expect(deltas).toEqual([
+      { text: "prior final", isFinal: true },
+      { text: "last word", isFinal: true },
+    ])
   })
 
   test("flush resolves on its safety timeout when no final frame ever lands", async () => {
@@ -185,6 +202,7 @@ describe("RealtimeDeepgramStrategy audio + transcripts", () => {
         channel: { alternatives: [{ transcript: "ok" }] },
       }),
     })
+    socket.dispatch("message", { data: JSON.stringify({ type: "Metadata" }) })
     await flushed
     // Deepgram closes the socket itself right after the final frame. That
     // socket teardown must not look like an unsolicited upstream drop.

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
@@ -252,6 +252,7 @@ class DeepgramSession implements TranscriptionSession {
 
   async close(): Promise<TranscriptionResult> {
     this.closed = true
+    this.resolvePendingFlush()
     if (this.ws && this.ws.readyState <= WebSocket.OPEN) {
       this.ws.close()
     }

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-deepgram.ts
@@ -177,12 +177,13 @@ class DeepgramSession implements TranscriptionSession {
       case "Results": {
         const text = data.channel?.alternatives?.[0]?.transcript ?? ""
         const isFinal = data.is_final === true
-        if (isFinal) this.resolvePendingFlush()
         if (!text) return
         this.emitDelta({ text, isFinal })
         return
       }
       case "Metadata":
+        this.resolvePendingFlush()
+        return
       case "SpeechStarted":
       case "UtteranceEnd":
         return
@@ -204,12 +205,9 @@ class DeepgramSession implements TranscriptionSession {
 
   async flush(): Promise<void> {
     if (this.closed || !this.ws || this.ws.readyState !== WebSocket.OPEN) return
-    // Deepgram's CloseStream is request-response: it asks the server to commit
-    // any buffered audio and reply with one last `is_final=true` Results frame.
-    // The gateway immediately calls close() after flush(), so if we returned
-    // here right away the socket teardown would race the final frame and the
-    // user's last utterance would silently disappear. Wait for the final
-    // Results (resolved from handleMessage) or the safety timeout.
+    // CloseStream completes with Metadata after any terminal Results frames.
+    // Waiting for that protocol boundary prevents an endpointing final already
+    // in flight from releasing the barrier before the buffered tail arrives.
     this.ws.send(JSON.stringify({ type: "CloseStream" }))
     await new Promise<void>((resolve) => {
       const timer = setTimeout(() => {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.test.ts
@@ -145,7 +145,7 @@ describe("RealtimeElevenLabsStrategy audio + transcripts", () => {
     expect(result.totalAudioMs).toBe(1000)
   })
 
-  test("flush waits until the committed transcript is delivered", async () => {
+  test("flush waits for post-commit quiet so an in-flight final cannot hide the terminal transcript", async () => {
     const { session, socket } = await openSession()
     const deltas: TranscriptionDelta[] = []
     session.onDelta((delta) => deltas.push(delta))
@@ -153,9 +153,19 @@ describe("RealtimeElevenLabsStrategy audio + transcripts", () => {
     const msg = JSON.parse(socket.sent.at(-1)!)
     expect(msg).toMatchObject({ message_type: "input_audio_chunk", commit: true, audio_base_64: "" })
 
+    let resolved = false
+    void flushed.then(() => {
+      resolved = true
+    })
+    socket.dispatch("message", { data: JSON.stringify({ message_type: "committed_transcript", text: "prior" }) })
+    await Promise.resolve()
+    expect(resolved).toBe(false)
     socket.dispatch("message", { data: JSON.stringify({ message_type: "committed_transcript", text: "tail" }) })
     await flushed
-    expect(deltas).toEqual([{ text: "tail", isFinal: true }])
+    expect(deltas).toEqual([
+      { text: "prior", isFinal: true },
+      { text: "tail", isFinal: true },
+    ])
   })
 
   test("close releases a pending flush", async () => {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.test.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.test.ts
@@ -145,11 +145,24 @@ describe("RealtimeElevenLabsStrategy audio + transcripts", () => {
     expect(result.totalAudioMs).toBe(1000)
   })
 
-  test("flush sends a commit with empty audio", async () => {
+  test("flush waits until the committed transcript is delivered", async () => {
     const { session, socket } = await openSession()
-    await session.flush()
+    const deltas: TranscriptionDelta[] = []
+    session.onDelta((delta) => deltas.push(delta))
+    const flushed = session.flush()
     const msg = JSON.parse(socket.sent.at(-1)!)
     expect(msg).toMatchObject({ message_type: "input_audio_chunk", commit: true, audio_base_64: "" })
+
+    socket.dispatch("message", { data: JSON.stringify({ message_type: "committed_transcript", text: "tail" }) })
+    await flushed
+    expect(deltas).toEqual([{ text: "tail", isFinal: true }])
+  })
+
+  test("close releases a pending flush", async () => {
+    const { session } = await openSession()
+    const flushed = session.flush()
+    await session.close()
+    await flushed
   })
 
   test("partial_transcript emits an interim delta, committed_transcript a final one", async () => {

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.ts
@@ -26,6 +26,7 @@ const MAX_KEYTERMS = 50
 const MAX_KEYTERM_LENGTH = 20
 /** PCM16 mono: 2 bytes/sample, so ms = bytes / (2 * 16000 / 1000) = bytes / 32. */
 const BYTES_PER_MS = (SAMPLE_RATE_HZ * 2) / 1000
+const FLUSH_FINAL_WAIT_MS = 1500
 
 /**
  * Map our registry model id (`elevenlabs:scribe-v2-realtime`) to the ElevenLabs
@@ -69,6 +70,7 @@ class ElevenLabsSession implements TranscriptionSession {
   private chunksSent = 0
   private openedAt = 0
   private closed = false
+  private pendingFlush: (() => void) | null = null
 
   constructor(
     private readonly apiKey: string,
@@ -171,6 +173,7 @@ class ElevenLabsSession implements TranscriptionSession {
       case "committed_transcript":
       case "committed_transcript_with_timestamps":
         if (data.text) this.emitDelta({ text: data.text, isFinal: true })
+        this.resolvePendingFlush()
         return
       case "input_error":
         this.emitError({ code: "INPUT_ERROR", message: data.error ?? data.message ?? "Upstream input error" })
@@ -204,6 +207,21 @@ class ElevenLabsSession implements TranscriptionSession {
         sample_rate: SAMPLE_RATE_HZ,
       })
     )
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingFlush = null
+        resolve()
+      }, FLUSH_FINAL_WAIT_MS)
+      this.pendingFlush = () => {
+        clearTimeout(timer)
+        this.pendingFlush = null
+        resolve()
+      }
+    })
+  }
+
+  private resolvePendingFlush(): void {
+    this.pendingFlush?.()
   }
 
   onDelta(cb: (delta: TranscriptionDelta) => void): void {
@@ -224,6 +242,7 @@ class ElevenLabsSession implements TranscriptionSession {
 
   async close(): Promise<TranscriptionResult> {
     this.closed = true
+    this.resolvePendingFlush()
     if (this.ws && this.ws.readyState <= WebSocket.OPEN) {
       this.ws.close()
     }

--- a/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.ts
+++ b/apps/backend/src/features/voice-transcription/transcription/realtime-elevenlabs.ts
@@ -27,6 +27,7 @@ const MAX_KEYTERM_LENGTH = 20
 /** PCM16 mono: 2 bytes/sample, so ms = bytes / (2 * 16000 / 1000) = bytes / 32. */
 const BYTES_PER_MS = (SAMPLE_RATE_HZ * 2) / 1000
 const FLUSH_FINAL_WAIT_MS = 1500
+const FLUSH_FINAL_QUIET_MS = 100
 
 /**
  * Map our registry model id (`elevenlabs:scribe-v2-realtime`) to the ElevenLabs
@@ -71,6 +72,7 @@ class ElevenLabsSession implements TranscriptionSession {
   private openedAt = 0
   private closed = false
   private pendingFlush: (() => void) | null = null
+  private flushQuietTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     private readonly apiKey: string,
@@ -173,7 +175,7 @@ class ElevenLabsSession implements TranscriptionSession {
       case "committed_transcript":
       case "committed_transcript_with_timestamps":
         if (data.text) this.emitDelta({ text: data.text, isFinal: true })
-        this.resolvePendingFlush()
+        this.schedulePendingFlushResolution()
         return
       case "input_error":
         this.emitError({ code: "INPUT_ERROR", message: data.error ?? data.message ?? "Upstream input error" })
@@ -208,16 +210,21 @@ class ElevenLabsSession implements TranscriptionSession {
       })
     )
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        this.pendingFlush = null
-        resolve()
-      }, FLUSH_FINAL_WAIT_MS)
+      const timer = setTimeout(() => this.resolvePendingFlush(), FLUSH_FINAL_WAIT_MS)
       this.pendingFlush = () => {
         clearTimeout(timer)
+        if (this.flushQuietTimer) clearTimeout(this.flushQuietTimer)
+        this.flushQuietTimer = null
         this.pendingFlush = null
         resolve()
       }
     })
+  }
+
+  private schedulePendingFlushResolution(): void {
+    if (!this.pendingFlush) return
+    if (this.flushQuietTimer) clearTimeout(this.flushQuietTimer)
+    this.flushQuietTimer = setTimeout(() => this.resolvePendingFlush(), FLUSH_FINAL_QUIET_MS)
   }
 
   private resolvePendingFlush(): void {

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { spyOnExport } from "@/test/spy"
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
+import { forwardRef, useEffect, useImperativeHandle, useState, type ForwardedRef } from "react"
 import { MessageComposer } from "./message-composer"
 import { StashedDraftsPicker } from "./stashed-drafts-picker"
 import type { CachedDraft } from "@/hooks"
@@ -11,6 +11,7 @@ import type { JSONContent } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
 import * as contextsModule from "@/contexts"
 import * as editorModule from "@/components/editor"
+import * as micButtonModule from "./mic-button"
 import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 let isMobileMockValue = false
@@ -168,6 +169,30 @@ describe("MessageComposer", () => {
     onSubmit: vi.fn(),
     canSubmit: false,
   }
+
+  it("aborts active dictation when a nonempty draft is cleared", async () => {
+    const abort = vi.fn()
+    const MockMicButton = forwardRef(function MockMicButton(
+      props: { onActiveChange: (active: boolean) => void },
+      ref: ForwardedRef<{ abort: () => void; prepareSendAsIs: () => void }>
+    ) {
+      useImperativeHandle(ref, () => ({ abort, prepareSendAsIs: vi.fn() }))
+      useEffect(() => props.onActiveChange(true), [props])
+      return null
+    })
+    spyOnExport(micButtonModule, "MicButton").mockReturnValue(
+      MockMicButton as unknown as typeof micButtonModule.MicButton
+    )
+    const nonempty: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "draft" }] }],
+    }
+    const { rerender } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" content={nonempty} />)
+
+    rerender(<MessageComposer {...defaultProps} workspaceId="ws_1" content={EMPTY_DOC} />)
+
+    await waitFor(() => expect(abort).toHaveBeenCalledOnce())
+  })
 
   describe("rendering", () => {
     it("should render the editor", () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -386,19 +386,14 @@ export function MessageComposer({
   // dictation take when it sends or clears the draft (drops the polish toggle
   // and any warning chrome rather than letting them ride out a timer).
   const micRef = useRef<MicButtonHandle | null>(null)
-  // Mirror so the content-empty effect can read it without re-subscribing.
-  const voiceActiveRef = useRef(voiceActive)
-  voiceActiveRef.current = voiceActive
   // Edge-detect the composer emptying (send-clear, manual delete, stash) so we
-  // tear down the dictation session exactly once on the non-empty → empty
-  // transition. Skipped while a take is live — clearing text mid-dictation
-  // shouldn't stop the recording.
+  // tear down the dictation session exactly once on the non-empty → empty transition.
   const wasEmptyRef = useRef(isEmptyContent(content))
   useEffect(() => {
     const empty = isEmptyContent(content)
     const wasEmpty = wasEmptyRef.current
     wasEmptyRef.current = empty
-    if (empty && !wasEmpty && !voiceActiveRef.current) micRef.current?.endSession()
+    if (empty && !wasEmpty) micRef.current?.abort()
   }, [content])
 
   // Close inline format toolbar and collapse expansion when navigating to a different stream/scope.
@@ -586,7 +581,7 @@ export function MessageComposer({
     // End any in-flight take first: this flushes the live hypothesis into the
     // editor (so the tail lands in the message) and drops the polish toggle +
     // warnings before we snapshot the content below.
-    micRef.current?.endSession()
+    micRef.current?.prepareSendAsIs()
     onSubmit(richEditorRef.current?.getEditor()?.getJSON() as JSONContent | undefined)
   }, [onSubmit])
 

--- a/apps/frontend/src/components/composer/mic-button.test.tsx
+++ b/apps/frontend/src/components/composer/mic-button.test.tsx
@@ -93,7 +93,8 @@ describe("MicButton state surfaces", () => {
       dismissError: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
-      endSession: vi.fn(),
+      prepareSendAsIs: vi.fn(),
+      abort: vi.fn(),
       ...overrides,
     })
   }
@@ -188,8 +189,8 @@ describe("MicButton state surfaces", () => {
 describe("MicButton imperative handle", () => {
   afterEach(() => vi.restoreAllMocks())
 
-  it("exposes endSession through the forwarded ref so the composer can end a take on send", () => {
-    const endSession = vi.fn()
+  it("exposes prepareSendAsIs through the forwarded ref so the composer can end a take on send", () => {
+    const prepareSendAsIs = vi.fn()
     vi.spyOn(voiceDictation, "useVoiceDictation").mockReturnValue({
       state: "recording",
       supported: true,
@@ -208,7 +209,8 @@ describe("MicButton imperative handle", () => {
       dismissError: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
-      endSession,
+      prepareSendAsIs,
+      abort: vi.fn(),
     })
 
     const ref = createRef<MicButtonHandle>()
@@ -218,7 +220,7 @@ describe("MicButton imperative handle", () => {
       </TooltipProvider>
     )
 
-    ref.current?.endSession()
-    expect(endSession).toHaveBeenCalledOnce()
+    ref.current?.prepareSendAsIs()
+    expect(prepareSendAsIs).toHaveBeenCalledOnce()
   })
 })

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -55,7 +55,8 @@ export interface MicButtonHandle {
    * any transient warning/error chrome. The composer calls this when it sends
    * or clears the draft so the dictation surfaces don't outlive the message.
    */
-  endSession: () => void
+  prepareSendAsIs: () => void
+  abort: () => void
 }
 
 interface MicButtonProps {
@@ -130,7 +131,8 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     dismissError,
     start,
     stop,
-    endSession,
+    prepareSendAsIs,
+    abort,
   } = useVoiceDictation({
     workspaceId,
     onCommittedText: onInsertText,
@@ -142,7 +144,7 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     language,
   })
 
-  useImperativeHandle(ref, () => ({ endSession }), [endSession])
+  useImperativeHandle(ref, () => ({ prepareSendAsIs, abort }), [prepareSendAsIs, abort])
 
   // Tell the host when a take is in flight. The mobile composer collapses its
   // action bar (and this button) on blur; without this signal a tap-outside

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
   vi.stubGlobal("cancelAnimationFrame", () => {})
 })
 
-function hookHarness(acks: VoiceStartAck[]) {
+function hookHarness(acks: VoiceStartAck[], callbacks: Partial<Parameters<typeof useVoiceDictation>[0]> = {}) {
   const sockets: FakeSocket[] = []
   let session = 0
   const abortSession = vi.fn(async () => {})
@@ -109,7 +109,7 @@ function hookHarness(acks: VoiceStartAck[]) {
   }
   const committed = vi.fn()
   const rendered = renderHook(() =>
-    useVoiceDictation({ workspaceId: "ws_1", onCommittedText: committed, dependencies })
+    useVoiceDictation({ workspaceId: "ws_1", onCommittedText: committed, dependencies, ...callbacks })
   )
   return { ...rendered, sockets, committed, abortSession, dependencies }
 }
@@ -195,6 +195,42 @@ describe("useVoiceDictation lifecycle", () => {
     vi.useRealTimers()
   })
 
+  it("gives deliberate formatting the full backend processing budget", async () => {
+    vi.useFakeTimers()
+    const harness = hookHarness([{ ok: true, protocolVersion: 2 }])
+    act(() => harness.result.current.start())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => harness.result.current.stop())
+    act(() => vi.advanceTimersByTime(3_000))
+    expect(harness.sockets[0].disconnected).toBe(false)
+    act(() => vi.advanceTimersByTime(4_000))
+    expect(harness.sockets[0].disconnected).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it("ignores detached send-as-is socket lifecycle callbacks during a new take", async () => {
+    const harness = hookHarness([
+      { ok: true, protocolVersion: 2 },
+      { ok: true, protocolVersion: 2 },
+    ])
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => harness.result.current.prepareSendAsIs())
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+
+    act(() => {
+      harness.sockets[0].fire("voice:stopped", { reason: "stopped", revision: 0, outcome: "success" })
+      harness.sockets[0].fire("disconnect", undefined)
+    })
+
+    expect(harness.result.current.state).toBe("recording")
+    expect(harness.result.current.error).toBeNull()
+  })
+
   it("aborts over HTTP after session creation but before socket setup", async () => {
     let releaseMic!: () => void
     Object.defineProperty(navigator, "mediaDevices", {
@@ -213,6 +249,77 @@ describe("useVoiceDictation lifecycle", () => {
 
     expect(harness.abortSession).toHaveBeenCalledWith("ws_1", "voicesess_1")
     releaseMic()
+  })
+
+  it("stops a microphone stream that resolves after abort", async () => {
+    let releaseMic!: () => void
+    const stopTrack = vi.fn()
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: () =>
+          new Promise((resolve) => {
+            releaseMic = () =>
+              resolve({ getAudioTracks: () => [], getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream)
+          }),
+      },
+    })
+    const harness = hookHarness([{ ok: true, protocolVersion: 2 }])
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.dependencies.createSession).toHaveBeenCalledTimes(1))
+    act(() => harness.result.current.abort())
+    await act(async () => releaseMic())
+
+    expect(stopTrack).toHaveBeenCalledTimes(1)
+    expect(harness.sockets).toHaveLength(0)
+  })
+
+  it("locks stale polished comparison state when authoritative formatting fails or the take aborts", async () => {
+    let chunkText = "raw tail"
+    const lockAll = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 2 }], {
+      onPolishedChunkInserted: ({ text }) => {
+        chunkText = text
+      },
+      onGetChunkText: () => chunkText,
+      onChunkSwap: ({ newText }) => {
+        chunkText = newText
+        return true
+      },
+      onLockAllChunks: lockAll,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    lockAll.mockClear()
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "raw tail",
+        isFinal: true,
+        chunkId: "chunk_1",
+      })
+      harness.sockets[0].fire("voice:transcript:polished", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        chunkId: "chunk_1",
+        raw: "raw tail",
+        polished: "polished",
+      })
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 2,
+        text: "new tail",
+        isFinal: true,
+        chunkId: "chunk_1",
+      })
+      harness.sockets[0].fire("voice:stopped", { reason: "stopped", revision: 2, outcome: "provider_error" })
+    })
+
+    expect(harness.result.current.hasUnlockedChunks).toBe(false)
+    expect(lockAll).toHaveBeenCalledTimes(1)
+    act(() => harness.result.current.abort())
+    expect(lockAll).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -1,11 +1,234 @@
-import { describe, it, expect } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, it, expect, vi } from "vitest"
+import type { VoiceStartAck, VoiceTranscriptDelta } from "@threa/types"
 import {
   friendlyTranscriptionError,
   shouldWarnNoAudio,
   noAudioWarningMessage,
   NO_AUDIO_INITIAL_WAIT_MS,
   NO_AUDIO_SILENCE_WAIT_MS,
+  resetVoiceTakeProtocol,
+  useVoiceDictation,
 } from "./use-voice-dictation"
+
+class FakeSocket {
+  handlers = new Map<string, (payload: unknown) => void>()
+  stopCallbacks: Array<() => void> = []
+  stopPayloads: unknown[] = []
+  disconnected = false
+  private timeoutMs: number | null = null
+  constructor(private readonly ack: VoiceStartAck) {}
+  on(event: string, callback: (payload: unknown) => void) {
+    this.handlers.set(event, callback)
+    return this
+  }
+  emit(event: string, ...args: unknown[]) {
+    if (event === "voice:start") (args[1] as (ack: VoiceStartAck) => void)(this.ack)
+    if (event === "voice:stop") {
+      this.stopPayloads.push(args[0])
+      const callback = args.at(-1)
+      if (typeof callback === "function") {
+        this.stopCallbacks.push(callback as () => void)
+        if (this.timeoutMs !== null) setTimeout(callback as () => void, this.timeoutMs)
+      }
+    }
+    return this
+  }
+  timeout(ms: number) {
+    this.timeoutMs = ms
+    return this
+  }
+  disconnect() {
+    this.disconnected = true
+    return this
+  }
+  fire(event: string, payload: unknown) {
+    this.handlers.get(event)?.(payload)
+  }
+}
+
+class FakeAudioContext {
+  state = "running"
+  destination = {}
+  audioWorklet = { addModule: async () => {} }
+  onstatechange: (() => void) | null = null
+  resume = async () => {}
+  close = async () => {}
+  createMediaStreamSource = () => ({ connect: () => {} })
+  createGain = () => ({ gain: { value: 0 }, connect: () => {} })
+  createAnalyser = () => ({
+    fftSize: 1024,
+    smoothingTimeConstant: 0,
+    disconnect: () => {},
+    getByteTimeDomainData: () => {},
+  })
+}
+
+class FakeWorklet {
+  port = { close: () => {}, onmessage: null }
+  connect() {}
+  disconnect() {}
+}
+
+const stream = {
+  getAudioTracks: () => [{ label: "Test mic", onmute: null, onunmute: null }],
+  getTracks: () => [{ stop: () => {} }],
+}
+
+beforeEach(() => {
+  localStorage.setItem("threa-ws-config:ws_1", JSON.stringify({ region: "test", wsUrl: "https://voice.test" }))
+  Object.defineProperty(window, "AudioContext", { configurable: true, value: FakeAudioContext })
+  Object.defineProperty(globalThis, "AudioWorkletNode", { configurable: true, value: FakeWorklet })
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: async () => stream },
+  })
+  vi.stubGlobal("requestAnimationFrame", () => 1)
+  vi.stubGlobal("cancelAnimationFrame", () => {})
+})
+
+function hookHarness(acks: VoiceStartAck[]) {
+  const sockets: FakeSocket[] = []
+  let session = 0
+  const abortSession = vi.fn(async () => {})
+  const dependencies = {
+    createSocket: (() => {
+      const socket = new FakeSocket(acks[sockets.length])
+      sockets.push(socket)
+      return socket
+    }) as never,
+    createSession: vi.fn(async () => ({
+      voiceSessionId: `voicesess_${++session}`,
+      model: "test",
+      provider: "test",
+      region: "test",
+      expiresAt: "later",
+      maxDurationMs: 600_000,
+    })),
+    abortSession,
+  }
+  const committed = vi.fn()
+  const rendered = renderHook(() =>
+    useVoiceDictation({ workspaceId: "ws_1", onCommittedText: committed, dependencies })
+  )
+  return { ...rendered, sockets, committed, abortSession, dependencies }
+}
+
+describe("useVoiceDictation lifecycle", () => {
+  it("accepts a lower revision in a second real hook session", async () => {
+    const harness = hookHarness([
+      { ok: true, protocolVersion: 2 },
+      { ok: true, protocolVersion: 2 },
+    ])
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 5,
+        text: "first",
+        isFinal: true,
+      } satisfies VoiceTranscriptDelta)
+    )
+    act(() => harness.result.current.stop())
+    act(() => harness.sockets[0].stopCallbacks[0]())
+    await waitFor(() => expect(harness.result.current.state).toBe("idle"))
+
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[1].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_2",
+        revision: 1,
+        text: "second",
+        isFinal: true,
+      } satisfies VoiceTranscriptDelta)
+    )
+
+    expect(harness.committed.mock.calls.map(([text]) => text)).toEqual(["first", "second"])
+  })
+
+  it("resets v2 capability before a legacy session and disconnects legacy send-as-is immediately", async () => {
+    const harness = hookHarness([
+      { ok: true, protocolVersion: 2 },
+      { ok: true, protocolVersion: 1 },
+    ])
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => harness.result.current.prepareSendAsIs())
+    expect(harness.sockets[0].disconnected).toBe(false)
+    act(() => harness.sockets[0].stopCallbacks[0]())
+
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => harness.result.current.prepareSendAsIs())
+
+    expect(harness.sockets[1].stopPayloads).toEqual([])
+    expect(harness.sockets[1].disconnected).toBe(true)
+  })
+
+  it("retains a v2 send-as-is socket through ACK and timeout", async () => {
+    vi.useFakeTimers()
+    const harness = hookHarness([
+      { ok: true, protocolVersion: 2 },
+      { ok: true, protocolVersion: 2 },
+    ])
+    act(() => harness.result.current.start())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => harness.result.current.prepareSendAsIs())
+    expect(harness.sockets[0].disconnected).toBe(false)
+    act(() => harness.sockets[0].stopCallbacks[0]())
+    expect(harness.sockets[0].disconnected).toBe(true)
+
+    act(() => harness.result.current.start())
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => harness.result.current.prepareSendAsIs())
+    expect(harness.sockets[1].disconnected).toBe(false)
+    act(() => vi.advanceTimersByTime(3_000))
+    expect(harness.sockets[1].disconnected).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it("aborts over HTTP after session creation but before socket setup", async () => {
+    let releaseMic!: () => void
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: () =>
+          new Promise((resolve) => {
+            releaseMic = () => resolve(stream)
+          }),
+      },
+    })
+    const harness = hookHarness([{ ok: true, protocolVersion: 2 }])
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.dependencies.createSession).toHaveBeenCalledTimes(1))
+    act(() => harness.result.current.abort())
+
+    expect(harness.abortSession).toHaveBeenCalledWith("ws_1", "voicesess_1")
+    releaseMic()
+  })
+})
+
+describe("resetVoiceTakeProtocol", () => {
+  it("accepts low revisions and legacy capability again in a second session", () => {
+    const acceptedRevision = { current: 5 }
+    const protocolVersion = { current: 2 }
+
+    resetVoiceTakeProtocol({ acceptedRevision, protocolVersion })
+
+    expect({ acceptedRevision: acceptedRevision.current, protocolVersion: protocolVersion.current }).toEqual({
+      acceptedRevision: 0,
+      protocolVersion: 1,
+    })
+  })
+})
 
 describe("friendlyTranscriptionError", () => {
   it("phrases known upstream codes as short human copy", () => {

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -3,6 +3,7 @@ import { io, type Socket } from "socket.io-client"
 import {
   VOICE_DRAFT_CONTEXT_MAX_CHARS,
   type VoiceStartAck,
+  type VoiceStoppedPayload,
   type VoiceTranscriptDelta,
   type VoiceTranscriptPolished,
 } from "@threa/types"
@@ -182,6 +183,7 @@ const SAMPLE_RATE_HZ = 16_000
 // If the server never acks voice:stop (dropped connection mid-stop), fall
 // through anyway so the button can't hang in the "stopping" state forever.
 const STOP_ACK_TIMEOUT_MS = 3000
+const FORMAT_STOP_ACK_TIMEOUT_MS = 7000
 
 // Silence-detection thresholds. Two failure modes to catch:
 //
@@ -573,6 +575,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         }
 
         const session = await dependencies.createSession(workspaceId, { language })
+        if (generation !== startGenerationRef.current) {
+          void dependencies.abortSession(workspaceId, session.voiceSessionId).catch(() => {})
+          return
+        }
         sessionIdRef.current = session.voiceSessionId
         setMaxDurationMs(session.maxDurationMs)
 
@@ -586,6 +592,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         const stream = await navigator.mediaDevices.getUserMedia({
           audio: { channelCount: 1, echoCancellation: false, noiseSuppression: false, autoGainControl: false },
         })
+        if (generation !== startGenerationRef.current) {
+          stream.getTracks().forEach((track) => track.stop())
+          void dependencies.abortSession(workspaceId, session.voiceSessionId).catch(() => {})
+          return
+        }
         streamRef.current = stream
         const track = stream.getAudioTracks()[0]
         // Capture the device label so the silence-detection warning can name
@@ -616,6 +627,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         }
 
         await audioContext.audioWorklet.addModule("/worklets/pcm16-processor.js")
+        if (generation !== startGenerationRef.current) {
+          stream.getTracks().forEach((track) => track.stop())
+          return
+        }
 
         const source = audioContext.createMediaStreamSource(stream)
         const worklet = new AudioWorkletNode(audioContext, "pcm16-processor", {
@@ -722,17 +737,17 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           })
           if (!accepted) sessionChunkIdRef.current = null
         })
-        socket.on("voice:transcription:error", (e: { code?: string }) => fail(friendlyTranscriptionError(e?.code)))
-        socket.on("voice:stopped", () => {
-          // Server-initiated stop (e.g. the max-duration guard). Keep any pending
-          // hypothesis and leave the recording state, not just tear down audio.
+        socket.on("voice:transcription:error", (e: { code?: string }) => {
+          if (socketRef.current === socket) fail(friendlyTranscriptionError(e?.code))
+        })
+        socket.on("voice:stopped", (payload: VoiceStoppedPayload) => {
+          if (socketRef.current !== socket) return
+          if (payload.outcome !== "success" && payload.outcome !== "empty_input") lockAllChunks()
           teardown()
           setState("idle")
         })
         socket.on("disconnect", () => {
-          // An unexpected drop while still capturing ends the take — surface it
-          // so the button leaves its recording state instead of hanging.
-          if (workletRef.current) fail("Dictation connection lost")
+          if (socketRef.current === socket && workletRef.current) fail("Dictation connection lost")
         })
 
         // Snapshot the draft around the caret as polish context. Captured at
@@ -760,7 +775,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
               return
             }
             worklet.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
-              socketRef.current?.emit("voice:audio", event.data)
+              if (socketRef.current === socket) socket.emit("voice:audio", event.data)
             }
             recordingStartRef.current = performance.now()
             lastElapsedTickRef.current = 0
@@ -817,7 +832,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         setState("idle")
       }
       if (protocolVersionRef.current >= 2)
-        socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "format" }, recover)
+        socket.timeout(FORMAT_STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "format" }, recover)
       else socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", recover)
     } else {
       setState("idle")
@@ -932,8 +947,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       void dependencies.abortSession(workspaceId, sessionId).catch(() => {})
     }
     coordinator.deactivate(coordinatedStop)
+    lockAllChunks()
     setState("idle")
-  }, [teardownAudio, updateInterim, workspaceId, coordinator, coordinatedStop, dependencies])
+  }, [teardownAudio, updateInterim, workspaceId, coordinator, coordinatedStop, dependencies, lockAllChunks])
 
   // Backgrounding the tab throttles the rAF meter and (on mobile) suspends audio
   // capture, so a take left "recording" would silently record nothing while the

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -1,31 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { io, type Socket } from "socket.io-client"
-import { VOICE_DRAFT_CONTEXT_MAX_CHARS } from "@threa/types"
+import {
+  VOICE_DRAFT_CONTEXT_MAX_CHARS,
+  type VoiceStartAck,
+  type VoiceTranscriptDelta,
+  type VoiceTranscriptPolished,
+} from "@threa/types"
 import { voiceApi } from "@/api/voice"
 import { getCachedWsConfig } from "@/lib/cached-ws-config"
 import { useDictationCoordinator, isDictationExternalHeld } from "@/contexts"
 
 export type VoiceDictationState = "idle" | "connecting" | "recording" | "stopping" | "error"
 
-interface VoiceDelta {
-  voiceSessionId: string
-  text: string
-  isFinal: boolean
-  /**
-   * Present only on finals when polish is enabled for the session. The same
-   * chunkId is reused for every final + every polished event in the session,
-   * so the editor tracks one growing range and the end-of-session polish swap
-   * targets it directly.
-   */
-  chunkId?: string
-}
-
-interface VoicePolishedChunk {
-  voiceSessionId: string
-  chunkId: string
-  raw: string
-  polished: string
-}
+type VoiceDelta = VoiceTranscriptDelta
+type VoicePolishedChunk = VoiceTranscriptPolished
 
 export interface DictationChunkRecord {
   /** Cumulative raw text the chunk would revert to if the toggle flips to "Show original". */
@@ -46,8 +34,21 @@ export interface DictationChunkRecord {
   locked: boolean
 }
 
+export interface VoiceDictationDependencies {
+  createSocket: typeof io
+  createSession: typeof voiceApi.createSession
+  abortSession: typeof voiceApi.abortSession
+}
+
+const DEFAULT_VOICE_DICTATION_DEPENDENCIES: VoiceDictationDependencies = {
+  createSocket: io,
+  createSession: voiceApi.createSession,
+  abortSession: voiceApi.abortSession,
+}
+
 interface UseVoiceDictationOptions {
   workspaceId: string
+  dependencies?: VoiceDictationDependencies
   /**
    * Called with a committed (final) transcript span when polish is OFF for
    * this session. When polish is ON, `onPolishedChunkInserted` is called
@@ -157,7 +158,8 @@ interface UseVoiceDictationResult {
    * draft: the message is gone, so the toggle pill and warnings have nothing
    * left to act on and shouldn't linger on a timer. Idempotent.
    */
-  endSession: () => void
+  prepareSendAsIs: () => void
+  abort: () => void
 }
 
 // Phrase structured upstream error codes as short, human copy. The raw provider
@@ -207,6 +209,14 @@ export function shouldWarnNoAudio(args: { elapsedMs: number; silenceMs: number; 
     return args.silenceMs >= NO_AUDIO_SILENCE_WAIT_MS
   }
   return args.elapsedMs >= NO_AUDIO_INITIAL_WAIT_MS
+}
+
+export function resetVoiceTakeProtocol(refs: {
+  acceptedRevision: { current: number }
+  protocolVersion: { current: number }
+}): void {
+  refs.acceptedRevision.current = 0
+  refs.protocolVersion.current = 1
 }
 
 export function noAudioWarningMessage(args: { deviceLabel: string | null; everHadSignal: boolean }): string {
@@ -273,6 +283,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     onGetChunkText,
     onGetDraftContext,
     language,
+    dependencies = DEFAULT_VOICE_DICTATION_DEPENDENCIES,
   } = options
   const [state, setState] = useState<VoiceDictationState>("idle")
   const [error, setError] = useState<string | null>(null)
@@ -289,6 +300,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   const audioContextRef = useRef<AudioContext | null>(null)
   const workletRef = useRef<AudioWorkletNode | null>(null)
   const sessionIdRef = useRef<string | null>(null)
+  const protocolVersionRef = useRef(1)
+  const acceptedRevisionRef = useRef(0)
   // Live input-level metering: an AnalyserNode taps the mic source and a rAF
   // loop computes a smoothed RMS level + elapsed time while recording.
   const analyserRef = useRef<AnalyserNode | null>(null)
@@ -490,12 +503,12 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     (message: string) => {
       // Don't throw away words the user already saw mid-segment — commit the
       // pending hypothesis before tearing the failed take down.
-      flushInterim()
+      updateInterim("")
       setError(message)
       setState("error")
       teardown()
     },
-    [teardown, flushInterim]
+    [teardown, updateInterim]
   )
 
   const start = useCallback(() => {
@@ -504,6 +517,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     // Composer dictation is disabled while a call holds the mic — two concurrent
     // getUserMedia captures conflict (fatally on iOS). The call owns the seam.
     if (isDictationExternalHeld()) return
+
+    resetVoiceTakeProtocol({ acceptedRevision: acceptedRevisionRef, protocolVersion: protocolVersionRef })
 
     // Take the single active slot, flushing+stopping any other composer's take.
     coordinator.activate(coordinatedStop)
@@ -557,7 +572,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           return
         }
 
-        const session = await voiceApi.createSession(workspaceId, { language })
+        const session = await dependencies.createSession(workspaceId, { language })
         sessionIdRef.current = session.voiceSessionId
         setMaxDurationMs(session.maxDurationMs)
 
@@ -627,13 +642,18 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         // the synchronous resume lost a race with this async setup.
         if (audioContext.state === "suspended") await audioContext.resume().catch(() => {})
 
-        const socket = io(voiceUrl, { path: "/socket.io/", withCredentials: true, autoConnect: true })
+        const socket = dependencies.createSocket(voiceUrl, {
+          path: "/socket.io/",
+          withCredentials: true,
+          autoConnect: true,
+        })
         socketRef.current = socket
 
         socket.on("voice:transcript:delta", (delta: VoiceDelta) => {
           // Ignore deltas from a session we've already moved past so a stale
           // socket can't leak text into a new take (plan §3).
-          if (delta.voiceSessionId !== sessionIdRef.current) return
+          if (delta.voiceSessionId !== sessionIdRef.current || delta.revision < acceptedRevisionRef.current) return
+          acceptedRevisionRef.current = delta.revision
           if (!delta.isFinal) {
             // Running hypothesis for the current segment — each partial replaces
             // the prior one rather than appending.
@@ -661,7 +681,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         socket.on("voice:transcript:polished", (chunk: VoicePolishedChunk) => {
           // Stale chunk from a previous take — ignore it so polishing latency
           // can't leak text into a new session.
-          if (chunk.voiceSessionId !== sessionIdRef.current) return
+          if (chunk.voiceSessionId !== sessionIdRef.current || chunk.revision < acceptedRevisionRef.current) return
+          acceptedRevisionRef.current = chunk.revision
           if (chunk.chunkId !== sessionChunkIdRef.current) return
           // Swap the editor's session chunk to whichever mode the toggle is
           // showing right now (the toggle can be flipped mid-session). If the
@@ -705,7 +726,6 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         socket.on("voice:stopped", () => {
           // Server-initiated stop (e.g. the max-duration guard). Keep any pending
           // hypothesis and leave the recording state, not just tear down audio.
-          flushInterim()
           teardown()
           setState("idle")
         })
@@ -727,13 +747,14 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         socket.emit(
           "voice:start",
           { workspaceId, voiceSessionId: session.voiceSessionId, draftBefore, draftAfter },
-          (result: { ok: boolean; error?: string }) => {
+          (result: VoiceStartAck) => {
             // The user stopped (or we tore down) while this ACK was in flight —
             // don't resurrect a dead take into the "recording" state.
             if (generation !== startGenerationRef.current) {
               socket.disconnect()
               return
             }
+            protocolVersionRef.current = result.protocolVersion ?? 1
             if (!result?.ok) {
               fail(result?.error || "Couldn't start dictation")
               return
@@ -767,11 +788,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     language,
     fail,
     teardown,
-    flushInterim,
     runMeter,
     coordinator,
     coordinatedStop,
     lockAllChunks,
+    dependencies,
   ])
 
   const stop = useCallback(() => {
@@ -781,22 +802,23 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     // Keep the in-flight hypothesis: the backend commits buffered audio on stop,
     // but we've already advanced past this session id (below), so its final delta
     // would be dropped — flush the local hypothesis so the tail isn't lost.
-    flushInterim()
     // Invalidate any in-flight `voice:start` ACK so a late accept can't flip us
     // back to "recording" after we've decided to stop.
     startGenerationRef.current++
     // Stop capture immediately; tell the backend to commit the buffered audio.
     teardownAudio()
     const socket = socketRef.current
-    socketRef.current = null
-    sessionIdRef.current = null
     if (socket) {
       // The ack callback fires on the server's confirmation or on the timeout —
       // either way we disconnect and return to idle so the UI never wedges.
-      socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", () => {
-        socket.disconnect()
+      const recover = () => {
+        flushInterim()
+        teardown()
         setState("idle")
-      })
+      }
+      if (protocolVersionRef.current >= 2)
+        socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "format" }, recover)
+      else socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", recover)
     } else {
       setState("idle")
     }
@@ -808,7 +830,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       lockTimerRef.current = null
       lockAllChunks()
     }, POST_SESSION_LOCK_MS)
-  }, [state, teardownAudio, flushInterim, coordinator, coordinatedStop, lockAllChunks])
+  }, [state, teardownAudio, flushInterim, teardown, coordinator, coordinatedStop, lockAllChunks])
   // Keep the stable coordinator handle pointed at the latest stop().
   stopRef.current = stop
 
@@ -873,28 +895,45 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     setState("idle")
   }, [])
 
-  const endSession = useCallback(() => {
-    // Stop a live take first so its tail flushes into the editor before we drop
-    // tracking (the user's words on a manual send should still land).
-    if (state === "recording" || state === "connecting") stop()
-    // Drop polished-chunk tracking + reset the toggle right now instead of
-    // waiting out the post-session grace window. Guarded so a speculative call
-    // (e.g. on every composer clear) doesn't dispatch a no-op editor transaction
-    // when there was nothing tracked. stop() above sets the lock timer, so the
-    // timer-ref check also covers the just-stopped case.
-    if (chunksRef.current.size > 0 || sessionChunkIdRef.current !== null || lockTimerRef.current !== null) {
-      lockAllChunks()
-    }
-    if (state === "error") {
-      setError(null)
+  const prepareSendAsIs = useCallback(() => {
+    if (state === "recording" || state === "connecting" || state === "stopping") {
+      flushInterim()
+      startGenerationRef.current++
+      teardownAudio()
+      const socket = socketRef.current
+      socketRef.current = null
+      sessionIdRef.current = null
+      if (socket) {
+        if (protocolVersionRef.current >= 2) {
+          socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "send_as_is" }, () => socket.disconnect())
+        } else {
+          socket.disconnect()
+        }
+      }
+      coordinator.deactivate(coordinatedStop)
       setState("idle")
     }
-    if (warningShownRef.current) {
-      warningShownRef.current = false
-      setNoAudioWarning(null)
+    if (chunksRef.current.size > 0 || sessionChunkIdRef.current !== null || lockTimerRef.current !== null)
+      lockAllChunks()
+  }, [state, flushInterim, teardownAudio, coordinator, coordinatedStop, lockAllChunks])
+
+  const abort = useCallback(() => {
+    startGenerationRef.current++
+    updateInterim("")
+    teardownAudio()
+    const socket = socketRef.current
+    const sessionId = sessionIdRef.current
+    socketRef.current = null
+    sessionIdRef.current = null
+    if (socket) {
+      if (protocolVersionRef.current >= 2) socket.emit("voice:stop", { mode: "abort" })
+      socket.disconnect()
+    } else if (sessionId) {
+      void dependencies.abortSession(workspaceId, sessionId).catch(() => {})
     }
-    noAudioDismissedRef.current = false
-  }, [state, stop, lockAllChunks])
+    coordinator.deactivate(coordinatedStop)
+    setState("idle")
+  }, [teardownAudio, updateInterim, workspaceId, coordinator, coordinatedStop, dependencies])
 
   // Backgrounding the tab throttles the rAF meter and (on mobile) suspends audio
   // capture, so a take left "recording" would silently record nothing while the
@@ -903,11 +942,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // their words and an idle mic rather than a dead one they think is recording.
   useEffect(() => {
     const onVisibilityChange = () => {
-      if (document.visibilityState === "hidden") stopRef.current()
+      if (document.visibilityState === "hidden") abort()
     }
     document.addEventListener("visibilitychange", onVisibilityChange)
     return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [])
+  }, [abort])
 
   // Abort a still-open session on unmount: disconnecting the socket makes the
   // gateway finalize it as aborted; if the socket never opened, abort over HTTP
@@ -923,10 +962,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         lockTimerRef.current = null
       }
       if (sessionId && !hadSocket) {
-        void voiceApi.abortSession(workspaceId, sessionId).catch(() => {})
+        void dependencies.abortSession(workspaceId, sessionId).catch(() => {})
       }
     }
-  }, [teardown, workspaceId])
+  }, [teardown, workspaceId, dependencies])
 
   let hasUnlockedChunks = false
   for (const record of chunks.values()) {
@@ -954,6 +993,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     dismissError,
     start,
     stop,
-    endSession,
+    prepareSendAsIs,
+    abort,
   }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,18 @@
 // Branded ID types
 export type { UserId, MemberId, WorkspaceId } from "./ids"
 
+export { VOICE_PROTOCOL_VERSION } from "./voice-dictation"
+export type {
+  VoiceTerminationMode,
+  VoiceRelayPhase,
+  VoiceStartAck,
+  VoiceStopPayload,
+  VoiceStopAck,
+  VoiceTranscriptDelta,
+  VoiceTranscriptPolished,
+  VoiceStoppedPayload,
+} from "./voice-dictation"
+
 // Constants and their types
 export {
   // Stream types

--- a/packages/types/src/voice-dictation.ts
+++ b/packages/types/src/voice-dictation.ts
@@ -1,0 +1,41 @@
+export const VOICE_PROTOCOL_VERSION = 2 as const
+
+export type VoiceTerminationMode = "format" | "send_as_is" | "abort"
+export type VoiceRelayPhase = "live" | "formatting" | "closing" | "closed"
+
+export interface VoiceStartAck {
+  ok: boolean
+  error?: string
+  protocolVersion: number
+}
+
+export interface VoiceStopPayload {
+  mode: VoiceTerminationMode
+}
+
+export interface VoiceStopAck {
+  ok: boolean
+}
+
+export interface VoiceTranscriptDelta {
+  voiceSessionId: string
+  revision: number
+  text: string
+  isFinal: boolean
+  chunkId?: string
+}
+
+export interface VoiceTranscriptPolished {
+  voiceSessionId: string
+  chunkId: string
+  revision: number
+  authoritative: boolean
+  raw: string
+  polished: string
+}
+
+export interface VoiceStoppedPayload {
+  reason: "stopped" | "max_duration"
+  revision: number
+  outcome: "success" | "empty_input" | "invalid_output" | "timeout" | "canceled" | "provider_error"
+}


### PR DESCRIPTION
## Problem

Dictation polish failures could return raw text as a successful polish, allowing timeout, provider, or stale results to replace accepted editor content. Deliberate stop also invalidated the frontend session before post-flush events arrived, while send, clear, disconnect, and concurrent termination shared lifecycle behavior that could flush, promote, or apply text after the user had moved on.

## Solution

Introduce revisioned voice events and explicit `format`, `send_as_is`, and `abort` lifecycles across the shared contract, gateway, providers, and composer.

- `createPolishTranscript` returns typed success, timeout, cancellation, provider-error, empty-input, and invalid-output outcomes. Only success can emit polished text.
- `PolishScheduler` bounds live work to one active pass plus the newest pending snapshot; generation and revision checks reject canceled or stale results. Deliberate stop cancels live work and runs one authoritative post-flush pass.
- Gateway termination is idempotent with `abort > send_as_is > format` precedence. Provider `flush()` now waits for terminal final delivery or a bounded release before formatting.
- Frontend stop retains event acceptance through final ACK. Send-as-is synchronously commits visible interim text before the composer snapshots JSON; abort paths discard interim text and invalidate late callbacks.
- String-based raw/polished editor insertion remains unchanged. Structured Markdown and `contentJson` insertion belong to the next stack layer.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/voice-dictation.ts`, `index.ts` | Add and export protocol v2 lifecycle, revision, event, and ACK types. |
| `apps/backend/src/features/voice-transcription/polish*.ts` | Add non-destructive outcomes and bounded polish scheduling with focused tests. |
| `apps/backend/src/features/voice-transcription/realtime-gateway*.ts` | Implement revision guards, explicit termination modes, authoritative final formatting, and idempotent cleanup. |
| `apps/backend/src/features/voice-transcription/transcription/realtime-{deepgram,elevenlabs}*.ts` | Make flush a final-delivery barrier and release pending barriers on close. |
| `apps/frontend/src/hooks/use-voice-dictation*.ts` | Split format, synchronous send-as-is, and abort behavior; retain or invalidate sessions by lifecycle. |
| `apps/frontend/src/components/composer/{mic-button,message-composer}*.tsx` | Expose lifecycle-specific commands and prepare visible dictation before submit snapshots. |

## Test plan

- [x] Focused backend voice tests: 84 pass, 0 fail
- [x] Focused frontend hook, mic, and composer tests: 68 pass, 0 fail
- [x] `bun run --cwd packages/types typecheck`
- [x] `bun run --cwd apps/backend typecheck`
- [x] `bun run --cwd apps/frontend typecheck`
- [x] `bun run --cwd apps/backend lint`
- [x] `bun run --cwd apps/frontend lint`
- [x] Post-commit checks: full monorepo lint, typecheck, migration checks, Dockerfile checks, and API documentation check
- [x] `git diff --check`

<details>
<summary>📋 Full implementation plan</summary>

This is PR1, based on `main`, in a three-layer stack:

1. `fix/dictation-polish-lifecycle`: typed outcomes, bounded scheduling, explicit termination, provider flush barriers, and frontend lifecycle separation.
2. `feat/dictation-structured-markdown`: canonical Markdown and `contentJson` socket/editor bridge.
3. `test/dictation-polish-evals`: production-entrypoint quality evaluation and measured prompt, model, and deadline calibration.

Actual implementation in this PR:

- Define one shared protocol v2 contract for termination modes, revisions, ACKs, transcript events, and stopped outcomes.
- Keep raw transcript deltas as the recovery path; classify formatter failures without presenting raw text as polished output.
- Coalesce live formatting, cancel stale generations, and reserve one post-flush authoritative pass for deliberate stop and max duration.
- Give send-as-is and abort precedence over in-flight formatting; close and record each session once.
- Wait for Deepgram and ElevenLabs terminal final delivery with bounded provider barriers.
- Preserve frontend acceptance through format completion; synchronously snapshot visible text for send-as-is; discard interim text on abort paths.
- Cover formatter outcomes, scheduler races, gateway precedence and idempotence, provider barriers, protocol resets, send ACK retention, pre-socket abort, and composer clearing.

Excluded: structured Markdown insertion, `contentJson` socket payloads, context serialization changes, prompt/model/deadline tuning, evals, settings or UI redesign, migrations, STT provider/model changes, audio capture redesign, and spoken editing commands.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
