### PR TITLE
feat: serialize core stream writes with read-only transitions

### DIFF
--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -326,7 +326,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
     }
 
     const editMessage: PersonaAgentDeps["editMessage"] = async (params) => {
-      const message = await evalEventService.editMessage({
+      const message = await evalEventService.editMessageInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -339,7 +339,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
     }
 
     const deleteMessage: PersonaAgentDeps["deleteMessage"] = async (params) => {
-      const message = await evalEventService.deleteMessage({
+      const message = await evalEventService.deleteMessageInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -350,7 +350,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
     }
 
     const addReaction: PersonaAgentDeps["addReaction"] = async (params) => {
-      const message = await evalEventService.addReaction({
+      const message = await evalEventService.addReactionInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -362,7 +362,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
     }
 
     const removeReaction: PersonaAgentDeps["removeReaction"] = async (params) => {
-      const message = await evalEventService.removeReaction({
+      const message = await evalEventService.removeReactionInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -337,7 +337,7 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
     }
 
     const editMessage: PersonaAgentDeps["editMessage"] = async (params) => {
-      const message = await evalEventService.editMessage({
+      const message = await evalEventService.editMessageInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -350,7 +350,7 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
     }
 
     const deleteMessage: PersonaAgentDeps["deleteMessage"] = async (params) => {
-      const message = await evalEventService.deleteMessage({
+      const message = await evalEventService.deleteMessageInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -361,7 +361,7 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
     }
 
     const addReaction: PersonaAgentDeps["addReaction"] = async (params) => {
-      const message = await evalEventService.addReaction({
+      const message = await evalEventService.addReactionInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,
@@ -373,7 +373,7 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
     }
 
     const removeReaction: PersonaAgentDeps["removeReaction"] = async (params) => {
-      const message = await evalEventService.removeReaction({
+      const message = await evalEventService.removeReactionInternal({
         workspaceId: params.workspaceId,
         streamId: params.streamId,
         messageId: params.messageId,

--- a/apps/backend/src/features/agents/message-mutation-outbox-handler.test.ts
+++ b/apps/backend/src/features/agents/message-mutation-outbox-handler.test.ts
@@ -28,7 +28,7 @@ function createHandler() {
   spyOn(MessageVersionRepository, "findLatestByMessageId").mockResolvedValue(null)
 
   const eventService = {
-    deleteMessage: mock(async () => null),
+    deleteMessageInternal: mock(async () => null),
   } as any
 
   const jobQueue = {
@@ -141,7 +141,7 @@ describe("AgentMessageMutationHandler", () => {
       SessionStatuses.SUPERSEDED,
       expect.objectContaining({ error: "Superseded by invoking message edit" })
     )
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       {
@@ -229,7 +229,7 @@ describe("AgentMessageMutationHandler", () => {
         onlyIfStatusIn: [SessionStatuses.COMPLETED, SessionStatuses.FAILED],
       })
     )
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -287,7 +287,7 @@ describe("AgentMessageMutationHandler", () => {
 
     await waitForDebounce()
 
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       expect.objectContaining({
@@ -357,7 +357,7 @@ describe("AgentMessageMutationHandler", () => {
     await waitForDebounce()
 
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       {
@@ -466,7 +466,7 @@ describe("AgentMessageMutationHandler", () => {
       SessionStatuses.SUPERSEDED,
       expect.objectContaining({ error: "Superseded by invoking message edit" })
     )
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       {
@@ -544,7 +544,7 @@ describe("AgentMessageMutationHandler", () => {
 
     expect(getRevisionSpy).not.toHaveBeenCalled()
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -603,7 +603,7 @@ describe("AgentMessageMutationHandler", () => {
     await waitForDebounce()
 
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -696,7 +696,7 @@ describe("AgentMessageMutationHandler", () => {
       SessionStatuses.SUPERSEDED,
       expect.objectContaining({ error: "Superseded by referenced message edit" })
     )
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).toHaveBeenCalledWith(
       "persona.agent",
       {
@@ -775,7 +775,7 @@ describe("AgentMessageMutationHandler", () => {
 
     expect(getRevisionSpy).not.toHaveBeenCalled()
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -835,7 +835,7 @@ describe("AgentMessageMutationHandler", () => {
     await waitForDebounce()
 
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -872,7 +872,7 @@ describe("AgentMessageMutationHandler", () => {
     expect(findByTriggerSpy).not.toHaveBeenCalled()
     expect(findLatestByStreamSpy).not.toHaveBeenCalled()
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -908,7 +908,7 @@ describe("AgentMessageMutationHandler", () => {
     expect(findByTriggerSpy).not.toHaveBeenCalled()
     expect(findLatestByStreamSpy).not.toHaveBeenCalled()
     expect(updateStatusSpy).not.toHaveBeenCalled()
-    expect(eventService.deleteMessage).not.toHaveBeenCalled()
+    expect(eventService.deleteMessageInternal).not.toHaveBeenCalled()
     expect(jobQueue.send).not.toHaveBeenCalled()
   })
 
@@ -1064,13 +1064,13 @@ describe("AgentMessageMutationHandler", () => {
         rootStreamId: "stream_root_1",
       })
     )
-    expect(eventService.deleteMessage).toHaveBeenCalledTimes(2)
-    expect(eventService.deleteMessage).toHaveBeenCalledWith(
+    expect(eventService.deleteMessageInternal).toHaveBeenCalledTimes(2)
+    expect(eventService.deleteMessageInternal).toHaveBeenCalledWith(
       expect.objectContaining({
         messageId: "msg_agent_live_1",
       })
     )
-    expect(eventService.deleteMessage).toHaveBeenCalledWith(
+    expect(eventService.deleteMessageInternal).toHaveBeenCalledWith(
       expect.objectContaining({
         messageId: "msg_agent_2",
       })

--- a/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
+++ b/apps/backend/src/features/agents/message-mutation-outbox-handler.ts
@@ -402,7 +402,8 @@ export class AgentMessageMutationHandler extends DebouncedOutboxHandler {
 
     for (const sentMessageId of messageIds) {
       try {
-        await this.eventService.deleteMessage({
+        // Unguarded on purpose: a session's own sent messages stay retractable on session delete even if the stream has since become read-only.
+        await this.eventService.deleteMessageInternal({
           workspaceId,
           streamId: session.streamId,
           messageId: sentMessageId,

--- a/apps/backend/src/features/agents/persona-config-service.test.ts
+++ b/apps/backend/src/features/agents/persona-config-service.test.ts
@@ -412,7 +412,7 @@ describe("PersonaConfigService.setOverride", () => {
 
     expect(result.outcome).toBe("written")
     expect("testStreamId" in result).toBe(false)
-    expect(archiveStream).toHaveBeenCalledWith("stream_test", CALLER_ID)
+    expect(archiveStream).toHaveBeenCalledWith("stream_test", WORKSPACE_ID, CALLER_ID)
 
     // A failed archive must not fail the save — the override is already committed.
     archiveStream.mockImplementation(async () => {
@@ -793,7 +793,7 @@ describe("PersonaConfigService draft lifecycle", () => {
 
     await service.discardDraft(WORKSPACE_ID, ARIADNE_AGENT_ID, CALLER)
 
-    expect(archiveStream).toHaveBeenCalledWith("stream_test", CALLER_ID)
+    expect(archiveStream).toHaveBeenCalledWith("stream_test", WORKSPACE_ID, CALLER_ID)
     expect(deleteByOwner).toHaveBeenCalledWith({}, WORKSPACE_ID, ARIADNE_AGENT_ID, CALLER_ID)
     // Archive first so a failed archive leaves the pointer to retry, never orphans.
     expect(order).toEqual(["archive", "delete"])

--- a/apps/backend/src/features/agents/persona-config-service.ts
+++ b/apps/backend/src/features/agents/persona-config-service.ts
@@ -683,7 +683,7 @@ export class PersonaConfigService {
       // override is already committed, so a failed archive leaves an archivable
       // scratchpad, not corrupt state.
       try {
-        await this.streamService.archiveStream(txnResult.testStreamId, callerId)
+        await this.streamService.archiveStream(txnResult.testStreamId, workspaceId, callerId)
       } catch (error) {
         logger.warn(
           { error, workspaceId, agentId, testStreamId: txnResult.testStreamId },
@@ -825,7 +825,7 @@ export class PersonaConfigService {
     // prevents the orphan. Re-archiving an already-archived stream is a no-op, so a
     // delete that fails after a successful archive self-heals on the next discard.
     if (draft.testStreamId) {
-      await this.streamService.archiveStream(draft.testStreamId, callerId)
+      await this.streamService.archiveStream(draft.testStreamId, workspaceId, callerId)
     }
     await PersonaConfigDraftRepository.deleteByOwner(this.pool, workspaceId, agentId, callerId)
   }
@@ -1027,7 +1027,7 @@ export class PersonaConfigService {
       // and post-commit only (a 409 must never kill the chat; the row is already
       // committed so a failed archive just leaves an archivable scratchpad).
       try {
-        await this.streamService.archiveStream(txnResult.testStreamId, callerId)
+        await this.streamService.archiveStream(txnResult.testStreamId, workspaceId, callerId)
       } catch (error) {
         logger.warn(
           { error, workspaceId, personaId, testStreamId: txnResult.testStreamId },

--- a/apps/backend/src/features/api-keys/repository.ts
+++ b/apps/backend/src/features/api-keys/repository.ts
@@ -81,6 +81,26 @@ export const BotChannelAccessRepository = {
     return result.rows[0].granted
   },
 
+  async lockGrants(
+    db: Querier,
+    workspaceId: string,
+    botId: string,
+    rootStreamIds: readonly string[]
+  ): Promise<Set<string>> {
+    const stableIds = [...new Set(rootStreamIds)].sort()
+    if (stableIds.length === 0) return new Set()
+    const result = await db.query<{ stream_id: string }>(sql`
+      SELECT stream_id
+      FROM bot_channel_access
+      WHERE workspace_id = ${workspaceId}
+        AND bot_id = ${botId}
+        AND stream_id = ANY(${stableIds})
+      ORDER BY stream_id
+      FOR UPDATE
+    `)
+    return new Set(result.rows.map((row) => row.stream_id))
+  },
+
   async getGrantedBotIds(db: Querier, workspaceId: string, streamId: string): Promise<string[]> {
     const result = await db.query<{ bot_id: string }>(sql`
       SELECT a.bot_id FROM bot_channel_access a

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -596,10 +596,10 @@ describe("EventService.editMessage version capture", () => {
       callback({})) as any)
     findByIdForUpdateSpy = spyOn(MessageRepository, "findByIdForUpdate").mockResolvedValue(existingMessage as any)
     spyOn(MessageRepository, "findById").mockResolvedValue(existingMessage as any)
-    // editMessage refuses edits in E2E streams at the sink (INV-E1); default to
+    // editMessageInternal refuses edits in E2E streams at the sink (INV-E1); default to
     // non-E2E so the plaintext edit path runs.
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
-    // editMessage looks up the stream post-edit to decide whether to publish a
+    // editMessageInternal looks up the stream post-edit to decide whether to publish a
     // thread-summary update to the parent (for reply edits). Default to a
     // non-thread stream so the emitThreadUpdate branch short-circuits
     // — tests that care about the thread path can override per case.
@@ -666,7 +666,7 @@ describe("EventService.editMessage version capture", () => {
 
     const service = new EventService({} as any)
     await expect(
-      service.editMessage({
+      service.editMessageInternal({
         workspaceId: "ws_1",
         messageId: "msg_1",
         streamId: "stream_1",
@@ -681,7 +681,7 @@ describe("EventService.editMessage version capture", () => {
   it("should snapshot pre-edit content as a version record", async () => {
     const service = new EventService({} as any)
 
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_1",
       streamId: "stream_1",
@@ -706,7 +706,7 @@ describe("EventService.editMessage version capture", () => {
 
     const service = new EventService({} as any)
 
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_nonexistent",
       streamId: "stream_1",
@@ -723,7 +723,7 @@ describe("EventService.editMessage version capture", () => {
     hasParticipatedSpy.mockResolvedValue(true)
     const service = new EventService({} as any)
 
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_1",
       streamId: "stream_1",
@@ -750,7 +750,7 @@ describe("EventService.editMessage version capture", () => {
     const service = new EventService({} as any)
 
     await expect(
-      service.editMessage({
+      service.editMessageInternal({
         workspaceId: "ws_1",
         messageId: "msg_1",
         streamId: "stream_1",
@@ -768,7 +768,7 @@ describe("EventService.editMessage version capture", () => {
     hasParticipatedSpy.mockResolvedValue(false)
     const service = new EventService({} as any)
 
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_1",
       streamId: "stream_1",
@@ -807,7 +807,7 @@ describe("EventService.editMessage attachment_references refresh", () => {
       callback({})) as any)
     spyOn(MessageRepository, "findByIdForUpdate").mockResolvedValue(existingMessage as any)
     spyOn(MessageRepository, "findById").mockResolvedValue(existingMessage as any)
-    // editMessage refuses edits in E2E streams at the sink (INV-E1).
+    // editMessageInternal refuses edits in E2E streams at the sink (INV-E1).
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
     spyOn(StreamRepository, "findById").mockResolvedValue({
       id: "stream_target",
@@ -848,7 +848,7 @@ describe("EventService.editMessage attachment_references refresh", () => {
     // referenced attachment. Without the delete the row stays and recipients
     // can still resolve a download for content that no longer cites it.
     const service = new EventService({} as any)
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_edit",
       streamId: "stream_target",
@@ -882,7 +882,7 @@ describe("EventService.editMessage attachment_references refresh", () => {
     ] as any)
 
     const service = new EventService({} as any)
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_edit",
       streamId: "stream_target",
@@ -920,7 +920,7 @@ describe("EventService.editMessage attachment_references refresh", () => {
 
     const service = new EventService({} as any)
     await expect(
-      service.editMessage({
+      service.editMessageInternal({
         workspaceId: "ws_1",
         messageId: "msg_edit",
         streamId: "stream_target",
@@ -1022,7 +1022,7 @@ describe("EventService.createMessage metadata propagation", () => {
     const service = new EventService({} as any)
     const onCreated = mock(async () => undefined)
 
-    await service.createMessageReturningConversation(baseParams, onCreated)
+    await service.createMessageReturningConversationInternal(baseParams, onCreated)
 
     expect(onCreated).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ contentMarkdown: "hello" }))
   })
@@ -1038,7 +1038,7 @@ describe("EventService.createMessage metadata propagation", () => {
     spyOn(MessageRepository, "findByClientMessageId").mockResolvedValue(existing as any)
     const onCreated = mock(async () => undefined)
 
-    const result = await service.createMessageReturningConversation(
+    const result = await service.createMessageReturningConversationInternal(
       { ...baseParams, clientMessageId: "temp_1" },
       onCreated
     )
@@ -1232,13 +1232,13 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
   it("surfaces the assigner's conversation id from createMessageReturningConversation for an optimistic board card", async () => {
     const service = new EventService({} as any, conversationAssigner)
 
-    const declared = await service.createMessageReturningConversation({
+    const declared = await service.createMessageReturningConversationInternal({
       ...baseParams,
       conversation: { intent: ConversationIntents.NEW },
     })
     expect(declared.conversationId).toBe("conv_assigned")
 
-    const undeclared = await service.createMessageReturningConversation({ ...baseParams })
+    const undeclared = await service.createMessageReturningConversationInternal({ ...baseParams })
     expect(undeclared.conversationId).toBeUndefined()
   })
 })
@@ -1312,7 +1312,7 @@ describe("EventService INV-E1 sink guard", () => {
     const service = new EventService({} as any)
 
     await expect(
-      service.editMessage({
+      service.editMessageInternal({
         workspaceId: "ws_1",
         messageId: "msg_1",
         streamId: "stream_1",
@@ -1633,7 +1633,7 @@ describe("EventService sharedMessages wire enrichment", () => {
 
   it("carries the hydrated sharedMessages map on the message:edited outbox payload when an edit adds a pointer", async () => {
     const service = new EventService({} as any)
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_1",
       streamId: "stream_1",
@@ -1783,7 +1783,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
 
   it("attaches the dual destination slot map to the messages:moved outbox payload", async () => {
     const service = new EventService({} as any)
-    await service.moveMessagesToThread({
+    await service.moveMessagesToThreadInternal({
       workspaceId: "ws_1",
       sourceStreamId: "stream_src",
       targetMessageId: "msg_target",
@@ -1811,7 +1811,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
 
   it("re-homes the moved messages' context rows onto the destination thread", async () => {
     const service = new EventService({} as any)
-    await service.moveMessagesToThread({
+    await service.moveMessagesToThreadInternal({
       workspaceId: "ws_1",
       sourceStreamId: "stream_src",
       targetMessageId: "msg_target",
@@ -1831,7 +1831,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
 
   it("writes the thread landmark for a thread the move just created", async () => {
     const service = new EventService({} as any)
-    await service.moveMessagesToThread({
+    await service.moveMessagesToThreadInternal({
       workspaceId: "ws_1",
       sourceStreamId: "stream_src",
       targetMessageId: "msg_target",
@@ -1864,7 +1864,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
     ;(StreamRepository.insertThreadOrFind as any).mockResolvedValue({ stream: destinationThread, created: false })
 
     const service = new EventService({} as any)
-    await service.moveMessagesToThread({
+    await service.moveMessagesToThreadInternal({
       workspaceId: "ws_1",
       sourceStreamId: "stream_src",
       targetMessageId: "msg_target",
@@ -1882,7 +1882,7 @@ describe("EventService.moveMessagesToThread destination slot carrier (B3)", () =
     ])
 
     const service = new EventService({} as any)
-    await service.moveMessagesToThread({
+    await service.moveMessagesToThreadInternal({
       workspaceId: "ws_1",
       sourceStreamId: "stream_src",
       targetMessageId: "msg_target",
@@ -2033,7 +2033,7 @@ describe("EventService stream-context projection", () => {
     spyOn(AttachmentReferenceRepository, "deleteByMessageId").mockResolvedValue(0)
 
     const service = new EventService({} as any)
-    await service.editMessage({
+    await service.editMessageInternal({
       workspaceId: "ws_1",
       messageId: "msg_edit",
       streamId: "stream_1",
@@ -2083,7 +2083,7 @@ describe("EventService stream-context projection", () => {
     spyOn(MessageRepository, "softDelete").mockResolvedValue(null as any)
 
     const service = new EventService({} as any)
-    await service.deleteMessage({
+    await service.deleteMessageInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       messageId: "msg_del",

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -3,7 +3,14 @@ import { withTransaction, withClient, sql } from "../../db"
 import { StreamEventRepository, type StreamEvent, type MoveEventIdSequenceUpdate } from "../streams"
 import { StreamRepository, type Stream } from "../streams"
 import { StreamMemberRepository, SparseReadRepository, ReadStateRepository } from "../streams"
-import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
+import {
+  assertStreamWritable,
+  assertStreamsWritable,
+  resolveLockedStreamAuthorities,
+  checkStreamAccess,
+  resolveEffectiveAccessStream,
+  type StreamWritePrincipal,
+} from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
 import {
   collectSharedMessageIds,
@@ -542,7 +549,7 @@ export class EventService {
   }
 
   async createMessage(params: CreateMessageParams): Promise<Message> {
-    return (await this.createMessageReturningConversation(params)).message
+    return (await this.createMessageReturningConversationInternal(params)).message
   }
 
   /**
@@ -554,19 +561,60 @@ export class EventService {
    * conversation id (no temp-id swap), reconciled by the `conversation:*` echo.
    * `onCreated` joins the same transaction and runs only for the winning insert.
    */
-  async createMessageReturningConversation(
+  async createMessageReturningConversationInternal(
+    params: CreateMessageParams,
+    onCreated?: (client: PoolClient, message: Message) => Promise<void>
+  ): Promise<{ message: Message; conversationId?: string }> {
+    return this.createMessageReturningConversationWithAuthority({ kind: "internal" }, params, onCreated)
+  }
+
+  async assertStreamWritableForPrincipal(
+    principal: StreamWritePrincipal,
+    workspaceId: string,
+    streamId: string
+  ): Promise<void> {
+    await withTransaction(this.pool, (client) => assertStreamWritable(client, { workspaceId, streamId, principal }))
+  }
+
+  async createMessageForPrincipalReturningConversation(
+    principal: StreamWritePrincipal,
+    params: CreateMessageParams,
+    onCreated?: (client: PoolClient, message: Message) => Promise<void>
+  ): Promise<{ message: Message; conversationId?: string }> {
+    return this.createMessageReturningConversationWithAuthority({ kind: "principal", principal }, params, onCreated)
+  }
+
+  private async createMessageReturningConversationWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
     params: CreateMessageParams,
     onCreated?: (client: PoolClient, message: Message) => Promise<void>
   ): Promise<{ message: Message; conversationId?: string }> {
     try {
-      const result = await this._createMessageTxn(params, onCreated)
+      const result = await this._createMessageTxn(authority, params, onCreated)
       return { message: result.message, ...(result.conversationId && { conversationId: result.conversationId }) }
     } catch (error) {
       // Concurrent duplicate: the txn rolled back (no orphaned stream_events/outbox),
       // and we return the already-committed message from the winning transaction.
       // No conversation id — the winner already surfaced its own; the loser's
       // optimistic card would double the winner's, so leave it to the echo/refetch.
-      if (error instanceof DuplicateMessageError) return { message: error.existingMessage }
+      if (error instanceof DuplicateMessageError) {
+        if (authority.kind === "principal") {
+          await withTransaction(this.pool, async (client) => {
+            await resolveLockedStreamAuthorities(client, {
+              workspaceId: params.workspaceId,
+              streamIds: [error.existingMessage.streamId],
+              principal: authority.principal,
+            })
+            const principalId =
+              authority.principal.kind === "user" ? authority.principal.userId : authority.principal.botId
+            const principalType = authority.principal.kind === "user" ? AuthorTypes.USER : AuthorTypes.BOT
+            if (error.existingMessage.authorId !== principalId || error.existingMessage.authorType !== principalType) {
+              throw new HttpError("Cannot return another actor's message", { status: 403, code: "FORBIDDEN" })
+            }
+          })
+        }
+        return { message: error.existingMessage }
+      }
       throw error
     }
   }
@@ -1019,6 +1067,7 @@ export class EventService {
   }
 
   private async _createMessageTxn(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
     params: CreateMessageParams,
     onCreated?: (client: PoolClient, message: Message) => Promise<void>
   ): Promise<{ message: Message; conversationId?: string; created: boolean }> {
@@ -1026,184 +1075,272 @@ export class EventService {
     // `createMessageInTransaction` can persist whatever reaches it.
     const gatedParams = (await this.shouldCaptureComposeTrace(params)) ? params : { ...params, composeTrace: undefined }
     return withTransaction(this.pool, async (client) => {
+      if (gatedParams.clientMessageId) {
+        const existing = await MessageRepository.findByClientMessageId(
+          client,
+          gatedParams.streamId,
+          gatedParams.clientMessageId
+        )
+        if (existing) {
+          if (authority.kind === "principal") {
+            await resolveLockedStreamAuthorities(client, {
+              workspaceId: gatedParams.workspaceId,
+              streamIds: [existing.streamId],
+              principal: authority.principal,
+            })
+            const principalId =
+              authority.principal.kind === "user" ? authority.principal.userId : authority.principal.botId
+            const principalType = authority.principal.kind === "user" ? AuthorTypes.USER : AuthorTypes.BOT
+            if (existing.authorId !== principalId || existing.authorType !== principalType) {
+              throw new HttpError("Cannot return another actor's message", { status: 403, code: "FORBIDDEN" })
+            }
+          }
+          return { message: existing, created: false }
+        }
+      }
+      if (authority.kind === "principal") {
+        await assertStreamWritable(client, {
+          workspaceId: gatedParams.workspaceId,
+          streamId: gatedParams.streamId,
+          principal: authority.principal,
+        })
+      }
       const result = await this.createMessageInTransaction(client, gatedParams)
       if (result.created) await onCreated?.(client, result.message)
       return result
     })
   }
 
-  async editMessage(params: EditMessageParams): Promise<Message | null> {
-    return withTransaction(this.pool, async (client) => {
-      // INV-E1: no sealed-edit path exists yet, so editing in an E2E stream would
-      // overwrite the sealed projection with plaintext and broadcast it. Refuse
-      // until a ciphertext edit payload exists (the frontend also hides Edit here).
-      if (await E2eStreamsRepository.isE2eStream(client, params.workspaceId, params.streamId)) {
-        throw new HttpError("Cannot edit a message in an end-to-end-encrypted stream", {
-          status: 400,
-          code: "E2E_STREAM_EDIT_UNSUPPORTED",
-        })
-      }
+  private async withPlacementRecovery<T>(
+    messageId: string,
+    candidateStreamId: string,
+    operation: (client: PoolClient) => Promise<T>
+  ): Promise<T | { kind: "retry"; streamId: string }> {
+    try {
+      return await withTransaction(this.pool, operation)
+    } catch (error) {
+      const denial = error as { code?: string }
+      if (denial.code !== "STREAM_READ_ONLY" && denial.code !== "STREAM_NOT_FOUND") throw error
+      const current = await MessageRepository.findById(this.pool, messageId)
+      if (current && current.streamId !== candidateStreamId) return { kind: "retry", streamId: current.streamId }
+      throw error
+    }
+  }
 
-      // Returns null if the message was concurrently deleted — prevents phantom edits
-      const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
-      if (!existing || existing.deletedAt) return null
+  async editMessageInternal(params: EditMessageParams): Promise<Message | null> {
+    return this.editMessageWithAuthority({ kind: "internal" }, params)
+  }
 
-      // No-op: content hasn't meaningfully changed
-      if (params.contentMarkdown.trim() === existing.contentMarkdown.trim()) return existing
+  async editMessageForPrincipal(principal: StreamWritePrincipal, params: EditMessageParams): Promise<Message | null> {
+    return this.editMessageWithAuthority({ kind: "principal", principal }, params)
+  }
 
-      const actorType = await this.resolveActorType(client, params.streamId, params.actorId, params.actorType, existing)
-
-      // Resolve slug-only mention/channel ids before the edited body feeds the
-      // event payload, projection, and outbox (INV-64). When resolution changes
-      // an id, re-derive the markdown so the stored wire form matches the JSON.
-      const resolvedEdit = await resolveMentionContent(
-        client,
-        params.workspaceId,
-        params.contentJson,
-        // Personal personas resolve by slug only for their owner (see create).
-        actorType === "user" ? params.actorId : undefined
-      )
-      if (resolvedEdit.changed) {
-        params.contentJson = resolvedEdit.contentJson
-        params.contentMarkdown = deriveContentMarkdown(resolvedEdit.contentJson)
-      }
-
-      await MessageVersionRepository.insert(client, {
-        id: messageVersionId(),
-        messageId: params.messageId,
-        contentJson: existing.contentJson,
-        contentMarkdown: existing.contentMarkdown,
-        editedBy: params.actorId,
-      })
-
-      const editStream = await StreamRepository.findById(client, params.streamId)
-      const memoEmbeds = await resolveMemoEmbedSummaries(
-        client,
-        params.workspaceId,
-        params.contentJson,
-        editStream?.rootStreamId ?? params.streamId
-      )
-
-      const event = await StreamEventRepository.insert(client, {
-        id: eventId(),
-        streamId: params.streamId,
-        eventType: "message_edited",
-        payload: {
-          messageId: params.messageId,
-          contentJson: params.contentJson,
-          contentMarkdown: params.contentMarkdown,
-          memoEmbeds,
-        } satisfies MessageEditedPayload,
-        actorId: params.actorId,
-        actorType,
-      })
-
-      const message = await MessageRepository.updateContent(
-        client,
-        params.messageId,
-        params.contentJson,
-        params.contentMarkdown
-      )
-
-      if (message) {
-        // Re-validate share nodes: edits that add, remove, or swap share
-        // references rewrite the shared_messages row set so
-        // hydration/authorization reflects the new content. Without this, an
-        // author could edit in a sharedMessage pointing at an arbitrary id and
-        // leak its content past the create-time check.
-        await ShareService.validateAndRecordShares({
-          client,
-          workspaceId: params.workspaceId,
-          targetStreamId: params.streamId,
-          shareMessageId: params.messageId,
-          sharerId: params.actorId,
-          accessibleStreamIds: params.accessibleStreamIds,
-          contentJson: params.contentJson,
-          findStream: (db, id) => StreamRepository.findById(db, id),
-          resolveEffectiveStream: resolveEffectiveStreamAdapter,
-          isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
-          countExposedMembers: (db, targetStreamId, sourceStreamId) =>
-            StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),
-          canReadStream: async (db, workspaceId, streamId, userId) =>
-            (await checkStreamAccess(db, streamId, workspaceId, userId)) !== null,
-          confirmedPrivacyWarning: params.confirmedPrivacyWarning,
-        })
-
-        // Refresh `attachment_references` projection to match the new
-        // contentJson (INV-7). Without this, an edit that adds or removes an
-        // `attachment:` link leaves stale rows behind and download
-        // authorization stops matching the persisted body. Reference-only —
-        // fresh uploads aren't supported on edit (a zero-`messageId`
-        // attachment id will fail the access validation here loudly).
-        // Full delete-then-insert per edit; the projection is small and this
-        // lets the helper share its access-check semantics with the create
-        // path verbatim.
-        const validatedReferenceIds = await this._validateEditAttachmentReferences(client, params)
-        await AttachmentReferenceRepository.deleteByMessageId(client, params.workspaceId, params.messageId)
-        if (validatedReferenceIds.length > 0) {
-          await AttachmentReferenceRepository.insertMany(
-            client,
-            validatedReferenceIds.map((aid) => ({
-              id: attachmentReferenceId(),
-              workspaceId: params.workspaceId,
-              attachmentId: aid,
-              messageId: params.messageId,
-              streamId: params.streamId,
-            }))
-          )
+  private async editMessageWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
+    params: EditMessageParams
+  ): Promise<Message | null> {
+    let streamId =
+      authority.kind === "principal"
+        ? ((await MessageRepository.findById(this.pool, params.messageId))?.streamId ?? params.streamId)
+        : params.streamId
+    for (let attempt = 0; attempt < 3; attempt++) {
+      params = { ...params, streamId }
+      const result = await this.withPlacementRecovery(params.messageId, streamId, async (client) => {
+        if (authority.kind === "principal") {
+          await assertStreamWritable(client, {
+            workspaceId: params.workspaceId,
+            streamId,
+            principal: authority.principal,
+          })
+        }
+        // INV-E1: no sealed-edit path exists yet, so editing in an E2E stream would
+        // overwrite the sealed projection with plaintext and broadcast it. Refuse
+        // until a ciphertext edit payload exists (the frontend also hides Edit here).
+        if (await E2eStreamsRepository.isE2eStream(client, params.workspaceId, params.streamId)) {
+          throw new HttpError("Cannot edit a message in an end-to-end-encrypted stream", {
+            status: 400,
+            code: "E2E_STREAM_EDIT_UNSUPPORTED",
+          })
         }
 
-        const sharedMessageIds = new Set<string>()
-        collectSharedMessageIds(params.contentJson, sharedMessageIds)
-        const slotMaps =
-          sharedMessageIds.size > 0
-            ? toDualSlotMaps(
-                await hydrateSharedMessagesForRoom(client, params.workspaceId, params.streamId, sharedMessageIds)
-              )
-            : undefined
+        // Returns null if the message was concurrently deleted — prevents phantom edits
+        const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
+        if (!existing || existing.deletedAt) return { kind: "done" as const, value: null }
+        if (existing.streamId !== streamId) return { kind: "retry" as const, streamId: existing.streamId }
+        if (authority.kind === "principal") {
+          const ownerId = authority.principal.kind === "user" ? authority.principal.userId : authority.principal.botId
+          if (existing.authorId !== ownerId) {
+            throw new HttpError("Cannot modify another actor's message", { status: 403, code: "FORBIDDEN" })
+          }
+        }
 
-        await OutboxRepository.insert(client, "message:edited", {
-          workspaceId: params.workspaceId,
-          streamId: params.streamId,
-          event: serializeBigInt(event),
-          ...(slotMaps && { slots: slotMaps.slots, sharedMessages: slotMaps.sharedMessages }),
-        })
+        // No-op: content hasn't meaningfully changed
+        if (params.contentMarkdown.trim() === existing.contentMarkdown.trim())
+          return { kind: "done" as const, value: existing }
 
-        const stream = await StreamRepository.findById(client, params.streamId)
-
-        // Rebuild the "In this stream" projection from the edited body. The
-        // landmark keeps the message's ORIGINAL created_at — an edit must not
-        // move it in the feed.
-        const contextAttachments =
-          validatedReferenceIds.length > 0 ? await AttachmentRepository.findByIds(client, validatedReferenceIds) : []
-        await StreamContextRepository.replaceForMessage(
+        const actorType = await this.resolveActorType(
           client,
-          params.workspaceId,
-          params.messageId,
-          contextRowsForMessage({
-            workspaceId: params.workspaceId,
-            streamId: params.streamId,
-            rootStreamId: stream?.rootStreamId ?? params.streamId,
-            messageId: params.messageId,
-            authorId: existing.authorId,
-            occurredAt: existing.createdAt,
-            sequence: existing.sequence,
-            contentJson: params.contentJson,
-            contentMarkdown: params.contentMarkdown,
-            attachments: contextAttachments,
-          })
+          params.streamId,
+          params.actorId,
+          params.actorType,
+          existing
         )
 
-        if (stream?.parentStreamId && stream.parentAnchorId) {
-          // No count change on edit — refresh only the thread summary; omit
-          // replyCount so a stale unlocked read can't clobber a concurrent
-          // create/delete's authoritative count (INV-20).
-          await this.emitThreadUpdate(client, stream, { includeReplyCount: false })
+        // Resolve slug-only mention/channel ids before the edited body feeds the
+        // event payload, projection, and outbox (INV-64). When resolution changes
+        // an id, re-derive the markdown so the stored wire form matches the JSON.
+        const resolvedEdit = await resolveMentionContent(
+          client,
+          params.workspaceId,
+          params.contentJson,
+          // Personal personas resolve by slug only for their owner (see create).
+          actorType === "user" ? params.actorId : undefined
+        )
+        if (resolvedEdit.changed) {
+          params.contentJson = resolvedEdit.contentJson
+          params.contentMarkdown = deriveContentMarkdown(resolvedEdit.contentJson)
         }
-      }
 
-      return message
-    })
+        await MessageVersionRepository.insert(client, {
+          id: messageVersionId(),
+          messageId: params.messageId,
+          contentJson: existing.contentJson,
+          contentMarkdown: existing.contentMarkdown,
+          editedBy: params.actorId,
+        })
+
+        const editStream = await StreamRepository.findById(client, params.streamId)
+        const memoEmbeds = await resolveMemoEmbedSummaries(
+          client,
+          params.workspaceId,
+          params.contentJson,
+          editStream?.rootStreamId ?? params.streamId
+        )
+
+        const event = await StreamEventRepository.insert(client, {
+          id: eventId(),
+          streamId: params.streamId,
+          eventType: "message_edited",
+          payload: {
+            messageId: params.messageId,
+            contentJson: params.contentJson,
+            contentMarkdown: params.contentMarkdown,
+            memoEmbeds,
+          } satisfies MessageEditedPayload,
+          actorId: params.actorId,
+          actorType,
+        })
+
+        const message = await MessageRepository.updateContent(
+          client,
+          params.messageId,
+          params.contentJson,
+          params.contentMarkdown
+        )
+
+        if (message) {
+          // Re-validate share nodes: edits that add, remove, or swap share
+          // references rewrite the shared_messages row set so
+          // hydration/authorization reflects the new content. Without this, an
+          // author could edit in a sharedMessage pointing at an arbitrary id and
+          // leak its content past the create-time check.
+          await ShareService.validateAndRecordShares({
+            client,
+            workspaceId: params.workspaceId,
+            targetStreamId: params.streamId,
+            shareMessageId: params.messageId,
+            sharerId: params.actorId,
+            accessibleStreamIds: params.accessibleStreamIds,
+            contentJson: params.contentJson,
+            findStream: (db, id) => StreamRepository.findById(db, id),
+            resolveEffectiveStream: resolveEffectiveStreamAdapter,
+            isAncestor: (db, ancestorId, streamId) => StreamRepository.isAncestor(db, ancestorId, streamId),
+            countExposedMembers: (db, targetStreamId, sourceStreamId) =>
+              StreamMemberRepository.countMembersNotIn(db, targetStreamId, sourceStreamId),
+            canReadStream: async (db, workspaceId, streamId, userId) =>
+              (await checkStreamAccess(db, streamId, workspaceId, userId)) !== null,
+            confirmedPrivacyWarning: params.confirmedPrivacyWarning,
+          })
+
+          // Refresh `attachment_references` projection to match the new
+          // contentJson (INV-7). Without this, an edit that adds or removes an
+          // `attachment:` link leaves stale rows behind and download
+          // authorization stops matching the persisted body. Reference-only —
+          // fresh uploads aren't supported on edit (a zero-`messageId`
+          // attachment id will fail the access validation here loudly).
+          // Full delete-then-insert per edit; the projection is small and this
+          // lets the helper share its access-check semantics with the create
+          // path verbatim.
+          const validatedReferenceIds = await this._validateEditAttachmentReferences(client, params)
+          await AttachmentReferenceRepository.deleteByMessageId(client, params.workspaceId, params.messageId)
+          if (validatedReferenceIds.length > 0) {
+            await AttachmentReferenceRepository.insertMany(
+              client,
+              validatedReferenceIds.map((aid) => ({
+                id: attachmentReferenceId(),
+                workspaceId: params.workspaceId,
+                attachmentId: aid,
+                messageId: params.messageId,
+                streamId: params.streamId,
+              }))
+            )
+          }
+
+          const sharedMessageIds = new Set<string>()
+          collectSharedMessageIds(params.contentJson, sharedMessageIds)
+          const slotMaps =
+            sharedMessageIds.size > 0
+              ? toDualSlotMaps(
+                  await hydrateSharedMessagesForRoom(client, params.workspaceId, params.streamId, sharedMessageIds)
+                )
+              : undefined
+
+          await OutboxRepository.insert(client, "message:edited", {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            event: serializeBigInt(event),
+            ...(slotMaps && { slots: slotMaps.slots, sharedMessages: slotMaps.sharedMessages }),
+          })
+
+          const stream = await StreamRepository.findById(client, params.streamId)
+
+          // Rebuild the "In this stream" projection from the edited body. The
+          // landmark keeps the message's ORIGINAL created_at — an edit must not
+          // move it in the feed.
+          const contextAttachments =
+            validatedReferenceIds.length > 0 ? await AttachmentRepository.findByIds(client, validatedReferenceIds) : []
+          await StreamContextRepository.replaceForMessage(
+            client,
+            params.workspaceId,
+            params.messageId,
+            contextRowsForMessage({
+              workspaceId: params.workspaceId,
+              streamId: params.streamId,
+              rootStreamId: stream?.rootStreamId ?? params.streamId,
+              messageId: params.messageId,
+              authorId: existing.authorId,
+              occurredAt: existing.createdAt,
+              sequence: existing.sequence,
+              contentJson: params.contentJson,
+              contentMarkdown: params.contentMarkdown,
+              attachments: contextAttachments,
+            })
+          )
+
+          if (stream?.parentStreamId && stream.parentAnchorId) {
+            // No count change on edit — refresh only the thread summary; omit
+            // replyCount so a stale unlocked read can't clobber a concurrent
+            // create/delete's authoritative count (INV-20).
+            await this.emitThreadUpdate(client, stream, { includeReplyCount: false })
+          }
+        }
+
+        return { kind: "done" as const, value: message }
+      })
+      if (result.kind === "done") return result.value
+      streamId = result.streamId
+    }
+    throw new Error(`Message ${params.messageId} placement changed too many times`)
   }
 
   /**
@@ -1282,31 +1419,71 @@ export class EventService {
     return validated
   }
 
-  async deleteMessage(params: DeleteMessageParams): Promise<Message | null> {
-    return withTransaction(this.pool, async (client) => {
-      const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
-      if (!existing || existing.deletedAt) return null
+  async deleteMessageInternal(params: DeleteMessageParams): Promise<Message | null> {
+    return this.deleteMessageWithAuthority({ kind: "internal" }, params)
+  }
 
-      const actorType = await this.resolveActorType(client, params.streamId, params.actorId, params.actorType, existing)
+  async deleteMessageForPrincipal(
+    principal: StreamWritePrincipal,
+    params: DeleteMessageParams
+  ): Promise<Message | null> {
+    return this.deleteMessageWithAuthority({ kind: "principal", principal }, params)
+  }
 
-      await StreamEventRepository.insert(client, {
-        id: eventId(),
-        streamId: params.streamId,
-        eventType: "message_deleted",
-        payload: {
-          messageId: params.messageId,
-        } satisfies MessageDeletedPayload,
-        actorId: params.actorId,
-        actorType,
-      })
+  private async deleteMessageWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
+    params: DeleteMessageParams
+  ): Promise<Message | null> {
+    let streamId =
+      authority.kind === "principal"
+        ? ((await MessageRepository.findById(this.pool, params.messageId))?.streamId ?? params.streamId)
+        : params.streamId
+    for (let attempt = 0; attempt < 3; attempt++) {
+      params = { ...params, streamId }
+      const result = await this.withPlacementRecovery(params.messageId, streamId, async (client) => {
+        if (authority.kind === "principal") {
+          await assertStreamWritable(client, {
+            workspaceId: params.workspaceId,
+            streamId,
+            principal: authority.principal,
+          })
+        }
+        const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
+        if (!existing || existing.deletedAt) return { kind: "done" as const, value: null }
+        if (existing.streamId !== streamId) return { kind: "retry" as const, streamId: existing.streamId }
+        if (authority.kind === "principal") {
+          const ownerId = authority.principal.kind === "user" ? authority.principal.userId : authority.principal.botId
+          if (existing.authorId !== ownerId) {
+            throw new HttpError("Cannot modify another actor's message", { status: 403, code: "FORBIDDEN" })
+          }
+        }
 
-      const message = await MessageRepository.softDelete(client, params.messageId)
+        const actorType = await this.resolveActorType(
+          client,
+          params.streamId,
+          params.actorId,
+          params.actorType,
+          existing
+        )
 
-      // A2 (sparse-read design): a deleted message's unread activity rows would
-      // otherwise survive forever unless the user opens that exact stream, keeping
-      // a phantom badge. Mark them read in the delete transaction; clients drop
-      // held rows for the id on the `message_deleted` stream event.
-      await client.query(sql`
+        await StreamEventRepository.insert(client, {
+          id: eventId(),
+          streamId: params.streamId,
+          eventType: "message_deleted",
+          payload: {
+            messageId: params.messageId,
+          } satisfies MessageDeletedPayload,
+          actorId: params.actorId,
+          actorType,
+        })
+
+        const message = await MessageRepository.softDelete(client, params.messageId)
+
+        // A2 (sparse-read design): a deleted message's unread activity rows would
+        // otherwise survive forever unless the user opens that exact stream, keeping
+        // a phantom badge. Mark them read in the delete transaction; clients drop
+        // held rows for the id on the `message_deleted` stream event.
+        await client.query(sql`
         UPDATE user_activity
         SET read_at = NOW()
         WHERE workspace_id = ${params.workspaceId}
@@ -1314,28 +1491,46 @@ export class EventService {
           AND read_at IS NULL
       `)
 
-      await StreamContextRepository.deleteByMessageId(client, params.workspaceId, params.messageId)
+        await StreamContextRepository.deleteByMessageId(client, params.workspaceId, params.messageId)
 
-      if (message) {
-        await OutboxRepository.insert(client, "message:deleted", {
-          workspaceId: params.workspaceId,
-          streamId: params.streamId,
-          messageId: params.messageId,
-          deletedAt: message.deletedAt!.toISOString(),
-        })
+        if (message) {
+          await OutboxRepository.insert(client, "message:deleted", {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            messageId: params.messageId,
+            deletedAt: message.deletedAt!.toISOString(),
+          })
 
-        const stream = await StreamRepository.findById(client, params.streamId)
-        if (stream?.parentStreamId && stream.parentAnchorId) {
-          const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
-          await this.emitThreadUpdate(client, updatedThread ?? stream)
+          const stream = await StreamRepository.findById(client, params.streamId)
+          if (stream?.parentStreamId && stream.parentAnchorId) {
+            const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
+            await this.emitThreadUpdate(client, updatedThread ?? stream)
+          }
         }
-      }
 
-      return message
-    })
+        return { kind: "done" as const, value: message }
+      })
+      if (result.kind === "done") return result.value
+      streamId = result.streamId
+    }
+    throw new Error(`Message ${params.messageId} placement changed too many times`)
   }
 
-  async moveMessagesToThread(params: MoveMessagesToThreadParams): Promise<MoveMessagesToThreadResult> {
+  async moveMessagesToThreadInternal(params: MoveMessagesToThreadParams): Promise<MoveMessagesToThreadResult> {
+    return this.moveMessagesToThreadWithAuthority({ kind: "internal" }, params)
+  }
+
+  async moveMessagesToThreadForPrincipal(
+    principal: StreamWritePrincipal,
+    params: MoveMessagesToThreadParams
+  ): Promise<MoveMessagesToThreadResult> {
+    return this.moveMessagesToThreadWithAuthority({ kind: "principal", principal }, params)
+  }
+
+  private async moveMessagesToThreadWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
+    params: MoveMessagesToThreadParams
+  ): Promise<MoveMessagesToThreadResult> {
     const uniqueMessageIds = Array.from(new Set(params.messageIds))
     if (uniqueMessageIds.length === 0) {
       throw new HttpError("At least one message is required", { status: 400, code: "NO_MESSAGES_SELECTED" })
@@ -1363,6 +1558,19 @@ export class EventService {
         throw new HttpError("Move validation lease does not match this request", {
           status: 409,
           code: "MOVE_LEASE_MISMATCH",
+        })
+      }
+
+      if (authority.kind === "principal") {
+        const existingDestination = await StreamRepository.findByAnchor(
+          client,
+          params.sourceStreamId,
+          params.targetMessageId
+        )
+        await assertStreamsWritable(client, {
+          workspaceId: params.workspaceId,
+          streamIds: [params.sourceStreamId, ...(existingDestination ? [existingDestination.id] : [])],
+          principal: authority.principal,
         })
       }
 
@@ -1898,7 +2106,7 @@ export class EventService {
       }
 
       const existingThread = await StreamRepository.findByAnchor(client, params.sourceStreamId, params.targetMessageId)
-      // Mirror the moveMessagesToThread guard so validate doesn't hand out
+      // Mirror the message-move guard so validate doesn't hand out
       // leases the move endpoint will reject — keeps the two-step contract
       // honest about what's actually movable.
       if (existingThread?.archivedAt) {
@@ -1927,77 +2135,142 @@ export class EventService {
     })
   }
 
-  async addReaction(params: AddReactionParams): Promise<Message | null> {
-    const actorType = params.actorType ?? AuthorTypes.USER
-    return withTransaction(this.pool, async (client) => {
-      await StreamEventRepository.insert(client, {
-        id: eventId(),
-        streamId: params.streamId,
-        eventType: "reaction_added",
-        payload: {
-          messageId: params.messageId,
-          emoji: params.emoji,
-          userId: params.userId,
-        } satisfies ReactionPayload,
-        actorId: params.userId,
-        actorType,
-      })
-
-      const message = await MessageRepository.addReaction(client, params.messageId, params.emoji, params.userId)
-
-      if (message && actorType === AuthorTypes.USER) {
-        // Reacting is engagement: a provisional conversation placement the
-        // reader just acknowledged stops being provisional (same transaction,
-        // INV-4/7).
-        await settleMessagesOnEngagement(client, params.workspaceId, [params.messageId])
-      }
-
-      if (message) {
-        await OutboxRepository.insert(client, "reaction:added", {
-          workspaceId: params.workspaceId,
-          streamId: params.streamId,
-          messageId: params.messageId,
-          emoji: params.emoji,
-          userId: params.userId,
-          actorType,
-        })
-      }
-
-      return message
-    })
+  async addReactionInternal(params: AddReactionParams): Promise<Message | null> {
+    return this.addReactionWithAuthority({ kind: "internal" }, params)
   }
 
-  async removeReaction(params: RemoveReactionParams): Promise<Message | null> {
+  async addReactionForPrincipal(principal: StreamWritePrincipal, params: AddReactionParams): Promise<Message | null> {
+    return this.addReactionWithAuthority({ kind: "principal", principal }, params)
+  }
+
+  private async addReactionWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
+    params: AddReactionParams
+  ): Promise<Message | null> {
     const actorType = params.actorType ?? AuthorTypes.USER
-    return withTransaction(this.pool, async (client) => {
-      await StreamEventRepository.insert(client, {
-        id: eventId(),
-        streamId: params.streamId,
-        eventType: "reaction_removed",
-        payload: {
-          messageId: params.messageId,
-          emoji: params.emoji,
-          userId: params.userId,
-        } satisfies ReactionPayload,
-        actorId: params.userId,
-        actorType,
-      })
-
-      const message = await MessageRepository.removeReaction(client, params.messageId, params.emoji, params.userId)
-
-      if (message) {
-        await OutboxRepository.insert(client, "reaction:removed", {
-          workspaceId: params.workspaceId,
+    let streamId =
+      authority.kind === "principal"
+        ? ((await MessageRepository.findById(this.pool, params.messageId))?.streamId ?? params.streamId)
+        : params.streamId
+    for (let attempt = 0; attempt < 3; attempt++) {
+      params = { ...params, streamId }
+      const result = await this.withPlacementRecovery(params.messageId, streamId, async (client) => {
+        if (authority.kind === "principal") {
+          await assertStreamWritable(client, {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            principal: authority.principal,
+          })
+        }
+        const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
+        if (!existing || existing.deletedAt) return { kind: "done" as const, value: null }
+        if (existing.streamId !== streamId) return { kind: "retry" as const, streamId: existing.streamId }
+        await StreamEventRepository.insert(client, {
+          id: eventId(),
           streamId: params.streamId,
-          messageId: params.messageId,
-          emoji: params.emoji,
-          userId: params.userId,
+          eventType: "reaction_added",
+          payload: {
+            messageId: params.messageId,
+            emoji: params.emoji,
+            userId: params.userId,
+          } satisfies ReactionPayload,
+          actorId: params.userId,
           actorType,
         })
-      }
 
-      return message
-    })
+        const message = await MessageRepository.addReaction(client, params.messageId, params.emoji, params.userId)
+
+        if (message && actorType === AuthorTypes.USER) {
+          // Reacting is engagement: a provisional conversation placement the
+          // reader just acknowledged stops being provisional (same transaction,
+          // INV-4/7).
+          await settleMessagesOnEngagement(client, params.workspaceId, [params.messageId])
+        }
+
+        if (message) {
+          await OutboxRepository.insert(client, "reaction:added", {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            messageId: params.messageId,
+            emoji: params.emoji,
+            userId: params.userId,
+            actorType,
+          })
+        }
+
+        return { kind: "done" as const, value: message }
+      })
+      if (result.kind === "done") return result.value
+      streamId = result.streamId
+    }
+    throw new Error(`Message ${params.messageId} placement changed too many times`)
+  }
+
+  async removeReactionInternal(params: RemoveReactionParams): Promise<Message | null> {
+    return this.removeReactionWithAuthority({ kind: "internal" }, params)
+  }
+
+  async removeReactionForPrincipal(
+    principal: StreamWritePrincipal,
+    params: RemoveReactionParams
+  ): Promise<Message | null> {
+    return this.removeReactionWithAuthority({ kind: "principal", principal }, params)
+  }
+
+  private async removeReactionWithAuthority(
+    authority: { kind: "internal" } | { kind: "principal"; principal: StreamWritePrincipal },
+    params: RemoveReactionParams
+  ): Promise<Message | null> {
+    const actorType = params.actorType ?? AuthorTypes.USER
+    let streamId =
+      authority.kind === "principal"
+        ? ((await MessageRepository.findById(this.pool, params.messageId))?.streamId ?? params.streamId)
+        : params.streamId
+    for (let attempt = 0; attempt < 3; attempt++) {
+      params = { ...params, streamId }
+      const result = await this.withPlacementRecovery(params.messageId, streamId, async (client) => {
+        if (authority.kind === "principal") {
+          await assertStreamWritable(client, {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            principal: authority.principal,
+          })
+        }
+        const existing = await MessageRepository.findByIdForUpdate(client, params.messageId)
+        if (!existing || existing.deletedAt) return { kind: "done" as const, value: null }
+        if (existing.streamId !== streamId) return { kind: "retry" as const, streamId: existing.streamId }
+        await StreamEventRepository.insert(client, {
+          id: eventId(),
+          streamId: params.streamId,
+          eventType: "reaction_removed",
+          payload: {
+            messageId: params.messageId,
+            emoji: params.emoji,
+            userId: params.userId,
+          } satisfies ReactionPayload,
+          actorId: params.userId,
+          actorType,
+        })
+
+        const message = await MessageRepository.removeReaction(client, params.messageId, params.emoji, params.userId)
+
+        if (message) {
+          await OutboxRepository.insert(client, "reaction:removed", {
+            workspaceId: params.workspaceId,
+            streamId: params.streamId,
+            messageId: params.messageId,
+            emoji: params.emoji,
+            userId: params.userId,
+            actorType,
+          })
+        }
+
+        return { kind: "done" as const, value: message }
+      })
+      if (result.kind === "done") return result.value
+      streamId = result.streamId
+    }
+    throw new Error(`Message ${params.messageId} placement changed too many times`)
   }
 
   async getMessages(

--- a/apps/backend/src/features/messaging/handlers.steer.test.ts
+++ b/apps/backend/src/features/messaging/handlers.steer.test.ts
@@ -30,17 +30,20 @@ describe("message + steer composite send", () => {
       contentMarkdown: "/steer I want option 2",
       ciphertext: null,
     }
-    const eventService = {
-      createMessageReturningConversation: async (
+    const createMessageForPrincipalReturningConversation = mock(
+      async (
+        principal: { kind: string; userId: string },
         params: { contentMarkdown: string },
         onCreated?: (db: unknown, message: unknown) => Promise<void>
       ) => {
         order.push("message")
+        expect(principal).toEqual({ kind: "user", userId: "usr_1" })
         expect(params.contentMarkdown).toBe("/steer I want option 2")
         await onCreated?.({ query: mock(async () => ({ rows: [], rowCount: 0 })) }, message)
         return { message }
-      },
-    }
+      }
+    )
+    const eventService = { createMessageForPrincipalReturningConversation }
     const commandAvailabilityService = {
       resolveCommandInTransaction: mock(async () => ({
         executionKind: CommandKinds.BOT_RUNTIME,
@@ -118,6 +121,7 @@ describe("message + steer composite send", () => {
       response as never
     )
 
+    expect(createMessageForPrincipalReturningConversation).toHaveBeenCalledTimes(1)
     expect(order).toEqual(["message", "message-invocation", "command-event", "steer-invocation"])
     expect(createInvocationInTransaction.mock.calls.map((call: unknown[]) => call[1])).toEqual([
       expect.objectContaining({

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -362,7 +362,8 @@ export function createMessageHandlers({
         // without crashing on null content. Attachments still bind: the rows are
         // `e2e_only` ciphertext (no real content to gate on), and the same
         // workspace + shareable check the plaintext path runs covers them.
-        const { message } = await eventService.createMessageReturningConversation(
+        const { message } = await eventService.createMessageForPrincipalReturningConversation(
+          { kind: "user", userId },
           {
             workspaceId,
             streamId,
@@ -445,7 +446,8 @@ export function createMessageHandlers({
       // `conversationId` is the id the declared directive assigned the message to
       // (a fresh mint for a board `new` post) — surfaced so the board composer can
       // slot an optimistic card keyed by the real id, reconciled by the echo.
-      const { message, conversationId } = await eventService.createMessageReturningConversation(
+      const { message, conversationId } = await eventService.createMessageForPrincipalReturningConversation(
+        { kind: "user", userId },
         {
           workspaceId,
           streamId,
@@ -499,16 +501,19 @@ export function createMessageHandlers({
       // content), so this is reference-only by construction.
       const attachmentIds = collectAttachmentReferenceIds(contentJson)
 
-      const message = await eventService.editMessage({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        contentJson,
-        contentMarkdown,
-        actorId: userId,
-        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        confirmedPrivacyWarning: data.confirmedPrivacyWarning,
-      })
+      const message = await eventService.editMessageForPrincipal(
+        { kind: "user", userId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing.streamId,
+          contentJson,
+          contentMarkdown,
+          actorId: userId,
+          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+          confirmedPrivacyWarning: data.confirmedPrivacyWarning,
+        }
+      )
 
       if (!message) {
         throw new MessageNotFoundError()
@@ -529,14 +534,17 @@ export function createMessageHandlers({
         target: { streamId: data.sourceStreamId },
       })
 
-      const moveResult = await eventService.moveMessagesToThread({
-        workspaceId,
-        sourceStreamId: data.sourceStreamId,
-        targetMessageId: data.targetMessageId,
-        messageIds: data.messageIds,
-        actorId: userId,
-        leaseKey: data.leaseKey,
-      })
+      const moveResult = await eventService.moveMessagesToThreadForPrincipal(
+        { kind: "user", userId },
+        {
+          workspaceId,
+          sourceStreamId: data.sourceStreamId,
+          targetMessageId: data.targetMessageId,
+          messageIds: data.messageIds,
+          actorId: userId,
+          leaseKey: data.leaseKey,
+        }
+      )
 
       res.json({
         sourceStreamId: moveResult.sourceStreamId,
@@ -594,12 +602,15 @@ export function createMessageHandlers({
         throw new HttpError("Can only delete your own messages", { status: 403, code: "FORBIDDEN" })
       }
 
-      await eventService.deleteMessage({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        actorId: userId,
-      })
+      await eventService.deleteMessageForPrincipal(
+        { kind: "user", userId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing.streamId,
+          actorId: userId,
+        }
+      )
 
       res.status(204).send()
     },
@@ -630,13 +641,16 @@ export function createMessageHandlers({
         throw new MessageNotFoundError()
       }
 
-      const message = await eventService.addReaction({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        emoji: shortcode,
-        userId,
-      })
+      const message = await eventService.addReactionForPrincipal(
+        { kind: "user", userId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing.streamId,
+          emoji: shortcode,
+          userId,
+        }
+      )
 
       if (!message) {
         throw new MessageNotFoundError()
@@ -668,13 +682,16 @@ export function createMessageHandlers({
         throw new MessageNotFoundError()
       }
 
-      const message = await eventService.removeReaction({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        emoji: shortcode,
-        userId,
-      })
+      const message = await eventService.removeReactionForPrincipal(
+        { kind: "user", userId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing.streamId,
+          emoji: shortcode,
+          userId,
+        }
+      )
 
       if (!message) {
         throw new MessageNotFoundError()

--- a/apps/backend/src/features/messaging/sharing/service.ts
+++ b/apps/backend/src/features/messaging/sharing/service.ts
@@ -131,7 +131,7 @@ export interface ValidateAndRecordSharesParams {
 /**
  * Validates any cross-stream share-nodes in a message's contentJson and
  * writes the corresponding shared_messages rows. Invoked from inside
- * MessageEventService.createMessage and editMessage transactions so the
+ * the EventService message create and edit transactions so the
  * share grant is committed atomically with the event-source + projection
  * (INV-7).
  *

--- a/apps/backend/src/features/public-api/bot-handlers.ts
+++ b/apps/backend/src/features/public-api/bot-handlers.ts
@@ -523,44 +523,15 @@ export function createBotHandlers({ botApiKeyService, avatarService, streamServi
       const workspaceId = req.workspaceId!
       const { botId: id, streamId } = req.params
 
-      await withTransaction(pool, async (client) => {
-        // Lock bot and stream rows to prevent race conditions
-        const { rows: botRows } = await client.query<{ archived_at: Date | null }>(sql`
-          SELECT archived_at FROM bots
-          WHERE id = ${id} AND workspace_id = ${workspaceId}
-          FOR UPDATE
-        `)
-        if (botRows.length === 0 || botRows[0].archived_at !== null) {
-          throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
-        }
-
-        const { rows: streamRows } = await client.query<{ archived_at: Date | null }>(sql`
-          SELECT archived_at FROM streams
-          WHERE id = ${streamId} AND workspace_id = ${workspaceId}
-          FOR UPDATE
-        `)
-        if (streamRows.length === 0 || streamRows[0].archived_at !== null) {
-          throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
-        }
-
-        // Personal bot owners must be members of the target stream
-        if (req.bot!.type === BotTypes.PERSONAL) {
-          const ownerId = resolveWorkspaceUserActorId(req)
-          if (!ownerId) {
-            throw new HttpError("Not authenticated", { status: 401, code: "UNAUTHORIZED" })
-          }
-          const ownerIsMember = await streamService.isMemberOn(client, streamId, ownerId)
-          if (!ownerIsMember) {
-            throw new HttpError("Forbidden", { status: 403, code: "FORBIDDEN" })
-          }
-        }
-
-        const grantActorId = resolveGrantActorId(req)
-        if (!grantActorId) {
-          throw new HttpError("Not authenticated", { status: 401, code: "UNAUTHORIZED" })
-        }
-        await streamService.addBotToStreamOn(client, streamId, id, workspaceId, grantActorId)
-      })
+      const personalOwnerId = req.bot!.type === BotTypes.PERSONAL ? resolveWorkspaceUserActorId(req) : undefined
+      if (req.bot!.type === BotTypes.PERSONAL && !personalOwnerId) {
+        throw new HttpError("Not authenticated", { status: 401, code: "UNAUTHORIZED" })
+      }
+      const grantActorId = resolveGrantActorId(req)
+      if (!grantActorId) {
+        throw new HttpError("Not authenticated", { status: 401, code: "UNAUTHORIZED" })
+      }
+      await streamService.addBotToStream(streamId, id, workspaceId, grantActorId, personalOwnerId ?? undefined)
 
       res.status(204).send()
     },

--- a/apps/backend/src/features/public-api/bot-repository.ts
+++ b/apps/backend/src/features/public-api/bot-repository.ts
@@ -154,6 +154,16 @@ export const BotRepository = {
     return mapRowToBot(result.rows[0])
   },
 
+  async findByIdForUpdate(db: Querier, workspaceId: string, id: string): Promise<Bot | null> {
+    const result = await db.query<BotRow>(sql`
+      SELECT ${sql.raw(BOT_COLUMNS)}
+      FROM bots
+      WHERE id = ${id} AND workspace_id = ${workspaceId}
+      FOR UPDATE
+    `)
+    return result.rows[0] ? mapRowToBot(result.rows[0]) : null
+  },
+
   async findByIds(db: Querier, workspaceId: string, ids: string[]): Promise<Bot[]> {
     if (ids.length === 0) return []
     const result = await db.query<BotRow>(sql`

--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -28,7 +28,9 @@ function createResponse(): Response {
 function createHandlers(overrides: Partial<PublicApiDeps> = {}): ReturnType<typeof createPublicApiHandlers> {
   const eventService = {
     createMessage: mock(() => Promise.resolve({ id: "msg_new" })),
-    editMessage: mock(() => Promise.resolve({ id: "msg_new" })),
+    assertStreamWritableForPrincipal: mock(() => Promise.resolve()),
+    createMessageForPrincipalReturningConversation: mock(() => Promise.resolve({ message: { id: "msg_new" } })),
+    editMessageForPrincipal: mock(() => Promise.resolve({ id: "msg_new" })),
     getMessageById: mock(() =>
       Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
     ),
@@ -38,7 +40,6 @@ function createHandlers(overrides: Partial<PublicApiDeps> = {}): ReturnType<type
   } as unknown as StreamService
 
   const deps: PublicApiDeps = {
-    eventService,
     streamService,
     searchService: {} as PublicApiDeps["searchService"],
     memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
@@ -50,6 +51,7 @@ function createHandlers(overrides: Partial<PublicApiDeps> = {}): ReturnType<type
     pool: {} as PublicApiDeps["pool"],
     io: {} as PublicApiDeps["io"],
     ...overrides,
+    eventService: { ...eventService, ...(overrides.eventService as object | undefined) } as unknown as EventService,
   }
   return createPublicApiHandlers(deps)
 }
@@ -86,23 +88,63 @@ describe("public API E2E-stream plaintext gate", () => {
     expect(createMessage).not.toHaveBeenCalled()
   })
 
-  it("rejects a plaintext updateMessage into an E2E stream with 400", async () => {
-    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
-    const editMessage = mock(() => Promise.resolve({ id: "msg_1" }))
-    const handlers = createHandlers({
-      eventService: {
-        editMessage,
-        getMessageById: mock(() =>
-          Promise.resolve({ id: "msg_1", streamId: "stream_1", authorId: "usr_1", deletedAt: null })
-        ),
-      } as unknown as EventService,
-    })
+  it("lets guarded edit resolve authority before preserving the E2E edit code", async () => {
+    const editMessageForPrincipal = mock(() =>
+      Promise.reject(Object.assign(new Error("sealed"), { status: 400, code: "E2E_STREAM_EDIT_UNSUPPORTED" }))
+    )
+    const handlers = createHandlers({ eventService: { editMessageForPrincipal } as unknown as EventService })
 
     await expect(handlers.updateMessage(userRequest(), createResponse())).rejects.toMatchObject({
       status: 400,
-      code: "E2E_STREAM_PLAINTEXT_UNSUPPORTED",
+      code: "E2E_STREAM_EDIT_UNSUPPORTED",
     })
-    expect(editMessage).not.toHaveBeenCalled()
+    expect(editMessageForPrincipal).toHaveBeenCalled()
+  })
+
+  it("defers ownership until guarded authority: inaccessible other-owned and missing are both 404", async () => {
+    for (const snapshot of [
+      { id: "msg_private", streamId: "stream_private", authorId: "usr_other", deletedAt: null },
+      null,
+    ]) {
+      const editMessageForPrincipal = mock(() =>
+        Promise.reject(Object.assign(new Error("hidden"), { status: 404, code: "STREAM_NOT_FOUND" }))
+      )
+      const handlers = createHandlers({
+        eventService: {
+          getMessageById: mock(() => Promise.resolve(snapshot)),
+          editMessageForPrincipal,
+        } as unknown as EventService,
+      })
+      await expect(handlers.updateMessage(userRequest(), createResponse())).rejects.toMatchObject({ status: 404 })
+      expect(editMessageForPrincipal).toHaveBeenCalled()
+    }
+  })
+
+  it("preserves 403 for an accessible message owned by another actor", async () => {
+    const editMessageForPrincipal = mock(() =>
+      Promise.reject(Object.assign(new Error("owner"), { status: 403, code: "FORBIDDEN" }))
+    )
+    const handlers = createHandlers({
+      eventService: {
+        getMessageById: mock(() => Promise.resolve({ id: "msg_other", streamId: "stream_1", authorId: "usr_other" })),
+        editMessageForPrincipal,
+      } as unknown as EventService,
+    })
+    await expect(handlers.updateMessage(userRequest(), createResponse())).rejects.toMatchObject({
+      status: 403,
+      code: "FORBIDDEN",
+    })
+  })
+
+  it("returns a structured 404 for archived bot CRUD", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", archivedAt: new Date() } as never)
+    const handlers = createHandlers()
+    await expect(
+      handlers.deleteMessage(
+        userRequest({ userApiKey: undefined, user: undefined, botApiKey: { botId: "bot_1" } } as never),
+        createResponse()
+      )
+    ).rejects.toMatchObject({ status: 404, code: "NOT_FOUND" })
   })
 
   it("rejects a bot-invocation completion targeting an E2E stream with 400 (E2EE-2)", async () => {
@@ -272,7 +314,7 @@ describe("public API E2E-stream plaintext gate", () => {
 
   it("lets a plaintext sendMessage into a non-E2E stream through to createMessage", async () => {
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
-    const createMessageReturningConversation = mock(() =>
+    const createMessageForPrincipalReturningConversation = mock(() =>
       Promise.resolve({
         message: {
           id: "msg_new",
@@ -292,13 +334,13 @@ describe("public API E2E-stream plaintext gate", () => {
     )
     const handlers = createHandlers({
       eventService: {
-        createMessageReturningConversation,
+        createMessageForPrincipalReturningConversation,
         getMessageById: mock(() => Promise.resolve(null)),
       } as unknown as EventService,
     })
 
     await handlers.sendMessage(userRequest(), createResponse())
-    expect(createMessageReturningConversation).toHaveBeenCalled()
+    expect(createMessageForPrincipalReturningConversation).toHaveBeenCalled()
   })
 })
 
@@ -320,7 +362,7 @@ describe("public API bot send trace stamping", () => {
   function sendHarness() {
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
     spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Bot", archivedAt: null } as never)
-    const createMessageReturningConversation = mock(() =>
+    const createMessageForPrincipalReturningConversation = mock(() =>
       Promise.resolve({
         message: {
           id: "msg_new",
@@ -343,12 +385,12 @@ describe("public API bot send trace stamping", () => {
     } as unknown as PublicApiDeps["botChannelService"]
     const handlers = createHandlers({
       eventService: {
-        createMessageReturningConversation,
+        createMessageForPrincipalReturningConversation,
         getMessageById: mock(() => Promise.resolve(null)),
       } as unknown as EventService,
       botChannelService,
     })
-    return { handlers, createMessageReturningConversation }
+    return { handlers, createMessageForPrincipalReturningConversation }
   }
 
   it("stamps sessionId when a running session on the stream belongs to this bot", async () => {
@@ -356,11 +398,12 @@ describe("public API bot send trace stamping", () => {
       id: "session_1",
       personaId: "bot_1",
     } as never)
-    const { handlers, createMessageReturningConversation } = sendHarness()
+    const { handlers, createMessageForPrincipalReturningConversation } = sendHarness()
 
     await handlers.sendMessage(botRequest(), createResponse())
 
-    expect(createMessageReturningConversation).toHaveBeenCalledWith(
+    expect(createMessageForPrincipalReturningConversation).toHaveBeenCalledWith(
+      { kind: "bot", botId: "bot_1" },
       expect.objectContaining({ sessionId: "session_1", authorId: "bot_1" })
     )
   })
@@ -370,20 +413,26 @@ describe("public API bot send trace stamping", () => {
       id: "session_1",
       personaId: "bot_2",
     } as never)
-    const { handlers, createMessageReturningConversation } = sendHarness()
+    const { handlers, createMessageForPrincipalReturningConversation } = sendHarness()
 
     await handlers.sendMessage(botRequest(), createResponse())
 
-    expect(createMessageReturningConversation).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }))
+    expect(createMessageForPrincipalReturningConversation).toHaveBeenCalledWith(
+      { kind: "bot", botId: "bot_1" },
+      expect.objectContaining({ sessionId: undefined })
+    )
   })
 
   it("does not stamp when no session is running on the stream", async () => {
     spyOn(AgentSessionRepository, "findRunningByStream").mockResolvedValue(null)
-    const { handlers, createMessageReturningConversation } = sendHarness()
+    const { handlers, createMessageForPrincipalReturningConversation } = sendHarness()
 
     await handlers.sendMessage(botRequest(), createResponse())
 
-    expect(createMessageReturningConversation).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }))
+    expect(createMessageForPrincipalReturningConversation).toHaveBeenCalledWith(
+      { kind: "bot", botId: "bot_1" },
+      expect.objectContaining({ sessionId: undefined })
+    )
   })
 })
 

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -814,38 +814,19 @@ export function createPublicApiHandlers({
     })
   }
 
-  /** Find a message, verify stream access, and verify ownership. Used by update/delete. */
-  async function resolveOwnedMessage(messageId: string, req: Request) {
+  /** Resolve mutation actor independently; message snapshot is only a placement hint. */
+  async function resolveMessageMutation(messageId: string, req: Request) {
     const message = await eventService.getMessageById(messageId)
-    if (!message || message.deletedAt) {
-      throw new HttpError("Message not found", { status: 404, code: "NOT_FOUND" })
-    }
-
-    await assertStreamAccessible(req, message.streamId)
-
-    // User-scoped key: can modify own messages (regardless of how they were sent)
     if (req.userApiKey) {
-      if (message.authorId !== req.user!.id) {
-        throw new HttpError("Cannot modify another user's messages", {
-          status: 403,
-          code: "FORBIDDEN",
-        })
-      }
       return { message, actorId: req.user!.id, actorType: AuthorTypes.USER as AuthorType, displayName: req.user!.name }
     }
-
-    // Bot-scoped key: verify the message was authored by the bot this key belongs to
     if (req.botApiKey) {
-      if (message.authorType !== AuthorTypes.BOT || message.authorId !== req.botApiKey.botId) {
-        throw new HttpError("Cannot modify messages created by another bot", { status: 403, code: "FORBIDDEN" })
-      }
-      const bot = await BotRepository.findById(pool, req.workspaceId!, message.authorId)
-      if (!bot) {
-        throw new HttpError("Bot not found", { status: 404, code: "NOT_FOUND" })
+      const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
+      if (!bot || bot.archivedAt) {
+        throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
       }
       return { message, actorId: bot.id, actorType: AuthorTypes.BOT as AuthorType, displayName: bot.name }
     }
-
     throw new HttpError("No API key context", { status: 401, code: "UNAUTHORIZED" })
   }
 
@@ -2459,7 +2440,14 @@ export function createPublicApiHandlers({
 
       const { content, clientMessageId, metadata, conversation } = validateRequest(sendMessageSchema, req.body)
 
-      await assertStreamAccessible(req, streamId)
+      let principal: { kind: "user"; userId: string } | { kind: "bot"; botId: string } | null = null
+      if (req.userApiKey) {
+        principal = { kind: "user", userId: req.user!.id }
+      } else if (req.botApiKey) {
+        principal = { kind: "bot", botId: req.botApiKey.botId }
+      }
+      if (!principal) throw new HttpError("No API key context", { status: 401, code: "UNAUTHORIZED" })
+      await eventService.assertStreamWritableForPrincipal(principal, workspaceId, streamId)
       await assertNotE2eStream(workspaceId, streamId)
 
       const contentMarkdown = normalizeMessage(content)
@@ -2476,19 +2464,22 @@ export function createPublicApiHandlers({
       if (req.userApiKey) {
         const user = req.user!
 
-        const { message, conversationId } = await eventService.createMessageReturningConversation({
-          workspaceId,
-          streamId,
-          authorId: user.id,
-          authorType: AuthorTypes.USER,
-          contentJson,
-          contentMarkdown,
-          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-          clientMessageId,
-          sentVia: sentViaApiKey(req.userApiKey.id),
-          metadata,
-          conversation,
-        })
+        const { message, conversationId } = await eventService.createMessageForPrincipalReturningConversation(
+          { kind: "user", userId: user.id },
+          {
+            workspaceId,
+            streamId,
+            authorId: user.id,
+            authorType: AuthorTypes.USER,
+            contentJson,
+            contentMarkdown,
+            attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+            clientMessageId,
+            sentVia: sentViaApiKey(req.userApiKey.id),
+            metadata,
+            conversation,
+          }
+        )
 
         res.status(201).json({
           data: serializeMessage(message, { authorDisplayName: user.name }),
@@ -2517,19 +2508,22 @@ export function createPublicApiHandlers({
         const runningSession = await AgentSessionRepository.findRunningByStream(pool, streamId)
         const sessionId = runningSession?.personaId === bot.id ? runningSession.id : undefined
 
-        const { message, conversationId } = await eventService.createMessageReturningConversation({
-          workspaceId,
-          streamId,
-          authorId: bot.id,
-          authorType: AuthorTypes.BOT,
-          contentJson,
-          contentMarkdown,
-          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-          clientMessageId,
-          metadata,
-          conversation,
-          sessionId,
-        })
+        const { message, conversationId } = await eventService.createMessageForPrincipalReturningConversation(
+          { kind: "bot", botId: bot.id },
+          {
+            workspaceId,
+            streamId,
+            authorId: bot.id,
+            authorType: AuthorTypes.BOT,
+            contentJson,
+            contentMarkdown,
+            attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+            clientMessageId,
+            metadata,
+            conversation,
+            sessionId,
+          }
+        )
 
         res.status(201).json({
           data: serializeMessage(message, { authorDisplayName: bot.name }),
@@ -2555,8 +2549,7 @@ export function createPublicApiHandlers({
       }
 
       const { content } = result.data
-      const { message: existing, actorId, actorType, displayName } = await resolveOwnedMessage(messageId, req)
-      await assertNotE2eStream(workspaceId, existing.streamId)
+      const { message: existing, actorId, actorType, displayName } = await resolveMessageMutation(messageId, req)
 
       const contentMarkdown = normalizeMessage(content)
       const contentJson = parseMarkdown(contentMarkdown, undefined, toEmoji)
@@ -2564,23 +2557,26 @@ export function createPublicApiHandlers({
       // (INV-7) — same derivation as the user UI handler and the agent adapter.
       const attachmentIds = collectAttachmentReferenceIds(contentJson)
 
-      const updated = await eventService.editMessage({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        contentJson,
-        contentMarkdown,
-        actorId,
-        actorType,
-        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-      })
+      const updated = await eventService.editMessageForPrincipal(
+        actorType === AuthorTypes.BOT ? { kind: "bot", botId: actorId } : { kind: "user", userId: actorId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing?.streamId ?? "stream_missing",
+          contentJson,
+          contentMarkdown,
+          actorId,
+          actorType,
+          attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        }
+      )
 
       if (!updated) {
         throw new HttpError("Message not found or was deleted", { status: 404, code: "NOT_FOUND" })
       }
 
       const [thread, slots] = await Promise.all([
-        StreamRepository.findByAnchor(pool, existing.streamId, messageId),
+        StreamRepository.findByAnchor(pool, updated.streamId, messageId),
         resolveSlots(req, [updated.contentJson]),
       ])
       res.json({
@@ -2596,15 +2592,18 @@ export function createPublicApiHandlers({
       const workspaceId = req.workspaceId!
       const messageId = req.params.messageId
 
-      const { message: existing, actorId, actorType } = await resolveOwnedMessage(messageId, req)
+      const { message: existing, actorId, actorType } = await resolveMessageMutation(messageId, req)
 
-      const deleted = await eventService.deleteMessage({
-        workspaceId,
-        messageId,
-        streamId: existing.streamId,
-        actorId,
-        actorType,
-      })
+      const deleted = await eventService.deleteMessageForPrincipal(
+        actorType === AuthorTypes.BOT ? { kind: "bot", botId: actorId } : { kind: "user", userId: actorId },
+        {
+          workspaceId,
+          messageId,
+          streamId: existing?.streamId ?? "stream_missing",
+          actorId,
+          actorType,
+        }
+      )
 
       if (!deleted) {
         throw new HttpError("Message not found or was deleted", { status: 404, code: "NOT_FOUND" })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -981,7 +981,7 @@ export function createStreamHandlers({
         return res.status(403).json({ error: "Only the creator can archive this stream" })
       }
 
-      const archived = await streamService.archiveStream(streamId, userId)
+      const archived = await streamService.archiveStream(streamId, workspaceId, userId)
       res.json({ stream: archived })
     },
 
@@ -996,7 +996,7 @@ export function createStreamHandlers({
         return res.status(403).json({ error: "Only the creator can unarchive this stream" })
       }
 
-      const unarchived = await streamService.unarchiveStream(streamId, userId)
+      const unarchived = await streamService.unarchiveStream(streamId, workspaceId, userId)
       res.json({ stream: unarchived })
     },
 
@@ -1242,7 +1242,7 @@ export function createStreamHandlers({
       const { streamId, memberId } = req.params
 
       await streamService.validateStreamAccess(streamId, workspaceId, actor.id)
-      await streamService.removeMember(streamId, memberId)
+      await streamService.removeMember(streamId, memberId, req.workspaceId!, req.user!.id)
       res.status(204).send()
     },
 

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -23,6 +23,9 @@ export {
   deriveStreamViewerState,
   createStreamReadOnlyError,
   assertViewerStreamWritable,
+  assertStreamWritable,
+  assertStreamsWritable,
+  resolveLockedStreamAuthorities,
   projectStreamForPrincipal,
   projectStreamsForPrincipal,
   projectStreamForUser,
@@ -30,7 +33,7 @@ export {
   projectStreamForBot,
   projectStreamsForBot,
 } from "./write-authority"
-export type { StreamWritePrincipal } from "./write-authority"
+export type { StreamWritePrincipal, LockedStreamAuthority } from "./write-authority"
 
 export { prependThreadNamingAnchor, renderNamingEventAnchor } from "./naming-context"
 

--- a/apps/backend/src/features/streams/member-repository.ts
+++ b/apps/backend/src/features/streams/member-repository.ts
@@ -229,6 +229,36 @@ export const StreamMemberRepository = {
     return result.rows.length > 0
   },
 
+  async lockMemberships(db: Querier, rootStreamIds: readonly string[], memberId: string): Promise<Set<string>> {
+    const stableIds = [...new Set(rootStreamIds)].sort()
+    if (stableIds.length === 0) return new Set()
+    const result = await db.query<{ stream_id: string }>(sql`
+      SELECT stream_id
+      FROM stream_members
+      WHERE stream_id = ANY(${stableIds}) AND member_id = ${memberId}
+      ORDER BY stream_id
+      FOR UPDATE
+    `)
+    return new Set(result.rows.map((row) => row.stream_id))
+  },
+
+  async lockMemberPairs(db: Querier, pairs: readonly { streamId: string; memberId: string }[]): Promise<Set<string>> {
+    const stable = [...new Map(pairs.map((pair) => [`${pair.streamId}:${pair.memberId}`, pair])).values()].sort(
+      (a, b) => a.streamId.localeCompare(b.streamId) || a.memberId.localeCompare(b.memberId)
+    )
+    if (stable.length === 0) return new Set()
+    const result = await db.query<{ stream_id: string; member_id: string }>(sql`
+      SELECT sm.stream_id, sm.member_id
+      FROM stream_members sm
+      JOIN unnest(${stable.map((pair) => pair.streamId)}::text[], ${stable.map((pair) => pair.memberId)}::text[])
+        AS requested(stream_id, member_id)
+        ON requested.stream_id = sm.stream_id AND requested.member_id = sm.member_id
+      ORDER BY sm.stream_id, sm.member_id
+      FOR UPDATE OF sm
+    `)
+    return new Set(result.rows.map((row) => `${row.stream_id}:${row.member_id}`))
+  },
+
   /**
    * Count members of `streamId` who are NOT members of `otherStreamId`.
    * Used by the sharing privacy boundary check: given a source and target

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -355,6 +355,19 @@ export const StreamRepository = {
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },
 
+  async findByIdsForUpdateBlocking(db: Querier, workspaceId: string, ids: readonly string[]): Promise<Stream[]> {
+    const stableIds = [...new Set(ids)].sort()
+    if (stableIds.length === 0) return []
+    const result = await db.query<StreamRow>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS)}
+      FROM streams
+      WHERE workspace_id = ${workspaceId} AND id = ANY(${stableIds})
+      ORDER BY id
+      FOR UPDATE
+    `)
+    return result.rows.map(mapRowToStream)
+  },
+
   async findByIds(db: Querier, ids: string[]): Promise<Stream[]> {
     if (ids.length === 0) return []
     const result = await db.query<StreamRow>(

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -21,6 +21,21 @@ import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
 
 const mockFindById = spyOn(StreamRepository, "findById")
+spyOn(StreamRepository, "findByIdsInWorkspace").mockImplementation(async (client, _workspaceId, ids) => {
+  const streams = await Promise.all(ids.map((id) => mockFindById(client, id)))
+  return streams.filter((stream): stream is NonNullable<typeof stream> => stream != null)
+})
+const mockFindByIdsForUpdateBlocking = spyOn(StreamRepository, "findByIdsForUpdateBlocking").mockImplementation(
+  async (client, _workspaceId, ids) => {
+    const streams = await Promise.all(ids.map((id) => mockFindById(client, id)))
+    return streams.filter((stream): stream is NonNullable<typeof stream> => stream != null)
+  }
+)
+const mockLockMemberships = spyOn(StreamMemberRepository, "lockMemberships").mockResolvedValue(new Set())
+spyOn(StreamMemberRepository, "lockMemberPairs").mockImplementation(
+  async (_client, pairs) => new Set(pairs.map(({ streamId, memberId }) => `${streamId}:${memberId}`))
+)
+const mockLockGrants = spyOn(BotChannelAccessRepository, "lockGrants").mockResolvedValue(new Set())
 const mockInsertOrFindByUniquenessKey = spyOn(StreamRepository, "insertOrFindByUniquenessKey")
 const mockInsertMember = spyOn(StreamMemberRepository, "insert")
 const mockInsertManyMembers = spyOn(StreamMemberRepository, "insertMany")
@@ -314,8 +329,10 @@ describe("StreamService.resolveWritableMessageStream", () => {
       id: "stream_1",
       workspaceId: "ws_1",
       type: "scratchpad",
+      visibility: "private",
       archivedAt: new Date(),
     } as never)
+    spyOn(service, "isMember").mockResolvedValue(true)
 
     const error = await service
       .resolveWritableMessageStream({
@@ -327,7 +344,8 @@ describe("StreamService.resolveWritableMessageStream", () => {
 
     expect(error).toBeInstanceOf(HttpError)
     expect((error as HttpError).status).toBe(403)
-    expect((error as HttpError).message).toBe("Cannot send messages to an archived stream")
+    expect((error as HttpError).code).toBe("STREAM_READ_ONLY")
+    expect((error as HttpError).details).toEqual({ reason: "archived" })
   })
 
   test("should throw 403 when member cannot write to stream", async () => {
@@ -335,6 +353,7 @@ describe("StreamService.resolveWritableMessageStream", () => {
       id: "stream_1",
       workspaceId: "ws_1",
       type: "scratchpad",
+      visibility: "public",
       archivedAt: null,
     } as never)
     spyOn(service, "isMember").mockResolvedValue(false)
@@ -349,7 +368,8 @@ describe("StreamService.resolveWritableMessageStream", () => {
 
     expect(error).toBeInstanceOf(HttpError)
     expect((error as HttpError).status).toBe(403)
-    expect((error as HttpError).message).toBe("Not a member of this stream")
+    expect((error as HttpError).code).toBe("STREAM_READ_ONLY")
+    expect((error as HttpError).details).toEqual({ reason: "not_a_member" })
   })
 
   test("should throw 403 when a thread's root stream is archived", async () => {
@@ -368,6 +388,7 @@ describe("StreamService.resolveWritableMessageStream", () => {
         id: "stream_root",
         workspaceId: "ws_1",
         type: "scratchpad",
+        visibility: "private",
         archivedAt: new Date(),
       } as never)
     const isMemberSpy = spyOn(service, "isMember").mockResolvedValue(true)
@@ -382,9 +403,9 @@ describe("StreamService.resolveWritableMessageStream", () => {
 
     expect(error).toBeInstanceOf(HttpError)
     expect((error as HttpError).status).toBe(403)
-    expect((error as HttpError).message).toBe("Cannot send messages to a thread under an archived stream")
-    // Membership is never checked once the root-archived seal is detected.
-    expect(isMemberSpy).not.toHaveBeenCalled()
+    expect((error as HttpError).code).toBe("STREAM_READ_ONLY")
+    expect((error as HttpError).details).toEqual({ reason: "archived" })
+    expect(isMemberSpy).toHaveBeenCalledWith("stream_root", "usr_1")
   })
 })
 
@@ -2292,7 +2313,7 @@ describe("StreamService.updateCompanionMode persona validation", () => {
 
 describe("StreamService.addBotToStream", () => {
   const mockGrantAccess = spyOn(BotChannelAccessRepository, "grantAccess")
-  const mockFindBotById = spyOn(BotRepository, "findById")
+  const mockFindBotById = spyOn(BotRepository, "findByIdForUpdate")
   let service: StreamService
 
   beforeEach(() => {
@@ -2362,6 +2383,12 @@ describe("StreamService.addBotToStream", () => {
 
   test("redirects a thread grant to its root channel", async () => {
     mockFindById
+      .mockResolvedValueOnce({
+        id: "stream_thread",
+        workspaceId: "ws_1",
+        type: "thread",
+        rootStreamId: "stream_root",
+      } as never)
       .mockResolvedValueOnce({
         id: "stream_thread",
         workspaceId: "ws_1",

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -28,6 +28,7 @@ import {
 } from "../../lib/errors"
 import { formatParticipantNames } from "./display-name"
 import { checkStreamAccess } from "./access"
+import { assertViewerStreamWritable, deriveStreamViewerState, lockEffectiveStreams } from "./write-authority"
 import { UserRepository } from "../workspaces"
 import { BotChannelAccessRepository } from "../api-keys"
 import {
@@ -198,6 +199,33 @@ function buildDmUniquenessKey(userOneId: string, userTwoId: string): string {
   return `${DM_UNIQUENESS_KEY_PREFIX}:${userAId}:${userBId}`
 }
 
+async function lockLifecycleStreams(
+  client: Querier,
+  workspaceId: string,
+  streamId: string
+): Promise<{ target: Stream; root: Stream }> {
+  const snapshot = await StreamRepository.findById(client, streamId)
+  if (!snapshot || snapshot.workspaceId !== workspaceId) throw new StreamNotFoundError()
+  const [facts] = await lockEffectiveStreams(client, workspaceId, [streamId], [snapshot])
+  return facts
+}
+
+async function lockActorAccess(
+  client: Querier,
+  root: Stream,
+  actorId: string,
+  affectedMemberId?: string
+): Promise<void> {
+  const memberIds = [...new Set([actorId, affectedMemberId].filter((id): id is string => Boolean(id)))].sort()
+  const memberships = await StreamMemberRepository.lockMemberPairs(
+    client,
+    memberIds.map((memberId) => ({ streamId: root.id, memberId }))
+  )
+  if (root.visibility !== Visibilities.PUBLIC && !memberships.has(`${root.id}:${actorId}`)) {
+    throw new StreamNotFoundError()
+  }
+}
+
 export class StreamService {
   constructor(private pool: Pool) {}
 
@@ -336,41 +364,17 @@ export class StreamService {
         throw new StreamNotFoundError()
       }
 
-      if (stream.archivedAt) {
-        throw new HttpError("Cannot send messages to an archived stream", { status: 403 })
-      }
-
+      assertViewerStreamWritable(deriveStreamViewerState({ target: stream, root: stream, participates: true }))
       return stream
     }
 
     const stream = await this.getStreamById(params.target.streamId)
-
-    if (!stream || stream.workspaceId !== params.workspaceId) {
-      throw new StreamNotFoundError()
-    }
-
-    if (stream.archivedAt) {
-      throw new HttpError("Cannot send messages to an archived stream", { status: 403 })
-    }
-
-    // A thread inherits its lifecycle from its root (INV-62): archiving marks
-    // only the root row, so the thread itself stays "active" and would otherwise
-    // still accept writes. Reject when the thread's root is archived so an
-    // archived scratchpad/channel seals every nested thread too. The sidebar
-    // already hides these (listWithPreviews excludes them), but this is the
-    // authoritative gate covering deep links, the API, and move-to-thread.
-    if (stream.type === StreamTypes.THREAD && stream.rootStreamId) {
-      const root = await this.getStreamById(stream.rootStreamId)
-      if (root?.archivedAt) {
-        throw new HttpError("Cannot send messages to a thread under an archived stream", { status: 403 })
-      }
-    }
-
-    const isMember = await this.isMember(stream.id, params.userId)
-    if (!isMember) {
-      throw new HttpError("Not a member of this stream", { status: 403 })
-    }
-
+    if (!stream || stream.workspaceId !== params.workspaceId) throw new StreamNotFoundError()
+    const root = stream.rootStreamId ? await this.getStreamById(stream.rootStreamId) : stream
+    if (!root || root.workspaceId !== params.workspaceId) throw new StreamNotFoundError()
+    const participates = await this.isMember(root.id, params.userId)
+    if (root.visibility !== Visibilities.PUBLIC && !participates) throw new StreamNotFoundError()
+    assertViewerStreamWritable(deriveStreamViewerState({ target: stream, root, participates }))
     return stream
   }
 
@@ -670,7 +674,7 @@ export class StreamService {
     let anchorMessage: Message | null = null
     let anchorEventRow: StreamEvent | null = null
     if (anchorId.startsWith("msg_")) {
-      // Lock the anchor message: a concurrent `moveMessagesToThread` re-parents
+      // Lock the anchor message: a concurrent message move re-parents
       // the message (UPDATE messages.stream_id) after an unlocked read would have
       // validated `streamId === parentStreamId`, letting this insert a thread under
       // the stale parent — a distinct row from any thread under the new parent (the
@@ -891,8 +895,13 @@ export class StreamService {
     return StreamPoliciesRepository.getToolPolicy(this.pool, workspaceId, streamId)
   }
 
-  async archiveStream(streamId: string, archivedBy: string): Promise<Stream | null> {
+  async archiveStream(streamId: string, workspaceId: string, archivedBy: string): Promise<Stream | null> {
     return withTransaction(this.pool, async (client) => {
+      const { target, root } = await lockLifecycleStreams(client, workspaceId, streamId)
+      await lockActorAccess(client, root, archivedBy)
+      if (target.createdBy !== archivedBy) {
+        throw new HttpError("Only the creator can archive this stream", { status: 403, code: "FORBIDDEN" })
+      }
       const stream = await StreamRepository.update(client, streamId, { archivedAt: new Date() })
       if (stream) {
         const evtId = eventId()
@@ -932,8 +941,13 @@ export class StreamService {
     })
   }
 
-  async unarchiveStream(streamId: string, unarchivedBy: string): Promise<Stream | null> {
+  async unarchiveStream(streamId: string, workspaceId: string, unarchivedBy: string): Promise<Stream | null> {
     return withTransaction(this.pool, async (client) => {
+      const { target, root } = await lockLifecycleStreams(client, workspaceId, streamId)
+      await lockActorAccess(client, root, unarchivedBy)
+      if (target.createdBy !== unarchivedBy) {
+        throw new HttpError("Only the creator can unarchive this stream", { status: 403, code: "FORBIDDEN" })
+      }
       const stream = await StreamRepository.update(client, streamId, { archivedAt: null })
       if (stream) {
         const evtId = eventId()
@@ -1651,9 +1665,9 @@ export class StreamService {
 
   async joinPublicChannel(streamId: string, workspaceId: string, memberId: string): Promise<StreamMember> {
     return withTransaction(this.pool, async (client) => {
-      const stream = await StreamRepository.findById(client, streamId)
+      const { target: stream } = await lockLifecycleStreams(client, workspaceId, streamId)
 
-      if (!stream || stream.workspaceId !== workspaceId) {
+      if (stream.workspaceId !== workspaceId) {
         throw new StreamNotFoundError()
       }
 
@@ -1661,6 +1675,7 @@ export class StreamService {
         throw new HttpError("Can only join public channels", { status: 403, code: "NOT_PUBLIC_CHANNEL" })
       }
 
+      await StreamMemberRepository.lockMemberships(client, [stream.id], memberId)
       const membership = await StreamMemberRepository.insert(client, streamId, memberId)
 
       const evtId = eventId()
@@ -1717,10 +1732,8 @@ export class StreamService {
 
   async addMember(streamId: string, memberId: string, workspaceId: string, actorId: string): Promise<StreamMember> {
     return withTransaction(this.pool, async (client) => {
-      const stream = await StreamRepository.findById(client, streamId)
-      if (!stream) {
-        throw new StreamNotFoundError()
-      }
+      const { target: stream, root } = await lockLifecycleStreams(client, workspaceId, streamId)
+      await lockActorAccess(client, root, actorId, memberId)
 
       if (stream.type === StreamTypes.DM) {
         throw new HttpError("Cannot add members to direct messages", {
@@ -1747,28 +1760,19 @@ export class StreamService {
   }
 
   /**
-   * Resolve the stream that holds bot grants for `target`. Bot access is
-   * channel-scoped: a thread redirects to its root channel, so grants and
-   * `member_added`/`member_left` events always land on the channel. Threads
-   * inherit mentionability from the channel and do not carry their own
-   * `bot_channel_access` rows.
-   */
-  private async resolveBotGrantStream(client: Querier, target: Stream): Promise<Stream> {
-    if (target.type === StreamTypes.THREAD && target.rootStreamId) {
-      const root = await StreamRepository.findById(client, target.rootStreamId)
-      if (root) return root
-    }
-    return target
-  }
-
-  /**
    * Grant a bot access to a stream. Idempotent and race-safe: emits
    * `member_added` only when a new grant was created. Threads are redirected
-   * to the root channel (see `resolveBotGrantStream`).
+   * to the effective root channel.
    */
-  async addBotToStream(targetStreamId: string, botId: string, workspaceId: string, actorId: string): Promise<void> {
+  async addBotToStream(
+    targetStreamId: string,
+    botId: string,
+    workspaceId: string,
+    actorId: string,
+    personalOwnerId?: string
+  ): Promise<void> {
     return withTransaction(this.pool, (client) =>
-      this.addBotToStreamOn(client, targetStreamId, botId, workspaceId, actorId)
+      this.addBotToStreamOn(client, targetStreamId, botId, workspaceId, actorId, personalOwnerId)
     )
   }
 
@@ -1782,18 +1786,29 @@ export class StreamService {
     targetStreamId: string,
     botId: string,
     workspaceId: string,
-    actorId: string
+    actorId: string,
+    personalOwnerId?: string
   ): Promise<void> {
-    const target = await StreamRepository.findById(client, targetStreamId)
-    if (!target) throw new StreamNotFoundError()
+    const { target, root: grantStream } = await lockLifecycleStreams(client, workspaceId, targetStreamId)
     if (target.workspaceId !== workspaceId) {
       throw new HttpError("Stream does not belong to this workspace", { status: 403, code: "WRONG_WORKSPACE" })
+    }
+    if (target.archivedAt || grantStream.archivedAt) throw new StreamNotFoundError()
+    const bot = await BotRepository.findByIdForUpdate(client, workspaceId, botId)
+    if (!bot || bot.archivedAt) {
+      throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
+    }
+    if (personalOwnerId) {
+      const ownerMemberships = await StreamMemberRepository.lockMemberships(client, [grantStream.id], personalOwnerId)
+      if (!ownerMemberships.has(grantStream.id)) {
+        throw new HttpError("Forbidden", { status: 403, code: "FORBIDDEN" })
+      }
     }
     // Unlike addMember, DMs are allowed: DM *contacts* are immutable
     // (stream_members), but bot grants live in bot_channel_access and don't
     // touch the peer pair — a bot must be addable so it can see and claim
     // delegations created in the DM.
-    const grantStream = await this.resolveBotGrantStream(client, target)
+    await BotChannelAccessRepository.lockGrants(client, workspaceId, botId, [grantStream.id])
     const inserted = await BotChannelAccessRepository.grantAccess(client, {
       id: streamId(),
       workspaceId,
@@ -1815,8 +1830,6 @@ export class StreamService {
     // Personal bots are visibility-scoped, so other members of the stream may
     // not hold this bot in their roster — the event carries its metadata so
     // their clients can render the new participant without a re-bootstrap.
-    const bot = await BotRepository.findById(client, workspaceId, botId)
-
     await OutboxRepository.insert(client, "stream:member_added", {
       workspaceId: grantStream.workspaceId,
       streamId: grantStream.id,
@@ -1860,12 +1873,10 @@ export class StreamService {
     return event
   }
 
-  async removeMember(streamId: string, memberId: string): Promise<boolean> {
+  async removeMember(streamId: string, memberId: string, workspaceId: string, actorId: string): Promise<boolean> {
     return withTransaction(this.pool, async (client) => {
-      const stream = await StreamRepository.findById(client, streamId)
-      if (!stream) {
-        throw new StreamNotFoundError()
-      }
+      const { target: stream, root } = await lockLifecycleStreams(client, workspaceId, streamId)
+      await lockActorAccess(client, root, actorId, memberId)
 
       if (stream.type === StreamTypes.DM) {
         throw new HttpError("Cannot remove members from direct messages", {
@@ -1916,13 +1927,12 @@ export class StreamService {
    */
   async removeBotFromStream(targetStreamId: string, botId: string, workspaceId: string): Promise<void> {
     return withTransaction(this.pool, async (client) => {
-      const target = await StreamRepository.findById(client, targetStreamId)
-      if (!target) throw new StreamNotFoundError()
+      const { target, root: grantStream } = await lockLifecycleStreams(client, workspaceId, targetStreamId)
       if (target.workspaceId !== workspaceId) {
         throw new HttpError("Stream does not belong to this workspace", { status: 403, code: "WRONG_WORKSPACE" })
       }
 
-      const grantStream = await this.resolveBotGrantStream(client, target)
+      await BotChannelAccessRepository.lockGrants(client, workspaceId, botId, [grantStream.id])
       const deleted = await BotChannelAccessRepository.revokeAccess(client, workspaceId, botId, grantStream.id)
       if (!deleted) return
 

--- a/apps/backend/src/features/streams/write-authority.test.ts
+++ b/apps/backend/src/features/streams/write-authority.test.ts
@@ -6,6 +6,7 @@ import { BotChannelAccessRepository } from "../api-keys"
 import { StreamMemberRepository } from "./member-repository"
 import { StreamRepository, type Stream } from "./repository"
 import {
+  assertStreamWritable,
   assertViewerStreamWritable,
   deriveStreamViewerState,
   projectStreamForBot,
@@ -181,6 +182,89 @@ describe("viewer projection", () => {
 
     expect(await projectStreamsForUser(db, { workspaceId: "ws_1", streams: [thread], userId: "usr_1" })).toEqual([])
     expect(memberships).toHaveBeenCalledWith(db, [], "usr_1")
+  })
+})
+
+describe("transactional write authority", () => {
+  test.each([
+    [stream({ archivedAt: new Date(0) }), stream(), "archived"],
+    [
+      stream({ id: "stream_thread", type: "thread", rootStreamId: "stream_archived_root" }),
+      stream({ id: "stream_archived_root", archivedAt: new Date(0) }),
+      "archived",
+    ],
+    [stream({ type: "system" }), stream(), "system_stream"],
+    [stream(), stream(), "not_a_member"],
+  ] as const)("returns the exact denial reason", async (target, root, reason) => {
+    spyOn(StreamRepository, "findByIdsInWorkspace").mockResolvedValue([target])
+    spyOn(StreamRepository, "findByIdsForUpdateBlocking").mockResolvedValue(
+      target.id === root.id ? [target] : [target, root]
+    )
+    spyOn(StreamMemberRepository, "lockMemberships").mockResolvedValue(new Set())
+    await expect(
+      assertStreamWritable(db, {
+        workspaceId: "ws_1",
+        streamId: target.id,
+        principal: { kind: "user", userId: "usr_1" },
+      })
+    ).rejects.toMatchObject({ status: 403, code: "STREAM_READ_ONLY", details: { reason } })
+  })
+
+  test("hides missing, cross-workspace, dangling-root, and private nonparticipant targets", async () => {
+    const cases = [
+      { initial: [], locked: [] },
+      { initial: [stream({ workspaceId: "ws_other" })], locked: [] },
+      {
+        initial: [stream({ id: "thread", type: "thread", rootStreamId: "missing" })],
+        locked: [stream({ id: "thread", type: "thread", rootStreamId: "missing" })],
+      },
+      { initial: [stream({ visibility: "private" })], locked: [stream({ visibility: "private" })] },
+    ]
+    for (const item of cases) {
+      mock.restore()
+      spyOn(StreamRepository, "findByIdsInWorkspace").mockResolvedValue(item.initial)
+      spyOn(StreamRepository, "findByIdsForUpdateBlocking").mockResolvedValue(item.locked)
+      spyOn(StreamMemberRepository, "lockMemberships").mockResolvedValue(new Set())
+      await expect(
+        assertStreamWritable(db, {
+          workspaceId: "ws_1",
+          streamId: item.initial[0]?.id ?? "missing",
+          principal: { kind: "user", userId: "usr_1" },
+        })
+      ).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    }
+  })
+
+  test("locks user membership and bot grants at a thread's effective root", async () => {
+    const root = stream({ visibility: "private" })
+    const thread = stream({ id: "thread", type: "thread", rootStreamId: root.id })
+    spyOn(StreamRepository, "findByIdsInWorkspace").mockResolvedValue([thread])
+    spyOn(StreamRepository, "findByIdsForUpdateBlocking").mockResolvedValue([root, thread])
+    const members = spyOn(StreamMemberRepository, "lockMemberships").mockResolvedValue(new Set([root.id]))
+    expect(
+      (
+        await assertStreamWritable(db, {
+          workspaceId: "ws_1",
+          streamId: thread.id,
+          principal: { kind: "user", userId: "usr_1" },
+        })
+      ).root.id
+    ).toBe(root.id)
+    expect(members).toHaveBeenCalledWith(db, [root.id], "usr_1")
+    mock.restore()
+    spyOn(StreamRepository, "findByIdsInWorkspace").mockResolvedValue([thread])
+    spyOn(StreamRepository, "findByIdsForUpdateBlocking").mockResolvedValue([root, thread])
+    const grants = spyOn(BotChannelAccessRepository, "lockGrants").mockResolvedValue(new Set([root.id]))
+    expect(
+      (
+        await assertStreamWritable(db, {
+          workspaceId: "ws_1",
+          streamId: thread.id,
+          principal: { kind: "bot", botId: "bot_1" },
+        })
+      ).root.id
+    ).toBe(root.id)
+    expect(grants).toHaveBeenCalledWith(db, "ws_1", "bot_1", [root.id])
   })
 })
 

--- a/apps/backend/src/features/streams/write-authority.ts
+++ b/apps/backend/src/features/streams/write-authority.ts
@@ -10,9 +10,11 @@ import {
   type Visibility,
 } from "@threa/types"
 import type { Querier } from "../../db"
+import { StreamNotFoundError } from "../../lib/errors"
 import { BotChannelAccessRepository } from "../api-keys"
 import { resolveEffectiveAccessStream, resolveEffectiveAccessStreams } from "./access"
 import { StreamMemberRepository } from "./member-repository"
+import { StreamRepository, type Stream } from "./repository"
 
 export type StreamWritePrincipal = { kind: "user"; userId: string } | { kind: "bot"; botId: string }
 
@@ -108,6 +110,90 @@ export async function projectStreamsForPrincipal<T extends AuthorityStream>(
     projected.push({ ...target, ...deriveStreamViewerState({ target, root, participates }) })
   }
   return projected
+}
+
+export interface LockedStreamAuthority {
+  target: Stream
+  root: Stream
+  state: StreamViewerState
+}
+
+export async function lockEffectiveStreams(
+  db: Querier,
+  workspaceId: string,
+  streamIds: readonly string[],
+  suppliedSnapshots?: readonly Stream[]
+): Promise<Array<{ target: Stream; root: Stream }>> {
+  const targetIds = [...new Set(streamIds)].sort()
+  if (targetIds.length === 0) return []
+  const snapshots = suppliedSnapshots ?? (await StreamRepository.findByIdsInWorkspace(db, workspaceId, targetIds))
+  const snapshotById = new Map(snapshots.map((stream) => [stream.id, stream]))
+  const lockIds = new Set<string>()
+  for (const targetId of targetIds) {
+    const target = snapshotById.get(targetId)
+    if (!target || target.workspaceId !== workspaceId) throw inaccessibleStream()
+    lockIds.add(target.id)
+    lockIds.add(target.rootStreamId ?? target.id)
+  }
+  const locked = await StreamRepository.findByIdsForUpdateBlocking(db, workspaceId, [...lockIds])
+  const lockedById = new Map(locked.map((stream) => [stream.id, stream]))
+  return targetIds.map((targetId) => {
+    const target = lockedById.get(targetId)
+    const root = target && lockedById.get(target.rootStreamId ?? target.id)
+    if (!target || !root || target.workspaceId !== workspaceId || root.workspaceId !== workspaceId) {
+      throw inaccessibleStream()
+    }
+    return { target, root }
+  })
+}
+
+function inaccessibleStream(): StreamNotFoundError {
+  return new StreamNotFoundError()
+}
+
+/**
+ * Transaction-only authority gate. All callers lock streams in id order first,
+ * then participation rows in root-id order; lifecycle transitions use the same order.
+ */
+export async function resolveLockedStreamAuthorities(
+  db: Querier,
+  params: { workspaceId: string; streamIds: readonly string[]; principal: StreamWritePrincipal }
+): Promise<LockedStreamAuthority[]> {
+  const facts = await lockEffectiveStreams(db, params.workspaceId, params.streamIds)
+  if (facts.length === 0) return []
+
+  const rootIds = [...new Set(facts.map(({ root }) => root.id))].sort()
+  const participatingRootIds =
+    params.principal.kind === "user"
+      ? await StreamMemberRepository.lockMemberships(db, rootIds, params.principal.userId)
+      : await BotChannelAccessRepository.lockGrants(db, params.workspaceId, params.principal.botId, rootIds)
+
+  return facts.map(({ target, root }) => {
+    const participates = participatingRootIds.has(root.id)
+    if (root.visibility !== Visibilities.PUBLIC && !participates) throw inaccessibleStream()
+    return { target, root, state: deriveStreamViewerState({ target, root, participates }) }
+  })
+}
+
+export async function assertStreamsWritable(
+  db: Querier,
+  params: { workspaceId: string; streamIds: readonly string[]; principal: StreamWritePrincipal }
+): Promise<LockedStreamAuthority[]> {
+  const authorities = await resolveLockedStreamAuthorities(db, params)
+  for (const authority of authorities) assertViewerStreamWritable(authority.state)
+  return authorities
+}
+
+export async function assertStreamWritable(
+  db: Querier,
+  params: { workspaceId: string; streamId: string; principal: StreamWritePrincipal }
+): Promise<LockedStreamAuthority> {
+  const [authority] = await assertStreamsWritable(db, {
+    workspaceId: params.workspaceId,
+    streamIds: [params.streamId],
+    principal: params.principal,
+  })
+  return authority
 }
 
 export function projectStreamForUser<T extends AuthorityStream>(

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -509,7 +509,7 @@ export async function startServer(): Promise<ServerInstance> {
     // sync with the new content (INV-7). Without this, an agent edit that
     // adds or removes an `attachment:` link leaves stale rows behind.
     const attachmentIds = collectAttachmentReferenceIds(contentJson)
-    return eventService.editMessage({
+    return eventService.editMessageInternal({
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       messageId: params.messageId,
@@ -522,7 +522,7 @@ export async function startServer(): Promise<ServerInstance> {
     })
   }
   const deleteMessage = (params: { workspaceId: string; streamId: string; messageId: string; actorId: string }) =>
-    eventService.deleteMessage({
+    eventService.deleteMessageInternal({
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       messageId: params.messageId,
@@ -536,7 +536,7 @@ export async function startServer(): Promise<ServerInstance> {
     emoji: string
     actorId: string
   }) =>
-    eventService.addReaction({
+    eventService.addReactionInternal({
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       messageId: params.messageId,
@@ -551,7 +551,7 @@ export async function startServer(): Promise<ServerInstance> {
     emoji: string
     actorId: string
   }) =>
-    eventService.removeReaction({
+    eventService.removeReactionInternal({
       workspaceId: params.workspaceId,
       streamId: params.streamId,
       messageId: params.messageId,

--- a/apps/backend/tests/e2e/attachments.test.ts
+++ b/apps/backend/tests/e2e/attachments.test.ts
@@ -20,7 +20,7 @@ import {
   sendMessageWithAttachments,
   sendMessage,
   joinWorkspace,
-  joinStream,
+  addStreamMember,
   reserveAttachment,
   uploadReservedContent,
   reportAttachmentUploadFailure,
@@ -322,10 +322,10 @@ describe("File Attachments E2E", () => {
       await loginAs(member1Client, testEmail("tl-member1"), "TL Member 1")
       await loginAs(member2Client, testEmail("tl-member2"), "TL Member 2")
 
-      await joinWorkspace(member1Client, workspace.id)
-      await joinWorkspace(member2Client, workspace.id)
-      await joinStream(member1Client, workspace.id, channel.id)
-      await joinStream(member2Client, workspace.id, channel.id)
+      const member1 = await joinWorkspace(member1Client, workspace.id)
+      const member2 = await joinWorkspace(member2Client, workspace.id)
+      expect((await addStreamMember(ownerClient, workspace.id, channel.id, member1.id)).status).toBe(201)
+      expect((await addStreamMember(ownerClient, workspace.id, channel.id, member2.id)).status).toBe(201)
 
       // Member1 uploads file to workspace (no stream specified)
       const attachment = await uploadAttachment(member1Client, workspace.id, {
@@ -361,10 +361,10 @@ describe("File Attachments E2E", () => {
       await loginAs(member1Client, testEmail("share-member1"), "Share Member 1")
       await loginAs(member2Client, testEmail("share-member2"), "Share Member 2")
 
-      await joinWorkspace(member1Client, workspace.id)
-      await joinWorkspace(member2Client, workspace.id)
-      await joinStream(member1Client, workspace.id, channel.id)
-      await joinStream(member2Client, workspace.id, channel.id)
+      const member1 = await joinWorkspace(member1Client, workspace.id)
+      const member2 = await joinWorkspace(member2Client, workspace.id)
+      expect((await addStreamMember(ownerClient, workspace.id, channel.id, member1.id)).status).toBe(201)
+      expect((await addStreamMember(ownerClient, workspace.id, channel.id, member2.id)).status).toBe(201)
 
       // Member1 uploads to workspace and attaches to channel message
       const content = `Shared content ${testRunId}`

--- a/apps/backend/tests/e2e/public-api-conversations.test.ts
+++ b/apps/backend/tests/e2e/public-api-conversations.test.ts
@@ -112,6 +112,12 @@ async function setupTestWorkspace(): Promise<TestContext> {
   })
   const botReadWriteKey = await createBotKey(client, workspace.id, botRes.id, ["messages:read", "messages:write"], "rw")
   const streamsReadOnlyKey = await createBotKey(client, workspace.id, botRes.id, ["streams:read"], "streams-only")
+  for (const streamId of [publicChannel.id, secondPublicChannel.id]) {
+    const grant = await client.post(`/api/workspaces/${workspace.id}/bots/${botRes.id}/streams/${streamId}/grant`, {})
+    if (grant.status !== 204) {
+      throw new Error(`Grant bot stream access failed (${grant.status}): ${JSON.stringify(grant.data)}`)
+    }
+  }
 
   const userKeyRes = await client.post<{ key: { id: string }; value: string }>(
     `/api/workspaces/${workspace.id}/user-api-keys`,

--- a/apps/backend/tests/e2e/public-api-crud.test.ts
+++ b/apps/backend/tests/e2e/public-api-crud.test.ts
@@ -36,6 +36,8 @@ interface TestContext {
   noScopeKey: string
   /** Key from a second bot (different bot identity) */
   secondBotWriteKey: string
+  /** Write key whose bot intentionally has no stream grant. */
+  ungrantedBotWriteKey: string
 }
 
 const baseUrl = () => process.env.TEST_BASE_URL || "http://localhost:3001"
@@ -117,6 +119,7 @@ async function setupTestWorkspace(): Promise<TestContext> {
   const messagesWriteKey = await createBotKey(client, workspace.id, bot1Id, "messages-write", ["messages:write"])
   const usersReadKey = await createBotKey(client, workspace.id, bot1Id, "users-read", ["users:read"])
   const noScopeKey = await createBotKey(client, workspace.id, bot1Id, "search-only", ["messages:search"])
+  await client.post(`/api/workspaces/${workspace.id}/bots/${bot1Id}/streams/${publicChannel.id}/grant`, {})
 
   // Create second bot for cross-bot ownership tests
   const bot2Res = await client.post(`/api/workspaces/${workspace.id}/bots`, {
@@ -129,6 +132,15 @@ async function setupTestWorkspace(): Promise<TestContext> {
     "messages:write",
     "messages:read",
   ])
+  await client.post(`/api/workspaces/${workspace.id}/bots/${bot2Id}/streams/${publicChannel.id}/grant`, {})
+
+  const ungrantedBotRes = await client.post(`/api/workspaces/${workspace.id}/bots`, {
+    type: "shared",
+    name: `Ungranted Bot ${testRunId}`,
+    slug: `ungranted-bot-${testRunId}`,
+  })
+  const ungrantedBotId = (ungrantedBotRes.data as { data: { id: string } }).data.id
+  const ungrantedBotWriteKey = await createBotKey(client, workspace.id, ungrantedBotId, "write", ["messages:write"])
 
   return {
     workspaceId: workspace.id,
@@ -146,6 +158,7 @@ async function setupTestWorkspace(): Promise<TestContext> {
     usersReadKey,
     noScopeKey,
     secondBotWriteKey,
+    ungrantedBotWriteKey,
   }
 }
 
@@ -273,6 +286,19 @@ describe("Public API v1 — CRUD Endpoints", () => {
   })
 
   describe("Send Message", () => {
+    test("denies a public-stream bot nonparticipant with structured read-only details", async () => {
+      const res = await apiPost(
+        `/api/v1/workspaces/${ctx.workspaceId}/streams/${ctx.publicChannelId}/messages`,
+        { content: "must not commit" },
+        ctx.ungrantedBotWriteKey
+      )
+      expect(res.status).toBe(403)
+      expect(await res.json()).toMatchObject({
+        code: "STREAM_READ_ONLY",
+        details: { reason: "not_a_member" },
+      })
+    })
+
     test("should create a bot message with bot name as display name", async () => {
       const res = await apiPost(
         `/api/v1/workspaces/${ctx.workspaceId}/streams/${ctx.publicChannelId}/messages`,
@@ -322,13 +348,13 @@ describe("Public API v1 — CRUD Endpoints", () => {
       expect(userMsg!.authorDisplayName).toBeString()
     })
 
-    test("should return 403 for inaccessible stream", async () => {
+    test("should hide an inaccessible private stream", async () => {
       const res = await apiPost(
         `/api/v1/workspaces/${ctx.workspaceId}/streams/${ctx.privateChannelId}/messages`,
         { content: "test" },
         ctx.messagesWriteKey
       )
-      expect(res.status).toBe(403)
+      expect(res.status).toBe(404)
     })
 
     test("should return 404 without messages:write scope", async () => {

--- a/apps/backend/tests/e2e/public-api-openapi.test.ts
+++ b/apps/backend/tests/e2e/public-api-openapi.test.ts
@@ -113,6 +113,10 @@ async function setupTestWorkspace(pool: Pool): Promise<TestContext> {
     slug: `oa-bot-${testRunId}`,
   })
   const botId = (botRes.data as { data: { id: string } }).data.id
+  const grantRes = await client.post(`/api/workspaces/${workspace.id}/bots/${botId}/streams/${channel.id}/grant`, {})
+  if (grantRes.status !== 204) {
+    throw new Error(`Grant bot stream access failed (${grantRes.status}): ${JSON.stringify(grantRes.data)}`)
+  }
 
   const allKeyRes = await client.post(`/api/workspaces/${workspace.id}/bots/${botId}/keys`, {
     name: "all-scopes",

--- a/apps/backend/tests/e2e/search.test.ts
+++ b/apps/backend/tests/e2e/search.test.ts
@@ -17,6 +17,7 @@ import {
   search,
   joinWorkspace,
   joinStream,
+  addStreamMember,
   archiveStream,
   unarchiveStream,
   getUserId,
@@ -235,7 +236,7 @@ describe("Search E2E Tests", () => {
       const clientB = new TestClient()
       const userB = await loginAs(clientB, testEmail("withB"), "With User B")
       const memberB = await joinWorkspace(clientB, workspace.id)
-      await joinStream(clientB, workspace.id, channelShared.id)
+      expect((await addStreamMember(clientA, workspace.id, channelShared.id, memberB.id)).status).toBe(201)
 
       // User A searches with userB's member ID - should only find messages in shared channel
       const results = await search(clientA, workspace.id, { query: keyword, with: [memberB.id] })
@@ -310,7 +311,7 @@ describe("Search E2E Tests", () => {
       const clientB = new TestClient()
       await loginAs(clientB, testEmail("withThreadB"), "WithThread User B")
       const memberB = await joinWorkspace(clientB, workspace.id)
-      await joinStream(clientB, workspace.id, channel.id)
+      expect((await addStreamMember(clientA, workspace.id, channel.id, memberB.id)).status).toBe(201)
 
       const keyword = `chimera${testRunId}`
       const rootMessage = await sendMessage(clientA, workspace.id, channel.id, `Root ${keyword}`)
@@ -541,7 +542,7 @@ describe("Search E2E Tests", () => {
       const creator = new TestClient()
       await loginAs(creator, testEmail("archcreator"), "Archive Creator")
       const workspace = await createWorkspace(creator, `ArchCreator WS ${testRunId}`)
-      const channel = await createChannel(creator, workspace.id, `archtest-${testRunId}`)
+      const channel = await createChannel(creator, workspace.id, `archtest-${testRunId}`, "public")
       await archiveStream(creator, workspace.id, channel.id)
 
       // Different user joins the workspace and the channel

--- a/apps/backend/tests/e2e/sidebar-archived-roots.test.ts
+++ b/apps/backend/tests/e2e/sidebar-archived-roots.test.ts
@@ -134,7 +134,11 @@ describe("Workspace bootstrap excludes threads rooted in archived streams", () =
       content: "reply after archive",
     })
     expect(status).toBe(403)
-    expect((data as { error?: string }).error).toBe("Cannot send messages to a thread under an archived stream")
+    expect(data).toMatchObject({
+      error: "This stream is read-only",
+      code: "STREAM_READ_ONLY",
+      details: { reason: "archived" },
+    })
   })
 
   test("a socket joined only to a thread's room receives the root's stream:archived event", async () => {

--- a/apps/backend/tests/integration/access-control.test.ts
+++ b/apps/backend/tests/integration/access-control.test.ts
@@ -192,7 +192,7 @@ describe("Access Control", () => {
       })
 
       // Add user as stream member
-      await streamService.addMember(channel.id, streamMemberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, streamMemberWorkspaceId, wsId, ownerId)
 
       // Now they can access
       const stream = await streamService.validateStreamAccess(channel.id, wsId, streamMemberWorkspaceId)
@@ -320,7 +320,7 @@ describe("Access Control", () => {
       )
 
       // Add as member
-      await streamService.addMember(channel.id, newMemberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, newMemberWorkspaceId, wsId, ownerId)
 
       // Now has access
       const stream = await streamService.validateStreamAccess(channel.id, wsId, newMemberWorkspaceId)
@@ -351,14 +351,14 @@ describe("Access Control", () => {
         createdBy: ownerId,
         visibility: Visibilities.PRIVATE,
       })
-      await streamService.addMember(channel.id, removedMemberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, removedMemberWorkspaceId, wsId, ownerId)
 
       // Verify access
       const accessBefore = await streamService.validateStreamAccess(channel.id, wsId, removedMemberWorkspaceId)
       expect(accessBefore.id).toBe(channel.id)
 
       // Remove member
-      await streamService.removeMember(channel.id, removedMemberWorkspaceId)
+      await streamService.removeMember(channel.id, removedMemberWorkspaceId, wsId, ownerId)
 
       // Access revoked
       await expect(streamService.validateStreamAccess(channel.id, wsId, removedMemberWorkspaceId)).rejects.toThrow(
@@ -637,7 +637,7 @@ describe("Access Control", () => {
       )
 
       // Add them to channel
-      await streamService.addMember(channel.id, nonMemberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, nonMemberWorkspaceId, wsId, ownerId)
 
       // Now they can access thread
       const access = await streamService.validateStreamAccess(thread.id, wsId, nonMemberWorkspaceId)
@@ -669,7 +669,7 @@ describe("Access Control", () => {
         createdBy: channelOwnerId,
         visibility: Visibilities.PRIVATE,
       })
-      await streamService.addMember(channel.id, channelMemberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, channelMemberWorkspaceId, wsId, channelOwnerId)
 
       // Create message and thread by a different user (e.g., persona creating thread for mention response)
       const parentMessage = await eventService.createMessage({
@@ -738,7 +738,7 @@ describe("Access Control", () => {
       expect(await streamService.isMember(thread.id, newMemberWorkspaceId)).toBe(false)
 
       // Add them to the thread
-      await streamService.addMember(thread.id, newMemberWorkspaceId, wsId)
+      await streamService.addMember(thread.id, newMemberWorkspaceId, wsId, ownerId)
 
       // Should now be member of both thread AND root channel
       expect(await streamService.isMember(thread.id, newMemberWorkspaceId)).toBe(true)
@@ -774,7 +774,7 @@ describe("Access Control", () => {
         createdBy: ownerId,
         visibility: Visibilities.PRIVATE,
       })
-      await streamService.addMember(channel.id, memberWorkspaceId, wsId)
+      await streamService.addMember(channel.id, memberWorkspaceId, wsId, ownerId)
 
       // Owner is member (auto-added on create)
       expect(await streamService.isMember(channel.id, ownerId)).toBe(true)
@@ -812,7 +812,7 @@ describe("Access Control", () => {
         createdBy: userAId,
         visibility: Visibilities.PUBLIC,
       })
-      await streamService.addMember(channel.id, userBMemberId, wsId)
+      await streamService.addMember(channel.id, userBMemberId, wsId, userAId)
 
       // Create a regular message (visible to both)
       await eventService.createMessage({
@@ -891,7 +891,7 @@ describe("Access Control", () => {
         createdBy: userAId,
         visibility: Visibilities.PUBLIC,
       })
-      await streamService.addMember(channel.id, userBMemberId, wsId)
+      await streamService.addMember(channel.id, userBMemberId, wsId, userAId)
 
       // Create command_dispatched and command_failed events as User A
       const cmdId = commandId()
@@ -982,7 +982,7 @@ describe("Access Control", () => {
         createdBy: ownerId,
         visibility: Visibilities.PRIVATE,
       })
-      await streamService.addMember(memberPrivateChannel.id, viewerId, wsId)
+      await streamService.addMember(memberPrivateChannel.id, viewerId, wsId, ownerId)
 
       // Thread inside the member channel; viewer is NOT added to the thread.
       const parentMessage = await eventService.createMessage({

--- a/apps/backend/tests/integration/agent-session.test.ts
+++ b/apps/backend/tests/integration/agent-session.test.ts
@@ -381,7 +381,7 @@ describe("Message Repository - listSince", () => {
       ...testMessageContent("Third"),
     })
 
-    await eventService.deleteMessage({
+    await eventService.deleteMessageInternal({
       workspaceId: testWorkspaceId,
       streamId: testStreamId,
       messageId: msg2.id,

--- a/apps/backend/tests/integration/conversation-provisional-attach.test.ts
+++ b/apps/backend/tests/integration/conversation-provisional-attach.test.ts
@@ -57,7 +57,7 @@ describe("provisional conversation attach", () => {
       conversation?: { intent: "existing"; conversationId: string }
     } = {}
   ) => {
-    return eventService.createMessageReturningConversation({
+    return eventService.createMessageReturningConversationInternal({
       workspaceId: testWorkspaceId,
       streamId: overrides.streamId ?? testStreamId,
       authorId: overrides.authorId ?? testUserId,

--- a/apps/backend/tests/integration/conversation-settling.test.ts
+++ b/apps/backend/tests/integration/conversation-settling.test.ts
@@ -367,7 +367,7 @@ describe("conversation settling", () => {
     const conversation = await service.processMessage(msgId, testStreamId, testWorkspaceId)
     await pool.query("DELETE FROM outbox")
 
-    await eventService.addReaction({
+    await eventService.addReactionInternal({
       workspaceId: testWorkspaceId,
       streamId: testStreamId,
       messageId: msgId,

--- a/apps/backend/tests/integration/event-sourcing.test.ts
+++ b/apps/backend/tests/integration/event-sourcing.test.ts
@@ -223,7 +223,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Original content"),
       })
 
-      const edited = await eventService.editMessage({
+      const edited = await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: original.id,
@@ -261,7 +261,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Original"),
       })
 
-      const edited = await eventService.editMessage({
+      const edited = await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: original.id,
@@ -290,7 +290,7 @@ describe("Event Sourcing", () => {
       const baselineResult = await pool.query("SELECT COALESCE(MAX(id), 0) as max_id FROM outbox")
       const baselineId = BigInt(baselineResult.rows[0].max_id)
 
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: original.id,
@@ -322,7 +322,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("To be deleted"),
       })
 
-      const deleted = await eventService.deleteMessage({
+      const deleted = await eventService.deleteMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -364,7 +364,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Delete me"),
       })
 
-      await eventService.deleteMessage({
+      await eventService.deleteMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: msg2.id,
@@ -393,7 +393,7 @@ describe("Event Sourcing", () => {
       const baselineResult = await pool.query("SELECT COALESCE(MAX(id), 0) as max_id FROM outbox")
       const baselineId = BigInt(baselineResult.rows[0].max_id)
 
-      await eventService.deleteMessage({
+      await eventService.deleteMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -425,7 +425,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("React to me"),
       })
 
-      const updated = await eventService.addReaction({
+      const updated = await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -464,7 +464,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Popular message"),
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -472,7 +472,7 @@ describe("Event Sourcing", () => {
         userId: user1,
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -480,7 +480,7 @@ describe("Event Sourcing", () => {
         userId: user2,
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -509,7 +509,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("React then unreact"),
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -517,7 +517,7 @@ describe("Event Sourcing", () => {
         userId: testUserId,
       })
 
-      const afterRemove = await eventService.removeReaction({
+      const afterRemove = await eventService.removeReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -549,7 +549,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Double react"),
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -558,7 +558,7 @@ describe("Event Sourcing", () => {
       })
 
       // Add same reaction again - should not duplicate in projection
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -588,7 +588,7 @@ describe("Event Sourcing", () => {
       const baselineResult = await pool.query("SELECT COALESCE(MAX(id), 0) as max_id FROM outbox")
       const baselineId = BigInt(baselineResult.rows[0].max_id)
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -596,7 +596,7 @@ describe("Event Sourcing", () => {
         userId: testUserId,
       })
 
-      await eventService.removeReaction({
+      await eventService.removeReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -668,7 +668,7 @@ describe("Event Sourcing", () => {
         ...testMessageContent("Test"),
       })
 
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -676,7 +676,7 @@ describe("Event Sourcing", () => {
         userId: testUserId,
       })
 
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: message.id,
@@ -753,14 +753,14 @@ describe("Event Sourcing", () => {
         authorType: "user",
         ...testMessageContent("first"),
       })
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: msg1.id,
         actorId: testUserId,
         ...testMessageContent("first (edited)"),
       })
-      await eventService.addReaction({
+      await eventService.addReactionInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: msg1.id,
@@ -774,7 +774,7 @@ describe("Event Sourcing", () => {
         authorType: "user",
         ...testMessageContent("second"),
       })
-      await eventService.deleteMessage({
+      await eventService.deleteMessageInternal({
         workspaceId: testWorkspaceId,
         streamId: testStreamId,
         messageId: msg2.id,

--- a/apps/backend/tests/integration/memo-card-updates.test.ts
+++ b/apps/backend/tests/integration/memo-card-updates.test.ts
@@ -328,7 +328,7 @@ describe("memo:updated", () => {
       messageIds: [citing.id],
       actorId: testUserId,
     })
-    await eventService.moveMessagesToThread({
+    await eventService.moveMessagesToThreadInternal({
       workspaceId: testWorkspaceId,
       sourceStreamId: publicChannel,
       targetMessageId: target.id,

--- a/apps/backend/tests/integration/memo-embed-payloads.test.ts
+++ b/apps/backend/tests/integration/memo-embed-payloads.test.ts
@@ -187,7 +187,7 @@ describe("memo embed summaries on message payloads", () => {
       ...testMessageContent("nothing cited yet"),
     })
 
-    await eventService.editMessage({
+    await eventService.editMessageInternal({
       workspaceId: testWorkspaceId,
       messageId: message.id,
       streamId: channel,
@@ -210,7 +210,7 @@ describe("memo embed summaries on message payloads", () => {
       ...bodyCiting("cited", [sameStreamMemo]),
     })
 
-    await eventService.editMessage({
+    await eventService.editMessageInternal({
       workspaceId: testWorkspaceId,
       messageId: message.id,
       streamId: channel,
@@ -235,7 +235,7 @@ describe("memo embed summaries on message payloads", () => {
         authorType: "user",
         ...bodyCiting("first", [sameStreamMemo]),
       })
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         messageId: message.id,
         streamId: channel,
@@ -263,7 +263,7 @@ describe("memo embed summaries on message payloads", () => {
         authorType: "user",
         ...bodyCiting("cited", [sameStreamMemo]),
       })
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: testWorkspaceId,
         messageId: message.id,
         streamId: channel,

--- a/apps/backend/tests/integration/message-idempotency.test.ts
+++ b/apps/backend/tests/integration/message-idempotency.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
 import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
-import { StreamRepository } from "../../src/features/streams"
+import { StreamMemberRepository, StreamRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
 import { EventService } from "../../src/features/messaging/event-service"
 import { userId, workspaceId, streamId } from "../../src/lib/id"
@@ -36,6 +36,7 @@ describe("Message idempotency", () => {
         companionMode: "off",
         createdBy: testUserId,
       })
+      await StreamMemberRepository.insert(client, testStreamId, testUserId)
     })
   })
 
@@ -67,6 +68,70 @@ describe("Message idempotency", () => {
 
     expect(second.id).toBe(first.id)
     expect(second.contentMarkdown).toBe("hello")
+  })
+
+  test("principal duplicate stays visible after archive and after leaving a public stream", async () => {
+    const service = new EventService(pool)
+    const clientMessageId = `authority_duplicate_${Date.now()}`
+    const params = {
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      authorId: testUserId,
+      authorType: "user" as const,
+      ...testMessageContent("duplicate authority"),
+      clientMessageId,
+    }
+    const first = await service.createMessageForPrincipalReturningConversation(
+      { kind: "user", userId: testUserId },
+      params
+    )
+    await pool.query("UPDATE streams SET archived_at=NOW() WHERE id=$1", [testStreamId])
+    expect(
+      (await service.createMessageForPrincipalReturningConversation({ kind: "user", userId: testUserId }, params))
+        .message.id
+    ).toBe(first.message.id)
+    await pool.query("UPDATE streams SET archived_at=NULL, visibility='public' WHERE id=$1", [testStreamId])
+    await pool.query("DELETE FROM stream_members WHERE stream_id=$1 AND member_id=$2", [testStreamId, testUserId])
+    expect(
+      (await service.createMessageForPrincipalReturningConversation({ kind: "user", userId: testUserId }, params))
+        .message.id
+    ).toBe(first.message.id)
+    await pool.query("UPDATE streams SET visibility='private' WHERE id=$1", [testStreamId])
+    await expect(
+      service.createMessageForPrincipalReturningConversation({ kind: "user", userId: testUserId }, params)
+    ).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    await StreamMemberRepository.insert(pool, testStreamId, testUserId)
+  })
+
+  test("principal duplicate never returns another principal's row", async () => {
+    const service = new EventService(pool)
+    const otherId = userId()
+    await withTransaction(pool, async (client) => {
+      await addTestMember(client, testWorkspaceId, otherId)
+      await StreamMemberRepository.insert(client, testStreamId, otherId)
+    })
+    const clientMessageId = `other_duplicate_${Date.now()}`
+    await service.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: testStreamId,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("owned"),
+      clientMessageId,
+    })
+    await expect(
+      service.createMessageForPrincipalReturningConversation(
+        { kind: "user", userId: otherId },
+        {
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          authorId: otherId,
+          authorType: "user",
+          ...testMessageContent("steal"),
+          clientMessageId,
+        }
+      )
+    ).rejects.toMatchObject({ status: 403, code: "FORBIDDEN" })
   })
 
   test("creates separate messages when clientMessageId differs", async () => {

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -146,7 +146,7 @@ describe("message move integration", () => {
       actorId: actor.id,
     })
 
-    const result = await eventService.moveMessagesToThread({
+    const result = await eventService.moveMessagesToThreadInternal({
       workspaceId: testWorkspaceId,
       sourceStreamId,
       targetMessageId: target.id,
@@ -378,7 +378,7 @@ describe("message move integration", () => {
       messageIds: [moved.id],
       actorId: actor.id,
     })
-    const result = await eventService.moveMessagesToThread({
+    const result = await eventService.moveMessagesToThreadInternal({
       workspaceId: testWorkspaceId,
       sourceStreamId,
       targetMessageId: target.id,

--- a/apps/backend/tests/integration/phantom-unread-fixes.test.ts
+++ b/apps/backend/tests/integration/phantom-unread-fixes.test.ts
@@ -76,7 +76,7 @@ describe("Phantom-unread drift fixes", () => {
       messageIds: [movedA, movedB],
       actorId: actor.id,
     })
-    await eventService.moveMessagesToThread({
+    await eventService.moveMessagesToThreadInternal({
       workspaceId: wid,
       sourceStreamId: source,
       targetMessageId: target,
@@ -129,7 +129,7 @@ describe("Phantom-unread drift fixes", () => {
       messageIds: [m2, m3],
       actorId: actor.id,
     })
-    await eventService.moveMessagesToThread({
+    await eventService.moveMessagesToThreadInternal({
       workspaceId: wid,
       sourceStreamId: source,
       targetMessageId: target,
@@ -178,7 +178,7 @@ describe("Phantom-unread drift fixes", () => {
       [activityId(), wid, recipient.id, source, msg, actor.id]
     )
 
-    await eventService.deleteMessage({
+    await eventService.deleteMessageInternal({
       workspaceId: wid,
       streamId: source,
       messageId: msg,

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -272,7 +272,7 @@ describe("Sparse read overlay", () => {
 
     // msg2 deleted: nobody can ever read it, so it must not hold the watermark
     // down. Reading msg1 + msg3 compacts the whole run.
-    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
+    await eventService.deleteMessageInternal({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
     const snapshot = await withTransaction(pool, (client) =>
       applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1, msg3] })
     )
@@ -293,8 +293,8 @@ describe("Sparse read overlay", () => {
     // must lift the watermark over the dead tail to msg3, or the stream can
     // never fully read from the board (the compaction window is bounded by the
     // overlay's max sequence, which sits below the deleted run).
-    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
-    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg3, actorId: authorId })
+    await eventService.deleteMessageInternal({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
+    await eventService.deleteMessageInternal({ workspaceId: wid, streamId: sid, messageId: msg3, actorId: authorId })
     const snapshot = await withTransaction(pool, (client) =>
       applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1] })
     )
@@ -370,7 +370,7 @@ describe("Sparse read overlay", () => {
     )
     expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(1)
 
-    await streamService.removeMember(sid, reader)
+    await streamService.removeMember(sid, reader, wid, other)
 
     expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
     // The other member's overlay state is untouched by reader's removal.

--- a/apps/backend/tests/integration/stream-read-only-locking.test.ts
+++ b/apps/backend/tests/integration/stream-read-only-locking.test.ts
@@ -1,0 +1,437 @@
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test"
+import type { Pool } from "pg"
+import { BotChannelAccessRepository } from "../../src/features/api-keys"
+import { EventService } from "../../src/features/messaging/event-service"
+import { MessageRepository } from "../../src/features/messaging/repository"
+import { BotRepository } from "../../src/features/public-api/bot-repository"
+import {
+  StreamMemberRepository,
+  StreamRepository,
+  StreamService,
+  assertStreamWritable,
+  type StreamWritePrincipal,
+} from "../../src/features/streams"
+import { setupTestDatabase } from "./setup"
+
+describe("stream write lock statements", () => {
+  let pool: Pool
+  const suffix = crypto.randomUUID().replaceAll("-", "").slice(0, 10)
+  const workspaceId = `ws_lock_${suffix}`
+  const userId = `usr_lock_${suffix}`
+  const botId = `bot_lock_${suffix}`
+  const rootId = `stream_root_${suffix}`
+  const threadId = `stream_thread_${suffix}`
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    await pool.query("INSERT INTO workspaces (id, name, slug, created_by) VALUES ($1, 'Locks', $2, $3)", [
+      workspaceId,
+      `locks-${suffix}`,
+      userId,
+    ])
+    await pool.query(
+      "INSERT INTO users (id, workspace_id, workos_user_id, email, role, slug, name) VALUES ($1,$2,$3,$4,'member',$5,'Locker')",
+      [userId, workspaceId, `wos_${suffix}`, `lock-${suffix}@test.local`, `locker-${suffix}`]
+    )
+    await pool.query(
+      "INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1,$2,'channel','private',$3)",
+      [rootId, workspaceId, userId]
+    )
+    await pool.query(
+      "INSERT INTO streams (id, workspace_id, type, visibility, parent_stream_id, root_stream_id, created_by) VALUES ($1,$2,'thread','private',$3,$3,$4)",
+      [threadId, workspaceId, rootId, userId]
+    )
+    await pool.query("INSERT INTO stream_members (stream_id, member_id) VALUES ($1,$2)", [rootId, userId])
+    await pool.query("INSERT INTO bots (id, workspace_id, api_key_id, name) VALUES ($1,$2,$3,'Locker bot')", [
+      botId,
+      workspaceId,
+      `key_${suffix}`,
+    ])
+    await BotChannelAccessRepository.grantAccess(pool, {
+      id: `bca_${suffix}`,
+      workspaceId,
+      botId,
+      streamId: rootId,
+      grantedBy: userId,
+    })
+  })
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM bot_channel_access WHERE workspace_id=$1", [workspaceId])
+    await pool.query("DELETE FROM stream_members WHERE stream_id = ANY($1)", [[rootId, threadId]])
+    await pool.query("DELETE FROM bots WHERE id=$1", [botId])
+    await pool.query("DELETE FROM streams WHERE workspace_id=$1", [workspaceId])
+    await pool.query("DELETE FROM users WHERE workspace_id=$1", [workspaceId])
+    await pool.query("DELETE FROM workspaces WHERE id=$1", [workspaceId])
+    await pool.end()
+  })
+
+  test("executes stable stream, membership, and grant FOR UPDATE statements against schema", async () => {
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      expect(
+        (await StreamRepository.findByIdsForUpdateBlocking(client, workspaceId, [threadId, rootId])).map((s) => s.id)
+      ).toEqual([rootId, threadId].sort())
+      expect(await StreamMemberRepository.lockMemberships(client, [rootId], userId)).toEqual(new Set([rootId]))
+      expect(await StreamMemberRepository.lockMemberPairs(client, [{ streamId: rootId, memberId: userId }])).toEqual(
+        new Set([`${rootId}:${userId}`])
+      )
+      expect(await BotChannelAccessRepository.lockGrants(client, workspaceId, botId, [rootId])).toEqual(
+        new Set([rootId])
+      )
+      await client.query("ROLLBACK")
+    } finally {
+      client.release()
+    }
+  })
+
+  test("locks a bot row with production SQL", async () => {
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      expect((await BotRepository.findByIdForUpdate(client, workspaceId, botId))?.id).toBe(botId)
+      await client.query("ROLLBACK")
+    } finally {
+      client.release()
+    }
+  })
+
+  test("grant and bot archive serialize; archive winner prevents a grant transition", async () => {
+    const service = new StreamService(pool)
+    await pool.query("DELETE FROM bot_channel_access WHERE workspace_id=$1 AND bot_id=$2", [workspaceId, botId])
+    const grant = await pool.connect()
+    const archive = await pool.connect()
+    try {
+      await grant.query("BEGIN")
+      await service.addBotToStreamOn(grant, threadId, botId, workspaceId, userId)
+      const archivePromise = BotRepository.archive(archive, botId, workspaceId)
+      expect(await Promise.race([archivePromise.then(() => "finished"), Bun.sleep(40).then(() => "blocked")])).toBe(
+        "blocked"
+      )
+      await grant.query("COMMIT")
+      expect((await archivePromise)?.archivedAt).not.toBeNull()
+      expect(
+        (await pool.query("SELECT 1 FROM bot_channel_access WHERE workspace_id=$1 AND bot_id=$2", [workspaceId, botId]))
+          .rowCount
+      ).toBe(1)
+      await pool.query("DELETE FROM bot_channel_access WHERE workspace_id=$1 AND bot_id=$2", [workspaceId, botId])
+      await expect(service.addBotToStream(threadId, botId, workspaceId, userId)).rejects.toMatchObject({ status: 404 })
+      expect(
+        (await pool.query("SELECT 1 FROM bot_channel_access WHERE workspace_id=$1 AND bot_id=$2", [workspaceId, botId]))
+          .rowCount
+      ).toBe(0)
+      await BotRepository.restore(pool, botId, workspaceId)
+      await BotChannelAccessRepository.grantAccess(pool, {
+        id: `bca_race_restore_${suffix}`,
+        workspaceId,
+        botId,
+        streamId: rootId,
+        grantedBy: userId,
+      })
+    } finally {
+      await grant.query("ROLLBACK").catch(() => {})
+      grant.release()
+      archive.release()
+    }
+  })
+
+  test("refuses a bot grant on an archived stream", async () => {
+    const archivedId = `stream_archived_grant_${suffix}`
+    await pool.query(
+      "INSERT INTO streams (id,workspace_id,type,visibility,created_by,archived_at) VALUES ($1,$2,'channel','private',$3,NOW())",
+      [archivedId, workspaceId, userId]
+    )
+    await expect(new StreamService(pool).addBotToStream(archivedId, botId, workspaceId, userId)).rejects.toMatchObject({
+      status: 404,
+      code: "STREAM_NOT_FOUND",
+    })
+    expect(
+      (
+        await pool.query("SELECT 1 FROM bot_channel_access WHERE workspace_id=$1 AND bot_id=$2 AND stream_id=$3", [
+          workspaceId,
+          botId,
+          archivedId,
+        ])
+      ).rowCount
+    ).toBe(0)
+  })
+
+  test("retries edit, delete, and reactions when stale archived placement masks a move", async () => {
+    const staleId = `stream_stale_${suffix}`
+    const currentId = `stream_current_${suffix}`
+    await pool.query(
+      "INSERT INTO streams (id,workspace_id,type,visibility,created_by,archived_at) VALUES ($1,$2,'channel','private',$3,NOW()),($4,$2,'channel','private',$3,NULL)",
+      [staleId, workspaceId, userId, currentId]
+    )
+    await pool.query("INSERT INTO stream_members (stream_id,member_id) VALUES ($1,$3),($2,$3)", [
+      staleId,
+      currentId,
+      userId,
+    ])
+    const service = new EventService(pool)
+    const principal = { kind: "user" as const, userId }
+    const makeMessage = async () =>
+      service.createMessage({
+        workspaceId,
+        streamId: currentId,
+        authorId: userId,
+        authorType: "user",
+        contentJson,
+        contentMarkdown: "locked",
+      })
+    const staleSnapshot = (message: Awaited<ReturnType<typeof makeMessage>>) => ({ ...message, streamId: staleId })
+
+    const editedMessage = await makeMessage()
+    spyOn(MessageRepository, "findById").mockResolvedValueOnce(staleSnapshot(editedMessage))
+    expect(
+      (
+        await service.editMessageForPrincipal(principal, {
+          workspaceId,
+          messageId: editedMessage.id,
+          streamId: staleId,
+          actorId: userId,
+          actorType: "user",
+          contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "edited" }] }] },
+          contentMarkdown: "edited",
+        })
+      )?.streamId
+    ).toBe(currentId)
+
+    const deletedMessage = await makeMessage()
+    spyOn(MessageRepository, "findById").mockResolvedValueOnce(staleSnapshot(deletedMessage))
+    expect(
+      (
+        await service.deleteMessageForPrincipal(principal, {
+          workspaceId,
+          messageId: deletedMessage.id,
+          streamId: staleId,
+          actorId: userId,
+          actorType: "user",
+        })
+      )?.streamId
+    ).toBe(currentId)
+
+    const reactionMessage = await makeMessage()
+    spyOn(MessageRepository, "findById").mockResolvedValueOnce(staleSnapshot(reactionMessage))
+    expect(
+      (
+        await service.addReactionForPrincipal(principal, {
+          workspaceId,
+          messageId: reactionMessage.id,
+          streamId: staleId,
+          emoji: "👍",
+          userId,
+          actorType: "user",
+        })
+      )?.streamId
+    ).toBe(currentId)
+    spyOn(MessageRepository, "findById").mockResolvedValueOnce(staleSnapshot(reactionMessage))
+    expect(
+      (
+        await service.removeReactionForPrincipal(principal, {
+          workspaceId,
+          messageId: reactionMessage.id,
+          streamId: staleId,
+          emoji: "👍",
+          userId,
+          actorType: "user",
+        })
+      )?.streamId
+    ).toBe(currentId)
+
+    const deniedMessages = await Promise.all([makeMessage(), makeMessage(), makeMessage(), makeMessage()])
+    await pool.query("UPDATE streams SET type='system' WHERE id=$1", [currentId])
+    const deniedOperations = [
+      () =>
+        service.editMessageForPrincipal(principal, {
+          workspaceId,
+          messageId: deniedMessages[0].id,
+          streamId: staleId,
+          actorId: userId,
+          actorType: "user",
+          contentJson,
+          contentMarkdown: "denied",
+        }),
+      () =>
+        service.deleteMessageForPrincipal(principal, {
+          workspaceId,
+          messageId: deniedMessages[1].id,
+          streamId: staleId,
+          actorId: userId,
+          actorType: "user",
+        }),
+      () =>
+        service.addReactionForPrincipal(principal, {
+          workspaceId,
+          messageId: deniedMessages[2].id,
+          streamId: staleId,
+          emoji: "👍",
+          userId,
+          actorType: "user",
+        }),
+      () =>
+        service.removeReactionForPrincipal(principal, {
+          workspaceId,
+          messageId: deniedMessages[3].id,
+          streamId: staleId,
+          emoji: "👍",
+          userId,
+          actorType: "user",
+        }),
+    ]
+    for (let index = 0; index < deniedOperations.length; index++) {
+      spyOn(MessageRepository, "findById").mockResolvedValueOnce(staleSnapshot(deniedMessages[index]))
+      await expect(deniedOperations[index]()).rejects.toMatchObject({
+        code: "STREAM_READ_ONLY",
+        details: { reason: "system_stream" },
+      })
+    }
+
+    await pool.query("DELETE FROM stream_members WHERE stream_id=ANY($1)", [[staleId, currentId]])
+    await pool.query("DELETE FROM streams WHERE id=ANY($1)", [[staleId, currentId]])
+  })
+
+  test("checks thread participation at the effective root for users and bots", async () => {
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      expect(
+        (await assertStreamWritable(client, { workspaceId, streamId: threadId, principal: { kind: "user", userId } }))
+          .root.id
+      ).toBe(rootId)
+      await client.query("ROLLBACK")
+      await client.query("BEGIN")
+      expect(
+        (await assertStreamWritable(client, { workspaceId, streamId: threadId, principal: { kind: "bot", botId } }))
+          .root.id
+      ).toBe(rootId)
+      await client.query("ROLLBACK")
+    } finally {
+      client.release()
+    }
+  })
+
+  const contentJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "locked" }] }] }
+
+  async function guardedSend(client: import("pg").PoolClient, principal: StreamWritePrincipal, streamId: string) {
+    const service = new EventService(pool)
+    await assertStreamWritable(client, { workspaceId, streamId, principal })
+    return service.createMessageInTransaction(client, {
+      workspaceId,
+      streamId,
+      authorId: principal.kind === "user" ? principal.userId : principal.botId,
+      authorType: principal.kind,
+      contentJson,
+      contentMarkdown: "locked",
+      clientMessageId: `cmid_${crypto.randomUUID()}`,
+    })
+  }
+
+  const cases = [
+    {
+      name: "direct archive",
+      streamId: rootId,
+      principal: { kind: "user", userId } as const,
+      transition: `UPDATE streams SET archived_at=NOW() WHERE id=$1`,
+      reset: `UPDATE streams SET archived_at=NULL WHERE id=$1`,
+    },
+    {
+      name: "root archive",
+      streamId: threadId,
+      principal: { kind: "user", userId } as const,
+      transition: `UPDATE streams SET archived_at=NOW() WHERE id=$1`,
+      reset: `UPDATE streams SET archived_at=NULL WHERE id=$1`,
+      transitionId: rootId,
+    },
+    {
+      name: "human removal",
+      streamId: rootId,
+      principal: { kind: "user", userId } as const,
+      transition: `DELETE FROM stream_members WHERE stream_id=$1 AND member_id='${userId}'`,
+      reset: `INSERT INTO stream_members (stream_id,member_id) VALUES ($1,'${userId}') ON CONFLICT DO NOTHING`,
+    },
+    {
+      name: "bot revoke",
+      streamId: rootId,
+      principal: { kind: "bot", botId } as const,
+      transition: `DELETE FROM bot_channel_access WHERE stream_id=$1 AND bot_id='${botId}'`,
+      reset: `INSERT INTO bot_channel_access (id,workspace_id,bot_id,stream_id,granted_by) VALUES ('bca_reset_${suffix}','${workspaceId}','${botId}',$1,'${userId}') ON CONFLICT (workspace_id,bot_id,stream_id) DO NOTHING`,
+    },
+  ]
+
+  async function resetAuthorityFacts() {
+    await pool.query("UPDATE streams SET archived_at=NULL WHERE id=$1", [rootId])
+    await pool.query("INSERT INTO stream_members (stream_id,member_id) VALUES ($1,$2) ON CONFLICT DO NOTHING", [
+      rootId,
+      userId,
+    ])
+    await pool.query(
+      "INSERT INTO bot_channel_access (id,workspace_id,bot_id,stream_id,granted_by) VALUES ($1,$2,$3,$4,$5) ON CONFLICT (workspace_id,bot_id,stream_id) DO NOTHING",
+      [`bca_reset_${suffix}`, workspaceId, botId, rootId, userId]
+    )
+  }
+
+  for (const scenario of cases) {
+    test(`${scenario.name}: send lock winner commits before transition`, async () => {
+      await resetAuthorityFacts()
+      await pool.query(scenario.reset, [scenario.transitionId ?? rootId])
+      const writer = await pool.connect()
+      const transition = await pool.connect()
+      try {
+        await writer.query("BEGIN")
+        const sent = await guardedSend(writer, scenario.principal, scenario.streamId)
+        const transitionPromise = transition.query(scenario.transition, [scenario.transitionId ?? rootId])
+        expect(
+          await Promise.race([transitionPromise.then(() => "finished"), Bun.sleep(40).then(() => "blocked")])
+        ).toBe("blocked")
+        await writer.query("COMMIT")
+        await transitionPromise
+        expect((await pool.query("SELECT 1 FROM messages WHERE id=$1", [sent.message.id])).rowCount).toBe(1)
+      } finally {
+        await writer.query("ROLLBACK").catch(() => {})
+        writer.release()
+        transition.release()
+      }
+    })
+
+    test(`${scenario.name}: completed transition denies queued send`, async () => {
+      await resetAuthorityFacts()
+      await pool.query(scenario.reset, [scenario.transitionId ?? rootId])
+      const transition = await pool.connect()
+      const writer = await pool.connect()
+      try {
+        const beforeCount = Number(
+          (await pool.query("SELECT COUNT(*)::int AS count FROM messages WHERE stream_id=$1", [scenario.streamId]))
+            .rows[0].count
+        )
+        await transition.query("BEGIN")
+        await transition.query(scenario.transition, [scenario.transitionId ?? rootId])
+        await writer.query("BEGIN")
+        const sendPromise = guardedSend(writer, scenario.principal, scenario.streamId)
+        expect(
+          await Promise.race([
+            sendPromise.then(
+              () => "finished",
+              () => "rejected"
+            ),
+            Bun.sleep(40).then(() => "blocked"),
+          ])
+        ).toBe("blocked")
+        await transition.query("COMMIT")
+        await expect(sendPromise).rejects.toMatchObject({ status: expect.any(Number) })
+        await writer.query("ROLLBACK")
+        const afterCount = Number(
+          (await pool.query("SELECT COUNT(*)::int AS count FROM messages WHERE stream_id=$1", [scenario.streamId]))
+            .rows[0].count
+        )
+        expect(afterCount).toBe(beforeCount)
+      } finally {
+        await transition.query("ROLLBACK").catch(() => {})
+        await writer.query("ROLLBACK").catch(() => {})
+        transition.release()
+        writer.release()
+      }
+    })
+  }
+})

--- a/apps/backend/tests/integration/thread-graph.test.ts
+++ b/apps/backend/tests/integration/thread-graph.test.ts
@@ -799,7 +799,7 @@ describe("Thread Graph", () => {
       expect(emitted.some((r) => r.event_type === "message:updated")).toBe(false)
 
       // Deleting the reply settles the count back to 0.
-      await eventService.deleteMessage({
+      await eventService.deleteMessageInternal({
         workspaceId: wsId,
         streamId: thread.id,
         messageId: reply.id,

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -208,7 +208,7 @@ describe("Thread Summary", () => {
       const f = await seedThread(1, 1)
       const onlyReply = f.replies[0]!
 
-      await eventService.deleteMessage({
+      await eventService.deleteMessageInternal({
         workspaceId: f.wsId,
         streamId: f.threadId,
         messageId: onlyReply.id,
@@ -321,7 +321,7 @@ describe("Thread Summary", () => {
       const baselineResult = await pool.query("SELECT COALESCE(MAX(id), 0) AS max_id FROM outbox")
       const baselineId = BigInt(baselineResult.rows[0].max_id)
 
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: f.wsId,
         streamId: f.threadId,
         messageId: latestReply.id,
@@ -354,7 +354,7 @@ describe("Thread Summary", () => {
       const baselineResult = await pool.query("SELECT COALESCE(MAX(id), 0) AS max_id FROM outbox")
       const baselineId = BigInt(baselineResult.rows[0].max_id)
 
-      await eventService.editMessage({
+      await eventService.editMessageInternal({
         workspaceId: f.wsId,
         streamId: f.threadId,
         messageId: latestReply.id,

--- a/tests/browser/bot-customization.spec.ts
+++ b/tests/browser/bot-customization.spec.ts
@@ -67,6 +67,9 @@ test.describe("Bot Customization", () => {
     expect(channel).toBeTruthy()
     const streamId = channel!.id
 
+    const grantRes = await page.request.post(`/api/workspaces/${workspaceId}/bots/${botId}/streams/${streamId}/grant`)
+    expect(grantRes.ok()).toBe(true)
+
     // Send a message via the public API using the bot key
     const messageContent = `Bot message from E2E test ${testId}`
     const sendRes = await page.request.post(`/api/v1/workspaces/${workspaceId}/streams/${streamId}/messages`, {


### PR DESCRIPTION
## Problem

Core stream writes currently authorize from snapshots taken outside the transaction that performs the mutation. Archive, membership, bot-grant, and message-placement changes can therefore commit between the check and the write. Public non-members can also read a stream and reach write paths that treat readability as write authority.

## Solution

Move content authority and lifecycle transitions onto one blocking lock protocol.

- `resolveLockedStreamAuthorities` locks effective root and target rows in stable order, then locks the user membership or bot grant before deriving the viewer-relative state.
- `EventService` provides principal-guarded create, edit, delete, reaction, and move entry points. Authority, ownership, mutation, event projection, and outbox writes share one transaction.
- Archive, unarchive, join, leave, remove, and bot-grant paths acquire the same stream and participation locks. Bot grants also pin the bot row against archival.
- Public API user and bot keys pass explicit principals. Accessible read-only streams return `403 STREAM_READ_ONLY` with `details.reason`; inaccessible private resources remain hidden as 404.
- Message mutations recover when a concurrent move invalidates their placement hint. Idempotent retries recheck read access and ownership without requiring the stream to remain writable.

This is PR 2 of the stream read-only stack. Later PRs cover the remaining synchronous surfaces, deferred output, viewer projections, live state, and UI. Plan visualization: https://seer.build/ws_vbyzjvdg6g/b/threa-stream-read-only-plan/

## Files

| Area | Change |
| --- | --- |
| `features/streams/{write-authority,repository,member-repository}.ts` | Blocking effective-stream and participation authority |
| `features/streams/service.ts` | Lifecycle and bot-grant serialization |
| `features/messaging/{event-service,handlers}.ts` | Principal-guarded message, reaction, and move sinks |
| `features/public-api/{handlers,bot-handlers,bot-repository}.ts` | User/bot principal wiring and bot archival locking |
| `tests/integration/stream-read-only-locking.test.ts` | Real-schema lock ordering, transition races, and stale-placement recovery |
| Focused unit, integration, and E2E tests | Structured denials, privacy ordering, idempotency, and public API parity |

## Test plan

- [x] focused backend unit suites: 327 tests
- [x] core locking and idempotency integration suites: 19 tests
- [x] public API E2E suite: 40 tests
- [x] pre-commit repository lint, monorepo typecheck, migration validation, and generated API-doc check

## Known coverage gaps

The production bot-row lock and archive serialization are implemented. The current race test invokes `StreamService.addBotToStreamOn` and `BotRepository.archive` directly; it does not run the HTTP archive adapter's revoke sequence or add guarded bot send to the same race. The suite also lacks a dedicated user-key public-nonparticipant endpoint case and an explicit final move-denial endpoint assertion. These remain in the stack's final mutation inventory and whole-stack pass.

<details>
<summary>📋 Full implementation plan</summary>

# Stream read-only state — implementation plan

## Baseline and scope

- Plan against `origin/main` / `abe0bb1a` (the inspected worktree is identical to that ref).
- This is a cross-layer authorization feature, not an archive-only UI cleanup. The server is authoritative; client state is a hint that suppresses impossible actions and explains denials.
- No database migration. Viewer state is derived from existing stream, root-stream, human-membership, and bot-channel-grant rows. IndexedDB fields are optional and unindexed, so no Dexie schema version is needed.
- Do not put viewer-relative fields on repository `Stream` rows or shared outbox/socket payloads. Add explicit viewer DTOs and project them only at request/bootstrap boundaries.
- Do not add a generic broadcast `stream_read_only_changed` event. Archive events remain shared facts; membership/grant changes remain scoped facts. Recipients recompute their own overlay.

## Binding state model

### Shared contract

Follow the repository’s existing constants SSOT pattern in `packages/types/src/constants.ts` and re-export it from `packages/types/src/index.ts`:

```ts
export const STREAM_READ_ONLY_REASONS = ["archived", "system_stream", "not_a_member"] as const
export type StreamReadOnlyReason = (typeof STREAM_READ_ONLY_REASONS)[number]

export const StreamReadOnlyReasons = {
  ARCHIVED: "archived",
  SYSTEM_STREAM: "system_stream",
  NOT_A_MEMBER: "not_a_member",
} as const satisfies Record<string, StreamReadOnlyReason>

export const StreamErrorCodes = {
  READ_ONLY: "STREAM_READ_ONLY",
} as const
```

`system_stream` is the sole wire value; never serialize, compare, or document `system` as a read-only reason. Define `StreamViewerState`, `ViewerStream`, and `ViewerStreamWithPreview` in `packages/types/src/domain.ts` using the constants type:

```ts
export interface StreamViewerState {
  readOnly: boolean
  readOnlyReason: StreamReadOnlyReason | null
}

export type ViewerStream = Stream & StreamViewerState
export type ViewerStreamWithPreview = StreamWithPreview & StreamViewerState
```

Use `ViewerStream`/`ViewerStreamWithPreview` in viewer-facing response types in `packages/types/src/api.ts`: `WorkspaceBootstrap.streams`, `StreamBootstrap.stream`, app stream list/get/create/update/archive responses, and any nested fresh stream response. Keep `Stream`, `StreamCreatedPayload`, `StreamUpdatedPayload`, archive events, outbox payloads, and internal repository types principal-free.

Add the generic overlay in parallel with existing archive-specific projections:

- Keep `StreamBootstrap.rootArchivedAt`. It is a distinct archive-inheritance fact used by existing archive behavior; generic viewer state does not replace it in this feature.
- Keep `BoardPost.rootArchived`. Board archive filtering specifically needs root archive state and must not filter on generic `streamReadOnly` (which would incorrectly filter system streams and public non-member rows).
- Add `BoardPost.streamReadOnly` and `streamReadOnlyReason` alongside `rootArchived` as the viewer-scoped effective state of the stream receiving the post/reply.
- Add required `readOnly` and nullable `readOnlyReason` properties to the public API `WireStream` schema in `apps/backend/src/features/public-api/routes.ts`.
- Defer removal of either archive-specific field until a separate cleanup proves every inheritance/filter consumer has an equivalent archive-specific source; that cleanup is not part of this stack.

### Truth table and precedence

First resolve access using the existing effective-root model. A missing stream, cross-workspace stream, dangling root, or private stream whose principal lacks effective-root participation/grant remains inaccessible and must not produce a read-only DTO. Preserve the current 404/non-disclosure behavior for those cases.

For every accessible target, derive exactly one state in this order:

| Condition | `readOnly` | `readOnlyReason` |
|---|---:|---|
| Target is archived, or its effective root is archived | `true` | `"archived"` |
| Otherwise target type is `system` | `true` | `"system_stream"` |
| Otherwise the principal lacks participation at the effective root | `true` | `"not_a_member"` |
| Otherwise | `false` | `null` |

Consequences that must be encoded in tests rather than left implicit:

- A public channel/thread remains readable without participation, but is `not_a_member` and cannot perform shared writes.
- A private channel/thread without participation is hidden/revoked, not returned as `not_a_member`.
- A target archive beats `system_stream` and `not_a_member`; `system_stream` beats `not_a_member`.
- Root archive state applies to descendants. A child’s own archive state also seals the child.
- Human participation is the effective-root `stream_members` row. API-key bot participation is the effective-root bot-channel grant. A user-scoped public API key uses its human principal; a bot key uses its bot principal.
- A persona/event actor is presentation identity, not write authority. Deferred work must retain and recheck the initiating human/bot principal.
- Unknown future reason strings received by the frontend still mean read-only and use generic copy.

### Backend authority API

Create `apps/backend/src/features/streams/write-authority.ts` and centralize both projection and mutation checks there; do not grow another collection of handler-local archive/member checks.

The module should expose:

1. A pure `deriveStreamViewerState({ target, root, participates })` implementing the table above.
2. User and API-principal single/batch projection functions. Batch functions load all required roots and participation/grant rows once and return new DTO objects; they never mutate repository rows.
3. A transaction-only `assertStreamWritable(client, { workspaceId, streamId, principal })` that locks, resolves, and returns the target/root plus writable authority, or throws the structured denial below.
4. A narrowly scoped trusted lifecycle capability for writes that exist to record state transitions (for example stream/member/archive system events and system-stream activity). It must be a non-forgeable exported token/constructor accepted only by the low-level mutation API—not a widely propagated `bypassReadOnly: boolean`.

Represent authorization principal separately from event actor:

```ts
type StreamWritePrincipal =
  | { kind: "user"; userId: string }
  | { kind: "bot"; botId: string }
```

Persona, companion, command, scheduled, delegation, enclave, and worker code must pass the initiating user/bot principal at execution time. Trusted lifecycle capability is not a fallback for missing principal data.

For an accessible but read-only target, throw:

```ts
new HttpError("This stream is read-only", {
  status: 403,
  code: "STREAM_READ_ONLY",
  details: { reason },
})
```

Use the same shape through app and public API error middleware. Keep privacy/E2E/validation failures distinct; do not wrap them as read-only. Inaccessible private targets remain 404. Export the error code in the relevant shared error constants so frontend, CLI, and tests do not compare message text.

### Lock protocol and linearization point

All archive/unarchive, leave/remove, and guarded stream mutation paths must use one deterministic protocol:

1. Begin a transaction.
2. Resolve target and effective-root ids in the workspace.
3. Lock stream rows with `SELECT ... FOR UPDATE` in stable id order (effective root and target; one lock if identical).
4. Lock the principal’s participation row/grant at the effective root. Membership removal locks that same row; membership insertion uses the same stream lock before inserting. Bot grants follow the same ordering.
5. Recompute access and read-only state from the locked rows.
6. Perform the mutation and insert its event/outbox records before commit.

Add repository methods in `apps/backend/src/features/streams/repository.ts`, `member-repository.ts`, and the bot channel access repository to support those locks. Do not perform a handler/service precheck and mutate in a later `EventService` transaction. Refactor `EventService` to accept an existing `PoolClient` (or add transaction-scoped variants) so its sequence/event/outbox operations share the authority transaction.

Archive/unarchive and leave/remove are not themselves blocked by the resulting read-only state. They acquire the same locks and serialize against writes. If a write gets the lock first it may commit before the transition; if the transition gets it first the write deterministically fails. Join/invite/remove/leave, unarchive, and stop/cancel controls remain available subject to their existing role/ownership rules.

### Event transitions and recipient-local recomputation

| Durable fact transition | Delivery | Recipient result |
|---|---|---|
| Target/root archived or unarchived | Reuse existing archive/unarchive causal event and shared stream delivery | Recompute target plus cached descendants. Archive produces `archived`; unarchive reveals `system_stream`, `not_a_member`, or writable according to current facts. |
| Current user self-joins or is added | Persist the membership delta with `OutboxRepository`; make `resolveDeliveryGroups` include the existing `userGroup(affectedUserId)` so `BroadcastHandler` writes it to `sync_log` and emits it live | Add effective-root participation, fetch a fresh viewer stream/bootstrap only if the stream is absent, then recompute target/descendants. |
| Current user leaves or is removed | Persist the removal delta and make `resolveDeliveryGroups` include `userGroup(affectedUserId)` as well as any existing `streamGroup(streamId)` lifecycle audience | Public root: retain readable cache and become `not_a_member`. Private root: revoke access and purge server-derived cache. |
| Bot grant added/removed | Persist the bot grant transition; public API bot requests derive from current grant rows | A subsequent list/get/write reflects the new bot overlay; do not broadcast bot-relative viewer state to humans. |

The affected-user membership delta contains only the identifiers/action needed to update participation; it does not carry `readOnly`, `readOnlyReason`, or another viewer’s projection. If the existing `stream:member_added` timeline envelope must retain its canonical `stream`/`event` payload for the stream audience, split the affected-user sync delta from that envelope rather than copying the full timeline payload into a new viewer hint. Offline/reconnect catch-up consumes durable `userGroup` deltas, then fresh bootstrap remains the reconciliation backstop. Shared canonical archive/stream events and viewer-scoped membership deltas must be safe in either arrival order because the client resolver applies precedence from facts.

## Current drifts this stack must remove

- `StreamService.resolveWritableMessageStream` performs an out-of-transaction archive/member check, has legacy text errors, and does not cover system streams.
- App and public message handlers authorize readability separately from `EventService` mutation; public non-members and bot keys without grants can currently reach writes on public streams.
- Edit/delete/reaction paths, message movement, and conversation assignment/merge/split use different or incomplete checks.
- Stream metadata, brief, companion settings, command dispatch, scheduling, and call start/join mostly gate on readability or local archive checks.
- Scheduled, command, companion/persona, delegation, bot-runtime, follow-up, and enclave output can be accepted before a state transition and execute afterward without a common execution-time recheck.
- `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, and `useEffectiveArchived` correctly model archive-specific behavior but do not model system-stream or participation read-only state; they must remain available while generic state is added in parallel.
- Shared stream events cannot safely carry viewer state; current client membership removal drops a private stream shell but does not comprehensively purge its cached event tree.
- `useMessageQueue` retries ordinary 403s. A stale `STREAM_READ_ONLY` rejection must become a terminal, editable failed message rather than an endless retry.

## Stacked delivery plan

Each branch is based on the preceding branch. The ordering intentionally lands server enforcement before advertising a complete viewer contract, and separates the lifecycle race fix from the broad mutation sweep.

### PR 1 — Contract and centralized resolver

- **Branch:** `feat/stream-readonly-contract`
- **base_ref:** `origin/main`
- **Owns:** Shared vocabulary, pure derivation, principal model, structured error, and projection primitives. It does not change endpoint responses or mutation behavior yet.

Changes:

- Add `STREAM_READ_ONLY_REASONS`, `StreamReadOnlyReason`, `StreamReadOnlyReasons`, and `StreamErrorCodes` to the SSOT in `packages/types/src/constants.ts` and export them through `packages/types/src/index.ts`; define `StreamViewerState` and viewer DTO aliases in `domain.ts`. PR 5, not this latent contract PR, switches `api.ts` response properties to those aliases so this PR remains type-correct without endpoint projection.
- Add `apps/backend/src/features/streams/write-authority.ts` with the truth-table function, user/bot participation adapters, single/batch projection helpers, and structured denial helper.
- Reuse effective-root resolution from `apps/backend/src/features/streams/access.ts`; consolidate duplicate root/membership semantics rather than creating a conflicting resolver. Keep read access and write authority as separate methods sharing the same intrinsic facts.
- Add batch queries to `member-repository.ts` and `apps/backend/src/features/public-api/bot-channel-service.ts`/its grant repository so workspace and public list projection will not become N+1.
- Add unit tests covering every precedence/access row, root inheritance, human vs bot principal, public/private behavior, and no mutation of canonical rows.

Acceptance:

- Pure resolver exhaustively matches the table.
- Private non-participants never receive a viewer state from the access+projection facade.
- Repository rows and shared payload types contain no viewer fields.

Focused gates (new test path is created by this PR):

```bash
bun run --cwd packages/types test
bun scripts/test-silent.ts backend-unit src/features/streams/write-authority.test.ts src/features/streams/access.test.ts
bun run --cwd packages/types typecheck
bun run --cwd apps/backend typecheck
```

Exclusions / compatibility / rollout:

- No endpoint projection, mutation enforcement, socket behavior, or UI change. The constants/resolver are latent and safe to deploy alone.
- PR 2 owns transaction enforcement; PR 5 owns response shapes; PRs 6–7 own client consumption.

### PR 2 — Core writes and transition locking

- **Branch:** `feat/stream-readonly-core-writes`
- **base_ref:** `feat/stream-readonly-contract`
- **Owns:** The transaction boundary, sequence of locks, and the highest-risk content mutations/transitions.

Changes:

- Add stable-order stream/member/bot-grant `FOR UPDATE` repository methods and transaction-scoped event mutation support.
- Move archive/unarchive permission checks and updates into one locked transaction in `apps/backend/src/features/streams/service.ts`; retain their lifecycle event/outbox emission through the trusted capability.
- Move join, leave, add, and remove membership/grant transitions onto the same lock protocol. Preserve public content access after human leave; preserve private revocation semantics.
- Replace `resolveWritableMessageStream` and handler-local checks with `assertStreamWritable` inside the transaction that creates a message.
- Guard app create/edit/delete/reaction paths and public API create/edit/delete paths in `apps/backend/src/features/messaging/event-service.ts`, `messaging/handlers.ts`, and `public-api/handlers.ts`. Resolve the API key into a user/bot write principal explicitly; the public API currently has no reaction operations to guard.
- Guard movement/refiling primitives that mutate message placement. Replace archive-specific `assertStreamNotArchived` in `conversations/service.ts` with authority checks for every source/destination stream in stable id order.
- Use the lifecycle capability only for stream-created/member/archive/system activity records. Ordinary user/bot messages into system streams must fail with reason `system_stream`.

Tests:

- Integration tests with two clients/connections coordinate on advisory barriers: write vs archive, write vs root archive, write vs self-leave, write vs admin removal, reaction/edit/delete vs transition, and bot write vs grant removal. Assert serializable outcomes and that no post-transition content event committed.
- Endpoint tests assert exact 403 code/details for all three reasons, app/public parity for both user-key and bot-key principals, public read still succeeds, private removal returns 404, and E2E/privacy errors retain their own codes.
- Existing archive/member event tests prove the trusted lifecycle records still commit.

Acceptance:

- No message/reaction/refile mutation can commit based on an authority snapshot older than a committed archive/member/grant transition.
- Public non-member reads still work; writes fail with `not_a_member`.
- Existing retry/idempotency behavior remains intact for non-read-only failures.

Focused gates (start the repository test database before integration/E2E commands):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/streams/write-authority.test.ts src/features/streams/service.test.ts src/features/public-api/handlers.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-locking.test.ts tests/integration/message-move.test.ts
bun scripts/test-silent.ts backend-e2e tests/e2e/stream-read-only-core.test.ts tests/e2e/public-api-crud.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not yet guard the PR 3 synchronous surfaces, deferred execution, or add response/UI hints. Older clients may first encounter structured 403s on core writes; that is the intended authoritative fallback.
- Existing error parsers that ignore `code/details` still receive a normal 403. PRs 5–7 add richer consumers only after enforcement exists.

### PR 3 — Remaining synchronous mutation boundaries

- **Branch:** `feat/stream-readonly-shared-writes`
- **base_ref:** `feat/stream-readonly-core-writes`
- **Owns:** Complete synchronous API coverage, without worker/agent execution paths.

Changes:

- Guard conversation assignment/unassignment, title/summary edits, merge/split, thread creation/branching, and other shared topology operations in `apps/backend/src/features/conversations/{handlers,service}.ts` and stream thread creation paths. Multi-stream operations lock all effective roots/targets in sorted order before any write.
- Guard shared stream metadata, visibility/name/description/memory/companion changes and stream brief writes in `streams/{handlers,service,brief-handlers,brief-service}.ts`. Keep archive/unarchive and membership management as explicit lifecycle exceptions. Keep personal safety/organization operations—mute, save, local drafts, notification/sidebar settings, and agent/call stop/cancel—outside this guard.
- Guard schedule creation and send-now acceptance in `scheduled-messages/service.ts`; cancellation remains available.
- Guard command dispatch/acceptance in `commands/{availability,handlers}.ts`.
- Guard call start/join in `calls/{access,handlers,service,signaling-gateway}.ts`; leave/end/stop remains available so read-only transitions cannot trap an active participant.
- Route each operation through a transaction-scoped authority check; remove legacy archive/member denial text and readability-as-write checks.

Tests:

- Add a mutation matrix test keyed by operation × reason × root/target to prevent uncovered endpoints.
- Add focused multi-stream lock-order tests for conversation merge/split/move.
- Verify lifecycle/personal exceptions remain callable while read-only and still enforce their pre-existing ownership rules.

Acceptance:

- A repository search for mutation endpoints finds either `assertStreamWritable`, a lower-level guarded service call, or a documented lifecycle/personal exception.
- No handler relies on client hints or an earlier readability check as write authorization.

Focused gates (new matrix path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/conversations/service.test.ts src/features/streams/brief-service.test.ts src/features/scheduled-messages/service.test.ts src/features/commands/handlers.test.ts src/features/calls/service.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-mutation-matrix.test.ts tests/integration/message-move.test.ts tests/integration/calls-leave-end.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not claim worker/agent execution-time safety; PR 4 owns already-queued work. Does not expose DTO hints or change sync/UI.
- Deploying this PR without later layers is safe: synchronous attempts fail authoritatively, while existing clients display their generic 403 handling.

### PR 4 — Deferred work and generated output

- **Branch:** `feat/stream-readonly-deferred-work`
- **base_ref:** `feat/stream-readonly-shared-writes`
- **Owns:** Execution-time authority for work accepted before a state transition.

Changes:

- In `scheduled-messages/worker.ts`, recheck the schedule creator’s principal immediately before sending. On read-only, move the row to the existing terminal/failed outcome with the structured reason; do not retry forever. Cancellation remains possible.
- In `commands/worker.ts`, recheck `requestedBy` before execution and before any eventual stream output. Emit the existing command-failed terminal event using the lifecycle capability; do not execute the command body after denial.
- Thread the initiating principal, distinct from persona actor, through `agents/persona-agent.ts`, companion session/context paths, follow-up service, delegation service, bot-runtime invocation handler, and enclave session handlers. Guard new/retry/steer/claim work acceptance before provider execution where that action starts new work, and recheck immediately before every eventual stream mutation. Stop/cancel/fail bookkeeping remains exempt.
- Route agent tools that mutate shared state (`send_message`, `react_to_message`, follow-up scheduling, `update_stream_brief`, and `delegate_task`) through the same authority service rather than relying only on the enclosing session’s initial check.
- Bot-runtime/public callbacks use the bot grant principal. Companion/persona/delegation/enclave work caused by a human action uses that human principal even when the resulting event actor is a persona.
- Permit only required bookkeeping/terminal status/system activity through the trusted capability; it must not publish generated user-visible content into a read-only target.
- Make denial idempotent and terminal. Preserve transport/provider/E2E failures as separate retry/error classes.

Tests:

- Deterministic tests pause each worker after dequeue/acceptance, archive/remove the principal, resume, and assert no generated content plus one terminal status/failure record.
- Cover human leave from a public channel, private removal, bot grant removal, root archive while targeting a thread, and system stream output.
- Assert stop/cancel and terminal bookkeeping still work after the transition.

Acceptance:

- There is no generic “system” escape hatch available to ordinary generated output.
- Every deferred row/session can identify an existing initiating user/bot principal at execution time; absent identity fails closed rather than being inferred from the presentation actor.

Focused gates (new integration path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/agents/persona-agent-worker.test.ts src/features/agents/follow-up-service.test.ts src/features/scheduled-messages/service.test.ts src/features/public-api/handlers.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-deferred.test.ts tests/integration/agent-session-effects.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- No viewer projection, membership delivery, IndexedDB, or affordance changes. PR 5 advertises state only after synchronous and deferred enforcement are complete.
- Terminal denial must use existing job/session terminal states; no schema migration or retry-policy redesign is included.

### PR 5 — Viewer projections, public contract, and CLI/MCP

- **Branch:** `feat/stream-readonly-projections`
- **base_ref:** `feat/stream-readonly-deferred-work`
- **Owns:** Fresh response coverage and the external API contract after server enforcement is complete.

Changes:

- Project viewer DTOs in workspace bootstrap (`workspaces/handlers.ts`), stream list/get/create/update/archive responses and stream bootstrap (`streams/handlers.ts`/service), and every public API stream list/get response. Use batch projection for lists/bootstrap.
- Keep `rootArchivedAt` in stream bootstrap and add effective `readOnly`/`readOnlyReason` on `stream` in parallel.
- In conversation/board bootstrap projection, populate `BoardPost.streamReadOnly` and `streamReadOnlyReason` using one batch keyed by target stream/effective root. Preserve `rootArchived` and its archive-only query/projection semantics for board filtering; optimize the two projections together only if tests prove both values remain distinct and correct.
- Update public Zod/OpenAPI schemas and examples in `public-api/routes.ts`.
- **Header-versioning policy:** the additive stream fields alone do not require a dated API version and must reach every supported pin, so do not add a downgrade response/spec that strips them. The authorization change is behaviorally breaking, however, so add one new date later than current `2026-07-24` to `packages/types/src/api-versions.ts` and a `VERSION_CHANGES` entry in `public-api/versions/index.ts`. Its operation set must enumerate the public routes whose behavior actually changed after the PR 2–4 inventory—expected stream-writing ids are `sendMessage`, `updateMessage`, `deleteMessage`, `updateStream`, `completeBotInvocation`, `completeBotInvocationSealed`, `sendBotInvocationSealedMessage`, and `completeDelegation`; add/remove an id only if its handler test proves it does/does not cross the guarded stream mutation boundary. Give the entry no downgrade transform: per the binding decision, older pins are documented as behind the behavior change but are not grandfathered into the write bypass. The generated changelog must explicitly say the date marks universal enforcement while `readOnly`/`readOnlyReason` are additive on every pin.
- Regenerate all committed OpenAPI artifacts with `bun run generate:api-docs`; do not hand-edit generated files.
- Update `packages/cli/src/commands/streams.ts` and `tools/streams.ts` response schemas/types. Extend `ThreaApiError` in `packages/cli/src/api-client.ts` to retain structured `details.reason`, so CLI and MCP callers can distinguish read-only from auth/scope failures.

Tests:

- Response-shape tests assert fields are present (including `false`/`null`) in every fresh app/public stream surface and board row.
- Query-count tests cover large workspace/public/board lists and reject N+1 projection.
- Public API version/OpenAPI snapshots verify old pins receive the additive fields and structured denial.
- CLI tests verify JSON/MCP schemas and error detail retention.

Acceptance:

- Fresh viewer stream/board responses include generic fields while retaining the independent archive-only fields and their consumers.
- No viewer-relative fields appear in a shared outbox payload or another principal’s response.
- `bun run generate:api-docs:check` is clean.

Focused gates (new projection path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/public-api/versions/index.test.ts src/features/public-api/handlers.test.ts src/features/streams/handlers.test.ts
bun scripts/test-silent.ts backend-e2e tests/e2e/stream-read-only-projection.test.ts tests/e2e/public-api-versioning.test.ts tests/e2e/public-api-openapi.test.ts tests/e2e/stream-bootstrap.test.ts
bun run --cwd packages/cli test
bun run generate:api-docs:check
bun run --cwd packages/types typecheck
bun run --cwd packages/cli typecheck
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not change shared events, IndexedDB reconciliation, or frontend controls; PRs 6–7 own those layers.
- Old app/CLI clients ignore additive fields. Every public API pin receives the fields and enforcement; the new date documents the universal behavioral break rather than preserving the bypass.
- Keep `rootArchivedAt`/`rootArchived` wire fields and archive filters unchanged; their removal is deferred beyond this stack.

### PR 6 — Live delivery and persisted client state

- **Branch:** `feat/stream-readonly-live-state`
- **base_ref:** `feat/stream-readonly-projections`
- **Owns:** One frontend source of truth across HTTP, IndexedDB, socket deltas, and reconnects.

Changes:

- Add optional `readOnly`/`readOnlyReason` to cached viewer stream rows in `apps/frontend/src/db/database.ts`; persist fresh workspace/stream bootstrap fields in `workspace-sync.ts` and `stream-sync.ts`. Preserve the cold-load overlay when applying principal-free shared `stream_created`/`stream_updated` payloads.
- Add a frontend pure resolver (for example `apps/frontend/src/lib/stream-read-only.ts`) with the same precedence, runtime normalization, and reason-to-copy mapping. Unknown non-null reason disables writes with generic copy.
- Add `useStreamWriteState` and generalize callers onto it while retaining `useEffectiveArchived` as an archive-specific compatibility wrapper. Draft streams remain writable. Fresh DTO/board fields are cold-load fallbacks; once live target/root/membership facts are present, those facts win. A missing legacy optional field must not override known archive/system-stream/non-member facts.
- On `stream_archived`/`stream_unarchived`, recompute and persist the affected target and all cached descendants/board generic fields atomically, while updating `rootArchivedAt`/`rootArchived` through their existing archive-specific paths.
- On current-user `stream_member_added`, persist the minimal membership delta, fetch a fresh viewer stream/bootstrap if no canonical stream is cached, recompute descendants/board generic fields, subscribe, and turn `not_a_member` into writable unless a higher-precedence reason remains.
- On current-user leave/removal, delete membership/read-state. For public roots, retain readable cached streams/events/board content and recompute them to `not_a_member`. For private roots, purge the root/descendant stream rows and server-derived events, slots, board conversations/posts, read/unread state, and query caches; unsubscribe. Keep canonical event payloads unchanged.
- Reconciliation after reconnect/bootstrap must overwrite stale local overlays from fresh viewer DTOs and membership rows.
- Teach `useMessageQueue.ts` and `operation-queue.ts` to classify `STREAM_READ_ONLY` as terminal. Preserve/edit the pending message body and failed optimistic row; remove impossible optimistic mutations for reactions/metadata/schedules. Never auto-retry read-only. A later join/unarchive may let the user explicitly retry.

Tests:

- Pure resolver parity table including unknown reason.
- Workspace/stream bootstrap persistence and principal-free socket merge tests.
- Live archive/unarchive, public leave/join, private removal/re-add, root-to-thread propagation, offline `sync_log` catch-up/reconnect-gap, and two-tab IndexedDB convergence tests.
- Queue tests prove stale submissions preserve authored content, become terminal, do not retry, and can be explicitly retried after writable state returns.

Acceptance:

- Public leave does not make readable content disappear; private removal leaves no server-derived content cache.
- No refresh is needed for archive/membership transitions.
- Draft/pending authored content survives a hint/server race.

Focused gates (new resolver path is created by this PR):

```bash
bun scripts/test-silent.ts frontend src/lib/stream-read-only.test.ts src/hooks/use-effective-archived.test.ts src/hooks/use-message-queue.test.ts src/sync/operation-queue.test.ts src/sync/workspace-sync.test.ts src/sync/stream-sync.test.ts
bun run --cwd apps/frontend typecheck
```

Exclusions / compatibility / rollout:

- Does not claim the complete mutation-affordance sweep; PR 7 owns component wiring and browser coverage.
- Legacy IndexedDB rows without generic fields remain supported through target/root/membership derivation and cold refetch. Live facts override cold DTO/board fallbacks.
- No Dexie schema bump and no product-database migration.

### PR 7 — Complete frontend affordance sweep and adversarial coverage

- **Branch:** `feat/stream-readonly-ui`
- **base_ref:** `feat/stream-readonly-live-state`
- **Owns:** Consistent UX across all mutation surfaces and final whole-feature regression coverage.

Changes:

- Replace archive-only **shared-mutation gating** in `timeline/stream-content.tsx`, `timeline/message-input.tsx`, `thread/stream-panel.tsx`, `conversations/conversation-panel.tsx`, `board/board-card.tsx`, and stream page/header/menu code with `useStreamWriteState` or projected board state. Keep archive inheritance/display/filter consumers on `rootArchivedAt`/`rootArchived`.
- Use one `ComposerDisabledNotice`/copy mapper everywhere:
  - archived: explain that the stream/root is archived;
  - `system_stream`: explain that the system stream is read-only;
  - not member: explain that joining is required and show Join only for a readable public channel when existing permissions allow it;
  - unknown: generic read-only copy.
- Disable or remove mutation affordances for sends/quick replies, reactions, edit/delete, pins/shared message state, thread/branch creation, conversation assignment/merge/split/title edits, shared stream/brief/companion metadata, schedule create/send-now, command dispatch, and call start/join. Destination state governs cross-stream actions; reading/copying/sharing from a read-only source is allowed only when the operation does not mutate that source and the destination is writable.
- Keep readable history, navigation, search, copy, saves, mutes, sidebar/notification preferences, local drafts, join/invite/remove/leave, archive/unarchive, schedule/agent cancellation, and call leave/end/stop controls available under their existing permission rules.
- If state flips while a composer/dialog is open, close or disable the action without clearing its draft/form. If a stale submit reaches the server, show reason-specific feedback and keep editable authored content.
- Keep `use-effective-archived.ts`, `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, and archive-filter tests in this stack. Any removal is a separately reviewed cleanup gated on proof that archive inheritance and board archive filtering are unchanged.

Tests:

- Component tests for each reason and unknown fallback on timeline, thread, conversation panel, board quick reply, message action menu, schedule/command controls, and call controls.
- Browser tests for: public non-member browse → denied write → join → write; public member leave without content loss; private removal with immediate cache/navigation revocation; root archive while a thread/board/conversation composer is open; system stream readability; stale send preserving content; cancel/leave/unarchive exceptions.
- Final endpoint inventory test/review pairs every server mutation route with a guarded service or explicit exception, and every frontend mutating control with generic write state.

Acceptance:

- No user-visible shared mutation appears enabled when the client knows the stream is read-only.
- The server still returns `STREAM_READ_ONLY` correctly when hints are stale or bypassed.
- Existing readable/public and lifecycle escape hatches remain usable.

Focused gates (new browser path is created by this PR):

```bash
bun scripts/test-silent.ts frontend src/components/timeline/message-input.test.tsx src/components/conversations/conversation-panel.test.tsx src/components/board/board-card.test.tsx src/components/call/call-start-menu.test.tsx src/components/composer/scheduled-messages-picker.test.tsx src/components/composer/use-composer-command-send.test.tsx
bun scripts/test-silent.ts browser tests/browser/stream-read-only.spec.ts
bun run --cwd apps/frontend typecheck
```

Exclusions / compatibility / rollout:

- No removal of archive-specific DTO fields, board filtering, hook wrapper, or tests. That cleanup is explicitly deferred.
- UI hints may be stale or absent; all controls still surface the server’s structured denial without discarding authored content.

## Validation gates

The commands below were audited against the root and workspace `package.json` scripts. Run from the repository root. `test:integration` and `test:e2e` require the repository test database; the browser script uses the repository Playwright harness. The per-PR focused commands above invoke the documented `scripts/test-silent.ts` path selector directly and are runnable once that PR’s named new test file exists.

```bash
bun run test:db:start
bun run --cwd packages/types test
bun run --cwd packages/cli test
bun run --cwd apps/backend test:unit
bun run --cwd apps/backend test:integration
bun run --cwd apps/backend test:e2e
bun run --cwd apps/frontend test
bun run typecheck
bun run lint
bun run generate:api-docs:check
bun run test:browser
bun run test:db:stop
```

Focused proof required before merge:

1. Resolver truth table is identical in backend projection, backend denial details, and frontend copy/state.
2. Concurrency tests prove the lock linearization behavior rather than merely sending requests sequentially.
3. Shared outbox/socket fixture snapshots contain no `readOnly` or `readOnlyReason` fields.
4. Public non-member reads survive; private non-member data is absent and purged.
5. Every accepted/deferred operation is rechecked at execution and terminates cleanly after denial.
6. Queue/browser tests prove no authored draft is silently lost and no terminal 403 retries forever.
7. OpenAPI, changelog, CLI, and MCP expose the additive fields and structured error details across supported API pins.

## Explicit non-goals / edge rules

- No persisted `read_only` column and no backfill.
- No admin-configured/custom reasons in this feature.
- No generic viewer-state broadcast and no principal-specific data in shared events/outbox rows.
- Do not conflate read-only with read access: inaccessible private streams remain hidden; public non-members remain readers.
- Do not block recovery/exit/safety operations (join/leave, member management, archive/unarchive, cancel/stop/end) merely because the target is read-only; their existing authorization still applies.
- Visibility changes that revoke private access must continue to use existing access-revocation behavior; they do not introduce a fourth read-only reason.
- Removal of `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, `useEffectiveArchived`, or archive-only board filtering is deferred to a separate proven cleanup.

## Final plan-conformance checklist

- [ ] Constants SSOT is in `packages/types/src/constants.ts` with exactly `archived | system_stream | not_a_member`; no read-only reason uses `system`.
- [ ] Fresh viewer DTOs always include `readOnly` and `readOnlyReason`, with reason non-null iff read-only and precedence archived → system stream → missing effective-root participation.
- [ ] `StreamBootstrap.rootArchivedAt` and `BoardPost.rootArchived` remain in parallel; board archive filtering still uses `rootArchived`, never generic read-only.
- [ ] State is derived with no product migration/column; canonical repository rows and shared stream/workspace outbox payloads remain principal-free.
- [ ] Effective-root access rules hold: public non-members remain readable/read-only; private non-members remain hidden/revoked; target and root archive both seal descendants.
- [ ] User-key and bot-key public list/get/write paths use the correct human membership or bot grant principal, with no pinned-version authorization bypass.
- [ ] Every shared mutation entry point is either transactionally guarded through the central resolver or listed as an intentional lifecycle/personal/stop-cancel exemption.
- [ ] Archive/unarchive, membership/grant transitions, and writes use the same deterministic stream→participation lock order and have real concurrent race tests.
- [ ] Deferred scheduled/command/persona/companion/delegation/bot/enclave outputs preserve the initiating principal and recheck at execution; trusted capabilities cover only lifecycle/system notifications.
- [ ] `STREAM_READ_ONLY` is 403 with `{ details: { reason } }`; E2E/privacy/transport errors remain distinct and private revocation remains non-disclosing.
- [ ] Archive events are reused; self-join/add/remove/leave reach the affected `userGroup` durably via outbox/sync; no generic read-only event exists.
- [ ] Cold DTO/board generic fields are fallbacks, live target/root/membership facts win, offline catch-up and multi-tab ordering converge, and legacy cache rows stay safe.
- [ ] Public leave retains readable cache; private removal purges server-derived cache; stale rejects become terminal without retry loops and preserve editable drafts/pending content.
- [ ] Public API date is justified by the behavioral authorization break, not additive fields; additive fields appear in every pin’s runtime/spec, and the generated changelog states universal enforcement.
- [ ] CLI/MCP retain the additive fields and structured error reason; frontend copy is centralized and unknown future reasons fail closed with generic copy.
- [ ] Every PR uses the stated branch/base_ref, has focused runnable gates, remains deployable with its exclusions, and leaves later-layer ownership explicit.
- [ ] Stack-tip typecheck, lint, docs check, unit/integration/E2E/frontend/browser suites, mutation inventory, race tests, and adversarial scenarios all pass.


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788786532&installation_model_id=20758&pr_number=1815&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1815&signature=7fd2ebb7d9a75c0fbc3df255706f064ec5e107f0047b7a9f6874a2a6c33d0c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->