### PR TITLE
feat(delegations): add recoverable clients and runner

### DIFF
--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -111,11 +111,12 @@ interface DelegationCalls {
   statuses: string[]
   completes: Array<{ id: string; resultMarkdown?: string }>
   fails: Array<{ id: string; errorMessage: string }>
+  releases: Array<{ id: string }>
 }
 
 /** One open delegation, then an empty queue — the runner claims it and waits on the executor. */
 function stubDelegationClient(id: string): { client: DelegationClient; calls: DelegationCalls } {
-  const calls: DelegationCalls = { statuses: [], completes: [], fails: [] }
+  const calls: DelegationCalls = { statuses: [], completes: [], fails: [], releases: [] }
   let listed = false
   const client = {
     listOpen: async () => {
@@ -135,6 +136,10 @@ function stubDelegationClient(id: string): { client: DelegationClient; calls: De
     },
     fail: async (failedId: string, _token: string, errorMessage: string) => {
       calls.fails.push({ id: failedId, errorMessage })
+      return claimedDelegation(id)
+    },
+    release: async (releasedId: string) => {
+      calls.releases.push({ id: releasedId })
       return claimedDelegation(id)
     },
   } as unknown as DelegationClient
@@ -263,35 +268,27 @@ describe("ChannelServer delegations", () => {
     expect(starts).toBe(0)
   })
 
-  test("force reconnect interrupts active delegation and waits for its fail report", async () => {
+  test("force reconnect delegates cancellation to the runner and waits for release", async () => {
     const server = new ChannelServer(makeConfig(), new ThreaClient(makeConfig()), makeFakeTransport())
     const internals = server as any
     let releaseStop!: () => void
-    let rejectedWith = ""
     internals.delegations = { stop: () => new Promise<void>((resolve) => (releaseStop = resolve)) }
-    internals.openDelegations.set("dlg_active", {
-      reject: (error: Error) => {
-        rejectedWith = error.message
-      },
-      clear: () => {},
-    })
+    internals.openDelegations.set("dlg_active", { clear: () => {} })
 
     let finished = false
     const stopping = internals.stopDelegationsForReconnect(true).then(() => (finished = true))
     await Promise.resolve()
-    expect({ rejectedWith, finished }).toEqual({
-      rejectedWith: "Claude Code channel reconnected mid-delegation",
-      finished: false,
-    })
+    expect(finished).toBe(false)
     releaseStop()
     await stopping
     expect(finished).toBe(true)
   })
 
-  test("shutdown fails an in-flight delegation instead of stranding its claim", async () => {
+  test("shutdown aborts and releases an in-flight delegation", async () => {
     const { server, calls } = await startDelegatingServer("dlg_1")
     await server.shutdown()
-    expect(calls.fails).toEqual([{ id: "dlg_1", errorMessage: "Claude Code channel shut down mid-delegation" }])
+    expect(calls.releases).toEqual([{ id: "dlg_1" }])
+    expect(calls.fails).toHaveLength(0)
     expect(calls.completes).toHaveLength(0)
   })
 

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -521,7 +521,6 @@ export class ChannelServer {
     const stopping = this.delegations?.stop(reason, { strict: true }) ?? Promise.resolve()
 
     if (force) {
-      this.failOpenDelegations(reason)
       await stopping
       return
     }
@@ -562,10 +561,6 @@ export class ChannelServer {
     this.shuttingDown = true
     this.tracer.stop()
     this.carryOn?.stop()
-    // Fail an in-flight delegation loudly (its executor promise rejects →
-    // the runner posts the failure) rather than stranding the claim until the
-    // 15-minute lease sweep. stop() resolves after that fail report lands.
-    this.failOpenDelegations("Claude Code channel shut down mid-delegation")
     await this.delegations?.stop()
     for (const [, open] of this.openPermissions) clearTimeout(open.cleanup)
     this.openPermissions.clear()
@@ -620,12 +615,17 @@ export class ChannelServer {
           )
         }
         arm()
+        const onAbort = () => reject(new Error("Delegation claim lost"))
+        ctx.signal.addEventListener("abort", onAbort, { once: true })
         this.openDelegations.set(task.id, {
           resolve,
           reject,
           ctx,
           keepAlive: arm,
-          clear: () => clearTimeout(deadline),
+          clear: () => {
+            clearTimeout(deadline)
+            ctx.signal.removeEventListener("abort", onAbort)
+          },
         })
         void this.notify("notifications/claude/channel", {
           content: formatDelegationContent(task),
@@ -637,11 +637,6 @@ export class ChannelServer {
       this.openDelegations.get(task.id)?.clear()
       this.openDelegations.delete(task.id)
     }
-  }
-
-  private failOpenDelegations(reason: string): void {
-    // Entries remove themselves via each executor's finally.
-    for (const [, open] of this.openDelegations) open.reject(new Error(reason))
   }
 
   // --- Turn delivery ----------------------------------------------------------

--- a/extensions/remote-session/README.md
+++ b/extensions/remote-session/README.md
@@ -18,7 +18,8 @@ published to npm). `extensions/claude-code-remote` is the reference consumer.
   busy semantics, `/steer` folding + `/stop`, presence, claim renewal, idle
   timeouts, inbound/outbound attachments, interim sends and final replies.
 - **Lifecycle** — `wireLifecycle` routes every process-death path through one
-  graceful teardown (presence offline + failing in-flight claims).
+  graceful teardown. Active delegation executions are aborted cooperatively and
+  live claims are released; shutdown waits briefly for release, then continues.
 
 ## What a connector implements
 

--- a/extensions/remote-session/src/delegation-client.test.ts
+++ b/extensions/remote-session/src/delegation-client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import { ThreaApiError } from "./client"
+import { DelegationClient, type InspectedDelegation } from "./delegation-client"
+
+const fetchSpy = spyOn(globalThis, "fetch")
+const client = new DelegationClient({ baseUrl: "https://example.test", workspaceId: "ws_1", apiKey: "key" })
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })
+}
+
+afterEach(() => fetchSpy.mockReset())
+
+describe("DelegationClient", () => {
+  it("inspects by id without exposing or sending a claim token", async () => {
+    fetchSpy.mockResolvedValue(
+      response(200, {
+        data: {
+          id: "dlg_1",
+          brief: "work",
+          contextRefs: ["msg_1"],
+          claimExpiresAt: "2026-07-12T10:15:00.000Z",
+        },
+      })
+    )
+    const result: InspectedDelegation = await client.get("dlg_1")
+    expect(result).toMatchObject({
+      id: "dlg_1",
+      brief: "work",
+      contextRefs: ["msg_1"],
+      claimExpiresAt: "2026-07-12T10:15:00.000Z",
+    })
+    expect(result).not.toHaveProperty("claimToken")
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(new URL(String(url)).pathname).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1")
+    expect((init as RequestInit).headers).not.toHaveProperty("X-Threa-Callback-Token")
+  })
+
+  it("releases with the callback token and no reason payload", async () => {
+    fetchSpy.mockResolvedValue(response(200, { data: { id: "dlg_1", status: "open" } }))
+    await client.release("dlg_1", "secret")
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(new URL(String(url)).pathname).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1/release")
+    expect(init).toMatchObject({
+      method: "POST",
+      body: "{}",
+      headers: { "X-Threa-Callback-Token": "secret" },
+    })
+  })
+
+  it("preserves structured 404 errors", async () => {
+    fetchSpy.mockResolvedValue(response(404, { code: "NOT_FOUND" }))
+    await expect(client.get("dlg_missing")).rejects.toEqual(new ThreaApiError("Threa API 404: ", 404, "NOT_FOUND"))
+  })
+})

--- a/extensions/remote-session/src/delegation-client.ts
+++ b/extensions/remote-session/src/delegation-client.ts
@@ -17,10 +17,15 @@ export interface DelegationSummary {
   statusChangedAt: string
 }
 
-/** The claim response: the executor's full working set plus the one-time token. */
-export interface ClaimedDelegation extends DelegationSummary {
+/** Inspect response: the full working set without claim credentials. */
+export interface InspectedDelegation extends DelegationSummary {
   brief: string
   contextRefs: string[]
+  claimExpiresAt?: string
+}
+
+/** The claim response: the executor's full working set plus the one-time token. */
+export interface ClaimedDelegation extends InspectedDelegation {
   /** Cleartext, returned exactly once — send it back as X-Threa-Callback-Token. */
   claimToken: string
   claimExpiresAt: string
@@ -86,6 +91,11 @@ export class DelegationClient {
     return data
   }
 
+  /** Inspect a delegation without claiming it. The response never contains claim credentials. */
+  async get(id: string): Promise<InspectedDelegation> {
+    return this.request(this.path(`/${encodeURIComponent(id)}`))
+  }
+
   /** Open delegations the key can access, oldest first. `since` narrows to a delta. */
   async listOpen(opts?: { since?: string }): Promise<DelegationSummary[]> {
     const query = opts?.since ? `?since=${encodeURIComponent(opts.since)}` : ""
@@ -102,6 +112,15 @@ export class DelegationClient {
     return this.request<ClaimedDelegation>(this.path(`/${id}/claim`), {
       method: "POST",
       body: JSON.stringify(body),
+    })
+  }
+
+  /** Release a live claim back to the open queue. */
+  async release(id: string, claimToken: string): Promise<DelegationSummary> {
+    return this.request(this.path(`/${encodeURIComponent(id)}/release`), {
+      method: "POST",
+      body: "{}",
+      claimToken,
     })
   }
 

--- a/extensions/remote-session/src/delegation-runner.test.ts
+++ b/extensions/remote-session/src/delegation-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, jest } from "bun:test"
 import { ThreaApiError } from "./client"
 import type { ClaimedDelegation, DelegationClient, DelegationSummary } from "./delegation-client"
 import { DELEGATION_STOP_REASON, DelegationRunner, type DelegationExecutor } from "./delegation-runner"
@@ -30,6 +30,7 @@ interface StubCalls {
   claims: Array<{ id: string; idempotencyKey?: string }>
   completes: Array<{ id: string; token: string; resultMarkdown?: string; metadata?: Record<string, string> }>
   fails: Array<{ id: string; token: string; errorMessage: string }>
+  releases: Array<{ id: string; token: string }>
   statuses: Array<{ id: string; note: string }>
   heartbeats: number
   accessRequests: string[]
@@ -48,6 +49,7 @@ function stubClient(overrides: {
     claims: [],
     completes: [],
     fails: [],
+    releases: [],
     statuses: [],
     heartbeats: 0,
     accessRequests: [],
@@ -85,6 +87,10 @@ function stubClient(overrides: {
       calls.fails.push({ id, token, errorMessage })
       if (overrides.failError) throw overrides.failError
       return { ...summary(id), status: "failed" }
+    },
+    release: async (id: string, token: string) => {
+      calls.releases.push({ id, token })
+      return { ...summary(id), status: "open" }
     },
     requestAccess: async (id: string) => {
       calls.accessRequests.push(id)
@@ -156,6 +162,36 @@ describe("DelegationRunner", () => {
 
     expect(calls.fails).toEqual([{ id: "dlg_1", token: "token-dlg_1", errorMessage: "build exploded" }])
     expect(calls.completes).toHaveLength(0)
+  })
+
+  it("contains a synchronous executor throw, clears its heartbeat, and continues draining", async () => {
+    jest.useFakeTimers()
+    try {
+      const { client, calls } = stubClient({
+        queue: [[summary("dlg_sync"), summary("dlg_next")], [summary("dlg_next")], []],
+      })
+      const runner = makeRunner(
+        client,
+        ((task: ClaimedDelegation) => {
+          if (task.id === "dlg_sync") throw new Error("sync exploded")
+          return Promise.resolve({ resultMarkdown: "done" })
+        }) as DelegationExecutor,
+        { heartbeatMs: 10 }
+      )
+
+      runner.start()
+      for (let index = 0; calls.listOpen < 3 && index < 100; index += 1) await Promise.resolve()
+
+      expect(calls.fails).toEqual([{ id: "dlg_sync", token: "token-dlg_sync", errorMessage: "sync exploded" }])
+      expect(calls.completes.map((call) => call.id)).toEqual(["dlg_next"])
+      expect(calls.releases).toEqual([])
+      jest.advanceTimersByTime(100)
+      await Promise.resolve()
+      expect(calls.heartbeats).toBe(0)
+      await runner.stop()
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it("skips quietly past lost claim races (409) and vanished tasks (404), claiming the next", async () => {
@@ -314,7 +350,7 @@ describe("DelegationRunner", () => {
       let releaseClaim!: (task: ClaimedDelegation) => void
       let claimStarted!: () => void
       const started = new Promise<void>((resolve) => (claimStarted = resolve))
-      const calls: StubCalls["fails"] = []
+      const calls: StubCalls["releases"] = []
       const client = {
         listOpen: async () => (trigger === "poll" ? [summary("dlg_race")] : []),
         claim: () =>
@@ -322,8 +358,8 @@ describe("DelegationRunner", () => {
             releaseClaim = resolve
             claimStarted()
           }),
-        fail: async (id: string, token: string, errorMessage: string) => {
-          calls.push({ id, token, errorMessage })
+        release: async (id: string, token: string) => {
+          calls.push({ id, token })
         },
       } as unknown as DelegationClient
       let executions = 0
@@ -340,7 +376,7 @@ describe("DelegationRunner", () => {
 
       expect({ executions, calls }).toEqual({
         executions: 0,
-        calls: [{ id: "dlg_race", token: "token-dlg_race", errorMessage: DELEGATION_STOP_REASON }],
+        calls: [{ id: "dlg_race", token: "token-dlg_race" }],
       })
     })
   }
@@ -359,7 +395,7 @@ describe("DelegationRunner", () => {
             releaseClaim = resolve
             claimStarted()
           }),
-        fail: async () => {
+        release: async () => {
           throw releaseError
         },
       } as unknown as DelegationClient
@@ -373,13 +409,13 @@ describe("DelegationRunner", () => {
 
       await expect(stopped).rejects.toBe(releaseError)
       expect(logs).toEqual([
-        `delegation dlg_race stop fail report failed: ${releaseError.message}`,
+        `delegation dlg_race release failed: ${releaseError.message}`,
         `delegation drain failed: ${releaseError.message}`,
       ])
     })
   }
 
-  it("normal shutdown stop clears an overlapping reconnect strict stop", async () => {
+  it("normal shutdown does not downgrade an overlapping strict stop", async () => {
     let releaseClaim!: (task: ClaimedDelegation) => void
     let claimStarted!: () => void
     const started = new Promise<void>((resolve) => (claimStarted = resolve))
@@ -391,7 +427,7 @@ describe("DelegationRunner", () => {
           releaseClaim = resolve
           claimStarted()
         }),
-      fail: async () => {
+      release: async () => {
         throw releaseError
       },
     } as unknown as DelegationClient
@@ -403,16 +439,82 @@ describe("DelegationRunner", () => {
     const shutdownStop = runner.stop()
     releaseClaim(claimed("dlg_race"))
 
-    await expect(reconnectStop).resolves.toBeUndefined()
+    await expect(reconnectStop).rejects.toBe(releaseError)
     await expect(shutdownStop).resolves.toBeUndefined()
   })
 
-  it("strict stop propagates a failed terminal fail for active work", async () => {
+  for (const phase of ["active", "pending"] as const) {
+    for (const order of ["normal-strict", "strict-normal"] as const) {
+      it(`${phase} overlapping stop applies policy per caller in ${order} order`, async () => {
+        let started!: () => void
+        const operationStarted = new Promise<void>((resolve) => (started = resolve))
+        const releaseError = new Error(`${phase} release failed`)
+        const client =
+          phase === "active"
+            ? {
+                listOpen: async () => [summary("dlg_overlap")],
+                claim: async () => claimed("dlg_overlap"),
+                release: async () => {
+                  throw releaseError
+                },
+              }
+            : {
+                listOpen: async () => [summary("dlg_overlap")],
+                claim: () => {
+                  started()
+                  return new Promise<never>(() => {})
+                },
+              }
+        const runner = makeRunner(
+          client as unknown as DelegationClient,
+          phase === "active"
+            ? async () => {
+                started()
+                return new Promise<never>(() => {})
+              }
+            : async () => {},
+          { shutdownWaitMs: phase === "pending" ? 5 : 100 }
+        )
+        runner.start()
+        await operationStarted
+        const firstStrict = order === "strict-normal"
+        const first = runner.stop(DELEGATION_STOP_REASON, { strict: firstStrict })
+        const second = runner.stop(DELEGATION_STOP_REASON, { strict: !firstStrict })
+        const strict = firstStrict ? first : second
+        const normal = firstStrict ? second : first
+
+        if (phase === "active") await expect(strict).rejects.toBe(releaseError)
+        else await expect(strict).rejects.toThrow("stop timed out after 5ms")
+        await expect(normal).resolves.toBeUndefined()
+      })
+    }
+  }
+
+  it("strict stop rejects on a pending claim timeout", async () => {
+    let started!: () => void
+    const claimStarted = new Promise<void>((resolve) => (started = resolve))
+    const client = {
+      listOpen: async () => [summary("dlg_pending")],
+      claim: () => {
+        started()
+        return new Promise<never>(() => {})
+      },
+    } as unknown as DelegationClient
+    const runner = makeRunner(client, async () => {}, { shutdownWaitMs: 5 })
+    runner.start()
+    await claimStarted
+    await expect(runner.stop(DELEGATION_STOP_REASON, { strict: true })).rejects.toThrow("stop timed out after 5ms")
+  })
+
+  it("strict stop propagates a failed release for active work", async () => {
     let rejectExecution!: (error: Error) => void
     let executionStarted!: () => void
     const started = new Promise<void>((resolve) => (executionStarted = resolve))
-    const releaseError = new Error("terminal fail 500")
-    const { client } = stubClient({ queue: [[summary("dlg_active")]], failError: releaseError })
+    const releaseError = new Error("release 500")
+    const { client } = stubClient({ queue: [[summary("dlg_active")]] })
+    client.release = async () => {
+      throw releaseError
+    }
     const runner = makeRunner(
       client,
       () =>
@@ -428,6 +530,283 @@ describe("DelegationRunner", () => {
     rejectExecution(new Error("reconnect"))
 
     await expect(stopped).rejects.toBe(releaseError)
+  })
+
+  it("releases a stale pre-stop claim after restart without executing it", async () => {
+    let resolveOld!: (task: ClaimedDelegation) => void
+    let listCount = 0
+    const releases: Array<{ id: string; token: string }> = []
+    const executions: string[] = []
+    const client = {
+      listOpen: async () => {
+        listCount += 1
+        if (listCount === 1) return [summary("dlg_old")]
+        if (listCount === 2) return [summary("dlg_new")]
+        return []
+      },
+      claim: async (id: string) =>
+        id === "dlg_old" ? new Promise<ClaimedDelegation>((resolve) => (resolveOld = resolve)) : claimed(id),
+      release: async (id: string, token: string) => {
+        releases.push({ id, token })
+      },
+      complete: async () => summary("done"),
+    } as unknown as DelegationClient
+    const runner = makeRunner(
+      client,
+      async (task) => {
+        executions.push(task.id)
+      },
+      { shutdownWaitMs: 5 }
+    )
+
+    runner.start()
+    await flush()
+    await runner.stop()
+    runner.start()
+    await flush()
+    resolveOld(claimed("dlg_old"))
+    await flush()
+    await runner.stop()
+
+    expect(executions).toEqual(["dlg_new"])
+    expect(releases).toEqual([{ id: "dlg_old", token: "token-dlg_old" }])
+  })
+
+  it("detaches a stopped non-cooperative executor and clears its heartbeat before restart", async () => {
+    let listCount = 0
+    let heartbeats = 0
+    const completes: string[] = []
+    const fails: string[] = []
+    const client = {
+      listOpen: async () => {
+        listCount += 1
+        if (listCount === 1) return [summary("dlg_stuck")]
+        if (listCount === 2) return [summary("dlg_new")]
+        return []
+      },
+      claim: async (id: string) => claimed(id),
+      heartbeat: async () => {
+        heartbeats += 1
+      },
+      release: () => new Promise<never>(() => {}),
+      complete: async (id: string) => {
+        completes.push(id)
+        return summary(id)
+      },
+      fail: async (id: string) => {
+        fails.push(id)
+        return summary(id)
+      },
+    } as unknown as DelegationClient
+    const runner = makeRunner(
+      client,
+      async (task) => {
+        if (task.id === "dlg_stuck") return new Promise<never>(() => {})
+        return { resultMarkdown: "done" }
+      },
+      { heartbeatMs: 2, shutdownWaitMs: 5 }
+    )
+
+    runner.start()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await runner.stop()
+    const stoppedHeartbeatCount = heartbeats
+    runner.start()
+    await flush()
+    await runner.stop()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(heartbeats).toBe(stoppedHeartbeatCount)
+    expect(completes).toEqual(["dlg_new"])
+    expect(fails).toEqual([])
+  })
+
+  it("aborts on heartbeat 404 and never completes or releases the lost claim", async () => {
+    const { client, calls } = stubClient({ queue: [[summary("dlg_lost")], []] })
+    client.heartbeat = async () => {
+      calls.heartbeats += 1
+      throw new ThreaApiError("lost", 404, "NOT_FOUND")
+    }
+    let aborted = false
+    const runner = makeRunner(
+      client,
+      async (_task, ctx) => {
+        await new Promise<void>((resolve) =>
+          ctx.signal.addEventListener(
+            "abort",
+            () => {
+              aborted = true
+              resolve()
+            },
+            { once: true }
+          )
+        )
+        return { resultMarkdown: "must not complete" }
+      },
+      { heartbeatMs: 5 }
+    )
+    runner.start()
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    await runner.stop()
+    expect({ aborted, completes: calls.completes, fails: calls.fails, releases: calls.releases }).toEqual({
+      aborted: true,
+      completes: [],
+      fails: [],
+      releases: [],
+    })
+  })
+
+  it("aborts on status-report 404 and suppresses terminal writes", async () => {
+    const { client, calls } = stubClient({ queue: [[summary("dlg_lost")], []] })
+    client.reportStatus = async () => {
+      throw new ThreaApiError("lost", 404, "NOT_FOUND")
+    }
+    const runner = makeRunner(client, async (_task, ctx) => {
+      await ctx.reportStatus("working")
+      return { resultMarkdown: "must not complete" }
+    })
+    runner.start()
+    await flush()
+    await runner.stop()
+    expect({ completes: calls.completes, fails: calls.fails, releases: calls.releases }).toEqual({
+      completes: [],
+      fails: [],
+      releases: [],
+    })
+  })
+
+  for (const failure of [new ThreaApiError("unavailable", 500, "INTERNAL"), new Error("network unavailable")]) {
+    const label = failure instanceof ThreaApiError ? "API 500" : "network error"
+    it(`keeps executing after a transient status-report ${label}`, async () => {
+      const { client, calls } = stubClient({ queue: [[summary("dlg_live")], []] })
+      client.reportStatus = async () => {
+        throw failure
+      }
+      const runner = makeRunner(client, async (_task, ctx) => {
+        await ctx.reportStatus("working")
+        return { resultMarkdown: "done" }
+      })
+      runner.start()
+      await flush()
+      await runner.stop()
+      expect({
+        completes: calls.completes.map((call) => call.id),
+        fails: calls.fails,
+        releases: calls.releases,
+      }).toEqual({
+        completes: ["dlg_live"],
+        fails: [],
+        releases: [],
+      })
+    })
+
+    it(`keeps executing after a transient heartbeat ${label}`, async () => {
+      const { client, calls } = stubClient({ queue: [[summary("dlg_live")], []] })
+      client.heartbeat = async () => {
+        calls.heartbeats += 1
+        throw failure
+      }
+      const runner = makeRunner(
+        client,
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          return { resultMarkdown: "done" }
+        },
+        { heartbeatMs: 5 }
+      )
+      runner.start()
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      await runner.stop()
+      expect({
+        completes: calls.completes.map((call) => call.id),
+        fails: calls.fails,
+        releases: calls.releases,
+      }).toEqual({
+        completes: ["dlg_live"],
+        fails: [],
+        releases: [],
+      })
+    })
+  }
+
+  for (const trigger of ["heartbeat", "status"] as const) {
+    for (const late of ["resolve", "reject"] as const) {
+      it(`drains after ${trigger} 404 with a non-cooperative executor and safely consumes late ${late}`, async () => {
+        let settleOld!: (value?: { resultMarkdown: string }) => void
+        let rejectOld!: (error: Error) => void
+        let listCount = 0
+        const completes: string[] = []
+        const fails: string[] = []
+        const releases: string[] = []
+        const client = {
+          listOpen: async () => {
+            listCount += 1
+            if (listCount === 1) return [summary("dlg_old")]
+            if (listCount === 2) return [summary("dlg_new")]
+            return []
+          },
+          claim: async (id: string) => claimed(id),
+          heartbeat: async (id: string) => {
+            if (trigger === "heartbeat" && id === "dlg_old") throw new ThreaApiError("lost", 404, "NOT_FOUND")
+          },
+          reportStatus: async (id: string) => {
+            if (trigger === "status" && id === "dlg_old") throw new ThreaApiError("lost", 404, "NOT_FOUND")
+          },
+          complete: async (id: string) => {
+            completes.push(id)
+            return summary(id)
+          },
+          fail: async (id: string) => {
+            fails.push(id)
+            return summary(id)
+          },
+          release: async (id: string) => {
+            releases.push(id)
+            return summary(id)
+          },
+        } as unknown as DelegationClient
+        const runner = makeRunner(
+          client,
+          async (task, ctx) => {
+            if (task.id === "dlg_new") return { resultMarkdown: "done" }
+            if (trigger === "status") await ctx.reportStatus("working")
+            return new Promise((resolve, reject) => {
+              settleOld = resolve
+              rejectOld = reject
+            })
+          },
+          { heartbeatMs: 2 }
+        )
+
+        runner.start()
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        expect(completes).toEqual(["dlg_new"])
+        if (late === "resolve") settleOld({ resultMarkdown: "stale" })
+        else rejectOld(new Error("late failure"))
+        await flush()
+        await runner.stop()
+        expect({ completes, fails, releases }).toEqual({ completes: ["dlg_new"], fails: [], releases: [] })
+      })
+    }
+  }
+
+  it("controlled stop aborts active work and releases instead of completing or failing", async () => {
+    const { client, calls } = stubClient({ queue: [[summary("dlg_active")], []] })
+    let started!: () => void
+    const executionStarted = new Promise<void>((resolve) => (started = resolve))
+    const runner = makeRunner(client, async (_task, ctx) => {
+      started()
+      await new Promise<void>((resolve) => ctx.signal.addEventListener("abort", () => resolve(), { once: true }))
+      return { resultMarkdown: "must not complete" }
+    })
+    runner.start()
+    await executionStarted
+    await runner.stop()
+    expect({ completes: calls.completes, fails: calls.fails, releases: calls.releases }).toEqual({
+      completes: [],
+      fails: [],
+      releases: [{ id: "dlg_active", token: "token-dlg_active" }],
+    })
   })
 
   it("does nothing after stop()", async () => {

--- a/extensions/remote-session/src/delegation-runner.ts
+++ b/extensions/remote-session/src/delegation-runner.ts
@@ -2,24 +2,17 @@ import { ThreaApiError } from "./client"
 import type { ClaimedDelegation, DelegationClient, DelegationSummary } from "./delegation-client"
 
 const DEFAULT_POLL_MS = 60_000
-/** Inside the server's 15-minute lease with two retries' worth of slack. */
 const DEFAULT_HEARTBEAT_MS = 5 * 60 * 1000
-/** The server's `errorMessage` validator cap (public-api schemas). */
 const FAIL_MESSAGE_MAX = 1_000
-/** The server's `statusNote` validator cap. */
 const STATUS_NOTE_MAX = 2_000
-export const DELEGATION_STOP_REASON = "Delegation runner stopped for reconnect or shutdown"
+const SHUTDOWN_WAIT_MS = 2_000
+export const DELEGATION_STOP_REASON = "runner_shutdown"
 
 export interface DelegationExecutorContext {
-  /** Put a progress note on the card (also renews the lease). Best-effort. */
+  signal: AbortSignal
   reportStatus(note: string): Promise<void>
 }
 
-/**
- * The connector's only contribution: run the brief, return the result. Throw
- * to fail the delegation with the error's message. Returning nothing completes
- * without a result message.
- */
 export type DelegationExecutor = (
   task: ClaimedDelegation,
   ctx: DelegationExecutorContext
@@ -28,34 +21,28 @@ export type DelegationExecutor = (
 export interface DelegationRunnerOptions {
   client: DelegationClient
   executor: DelegationExecutor
-  /** Shown on the card while this runner holds the claim, e.g. "Kris's MacBook / Claude Code". */
   claimedByLabel: string
-  /**
-   * Durable-write hook for the claim idempotency key, awaited BEFORE the claim
-   * request — persist it and a crash between the claim response and saving the
-   * one-time token is recoverable (retrying with the key re-keys the claim).
-   * Default: in-memory only (no crash recovery, still correct).
-   */
   persistIdempotencyKey?: (delegationId: string, key: string) => void | Promise<void>
-  /** Fallback poll interval. With a socket nudge wired, this is only a backstop. Default 60s. */
   pollMs?: number
-  /** Lease renewal interval. Default 5 minutes against the 15-minute lease. */
   heartbeatMs?: number
+  /** Maximum controlled-stop wait. Primarily useful to bound host reconnects. */
+  shutdownWaitMs?: number
   log?: (message: string) => void
 }
 
-/**
- * Drains the delegation queue for one runner (roadmap 5.4): nudge-or-poll →
- * claim → heartbeat → executor → complete/fail. The simple cousin of
- * `RemoteSession`'s claim drain — one delegation at a time, no busy-capability
- * split, no sealed variant (delegations never exist on E2E streams).
- *
- * Delivery: call `notifyAvailable()` from a `delegation:available` socket
- * nudge (`BotRuntimeTransport.onDelegationAvailable`) for instant pickup; the
- * poll timer is the headless fallback and the backstop for missed nudges.
- * Racing runners are safe by construction — the claim CAS picks one winner and
- * the rest see 409 and go back to sleep.
- */
+type ActiveClaim = {
+  task: ClaimedDelegation
+  generation: number
+  controller: AbortController
+  lost: boolean
+  settleLost: () => void
+  lostPromise: Promise<void>
+  release?: Promise<void>
+  cleanupHeartbeat?: () => void
+}
+
+type Drain = { generation: number; promise: Promise<void> }
+
 export class DelegationRunner {
   private readonly client: DelegationClient
   private readonly executor: DelegationExecutor
@@ -63,23 +50,16 @@ export class DelegationRunner {
   private readonly persistIdempotencyKey?: DelegationRunnerOptions["persistIdempotencyKey"]
   private readonly pollMs: number
   private readonly heartbeatMs: number
+  private readonly shutdownWaitMs: number
   private readonly log: (message: string) => void
 
   private stopped = true
-  private stopReason = DELEGATION_STOP_REASON
-  private strictStop = false
-  /** The in-flight drain, when one is running — the single-flight latch. */
-  private current: Promise<void> | undefined
+  private generation = 0
+  private current: Drain | undefined
+  private stopOperation: Drain | undefined
   private pollTimer: ReturnType<typeof setInterval> | undefined
-  /**
-   * Delegation ids carried by `delegation:available` nudges. A bot without a
-   * stream grant never sees these in `listOpen`, so the drain claims them
-   * directly by id; on a 404 (no grant) it files an access request. Cleared
-   * once the id is claimed, taken by another runner (409), or its request is
-   * filed.
-   */
+  private active: ActiveClaim | undefined
   private readonly pendingNudged = new Set<string>()
-  /** Delegation ids we have already filed an access request for — file once per lifetime. */
   private readonly accessRequested = new Set<string>()
 
   constructor(opts: DelegationRunnerOptions) {
@@ -89,96 +69,103 @@ export class DelegationRunner {
     this.persistIdempotencyKey = opts.persistIdempotencyKey
     this.pollMs = opts.pollMs ?? DEFAULT_POLL_MS
     this.heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS
+    this.shutdownWaitMs = opts.shutdownWaitMs ?? SHUTDOWN_WAIT_MS
     this.log = opts.log ?? (() => {})
   }
 
   start(): void {
     if (!this.stopped) return
     this.stopped = false
-    this.stopReason = DELEGATION_STOP_REASON
-    this.strictStop = false
-    this.pollTimer = setInterval(() => this.drain(), this.pollMs)
-    this.drain()
+    this.generation += 1
+    const generation = this.generation
+    this.pollTimer = setInterval(() => this.drain(generation), this.pollMs)
+    this.drain(generation)
   }
 
-  /**
-   * Resolves once the in-flight drain (if any) has finished, so a graceful
-   * shutdown can reject its executor and still see the fail report posted.
-   */
-  stop(reason = DELEGATION_STOP_REASON, options?: { strict?: boolean }): Promise<void> {
-    this.stopped = true
-    this.stopReason = reason
-    this.strictStop = options?.strict ?? false
+  async stop(_reason = DELEGATION_STOP_REASON, options?: { strict?: boolean }): Promise<void> {
+    if (!this.stopped) this.stopped = true
+    const generation = this.generation
     if (this.pollTimer) clearInterval(this.pollTimer)
     this.pollTimer = undefined
-    return this.current ?? Promise.resolve()
+
+    const active = this.active?.generation === generation ? this.active : undefined
+    active?.cleanupHeartbeat?.()
+    active?.controller.abort()
+    let pending = this.stopOperation?.generation === generation ? this.stopOperation.promise : undefined
+    if (!pending) {
+      const release = active && !active.lost ? this.releaseActive(active) : undefined
+      pending = release ?? (this.current?.generation === generation ? this.current.promise : Promise.resolve())
+      this.stopOperation = { generation, promise: pending }
+    }
+
+    if (this.current?.generation === generation) this.current = undefined
+    if (this.active === active) this.active = undefined
+
+    const timeoutError = new Error(`delegation runner stop timed out after ${this.shutdownWaitMs}ms`)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(timeoutError), this.shutdownWaitMs)
+    })
+    try {
+      if (options?.strict) await Promise.race([pending, timeout])
+      else await Promise.race([pending.catch(() => undefined), timeout.catch(() => undefined)])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
   }
 
-  /**
-   * Wire this to the `delegation:available` socket nudge for instant pickup. A
-   * nudge carries the delegation id; a bot lacking the stream grant never sees
-   * that id in `listOpen`, so it is tracked for a direct claim-by-id (which, on
-   * a 404, files an access request).
-   */
   notifyAvailable(nudge?: { delegationId?: string }): void {
     if (nudge?.delegationId) this.pendingNudged.add(nudge.delegationId)
-    this.drain()
+    this.drain(this.generation)
   }
 
-  /**
-   * Single-flight queue drain. While a delegation is executing, nudges and
-   * poll ticks fall through — the re-list after each completion picks up
-   * whatever accumulated, so nothing is lost, just serialized.
-   */
-  private drain(): void {
-    if (this.stopped || this.current) return
-    this.current = this.runDrain().finally(() => {
-      this.current = undefined
+  private isCurrent(generation: number): boolean {
+    return !this.stopped && this.generation === generation
+  }
+
+  private drain(generation: number): void {
+    if (!this.isCurrent(generation) || this.current?.generation === generation) return
+    const promise = this.runDrain(generation).finally(() => {
+      if (this.current?.promise === promise) this.current = undefined
+    })
+    this.current = { generation, promise }
+    void promise.catch((error) => {
+      this.log(`delegation drain failed: ${error instanceof Error ? error.message : String(error)}`)
     })
   }
 
-  private async runDrain(): Promise<void> {
-    try {
-      let executed = true
-      while (executed && !this.stopped) {
-        executed = false
-        const open = await this.client.listOpen()
-        // A listable id is one the bot can already access — the list path owns
-        // it, so drop it from the nudge-tracked set (no access request needed).
-        for (const summary of open) this.pendingNudged.delete(summary.id)
-        for (const summary of open) {
-          if (this.stopped) return
-          const claimed = await this.tryClaim(summary)
-          if (!claimed) continue
-          if (this.stopped) {
-            await this.releaseStoppedClaim(claimed)
-            return
-          }
-          await this.execute(claimed)
-          // One at a time: after finishing, re-list rather than working a
-          // possibly-stale snapshot of the queue.
-          executed = true
-          break
+  private async runDrain(generation: number): Promise<void> {
+    let executed = true
+    while (executed && this.isCurrent(generation)) {
+      executed = false
+      const open = await this.client.listOpen()
+      if (!this.isCurrent(generation)) return
+      for (const summary of open) this.pendingNudged.delete(summary.id)
+      for (const summary of open) {
+        if (!this.isCurrent(generation)) return
+        const claimed = await this.tryClaim(summary)
+        if (!claimed) continue
+        if (!this.isCurrent(generation)) {
+          await this.releaseStoppedClaim(claimed, generation)
+          return
         }
-        if (executed) continue
-        // Nudge-carried ids the bot cannot see in the list (no stream grant):
-        // claim directly; a 404 files an access request once per id.
-        for (const id of [...this.pendingNudged]) {
-          if (this.stopped) return
-          const claimed = await this.tryClaimNudged(id)
-          if (!claimed) continue
-          if (this.stopped) {
-            await this.releaseStoppedClaim(claimed)
-            return
-          }
-          await this.execute(claimed)
-          executed = true
-          break
-        }
+        await this.execute(claimed, generation)
+        executed = true
+        break
       }
-    } catch (error) {
-      this.log(`delegation drain failed: ${error instanceof Error ? error.message : String(error)}`)
-      if (this.stopped && this.strictStop) throw error
+      if (executed) continue
+      for (const id of [...this.pendingNudged]) {
+        if (!this.isCurrent(generation)) return
+        const claimed = await this.tryClaimNudged(id)
+        if (!claimed) continue
+        if (!this.isCurrent(generation)) {
+          await this.releaseStoppedClaim(claimed, generation)
+          return
+        }
+        await this.execute(claimed, generation)
+        executed = true
+        break
+      }
     }
   }
 
@@ -188,20 +175,11 @@ export class DelegationRunner {
     try {
       return await this.client.claim(summary.id, { claimedByLabel: this.claimedByLabel, idempotencyKey })
     } catch (error) {
-      // 409: another runner won; 404: it vanished (cancelled) or we lost
-      // access. Both mean "not ours" — move on quietly.
       if (error instanceof ThreaApiError && (error.status === 409 || error.status === 404)) return null
       throw error
     }
   }
 
-  /**
-   * Claim a nudge-carried id directly. Unlike {@link tryClaim}, a 404 here means
-   * "no stream grant" (the bot never saw this id in the list), so it files an
-   * access request instead of silently moving on. Any terminal outcome —
-   * claimed, taken by another runner (409), or request filed (404) — clears the
-   * id from the nudge-tracked set.
-   */
   private async tryClaimNudged(id: string): Promise<ClaimedDelegation | null> {
     const idempotencyKey = crypto.randomUUID()
     await this.persistIdempotencyKey?.(id, idempotencyKey)
@@ -223,19 +201,10 @@ export class DelegationRunner {
     }
   }
 
-  /**
-   * File an access request for a delegation the bot cannot claim, at most once
-   * per id per runner lifetime. Best-effort: a failed request is logged and
-   * swallowed — the runner must never crash on it (a re-nudge retries the claim
-   * and, since the id is already marked, files nothing further).
-   */
   private async requestAccessOnce(id: string): Promise<void> {
     if (this.accessRequested.has(id)) return
     try {
       await this.client.requestAccess(id, { requestedByLabel: this.claimedByLabel })
-      // Mark AFTER success: a transient failure must stay retryable on the next
-      // nudge or the card is silently never filed — the failure F3 exists to
-      // fix. The server insert is idempotent, so a duplicate attempt is safe.
       this.accessRequested.add(id)
       this.log(`delegation ${id} not claimable (no access) — filed an access request`)
     } catch (error) {
@@ -243,59 +212,104 @@ export class DelegationRunner {
     }
   }
 
-  private async releaseStoppedClaim(task: ClaimedDelegation): Promise<void> {
-    try {
-      await this.client.fail(task.id, task.claimToken, this.stopReason)
-    } catch (error) {
-      this.log(
-        `delegation ${task.id} stop fail report failed: ${error instanceof Error ? error.message : String(error)}`
-      )
-      if (this.strictStop) throw error
-    }
+  private async releaseStoppedClaim(task: ClaimedDelegation, generation: number): Promise<void> {
+    const active = this.createActiveClaim(task, generation)
+    await this.releaseActive(active)
   }
 
-  private async execute(task: ClaimedDelegation): Promise<void> {
+  private createActiveClaim(task: ClaimedDelegation, generation: number): ActiveClaim {
+    let settleLost!: () => void
+    const lostPromise = new Promise<void>((resolve) => (settleLost = resolve))
+    return { task, generation, controller: new AbortController(), lost: false, settleLost, lostPromise }
+  }
+
+  private releaseActive(active: ActiveClaim): Promise<void> {
+    if (active.release) return active.release
+    const release = this.client.release(active.task.id, active.task.claimToken).then(() => undefined)
+    active.release = release
+    void release.catch((error) => {
+      this.log(`delegation ${active.task.id} release failed: ${error instanceof Error ? error.message : String(error)}`)
+    })
+    return release
+  }
+
+  private async execute(task: ClaimedDelegation, generation: number): Promise<void> {
     const { id, claimToken } = task
-    const heartbeat = setInterval(() => {
-      this.client.heartbeat(id, claimToken).catch((error) => {
-        // A 404 means the claim is gone (cancelled under us, or expired); the
-        // terminal complete/fail below will surface the same 404. Nothing to
-        // do mid-execution — the executor cannot be safely interrupted.
-        this.log(`delegation ${id} heartbeat failed: ${error instanceof Error ? error.message : String(error)}`)
-      })
+    const active = this.createActiveClaim(task, generation)
+    this.active = active
+    let heartbeatBusy = false
+    const cleanupHeartbeat = () => {
+      if (!active.cleanupHeartbeat) return
+      active.cleanupHeartbeat = undefined
+      clearInterval(heartbeat)
+    }
+    const loseClaim = () => {
+      if (active.lost) return
+      active.lost = true
+      cleanupHeartbeat()
+      active.controller.abort()
+      active.settleLost()
+    }
+    const handleLifecycleError = (kind: string, error: unknown) => {
+      if (error instanceof ThreaApiError && error.status === 404) loseClaim()
+      this.log(`delegation ${id} ${kind} failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    const heartbeat = setInterval(async () => {
+      if (heartbeatBusy || active.lost || active.controller.signal.aborted) return
+      heartbeatBusy = true
+      try {
+        await this.client.heartbeat(id, claimToken)
+      } catch (error) {
+        handleLifecycleError("heartbeat", error)
+      } finally {
+        heartbeatBusy = false
+      }
     }, this.heartbeatMs)
+    active.cleanupHeartbeat = cleanupHeartbeat
 
     const ctx: DelegationExecutorContext = {
+      signal: active.controller.signal,
       reportStatus: async (note: string) => {
+        if (active.lost || active.controller.signal.aborted) return
         try {
           await this.client.reportStatus(id, claimToken, note.slice(0, STATUS_NOTE_MAX))
         } catch (error) {
-          this.log(`delegation ${id} status report failed: ${error instanceof Error ? error.message : String(error)}`)
+          handleLifecycleError("status report", error)
         }
       },
     }
 
+    const execution = Promise.resolve()
+      .then(() => this.executor(task, ctx))
+      .then(
+        (result) => ({ kind: "result" as const, result }),
+        (error: unknown) => ({ kind: "error" as const, error })
+      )
     try {
-      const result = await this.executor(task, ctx)
+      const outcome = await Promise.race([execution, active.lostPromise.then(() => ({ kind: "lost" as const }))])
+      if (outcome.kind === "lost") return
+      if (active.lost || active.controller.signal.aborted || !this.isCurrent(generation) || this.active !== active)
+        return
+      if (outcome.kind === "error") throw outcome.error
       await this.client.complete(id, claimToken, {
-        resultMarkdown: result?.resultMarkdown,
-        metadata: result?.metadata,
+        resultMarkdown: outcome.result?.resultMarkdown,
+        metadata: outcome.result?.metadata,
       })
       this.log(`delegation ${id} completed`)
     } catch (error) {
+      if (active.lost || active.controller.signal.aborted || !this.isCurrent(generation) || this.active !== active)
+        return
       const message = (error instanceof Error ? error.message : String(error)).slice(0, FAIL_MESSAGE_MAX)
       try {
         await this.client.fail(id, claimToken, message || "Delegation runner failed without a message")
       } catch (failError) {
         this.log(
-          `delegation ${id} failed AND the fail report failed: ${
-            failError instanceof Error ? failError.message : String(failError)
-          }`
+          `delegation ${id} failed AND the fail report failed: ${failError instanceof Error ? failError.message : String(failError)}`
         )
-        if (this.stopped && this.strictStop) throw failError
       }
     } finally {
-      clearInterval(heartbeat)
+      cleanupHeartbeat()
+      if (this.active === active) this.active = undefined
     }
   }
 }

--- a/extensions/remote-session/src/index.ts
+++ b/extensions/remote-session/src/index.ts
@@ -57,6 +57,7 @@ export {
   DelegationClient,
   type DelegationClientOptions,
   type DelegationSummary,
+  type InspectedDelegation,
   type ClaimedDelegation,
 } from "./delegation-client"
 export {

--- a/packages/cli/src/commands/delegations.test.ts
+++ b/packages/cli/src/commands/delegations.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { run } from "../cli"
 import { jsonResponse, TEST_CONFIG } from "../test-support"
+import { TokenStore } from "../token-store"
 
 const fetchSpy = spyOn(globalThis, "fetch")
 
@@ -37,6 +38,88 @@ function callbackHeader(index: number): string | undefined {
 function bodyOf(index: number): Record<string, unknown> {
   return JSON.parse(String((fetchSpy.mock.calls[index]![1] as RequestInit).body)) as Record<string, unknown>
 }
+
+test("get inspects the full delegation without writing token state", async () => {
+  fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "dlg_1", brief: "do it", contextRefs: ["msg_1"] } }))
+  const result = await run(["delegations", "get", "dlg_1", "--json"], { config: TEST_CONFIG })
+  expect(result.exitCode).toBe(0)
+  expect(pathOf(0)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1")
+  expect(JSON.parse(result.stdout)).toEqual({ data: { id: "dlg_1", brief: "do it", contextRefs: ["msg_1"] } })
+  expect(existsSync(statePath)).toBe(false)
+})
+
+test("release uses stored token and clears it only after success", async () => {
+  fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", claimToken: "tok_stored" } }))
+  await run(["delegations", "claim", "dlg_1", "--label", "runner"], { config: TEST_CONFIG })
+  fetchSpy.mockResolvedValueOnce(jsonResponse(500, { code: "INTERNAL" }))
+  expect((await run(["delegations", "release", "dlg_1"], { config: TEST_CONFIG })).exitCode).toBe(1)
+  fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", status: "open" } }))
+  expect(
+    (await run(["delegations", "release", "dlg_1", "--claim-token", "tok_explicit"], { config: TEST_CONFIG })).exitCode
+  ).toBe(0)
+  expect(callbackHeader(1)).toBe("tok_stored")
+  expect(callbackHeader(2)).toBe("tok_explicit")
+  const state = JSON.parse(readFileSync(statePath, "utf8")) as { claimTokens: Record<string, unknown> }
+  expect(state.claimTokens.ws_1).toEqual({ dlg_1: "tok_stored" })
+})
+
+test("a delayed release response does not delete a replacement claim token", async () => {
+  const store = new TokenStore(statePath)
+  store.set("ws_1", "dlg_1", "tok_old")
+  let resolveResponse!: (response: Response) => void
+  fetchSpy.mockImplementationOnce(
+    (() => new Promise<Response>((resolve) => (resolveResponse = resolve))) as unknown as typeof fetch
+  )
+
+  const releasing = run(["delegations", "release", "dlg_1"], { config: TEST_CONFIG, tokenStore: store })
+  while (fetchSpy.mock.calls.length === 0) await Promise.resolve()
+  new TokenStore(statePath).set("ws_1", "dlg_1", "tok_new")
+  resolveResponse(jsonResponse(200, { data: { id: "dlg_1", status: "open" } }))
+
+  expect((await releasing).exitCode).toBe(0)
+  expect(new TokenStore(statePath).get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("a delayed explicit-token release does not delete another store's replacement token", async () => {
+  new TokenStore(statePath).set("ws_1", "dlg_1", "tok_stored")
+  let resolveResponse!: (response: Response) => void
+  fetchSpy.mockImplementationOnce(
+    (() => new Promise<Response>((resolve) => (resolveResponse = resolve))) as unknown as typeof fetch
+  )
+
+  const releasing = run(["delegations", "release", "dlg_1", "--claim-token", "tok_explicit_old"], {
+    config: TEST_CONFIG,
+    tokenStore: new TokenStore(statePath),
+  })
+  while (fetchSpy.mock.calls.length === 0) await Promise.resolve()
+  new TokenStore(statePath).set("ws_1", "dlg_1", "tok_new")
+  resolveResponse(jsonResponse(200, { data: { id: "dlg_1", status: "open" } }))
+
+  expect((await releasing).exitCode).toBe(0)
+  expect(new TokenStore(statePath).get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("a loaded shared-head store resolves a token written by another process for lifecycle calls", async () => {
+  const sharedHead = new TokenStore(statePath)
+  expect(sharedHead.get("ws_1", "dlg_1")).toBeUndefined()
+  new TokenStore(statePath).set("ws_1", "dlg_1", "tok_shared")
+  fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "dlg_1", status: "running" } }))
+
+  const result = await run(["delegations", "update", "dlg_1", "--note", "working"], {
+    config: TEST_CONFIG,
+    tokenStore: sharedHead,
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(callbackHeader(0)).toBe("tok_shared")
+})
+
+test("release without a token fails before HTTP", async () => {
+  const result = await run(["delegations", "release", "dlg_1"], { config: TEST_CONFIG })
+  expect(result.exitCode).toBe(1)
+  expect((JSON.parse(result.stderr) as { code: string }).code).toBe("MISSING_CLAIM_TOKEN")
+  expect(fetchSpy).not.toHaveBeenCalled()
+})
 
 test("claim persists the token to the state file and prints it in the result", async () => {
   fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "dlg_1", brief: "do it", claimToken: "tok_secret" } }))

--- a/packages/cli/src/commands/delegations.ts
+++ b/packages/cli/src/commands/delegations.ts
@@ -2,7 +2,9 @@ import {
   claimDelegation,
   finishDelegation,
   finishDelegationArgError,
+  getDelegation,
   listDelegations,
+  releaseDelegation,
   requestDelegationAccess,
   updateDelegation,
 } from "../ops"
@@ -30,13 +32,13 @@ function renderLifecycle(payload: unknown): string {
 
 const listVerb: VerbSpec = {
   name: "list",
-  summary: "List open delegations; --since iso returns only tasks after that instant",
+  summary: "List open delegations; --since iso returns availability changes after that instant",
   usage: "threa delegations list [--since iso]",
   help:
     "threa delegations list [flags]\n\n" +
     "List open delegations. Pass --since to poll for a cheap delta.\n\n" +
     "Flags:\n" +
-    "  --since iso   tasks created after this ISO-8601 instant\n" +
+    "  --since iso   tasks whose availability changed after this ISO-8601 instant\n" +
     "  --json        force JSON output\n" +
     "  --help        show this help",
   options: {
@@ -50,6 +52,20 @@ const listVerb: VerbSpec = {
       { empty: "(no open delegations)" }
     )
   },
+}
+
+const getVerb: VerbSpec = {
+  name: "get",
+  summary: "Inspect a delegation's brief and context before claiming it",
+  usage: "threa delegations get <id>",
+  help: "threa delegations get <id> [--json]\n\nInspect a delegation without claiming it.\n",
+  options: {},
+  run: (ctx, positionals) => {
+    const id = positionals[0]
+    if (!id) throw new UsageError("delegations get requires a <delegation-id>")
+    return getDelegation(ctx.client, id)
+  },
+  render: (payload) => JSON.stringify(payload, null, 2),
 }
 
 const claimVerb: VerbSpec = {
@@ -78,6 +94,25 @@ const claimVerb: VerbSpec = {
       delegationId: id,
       claimedByLabel: label,
       idempotencyKey: stringFlag(values, "idempotency-key"),
+    })
+  },
+  render: renderLifecycle,
+}
+
+const releaseVerb: VerbSpec = {
+  name: "release",
+  summary: "Release a live claim back to the open queue",
+  usage: "threa delegations release <id> [--claim-token t]",
+  help:
+    "threa delegations release <id> [flags]\n\nRelease a live claim. The stored token is cleared only after success.\n\n" +
+    "Flags:\n  --claim-token t    override the stored token\n  --json             force JSON output\n  --help             show this help",
+  options: { "claim-token": { type: "string" } },
+  run: (ctx, positionals, values) => {
+    const id = positionals[0]
+    if (!id) throw new UsageError("delegations release requires a <delegation-id>")
+    return releaseDelegation(ctx.client, ctx.tokenStore, ctx.config.workspaceId, {
+      delegationId: id,
+      claimToken: stringFlag(values, "claim-token"),
     })
   },
   render: renderLifecycle,
@@ -180,5 +215,5 @@ const requestAccessVerb: VerbSpec = {
 export const delegationsNoun: NounSpec = {
   name: "delegations",
   summary: "Run the delegation lifecycle end to end",
-  verbs: [listVerb, claimVerb, updateVerb, finishVerb, requestAccessVerb],
+  verbs: [listVerb, getVerb, claimVerb, releaseVerb, updateVerb, finishVerb, requestAccessVerb],
 }

--- a/packages/cli/src/ops.ts
+++ b/packages/cli/src/ops.ts
@@ -389,6 +389,10 @@ export function listDelegations(client: ThreaApiClient, p: ListDelegationsParams
   return client.get(`/delegations${buildQuery({ status: p.status, since: p.since })}`)
 }
 
+export function getDelegation(client: ThreaApiClient, delegationId: string): Promise<unknown> {
+  return client.get(`/delegations/${encodeURIComponent(delegationId)}`)
+}
+
 export interface ClaimDelegationParams {
   delegationId: string
   claimedByLabel: string
@@ -425,6 +429,24 @@ function resolveDelegationToken(
     )
   }
   return token
+}
+
+export interface ReleaseDelegationParams {
+  delegationId: string
+  claimToken?: string
+}
+
+export async function releaseDelegation(
+  client: ThreaApiClient,
+  store: TokenStore,
+  workspaceId: string,
+  p: ReleaseDelegationParams
+): Promise<unknown> {
+  const token = resolveDelegationToken(store, workspaceId, p.delegationId, p.claimToken)
+  const headers = { [CALLBACK_TOKEN_HEADER]: token }
+  const response = await client.post(`/delegations/${encodeURIComponent(p.delegationId)}/release`, undefined, headers)
+  store.deleteIfMatches(workspaceId, p.delegationId, token)
+  return response
 }
 
 export interface UpdateDelegationParams {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -39,9 +39,10 @@ const INSTRUCTIONS =
   "(labels are private to the key actor and found-or-created by name). Memory provenance: get_memo traces a " +
   "memo to its source messages. Attachments: get_attachment (metadata plus extracted text), " +
   "get_attachment_download_url (short-lived signed URL for the raw bytes). Delegations: close the loop on a " +
-  "delegated task with list_delegations (the open queue) → claim_delegation (returns a claim token shown once " +
-  "and persisted to ~/.threa/state.json; 15-min TTL) → update_delegation while working (status_note reports " +
-  "progress and renews the claim, no note is a pure heartbeat) → finish_delegation (outcome complete or fail). " +
+  "delegated task with list_delegations (the open queue) → get_delegation (inspect brief/context) → " +
+  "claim_delegation (returns a claim token shown once and persisted to ~/.threa/state.json; 15-min TTL) → optional " +
+  "update_delegation while working (status_note reports progress and renews the claim, no note is a pure heartbeat) → " +
+  "finish_delegation (outcome complete or fail) or release_delegation for controlled stop. " +
   "A completed result is posted into the delegation's stream so GAM memorizes it. Lifecycle tools reuse the " +
   "stored token; pass claim_token to override or to recover on another machine. request_delegation_access " +
   "is bot-key only."

--- a/packages/cli/src/token-store.test.ts
+++ b/packages/cli/src/token-store.test.ts
@@ -2,15 +2,31 @@ import { afterEach, beforeEach, expect, spyOn, test } from "bun:test"
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 import { TokenStore } from "./token-store"
 
 let dir: string
+
+type Child = {
+  exitCode: number | null
+  exited: Promise<number>
+  kill(signal?: NodeJS.Signals): void
+  stderrText: Promise<string>
+  stdoutText: Promise<string>
+}
+
+const children = new Set<Child>()
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "threa-token-store-"))
 })
 
-afterEach(() => {
+afterEach(async () => {
+  for (const child of children) {
+    if (child.exitCode === null) child.kill("SIGKILL")
+  }
+  await Promise.all([...children].map((child) => child.exited))
+  children.clear()
   rmSync(dir, { recursive: true, force: true })
 })
 
@@ -30,6 +46,27 @@ test("get returns undefined for an unknown workspace or delegation, and when no 
   expect(store.get("ws_1", "dlg_2")).toBeUndefined()
 })
 
+test("an already-loaded store observes another store creating the shared state file", () => {
+  const path = join(dir, "state.json")
+  const sharedHead = new TokenStore(path)
+  expect(sharedHead.get("ws_1", "dlg_1")).toBeUndefined()
+
+  new TokenStore(path).set("ws_1", "dlg_1", "tok_new")
+
+  expect(sharedHead.get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("an already-loaded store observes another store replacing a shared claim token", () => {
+  const path = join(dir, "state.json")
+  const sharedHead = new TokenStore(path)
+  sharedHead.set("ws_1", "dlg_1", "tok_old")
+  expect(sharedHead.get("ws_1", "dlg_1")).toBe("tok_old")
+
+  new TokenStore(path).set("ws_1", "dlg_1", "tok_new")
+
+  expect(sharedHead.get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
 test("delete clears one token and prunes an emptied workspace, leaving siblings intact", () => {
   const path = join(dir, "state.json")
   const store = new TokenStore(path)
@@ -46,6 +83,216 @@ test("delete clears one token and prunes an emptied workspace, leaving siblings 
   expect(state.claimTokens.ws_1).toBeUndefined()
   expect(state.claimTokens.ws_2).toEqual({ dlg_9: "tok_c" })
 })
+
+test("deleteIfMatches preserves a replacement token", () => {
+  const path = join(dir, "state.json")
+  const store = new TokenStore(path)
+  store.set("ws_1", "dlg_1", "tok_old")
+  store.set("ws_1", "dlg_1", "tok_new")
+
+  expect(store.deleteIfMatches("ws_1", "dlg_1", "tok_old")).toBe(false)
+  expect(store.get("ws_1", "dlg_1")).toBe("tok_new")
+  expect(store.deleteIfMatches("ws_1", "dlg_1", "tok_new")).toBe(true)
+  expect(store.get("ws_1", "dlg_1")).toBeUndefined()
+})
+
+test("deleteIfMatches reloads under lock so another store's replacement survives", () => {
+  const path = join(dir, "state.json")
+  const releasingStore = new TokenStore(path)
+  releasingStore.set("ws_1", "dlg_1", "tok_old")
+  expect(releasingStore.get("ws_1", "dlg_1")).toBe("tok_old")
+
+  new TokenStore(path).set("ws_1", "dlg_1", "tok_new")
+
+  expect(releasingStore.deleteIfMatches("ws_1", "dlg_1", "tok_old")).toBe(false)
+  expect(new TokenStore(path).get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("an explicit old token compare-delete cannot remove another store's replacement", () => {
+  const path = join(dir, "state.json")
+  const releaseStore = new TokenStore(path)
+  new TokenStore(path).set("ws_1", "dlg_1", "tok_new")
+
+  expect(releaseStore.deleteIfMatches("ws_1", "dlg_1", "tok_explicit_old")).toBe(false)
+  expect(new TokenStore(path).get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("mutations from stale store instances preserve unrelated tokens", () => {
+  const path = join(dir, "state.json")
+  const first = new TokenStore(path)
+  const second = new TokenStore(path)
+  first.set("ws_1", "dlg_1", "tok_a")
+  second.set("ws_1", "dlg_2", "tok_b")
+  first.set("ws_2", "dlg_3", "tok_c")
+
+  expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+    claimTokens: { ws_1: { dlg_1: "tok_a", dlg_2: "tok_b" }, ws_2: { dlg_3: "tok_c" } },
+  })
+})
+
+const moduleUrl = pathToFileURL(join(import.meta.dir, "token-store.ts")).href
+
+async function waitForFile(path: string, child: Child): Promise<void> {
+  const deadline = Date.now() + 5_000
+  while (!existsSync(path)) {
+    if (child.exitCode !== null) {
+      throw new Error(`child exited before creating ${path}: ${await child.stderrText}`)
+    }
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path}`)
+    await Bun.sleep(5)
+  }
+}
+
+function spawnChild(args: string[]): Child {
+  const process = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" })
+  const child: Child = {
+    get exitCode() {
+      return process.exitCode
+    },
+    exited: process.exited,
+    kill: (signal) => process.kill(signal),
+    stderrText: new Response(process.stderr).text(),
+    stdoutText: new Response(process.stdout).text(),
+  }
+  children.add(child)
+  return child
+}
+
+function spawnHolder(path: string, ready: string): Child {
+  return spawnChild([
+    process.execPath,
+    "-e",
+    `import { writeFileSync } from "node:fs";
+       import { TokenStore } from ${JSON.stringify(moduleUrl)};
+       const [path, ready] = process.argv.slice(1);
+       const unlock = new TokenStore(path).lock();
+       writeFileSync(ready, "");
+       while (!(await Bun.file(ready + ".release").exists())) await Bun.sleep(5);
+       unlock();`,
+    path,
+    ready,
+  ])
+}
+
+function spawnSet(path: string, delegationId: string, token: string): Child {
+  return spawnChild([
+    process.execPath,
+    "-e",
+    `import { TokenStore } from ${JSON.stringify(moduleUrl)};
+       const [path, delegationId, token] = process.argv.slice(1);
+       new TokenStore(path).set("ws_1", delegationId, token);`,
+    path,
+    delegationId,
+    token,
+  ])
+}
+
+function spawnTimedSet(path: string): Child {
+  return spawnChild([
+    process.execPath,
+    "-e",
+    `import { TokenStore } from ${JSON.stringify(moduleUrl)};
+     const started = Date.now();
+     try {
+       new TokenStore(process.argv[1]).set("ws_1", "dlg_timeout", "tok_timeout");
+     } catch {
+       console.log(Date.now() - started);
+       process.exit(1);
+     }`,
+    path,
+  ])
+}
+
+test("a healthy owner releases immediately for another process", async () => {
+  const path = join(dir, "state.json")
+  const unlock = (new TokenStore(path) as unknown as { lock(): () => void }).lock()
+  expect(statSync(`${path}.lock.sqlite`).mode & 0o777).toBe(0o600)
+  unlock()
+
+  const child = spawnSet(path, "dlg_1", "tok_1")
+  await child.exited
+  expect(child.exitCode).toBe(0)
+  expect(new TokenStore(path).get("ws_1", "dlg_1")).toBe("tok_1")
+})
+
+test("a child transaction blocks another mutation until release", async () => {
+  const path = join(dir, "state.json")
+  const ready = join(dir, "owner-ready")
+  const owner = spawnHolder(path, ready)
+  try {
+    await waitForFile(ready, owner)
+    const waiter = spawnSet(path, "dlg_1", "tok_1")
+    await Bun.sleep(100)
+    expect(waiter.exitCode).toBeNull()
+
+    writeFileSync(`${ready}.release`, "")
+    await Promise.all([owner.exited, waiter.exited])
+    expect(waiter.exitCode).toBe(0)
+    expect(new TokenStore(path).get("ws_1", "dlg_1")).toBe("tok_1")
+  } finally {
+    if (owner.exitCode === null) owner.kill("SIGKILL")
+    await owner.exited
+  }
+})
+
+test("killing a holder releases the OS lock and concurrent recoverers preserve every token", async () => {
+  const path = join(dir, "state.json")
+  const ready = join(dir, "owner-ready")
+  const owner = spawnHolder(path, ready)
+  const recoverers: Child[] = []
+  try {
+    await waitForFile(ready, owner)
+    owner.kill("SIGKILL")
+    await owner.exited
+
+    recoverers.push(...Array.from({ length: 4 }, (_, index) => spawnSet(path, `dlg_${index}`, `tok_${index}`)))
+    await Promise.all(recoverers.map((child) => child.exited))
+    expect(recoverers.map((child) => child.exitCode)).toEqual([0, 0, 0, 0])
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+      claimTokens: { ws_1: { dlg_0: "tok_0", dlg_1: "tok_1", dlg_2: "tok_2", dlg_3: "tok_3" } },
+    })
+  } finally {
+    for (const child of [owner, ...recoverers]) {
+      if (child.exitCode === null) child.kill("SIGKILL")
+    }
+    await Promise.all([owner, ...recoverers].map((child) => child.exited))
+  }
+}, 10_000)
+
+test("compare-delete reloads a child-process replacement under the lock", async () => {
+  const path = join(dir, "state.json")
+  const stale = new TokenStore(path)
+  stale.set("ws_1", "dlg_1", "tok_old")
+
+  const replacement = spawnSet(path, "dlg_1", "tok_new")
+  await replacement.exited
+  expect(replacement.exitCode).toBe(0)
+  expect(stale.deleteIfMatches("ws_1", "dlg_1", "tok_old")).toBe(false)
+  expect(new TokenStore(path).get("ws_1", "dlg_1")).toBe("tok_new")
+})
+
+test("lock timeout is bounded and the failed acquisition closes cleanly", async () => {
+  const path = join(dir, "state.json")
+  const ready = join(dir, "owner-ready")
+  const owner = spawnHolder(path, ready)
+  try {
+    await waitForFile(ready, owner)
+    const timedOut = spawnTimedSet(path)
+    await timedOut.exited
+    const elapsed = Number(await timedOut.stdoutText)
+    expect(timedOut.exitCode).not.toBe(0)
+    expect(elapsed).toBeGreaterThanOrEqual(4_000)
+    expect(elapsed).toBeLessThan(8_000)
+
+    writeFileSync(`${ready}.release`, "")
+    await owner.exited
+    new TokenStore(path).set("ws_1", "dlg_after", "tok_after")
+    expect(new TokenStore(path).get("ws_1", "dlg_after")).toBe("tok_after")
+  } finally {
+    if (owner.exitCode === null) owner.kill("SIGKILL")
+    await owner.exited
+  }
+}, 20_000)
 
 test("a later set overwrites the token for the same key", () => {
   const path = join(dir, "state.json")
@@ -66,6 +313,55 @@ test("a corrupt state file warns once on stderr and starts empty rather than thr
     expect(store.get("ws_1", "dlg_2")).toBeUndefined()
     const warnings = warn.mock.calls.filter((c) => String(c[0]).includes("corrupt"))
     expect(warnings.length).toBe(1)
+  } finally {
+    warn.mockRestore()
+  }
+})
+
+test("a healthy read followed by external corruption warns exactly once across refreshed gets", () => {
+  const path = join(dir, "state.json")
+  new TokenStore(path).set("ws_1", "dlg_1", "tok_a")
+  const store = new TokenStore(path)
+  expect(store.get("ws_1", "dlg_1")).toBe("tok_a")
+  const warn = spyOn(process.stderr, "write").mockImplementation(() => true)
+
+  try {
+    writeFileSync(path, "{ not json")
+    expect(store.get("ws_1", "dlg_1")).toBeUndefined()
+    expect(store.get("ws_1", "dlg_1")).toBeUndefined()
+    expect(warn.mock.calls.filter((call) => String(call[0]).includes("corrupt")).length).toBe(1)
+  } finally {
+    warn.mockRestore()
+  }
+})
+
+test("a missing read does not consume the warning before later corruption", () => {
+  const path = join(dir, "state.json")
+  const store = new TokenStore(path)
+  const warn = spyOn(process.stderr, "write").mockImplementation(() => true)
+
+  try {
+    expect(store.get("ws_1", "dlg_1")).toBeUndefined()
+    writeFileSync(path, "{ not json")
+    expect(store.get("ws_1", "dlg_1")).toBeUndefined()
+    expect(warn.mock.calls.filter((call) => String(call[0]).includes("corrupt")).length).toBe(1)
+  } finally {
+    warn.mockRestore()
+  }
+})
+
+test("mutation reloads warn once for corruption and continue persisting tokens", () => {
+  const path = join(dir, "state.json")
+  const store = new TokenStore(path)
+  const warn = spyOn(process.stderr, "write").mockImplementation(() => true)
+
+  try {
+    writeFileSync(path, "{ first corruption")
+    store.set("ws_1", "dlg_1", "tok_a")
+    writeFileSync(path, "{ second corruption")
+    store.set("ws_1", "dlg_2", "tok_b")
+    expect(warn.mock.calls.filter((call) => String(call[0]).includes("corrupt")).length).toBe(1)
+    expect(store.get("ws_1", "dlg_2")).toBe("tok_b")
   } finally {
     warn.mockRestore()
   }

--- a/packages/cli/src/token-store.ts
+++ b/packages/cli/src/token-store.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { Database } from "bun:sqlite"
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 
@@ -6,67 +7,122 @@ interface StateShape {
   claimTokens: Record<string, Record<string, string>>
 }
 
+const LOCK_WAIT_MS = 5_000
+
 function defaultPath(): string {
   return process.env.THREA_STATE_FILE ?? join(homedir(), ".threa", "state.json")
 }
 
+function emptyState(): StateShape {
+  return { claimTokens: {} }
+}
+
 export class TokenStore {
   private readonly path: string
-  private state: StateShape = { claimTokens: {} }
-  private loaded = false
+  private state: StateShape = emptyState()
+  private warned = false
 
   constructor(pathOverride?: string) {
     this.path = pathOverride ?? defaultPath()
   }
 
-  private load(): void {
-    if (this.loaded) return
-    this.loaded = true
+  private readState(): StateShape {
     let raw: string
     try {
       raw = readFileSync(this.path, "utf8")
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        process.stderr.write(
-          `[threa] state file ${this.path} could not be read; starting with an empty claim-token store\n`
-        )
+        this.warnOnce(`[threa] state file ${this.path} could not be read; starting with an empty claim-token store\n`)
       }
-      return
+      return emptyState()
     }
     try {
       const parsed = JSON.parse(raw) as { claimTokens?: unknown }
       if (parsed && typeof parsed.claimTokens === "object" && parsed.claimTokens !== null) {
-        this.state = { claimTokens: parsed.claimTokens as Record<string, Record<string, string>> }
+        return { claimTokens: parsed.claimTokens as Record<string, Record<string, string>> }
       }
     } catch {
-      process.stderr.write(`[threa] state file ${this.path} is corrupt; starting with an empty claim-token store\n`)
+      this.warnOnce(`[threa] state file ${this.path} is corrupt; starting with an empty claim-token store\n`)
     }
+    return emptyState()
+  }
+
+  private warnOnce(message: string): void {
+    if (this.warned) return
+    this.warned = true
+    process.stderr.write(message)
   }
 
   get(workspaceId: string, delegationId: string): string | undefined {
-    this.load()
+    this.state = this.readState()
     return this.state.claimTokens[workspaceId]?.[delegationId]
   }
 
   set(workspaceId: string, delegationId: string, token: string): void {
-    this.load()
-    ;(this.state.claimTokens[workspaceId] ??= {})[delegationId] = token
-    this.persist()
+    this.mutate((state) => {
+      ;(state.claimTokens[workspaceId] ??= {})[delegationId] = token
+      return true
+    })
   }
 
   delete(workspaceId: string, delegationId: string): void {
-    this.load()
-    const ws = this.state.claimTokens[workspaceId]
-    if (!ws?.[delegationId]) return
-    delete ws[delegationId]
-    if (Object.keys(ws).length === 0) delete this.state.claimTokens[workspaceId]
-    this.persist()
+    this.mutate((state) => this.remove(state, workspaceId, delegationId))
   }
 
-  private persist(): void {
+  deleteIfMatches(workspaceId: string, delegationId: string, observedToken: string): boolean {
+    return this.mutate((state) => {
+      if (state.claimTokens[workspaceId]?.[delegationId] !== observedToken) return false
+      this.remove(state, workspaceId, delegationId)
+      return true
+    })
+  }
+
+  private remove(state: StateShape, workspaceId: string, delegationId: string): boolean {
+    const ws = state.claimTokens[workspaceId]
+    if (ws?.[delegationId] === undefined) return false
+    delete ws[delegationId]
+    if (Object.keys(ws).length === 0) delete state.claimTokens[workspaceId]
+    return true
+  }
+
+  private mutate<T>(change: (state: StateShape) => T): T {
+    const unlock = this.lock()
+    try {
+      const state = this.readState()
+      const result = change(state)
+      this.state = state
+      if (result !== false) this.persist(state)
+      return result
+    } finally {
+      unlock()
+    }
+  }
+
+  private lock(): () => void {
     mkdirSync(dirname(this.path), { recursive: true })
+    const lockPath = `${this.path}.lock.sqlite`
+    const db = new Database(lockPath, { create: true })
+    try {
+      chmodSync(lockPath, 0o600)
+      db.run(`PRAGMA busy_timeout = ${LOCK_WAIT_MS}`)
+      db.run("BEGIN IMMEDIATE")
+    } catch (error) {
+      db.close()
+      throw error
+    }
+
+    return () => {
+      try {
+        db.run("COMMIT")
+      } finally {
+        db.close()
+      }
+    }
+  }
+
+  private persist(state: StateShape): void {
     const tmp = `${this.path}.${process.pid}.${Date.now()}.tmp`
-    writeFileSync(tmp, JSON.stringify(this.state), { mode: 0o600 })
+    writeFileSync(tmp, JSON.stringify(state), { mode: 0o600 })
     renameSync(tmp, this.path)
   }
 }

--- a/packages/cli/src/tools/delegations.test.ts
+++ b/packages/cli/src/tools/delegations.test.ts
@@ -42,6 +42,50 @@ test("list_delegations passes status and since as query params", async () => {
   expect(textPayload(result)).toEqual({ data: [{ id: "dlg_1" }] })
 })
 
+test("get_delegation inspects without a token", async () => {
+  fetchSpy.mockResolvedValue(jsonResponse(200, { data: { id: "dlg_1", brief: "do it", contextRefs: ["msg_1"] } }))
+  const client = await connectClient()
+  const result = (await client.callTool({
+    name: "get_delegation",
+    arguments: { delegation_id: "dlg_1" },
+  })) as CallToolResult
+  expect(result.isError).toBeFalsy()
+  expect(pathOf(0)).toBe("/api/v1/workspaces/ws_1/delegations/dlg_1")
+  expect(callbackHeader()).toBeUndefined()
+})
+
+test("release_delegation supports stored and explicit tokens and retains a token after failure", async () => {
+  const client = await connectClient()
+  await claim(client)
+  fetchSpy.mockResolvedValueOnce(jsonResponse(500, { code: "INTERNAL" }))
+  expect(
+    ((await client.callTool({ name: "release_delegation", arguments: { delegation_id: "dlg_1" } })) as CallToolResult)
+      .isError
+  ).toBe(true)
+  fetchSpy.mockResolvedValueOnce(jsonResponse(200, { data: { id: "dlg_1", status: "open" } }))
+  expect(
+    (
+      (await client.callTool({
+        name: "release_delegation",
+        arguments: { delegation_id: "dlg_1", claim_token: "tok_explicit" },
+      })) as CallToolResult
+    ).isError
+  ).toBeFalsy()
+  expect(callbackHeader(1)).toBe("tok_stored")
+  expect(callbackHeader(2)).toBe("tok_explicit")
+})
+
+test("release_delegation without a token is a tool error", async () => {
+  const client = await connectClient()
+  const result = (await client.callTool({
+    name: "release_delegation",
+    arguments: { delegation_id: "dlg_1" },
+  })) as CallToolResult
+  expect(result.isError).toBe(true)
+  expect(textPayload(result).code).toBe("MISSING_CLAIM_TOKEN")
+  expect(fetchSpy).not.toHaveBeenCalled()
+})
+
 test("claim_delegation maps body fields, stores the token, and returns it", async () => {
   fetchSpy.mockResolvedValue(
     jsonResponse(200, { data: { id: "dlg_1", brief: "do the thing", claimToken: "tok_secret" } })

--- a/packages/cli/src/tools/delegations.ts
+++ b/packages/cli/src/tools/delegations.ts
@@ -1,7 +1,15 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import type { ThreaApiClient } from "../api-client"
-import { claimDelegation, finishDelegation, listDelegations, requestDelegationAccess, updateDelegation } from "../ops"
+import {
+  claimDelegation,
+  finishDelegation,
+  getDelegation,
+  listDelegations,
+  releaseDelegation,
+  requestDelegationAccess,
+  updateDelegation,
+} from "../ops"
 import type { TokenStore } from "../token-store"
 import { runTool } from "./result"
 
@@ -17,10 +25,10 @@ export function registerDelegationTools(
       title: "List open delegations",
       description:
         "List the delegated tasks that are open to claim (the queue a `delegate_task` hand-off lands in). Only " +
-        "streams this key can access appear. The lifecycle loop is: list_delegations → claim_delegation → " +
-        "update_delegation while you work → finish_delegation (outcome complete or fail). A completed result is " +
+        "streams this key can access appear. The lifecycle loop is: list_delegations → get_delegation → " +
+        "claim_delegation → optional update_delegation while you work → finish_delegation or release_delegation. A completed result is " +
         "posted into the delegation's stream and GAM memorizes it. `status` is `open` (the only listable state " +
-        "today). `since` is an ISO-8601 datetime that returns only tasks created after that instant — a cheap " +
+        "today). `since` is an ISO-8601 datetime that returns tasks whose availability changed after that instant — a cheap " +
         "delta for a polling runner.",
       inputSchema: {
         status: z.literal("open").optional(),
@@ -28,6 +36,17 @@ export function registerDelegationTools(
       },
     },
     async ({ status, since }) => runTool(() => listDelegations(client, { status, since }))
+  )
+
+  server.registerTool(
+    "get_delegation",
+    {
+      title: "Inspect a delegation",
+      description:
+        "Inspect the full brief and context refs before deciding whether to claim. This never creates a claim or token.",
+      inputSchema: { delegation_id: z.string() },
+    },
+    async ({ delegation_id }) => runTool(() => getDelegation(client, delegation_id))
   )
 
   server.registerTool(
@@ -58,6 +77,20 @@ export function registerDelegationTools(
           claimedByLabel: claimed_by_label,
           idempotencyKey: idempotency_key,
         })
+      )
+  )
+
+  server.registerTool(
+    "release_delegation",
+    {
+      title: "Release a delegation claim",
+      description:
+        "Return a live claim to the open queue without failing it. Uses the stored token unless `claim_token` overrides it. The stored token is cleared only after a successful release.",
+      inputSchema: { delegation_id: z.string(), claim_token: z.string().optional() },
+    },
+    async ({ delegation_id, claim_token }) =>
+      runTool(() =>
+        releaseDelegation(client, store, workspaceId, { delegationId: delegation_id, claimToken: claim_token })
       )
   )
 


### PR DESCRIPTION
## Problem

The protocol now supports inspection and release, but clients still need first-class commands and the optional SDK runner must stop work without fabricating failures or writing with a lost claim.

Stacked on #1797.

## Solution

- Add inspect and release operations to the CLI and MCP server.
- Preserve claim tokens on ambiguous release failures and clear them with an inter-process-safe compare-and-delete after success.
- Add `DelegationClient.get()` and `release()` without automatic token persistence.
- Pass `AbortSignal` through the runner and Claude adapter.
- Treat authenticated heartbeat/status 404s as claim loss, cancel execution cooperatively, and suppress stale terminal writes.
- Release live claims during controlled shutdown with bounded, caller-specific strict or best-effort behavior.

## Verification

- `bun run --cwd packages/cli test` — 161 passed
- `bun run --cwd extensions/remote-session test` — 171 passed
- `bun run --cwd extensions/claude-code-remote test` — 122 passed
- `bun run typecheck`
- `bun run lint`
- OpenAPI drift, migration, Docker workspace, and `git diff --check` checks passed through commit hooks

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Expose the recoverable delegation protocol through generic clients and make the optional runner relinquish or abandon claims safely when it stops or loses authorization.

## What Was Built

### CLI and MCP clients

- `packages/cli/src/ops.ts` adds inspect-by-id and token-authenticated release operations.
- `packages/cli/src/commands/delegations.ts` adds `delegations get` and `delegations release` with stored or explicit callback tokens.
- `packages/cli/src/tools/delegations.ts` adds `get_delegation` and `release_delegation`.
- `packages/cli/src/server.ts` describes the generic inspect, claim, heartbeat/progress, complete/fail/release loop without requiring a runner.

### Token lifecycle safety

- `packages/cli/src/token-store.ts` clears a released token only if the persisted token still matches the credential used by that release.
- State mutations reload under an ownership-safe inter-process lock, retain atomic rename and 0600 permissions, and use bounded lock waits.
- Race tests cover separate store instances, replacement claims, stale takeover, old-owner unlock, and concurrent mutations.

### SDK client and runner

- `extensions/remote-session/src/delegation-client.ts` adds secret-free GET inspection and callback-token release.
- `extensions/remote-session/src/delegation-runner.ts` adds cooperative cancellation, lifecycle generations, claim-loss settlement, bounded shutdown, and release deduplication.
- Authenticated heartbeat or status 404 aborts execution and suppresses complete, fail, and release from the stale holder.
- Network and 5xx heartbeat/status failures remain non-terminal because server CAS remains authoritative.

### Claude adapter compatibility

- `extensions/claude-code-remote/src/channel-server.ts` observes the executor abort signal and settles the open invocation without reporting a false delegation failure.
- Reconnect uses strict release handling; normal shutdown remains bounded and best effort.

## Design Decisions

### Protocol stays client-independent

**Chose:** Keep manual heartbeat public and make runner automation optional.  
**Why:** Any HTTP client must be able to inspect, claim, renew, complete, fail, or release work.

### Controlled stop releases rather than fails

**Chose:** Abort local execution and call release while the live claim is still held.  
**Why:** Shutdown is not task failure; reopening lets another client continue immediately.

### Lost claims detach non-cooperative executors

**Chose:** Race executor settlement against claim loss and consume late outcomes without terminal writes.  
**Why:** Existing executors may ignore `AbortSignal`; stale-token CAS is the final safety boundary.

### Persisted token deletion uses CAS semantics

**Chose:** Reload, compare, and delete under an ownership-safe file lock.  
**Why:** A delayed old release response must not erase a replacement claim token written by another process.

## Design Evolution

- Shared mutable stop strictness was replaced with a raw per-generation operation and caller-specific wait policy so overlapping stops cannot downgrade errors.
- Executor-only cancellation was extended with claim-loss settlement so a non-cooperative executor cannot block future drains.
- In-memory compare-delete was strengthened to an inter-process file-boundary CAS after race review.

## Schema Changes

None.

## What's NOT Included

- No automatic CLI/MCP heartbeat loop.
- No claim-token transfer or handover protocol.
- No bot invocation, Pi, harnessd, or delegation creation changes.
- No frontend outcome or recovery-state changes; those are in the next stacked PR.
- Final public documentation and copy are deferred to PR 4.

## Status

- [x] CLI inspect/release and token lifecycle
- [x] MCP inspect/release tools and guidance
- [x] SDK GET/release methods
- [x] Runner cancellation, claim-loss, and shutdown recovery
- [x] Claude adapter integration
- [x] Focused tests and monorepo gates

</details>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788699957&installation_model_id=20758&pr_number=1800&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1800&signature=9d56a0b04b2e77b87a34b4a3d34f7de9704aa40ac2f7accbdec7ae9c4ff42262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->