### PR TITLE
feat: expose voice polish reasoning telemetry

### DIFF
--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -348,6 +348,7 @@ async function runPermutation<TInput, TOutput, TExpected>(
     usage: {
       inputTokens: totalUsage.inputTokens,
       outputTokens: totalUsage.outputTokens,
+      reasoningTokens: totalUsage.reasoningTokens,
       totalCost: totalUsage.totalCost,
     },
   }

--- a/apps/backend/evals/framework/types.test.ts
+++ b/apps/backend/evals/framework/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { createUsageAccumulator } from "./types"
+
+describe("createUsageAccumulator", () => {
+  test("aggregates reasoning tokens with the other eval usage totals", () => {
+    const usage = createUsageAccumulator()
+
+    usage.recordUsage({ promptTokens: 10, completionTokens: 6, reasoningTokens: 4, cost: 0.01 })
+    usage.recordUsage({ promptTokens: 3, completionTokens: 2, reasoningTokens: 1, cost: 0.02 })
+
+    expect(usage.getTotal()).toEqual({
+      inputTokens: 13,
+      outputTokens: 8,
+      reasoningTokens: 5,
+      totalCost: 0.03,
+    })
+  })
+})

--- a/apps/backend/evals/framework/types.ts
+++ b/apps/backend/evals/framework/types.ts
@@ -18,13 +18,26 @@ import type { ComponentOverrides } from "./config-types"
  * Accumulates token usage and cost across AI calls.
  * Call recordUsage() after each AI call to track costs.
  */
+export interface EvalUsage {
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens?: number
+  totalCost: number
+}
+
 export interface UsageAccumulator {
   /** Record usage from an AI call */
-  recordUsage(usage: { promptTokens?: number; completionTokens?: number; totalTokens?: number; cost?: number }): void
+  recordUsage(usage: {
+    promptTokens?: number
+    completionTokens?: number
+    reasoningTokens?: number
+    totalTokens?: number
+    cost?: number
+  }): void
   /** Record the model id an AI call actually executed with */
   recordModel(modelId: string): void
   /** Get accumulated totals */
-  getTotal(): { inputTokens: number; outputTokens: number; totalCost: number }
+  getTotal(): EvalUsage
   /** Executed model ids → call counts. The ground truth a -m override is verified against. */
   getModels(): Record<string, number>
 }
@@ -35,6 +48,7 @@ export interface UsageAccumulator {
 export function createUsageAccumulator(): UsageAccumulator {
   let inputTokens = 0
   let outputTokens = 0
+  let reasoningTokens = 0
   let totalCost = 0
   const models: Record<string, number> = {}
 
@@ -42,13 +56,14 @@ export function createUsageAccumulator(): UsageAccumulator {
     recordUsage(usage) {
       inputTokens += usage.promptTokens ?? 0
       outputTokens += usage.completionTokens ?? 0
+      reasoningTokens += usage.reasoningTokens ?? 0
       totalCost += usage.cost ?? 0
     },
     recordModel(modelId) {
       models[modelId] = (models[modelId] ?? 0) + 1
     },
     getTotal() {
-      return { inputTokens, outputTokens, totalCost }
+      return { inputTokens, outputTokens, reasoningTokens, totalCost }
     },
     getModels() {
       return { ...models }
@@ -204,11 +219,7 @@ export interface PermutationResult<TOutput, TExpected> {
   /** Total duration in milliseconds */
   totalDurationMs: number
   /** Token usage stats */
-  usage?: {
-    inputTokens: number
-    outputTokens: number
-    totalCost?: number
-  }
+  usage?: EvalUsage
 }
 
 /**

--- a/apps/backend/src/features/voice-transcription/config.ts
+++ b/apps/backend/src/features/voice-transcription/config.ts
@@ -3,7 +3,7 @@
  * and is read via ModelRegistry (INV-33).
  */
 
-import { parseModelId } from "@threa/agent-runtime"
+import { parseModelId, type ReasoningEffort } from "@threa/agent-runtime"
 import { VOICE_STEERING_BASE_TERMS, VOICE_STEERING_WORDS_MAX } from "@threa/types"
 
 export const VOICE_DEFAULT_MODEL = "elevenlabs:scribe-v2-realtime"
@@ -73,6 +73,7 @@ export interface VoicePolishConfig {
   finalTimeoutMs: number
   maxTokens: number
   temperature: number
+  reasoningEffort: ReasoningEffort
 }
 
 // Deadlines calibrated by the voice-polish eval matrix. Live passes are
@@ -86,6 +87,7 @@ export const voicePolishConfig: VoicePolishConfig = {
   finalTimeoutMs: 8000,
   maxTokens: 2048,
   temperature: 0.2,
+  reasoningEffort: "medium",
 }
 
 // The example vocabulary in both prompts is English; without this note,

--- a/apps/backend/src/features/voice-transcription/polish.test.ts
+++ b/apps/backend/src/features/voice-transcription/polish.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, mock } from "bun:test"
+import { describe, expect, it, mock, spyOn } from "bun:test"
 import { buildPolishUserMessage, createPolishTranscript, scrubDashes } from "./polish"
 import { voicePolishConfig } from "./config"
 import type { AI } from "@threa/agent-runtime"
+import { logger } from "../../lib/logger"
 
 type GenerateTextArgs = Parameters<AI["generateText"]>[0]
 
@@ -36,9 +37,264 @@ describe("createPolishTranscript", () => {
     })
     const call = generateText.mock.calls[0][0]
     expect(call.model).toBe(voicePolishConfig.model)
+    expect(call.reasoningEffort).toBe("medium")
     expect(call.telemetry?.functionId).toBe("voice-transcript-polish")
-    expect(call.telemetry?.metadata).toMatchObject({ level: "opinionated" })
+    expect(call.telemetry?.metadata).toMatchObject({
+      level: "opinionated",
+      stage: "format_live",
+      deadline: "live",
+      reasoningEffort: "medium",
+    })
     expect(call.context).toMatchObject({ workspaceId: "ws_1", userId: "user_1", origin: "user" })
+  })
+
+  it("allows injected config to override reasoning effort", async () => {
+    const generateText = mock(async (_args: GenerateTextArgs) => textResult("Polished.") as never)
+    const polish = createPolishTranscript({
+      ai: fakeAI(generateText),
+      config: { ...voicePolishConfig, reasoningEffort: "low" },
+    })
+
+    await polish({
+      rawTranscript: "raw",
+      level: "minor",
+      workspaceId: "ws_1",
+      userId: "user_1",
+      sessionId: "voicesess_1",
+      deadline: "final",
+    })
+
+    expect(generateText.mock.calls[0][0]).toMatchObject({
+      reasoningEffort: "low",
+      telemetry: { metadata: { reasoningEffort: "low", stage: "format_final", deadline: "final" } },
+    })
+  })
+
+  it("logs one privacy-safe completion diagnostic with usage", async () => {
+    const rawSentinel = "RAW_SECRET_SENTINEL"
+    const draftSentinel = "DRAFT_SECRET_SENTINEL"
+    const logs: unknown[][] = []
+    const info = spyOn(logger, "info").mockImplementation((...args: unknown[]) => {
+      logs.push(args)
+      return logger
+    })
+    try {
+      const generateText = mock(
+        async () =>
+          ({
+            ...textResult("Safe output."),
+            usage: { promptTokens: 11, completionTokens: 7, reasoningTokens: 3 },
+          }) as never
+      )
+      const polish = createPolishTranscript({ ai: fakeAI(generateText) })
+      await polish({
+        rawTranscript: rawSentinel,
+        draftBefore: draftSentinel,
+        steeringTerms: ["STEERING_SECRET_SENTINEL"],
+        level: "minor",
+        workspaceId: "ws_1",
+        userId: "user_1",
+        sessionId: "voicesess_1",
+      })
+
+      expect(logs).toHaveLength(1)
+      expect(logs[0]?.[0]).toMatchObject({
+        outcome: "success",
+        deadline: "live",
+        rawLength: rawSentinel.length,
+        draftLength: draftSentinel.length,
+        steeringTermCount: 1,
+        reasoningEffort: "medium",
+        promptTokens: 11,
+        completionTokens: 7,
+        reasoningTokens: 3,
+      })
+      const serialized = JSON.stringify(logs)
+      expect(serialized).not.toContain(rawSentinel)
+      expect(serialized).not.toContain(draftSentinel)
+      expect(serialized).not.toContain("STEERING_SECRET_SENTINEL")
+    } finally {
+      info.mockRestore()
+    }
+  })
+
+  it("logs timeouts without transcript or draft content", async () => {
+    const logs: unknown[][] = []
+    const info = spyOn(logger, "info").mockImplementation((...args: unknown[]) => {
+      logs.push(args)
+      return logger
+    })
+    try {
+      const generateText = mock(async (args: GenerateTextArgs) => {
+        await new Promise<void>((resolve) =>
+          args.abortSignal?.addEventListener("abort", () => resolve(), { once: true })
+        )
+        throw new Error("TIMEOUT_PROVIDER_SENTINEL")
+      })
+      const polish = createPolishTranscript({
+        ai: fakeAI(generateText),
+        config: { ...voicePolishConfig, liveTimeoutMs: 1 },
+      })
+      expect(
+        await polish({
+          rawTranscript: "TIMEOUT_RAW_SENTINEL",
+          draftBefore: "TIMEOUT_DRAFT_SENTINEL",
+          level: "minor",
+          workspaceId: "ws_1",
+          userId: "user_1",
+          sessionId: "voicesess_1",
+        })
+      ).toEqual({ status: "timeout" })
+
+      expect(logs).toHaveLength(1)
+      expect(logs[0]?.[0]).toMatchObject({ outcome: "timeout", deadline: "live", deadlineMs: 1 })
+      expect(JSON.stringify(logs)).not.toContain("SENTINEL")
+    } finally {
+      info.mockRestore()
+    }
+  })
+
+  it("logs provider failures without provider error content", async () => {
+    const errorSentinel = "PROVIDER_ERROR_SECRET_SENTINEL"
+    const logs: unknown[][] = []
+    const info = spyOn(logger, "info").mockImplementation((...args: unknown[]) => {
+      logs.push(args)
+      return logger
+    })
+    try {
+      const generateText = mock(async () => {
+        const error = new Error(errorSentinel) as Error & { code: string; status: number; requestBody: string }
+        error.code = "SAFE_CODE"
+        error.status = 503
+        error.requestBody = errorSentinel
+        throw error
+      })
+      const polish = createPolishTranscript({ ai: fakeAI(generateText) })
+      await polish({
+        rawTranscript: "RAW_PROVIDER_SENTINEL",
+        draftAfter: "DRAFT_PROVIDER_SENTINEL",
+        level: "minor",
+        workspaceId: "ws_1",
+        userId: "user_1",
+        sessionId: "voicesess_1",
+      })
+
+      expect(logs).toHaveLength(1)
+      expect(logs[0]?.[0]).toMatchObject({
+        outcome: "provider_error",
+        errorName: "Error",
+        errorCode: "SAFE_CODE",
+        errorStatus: 503,
+      })
+      const serialized = JSON.stringify(logs)
+      expect(serialized).not.toContain("SENTINEL")
+      expect(serialized).not.toContain(errorSentinel)
+    } finally {
+      info.mockRestore()
+    }
+  })
+
+  it("keeps completion diagnostics private across all attempted outcomes", async () => {
+    const logs: unknown[][] = []
+    const spies = (["info", "warn", "error"] as const).map((level) =>
+      spyOn(logger, level).mockImplementation((...args: unknown[]) => {
+        logs.push([level, ...args])
+        return logger
+      })
+    )
+    const sentinels = {
+      raw: "RAW PRIVATE SENTINEL",
+      draft: "DRAFT PRIVATE SENTINEL",
+      steering: "STEERING PRIVATE SENTINEL",
+      output: "OUTPUT PRIVATE SENTINEL",
+      error: "ERROR PRIVATE SENTINEL",
+      timeoutError: "TIMEOUT ERROR PRIVATE SENTINEL",
+      parserError: "PARSER ERROR PRIVATE SENTINEL",
+    }
+    const input = {
+      rawTranscript: sentinels.raw,
+      draftBefore: sentinels.draft,
+      steeringTerms: [sentinels.steering],
+      level: "minor" as const,
+      workspaceId: "ws_1",
+      userId: "user_1",
+      sessionId: "voicesess_1",
+    }
+
+    try {
+      const results = []
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(mock(async () => textResult(sentinels.output) as never)),
+        })(input)
+      )
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(mock(async () => textResult("   ") as never)),
+        })(input)
+      )
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(mock(async () => ({ ...textResult(sentinels.output), finishReason: "length" }) as never)),
+        })(input)
+      )
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(
+            mock(async () => {
+              throw {
+                name: sentinels.error,
+                code: 8675309,
+                status: 502,
+                message: sentinels.error,
+                requestBody: sentinels.raw,
+              }
+            })
+          ),
+        })(input)
+      )
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(
+            mock(async (args: GenerateTextArgs) => {
+              await new Promise<void>((resolve) =>
+                args.abortSignal?.addEventListener("abort", () => resolve(), { once: true })
+              )
+              throw new Error(sentinels.timeoutError)
+            })
+          ),
+          config: { ...voicePolishConfig, liveTimeoutMs: 1 },
+        })(input)
+      )
+      results.push(
+        await createPolishTranscript({
+          ai: fakeAI(mock(async () => textResult(sentinels.output) as never)),
+          parseMarkdown: () => {
+            throw new Error(sentinels.parserError)
+          },
+        })(input)
+      )
+
+      expect(results).toEqual([
+        expect.objectContaining({ status: "success" }),
+        { status: "invalid_output", reason: "empty" },
+        { status: "invalid_output", reason: "truncated" },
+        { status: "provider_error" },
+        { status: "timeout" },
+        { status: "invalid_output", reason: "unparseable" },
+      ])
+      expect(logs).toHaveLength(results.length)
+      expect(logs.map((call) => (call[1] as { outcome: string }).outcome)).toEqual(
+        results.map((result) => result.status)
+      )
+      expect(logs[3]?.[1]).toMatchObject({ errorStatus: 502 })
+      expect(logs[3]?.[1]).not.toHaveProperty("errorName")
+      expect(logs[3]?.[1]).not.toHaveProperty("errorCode")
+      const serialized = JSON.stringify(logs)
+      for (const sentinel of Object.values(sentinels)) expect(serialized).not.toContain(sentinel)
+    } finally {
+      for (const spy of spies) spy.mockRestore()
+    }
   })
 
   it("sends the full cumulative transcript in the user message", async () => {

--- a/apps/backend/src/features/voice-transcription/polish.ts
+++ b/apps/backend/src/features/voice-transcription/polish.ts
@@ -1,5 +1,5 @@
 import type { VoicePolishLevel } from "@threa/types"
-import type { AI } from "@threa/agent-runtime"
+import type { AI, UsageWithCost } from "@threa/agent-runtime"
 import { parseMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import { logger } from "../../lib/logger"
@@ -34,8 +34,13 @@ export type PolishOutcome =
 
 export type PolishTranscript = (input: PolishTranscriptInput) => Promise<PolishOutcome>
 
-export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfig }): PolishTranscript {
+export function createPolishTranscript(deps: {
+  ai: AI
+  config?: VoicePolishConfig
+  parseMarkdown?: (markdown: string) => JSONContent
+}): PolishTranscript {
   const config = deps.config ?? voicePolishConfig
+  const parse = deps.parseMarkdown ?? parseMarkdown
   return async ({
     rawTranscript,
     level,
@@ -51,7 +56,7 @@ export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfi
   }) => {
     const trimmed = rawTranscript.trim()
     if (!trimmed) return { status: "empty_input" }
-    if (level === "none") return parsePolishSuccess(trimmed)
+    if (level === "none") return parsePolishSuccess(trimmed, parse)
 
     const systemPrompt = level === "opinionated" ? POLISH_OPINIONATED_SYSTEM_PROMPT : POLISH_MINOR_SYSTEM_PROMPT
     const userMessage = buildPolishUserMessage({
@@ -62,6 +67,9 @@ export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfi
       previousAcceptedMarkdown,
     })
     const controller = new AbortController()
+    const startedAt = performance.now()
+    const draftLength = (draftBefore?.length ?? 0) + (draftAfter?.length ?? 0)
+    let usage: UsageWithCost | undefined
     let timedOut = false
     const onCancel = () => controller.abort()
     signal?.addEventListener("abort", onCancel, { once: true })
@@ -73,8 +81,33 @@ export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfi
       deadline === "final" ? config.finalTimeoutMs : config.liveTimeoutMs
     )
 
+    const complete = (outcome: PolishOutcome, providerError?: unknown): PolishOutcome => {
+      logger.info(
+        {
+          sessionId,
+          workspaceId,
+          level,
+          outcome: outcome.status,
+          invalidReason: outcome.status === "invalid_output" ? outcome.reason : undefined,
+          deadline,
+          deadlineMs: deadline === "final" ? config.finalTimeoutMs : config.liveTimeoutMs,
+          durationMs: Math.round(performance.now() - startedAt),
+          rawLength: trimmed.length,
+          draftLength,
+          steeringTermCount: steeringTerms?.length ?? 0,
+          reasoningEffort: config.reasoningEffort,
+          promptTokens: usage?.promptTokens,
+          completionTokens: usage?.completionTokens,
+          reasoningTokens: usage?.reasoningTokens,
+          ...(providerError === undefined ? {} : safeProviderError(providerError)),
+        },
+        "Voice transcript polish attempt completed"
+      )
+      return outcome
+    }
+
     try {
-      if (signal?.aborted) return { status: "canceled" }
+      if (signal?.aborted) return complete({ status: "canceled" })
       const result = await deps.ai.generateText({
         model: config.model,
         messages: [
@@ -83,33 +116,38 @@ export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfi
         ],
         maxTokens: config.maxTokens,
         temperature: config.temperature,
+        reasoningEffort: config.reasoningEffort,
         telemetry: {
           functionId: "voice-transcript-polish",
           metadata: {
             sessionId,
             rawLen: trimmed.length,
-            draftContextLen: (draftBefore?.length ?? 0) + (draftAfter?.length ?? 0),
+            draftContextLen: draftLength,
             steeringTermCount: steeringTerms?.length ?? 0,
             level,
+            stage: deadline === "final" ? "format_final" : "format_live",
+            deadline,
+            deadlineMs: deadline === "final" ? config.finalTimeoutMs : config.liveTimeoutMs,
+            reasoningEffort: config.reasoningEffort,
           },
         },
         context: { workspaceId, userId, origin: "user" },
         abortSignal: controller.signal,
       })
-      if (signal?.aborted) return { status: "canceled" }
-      if (timedOut) return { status: "timeout" }
+      usage = result.usage
+      if (signal?.aborted) return complete({ status: "canceled" })
+      if (timedOut) return complete({ status: "timeout" })
       const finishReason =
         (result as { finishReason?: string; response?: { finishReason?: string } }).finishReason ??
         (result as { response?: { finishReason?: string } }).response?.finishReason
-      if (finishReason === "length") return { status: "invalid_output", reason: "truncated" }
+      if (finishReason === "length") return complete({ status: "invalid_output", reason: "truncated" })
       const polished = result.value.trim()
-      if (!polished) return { status: "invalid_output", reason: "empty" }
-      return parsePolishSuccess(scrubDashes(polished))
+      if (!polished) return complete({ status: "invalid_output", reason: "empty" })
+      return complete(parsePolishSuccess(scrubDashes(polished), parse))
     } catch (err) {
-      if (signal?.aborted) return { status: "canceled" }
-      if (timedOut) return { status: "timeout" }
-      logger.warn({ err, sessionId, workspaceId, level }, "Voice transcript polish provider failed")
-      return { status: "provider_error" }
+      if (signal?.aborted) return complete({ status: "canceled" })
+      if (timedOut) return complete({ status: "timeout" })
+      return complete({ status: "provider_error" }, err)
     } finally {
       clearTimeout(timer)
       signal?.removeEventListener("abort", onCancel)
@@ -117,9 +155,23 @@ export function createPolishTranscript(deps: { ai: AI; config?: VoicePolishConfi
   }
 }
 
-function parsePolishSuccess(markdown: string): PolishOutcome {
+function safeProviderError(error: unknown): Record<string, string | number> {
+  if (!error || typeof error !== "object") return { errorType: typeof error }
+  const value = error as Record<string, unknown>
+  const safe: Record<string, string | number> = {}
+  if (isErrorClassification(value.name)) safe.errorName = value.name
+  if (isErrorClassification(value.code)) safe.errorCode = value.code
+  if (typeof value.status === "number" && Number.isFinite(value.status)) safe.errorStatus = value.status
+  return safe
+}
+
+function isErrorClassification(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(value)
+}
+
+function parsePolishSuccess(markdown: string, parse: (markdown: string) => JSONContent): PolishOutcome {
   try {
-    const contentJson = parseMarkdown(markdown)
+    const contentJson = parse(markdown)
     return { status: "success", markdown, contentJson }
   } catch {
     return { status: "invalid_output", reason: "unparseable" }

--- a/packages/agent-runtime/src/ai/ai.test.ts
+++ b/packages/agent-runtime/src/ai/ai.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, mock } from "bun:test"
-import { parseModelId, createAI, AIBudgetExceededError, applyCacheBreakpoints } from "./ai"
+import { describe, it, expect, mock, spyOn } from "bun:test"
+import { z } from "zod"
+import { parseModelId, createAI, AIBudgetExceededError, applyCacheBreakpoints, extractUsageWithCost } from "./ai"
 
 // Import fixture data captured from real OpenRouter API calls (2026-01-06)
 import fixtures from "./fixtures/openrouter-responses.json"
@@ -211,6 +212,112 @@ describe("budget enforcement", () => {
       budget_current_usage_usd: 85,
       budget_limit_usd: 100,
     })
+  })
+})
+
+describe("generation reasoning and usage", () => {
+  function openRouterResponse(content: string, usage: Record<string, unknown> = {}) {
+    return new Response(
+      JSON.stringify({
+        id: "gen_test",
+        model: "openai/gpt-5.6-luna",
+        choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 6, total_tokens: 16, ...usage },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    )
+  }
+
+  it("forwards medium reasoning for text and omits reasoning options when unset", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
+      _input: Parameters<typeof globalThis.fetch>[0],
+      init: Parameters<typeof globalThis.fetch>[1]
+    ) => {
+      bodies.push(JSON.parse(String(init?.body)))
+      return openRouterResponse("ok")
+    }) as unknown as typeof globalThis.fetch)
+    try {
+      const ai = createAI({ openrouter: { apiKey: "test-key" } })
+      await ai.generateText({
+        model: "openrouter:openai/gpt-5.6-luna",
+        messages: [{ role: "user", content: "test" }],
+        reasoningEffort: "medium",
+      })
+      await ai.generateText({
+        model: "openrouter:openai/gpt-5.6-luna",
+        messages: [{ role: "user", content: "test" }],
+      })
+      expect(bodies[0]?.reasoning).toEqual({ effort: "medium", exclude: true })
+      expect(bodies[1]).not.toHaveProperty("reasoning")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it("forwards medium reasoning for object generation", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
+      _input: Parameters<typeof globalThis.fetch>[0],
+      init: Parameters<typeof globalThis.fetch>[1]
+    ) => {
+      bodies.push(JSON.parse(String(init?.body)))
+      return openRouterResponse('{"answer":"ok"}')
+    }) as unknown as typeof globalThis.fetch)
+    try {
+      const ai = createAI({ openrouter: { apiKey: "test-key" } })
+      await ai.generateObject({
+        model: "openrouter:openai/gpt-5.6-luna",
+        schema: z.object({ answer: z.string() }),
+        messages: [{ role: "user", content: "test" }],
+        reasoningEffort: "medium",
+      })
+      expect(bodies[0]?.reasoning).toEqual({ effort: "medium", exclude: true })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it("prefers standard reasoning-token details and falls back to OpenRouter metadata", () => {
+    expect(
+      extractUsageWithCost({
+        usage: { outputTokenDetails: { reasoningTokens: 5 } },
+        providerMetadata: {
+          openrouter: { usage: { completionTokensDetails: { reasoningTokens: 3 } } },
+        },
+      }).reasoningTokens
+    ).toBe(5)
+    expect(
+      extractUsageWithCost({
+        usage: {},
+        providerMetadata: {
+          openrouter: { usage: { completionTokensDetails: { reasoningTokens: 3 } } },
+        },
+      }).reasoningTokens
+    ).toBe(3)
+  })
+
+  it("extracts standard reasoning tokens and forwards them to the cost recorder", async () => {
+    const recorded: Array<{ usage: { reasoningTokens?: number } }> = []
+    const recordUsage = mock(async (params: { usage: { reasoningTokens?: number } }) => {
+      recorded.push(params)
+    })
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async () =>
+      openRouterResponse("ok", {
+        completion_tokens_details: { reasoning_tokens: 4 },
+      })) as unknown as typeof globalThis.fetch)
+    try {
+      const ai = createAI({ openrouter: { apiKey: "test-key" }, costRecorder: { recordUsage } })
+      const result = await ai.generateText({
+        model: "openrouter:openai/gpt-5.6-luna",
+        messages: [{ role: "user", content: "test" }],
+        context: { workspaceId: "ws_1" },
+      })
+      expect(result.usage.reasoningTokens).toBe(4)
+      expect(recorded[0]?.usage.reasoningTokens).toBe(4)
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 })
 

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -187,11 +187,14 @@ export interface Message {
   content: MessageContent
 }
 
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+
 export interface GenerateTextOptions {
   model: string
   messages: Message[]
   maxTokens?: number
   temperature?: number
+  reasoningEffort?: ReasoningEffort
   telemetry?: TelemetryConfig
   /** When provided, usage will be recorded to the database */
   context?: CostContext
@@ -259,6 +262,7 @@ export interface GenerateObjectOptions<T extends z.ZodType> {
   messages: Message[]
   maxTokens?: number
   temperature?: number
+  reasoningEffort?: ReasoningEffort
   /** Set to false to disable repair, or provide custom repair function */
   repair?: RepairFunction | false
   telemetry?: TelemetryConfig
@@ -306,6 +310,7 @@ export interface UsageWithCost {
    * for its 1.25x write premium on a given surface.
    */
   cachedPromptTokens?: number
+  reasoningTokens?: number
   /** Cost in USD from OpenRouter, if available */
   cost?: number
 }
@@ -564,6 +569,52 @@ export function parseModelId(providerModelString: string): ParsedModel {
   return { provider, modelId, modelProvider, modelName }
 }
 
+export function extractUsageWithCost(response: {
+  usage?:
+    | {
+        promptTokens?: number
+        completionTokens?: number
+        totalTokens?: number
+        outputTokenDetails?: { reasoningTokens?: number }
+      }
+    | { tokens?: number }
+  providerMetadata?: {
+    openrouter?: {
+      usage?: {
+        cost?: number
+        totalTokens?: number
+        promptTokens?: number
+        completionTokens?: number
+        promptTokensDetails?: { cachedTokens?: number }
+        completionTokensDetails?: { reasoningTokens?: number }
+      }
+    }
+  }
+}): UsageWithCost {
+  const usage = response.usage ?? {}
+  const openrouterUsage = response.providerMetadata?.openrouter?.usage
+
+  if ("tokens" in usage && usage.tokens !== undefined) {
+    return { totalTokens: usage.tokens, cost: openrouterUsage?.cost }
+  }
+
+  const langUsage = usage as {
+    promptTokens?: number
+    completionTokens?: number
+    totalTokens?: number
+    outputTokenDetails?: { reasoningTokens?: number }
+  }
+  return {
+    promptTokens: openrouterUsage?.promptTokens ?? langUsage.promptTokens,
+    completionTokens: openrouterUsage?.completionTokens ?? langUsage.completionTokens,
+    totalTokens: openrouterUsage?.totalTokens ?? langUsage.totalTokens,
+    cachedPromptTokens: openrouterUsage?.promptTokensDetails?.cachedTokens,
+    reasoningTokens:
+      langUsage.outputTokenDetails?.reasoningTokens ?? openrouterUsage?.completionTokensDetails?.reasoningTokens,
+    cost: openrouterUsage?.cost,
+  }
+}
+
 export function createAI(config: AIConfig): AI {
   const providers = {
     openrouter: config.openrouter ? createOpenRouter({ apiKey: config.openrouter.apiKey }) : null,
@@ -809,56 +860,6 @@ export function createAI(config: AIConfig): AI {
   }
 
   /**
-   * Extract usage with cost from AI SDK response.
-   * OpenRouter provides cost via providerMetadata.openrouter.usage.cost
-   *
-   * Handles two different usage shapes:
-   * - Language model: { promptTokens, completionTokens, totalTokens }
-   * - Embedding model: { tokens }
-   */
-  function extractUsageWithCost(response: {
-    // Language model usage shape
-    usage?:
-      | { promptTokens?: number; completionTokens?: number; totalTokens?: number }
-      // Embedding model usage shape
-      | { tokens?: number }
-    // AI SDK v7 uses providerMetadata (not experimental_providerMetadata)
-    providerMetadata?: {
-      openrouter?: {
-        usage?: {
-          cost?: number
-          totalTokens?: number
-          promptTokens?: number
-          completionTokens?: number
-          promptTokensDetails?: { cachedTokens?: number }
-        }
-      }
-    }
-  }): UsageWithCost {
-    const usage = response.usage ?? {}
-    // OpenRouter provides detailed usage via providerMetadata
-    const openrouterUsage = response.providerMetadata?.openrouter?.usage
-
-    // Handle embedding model usage (only has 'tokens')
-    if ("tokens" in usage && usage.tokens !== undefined) {
-      return {
-        totalTokens: usage.tokens,
-        cost: openrouterUsage?.cost,
-      }
-    }
-
-    // Handle language model usage - prefer OpenRouter data if available
-    const langUsage = usage as { promptTokens?: number; completionTokens?: number; totalTokens?: number }
-    return {
-      promptTokens: openrouterUsage?.promptTokens ?? langUsage.promptTokens,
-      completionTokens: openrouterUsage?.completionTokens ?? langUsage.completionTokens,
-      totalTokens: openrouterUsage?.totalTokens ?? langUsage.totalTokens,
-      cachedPromptTokens: openrouterUsage?.promptTokensDetails?.cachedTokens,
-      cost: openrouterUsage?.cost,
-    }
-  }
-
-  /**
    * Emit a `disclose` access-log row for this egress, if a sink is configured.
    * Fired synchronously at send time — the content crosses the trust boundary the
    * moment it is dispatched, so a provider call that errors after receiving the
@@ -966,6 +967,9 @@ export function createAI(config: AIConfig): AI {
         maxOutputTokens: options.maxTokens,
         temperature: options.temperature,
         abortSignal: options.abortSignal,
+        ...(options.reasoningEffort
+          ? { providerOptions: { openrouter: { reasoning: { effort: options.reasoningEffort, exclude: true } } } }
+          : {}),
         experimental_telemetry: buildTelemetry(options.telemetry),
       })
 
@@ -1081,6 +1085,9 @@ export function createAI(config: AIConfig): AI {
         maxOutputTokens: options.maxTokens,
         temperature: options.temperature,
         abortSignal: options.abortSignal,
+        ...(options.reasoningEffort
+          ? { providerOptions: { openrouter: { reasoning: { effort: options.reasoningEffort, exclude: true } } } }
+          : {}),
         experimental_repairText: repair,
         experimental_telemetry: buildTelemetry(options.telemetry),
       })

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -112,6 +112,7 @@ export { createKeepResponseTool } from "./tools/keep-response-tool"
 
 export {
   createAI,
+  extractUsageWithCost,
   parseModelId,
   providerRequiresCacheBreakpoints,
   applyCacheBreakpoints,
@@ -139,6 +140,7 @@ export {
   type MessageRole,
   type ObjectResult,
   type ParsedModel,
+  type ReasoningEffort,
   type RepairFunction,
   type SingleEmbedResult,
   type TelemetryConfig,


### PR DESCRIPTION
## Problem

Voice polishing relies on Luna’s implicit reasoning default, so provider-default drift can silently change quality and latency. The AI wrapper also discards reasoning-token usage, while `createPolishTranscript` logs raw provider errors that may contain request content. Those gaps prevent safe calibration of the bounded formatter planned above this branch.

## Solution

- Add typed `reasoningEffort` support to `createAI.generateText` and `generateObject`; send OpenRouter reasoning with returned reasoning text excluded.
- Configure voice polish explicitly at `medium`, preserving the calibrated model, prompts, temperature, and deadlines.
- Extract standard/OpenRouter reasoning-token usage and carry it through cost recording and eval aggregation.
- Replace raw provider-error logging with one privacy-safe attempt record containing only outcomes, timings, lengths, bounded classifications, and token counts.
- Prove transcript, draft, steering, model-output, parser-error, and provider-error sentinels never enter info/warn/error logs.

## Files

| File | Change |
| ---- | ------ |
| `packages/agent-runtime/src/ai/ai.ts` | Typed reasoning requests and reasoning-token extraction. |
| `apps/backend/src/features/voice-transcription/config.ts` | Explicit production `medium` effort. |
| `apps/backend/src/features/voice-transcription/polish.ts` | Reasoning propagation and content-free attempt diagnostics. |
| `apps/backend/evals/framework/{types,runner}.ts` | Reasoning-token aggregation in eval artifacts. |
| Associated tests | Provider wire shape, usage forwarding, aggregation, and privacy matrix. |

## Test plan

- [x] Agent-runtime AI tests — 38 passed
- [x] Voice polish, suite, and eval usage tests — 29 passed
- [x] Full pre-commit monorepo lint and typecheck
- [x] Dockerfile, migration, API-doc, and `git diff --check` gates

<details>
<summary>📋 Full implementation plan</summary>

# Bounded incremental dictation formatting plan

## Scope and fixed decisions

- The stack was originally cut from `abe0bb1a0c8f60bf4928d11542894c073c559aa7` and was subsequently synced onto `origin/main` at `54143917f1c28cccb3e69174263e2cc51d20417f` after the transcript-loss hotfix and adjacent composer changes merged. PR ownership and dependency order remain unchanged.
- Keep `openrouter:openai/gpt-5.6-luna`, temperature `0.2`, live wall-clock budget `6,500ms`, final wall-clock budget `8,000ms`, and `maxTokens: 2,048`.
- Add `reasoning: "medium"` to `voicePolishConfig`; pass it through `createAI.generateText` and `createAI.generateObject`. Do not rely on Luna's provider default.
- No migration, persisted transcript state, setting/UI change, STT strategy change, or model change.
- Formatter output remains Markdown. A successful result is accepted only after `parseMarkdown` produces canonical `contentJson`; only `contentJson` enters the editor (INV-58). A separate model-based boundary-scope decision returns control data only and never editor content.

## 1. Incremental state machine

### Bounds

Colocate these constants with `voicePolishConfig` and use them in production and evals (INV-33/44):

- `VOICE_POLISH_WINDOW_MAX_CHARS = 1_200` Unicode scalar values, including spaces inserted between STT finals.
- `VOICE_POLISH_WINDOW_MAX_FINALS = 4` upstream final segments.
- `VOICE_POLISH_WIDEN_MAX_WINDOWS = 2`: current mutable window plus its immediately preceding accepted window.
- `VOICE_POLISH_READ_ONLY_SUFFIX_MAX_CHARS = 1_200`: older accepted Markdown visible only to the boundary-scope decision.
- Normal formatter target: at most 1,200 raw characters and four finals.
- Exceptional widened formatter target: at most two adjacent windows / 2,400 raw characters.
- Initial composer context remains capped independently at 2,000 Markdown characters on each side by `VOICE_DRAFT_CONTEXT_MAX_CHARS`.

Rationale: the observed successful cumulative calls were 480 and 815 characters. A 1,200-character window leaves 47% headroom over the larger successful input and normally contains the observed three-final take, while making every later take length-independent. Four finals prevents many tiny STT commits from keeping one window mutable indefinitely. A 2,400-character exceptional window is enough to repair one boundary without reopening the whole take and still fits the existing 2,048 output-token allowance for transcript text plus medium reasoning. Every split and count is language-neutral (INV-54).

If one upstream final exceeds 1,200 characters, split it at the last Unicode whitespace that fits; if none exists, split on a Unicode scalar boundary. Emit each piece as a separately revisioned raw delta. This is transport bounding, not a semantic language decision. Do not split surrogate pairs or drop whitespace.

### Session and window state

Replace `rawFinals`, `sessionChunkId`, and `previousAcceptedMarkdown` with an in-memory session engine used by the gateway and eval suite:

```text
Session
  generation
  phase: live | formatting | closing | closed
  negotiatedProtocol
  sessionRevision
  windows[]
  activeWindowId
  scheduler
  terminationMode / terminationPromise

Window
  chunkId
  predecessorChunkId?
  firstRevision / latestRevision
  rawParts[] / rawCharCount / finalCount
  state: open | sealed
  accepted?: {
    operationId
    resultChunkId
    throughRevision
    markdown
    contentJson
    rawMarkdown
    rawContentJson
  }
```

`rawParts` exist only for the socket session, as today; never persist or log them.

Window transitions:

1. **Open:** append a final if both limits still fit; emit its raw `contentJson` immediately under this window's `chunkId`; schedule the newest immutable snapshot.
2. **Seal:** before a fifth final or an append that would cross 1,200 characters. A sealed window never receives more raw text. Its already accepted formatting is immutable on the common path.
3. **Roll:** create a new `chunkId`, linked by `predecessorChunkId`; raw insertion remains immediate. A late result for the sealed predecessor may still land if its own source revisions match, even though the session revision advanced.
4. **Accept:** formatter Markdown parses successfully, the operation still exactly covers every source window revision, and the client acknowledges an atomic editor application. A stale/locked/missing operation is not accepted for reuse.
5. **Fail:** timeout, provider error, cancellation, empty/truncated/unparseable output, stale coverage, or editor rejection leaves existing accepted chunks and raw source chunks untouched.

The scheduler keeps one active model attempt and only the newest pending snapshot. Supersession is per source window, not by one session-wide revision: a result for sealed window A can land after raw window B starts, while an older result for a still-growing B cannot replace B's newer raw revision. If rapid speech creates more sealed windows than the active/newest-pending pair can format, skipped windows remain visible raw; stop never drains an unbounded backlog.

### Normal formatting

For the first window, and for later windows whose boundary scope is `tail`, call the formatter with only that window's cumulative raw text. Pass the immediate accepted predecessor and bounded composer context as explicitly read-only prompt sections. The output contract changes from “complete take” to “only the mutable raw window.” Lists, paragraphs, corrections, and false starts wholly inside the window remain model-owned.

Every successful live result replaces only that window's chunk. Rolling to the next window freezes this accepted result on the common path. Thus take length grows the number of stable editor chunks, not model input or replacement size.

### Deliberate stop

1. Enter `formatting`; stop accepting audio pushes but continue accepting terminal upstream deltas.
2. Cancel pending live scheduling, flush upstream, and commit any remaining interim exactly once. Terminal final delivery clears `lastInterim`; synthetic promotion is only used when flush returns without a final.
3. Compare the newest mutable window's accepted `throughRevision` with the post-flush `latestRevision`.
   - Exact match: reuse it; make no model call and report `finalReused: true`.
   - No exact match: run one final attempt for the newest mutable window under one 8,000ms wall-clock budget.
4. Do not sequentially format older skipped/failed windows. They remain raw, so stop work stays constant regardless of take length.
5. Emit `voice:stopped` only after the replacement event/ack opportunity and session close. A failed final reports its typed outcome and raw-tail metadata but does not clear or lock successful earlier chunks.

The boundary-scope and formatter stages share the same absolute live/final deadline. Parallel/speculative work cannot turn the 8,000ms final cap into 8,000ms per stage.

## 2. Boundary behavior and replacement protocol

### Model-based scope decision

When a mutable window has an immediately preceding accepted window, run a Luna scope decision in parallel with the normal tail formatter. It receives:

- current raw window;
- immediate predecessor raw plus accepted Markdown;
- at most 1,200 characters of older accepted Markdown as read-only suffix;
- surrounding draft context.

It returns one enum through `createAI.generateObject`:

- `tail`: current text can be formatted without changing prior accepted content;
- `widen_previous`: a correction, false start, list continuation, or paragraph continuation requires the immediately preceding window;
- `preserve_raw`: the intended change reaches farther back than one window, is ambiguous, or cannot be applied safely inside the bound.

This is a semantic model decision, not a correction-word regex or English keyword list (INV-54). Both scope and formatter calls use the same Luna model and explicit medium reasoning. The speculative tail result is used only for `tail`; it is discarded for either other scope.

- `tail`: parse and replace current chunk only.
- `widen_previous`: run one Markdown formatter over exactly predecessor + current using the remaining shared deadline. The prompt names both as the complete replacement target. Parse the full Markdown to one canonical `contentJson` result.
- `preserve_raw`, scope failure, or insufficient remaining deadline: emit no replacement; leave the accepted predecessor plus visible raw current chunk.

The oldest accepted prefix is never targeted. A widened operation can target only the immediately preceding accepted chunk and current raw chunk. Clean boundary cases must eval as `tail`; widening is reserved for actual cross-boundary semantics.

### Lists and paragraphs

- Enumeration, paragraph breaks, false starts, and corrections inside one window are handled in one cumulative Markdown result, preserving PR #1802's structured parse path.
- A new independent paragraph/list in a later window is `tail` and inserts as a separate canonical chunk; ProseMirror may normalize adjacent compatible blocks without losing tracked boundaries.
- A spoken continuation that must join the prior paragraph, append list items to the prior list, change list type, or remove prior terminal punctuation is `widen_previous`. The full two-window Markdown is parsed once and atomically replaces both editor chunks, so the server never has to infer a character offset inside Markdown.
- A correction aimed at the immediate predecessor is the same bounded widened operation.
- A correction aimed before the predecessor returns `preserve_raw`; the narration stays visible as raw text rather than destructively guessing or reopening the take. Arbitrary older correction is explicitly out of horizon.

### Protocol v4

Keep the event name `voice:transcript:polished`, but add a v4 replacement envelope. Shared types should be a discriminated v3/v4 union rather than optional fields interpreted ad hoc.

```text
VoiceTranscriptDeltaV4
  voiceSessionId
  revision
  text
  isFinal
  chunkId
  afterChunkId?
  contentJson

VoiceTranscriptReplacementV4
  protocolVersion: 4
  operationId
  voiceSessionId
  authoritative
  resultChunkId
  throughRevision
  sources: [{ chunkId, throughRevision }]   // one normal, two widened
  raw / polished                           // Markdown wire/debug-toggle values
  rawContentJson / polishedContentJson     // canonical parsed values

VoiceTranscriptReplacementAck
  operationId
  status: applied | stale | locked | missing | non_contiguous | invalid
```

`afterChunkId` tells the editor where a rolled window follows the prior dictation chunk; numeric ProseMirror positions never cross the socket. `sources` tells the client exactly which live mapped ranges the server intends to replace. `resultChunkId` is the source `chunkId` for a normal swap and a fresh ID for a two-window collapse.

The editor extension adds one atomic command:

```text
replaceDictationChunks({ sources, resultChunkId, contentJson })
```

It resolves current positions by source IDs, checks each source is unlocked and still equals its `expectedContentJson`, checks source order/contiguity and absence of untracked user content between them, then performs one transaction. Success removes source tracking and installs one result range. Failure changes no document content; only a source proven user-modified is locked. Untouched chunks remain independently swappable.

The hook keeps `latestRawRevisionByChunk`, not one `sessionChunkIdRef`/global stale gate. It rejects an operation unless every source revision is exact, invokes the editor command synchronously, updates the raw/polished toggle records only on success, and acknowledges the result. If a widened operation fails, the accepted predecessor and raw tail remain exactly as displayed; later single-chunk operations can still target the current chunk.

A successful operation is recorded even while “Show original” is selected: the editor atomically installs the composite raw `contentJson`, while the hook stores both raw and polished canonical forms for later toggles.

## 3. Race analysis

### Active and pending live work

- Every scheduled snapshot carries session generation, source IDs, source revisions, scope, raw lengths, and an operation ID.
- A new final in the same open window makes an older snapshot stale; only the newest pending snapshot survives.
- Rollover seals the old source. Its active exact result may still apply after a new-window delta because validation is per source, not against the session's latest revision.
- A late provider completion after abort/cancel/generation change is discarded before parse emission and cannot be accepted by a late ack.
- Duplicate operation delivery/ack is idempotent by `operationId`; conflicting or already superseded acks are ignored.

### Flush and stop escalation

- `format` preserves the socket/session identity through flush, final replacement, `voice:stopped`, and stop ack, retaining PR #1798 ordering.
- A live result that was parsed and editor-acknowledged at the exact post-flush revision is reused. A result still active, stale, or unacknowledged is canceled and replaced by at most one bounded final attempt.
- `send_as_is` outranks `format`: increment generation, cancel scope/formatter work, interrupt flush, stop audio, detach the frontend session before the composer snapshot, synchronously insert the visible interim as canonical local raw recovery, and finish without waiting for formatting.
- `abort` outranks both: cancel work, discard intentional-abort interim, close once, and emit no replacement/stopped event.
- Close/finalize remains single-flight under repeated stop, max-duration, disconnect, and provider-close races.

### Stale revisions and event ordering

- Raw delta always reaches the editor before any operation that names it.
- A newer raw delta for source B makes an older B operation `stale`, even if the editor range itself is otherwise editable.
- A late operation for sealed A remains valid after B starts if A's own revision is exact.
- `voice:stopped` follows the authoritative operation on the same socket. Final failure leaves earlier records swappable for the existing grace window and only the failed/raw tail unpolished; remove the current v4 behavior that calls `lockAllChunks()` for any non-success outcome.

### User edits

- ProseMirror mapping follows edits outside a chunk.
- An edit inside one chunk locks only that chunk. Normal operations for other chunk IDs continue.
- A two-source operation is all-or-nothing. If either source was edited, missing, or separated by user text, neither source is replaced; the user's edit and raw tail win.
- Toggle operations use the same expected-JSON CAS and never resurrect a locked range.

### Disconnect and provider failures

- Unexpected socket disconnect increments generation and aborts server work. Already inserted finals remain. The frontend commits the currently visible interim once as a local raw recovery before teardown; no transcript is lost merely because no stop ack arrives.
- Provider error, timeout, parse failure, truncation, scope failure, or ack failure emits/logs only a typed outcome. No fallback is represented as “successful raw polish.”
- No reconnect/resume is attempted for an in-memory voice session; stale events retain the `voiceSessionId` guard and cannot enter the next take.

## 4. Reasoning, diagnostics, and evals

### `createAI` and feature telemetry

- Extend `GenerateTextOptions` and `GenerateObjectOptions` with the AI SDK's typed reasoning effort; forward it to `aiGenerateText`/`aiGenerateObject` (INV-28/33).
- Extend `UsageWithCost` with `reasoningTokens`, sourced first from standard `usage.outputTokenDetails.reasoningTokens`, then OpenRouter `completionTokensDetails.reasoningTokens`. Pass it to cost recording and eval results.
- Add `reasoning: "medium"` to `VoicePolishConfig`; production and eval calls read the same value (INV-44/45).
- Telemetry metadata for every scope/format call: `stage` (`scope_live`, `format_live`, `scope_final`, `format_final`, `format_widen`), `reasoningEffort`, deadline class, raw character count, read-only context character count, source window count, final count, and protocol version. Keep `functionId` distinct for scope and Markdown formatting (INV-19).
- Feature completion logs: duration, outcome, prompt/completion/reasoning tokens, timeout/cancel flags, widened flag, and ack status. Session-close logs: negotiated protocol, audio duration, revision/window/final counts, successful/raw/locked/stale counts, max observed mutable length, flush/final stage durations, and `finalReused`.
- Never log transcript, Markdown, `contentJson`, draft context, steering terms, model response, or raw provider error objects. Replace the current polish `logger.warn({ err, ... })` with a safe error class/code/status projection; provider errors can contain request bodies.

### Production-entrypoint eval redesign

Refactor `apps/backend/evals/suites/voice-polish/` to drive the same incremental session engine used by `realtime-gateway.ts`, feeding non-cumulative STT finals and applying emitted operations to an in-memory chunk document (INV-45). Do not keep the existing eval-only cumulative `previousAcceptedMarkdown` loop.

Add/convert cases for:

1. one-window append, inline correction, false start, Swedish/German correction, bullets, ordered lists, and paragraphs;
2. four-final and 1,200-character rollover boundaries;
3. clean cross-boundary prose that must choose `tail` and leave predecessor canonical JSON byte-stable;
4. cross-boundary list and paragraph continuation that must choose a two-source atomic replacement;
5. immediate-predecessor retroactive correction in English, Swedish, and German;
6. out-of-horizon correction that must choose `preserve_raw`;
7. a multi-window long take asserting all distinct details survive, every normal target is at most 1,200 chars, every widened target at most 2,400, and stop formats at most one current window;
8. stop reuse when the live accepted revision exactly equals the flushed revision (zero final model calls);
9. failed final preserving accepted chunk JSON plus raw-tail JSON.

Deterministic unit tests own races, locked-editor fallback, split boundaries, no partial replacement, protocol negotiation, and privacy-safe logs. Stochastic six-run eval gates remain model behavior gates:

- safety/parse/context-non-echo/language: 100%;
- each correction/structure case: at least 5/6;
- clean boundary false widening: 0/6;
- out-of-horizon destructive widening: 0/6;
- final completed-call p95 + 750ms recommendation at or below 8,000ms; final timeout rate at or below 15%;
- report p50/p95 and timeout rate separately for scope, normal live, normal final, and widened format;
- report prompt/completion/reasoning token distributions and verify every production-entrypoint request declares `medium` (do not gate on a provider always reporting nonzero reasoning tokens);
- assert model-input bounds mechanically on every eval step.

Runtime privacy tests pass distinctive transcript/draft sentinels through timeout/provider/parse paths and inspect captured logger objects/messages to prove neither sentinel appears.

## 5. Stacked PRs, bottom to top

Use linked GitHub Stack #1814; the current stack root is synced to `origin/main` at `54143917f1c28cccb3e69174263e2cc51d20417f`.

### PR 1 — AI reasoning and privacy-safe usage plumbing

- Branch: `improve/dictation-reasoning-telemetry`
- Base ref: current `origin/main` at `54143917f1c28cccb3e69174263e2cc51d20417f`
- Deliverables:
  - typed reasoning option through `createAI.generateText` and `generateObject`;
  - `reasoningTokens` extraction/cost/eval exposure;
  - explicit `medium` in colocated voice config and all production/eval polish calls;
  - safe per-attempt voice usage/timing diagnostics; remove raw provider-error logging.
- Tests/gates:
  1. agent-runtime request test proves `medium` reaches the AI SDK/OpenRouter request;
  2. standard and OpenRouter usage fixtures prove reasoning-token extraction and recorder forwarding;
  3. voice config/polish tests prove production and overridden eval config preserve explicit effort and INV-19 metadata;
  4. logger-capture tests prove transcript/draft sentinels do not appear on success, timeout, truncation, parse, or provider failure;
  5. `bun run --cwd packages/agent-runtime test`;
  6. targeted backend voice unit tests;
  7. `bun run typecheck` and affected-workspace lint.
- Exclusions: no prompt semantics, chunk state, socket protocol, frontend/editor behavior, model/deadline change.

### PR 2 — Negotiated v4 bounded backend and production eval engine

- Branch: `improve/dictation-bounded-backend`
- Base ref: `improve/dictation-reasoning-telemetry`
- Deliverables:
  - shared v4 discriminated protocol types and centralized bounds;
  - incremental session/window engine, bounded scheduler snapshots, stop reuse, and typed replacement acks;
  - Luna boundary-scope production entrypoint plus tail/widen/preserve-raw prompts;
  - v4 gateway path with per-window revisions and v3 legacy path selected by negotiation;
  - privacy-safe window/stage/session metrics;
  - voice-polish eval suite driven through the production incremental engine.
- Tests/gates:
  1. pure window tests for exact 1,200-char/four-final rollover, huge-final Unicode splitting, immutable sealed windows, and skipped-backlog raw preservation;
  2. scheduler tests for active/newest-pending, same-window staleness, sealed-window late acceptance, cancellation, duplicate ack, and final exact reuse;
  3. gateway tests for flush-delivered finals, no-op stop reuse, one bounded final, format→send-as-is→abort escalation, max duration, disconnect, and close-once behavior;
  4. protocol tests: omitted client version negotiates v3; requested v4 negotiates v4; invalid/future versions clamp safely; v3 payloads remain byte-shape compatible;
  5. formatter tests: all accepted Markdown parses to `contentJson`; tail scope never targets predecessor; widen targets exactly two; preserve-raw/failures emit no destructive operation;
  6. eval unit/evaluator/reporting tests, including stage latency and bounds;
  7. six-run real `voice-polish` production-entrypoint eval meeting the gates above, with JSON artifact kept outside the repo;
  8. backend unit suite, `bun run typecheck`, and affected-workspace lint.
- Exclusions: no v4 activation for current clients, editor range changes, setting/UI/STT/database work. The backend remains deployable because clients that omit v4 stay on legacy v3.

### PR 3 — Multi-chunk editor/client activation

- Branch: `improve/dictation-bounded-client`
- Base ref: `improve/dictation-bounded-backend`
- Deliverables:
  - frontend requests protocol v4 and falls back to existing v2/v3 handling from the negotiated ack;
  - per-chunk revision/record maps replace the session-wide chunk latch on v4;
  - `afterChunkId` insertion and atomic multi-source replacement in `dictation-chunk-extension.ts`;
  - synchronous replacement ack, independent locking/toggles, raw-tail failure retention, immediate send invalidation, and disconnect interim recovery;
  - composer/rich-editor callback plumbing without UI redesign.
- Tests/gates:
  1. editor tests for multiple adjacent paragraph/list chunks, normal swap, two-source collapse, mapped outside edits, inside-edit single lock, non-contiguous rejection, no partial transaction, and independent toggles after one lock;
  2. hook tests for v4 per-source stale handling, sealed-old result after new delta, operation dedupe/acks, show-original arrival, widened fallback, failed stop retaining prior chunks, exact stop ordering, send-as-is, abort, disconnect, and next-session isolation;
  3. compatibility tests for new client against v2/v3 ack and v4 client against negotiated v4 payloads;
  4. composer tests prove send snapshots include synchronous raw interim and late formatter output cannot re-enter the cleared draft;
  5. targeted frontend suite, backend protocol tests, `bun run typecheck`, affected-workspace lint, then full `bun run test:unit` and `bun run --cwd apps/frontend test`.
- Exclusions: no visual/settings changes, persisted chunk metadata, protocol-v3 removal, or arbitrary historical correction UI.

## 6. Rollout and compatibility

- Raise server maximum to v4, but make `voice:start` accept optional `maxProtocolVersion`. Missing means legacy v3, preserving all existing clients. Ack returns the negotiated version, not blindly the server maximum.
- PR 2 can deploy first: existing clients remain on the current cumulative v3 implementation and payloads.
- PR 3 clients send `maxProtocolVersion: 4`. Against an older v2/v3 backend, Zod strips the unknown field, the old ack returns 2/3, and the hook follows its existing legacy branch. Against the new backend, v4 activates bounded chunks.
- Same event names are safe because only negotiated v4 sessions receive v4 replacement envelopes. V2/v3 sessions retain one session chunk, cumulative raw/polished Markdown fields, v3 `contentJson`, and current stop modes.
- Rollback is symmetric: rolling back frontend stops v4 negotiation; rolling back backend makes new frontend negotiate 2/3. No persisted state or migration couples versions.
- Log only negotiated-version counts and outcomes. After v4 adoption is effectively complete and rollback windows expire, remove the isolated v3 cumulative strategy in a follow-up rather than letting both implementations drift.

## 7. Deferred

- Reformatting or correcting more than one accepted window back; v4 preserves such speech raw.
- Persisting/replaying formatter operations across socket disconnects.
- Client-authored live draft context updates after dictation starts; v4 still uses start-time composer context plus accepted bounded suffixes.
- Adaptive/token-based horizons, model changes, lower/disabled reasoning, deadline retuning, or speculative provider parallelism.
- UI for manual “reformat this range,” correction conflict resolution, per-chunk controls, or polish settings redesign.
- STT provider/finalization cadence changes and audio pipeline work.
- Removal of v2/v3 compatibility before adoption telemetry and rollback windows justify it.
- Database storage, migrations, transcript retention, or analytics containing transcript/draft content.


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788776237&installation_model_id=20758&pr_number=1811&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1811&signature=5d949ba2d0d6ae693fe62ced6f71d3eb137a73ec9cbe8ea9f40feac1297eccf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->