### PR TITLE
fix: complete Claude channel standalone install

### DIFF
--- a/extensions/claude-code-remote/install-local.ts
+++ b/extensions/claude-code-remote/install-local.ts
@@ -11,7 +11,7 @@
 //
 // Usage: bun run extensions/claude-code-remote/install-local.ts [destDir]
 
-import { cpSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { homedir } from "node:os"
@@ -37,6 +37,9 @@ const VENDORED = [
       "harness-kick.ts",
       "harness-reconnect.ts",
       "tmux-key.ts",
+      "tmux-window.ts",
+      "archive-grace.ts",
+      "harness-links.ts",
     ],
     dir: "bot-runtime-client",
   },
@@ -74,6 +77,25 @@ for (const pkg of VENDORED) {
   const vendorDir = join(vendorRoot, pkg.dir)
   mkdirSync(vendorDir, { recursive: true })
   for (const f of pkg.files) cpSync(join(pkg.src, "src", f), join(vendorDir, f))
+}
+
+const missingImports: string[] = []
+const relativeImportPattern = /(?:\bfrom\s+|\bimport\s*(?:\(\s*)?)["'](\.\.?\/[^"']+)["']/g
+for (const pkg of VENDORED) {
+  const vendorDir = join(vendorRoot, pkg.dir)
+  for (const file of pkg.files) {
+    const source = readFileSync(join(vendorDir, file), "utf8")
+    for (const [, specifier] of source.matchAll(relativeImportPattern)) {
+      const target = resolve(dirname(join(vendorDir, file)), specifier)
+      const extensionlessTarget = target.replace(/\.[cm]?js$/, "")
+      if (![target, `${target}.ts`, `${extensionlessTarget}.ts`, join(target, "index.ts")].some(existsSync)) {
+        missingImports.push(`${pkg.dep}/${file} imports ${specifier}`)
+      }
+    }
+  }
+}
+if (missingImports.length > 0) {
+  throw new Error(`vendored packages are incomplete:\n  ${missingImports.join("\n  ")}`)
 }
 
 // 4. Repoint every import of the vendored deps at the vendored copies — in the


### PR DESCRIPTION
## Problem

`extensions/claude-code-remote/install-local.ts` copies an explicit list of runtime files from `@threa/bot-runtime-client`. The package now exports `archive-grace.ts`, `tmux-window.ts`, and `harness-links.ts`, but the installer omitted them. A generated standalone channel exited before the MCP handshake with `Cannot find module './archive-grace'`.

## Solution

- Vendor the three missing runtime files.
- Validate every copied package's relative imports before installing dependencies. The check covers static, side-effect, and dynamic imports; `./` and `../` paths; directory indexes; and TypeScript sources referenced with `.js` specifiers.
- Fail from the installer with the source file and missing specifier instead of producing a package that fails at startup.

The in-repo channel path is unchanged.

## Test plan

- [x] Built a standalone install in a temporary directory
- [x] Typechecked the generated package
- [x] Ran the generated package's channel suite: 126 tests passed
- [x] Repository commit gates: workspace lint/typecheck, migration checks, and generated API docs

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788770964&installation_model_id=20758&pr_number=1810&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1810&signature=76304aed5d9f4040ee17a5ff5baaced3711f4daf16db5da6d8176fe49a83fe04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->