### PR TITLE
feat(delegations): add recoverable task states

### DIFF
--- a/apps/backend/src/features/agent-outcomes/service.test.ts
+++ b/apps/backend/src/features/agent-outcomes/service.test.ts
@@ -65,14 +65,14 @@ describe("statusesForState", () => {
   it("resolves outstanding to the non-terminal statuses of both kinds", () => {
     expect(statusesForState("outstanding")).toEqual({
       followUpStatuses: ["pending"],
-      delegationStatuses: ["open", "claimed", "running"],
+      delegationStatuses: ["open", "claimed", "running", "expired"],
     })
   })
 
   it("resolves settled to the terminal statuses of both kinds", () => {
     expect(statusesForState("settled")).toEqual({
       followUpStatuses: ["fired", "cancelled", "failed"],
-      delegationStatuses: ["completed", "failed", "cancelled", "expired"],
+      delegationStatuses: ["completed", "failed", "cancelled"],
     })
   })
 

--- a/apps/backend/tests/integration/agent-outcomes-read.test.ts
+++ b/apps/backend/tests/integration/agent-outcomes-read.test.ts
@@ -87,6 +87,7 @@ describe("agent outcomes read path", () => {
   let privateDelegationId: string
   let channelFollowUpId: string
   let channelDelegationId: string
+  let expiredDelegationId: string
   let threadFollowUpEventId: string
 
   beforeAll(async () => {
@@ -162,6 +163,13 @@ describe("agent outcomes read path", () => {
       title: "Ship the migration",
       status: "running",
       statusChangedAt: new Date("2126-01-01T00:00:00.000Z"),
+    })
+    expiredDelegationId = await seedDelegation(pool, {
+      workspaceId: wsId,
+      streamId: channelId,
+      title: "Recover the expired claim",
+      status: "expired",
+      statusChangedAt: new Date("2126-01-01T00:01:00.000Z"),
     })
     threadFollowUpEventId = eventId()
     await withTransaction(pool, async (client) => {
@@ -253,7 +261,7 @@ describe("agent outcomes read path", () => {
       withCount: true,
     })
 
-    expect({ off: withoutCount.outstandingCount, on: withCount.outstandingCount }).toEqual({ off: null, on: 2 })
+    expect({ off: withoutCount.outstandingCount, on: withCount.outstandingCount }).toEqual({ off: null, on: 3 })
   })
 
   test("scope=stream drops a thread's follow-up that scope=tree includes", async () => {
@@ -280,7 +288,7 @@ describe("agent outcomes read path", () => {
     }).toEqual({
       treeHasThreadRow: true,
       streamHasThreadRow: false,
-      streamIds: [channelDelegationId, channelFollowUpId].sort(),
+      streamIds: [channelDelegationId, expiredDelegationId, channelFollowUpId].sort(),
     })
   })
 
@@ -288,7 +296,9 @@ describe("agent outcomes read path", () => {
     const outstanding = await service().list({ workspaceId: wsId, userId: memberId, state: "outstanding", limit: 50 })
     const settled = await service().list({ workspaceId: wsId, userId: memberId, state: "settled", limit: 50 })
 
-    expect(outstanding.items.map((i) => i.id).sort()).toEqual([threadFollowUpId, channelDelegationId].sort())
+    expect(outstanding.items.map((i) => i.id).sort()).toEqual(
+      [threadFollowUpId, channelDelegationId, expiredDelegationId].sort()
+    )
     expect(settled.items.map((i) => i.id)).toEqual([channelFollowUpId])
   })
 
@@ -302,7 +312,7 @@ describe("agent outcomes read path", () => {
     })
 
     expect(response.items.map((i) => i.id).sort()).toEqual(
-      [threadFollowUpId, channelDelegationId, channelFollowUpId].sort()
+      [threadFollowUpId, channelDelegationId, expiredDelegationId, channelFollowUpId].sort()
     )
   })
 

--- a/apps/frontend/src/api/delegations.ts
+++ b/apps/frontend/src/api/delegations.ts
@@ -28,10 +28,14 @@ export const delegationsApi = {
     return api.get<DelegationSummary>(`/api/workspaces/${workspaceId}/delegations/${id}`)
   },
 
+  /** Reopen an expired delegation. `requeued` is false when another transition won first. */
+  async requeue(workspaceId: string, id: string): Promise<{ requeued: boolean }> {
+    return api.post<{ requeued: boolean }>(`/api/workspaces/${workspaceId}/delegations/${id}/requeue`, {})
+  },
+
   /**
-   * Cancel a non-terminal delegation. `cancelled` is `false` when the cancel
-   * lost the race (already completed/failed/expired/cancelled); the call still
-   * resolves so a double-click is harmless.
+   * Cancel a non-terminal delegation, including an expired one. `cancelled` is
+   * false when a completed, failed, or cancelled transition won first.
    */
   async cancel(workspaceId: string, id: string): Promise<{ cancelled: boolean }> {
     return api.post<{ cancelled: boolean }>(`/api/workspaces/${workspaceId}/delegations/${id}/cancel`, {})

--- a/apps/frontend/src/components/agent-outcomes/outcomes-detail.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-detail.tsx
@@ -8,6 +8,7 @@ import { useAsyncAction } from "@/hooks/use-async-action"
 import { useFormattedDate } from "@/hooks"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { agentOutcomeKeys } from "@/hooks/use-agent-outcomes"
+import { delegationKeys } from "@/hooks/use-stream-delegations"
 import { OUTCOME_KIND_LABEL, type OutcomeItem } from "@/lib/agent-outcomes/items"
 import { cn } from "@/lib/utils"
 
@@ -30,7 +31,12 @@ export function OutcomesDetail({ workspaceId, item }: OutcomesDetailProps) {
   const streamName = useStreamName(workspaceId, item?.streamId ?? "", "noun")
   const queryClient = useQueryClient()
 
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: agentOutcomeKeys.all })
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: agentOutcomeKeys.all }),
+      queryClient.invalidateQueries({ queryKey: delegationKeys.all }),
+    ])
+  }
 
   const cancel = useAsyncAction(
     async () => {
@@ -45,6 +51,16 @@ export function OutcomesDetail({ workspaceId, item }: OutcomesDetailProps) {
       await invalidate()
     },
     { errorMessage: "Couldn't cancel" }
+  )
+
+  const requeue = useAsyncAction(
+    async () => {
+      if (!item || item.kind !== "delegation") return
+      const { requeued } = await delegationsApi.requeue(workspaceId, item.id)
+      if (!requeued) toast.info("This delegation is no longer expired")
+      await invalidate()
+    },
+    { errorMessage: "Couldn't requeue" }
   )
 
   const markDone = useAsyncAction(
@@ -104,6 +120,11 @@ export function OutcomesDetail({ workspaceId, item }: OutcomesDetailProps) {
         ) : (
           <span className="text-xs text-muted-foreground">No card to open — its source event is gone.</span>
         )}
+        {item.canRequeue ? (
+          <Button size="sm" variant="outline" onClick={requeue.run} disabled={requeue.pending}>
+            Requeue
+          </Button>
+        ) : null}
         {item.canMarkDone ? (
           <Button size="sm" variant="outline" onClick={markDone.run} disabled={markDone.pending}>
             Mark done

--- a/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
+++ b/apps/frontend/src/components/agent-outcomes/outcomes-shell.integration.test.tsx
@@ -2,8 +2,10 @@ import type { AgentOutcomeSummary, ListAgentOutcomesResponse } from "@threa/type
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter, useLocation } from "react-router-dom"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { toast } from "sonner"
 import { render, screen, userEvent, waitFor } from "@/test"
 import * as agentOutcomesApiModule from "@/api/agent-outcomes"
+import { delegationsApi } from "@/api/delegations"
 import * as preferencesModule from "@/contexts/preferences-context"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as mobileModule from "@/hooks/use-mobile"
@@ -28,6 +30,18 @@ function makeFollowUp(overrides: Partial<AgentOutcomeSummary> = {}): AgentOutcom
     occursAt: "2026-08-01T18:00:00.000Z",
     anchorEventId: "event_1",
     ...overrides,
+  } as AgentOutcomeSummary
+}
+
+function expiredDelegation(): AgentOutcomeSummary {
+  return {
+    ...makeFollowUp(),
+    kind: "delegation",
+    id: "dlg_expired",
+    title: "Recover the claim",
+    status: "expired",
+    scheduledFor: null,
+    occursAt: "2026-07-28T10:00:00.000Z",
   } as AgentOutcomeSummary
 }
 
@@ -122,6 +136,53 @@ describe("OutcomesShell", () => {
     const detail = await screen.findByTestId("outcomes-detail")
     expect(detail).toHaveTextContent("Follow-up")
     expect(detail).toHaveTextContent("Scheduled")
+  })
+
+  it("offers expired recovery and invalidates the outcome after requeue", async () => {
+    const listSpy = vi
+      .spyOn(agentOutcomesApiModule.agentOutcomesApi, "list")
+      .mockResolvedValue(page([expiredDelegation()]))
+    const requeue = vi.spyOn(delegationsApi, "requeue").mockResolvedValue({ requeued: true })
+
+    renderShell("/w/ws_1/agenda?aSelected=dlg_expired")
+    expect(await screen.findAllByText("Claim expired")).toHaveLength(2)
+    expect(screen.getByRole("button", { name: "Mark done" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+    await userEvent.setup().click(screen.getByRole("button", { name: "Requeue" }))
+
+    expect(requeue).toHaveBeenCalledWith("ws_1", "dlg_expired")
+    await waitFor(() => expect(listSpy.mock.calls.length).toBeGreaterThan(1))
+  })
+
+  it("reports a lost requeue race and refreshes authoritative outcomes", async () => {
+    const listSpy = vi
+      .spyOn(agentOutcomesApiModule.agentOutcomesApi, "list")
+      .mockResolvedValue(page([expiredDelegation()]))
+    vi.spyOn(delegationsApi, "requeue").mockResolvedValue({ requeued: false })
+    const info = vi.spyOn(toast, "info")
+
+    renderShell("/w/ws_1/agenda?aSelected=dlg_expired")
+    await userEvent.setup().click(await screen.findByRole("button", { name: "Requeue" }))
+
+    await waitFor(() => expect(info).toHaveBeenCalledWith("This delegation is no longer expired"))
+    await waitFor(() => expect(listSpy.mock.calls.length).toBeGreaterThan(1))
+  })
+
+  it("keeps truthful expired state and reports a requeue error without refreshing", async () => {
+    const listSpy = vi
+      .spyOn(agentOutcomesApiModule.agentOutcomesApi, "list")
+      .mockResolvedValue(page([expiredDelegation()]))
+    vi.spyOn(delegationsApi, "requeue").mockRejectedValue(new Error("offline"))
+    const error = vi.spyOn(toast, "error")
+
+    renderShell("/w/ws_1/agenda?aSelected=dlg_expired")
+    await screen.findByRole("button", { name: "Requeue" })
+    const before = listSpy.mock.calls.length
+    await userEvent.setup().click(screen.getByRole("button", { name: "Requeue" }))
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith("Couldn't requeue"))
+    expect(listSpy).toHaveBeenCalledTimes(before)
+    expect(screen.getByTestId("outcomes-detail")).toHaveTextContent("Claim expired")
   })
 
   it("the back arrow returns a deep-linked detail to the list, without closing the surface", async () => {

--- a/apps/frontend/src/components/stream-context/stream-context-row.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-row.test.tsx
@@ -125,6 +125,19 @@ describe("StreamContextRow delegation", () => {
     expect(screen.getByText("Delegated task")).toBeInTheDocument()
   })
 
+  it("styles expired work as active", () => {
+    renderRow(delegationItem({ status: "expired", claimedByLabel: null, statusNote: null }))
+    const expired = screen.getByText("Claim expired")
+    expect(expired).toHaveClass("bg-primary/15", "text-primary")
+    expect(screen.getByText("Add rate limiting")).not.toHaveClass("line-through")
+  })
+
+  it("labels an authoritative reopened delegation Open with active styling", () => {
+    renderRow(delegationItem({ status: "open", claimedByLabel: null, statusNote: null }))
+    expect(screen.getByText("Open")).toHaveClass("bg-sky-500/15")
+    expect(screen.getByText("Add rate limiting")).not.toHaveClass("line-through")
+  })
+
   it("renders inert (no dead-click button) when the created event id is missing", () => {
     renderRow(delegationItem({ sourceMessageId: null }))
     expect(screen.getByText("Add rate limiting")).toBeInTheDocument()

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -2,12 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { DelegationCreatedEventPayload, DelegationStatusChangedEventPayload, StreamEvent } from "@threa/types"
 import { toast } from "sonner"
 import * as hooksModule from "@/hooks"
 import { PanelProvider } from "@/contexts"
 import { delegationsApi } from "@/api"
 import { buildDelegationPrompt, DelegationEvent } from "./delegation-event"
+import {
+  collectDelegationStatusPatches,
+  TimelineItemContent,
+  type TimelineItem,
+  type TimelineItemRenderContext,
+} from "./event-list"
 
 afterEach(() => vi.useRealTimers())
 
@@ -58,19 +65,23 @@ function renderCard(
   payloadOverride?: Partial<CardPayload>,
   isThreadParent = false
 ) {
-  return render(
-    <MemoryRouter initialEntries={["/w/ws_1"]}>
-      <PanelProvider>
-        <DelegationEvent
-          event={createdEvent({ ...CREATED_PAYLOAD, ...payloadOverride })}
-          workspaceId="ws_1"
-          streamId="stream_1"
-          statusPatch={statusPatch}
-          isThreadParent={isThreadParent}
-        />
-      </PanelProvider>
-    </MemoryRouter>
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const rendered = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/w/ws_1"]}>
+        <PanelProvider>
+          <DelegationEvent
+            event={createdEvent({ ...CREATED_PAYLOAD, ...payloadOverride })}
+            workspaceId="ws_1"
+            streamId="stream_1"
+            statusPatch={statusPatch}
+            isThreadParent={isThreadParent}
+          />
+        </PanelProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
+  return { ...rendered, queryClient }
 }
 
 describe("buildDelegationPrompt", () => {
@@ -189,7 +200,8 @@ describe("DelegationEvent", () => {
     expect(chip).toHaveAttribute("href", "/w/ws_1?panel=stream_thread")
   })
 
-  it.each(["failed", "expired"] as const)("%s is terminal: no Cancel action, status in meta", async (status) => {
+  it("failed is terminal: no Cancel action, status in meta", async () => {
+    const status = "failed" as const
     renderCard({ delegationId: "dlg_1", status })
 
     expect(screen.getByText(new RegExp(`Ariadne · ${status}`, "i"))).toBeInTheDocument()
@@ -267,12 +279,156 @@ describe("DelegationEvent", () => {
     expect(screen.getByText(/Ariadne · Open/)).toBeInTheDocument()
   })
 
-  it("embeds the lifecycle breadcrumb (id + claim endpoint) in the compiled prompt", () => {
+  it("describes the executor-neutral inspect, claim, liveness, and release order", () => {
     const prompt = buildDelegationPrompt(CREATED_PAYLOAD, { workspaceId: "ws_1", origin: "https://threa.test" })
-    expect(prompt).toContain("## Threa delegation lifecycle")
-    expect(prompt).toContain("https://threa.test/api/v1/workspaces/ws_1/delegations/dlg_1/claim")
-    expect(prompt).toContain("X-Threa-Callback-Token")
-    expect(prompt).toContain('press "Mark done"')
+    expect(prompt.indexOf("1. Inspect: GET")).toBeLessThan(prompt.indexOf("2. If you accept the work, claim it"))
+    expect(prompt).toContain("optionally renews the lease")
+    expect(prompt).toContain("For a controlled stop")
+    expect(prompt).toContain("/release")
+    expect(prompt).not.toContain("resolved context refs")
+    expect(prompt).not.toContain("Claude Code")
+  })
+
+  it.each([
+    ["claim_expired", "Claim expired · Open again"],
+    ["claim_released", "Claim released · Open again"],
+    ["requeued", "Requeued · Open"],
+  ] as const)("renders %s with distinct frontend-owned availability copy", (reason, label) => {
+    renderCard({ delegationId: "dlg_1", status: "open", reason })
+    expect(screen.getByText(new RegExp(label.replace("·", "·")))).toBeInTheDocument()
+  })
+
+  it("keeps historical expired work active and exposes every recovery action", async () => {
+    renderCard({ delegationId: "dlg_1", status: "expired" })
+    expect(screen.getByText("Add rate limiting to the webhook endpoint")).not.toHaveClass("line-through")
+    expect(screen.getByText(/Ariadne · Claim expired/)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Card actions" }))
+    expect(screen.getByRole("menuitem", { name: "Requeue" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Mark done" })).toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Cancel delegation" })).toBeInTheDocument()
+  })
+
+  it("shows a winning requeue before pending invalidations finish", async () => {
+    vi.spyOn(delegationsApi, "requeue").mockResolvedValue({ requeued: true })
+    const { queryClient } = renderCard({ delegationId: "dlg_1", status: "expired" })
+    let finishInvalidations!: () => void
+    const invalidations = new Promise<void>((resolve) => {
+      finishInvalidations = resolve
+    })
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries").mockReturnValue(invalidations)
+
+    await selectCardAction("Requeue")
+
+    expect(await screen.findByText(/Requeued · Open/)).toBeInTheDocument()
+    expect(invalidate).toHaveBeenCalledTimes(2)
+    finishInvalidations()
+  })
+
+  it("keeps requeue optimism for an equivalent reconstructed baseline and yields to newer lifecycle patches", async () => {
+    vi.spyOn(delegationsApi, "requeue").mockResolvedValue({ requeued: true })
+    const expired = { delegationId: "dlg_1", status: "expired", reason: "claim_expired" } as const
+    const { queryClient, rerender } = renderCard(expired)
+    await selectCardAction("Requeue")
+    expect(await screen.findByText(/Requeued · Open/)).toBeInTheDocument()
+
+    const renderPatch = (statusPatch: DelegationStatusChangedEventPayload) =>
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={["/w/ws_1"]}>
+            <PanelProvider>
+              <DelegationEvent
+                event={createdEvent(CREATED_PAYLOAD)}
+                workspaceId="ws_1"
+                streamId="stream_1"
+                statusPatch={statusPatch}
+              />
+            </PanelProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+
+    renderPatch({ ...expired })
+    expect(screen.getByText(/Requeued · Open/)).toBeInTheDocument()
+    expect(screen.queryByText(/Claim expired/)).not.toBeInTheDocument()
+
+    renderPatch({ delegationId: "dlg_1", status: "open", reason: "requeued" })
+    expect(await screen.findByText(/Requeued · Open/)).toBeInTheDocument()
+
+    renderPatch({ delegationId: "dlg_1", status: "claimed", claimedByLabel: "New owner" })
+    expect(await screen.findByText(/Ariadne · Claimed · New owner/)).toBeInTheDocument()
+
+    renderPatch({ delegationId: "dlg_1", status: "completed" })
+    expect(await screen.findByText(/Ariadne · Completed/)).toBeInTheDocument()
+  })
+
+  it("renders each collected last patch through the mounted memoized timeline row", async () => {
+    const cardItem: TimelineItem = { type: "event", event: createdEvent(CREATED_PAYLOAD) }
+    const patchItem = (id: string, status: string, reason?: string): TimelineItem => ({
+      type: "event",
+      event: {
+        ...createdEvent(CREATED_PAYLOAD),
+        id,
+        eventType: "delegation:status_changed",
+        payload: { delegationId: "dlg_1", status, reason },
+      },
+    })
+    const ctx = (patches: TimelineItem[]): TimelineItemRenderContext => ({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sessionLiveCounts: new Map(),
+      sessionLiveSubsteps: new Map(),
+      cancelledFollowUpIds: new Set(),
+      delegationStatusPatches: collectDelegationStatusPatches(patches),
+      botAccessStatusPatches: new Map(),
+      callEndedPatches: new Map(),
+    })
+    const queryClient = new QueryClient()
+    const row = (patches: TimelineItem[]) => (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/w/ws_1"]}>
+          <PanelProvider>
+            <TimelineItemContent item={cardItem} ctx={ctx(patches)} deferSecondaryHydration={false} />
+          </PanelProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    const expired = patchItem("evt_expired", "expired", "claim_expired")
+    const released = patchItem("evt_released", "open", "claim_released")
+    const claimed = patchItem("evt_claimed", "claimed")
+    const { rerender } = render(row([expired]))
+    expect(screen.getByText(/Claim expired/)).toBeInTheDocument()
+
+    rerender(row([expired, patchItem("evt_open_expired", "open", "claim_expired")]))
+    expect(await screen.findByText(/Claim expired · Open again/)).toBeInTheDocument()
+
+    rerender(row([expired, released]))
+    expect(await screen.findByText(/Claim released · Open again/)).toBeInTheDocument()
+
+    rerender(row([expired, released, claimed]))
+    expect(await screen.findByText(/Ariadne · Claimed/)).toBeInTheDocument()
+  })
+
+  it("invalidates definitive lost races without lying about local state", async () => {
+    vi.spyOn(delegationsApi, "requeue").mockResolvedValue({ requeued: false })
+    const info = vi.spyOn(toast, "info")
+    const { queryClient } = renderCard({ delegationId: "dlg_1", status: "expired" })
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    await selectCardAction("Requeue")
+    await waitFor(() => expect(info).toHaveBeenCalledWith("This delegation is no longer expired"))
+    expect(invalidate).toHaveBeenCalledTimes(2)
+    expect(screen.getByText(/Ariadne · Claim expired/)).toBeInTheDocument()
+  })
+
+  it("preserves expired state and caches when requeue errors", async () => {
+    vi.spyOn(delegationsApi, "requeue").mockRejectedValue(new Error("offline"))
+    const error = vi.spyOn(toast, "error")
+    const { queryClient } = renderCard({ delegationId: "dlg_1", status: "expired" })
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    await selectCardAction("Requeue")
+    await waitFor(() => expect(error).toHaveBeenCalledWith("Couldn't requeue the delegation"))
+    expect(invalidate).not.toHaveBeenCalled()
+    expect(screen.getByText(/Ariadne · Claim expired/)).toBeInTheDocument()
   })
 
   it("cancels via the API and flips to Cancelled for the clicking member", async () => {
@@ -342,12 +498,13 @@ describe("DelegationEvent", () => {
     vi.useFakeTimers()
     vi.spyOn(hooksModule, "useTouchCapable").mockReturnValue(true)
     vi.spyOn(hooksModule, "useInputMode").mockReturnValue("touch")
-    renderCard()
+    renderCard({ delegationId: "dlg_1", status: "expired" })
 
     const title = screen.getByText("Add rate limiting to the webhook endpoint")
     fireEvent.touchStart(title, { touches: [{ clientX: 10, clientY: 10 }] })
     act(() => vi.advanceTimersByTime(500))
 
+    expect(screen.getByRole("button", { name: "Requeue" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Mark done" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Cancel delegation" })).toBeInTheDocument()
     vi.useRealTimers()
@@ -369,15 +526,17 @@ describe("DelegationEvent", () => {
 
   it("renders nothing without a payload", () => {
     const { container } = render(
-      <MemoryRouter initialEntries={["/w/ws_1"]}>
-        <PanelProvider>
-          <DelegationEvent
-            event={{ ...createdEvent(CREATED_PAYLOAD), payload: undefined }}
-            workspaceId="ws_1"
-            streamId="stream_1"
-          />
-        </PanelProvider>
-      </MemoryRouter>
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter initialEntries={["/w/ws_1"]}>
+          <PanelProvider>
+            <DelegationEvent
+              event={{ ...createdEvent(CREATED_PAYLOAD), payload: undefined }}
+              workspaceId="ws_1"
+              streamId="stream_1"
+            />
+          </PanelProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
     expect(container).toBeEmptyDOMElement()
   })

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
   ArrowUpRight,
@@ -10,6 +11,7 @@ import {
   Link2,
   Loader2,
   MessageSquareReply,
+  RotateCcw,
   TerminalSquare,
   X,
 } from "lucide-react"
@@ -24,7 +26,13 @@ import {
 import { delegationsApi } from "@/api"
 import { usePanel } from "@/contexts"
 import { useActors } from "@/hooks"
-import { DELEGATION_STATUS_LABEL, DELEGATION_TERMINAL } from "@/lib/delegation-display"
+import { agentOutcomeKeys } from "@/hooks/use-agent-outcomes"
+import { delegationKeys } from "@/hooks/use-stream-delegations"
+import {
+  delegationAvailabilityLabel,
+  DELEGATION_REOPEN_REASON_LABEL,
+  DELEGATION_TERMINAL,
+} from "@/lib/delegation-display"
 import { buildDelegationLink } from "@/lib/stream-links"
 import { cn } from "@/lib/utils"
 import { ThreadSlot } from "./thread-slot"
@@ -36,6 +44,19 @@ import {
   useTimelineCardActionSurface,
 } from "./timeline-card-actions"
 import { useThreadAnchor } from "./use-thread-anchor"
+
+function delegationPatchSignature(patch: DelegationStatusChangedEventPayload | undefined): string | undefined {
+  if (!patch) return undefined
+  return JSON.stringify([
+    patch.delegationId,
+    patch.status,
+    patch.claimedByLabel ?? null,
+    patch.resultMessageId ?? null,
+    patch.threadStreamId ?? null,
+    patch.statusNote ?? null,
+    patch.reason ?? null,
+  ])
+}
 
 interface DelegationEventProps {
   event: StreamEvent
@@ -84,14 +105,16 @@ export function buildDelegationPrompt(
       `(created in Threa under Settings > API keys, scopes delegations:read + delegations:write),`,
       `work it through the API so the card tracks your progress:`,
       "",
-      `1. Claim: POST ${base}/claim with body {"claimedByLabel":"<who/what you are>"}.`,
-      `   The response carries the brief, the resolved context refs, and a claimToken (shown once, 15-minute lease).`,
-      `2. Send the token as an X-Threa-Callback-Token header on every later call:`,
-      `   POST ${base}/heartbeat (renew the lease), POST ${base}/status {"statusNote":"..."} (progress on the card),`,
-      `   then POST ${base}/complete {"resultMarkdown":"..."} or POST ${base}/fail {"errorMessage":"..."}.`,
+      `1. Inspect: GET ${base}. Review the brief and context refs, which are pointers into Threa.`,
+      `2. If you accept the work, claim it: POST ${base}/claim with body {"claimedByLabel":"<executor label>"}.`,
+      `   The response includes a claimToken shown once and a 15-minute lease.`,
+      `3. Send the token as an X-Threa-Callback-Token header on later calls.`,
+      `   POST ${base}/heartbeat optionally renews the lease; POST ${base}/status {"statusNote":"..."} reports progress.`,
+      `   POST ${base}/complete {"resultMarkdown":"..."} completes the work; POST ${base}/fail {"errorMessage":"..."} reports an execution failure.`,
+      `   For a controlled stop, POST ${base}/release so another executor can claim it.`,
       `   Completing posts your result into the conversation.`,
       "",
-      `Without API access: the context refs above are Threa-internal pointers you cannot resolve —`,
+      `Without API access, the context refs above are Threa-internal pointers you cannot resolve.`,
       `ask the requester to paste their content, and when the work is finished tell them so they`,
       `can press "Mark done" on the delegation card.`
     )
@@ -108,6 +131,7 @@ export function buildDelegationPrompt(
 export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isThreadParent }: DelegationEventProps) {
   const { getActorName } = useActors(workspaceId)
   const { getPanelUrl } = usePanel()
+  const queryClient = useQueryClient()
   // Healing (chunk-2) lands thread stats on the card's own payload once a thread
   // exists, keyed on this event's id — the same anchor the thread was created on.
   const payload = event.payload as
@@ -119,23 +143,36 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
   const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
   const [optimisticallyCancelled, setOptimisticallyCancelled] = useState(false)
   const [optimisticallyDone, setOptimisticallyDone] = useState(false)
+  const [optimisticallyRequeued, setOptimisticallyRequeued] = useState(false)
+  const requeuePatchSignatureRef = useRef<string | undefined>(undefined)
   const [cancelling, setCancelling] = useState(false)
   const [markingDone, setMarkingDone] = useState(false)
+  const [requeueing, setRequeueing] = useState(false)
   const [copyDone, setCopyDone] = useState(false)
   const [briefOpen, setBriefOpen] = useState(false)
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const actionSurface = useTimelineCardActionSurface()
+
+  const statusPatchSignature = delegationPatchSignature(statusPatch)
+  useEffect(() => {
+    if (optimisticallyRequeued && statusPatchSignature !== requeuePatchSignatureRef.current) {
+      setOptimisticallyRequeued(false)
+    }
+  }, [optimisticallyRequeued, statusPatchSignature])
 
   if (!payload) return null
 
   let status: DelegationStatus = statusPatch?.status ?? DelegationStatuses.OPEN
   if (optimisticallyDone) status = DelegationStatuses.COMPLETED
   else if (optimisticallyCancelled) status = DelegationStatuses.CANCELLED
+  else if (optimisticallyRequeued) status = DelegationStatuses.OPEN
   const terminal = DELEGATION_TERMINAL.has(status)
-  const optimisticFlip = optimisticallyCancelled || optimisticallyDone
+  const optimisticFlip = optimisticallyCancelled || optimisticallyDone || optimisticallyRequeued
   const actorName = getActorName(event.actorId, event.actorType)
 
-  const metaParts = [`${actorName} · ${DELEGATION_STATUS_LABEL[status]}`]
+  let availabilityLabel = delegationAvailabilityLabel(status, statusPatch?.reason)
+  if (optimisticallyRequeued) availabilityLabel = DELEGATION_REOPEN_REASON_LABEL.requeued
+  const metaParts = [`${actorName} · ${availabilityLabel}`]
   if (statusPatch?.claimedByLabel && !optimisticFlip) metaParts.push(statusPatch.claimedByLabel)
   const statusNote = !optimisticFlip ? statusPatch?.statusNote : null
 
@@ -179,6 +216,28 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
     }
   }
 
+  async function handleRequeue() {
+    if (!payload || requeueing || status !== DelegationStatuses.EXPIRED) return
+    setRequeueing(true)
+    try {
+      const { requeued } = await delegationsApi.requeue(workspaceId, payload.delegationId)
+      if (requeued) {
+        requeuePatchSignatureRef.current = statusPatchSignature
+        setOptimisticallyRequeued(true)
+      } else {
+        toast.info("This delegation is no longer expired")
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: delegationKeys.all }),
+        queryClient.invalidateQueries({ queryKey: agentOutcomeKeys.all }),
+      ])
+    } catch {
+      toast.error("Couldn't requeue the delegation")
+    } finally {
+      setRequeueing(false)
+    }
+  }
+
   async function handleMarkDone() {
     if (!payload || markingDone || terminal) return
     setMarkingDone(true)
@@ -204,7 +263,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
       if (didCancel) {
         setOptimisticallyCancelled(true)
       } else {
-        // Lost the race (completed/failed/expired/cancelled elsewhere). Don't
+        // Lost the race (completed/failed/cancelled elsewhere). Don't
         // flip — the authoritative patch will land with what actually happened.
         toast.info("This delegation already finished or was cancelled")
       }
@@ -251,6 +310,17 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
       onSelect: () => setBriefOpen((open) => !open),
     }
   )
+  if (status === DelegationStatuses.EXPIRED) {
+    actions.push({
+      id: "requeue",
+      label: requeueing ? "Requeueing…" : "Requeue",
+      icon: requeueing ? Loader2 : RotateCcw,
+      onSelect: handleRequeue,
+      disabled: requeueing,
+      loading: requeueing,
+      separatorBefore: true,
+    })
+  }
   if (!terminal) {
     actions.push(
       {
@@ -286,7 +356,8 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
       <div
         className={cn(
           "rounded-[10px] border px-3 py-2 transition-colors",
-          terminal ? "border-border/60 bg-muted/20" : "border-border bg-muted/40"
+          terminal ? "border-border/60 bg-muted/20" : "border-border bg-muted/40",
+          status === DelegationStatuses.EXPIRED && "border-primary/35 bg-primary/[0.04]"
         )}
       >
         <div className="flex items-center gap-3">
@@ -303,9 +374,7 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
             <p
               className={cn(
                 "truncate text-[13px] font-medium",
-                status === DelegationStatuses.CANCELLED || status === DelegationStatuses.EXPIRED
-                  ? "text-muted-foreground line-through"
-                  : "text-foreground/90"
+                status === DelegationStatuses.CANCELLED ? "text-muted-foreground line-through" : "text-foreground/90"
               )}
             >
               {payload.title}
@@ -355,8 +424,8 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
               {promptText()}
             </pre>
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              Paste this into your local agent (Claude Code, etc.). An agent with a Threa API key can claim the task and
-              update this card; otherwise press Mark done when the work is finished.
+              Give this prompt to an executor. With a Threa API key it can inspect the task, claim it if accepted, and
+              update this card. Otherwise press Mark done when the work is finished.
             </p>
           </div>
         )}

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -991,6 +991,33 @@ describe("timelineRowPropsEqual (memoized row comparator)", () => {
     payload: { messageId: "msg_b", contentMarkdown: "b" },
   })
 
+  it("repaints a delegation row when rendered reason or thread target changes", () => {
+    const item: TimelineItem = {
+      type: "event",
+      event: createEvent({
+        id: "evt_delegation",
+        sequence: "90",
+        eventType: "delegation:created",
+        payload: { delegationId: "dlg_1" },
+      }),
+    }
+    const props = (patch: Record<string, unknown>) => ({
+      item,
+      ctx: makeCtx({
+        delegationStatusPatches: new Map([["dlg_1", { delegationId: "dlg_1", status: "open", ...patch } as never]]),
+      }),
+      deferSecondaryHydration: false,
+    })
+
+    expect(timelineRowPropsEqual(props({ reason: "claim_expired" }), props({ reason: "claim_released" }))).toBe(false)
+    expect(
+      timelineRowPropsEqual(
+        props({ status: "completed", threadStreamId: "thread_1" }),
+        props({ status: "completed", threadStreamId: "thread_2" })
+      )
+    ).toBe(false)
+  })
+
   it("equal when ctx is rebuilt with fresh containers but same per-item content", () => {
     // Simulates a data tick: new ctx object, new Set/Map identities, same content.
     const prev = {

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1105,7 +1105,9 @@ function delegationPatchEqual(
     a.status === b.status &&
     a.claimedByLabel === b.claimedByLabel &&
     a.resultMessageId === b.resultMessageId &&
-    a.statusNote === b.statusNote
+    a.threadStreamId === b.threadStreamId &&
+    a.statusNote === b.statusNote &&
+    a.reason === b.reason
   )
 }
 

--- a/apps/frontend/src/components/timeline/timeline-card-actions.tsx
+++ b/apps/frontend/src/components/timeline/timeline-card-actions.tsx
@@ -231,10 +231,10 @@ export function TimelineCardActionDrawer({
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="max-h-[85dvh]">
+      <DrawerContent className="flex max-h-[85dvh] min-h-0 flex-col">
         <DrawerTitle className="sr-only">Actions for {title}</DrawerTitle>
         <DrawerDescription className="sr-only">Choose an action for this card.</DrawerDescription>
-        <div className="min-h-0 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="px-4 pb-3 pt-2">
             <p className="break-words text-base font-semibold text-foreground">{title}</p>
             {subtitle && <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>}

--- a/apps/frontend/src/lib/agent-outcomes/grouping.test.ts
+++ b/apps/frontend/src/lib/agent-outcomes/grouping.test.ts
@@ -19,6 +19,7 @@ function item(overrides: Partial<OutcomeItem> & { id: string; occursAt: string }
     statusChangedAt: overrides.occursAt,
     anchorPath: null,
     canCancel: true,
+    canRequeue: false,
     canMarkDone: false,
     ...overrides,
   }

--- a/apps/frontend/src/lib/agent-outcomes/items.test.ts
+++ b/apps/frontend/src/lib/agent-outcomes/items.test.ts
@@ -62,6 +62,7 @@ describe("toOutcomeItem", () => {
       statusChangedAt: "2026-07-28T09:00:00.000Z",
       anchorPath: "/w/ws_1/s/str_design?m=event_1",
       canCancel: true,
+      canRequeue: false,
       canMarkDone: false,
     })
   })
@@ -75,6 +76,7 @@ describe("toOutcomeItem", () => {
       statusNote: "step 2 of 4",
       anchorPath: "/w/ws_1/s/str_strategy?m=event_2",
       canCancel: true,
+      canRequeue: false,
       canMarkDone: true,
     })
   })
@@ -84,13 +86,25 @@ describe("toOutcomeItem", () => {
       statusLabel: "Ran",
       isSettled: true,
       canCancel: false,
+      canRequeue: false,
       canMarkDone: false,
     })
     expect(toOutcomeItem("ws_1", delegation({ status: "completed" }))).toMatchObject({
       statusLabel: "Completed",
       isSettled: true,
       canCancel: false,
+      canRequeue: false,
       canMarkDone: false,
+    })
+  })
+
+  it("keeps an expired delegation outstanding and recoverable", () => {
+    expect(toOutcomeItem("ws_1", delegation({ status: "expired" }))).toMatchObject({
+      statusLabel: "Claim expired",
+      isSettled: false,
+      canCancel: true,
+      canRequeue: true,
+      canMarkDone: true,
     })
   })
 

--- a/apps/frontend/src/lib/agent-outcomes/items.ts
+++ b/apps/frontend/src/lib/agent-outcomes/items.ts
@@ -30,6 +30,7 @@ export interface OutcomeItem {
    */
   anchorPath: string | null
   canCancel: boolean
+  canRequeue: boolean
   /** Only a delegation can be closed out by hand; a follow-up has no such affordance. */
   canMarkDone: boolean
 }
@@ -68,6 +69,7 @@ export function toOutcomeItem(workspaceId: string, outcome: AgentOutcomeSummary)
     statusChangedAt: outcome.statusChangedAt,
     anchorPath: outcomeAnchorPath(workspaceId, outcome),
     canCancel: !settled,
+    canRequeue: outcome.kind === "delegation" && outcome.status === "expired",
     canMarkDone: outcome.kind === "delegation" && !settled,
   }
 }

--- a/apps/frontend/src/lib/board/ledger.test.ts
+++ b/apps/frontend/src/lib/board/ledger.test.ts
@@ -395,6 +395,35 @@ describe("ledgerEventContent", () => {
     expect(ledgerEventContent(row, ctx)?.meta).toBe("Open")
   })
 
+  it.each([
+    ["claim_expired", "Claim expired · Open again"],
+    ["claim_released", "Claim released · Open again"],
+    ["requeued", "Requeued · Open"],
+    [undefined, "Open"],
+  ] as const)("carries the delegation's %s reopen reason", (reason, label) => {
+    const row: BoardEventRow = {
+      kind: "delegation",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("delegation:created", { delegationId: "dlg_1", title: "Migrate", brief: "…", contextRefs: [] }),
+      statusPatch: { delegationId: "dlg_1", status: "open", reason },
+    }
+    expect(ledgerEventContent(row, ctx).meta).toBe(label)
+  })
+
+  it("keeps historical expired delegations active in the compact ledger", () => {
+    const row: BoardEventRow = {
+      kind: "delegation",
+      key: "evt_1",
+      sortMs: 0,
+      streamId: "stream_1",
+      event: event("delegation:created", { delegationId: "dlg_1", title: "Migrate", brief: "…", contextRefs: [] }),
+      statusPatch: { delegationId: "dlg_1", status: "expired" },
+    }
+    expect(ledgerEventContent(row, ctx).meta).toBe("Claim expired")
+  })
+
   it("carries a delegation's title and its latest status", () => {
     const row: BoardEventRow = {
       kind: "delegation",

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -15,7 +15,7 @@ import {
 } from "@threa/types"
 
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
-import { DELEGATION_STATUS_LABEL } from "@/lib/delegation-display"
+import { delegationAvailabilityLabel } from "@/lib/delegation-display"
 import { formatDuration, formatFireTime } from "@/lib/dates"
 import { resolveEmojiShortcodes, stripMarkdownKeepingCode, truncateInline } from "@/lib/markdown/strip"
 
@@ -265,7 +265,7 @@ export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCt
         key: row.key,
         kind: "delegation",
         label: payload?.title ? `Delegation: ${payload.title}` : "Delegation",
-        meta: DELEGATION_STATUS_LABEL[row.statusPatch?.status ?? DelegationStatuses.OPEN],
+        meta: delegationAvailabilityLabel(row.statusPatch?.status ?? DelegationStatuses.OPEN, row.statusPatch?.reason),
       }
     }
     default: {

--- a/apps/frontend/src/lib/delegation-display.test.ts
+++ b/apps/frontend/src/lib/delegation-display.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { DELEGATION_REOPEN_REASONS, DELEGATION_STATUSES } from "@threa/types"
+import {
+  DELEGATION_REOPEN_REASON_LABEL,
+  DELEGATION_STATUS_LABEL,
+  DELEGATION_TERMINAL,
+  delegationAvailabilityLabel,
+  delegationStatusPillClass,
+} from "./delegation-display"
+
+describe("delegation display", () => {
+  it("owns distinct copy for every reopen reason", () => {
+    expect(DELEGATION_REOPEN_REASONS.map((reason) => DELEGATION_REOPEN_REASON_LABEL[reason])).toEqual([
+      "Claim expired · Open again",
+      "Claim released · Open again",
+      "Requeued · Open",
+    ])
+  })
+
+  it("uses reopen reasons only for open availability", () => {
+    expect(delegationAvailabilityLabel("open", "claim_released")).toBe("Claim released · Open again")
+    expect(delegationAvailabilityLabel("claimed", "claim_released")).toBe("Claimed")
+    expect(delegationAvailabilityLabel("open")).toBe("Open")
+  })
+
+  it("exhaustively maps every status and keeps expired recoverable", () => {
+    expect(
+      DELEGATION_STATUSES.map((status) => [DELEGATION_STATUS_LABEL[status], delegationStatusPillClass(status)])
+    ).toHaveLength(DELEGATION_STATUSES.length)
+    expect(DELEGATION_STATUS_LABEL.expired).toBe("Claim expired")
+    expect(DELEGATION_TERMINAL.has("expired")).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/delegation-display.ts
+++ b/apps/frontend/src/lib/delegation-display.ts
@@ -1,6 +1,6 @@
-import { DELEGATION_TERMINAL_STATUSES, type DelegationStatus } from "@threa/types"
+import { DELEGATION_TERMINAL_STATUSES, type DelegationReopenReason, type DelegationStatus } from "@threa/types"
 
-/** Display labels for delegation statuses — shared by the timeline card and the "In this stream" panel. */
+/** Display labels for delegation statuses shared by first-party surfaces. */
 export const DELEGATION_STATUS_LABEL: Record<DelegationStatus, string> = {
   open: "Open",
   claimed: "Claimed",
@@ -8,19 +8,27 @@ export const DELEGATION_STATUS_LABEL: Record<DelegationStatus, string> = {
   completed: "Completed",
   failed: "Failed",
   cancelled: "Cancelled",
-  expired: "Expired",
+  expired: "Claim expired",
+}
+
+export const DELEGATION_REOPEN_REASON_LABEL: Record<DelegationReopenReason, string> = {
+  claim_expired: "Claim expired · Open again",
+  claim_released: "Claim released · Open again",
+  requeued: "Requeued · Open",
 }
 
 export const DELEGATION_TERMINAL: ReadonlySet<DelegationStatus> = new Set(DELEGATION_TERMINAL_STATUSES)
 
-/**
- * Pill classes for a delegation status badge. In-flight states get a color so
- * they're scannable in a list; ended-without-result states recede into muted.
- */
+export function delegationAvailabilityLabel(status: DelegationStatus, reason?: DelegationReopenReason): string {
+  return status === "open" && reason ? DELEGATION_REOPEN_REASON_LABEL[reason] : DELEGATION_STATUS_LABEL[status]
+}
+
 export function delegationStatusPillClass(status: DelegationStatus): string {
   switch (status) {
     case "open":
       return "bg-sky-500/15 text-sky-600 dark:text-sky-400"
+    case "expired":
+      return "bg-primary/15 text-primary"
     case "claimed":
     case "running":
       return "bg-amber-500/15 text-amber-600 dark:text-amber-400"
@@ -29,7 +37,6 @@ export function delegationStatusPillClass(status: DelegationStatus): string {
     case "failed":
       return "bg-red-500/15 text-red-600 dark:text-red-400"
     case "cancelled":
-    case "expired":
       return "bg-muted text-muted-foreground"
   }
 }

--- a/packages/types/src/agent-outcomes.test.ts
+++ b/packages/types/src/agent-outcomes.test.ts
@@ -18,6 +18,11 @@ describe("agent outcome constants", () => {
       (status) => !(FOLLOW_UP_TERMINAL_STATUSES as readonly string[]).includes(status)
     )
     expect(outstanding).toEqual(["pending"])
+
+    const outstandingDelegations = DELEGATION_STATUSES.filter(
+      (status) => !(DELEGATION_TERMINAL_STATUSES as readonly string[]).includes(status)
+    )
+    expect(outstandingDelegations).toEqual(["open", "claimed", "running", "expired"])
   })
 
   it("enumerates the kinds and states the endpoint accepts", () => {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -747,7 +747,7 @@ export const FollowUpStatuses = {
 // person, later) for the user's local agent to execute. `open` until a local
 // agent claims it via the public API (5.3); `claimed`/`running` while held under
 // a TTL'd claim token; `completed`/`failed` are terminal reports; `cancelled` by
-// a stream member from the card; `expired` when the sweep finds a lapsed claim.
+// a stream member from the card; historical `expired` claims remain recoverable.
 export const DELEGATION_STATUSES = [
   "open",
   "claimed",
@@ -772,12 +772,11 @@ export const DelegationStatuses = {
 export const DELEGATION_REOPEN_REASONS = ["claim_expired", "claim_released", "requeued"] as const
 export type DelegationReopenReason = (typeof DELEGATION_REOPEN_REASONS)[number]
 
-/** Terminal delegation statuses — no further transitions (and no expiry sweep interest). */
+/** Settled delegation statuses with no further transitions. */
 export const DELEGATION_TERMINAL_STATUSES = [
   "completed",
   "failed",
   "cancelled",
-  "expired",
 ] as const satisfies readonly DelegationStatus[]
 
 // Bot access-request lifecycle (F3): a bot runtime that lacks stream access


### PR DESCRIPTION
## Problem

Recoverable leases are now part of the protocol, but the product still treated historical `expired` delegations as settled and displayed reopened work as a generic open card.

Stacked on #1800.

## Solution

- Treat `expired` as outstanding and recoverable while keeping completed, failed, and cancelled settled.
- Map structured reopen reasons to frontend-owned labels across timeline and board surfaces.
- Add Requeue, Mark done, and Cancel actions for historical expired work on desktop and mobile.
- Keep optimistic requeue state truthful across lost races and authoritative status patches.
- Update copied task instructions to inspect before claiming and describe release/manual heartbeat accurately.
- Make the shared mobile action drawer scroll correctly at narrow viewport heights.

## Verification

- Frontend full suite: 6,269 passed
- Focused recovery UI: 191 passed
- Types: 157 passed
- Backend unit: 3,931 passed
- Agent-outcomes integration: 12 passed
- Four unrelated full-integration timeout flakes passed on isolated rerun: 10/10
- Frontend typecheck and lint passed
- Playwright visual pass at 1440px and 390px passed after fixing drawer clipping

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Represent expired and reopened delegations honestly across outcome grouping, timeline cards, compact board rows, and recovery actions without changing the wire status or persisting presentation copy.

## What Was Built

### Outcome semantics

- `packages/types/src/constants.ts` keeps `expired` valid but removes it from terminal statuses.
- Backend outcome grouping places expired tasks under Outstanding.
- Frontend outcome grouping and capability flags expose recovery actions while completed, failed, and cancelled remain settled.

### Frontend-owned recovery display

- `apps/frontend/src/lib/delegation-display.ts` owns labels for `claim_expired`, `claim_released`, and `requeued`.
- Timeline and compact board rows use the same status/reason mapping.
- Historical expired cards remain active, visually distinct, and actionable.
- Timeline memo equality includes reason and rendered result-thread fields so the latest patch wins.

### Recovery actions and races

- `apps/frontend/src/api/delegations.ts` adds first-party requeue.
- Expired timeline cards and outcome details expose Requeue, Mark done, and Cancel.
- A winning requeue shows Requeued/Open immediately while invalidating delegation and outcome queries.
- False responses invalidate query-backed surfaces without lying about local status; errors preserve expired state.
- Semantic patch reconciliation retains optimism across equivalent rerenders and clears it when a newer authoritative transition arrives.

### Executor-neutral copied instructions

- Copied prompts inspect the delegation before claim, claim only when accepting, describe context refs as pointers, keep heartbeat optional, and use release for controlled stop.

### Responsive action surface

- `apps/frontend/src/components/timeline/timeline-card-actions.tsx` constrains the mobile drawer as a flex column with an inner scroll region so every recovery action remains reachable at 390×844.

## Design Decisions

### Display copy stays in the frontend

**Chose:** Map structured protocol reasons to labels at render time.  
**Why:** Clients can branch on stable status/reason constants while presentation remains localizable and changeable.

### Historical expired differs from reopened open

**Chose:** Keep the expired status and show explicit recovery actions.  
**Why:** Historical rows are not automatically changed at deployment, while new lease lapses reopen to `open`.

### Socket patches remain authoritative

**Chose:** Use optimistic state only as a fast local response and reconcile on semantic patch changes.  
**Why:** Lost races and rebuilt patch objects must not produce stale or flickering cards.

## Design Evolution

- Reason rendering was centralized after review found compact board rows discarded loaded reasons.
- Requeue reconciliation moved from object identity to semantic patch comparison.
- Visual verification found an unreachable mobile Cancel action; the shared drawer now owns bounded inner scrolling.
- The SQL assertion allowlist correction was moved down-stack into PR #1797, where the assertion count changed.

## Schema Changes

None.

## What's NOT Included

- No first-party claim UI.
- No status rename or deletion of `expired`.
- No persisted display reason or new migration.
- No transfer, handover, or success-toast expansion.
- Final docs and prose review are in PR 4.

## Status

- [x] Settled/outstanding contract
- [x] Reason-aware timeline and board display
- [x] Historical expired recovery actions
- [x] Race-honest optimistic requeue
- [x] Executor-neutral copied instructions
- [x] Desktop/mobile tests and visual verification

</details>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707468&installation_model_id=20758&pr_number=1804&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1804&signature=f3e06351d3cedf34019b6bc8b01996d6e0c99966a80ccfbca6d73b859a4778c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->