### PR TITLE
chore: drop legacy naming timestamp column

### DIFF
--- a/apps/backend/src/db/migrations/20260808080503_drop_stream_display_name_generated_at.sql
+++ b/apps/backend/src/db/migrations/20260808080503_drop_stream_display_name_generated_at.sql
@@ -1,0 +1,5 @@
+-- Remove timestamp naming provenance after the revision-fenced lifecycle is
+-- fleet-wide. Title ownership now comes exclusively from display_name_source.
+
+ALTER TABLE streams
+DROP COLUMN IF EXISTS display_name_generated_at;

--- a/apps/backend/tests/integration/legacy-naming-cleanup.test.ts
+++ b/apps/backend/tests/integration/legacy-naming-cleanup.test.ts
@@ -6,6 +6,10 @@ const CLEANUP_MIGRATION = new URL(
   "../../src/db/migrations/20260808065950_remove_legacy_naming_compatibility.sql",
   import.meta.url
 )
+const DROP_TIMESTAMP_MIGRATION = new URL(
+  "../../src/db/migrations/20260808080503_drop_stream_display_name_generated_at.sql",
+  import.meta.url
+)
 
 describe("legacy naming cleanup migration", () => {
   let pool: Pool
@@ -18,7 +22,7 @@ describe("legacy naming cleanup migration", () => {
     await pool.end()
   })
 
-  test("removes rollout triggers and cancels unfinished legacy queue work", async () => {
+  test("removes rollout triggers, queue work, and timestamp provenance", async () => {
     const client = await pool.connect()
     try {
       await client.query("BEGIN")
@@ -35,6 +39,8 @@ describe("legacy naming cleanup migration", () => {
       `)
 
       await client.query(await Bun.file(CLEANUP_MIGRATION).text())
+      await client.query("ALTER TABLE streams ADD COLUMN IF NOT EXISTS display_name_generated_at TIMESTAMPTZ")
+      await client.query(await Bun.file(DROP_TIMESTAMP_MIGRATION).text())
 
       const message = await client.query(
         "SELECT cancelled_at, process_after, claimed_by FROM queue_messages WHERE id = 'queue_legacy_naming_test'"
@@ -62,7 +68,7 @@ describe("legacy naming cleanup migration", () => {
         processAfter: null,
         claimedBy: null,
         tokens: 0,
-        legacyColumn: 1,
+        legacyColumn: 0,
         triggers: [],
       })
     } finally {


### PR DESCRIPTION
## Problem

PR #1807 removed all runtime reads and writes of `streams.display_name_generated_at` but retained the physical column for one rolling deploy window. The revision-fenced naming lifecycle is now fleet-wide, so that compatibility window is complete.

## Solution

Append `20260808080503_drop_stream_display_name_generated_at.sql` to remove the inert timestamp column. The migration is idempotent and leaves `display_name_source` as stream title ownership provenance. Integration coverage recreates the legacy column against the real schema, applies the migration, and verifies its removal.

## Test plan

- [x] Focused backend integration test — 1 pass
- [x] Repository pre-commit gates — lint, monorepo typecheck, migration validation, Dockerfile validation, API docs

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788768571&installation_model_id=20758&pr_number=1809&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1809&signature=f73dbeec1cd80bf086b6f4dd3378fcdeb33c85d5cafd573aa7f23b0a5c377914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->