### PR TITLE
feat: preserve structured dictation Markdown

### DIFF
--- a/apps/backend/src/features/voice-transcription/polish-scheduler.test.ts
+++ b/apps/backend/src/features/voice-transcription/polish-scheduler.test.ts
@@ -9,7 +9,11 @@ function deferred() {
   })
   return { promise, resolve }
 }
-const success = (markdown: string): PolishOutcome => ({ status: "success", markdown })
+const success = (markdown: string): PolishOutcome => ({
+  status: "success",
+  markdown,
+  contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: markdown }] }] },
+})
 
 describe("PolishScheduler", () => {
   it("runs one active pass and only the newest pending snapshot", async () => {

--- a/apps/backend/src/features/voice-transcription/polish.test.ts
+++ b/apps/backend/src/features/voice-transcription/polish.test.ts
@@ -26,7 +26,14 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toEqual({ status: "success", markdown: "Hello, world." })
+    expect(out).toEqual({
+      status: "success",
+      markdown: "Hello, world.",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Hello, world." }] }],
+      },
+    })
     const call = generateText.mock.calls[0][0]
     expect(call.model).toBe(POLISH_MODEL)
     expect(call.telemetry?.functionId).toBe("voice-transcript-polish")
@@ -202,7 +209,14 @@ describe("createPolishTranscript", () => {
       sessionId: "voicesess_1",
     })
 
-    expect(out).toEqual({ status: "success", markdown: "here's what I'm thinking: pie" })
+    expect(out).toEqual({
+      status: "success",
+      markdown: "here's what I'm thinking: pie",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "here's what I'm thinking: pie" }] }],
+      },
+    })
 
     const sys = generateText.mock.calls[0][0].messages.find((m: { role: string }) => m.role === "system")
     expect(sys?.content).toContain("em dashes")

--- a/apps/backend/src/features/voice-transcription/polish.ts
+++ b/apps/backend/src/features/voice-transcription/polish.ts
@@ -1,5 +1,7 @@
 import type { VoicePolishLevel } from "@threa/types"
 import type { AI } from "@threa/agent-runtime"
+import { parseMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
 import { logger } from "../../lib/logger"
 import {
   POLISH_MAX_TOKENS,
@@ -22,7 +24,7 @@ export interface PolishTranscriptInput {
 }
 
 export type PolishOutcome =
-  | { status: "success"; markdown: string }
+  | { status: "success"; markdown: string; contentJson: JSONContent }
   | { status: "empty_input" }
   | { status: "invalid_output"; reason: "empty" | "truncated" | "unparseable" }
   | { status: "timeout" }
@@ -45,7 +47,7 @@ export function createPolishTranscript(deps: { ai: AI }): PolishTranscript {
   }) => {
     const trimmed = rawTranscript.trim()
     if (!trimmed) return { status: "empty_input" }
-    if (level === "none") return { status: "success", markdown: trimmed }
+    if (level === "none") return parsePolishSuccess(trimmed)
 
     const systemPrompt = level === "opinionated" ? POLISH_OPINIONATED_SYSTEM_PROMPT : POLISH_MINOR_SYSTEM_PROMPT
     const userMessage = buildPolishUserMessage({ rawTranscript: trimmed, draftBefore, draftAfter, steeringTerms })
@@ -89,7 +91,7 @@ export function createPolishTranscript(deps: { ai: AI }): PolishTranscript {
       if (finishReason === "length") return { status: "invalid_output", reason: "truncated" }
       const polished = result.value.trim()
       if (!polished) return { status: "invalid_output", reason: "empty" }
-      return { status: "success", markdown: scrubDashes(polished) }
+      return parsePolishSuccess(scrubDashes(polished))
     } catch (err) {
       if (signal?.aborted) return { status: "canceled" }
       if (timedOut) return { status: "timeout" }
@@ -99,6 +101,15 @@ export function createPolishTranscript(deps: { ai: AI }): PolishTranscript {
       clearTimeout(timer)
       signal?.removeEventListener("abort", onCancel)
     }
+  }
+}
+
+function parsePolishSuccess(markdown: string): PolishOutcome {
+  try {
+    const contentJson = parseMarkdown(markdown)
+    return { status: "success", markdown, contentJson }
+  } catch {
+    return { status: "invalid_output", reason: "unparseable" }
   }
 }
 

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.test.ts
@@ -149,7 +149,7 @@ describe("registerVoiceGateway voice:start", () => {
 
     await socket.trigger("voice:start", START_PAYLOAD, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: true, protocolVersion: 2 })
+    expect(cb).toHaveBeenCalledWith({ ok: true, protocolVersion: 3 })
     expect(transcription.open).toHaveBeenCalledWith({
       model: "elevenlabs:scribe-v2-realtime",
       language: undefined,
@@ -280,7 +280,7 @@ describe("registerVoiceGateway voice:start", () => {
 
     await socket.trigger("voice:start", {}, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "workspaceId and voiceSessionId required", protocolVersion: 2 })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "workspaceId and voiceSessionId required", protocolVersion: 3 })
     expect(transcription.open).not.toHaveBeenCalled()
   })
 
@@ -295,7 +295,7 @@ describe("registerVoiceGateway voice:start", () => {
     const cb = mock(() => {})
     await socket.trigger("voice:start", START_PAYLOAD, cb)
 
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session already started", protocolVersion: 2 })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session already started", protocolVersion: 3 })
   })
 
   it("tears down the upstream when the socket disconnects mid-start", async () => {
@@ -320,7 +320,7 @@ describe("registerVoiceGateway voice:start", () => {
       sessionId: "voicesess_1",
       totalAudioMs: 0,
     })
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session ended before it started", protocolVersion: 2 })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Session ended before it started", protocolVersion: 3 })
   })
 
   it("aborts the resolved session when opening the upstream fails", async () => {
@@ -339,7 +339,7 @@ describe("registerVoiceGateway voice:start", () => {
       sessionId: "voicesess_1",
       totalAudioMs: 0,
     })
-    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Failed to start voice session", protocolVersion: 2 })
+    expect(cb).toHaveBeenCalledWith({ ok: false, error: "Failed to start voice session", protocolVersion: 3 })
   })
 })
 

--- a/apps/backend/src/features/voice-transcription/realtime-gateway.ts
+++ b/apps/backend/src/features/voice-transcription/realtime-gateway.ts
@@ -2,6 +2,7 @@ import type { Server } from "socket.io"
 import { ulid } from "ulid"
 import { z } from "zod"
 import type { AuthService } from "@threa/backend-common"
+import { parseMarkdown } from "@threa/prosemirror"
 import {
   VOICE_DRAFT_CONTEXT_MAX_CHARS,
   VOICE_PROTOCOL_VERSION,
@@ -94,7 +95,9 @@ export function registerVoiceGateway(io: Server, deps: Dependencies) {
         steeringTerms: current.steeringTerms,
         signal,
       })
-      return typeof outcome === "string" ? { status: "success", markdown: outcome } : outcome
+      return typeof outcome === "string"
+        ? { status: "success", markdown: outcome, contentJson: parseMarkdown(outcome) }
+        : outcome
     }
 
     function emitPolish(
@@ -113,6 +116,8 @@ export function registerVoiceGateway(io: Server, deps: Dependencies) {
         authoritative,
         raw,
         polished: outcome.markdown,
+        rawContentJson: parseMarkdown(raw),
+        polishedContentJson: outcome.contentJson,
       })
     }
 
@@ -127,7 +132,7 @@ export function registerVoiceGateway(io: Server, deps: Dependencies) {
         revision,
         text: raw,
         isFinal: true,
-        ...(current.polishLevel === "none" ? {} : { chunkId: current.sessionChunkId }),
+        ...(current.polishLevel === "none" ? {} : { chunkId: current.sessionChunkId, contentJson: parseMarkdown(raw) }),
       })
       if (schedule && current.phase === "live" && current.polishLevel !== "none") {
         const cumulative = current.rawFinals.join(" ")

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -18,6 +18,8 @@ import { useComposerActionSide } from "@/hooks/use-composer-action-side"
 import { usePreferencesOptional } from "@/contexts"
 import { getEffectiveKeyBinding, matchesKeyBinding } from "@/lib/keyboard-shortcuts"
 import { RichEditor, EditorToolbar, EditorActionBar } from "@/components/editor"
+import { getDictationMarkdownContext } from "@/components/editor/dictation-markdown"
+import { VOICE_DRAFT_CONTEXT_MAX_CHARS } from "@threa/types"
 import type { RichEditorHandle } from "@/components/editor"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -742,17 +744,17 @@ export function MessageComposer({
   // Polished-chunk wiring: the editor tracks each polished chunk by id so a
   // session-wide toggle can swap them in-place between polished and raw.
   const insertPolishedDictationChunk = useCallback(
-    (args: { chunkId: string; text: string }) => richEditorRef.current?.insertDictationChunk(args),
+    (args: { chunkId: string; contentJson: JSONContent }) => richEditorRef.current?.insertDictationChunk(args),
     []
   )
   const swapDictationChunk = useCallback(
-    (args: { chunkId: string; newText: string; expectedText: string }) =>
-      richEditorRef.current?.replaceDictationChunkText(args) ?? false,
+    (args: { chunkId: string; contentJson: JSONContent }) =>
+      richEditorRef.current?.replaceDictationChunk?.(args) ?? false,
     []
   )
   const lockAllDictationChunks = useCallback(() => richEditorRef.current?.lockAllDictationChunks(), [])
-  const getDictationChunkText = useCallback(
-    (chunkId: string) => richEditorRef.current?.getDictationChunkText(chunkId) ?? null,
+  const getDictationChunkContent = useCallback(
+    (chunkId: string) => richEditorRef.current?.getDictationChunkContent?.(chunkId) ?? null,
     []
   )
   // Draft text around the caret, captured when a take starts and sent as
@@ -765,10 +767,7 @@ export function MessageComposer({
     const editor = richEditorRef.current?.getEditor()
     if (!editor) return null
     const { doc, selection } = editor.state
-    return {
-      before: doc.textBetween(0, selection.from, "\n"),
-      after: doc.textBetween(selection.to, doc.content.size, "\n"),
-    }
+    return getDictationMarkdownContext(doc, selection, VOICE_DRAFT_CONTEXT_MAX_CHARS)
   }, [])
   // Keyed by scopeId so navigating to a different stream remounts the button, tearing down any
   // in-flight dictation session (the unmount cleanup aborts the take) instead of carrying it over.
@@ -783,7 +782,7 @@ export function MessageComposer({
       onInsertPolishedChunk={insertPolishedDictationChunk}
       onChunkSwap={swapDictationChunk}
       onLockAllChunks={lockAllDictationChunks}
-      onGetChunkText={getDictationChunkText}
+      onGetChunkContent={getDictationChunkContent}
       onGetDraftContext={getDictationDraftContext}
       disabled={controlsDisabled}
     />
@@ -799,7 +798,7 @@ export function MessageComposer({
       onInsertPolishedChunk={insertPolishedDictationChunk}
       onChunkSwap={swapDictationChunk}
       onLockAllChunks={lockAllDictationChunks}
-      onGetChunkText={getDictationChunkText}
+      onGetChunkContent={getDictationChunkContent}
       onGetDraftContext={getDictationDraftContext}
       disabled={controlsDisabled}
       className="h-[30px] w-[30px] rounded-md border bg-background shadow-md"

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -1,3 +1,4 @@
+import type { JSONContent } from "@threa/types"
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 import { Mic, Loader2, AlertTriangle, Sparkles, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -73,9 +74,9 @@ interface MicButtonProps {
    * the editor's POV (the backend still emits the events, but nothing tracks
    * them) — surfaces that don't support inline swap can leave this off.
    */
-  onInsertPolishedChunk?: (args: { chunkId: string; text: string }) => void
+  onInsertPolishedChunk?: (args: { chunkId: string; contentJson: JSONContent }) => void
   /** Swap a tracked chunk's text. Returns false if the user edited inside it. */
-  onChunkSwap?: (args: { chunkId: string; newText: string; expectedText: string }) => boolean
+  onChunkSwap?: (args: { chunkId: string; contentJson: JSONContent }) => boolean
   /** Drop tracking for every chunk (post-session lock, or starting a new take). */
   onLockAllChunks?: () => void
   /**
@@ -84,7 +85,7 @@ interface MicButtonProps {
    * editor is the source of truth (mapping accounts for adjacent user edits),
    * so a parallel prediction in the hook drifts.
    */
-  onGetChunkText?: (chunkId: string) => string | null
+  onGetChunkContent?: (chunkId: string) => JSONContent | null
   /**
    * Read the draft text around the caret so the polish model sees the rest of
    * the message as read-only context. Optional — surfaces without a persistent
@@ -105,7 +106,7 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     onInsertPolishedChunk,
     onChunkSwap,
     onLockAllChunks,
-    onGetChunkText,
+    onGetChunkContent,
     onGetDraftContext,
     disabled,
     className,
@@ -139,7 +140,7 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     onPolishedChunkInserted: onInsertPolishedChunk,
     onChunkSwap,
     onLockAllChunks,
-    onGetChunkText,
+    onGetChunkContent,
     onGetDraftContext,
     language,
   })

--- a/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
+++ b/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@tiptap/react"
+import { createEditorExtensions } from "./editor-extensions"
+
+const paragraph = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", ...(text ? { content: [{ type: "text", text }] } : {}) }],
+})
+const list: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "bulletList",
+      content: ["one", "two"].map((text) => ({
+        type: "listItem",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+  ],
+}
+
+function make(content: JSONContent = paragraph("before after")) {
+  const element = document.createElement("div")
+  document.body.append(element)
+  const editor = new Editor({ element, extensions: createEditorExtensions({ placeholder: "" }), content })
+  editor.on("destroy", () => element.remove())
+  return editor
+}
+
+let editor: Editor
+afterEach(() => editor?.destroy())
+
+describe("structured dictation chunks", () => {
+  it("replaces the selection and inserts a naturally spaced inline paragraph", () => {
+    editor = make()
+    editor.commands.setTextSelection({ from: 8, to: 13 })
+    expect(editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("hello") })).toBe(true)
+    expect(editor.getText()).toBe("before hello")
+  })
+
+  it("preserves boundary spacing across cumulative insertion, replacement, and toggles", () => {
+    editor = make(paragraph("Typed"))
+    editor.commands.setTextSelection(6)
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("hello") })
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("world") })
+    expect(editor.getText()).toBe("Typed hello world")
+
+    editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("hello polished world") })
+    expect(editor.getText()).toBe("Typed hello polished world")
+    editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("hello world") })
+    expect(editor.getText()).toBe("Typed hello world")
+  })
+
+  it("replaces cumulative content with multiple paragraphs without corrupting its range", () => {
+    editor = make(paragraph("Typed"))
+    editor.commands.setTextSelection(6)
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("first") })
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("second") })
+    const multiBlock: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "first polished" }] },
+        { type: "paragraph", content: [{ type: "text", text: "second polished" }] },
+      ],
+    }
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: multiBlock })).toBe(true)
+    expect(editor.getText()).toBe("Typed first polished\n\nsecond polished")
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("first second") })).toBe(
+      true
+    )
+    expect(editor.getText()).toBe("Typed first second")
+  })
+
+  it("round-trips exact raw and polished JSON including marks", () => {
+    const raw: JSONContent = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "raw" }] }] }
+    const polished: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "bold" }], text: "polished" }] }],
+    }
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: raw })
+    editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: polished })
+    expect(editor.getJSON()).toEqual(polished)
+    editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: raw })
+    expect(editor.getJSON()).toEqual(raw)
+  })
+
+  it("replaces a selection spanning blocks on first insertion", () => {
+    editor = make({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "one" }] },
+        { type: "paragraph", content: [{ type: "text", text: "two" }] },
+      ],
+    })
+    editor.commands.setTextSelection({ from: 2, to: 8 })
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("hello") })
+    expect(editor.getText()).toBe("o helloo")
+  })
+
+  it("preserves complete lists and surrounding text across replacement and toggles", () => {
+    editor = make()
+    editor.commands.setTextSelection(8)
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: list })
+    expect(editor.getJSON()).toMatchObject({
+      content: [
+        { type: "paragraph" },
+        { type: "bulletList", content: [{ type: "listItem" }, { type: "listItem" }] },
+        { type: "paragraph" },
+      ],
+    })
+    expect(editor.getText()).not.toContain("-")
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("raw words") })).toBe(true)
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: list })).toBe(true)
+    expect(editor.getJSON().content?.[1]).toMatchObject({
+      type: "bulletList",
+      content: [{ type: "listItem" }, { type: "listItem" }],
+    })
+  })
+
+  it("maps adjacent edits but tombstones a chunk after an inside edit", () => {
+    editor = make(paragraph("typed"))
+    editor.commands.setTextSelection(6)
+    editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("hello") })
+    editor.commands.setTextSelection(1)
+    editor.commands.insertContent("X")
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("hello world") })).toBe(true)
+    const beforeEdit = editor.getText()
+    editor.commands.setTextSelection(9)
+    editor.commands.insertContent("E")
+    const edited = editor.getText()
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: list })).toBe(false)
+    expect(editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("resurrected") })).toBe(false)
+    expect(editor.getText()).not.toBe(beforeEdit)
+    expect(editor.getText()).toBe(edited)
+  })
+})

--- a/apps/frontend/src/components/editor/dictation-chunk-extension.ts
+++ b/apps/frontend/src/components/editor/dictation-chunk-extension.ts
@@ -1,172 +1,116 @@
 import { Extension } from "@tiptap/core"
+import { Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state"
 import { Decoration, DecorationSet } from "@tiptap/pm/view"
+import type { JSONContent } from "@threa/types"
+import { canonicalContentSlice } from "./multiline-blocks"
 
 export interface DictationChunkInfo {
   chunkId: string
   from: number
   to: number
-  /** Text currently sitting inside the chunk range (read from the live doc). */
-  text: string
+  contentJson: JSONContent
+}
+
+type Chunk = { chunkId: string; from: number; to: number; expectedContentJson: JSONContent; locked: boolean }
+type ChunkState = Map<string, Chunk>
+type ChunkMeta = { type: "set"; chunk: Chunk } | { type: "lock"; chunkId: string } | { type: "removeAll" }
+
+const DictationChunkPluginKey = new PluginKey<ChunkState>("dictationChunk")
+
+function sliceJson(doc: ProseMirrorNode, from: number, to: number): JSONContent {
+  return { type: "doc", content: doc.slice(from, to).content.toJSON() as JSONContent[] }
+}
+
+function equalJson(a: JSONContent, b: JSONContent): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function withBoundarySpace(state: EditorState, from: number, contentJson: JSONContent): JSONContent {
+  const content = contentJson.content
+  if (!content?.length || content[0].type !== "paragraph") return contentJson
+  const charBefore = from > 0 ? state.doc.textBetween(from - 1, from) : ""
+  if (!charBefore || /\s/.test(charBefore)) return contentJson
+  const first = content[0]
+  return {
+    ...contentJson,
+    content: [{ ...first, content: [{ type: "text", text: " " }, ...(first.content ?? [])] }, ...content.slice(1)],
+  }
 }
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     dictationChunk: {
-      /**
-       * Insert a polished dictation chunk at the caret, prefixing with a single
-       * space when the preceding character isn't whitespace (mirrors
-       * insertTranscribedText). The inserted range is wrapped in a tracking
-       * decoration that auto-maps through later edits, so it can be found and
-       * replaced when the user toggles "Show original".
-       */
-      insertDictationChunk: (args: { chunkId: string; text: string }) => ReturnType
-      /**
-       * Replace the text inside a chunk with `newText`, but only if the chunk's
-       * current text still matches `expectedText`. If the user has edited inside
-       * the chunk (current text differs), the chunk is locked instead (its
-       * decoration is removed) and the swap is skipped — the user's edit wins.
-       */
-      replaceDictationChunkText: (args: { chunkId: string; newText: string; expectedText: string }) => ReturnType
-      /** Drop the tracking decoration for one chunk; its text stays in the doc. */
+      insertDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => ReturnType
+      replaceDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => ReturnType
       lockDictationChunk: (args: { chunkId: string }) => ReturnType
-      /** Drop tracking decorations for every chunk. */
       lockAllDictationChunks: () => ReturnType
     }
   }
 }
 
-type ChunkSpec = { chunkId: string }
-
-type ChunkMeta =
-  | { type: "add"; chunkId: string; from: number; to: number }
-  | { type: "remove"; chunkId: string }
-  | { type: "removeAll" }
-  | { type: "replace"; chunkId: string; from: number; to: number }
-
-const DictationChunkPluginKey = new PluginKey<DecorationSet>("dictationChunk")
-
-function isChunkSpec(spec: unknown): spec is ChunkSpec {
-  return typeof spec === "object" && spec !== null && typeof (spec as ChunkSpec).chunkId === "string"
-}
-
-function findChunk(set: DecorationSet, chunkId: string): Decoration | null {
-  const decos = set.find(undefined, undefined, (spec) => isChunkSpec(spec) && spec.chunkId === chunkId)
-  return decos[0] ?? null
-}
-
-function chunkDecoration(from: number, to: number, chunkId: string): Decoration {
-  // Non-inclusive on both sides: typing right at the chunk's boundary lands
-  // outside the chunk, so post-chunk edits don't extend the tracked range.
-  return Decoration.inline(
-    from,
-    to,
-    { class: "dictation-chunk", "data-chunk-id": chunkId },
-    { chunkId, inclusiveStart: false, inclusiveEnd: false }
-  )
-}
-
-/**
- * Tracks ranges of inserted polished dictation chunks so the session toggle can
- * later swap them between polished and raw text. The tracking is decoration-
- * only: chunk metadata never enters the document JSON, so it doesn't serialize
- * to markdown, doesn't survive a send, and doesn't leak into other surfaces.
- */
 export const DictationChunkExtension = Extension.create({
   name: "dictationChunk",
 
   addCommands() {
     return {
       insertDictationChunk:
-        ({ chunkId, text }) =>
+        ({ chunkId, contentJson }) =>
         ({ state, tr, dispatch }) => {
-          if (!text) return false
-          const set = DictationChunkPluginKey.getState(state)
-          const existing = set ? findChunk(set, chunkId) : null
-
-          if (existing) {
-            // Extend the existing chunk by inserting at its end position
-            // rather than at the user's caret. A dictation session keeps
-            // every emitted final inside one tracked range so the end-of-
-            // session polish swap can replace the whole thing as one piece —
-            // even if the user moved the caret away mid-take. The space we
-            // insert when butting against text is absorbed INTO the chunk so
-            // the decoration stays a single contiguous range.
-            const insertAt = existing.to
-            const charBefore = insertAt > 0 ? state.doc.textBetween(insertAt - 1, insertAt) : ""
-            const prefix = charBefore && !/\s/.test(charBefore) ? " " : ""
-            const inserted = `${prefix}${text}`
-            tr.insertText(inserted, insertAt)
-            tr.setMeta(DictationChunkPluginKey, {
-              type: "replace",
-              chunkId,
-              from: existing.from,
-              to: insertAt + inserted.length,
-            } satisfies ChunkMeta)
-            if (dispatch) dispatch(tr.scrollIntoView())
-            return true
-          }
-
-          const from = state.selection.from
-          const charBefore = from > 0 ? state.doc.textBetween(from - 1, from) : ""
-          const prefix = charBefore && !/\s/.test(charBefore) ? " " : ""
-          const inserted = `${prefix}${text}`
-          tr.insertText(inserted, from)
-          const chunkFrom = from + prefix.length
-          const chunkTo = from + inserted.length
+          const existing = DictationChunkPluginKey.getState(state)?.get(chunkId)
+          if (existing?.locked) return false
+          const from = existing?.to ?? state.selection.from
+          const to = existing?.to ?? state.selection.to
+          const normalized = withBoundarySpace(state, from, contentJson)
+          const slice = canonicalContentSlice(state.schema, normalized)
+          if (!slice) return false
+          tr.replaceRange(from, to, slice)
+          const insertedFrom = tr.mapping.map(from, -1)
+          const insertedTo = tr.mapping.map(to, 1)
+          const chunkFrom = existing?.from ?? insertedFrom
           tr.setMeta(DictationChunkPluginKey, {
-            type: "add",
-            chunkId,
-            from: chunkFrom,
-            to: chunkTo,
+            type: "set",
+            chunk: {
+              chunkId,
+              from: chunkFrom,
+              to: insertedTo,
+              expectedContentJson: sliceJson(tr.doc, chunkFrom, insertedTo),
+              locked: false,
+            },
           } satisfies ChunkMeta)
-          if (dispatch) dispatch(tr.scrollIntoView())
+          dispatch?.(tr.scrollIntoView())
           return true
         },
 
-      replaceDictationChunkText:
-        ({ chunkId, newText, expectedText }) =>
+      replaceDictationChunk:
+        ({ chunkId, contentJson }) =>
         ({ state, tr, dispatch }) => {
-          const set = DictationChunkPluginKey.getState(state)
-          if (!set) return false
-          const deco = findChunk(set, chunkId)
-          if (!deco) return false
-          const currentText = state.doc.textBetween(deco.from, deco.to)
-          if (currentText !== expectedText) {
-            // The user edited inside the chunk between renders — preserve their
-            // edit rather than overwriting it, and stop tracking this chunk so
-            // a later toggle never resurrects the lost text.
-            tr.setMeta(DictationChunkPluginKey, { type: "remove", chunkId } satisfies ChunkMeta)
-            if (dispatch) dispatch(tr)
+          const chunk = DictationChunkPluginKey.getState(state)?.get(chunkId)
+          if (!chunk || chunk.locked) return false
+          const normalized = withBoundarySpace(state, chunk.from, contentJson)
+          const slice = canonicalContentSlice(state.schema, normalized)
+          if (!slice) return false
+          if (!equalJson(sliceJson(state.doc, chunk.from, chunk.to), chunk.expectedContentJson)) {
+            tr.setMeta(DictationChunkPluginKey, { type: "lock", chunkId } satisfies ChunkMeta)
+            dispatch?.(tr)
             return false
           }
-          if (!newText) {
-            tr.delete(deco.from, deco.to)
-            tr.setMeta(DictationChunkPluginKey, { type: "remove", chunkId } satisfies ChunkMeta)
-            if (dispatch) dispatch(tr)
-            return true
-          }
-          const newFrom = deco.from
-          const newTo = newFrom + newText.length
-          tr.insertText(newText, deco.from, deco.to)
-          // The "replace" meta below is applied AFTER the doc-change mapping,
-          // so the plugin can re-anchor the decoration at the new bounds even
-          // if mapping collapsed the original range.
+          tr.replaceRange(chunk.from, chunk.to, slice)
+          const from = tr.mapping.map(chunk.from, -1)
+          const to = tr.mapping.map(chunk.to, 1)
           tr.setMeta(DictationChunkPluginKey, {
-            type: "replace",
-            chunkId,
-            from: newFrom,
-            to: newTo,
+            type: "set",
+            chunk: { chunkId, from, to, expectedContentJson: sliceJson(tr.doc, from, to), locked: false },
           } satisfies ChunkMeta)
-          if (dispatch) dispatch(tr)
+          dispatch?.(tr)
           return true
         },
 
       lockDictationChunk:
         ({ chunkId }) =>
         ({ tr, dispatch }) => {
-          tr.setMeta(DictationChunkPluginKey, { type: "remove", chunkId } satisfies ChunkMeta)
-          if (dispatch) dispatch(tr)
+          tr.setMeta(DictationChunkPluginKey, { type: "lock", chunkId } satisfies ChunkMeta)
+          dispatch?.(tr)
           return true
         },
 
@@ -174,7 +118,7 @@ export const DictationChunkExtension = Extension.create({
         () =>
         ({ tr, dispatch }) => {
           tr.setMeta(DictationChunkPluginKey, { type: "removeAll" } satisfies ChunkMeta)
-          if (dispatch) dispatch(tr)
+          dispatch?.(tr)
           return true
         },
     }
@@ -182,45 +126,45 @@ export const DictationChunkExtension = Extension.create({
 
   addProseMirrorPlugins() {
     return [
-      new Plugin<DecorationSet>({
+      new Plugin<ChunkState>({
         key: DictationChunkPluginKey,
         state: {
-          init: () => DecorationSet.empty,
-          apply(tr, oldSet) {
-            // Map existing chunk ranges through the doc change before applying
-            // explicit meta operations — that way add/remove always work on
-            // up-to-date ranges.
-            let set = oldSet.map(tr.mapping, tr.doc)
+          init: () => new Map(),
+          apply(tr, previous) {
             const meta = tr.getMeta(DictationChunkPluginKey) as ChunkMeta | undefined
-            if (!meta) return set
-            if (meta.type === "add") {
-              set = set.add(tr.doc, [chunkDecoration(meta.from, meta.to, meta.chunkId)])
-              return set
+            if (meta?.type === "removeAll") return new Map()
+            const next = new Map<string, Chunk>()
+            for (const [id, chunk] of previous) {
+              if (meta?.type === "set" && meta.chunk.chunkId === id) continue
+              const from = tr.mapping.map(chunk.from, 1)
+              const to = tr.mapping.map(chunk.to, -1)
+              let locked = chunk.locked || (meta?.type === "lock" && meta.chunkId === id)
+              if (tr.docChanged && !meta && !locked) {
+                locked = from >= to || !equalJson(sliceJson(tr.doc, from, to), chunk.expectedContentJson)
+              }
+              next.set(id, { ...chunk, from, to: Math.max(from, to), locked })
             }
-            if (meta.type === "remove") {
-              const existing = findChunk(set, meta.chunkId)
-              if (existing) set = set.remove([existing])
-              return set
-            }
-            if (meta.type === "removeAll") {
-              return DecorationSet.empty
-            }
-            if (meta.type === "replace") {
-              // The range may or may not still exist after mapping; remove it
-              // explicitly so we never end up with two decorations for the same
-              // chunkId, then add the new tracked range.
-              const existing = findChunk(set, meta.chunkId)
-              if (existing) set = set.remove([existing])
-              set = set.add(tr.doc, [chunkDecoration(meta.from, meta.to, meta.chunkId)])
-              return set
-            }
-            return set
+            if (meta?.type === "set") next.set(meta.chunk.chunkId, meta.chunk)
+            return next
           },
         },
         props: {
           decorations(state) {
-            const set = DictationChunkPluginKey.getState(state)
-            return set && set !== DecorationSet.empty ? set : null
+            const chunks = DictationChunkPluginKey.getState(state)
+            if (!chunks?.size) return null
+            return DecorationSet.create(
+              state.doc,
+              [...chunks.values()]
+                .filter((chunk) => !chunk.locked && chunk.from < chunk.to)
+                .map((chunk) =>
+                  Decoration.inline(
+                    chunk.from,
+                    chunk.to,
+                    { class: "dictation-chunk", "data-chunk-id": chunk.chunkId },
+                    { inclusiveStart: false, inclusiveEnd: false }
+                  )
+                )
+            )
           },
         },
       }),
@@ -228,21 +172,13 @@ export const DictationChunkExtension = Extension.create({
   },
 })
 
-/**
- * Snapshot the current chunk positions + the text sitting inside each one.
- * Callers (the dictation hook) use this to verify a chunk's text hasn't
- * drifted before issuing a swap.
- */
 export function getDictationChunkPositions(state: EditorState): DictationChunkInfo[] {
-  const set = DictationChunkPluginKey.getState(state)
-  if (!set) return []
-  return set
-    .find()
-    .filter((d) => isChunkSpec(d.spec))
-    .map((d) => ({
-      chunkId: (d.spec as ChunkSpec).chunkId,
-      from: d.from,
-      to: d.to,
-      text: state.doc.textBetween(d.from, d.to),
+  return [...(DictationChunkPluginKey.getState(state)?.values() ?? [])]
+    .filter((chunk) => !chunk.locked)
+    .map((chunk) => ({
+      chunkId: chunk.chunkId,
+      from: chunk.from,
+      to: chunk.to,
+      contentJson: sliceJson(state.doc, chunk.from, chunk.to),
     }))
 }

--- a/apps/frontend/src/components/editor/dictation-markdown.test.ts
+++ b/apps/frontend/src/components/editor/dictation-markdown.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@tiptap/react"
+import { createEditorExtensions } from "./editor-extensions"
+import { getDictationMarkdownContext } from "./dictation-markdown"
+
+function make(content: JSONContent) {
+  const element = document.createElement("div")
+  document.body.append(element)
+  const editor = new Editor({ element, extensions: createEditorExtensions({ placeholder: "" }), content })
+  editor.on("destroy", () => element.remove())
+  return editor
+}
+
+let editor: Editor
+afterEach(() => editor?.destroy())
+
+describe("dictation Markdown context", () => {
+  it("preserves headings, marks, lists, and excludes the selection", () => {
+    editor = make({
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Title" }] },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", marks: [{ type: "bold" }], text: "before" },
+            { type: "text", text: " selected after" },
+          ],
+        },
+        {
+          type: "bulletList",
+          content: [{ type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "item" }] }] }],
+        },
+      ],
+    })
+    const selectedFrom = 15
+    const context = getDictationMarkdownContext(editor.state.doc, { from: selectedFrom, to: selectedFrom + 9 }, 200)
+    expect(context).toEqual({ before: "## Title\n\n**before**", after: "after\n\n- item" })
+  })
+
+  it("caps at serializable structure and Unicode boundaries", () => {
+    editor = make({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "bold" }], text: "ab😀cdefghij" }] }],
+    })
+    const middle = 7
+    const context = getDictationMarkdownContext(editor.state.doc, { from: middle, to: middle }, 8)
+    expect(context.before.length).toBeLessThanOrEqual(8)
+    expect(context.after.length).toBeLessThanOrEqual(8)
+    expect(context.before).not.toMatch(/[\uD800-\uDBFF]$/)
+    expect(context.after).not.toMatch(/^[\uDC00-\uDFFF]/)
+    expect(() => context.before.match(/\*\*/g)).not.toThrow()
+  })
+})

--- a/apps/frontend/src/components/editor/dictation-markdown.test.ts
+++ b/apps/frontend/src/components/editor/dictation-markdown.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { Editor } from "@tiptap/core"
 import type { JSONContent } from "@tiptap/react"
 import { createEditorExtensions } from "./editor-extensions"
@@ -51,5 +51,17 @@ describe("dictation Markdown context", () => {
     expect(context.before).not.toMatch(/[\uD800-\uDBFF]$/)
     expect(context.after).not.toMatch(/^[\uDC00-\uDFFF]/)
     expect(() => context.before.match(/\*\*/g)).not.toThrow()
+  })
+
+  it("bounds serialization attempts for a long draft", () => {
+    const text = "a".repeat(100_000)
+    editor = make({ type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] })
+    const cut = vi.spyOn(editor.state.doc, "cut")
+    const middle = Math.floor(editor.state.doc.content.size / 2)
+
+    const context = getDictationMarkdownContext(editor.state.doc, { from: middle, to: middle }, 2_000)
+
+    expect(context).toEqual({ before: "a".repeat(2_000), after: "a".repeat(2_000) })
+    expect(cut.mock.calls.length).toBeLessThanOrEqual(40)
   })
 })

--- a/apps/frontend/src/components/editor/dictation-markdown.ts
+++ b/apps/frontend/src/components/editor/dictation-markdown.ts
@@ -12,19 +12,37 @@ function serializeCut(doc: ProseMirrorNode, from: number, to: number): string | 
 }
 
 function nearestBefore(doc: ProseMirrorNode, to: number, maxChars: number): string {
-  for (let from = 0; from < to; from++) {
+  let low = 0
+  let high = to
+  let nearest = ""
+  while (low <= high) {
+    const from = Math.floor((low + high) / 2)
     const markdown = serializeCut(doc, from, to)
-    if (markdown !== null && markdown.length <= maxChars) return markdown
+    if (markdown !== null && markdown.length <= maxChars) {
+      nearest = markdown
+      high = from - 1
+    } else {
+      low = from + 1
+    }
   }
-  return ""
+  return nearest
 }
 
 function nearestAfter(doc: ProseMirrorNode, from: number, maxChars: number): string {
-  for (let to = doc.content.size; to > from; to--) {
+  let low = from
+  let high = doc.content.size
+  let nearest = ""
+  while (low <= high) {
+    const to = Math.floor((low + high) / 2)
     const markdown = serializeCut(doc, from, to)
-    if (markdown !== null && markdown.length <= maxChars) return markdown
+    if (markdown !== null && markdown.length <= maxChars) {
+      nearest = markdown
+      low = to + 1
+    } else {
+      high = to - 1
+    }
   }
-  return ""
+  return nearest
 }
 
 export function getDictationMarkdownContext(

--- a/apps/frontend/src/components/editor/dictation-markdown.ts
+++ b/apps/frontend/src/components/editor/dictation-markdown.ts
@@ -1,0 +1,39 @@
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+
+function serializeCut(doc: ProseMirrorNode, from: number, to: number): string | null {
+  if (from >= to) return ""
+  try {
+    const markdown = serializeToMarkdown(doc.cut(from, to).toJSON()).trim()
+    return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(markdown) ? null : markdown
+  } catch {
+    return null
+  }
+}
+
+function nearestBefore(doc: ProseMirrorNode, to: number, maxChars: number): string {
+  for (let from = 0; from < to; from++) {
+    const markdown = serializeCut(doc, from, to)
+    if (markdown !== null && markdown.length <= maxChars) return markdown
+  }
+  return ""
+}
+
+function nearestAfter(doc: ProseMirrorNode, from: number, maxChars: number): string {
+  for (let to = doc.content.size; to > from; to--) {
+    const markdown = serializeCut(doc, from, to)
+    if (markdown !== null && markdown.length <= maxChars) return markdown
+  }
+  return ""
+}
+
+export function getDictationMarkdownContext(
+  doc: ProseMirrorNode,
+  selection: { from: number; to: number },
+  maxChars: number
+): { before: string; after: string } {
+  return {
+    before: nearestBefore(doc, selection.from, maxChars),
+    after: nearestAfter(doc, selection.to, maxChars),
+  }
+}

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -684,6 +684,25 @@ export function toggleMultilineBlock(editor: Editor, nodeName: "codeBlock" | "bl
   return toggleBlockquoteOff(editor)
 }
 
+export function canonicalContentSlice(schema: Schema, contentJson: JSONContent): Slice | null {
+  try {
+    const doc = schema.nodeFromJSON(contentJson)
+    const blocks = [...doc.content.content]
+    if (blocks.length === 0) return null
+    if (blocks.length === 1 && blocks[0].type.name === "paragraph") {
+      return blocks[0].content.size ? new Slice(blocks[0].content, 0, 0) : null
+    }
+    const fragment = Fragment.fromArray(blocks)
+    return new Slice(
+      fragment,
+      blocks.every((block) => block.type.name === "paragraph") ? 1 : 0,
+      blocks.every((block) => block.type.name === "paragraph") ? 1 : 0
+    )
+  } catch {
+    return null
+  }
+}
+
 function getParsedContent(
   text: string,
   getMentionType?: MentionTypeLookup,
@@ -728,30 +747,19 @@ export function insertPastedText(
   // marks (bold, inline code, link, ...).
   if (blocks.length === 1 && blocks[0].type === "paragraph") {
     const inline = blocks[0].content
-    if (!inline || inline.length === 0) {
-      return false
-    }
-    return editor.commands.insertContent(inline)
+    return inline?.length ? editor.commands.insertContent(inline) : false
   }
 
-  // Multi-paragraph plain-text paste: build a slice open at both ends so the
-  // first and last pasted paragraphs merge with the paragraph surrounding the
-  // cursor, matching native paste behavior.
-  if (blocks.every((block) => block.type === "paragraph")) {
-    const { schema } = editor.state
-    const fragment = Fragment.fromArray(blocks.map((block) => schema.nodeFromJSON(block)))
-    const slice = new Slice(fragment, 1, 1)
-    return editor
-      .chain()
-      .focus()
-      .command(({ tr }) => {
-        tr.replaceSelection(slice)
-        return true
-      })
-      .run()
-  }
-
-  return editor.commands.insertContent(blocks)
+  const slice = canonicalContentSlice(editor.state.schema, { type: "doc", content: blocks })
+  if (!slice) return false
+  return editor
+    .chain()
+    .focus()
+    .command(({ tr }) => {
+      tr.replaceSelection(slice)
+      return true
+    })
+    .run()
 }
 
 /**

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -80,13 +80,13 @@ export interface RichEditorHandle {
    * later be swapped (Show original / Show polished) or locked when the user
    * edits inside it.
    */
-  insertDictationChunk(args: { chunkId: string; text: string }): void
+  insertDictationChunk(args: { chunkId: string; contentJson: JSONContent }): void
   /**
    * Swap a tracked chunk's text in place. Returns true if the swap happened,
    * false if the chunk was missing or the user edited inside it (the chunk is
    * locked in that case and the swap is skipped).
    */
-  replaceDictationChunkText(args: { chunkId: string; newText: string; expectedText: string }): boolean
+  replaceDictationChunk?(args: { chunkId: string; contentJson: JSONContent }): boolean
   /** Drop tracking for a single chunk (leaves its text in the doc). */
   lockDictationChunk(args: { chunkId: string }): void
   /** Drop tracking for every chunk. */
@@ -97,7 +97,7 @@ export interface RichEditorHandle {
    * The dictation hook uses this as the canonical `expectedText` for swap calls,
    * rather than maintaining a parallel prediction that drifts from the doc.
    */
-  getDictationChunkText(chunkId: string): string | null
+  getDictationChunkContent?(chunkId: string): JSONContent | null
   /** Access the TipTap editor instance for external toolbar rendering */
   getEditor(): import("@tiptap/react").Editor | null
 }
@@ -1113,17 +1113,17 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   )
 
   const insertDictationChunk = useCallback(
-    ({ chunkId, text }: { chunkId: string; text: string }) => {
-      if (!editor || editor.isDestroyed || !text) return
-      editor.chain().focus().insertDictationChunk({ chunkId, text }).run()
+    ({ chunkId, contentJson }: { chunkId: string; contentJson: JSONContent }) => {
+      if (!editor || editor.isDestroyed) return
+      editor.chain().focus().insertDictationChunk({ chunkId, contentJson }).run()
     },
     [editor]
   )
 
-  const replaceDictationChunkText = useCallback(
-    ({ chunkId, newText, expectedText }: { chunkId: string; newText: string; expectedText: string }) => {
+  const replaceDictationChunk = useCallback(
+    ({ chunkId, contentJson }: { chunkId: string; contentJson: JSONContent }) => {
       if (!editor || editor.isDestroyed) return false
-      return editor.chain().replaceDictationChunkText({ chunkId, newText, expectedText }).run()
+      return editor.chain().replaceDictationChunk({ chunkId, contentJson }).run()
     },
     [editor]
   )
@@ -1141,11 +1141,10 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     editor.chain().lockAllDictationChunks().run()
   }, [editor])
 
-  const getDictationChunkText = useCallback(
-    (chunkId: string): string | null => {
+  const getDictationChunkContent = useCallback(
+    (chunkId: string): JSONContent | null => {
       if (!editor || editor.isDestroyed) return null
-      const positions = getDictationChunkPositions(editor.state)
-      return positions.find((c) => c.chunkId === chunkId)?.text ?? null
+      return getDictationChunkPositions(editor.state).find((c) => c.chunkId === chunkId)?.contentJson ?? null
     },
     [editor]
   )
@@ -1162,10 +1161,10 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,
-      replaceDictationChunkText,
+      replaceDictationChunk,
       lockDictationChunk,
       lockAllDictationChunks,
-      getDictationChunkText,
+      getDictationChunkContent,
       getEditor: () => editor,
     }),
     [
@@ -1178,10 +1177,10 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,
-      replaceDictationChunkText,
+      replaceDictationChunk,
       lockDictationChunk,
       lockAllDictationChunks,
-      getDictationChunkText,
+      getDictationChunkContent,
       editor,
     ]
   )

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, it, expect, vi } from "vitest"
-import type { VoiceStartAck, VoiceTranscriptDelta } from "@threa/types"
+import type { JSONContent, VoiceStartAck, VoiceTranscriptDelta } from "@threa/types"
 import {
   friendlyTranscriptionError,
   shouldWarnNoAudio,
@@ -274,16 +274,104 @@ describe("useVoiceDictation lifecycle", () => {
     expect(harness.sockets).toHaveLength(0)
   })
 
+  it("canonically inserts send-as-is interim recovery synchronously before the composer snapshot", async () => {
+    const order: string[] = []
+    const inserted = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
+      order.push("insert")
+      expect(contentJson).toEqual({
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "bold" }], text: "recovered" }] }],
+      })
+    })
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "**recovered**",
+        isFinal: false,
+      })
+    )
+    act(() => {
+      harness.result.current.prepareSendAsIs()
+      order.push("snapshot")
+    })
+
+    expect(order).toEqual(["insert", "snapshot"])
+    expect(inserted).toHaveBeenCalledTimes(1)
+    expect(harness.committed).not.toHaveBeenCalled()
+  })
+
+  it("normalizes v2 Markdown and preserves exact v3 raw and polished JSON payloads", async () => {
+    let current: JSONContent | null = null
+    const inserted = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
+      current = contentJson
+    })
+    const swapped = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
+      current = contentJson
+      return true
+    })
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], {
+      onPolishedChunkInserted: inserted,
+      onGetChunkContent: () => current,
+      onChunkSwap: swapped,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "**legacy final**",
+        isFinal: true,
+        chunkId: "chunk_1",
+      })
+    })
+    expect(current).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "bold" }], text: "legacy final" }] }],
+    })
+
+    const rawContentJson: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "italic" }], text: "raw exact" }] }],
+    }
+    const polishedContentJson: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "code" }], text: "polished exact" }] }],
+    }
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:polished", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        chunkId: "chunk_1",
+        authoritative: true,
+        raw: "ignored raw wire text",
+        polished: "ignored polished wire text",
+        rawContentJson,
+        polishedContentJson,
+      })
+    })
+    expect(swapped).toHaveBeenLastCalledWith({ chunkId: "chunk_1", contentJson: polishedContentJson })
+    act(() => harness.result.current.setShowOriginal(true))
+    expect(swapped).toHaveBeenLastCalledWith({ chunkId: "chunk_1", contentJson: rawContentJson })
+  })
+
   it("locks stale polished comparison state when authoritative formatting fails or the take aborts", async () => {
-    let chunkText = "raw tail"
+    let chunkContent: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "raw tail" }] }],
+    }
     const lockAll = vi.fn()
     const harness = hookHarness([{ ok: true, protocolVersion: 2 }], {
-      onPolishedChunkInserted: ({ text }) => {
-        chunkText = text
+      onPolishedChunkInserted: ({ contentJson }) => {
+        chunkContent = contentJson
       },
-      onGetChunkText: () => chunkText,
-      onChunkSwap: ({ newText }) => {
-        chunkText = newText
+      onGetChunkContent: () => chunkContent,
+      onChunkSwap: ({ contentJson }) => {
+        chunkContent = contentJson
         return true
       },
       onLockAllChunks: lockAll,

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { io, type Socket } from "socket.io-client"
 import {
-  VOICE_DRAFT_CONTEXT_MAX_CHARS,
   type VoiceStartAck,
   type VoiceStoppedPayload,
   type VoiceTranscriptDelta,
   type VoiceTranscriptPolished,
 } from "@threa/types"
 import { voiceApi } from "@/api/voice"
+import { parseMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
 import { getCachedWsConfig } from "@/lib/cached-ws-config"
 import { useDictationCoordinator, isDictationExternalHeld } from "@/contexts"
 
@@ -19,12 +20,9 @@ type VoicePolishedChunk = VoiceTranscriptPolished
 export interface DictationChunkRecord {
   /** Cumulative raw text the chunk would revert to if the toggle flips to "Show original". */
   raw: string
-  /**
-   * Latest polished snapshot from the backend. Each new final delta triggers
-   * a cumulative polish whose output supersedes this — so an earlier
-   * misspoken phrase can be rewritten by a later self-correction.
-   */
+  rawContentJson?: JSONContent
   polished: string
+  polishedContentJson?: JSONContent
   /** Whether the editor currently shows the polished or the raw text for this chunk. */
   currentlyShowing: "polished" | "raw"
   /**
@@ -61,13 +59,13 @@ interface UseVoiceDictationOptions {
    * can swap it back to raw. The text passed is whatever the toggle currently
    * resolves to (polished by default).
    */
-  onPolishedChunkInserted?: (args: { chunkId: string; text: string }) => void
+  onPolishedChunkInserted?: (args: { chunkId: string; contentJson: JSONContent }) => void
   /**
    * Swap a tracked chunk's text in the editor. Must return true if the swap
    * landed cleanly, false if the chunk was missing or the user edited inside
    * it (the hook then locks that chunk locally so the toggle stops touching it).
    */
-  onChunkSwap?: (args: { chunkId: string; newText: string; expectedText: string }) => boolean
+  onChunkSwap?: (args: { chunkId: string; contentJson: JSONContent }) => boolean
   /** Drop tracking for all polished chunks (e.g. session-expired or new take starting). */
   onLockAllChunks?: () => void
   /**
@@ -77,7 +75,7 @@ interface UseVoiceDictationOptions {
    * tracked range, and we want the actual mapped text rather than a
    * parallel prediction. Returns null when the chunkId isn't tracked.
    */
-  onGetChunkText?: (chunkId: string) => string | null
+  onGetChunkContent?: (chunkId: string) => JSONContent | null
   /**
    * Read the draft text around the caret (where dictation will be inserted)
    * from the editor. Captured once when the take starts and sent with
@@ -282,7 +280,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     onPolishedChunkInserted,
     onChunkSwap,
     onLockAllChunks,
-    onGetChunkText,
+    onGetChunkContent,
     onGetDraftContext,
     language,
     dependencies = DEFAULT_VOICE_DICTATION_DEPENDENCIES,
@@ -345,8 +343,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   onChunkSwapRef.current = onChunkSwap
   const onLockAllChunksRef = useRef(onLockAllChunks)
   onLockAllChunksRef.current = onLockAllChunks
-  const onGetChunkTextRef = useRef(onGetChunkText)
-  onGetChunkTextRef.current = onGetChunkText
+  const onGetChunkContentRef = useRef(onGetChunkContent)
+  onGetChunkContentRef.current = onGetChunkContent
   const onGetDraftContextRef = useRef(onGetDraftContext)
   onGetDraftContextRef.current = onGetDraftContext
   // Read by the socket handler at insert time so the chunk lands in whichever
@@ -374,6 +372,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // Mirror the interim hypothesis into a ref so teardown/stop/fail can read and
   // flush it synchronously, without those callbacks depending on render state.
   const interimRef = useRef("")
+  const recoveryChunkSequenceRef = useRef(0)
   const updateInterim = useCallback((text: string) => {
     interimRef.current = text
     setInterimText(text)
@@ -384,7 +383,16 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // silently discarded.
   const flushInterim = useCallback(() => {
     const pending = interimRef.current
-    if (pending) onCommittedTextRef.current(pending)
+    if (pending) {
+      if (onPolishedChunkInsertedRef.current) {
+        onPolishedChunkInsertedRef.current({
+          chunkId: `local_recovery_${++recoveryChunkSequenceRef.current}`,
+          contentJson: parseMarkdown(pending),
+        })
+      } else {
+        onCommittedTextRef.current(pending)
+      }
+    }
     updateInterim("")
   }, [updateInterim])
 
@@ -687,7 +695,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             // decoration is the source of truth and we read it via
             // onGetChunkText when we need the canonical expectedText.
             if (!sessionChunkIdRef.current) sessionChunkIdRef.current = delta.chunkId
-            onPolishedChunkInsertedRef.current?.({ chunkId: delta.chunkId, text: delta.text })
+            onPolishedChunkInsertedRef.current?.({
+              chunkId: delta.chunkId,
+              contentJson: delta.contentJson ?? parseMarkdown(delta.text),
+            })
           } else if (delta.text) {
             onCommittedTextRef.current(delta.text)
           }
@@ -708,17 +719,13 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           // hook-side prediction: ProseMirror's mapping is the source of
           // truth for what's currently inside the tracked range (including
           // any spaces the extension absorbed when extending the chunk).
-          const target = showOriginalRef.current ? chunk.raw : chunk.polished
-          const expected = onGetChunkTextRef.current?.(chunk.chunkId) ?? null
-          let accepted = true
-          if (expected === null) {
-            // No tracked chunk in the editor — either it was never inserted
-            // here or it has already been locked/cleared. Drop our tracking
-            // for it so the toggle never tries to act on a missing chunk.
-            accepted = false
-          } else if (target !== expected) {
-            accepted =
-              onChunkSwapRef.current?.({ chunkId: chunk.chunkId, newText: target, expectedText: expected }) ?? false
+          const rawContentJson = chunk.rawContentJson ?? parseMarkdown(chunk.raw)
+          const polishedContentJson = chunk.polishedContentJson ?? parseMarkdown(chunk.polished)
+          const target = showOriginalRef.current ? rawContentJson : polishedContentJson
+          const current = onGetChunkContentRef.current?.(chunk.chunkId) ?? null
+          let accepted = current !== null
+          if (accepted && JSON.stringify(target) !== JSON.stringify(current)) {
+            accepted = onChunkSwapRef.current?.({ chunkId: chunk.chunkId, contentJson: target }) ?? false
           }
           setChunks((prev) => {
             const next = new Map(prev)
@@ -729,7 +736,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             }
             next.set(chunk.chunkId, {
               raw: chunk.raw,
+              rawContentJson,
               polished: chunk.polished,
+              polishedContentJson,
               currentlyShowing: showOriginalRef.current ? "raw" : "polished",
               locked: false,
             })
@@ -756,8 +765,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         // END of the before-text and the START of the after-text; empty sides
         // are omitted so the wire payload stays minimal.
         const draftContext = onGetDraftContextRef.current?.() ?? null
-        const draftBefore = draftContext?.before.slice(-VOICE_DRAFT_CONTEXT_MAX_CHARS).trim() || undefined
-        const draftAfter = draftContext?.after.slice(0, VOICE_DRAFT_CONTEXT_MAX_CHARS).trim() || undefined
+        const draftBefore = draftContext?.before.trim() || undefined
+        const draftAfter = draftContext?.after.trim() || undefined
 
         socket.emit(
           "voice:start",
@@ -869,20 +878,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       const next = new Map(chunks)
       for (const [chunkId, record] of chunks) {
         if (record.locked) continue
-        const newText = target ? record.raw : record.polished
-        // Query the editor for the true current text of this chunk. ProseMirror
-        // mapping absorbs adjacent edits into the tracked range, so the live
-        // decoration text is the only reliable expectedText.
-        const expectedText =
-          onGetChunkTextRef.current?.(chunkId) ?? (record.currentlyShowing === "raw" ? record.raw : record.polished)
-        if (newText === expectedText) {
-          // No textual difference (polish was a no-op for this chunk). Still
-          // update the bookkeeping so currentlyShowing reflects the user's
-          // intent.
+        const contentJson =
+          (target ? record.rawContentJson : record.polishedContentJson) ??
+          parseMarkdown(target ? record.raw : record.polished)
+        const current = onGetChunkContentRef.current?.(chunkId)
+        if (current && JSON.stringify(contentJson) === JSON.stringify(current)) {
           next.set(chunkId, { ...record, currentlyShowing: target ? "raw" : "polished" })
           continue
         }
-        const accepted = onChunkSwapRef.current?.({ chunkId, newText, expectedText }) ?? false
+        const accepted = onChunkSwapRef.current?.({ chunkId, contentJson }) ?? false
         if (accepted) {
           next.set(chunkId, { ...record, currentlyShowing: target ? "raw" : "polished" })
         } else {

--- a/packages/types/src/voice-dictation.ts
+++ b/packages/types/src/voice-dictation.ts
@@ -1,4 +1,6 @@
-export const VOICE_PROTOCOL_VERSION = 2 as const
+import type { JSONContent } from "./prosemirror"
+
+export const VOICE_PROTOCOL_VERSION = 3 as const
 
 export type VoiceTerminationMode = "format" | "send_as_is" | "abort"
 export type VoiceRelayPhase = "live" | "formatting" | "closing" | "closed"
@@ -23,6 +25,7 @@ export interface VoiceTranscriptDelta {
   text: string
   isFinal: boolean
   chunkId?: string
+  contentJson?: JSONContent
 }
 
 export interface VoiceTranscriptPolished {
@@ -32,6 +35,8 @@ export interface VoiceTranscriptPolished {
   authoritative: boolean
   raw: string
   polished: string
+  rawContentJson?: JSONContent
+  polishedContentJson?: JSONContent
 }
 
 export interface VoiceStoppedPayload {


### PR DESCRIPTION
## Problem

Dictation polish crossed the editor boundary as text, flattening paragraphs, lists, headings, and marks. Draft context used plain `textBetween`, structured toggles depended on parallel expected-text state, and late polish could not safely replace a mapped multi-block range.

## Solution

The model still reads and returns Markdown. The app parses successful model Markdown with `@threa/prosemirror` to canonical `contentJson` before internal delivery or editor insertion. Protocol v3 carries canonical raw and polished documents alongside Markdown used for model and comparison boundaries; v2 Markdown-only events normalize once at the socket boundary. Fresh caret context is serialized from ProseMirror to bounded Markdown on every take. Structured chunk records map exact slices, preserve inline spacing and real block nodes, and lock permanently when users edit inside them.

## Files

- Backend: polish parsing and structured gateway payloads.
- Shared types: protocol v3 structured voice fields.
- Frontend: Markdown context serialization, canonical recovery, structured editor commands, hook/composer/mic wiring, and focused tests.

## Tests

- `git diff --check`: pass
- Backend polish/gateway tests: 52 pass
- Frontend structured dictation/hook/composer/inspector tests: 86 pass
- Shared Markdown tests: 96 pass
- Types/prosemirror/backend/frontend typecheck: pass
- Backend/frontend lint: pass
- Post-commit hook: full monorepo lint/typecheck, migration, Dockerfile, and API-doc checks pass

<details>
<summary>📋 Full implementation plan</summary>

### Actual PR2 implementation

- Parse successful polished Markdown immediately; empty, truncated, or unparseable output remains non-success.
- Emit raw and polished `contentJson` with Markdown; prefer protocol v3 JSON and normalize v2 Markdown once.
- Serialize valid, Unicode-safe ProseMirror cuts around the selection to capped Markdown while preserving headings, marks, paragraphs, and lists.
- Replace text-only chunk tracking with mapped structured ranges and exact expected slice JSON. Inline paragraphs merge naturally; multi-block content uses canonical ProseMirror slices; internal edits create locked tombstones that reject later insertion or replacement.
- Route canonical JSON through `RichEditor`, dictation hooks, toggles, and synchronous send-as-is recovery. Keep Markdown in inspector records for comparison.

### Stack context

Stack layer 2: `feat/dictation-structured-markdown` targets `fix/dictation-polish-lifecycle` at `fa523f1f`. PR1 owns lifecycle, cancellation, revision, termination-mode, and provider-flush behavior. PR3 owns evals and calibration.

### Decisions

- The model still reads and returns Markdown; the app parses it to canonical `contentJson`.
- `@threa/prosemirror` remains the only Markdown parser/serializer.
- Canonical JSON is replacement authority; Markdown remains the model, wire, and comparison form.
- Existing TipTap schema and ProseMirror transactions own insertion and mapping. No HTML path or parallel expected-text state.
- User edits inside tracked content always win; adjacent edits only remap the range.

### Exclusions

No prompt, model, or deadline calibration; eval suite; mention/channel behavior beyond existing parser semantics; editor schema fork; persistence or migration; collaboration redesign; settings/UI redesign; STT/audio changes; spoken editing commands.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
