### PR TITLE
feat: guard synchronous stream mutations

### DIFF
--- a/apps/backend/evals/suites/brief-correction/suite.ts
+++ b/apps/backend/evals/suites/brief-correction/suite.ts
@@ -155,7 +155,7 @@ async function setupTestData(
   // Seed a standing brief as a prior member edit (the contradicts-brief arm).
   if (input.existingBrief) {
     const briefService = new StreamBriefService({ pool })
-    const result = await briefService.update({
+    const result = await briefService.updateInternal({
       workspaceId: ctx.workspaceId,
       streamId: testStreamId,
       content: input.existingBrief,
@@ -250,7 +250,7 @@ async function runBriefCorrectionTask(input: BriefCorrectionInput, ctx: EvalCont
     // as server.ts binds it, so the eval exercises the real write path (INV-45).
     const briefService = new StreamBriefService({ pool: ctx.pool })
     const updateBrief: PersonaAgentDeps["updateBrief"] = async ({ content, reason, expectedVersion }) => {
-      const result = await briefService.update({
+      const result = await briefService.updateInternal({
         workspaceId: ctx.workspaceId,
         streamId,
         content,

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -116,6 +116,9 @@ describe("CallService.startCall — product glare", () => {
 
   it("the winner creates the call and is admitted with a leased endpoint (created=true)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(fakeCall())
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
@@ -141,6 +144,9 @@ describe("CallService.startCall — product glare", () => {
 
   it("the loser re-reads the winning call and is still admitted (created=false)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     const findOpen = spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall({ id: "call_winner" }))
@@ -171,6 +177,9 @@ describe("CallService.startCall — product glare", () => {
 
   it("start into an empty_grace call revives it (no wedge, same locked join path)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall({ status: "empty_grace" }))
@@ -194,6 +203,9 @@ describe("CallService.startCall — product glare", () => {
 
   it("start as join past the cap rejects with CALL_FULL", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall())
@@ -211,6 +223,7 @@ describe("CallService.startCall — DM ring", () => {
 
   it("rings the DM peer with a fresh ringing invitation", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({ target: { id: "stream_dm", type: "dm" } } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_dm", type: "dm" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(fakeCall({ streamId: "stream_dm" }))
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall({ streamId: "stream_dm" }))
@@ -249,6 +262,7 @@ describe("CallService.startCall — DM ring", () => {
 
   it("does not ring when joining an already-active DM call (created=false)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({ target: { id: "stream_dm", type: "dm" } } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_dm", type: "dm" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall({ streamId: "stream_dm" }))
@@ -271,11 +285,13 @@ describe("CallService.startCall — DM ring", () => {
 
   it("rejects a start the user cannot access", async () => {
     stubTransaction()
-    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue(null)
+    spyOn(streamsModule, "assertStreamWritable").mockRejectedValue(
+      Object.assign(new Error("Stream not found"), { status: 404, code: "STREAM_NOT_FOUND" })
+    )
 
     await expect(
       makeService().startCall({ workspaceId: "ws_1", streamId: "stream_x", userId: "usr_a", mode: "video" })
-    ).rejects.toMatchObject({ code: "CALL_STREAM_ACCESS_DENIED", status: 403 })
+    ).rejects.toMatchObject({ code: "STREAM_NOT_FOUND", status: 404 })
   })
 })
 
@@ -284,6 +300,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("revives an empty_grace call and accepts a ringing invitation on join", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall({ status: "empty_grace" }) })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall({ status: "empty_grace" }))
     const revive = spyOn(CallRepository, "reviveFromGrace").mockResolvedValue(fakeCall({ status: "active" }))
@@ -313,6 +332,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("rejects join #51 with CALL_FULL", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(CALL_PRODUCT_CAP)
@@ -324,6 +346,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("rejects a removed participant's self-rejoin", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -336,6 +361,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("lets a left participant rejoin", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -351,6 +379,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("rejects joining an ended call", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall({ status: "ended" }) })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall({ status: "ended" }))
 
@@ -361,6 +392,9 @@ describe("CallService.joinCall — revive, capacity, membership", () => {
 
   it("rejects a join with no call access", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue(null)
 
     await expect(
@@ -374,6 +408,9 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
 
   it("rejects a second live endpoint without takeover", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -389,6 +426,9 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
 
   it("takeover closes the old endpoint and mints epoch max+1", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -420,6 +460,9 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
   it("closes the superseded endpoint's CF session after a takeover commit (S3)", async () => {
     stubTransaction()
     const order: string[] = []
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -452,6 +495,9 @@ describe("CallService.joinCall — second endpoint / takeover", () => {
 
   it("reports the displaced endpoint on a takeover and nothing on a rebind", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(1)
@@ -497,6 +543,9 @@ describe("CallService.startCall — takeover", () => {
 
   it("forwards takeover into the locked join so a second device can displace the first", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall())
@@ -534,6 +583,9 @@ describe("CallService.startCall — takeover", () => {
 
   it("still rejects a second device when takeover is not asked for", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall())
@@ -1218,6 +1270,9 @@ describe("CallService — call_started / call_ended timeline (1.4)", () => {
 
   it("appends a call_started row + stream:call_started outbox + participants_changed when a call is created", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel", visibility: "public" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({
       id: "stream_1",
       type: "channel",
@@ -1261,6 +1316,9 @@ describe("CallService — call_started / call_ended timeline (1.4)", () => {
 
   it("appends NO call_started row when joining an existing call (created=false)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({
       id: "stream_1",
       type: "channel",
@@ -1737,6 +1795,9 @@ describe("CallService.joinCall — incarnation rebind", () => {
 
   it("re-binds a reconnecting endpoint to the same epoch on a reload (new incarnation)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
@@ -1777,6 +1838,9 @@ describe("CallService.joinCall — incarnation rebind", () => {
 
   it("closes the OLD incarnation's CF session after a reload rebind commit (S3)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
@@ -1818,6 +1882,9 @@ describe("CallService.joinCall — incarnation rebind", () => {
 
   it("does NOT close the CF session on a same-incarnation transient reconnect (S3)", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(accessModule, "checkCallAccess").mockResolvedValue({ call: fakeCall() })
     spyOn(CallRepository, "findByIdForUpdate").mockResolvedValue(fakeCall())
     spyOn(CallParticipantRepository, "countJoined").mockResolvedValue(0)
@@ -2013,6 +2080,9 @@ describe("CallService.startCall — expectedCallId ring-acceptance guard (S11)",
 
   it("409 CALL_ENDED when the call it would re-enter differs from expectedCallId", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall({ id: "call_current" }))
@@ -2033,6 +2103,9 @@ describe("CallService.startCall — expectedCallId ring-acceptance guard (S11)",
 
   it("409 CALL_ENDED when a fresh call is created but a specific prior call was expected", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(fakeCall({ id: "call_new" }))
     const admit = spyOn(CallParticipantRepository, "admit").mockResolvedValue(fakeParticipant())
@@ -2051,6 +2124,9 @@ describe("CallService.startCall — expectedCallId ring-acceptance guard (S11)",
 
   it("proceeds when expectedCallId matches the call being re-entered", async () => {
     stubTransaction()
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: { id: "stream_1", type: "channel" },
+    } as never)
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1", type: "channel" } as never)
     spyOn(CallRepository, "insertIfNoActiveCall").mockResolvedValue(null)
     spyOn(CallRepository, "findOpenByStream").mockResolvedValue(fakeCall({ id: "call_expected" }))

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -21,7 +21,13 @@ import {
   callRingOutcomesTotal,
 } from "../../lib/observability"
 import { callId, callInvitationId, callParticipantId, callEndpointId, eventId } from "../../lib/id"
-import { checkStreamAccess, StreamMemberRepository, StreamRepository, StreamEventRepository } from "../streams"
+import {
+  assertStreamWritable,
+  checkStreamAccess,
+  StreamMemberRepository,
+  StreamRepository,
+  StreamEventRepository,
+} from "../streams"
 import { UserRepository } from "../workspaces"
 import { ActivityRepository } from "../activity"
 import { OutboxRepository } from "../../lib/outbox"
@@ -158,10 +164,11 @@ export class CallService {
     tx?: PoolClient
   ): Promise<StartCallResult> {
     const { result, closedSessionIds } = await withTransaction(tx ?? this.pool, async (client) => {
-      const stream = await checkStreamAccess(client, params.streamId, params.workspaceId, params.userId)
-      if (!stream) {
-        throw new HttpError("No access to this stream", { status: 403, code: "CALL_STREAM_ACCESS_DENIED" })
-      }
+      const { target: stream } = await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: params.streamId,
+        principal: { kind: "user", userId: params.userId },
+      })
 
       const inserted = await CallRepository.insertIfNoActiveCall(client, {
         id: callId(),
@@ -287,9 +294,12 @@ export class CallService {
         userId: params.userId,
         callId: params.callId,
       })
-      if (!access) {
-        throw new HttpError("Call not found", { status: 404, code: "CALL_NOT_FOUND" })
-      }
+      if (!access) throw new HttpError("Call not found", { status: 404, code: "CALL_NOT_FOUND" })
+      await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: access.call.streamId,
+        principal: { kind: "user", userId: params.userId },
+      })
 
       return this.joinLockedCall(client, params)
     })

--- a/apps/backend/src/features/commands/availability.test.ts
+++ b/apps/backend/src/features/commands/availability.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from "bun:test"
 import type { BotRuntimeInstance } from "../bot-runtimes"
-import { resolveAdvertisedSessionControlCommandNames } from "./availability"
+import { commandRequiresWritableAuthority, resolveAdvertisedSessionControlCommandNames } from "./availability"
 
 function presence(capabilities: Record<string, unknown>): BotRuntimeInstance {
   return { capabilities } as BotRuntimeInstance
 }
+
+describe("command writable-authority classification", () => {
+  it("exempts exactly invite, stop, and status", () => {
+    expect(["invite", "stop", "status", "reconnect", "key", "unknown"].map(commandRequiresWritableAuthority)).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+    ])
+  })
+})
 
 describe("session-control command advertisement", () => {
   it("makes reconnect available only when the runtime advertises it", () => {

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -13,7 +13,7 @@ import {
   type CommandInfo,
 } from "@threa/types"
 import { withClient, type Querier } from "../../db"
-import { checkStreamAccess, StreamRepository, type Stream } from "../streams"
+import { checkStreamAccess, projectStreamForUser, StreamRepository, type Stream } from "../streams"
 import { BotRepository } from "../public-api"
 import {
   BotRuntimeInstanceRepository,
@@ -30,6 +30,12 @@ import {
   listWorkspaceCommandInfos,
   SESSION_CONTROL_COMMAND_NAMES,
 } from "./catalog"
+
+const READ_ONLY_COMMAND_NAMES = new Set(["invite", "stop", "status"])
+
+export function commandRequiresWritableAuthority(name: string): boolean {
+  return !READ_ONLY_COMMAND_NAMES.has(name.toLowerCase())
+}
 
 export type ResolvedCommand =
   | { info: CommandInfo; executionKind: "server" }
@@ -83,11 +89,23 @@ export class CommandAvailabilityService {
 
   async resolveCommandInTransaction(
     db: Querier,
-    params: { workspaceId: string; userId: string; streamId: string; name: string }
+    params: { workspaceId: string; userId: string; streamId: string; name: string },
+    options?: { includeReadOnlyWorkCommands?: boolean }
   ): Promise<ResolvedCommand | null> {
-    const commands = await this.resolveStreamCommandsInTransaction(db, params)
+    const commands = await this.resolveStreamCommandsInTransaction(db, params, options)
     const lower = params.name.toLowerCase()
     return commands.find((command) => command.info.name.toLowerCase() === lower) ?? null
+  }
+
+  async resolveCommandForDispatch(params: {
+    workspaceId: string
+    userId: string
+    streamId: string
+    name: string
+  }): Promise<ResolvedCommand | null> {
+    return withClient(this.deps.pool, (db) =>
+      this.resolveCommandInTransaction(db, params, { includeReadOnlyWorkCommands: true })
+    )
   }
 
   private async resolveStreamCommands(params: {
@@ -100,15 +118,26 @@ export class CommandAvailabilityService {
 
   private async resolveStreamCommandsInTransaction(
     db: Querier,
-    params: { workspaceId: string; userId: string; streamId: string }
+    params: { workspaceId: string; userId: string; streamId: string },
+    options?: { includeReadOnlyWorkCommands?: boolean }
   ): Promise<ResolvedCommand[]> {
     const stream = await checkStreamAccess(db, params.streamId, params.workspaceId, params.userId)
-    if (!stream || stream.archivedAt) return []
+    if (!stream) return []
+    const projected = await projectStreamForUser(db, {
+      workspaceId: params.workspaceId,
+      stream,
+      userId: params.userId,
+    })
+    if (!projected) return []
+    const writable = !projected.readOnly
 
     const commands: ResolvedCommand[] = []
 
     for (const info of listServerCommandInfos(this.deps.commandRegistry)) {
-      if (await isServerCommandAvailableInStream(info.name, stream, db)) {
+      if (
+        (options?.includeReadOnlyWorkCommands || writable || !commandRequiresWritableAuthority(info.name)) &&
+        (await isServerCommandAvailableInStream(info.name, stream, db))
+      ) {
         commands.push({ info, executionKind: CommandKinds.SERVER })
       }
     }
@@ -127,6 +156,7 @@ export class CommandAvailabilityService {
     if (runtimeTarget) {
       for (const info of listSessionControlCommandInfos()) {
         if (!runtimeTarget.advertisedCommandNames.has(info.name.toLowerCase())) continue
+        if (!options?.includeReadOnlyWorkCommands && !writable && commandRequiresWritableAuthority(info.name)) continue
         commands.push({
           info: applyAdvertisedSuggestions(info, runtimeTarget),
           executionKind: CommandKinds.BOT_RUNTIME,
@@ -161,7 +191,6 @@ async function resolveRuntimeCommandTarget(
   const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(db, rootStreamId)
 
   if (!rootStream || rootStream.workspaceId !== workspaceId) return null
-  if (rootStream.archivedAt) return null
   if (rootStream.type !== StreamTypes.SCRATCHPAD) return null
 
   const active = await StreamActiveActorRepository.findByRootStream(db, workspaceId, rootStream.id)

--- a/apps/backend/src/features/commands/handlers.test.ts
+++ b/apps/backend/src/features/commands/handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Request, Response } from "express"
 import type { Pool, PoolClient } from "pg"
 import { CommandKinds } from "@threa/types"
@@ -33,6 +33,10 @@ function makeResponse() {
 }
 
 describe("command dispatch idempotency", () => {
+  beforeEach(() => {
+    spyOn(streamsModule, "resolveLockedStreamAuthorities").mockResolvedValue([])
+  })
+
   afterEach(() => {
     mock.restore()
   })
@@ -66,7 +70,7 @@ describe("command dispatch idempotency", () => {
     const handlers = createCommandHandlers({
       pool: makePool(),
       commandAvailabilityService: {
-        resolveCommand,
+        resolveCommandForDispatch: resolveCommand,
         listStreamCommands: mock(async () => []),
         listWorkspaceCommands: mock(() => []),
       } as never,
@@ -95,7 +99,9 @@ describe("command dispatch idempotency", () => {
   })
 
   it("refuses replay after stream access is revoked", async () => {
-    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue(null)
+    spyOn(streamsModule, "resolveLockedStreamAuthorities").mockRejectedValue(
+      Object.assign(new Error("Stream not found"), { status: 404, code: "STREAM_NOT_FOUND" })
+    )
     const findReplay = spyOn(CommandDispatchRepository, "findByClientId")
     const handlers = createCommandHandlers({
       pool: makePool(),
@@ -109,14 +115,60 @@ describe("command dispatch idempotency", () => {
     } as Request
     const res = makeResponse()
 
-    await handlers.dispatch(req, res)
-
-    expect({ status: res.statusCode, body: res.body, replayReads: findReplay.mock.calls.length }).toEqual({
-      status: 404,
-      body: { success: false, error: "Stream not found" },
-      replayReads: 0,
-    })
+    await expect(handlers.dispatch(req, res)).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    expect(findReplay).not.toHaveBeenCalled()
   })
+
+  for (const executionKind of [CommandKinds.SERVER, CommandKinds.BOT_RUNTIME] as const) {
+    it(`replays a committed work command under final locked read-only state for ${executionKind}`, async () => {
+      const workEvent = {
+        ...event,
+        payload: { ...event.payload, name: "steer", executionKind },
+      }
+      spyOn(streamsModule, "resolveLockedStreamAuthorities").mockResolvedValue([
+        { state: { readOnly: true, readOnlyReason: "archived" } } as never,
+      ])
+      spyOn(CommandDispatchRepository, "findByClientId")
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ commandId: "cmd_existing", eventId: event.id })
+      spyOn(StreamEventRepository, "findById").mockResolvedValue(workEvent)
+      const insert = spyOn(StreamEventRepository, "insert")
+      const createInvocation = mock(async () => undefined)
+      const resolveInTransaction = mock(async () => null)
+      const handlers = createCommandHandlers({
+        pool: makePool(),
+        commandAvailabilityService: {
+          resolveCommandForDispatch: mock(async () => ({ executionKind, info: {} })),
+          resolveCommandInTransaction: resolveInTransaction,
+          listStreamCommands: mock(async () => []),
+          listWorkspaceCommands: mock(() => []),
+        } as never,
+        botRuntimeService: { createInvocationInTransaction: createInvocation } as never,
+      })
+      const req = {
+        user: { id: "usr_1" },
+        workspaceId: "ws_1",
+        body: { streamId: "stream_1", command: "/steer continue", clientCommandId: "temp_cmd_1" },
+      } as Request
+      const res = makeResponse()
+
+      await handlers.dispatch(req, res)
+
+      expect({
+        status: res.statusCode,
+        commandId: (res.body as { commandId: string }).commandId,
+        inserts: insert.mock.calls.length,
+        invocations: createInvocation.mock.calls.length,
+        transactionAvailabilityCalls: resolveInTransaction.mock.calls.length,
+      }).toEqual({
+        status: 202,
+        commandId: "cmd_existing",
+        inserts: 0,
+        invocations: 0,
+        transactionAvailabilityCalls: 0,
+      })
+    })
+  }
 
   it("replays the winner when a concurrent request wins the idempotency claim", async () => {
     spyOn(streamsModule, "checkStreamAccess").mockResolvedValue({ id: "stream_1" } as never)
@@ -128,7 +180,8 @@ describe("command dispatch idempotency", () => {
     const handlers = createCommandHandlers({
       pool: makePool(),
       commandAvailabilityService: {
-        resolveCommand: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        resolveCommandForDispatch: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        resolveCommandInTransaction: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
         listStreamCommands: mock(async () => []),
         listWorkspaceCommands: mock(() => []),
       } as never,
@@ -157,7 +210,8 @@ describe("command dispatch idempotency", () => {
     const handlers = createCommandHandlers({
       pool: makePool(),
       commandAvailabilityService: {
-        resolveCommand: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        resolveCommandForDispatch: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
+        resolveCommandInTransaction: mock(async () => ({ executionKind: CommandKinds.SERVER, info: {} })),
         listStreamCommands: mock(async () => []),
         listWorkspaceCommands: mock(() => []),
       } as never,

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -6,12 +6,18 @@ import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds, Comm
 import type { BotRuntimeKind, CommandDispatchedPayload } from "@threa/types"
 import { withClient, withTransaction, type Querier } from "../../db"
 import { commandId as generateCommandId, eventId as generateEventId } from "../../lib/id"
+import { HttpError } from "../../lib/errors"
 import { parseCommand } from "./registry"
-import type { CommandAvailabilityService } from "./availability"
+import { commandRequiresWritableAuthority, type CommandAvailabilityService } from "./availability"
 import type { BotRuntimeService } from "../bot-runtimes"
 import { buildRuntimeCommandInvocationMetadata, insertCommandDispatchedEvent } from "./events"
 import { CommandDispatchRepository } from "./repository"
-import { checkStreamAccess, StreamEventRepository, type StreamEvent } from "../streams"
+import {
+  assertViewerStreamWritable,
+  resolveLockedStreamAuthorities,
+  StreamEventRepository,
+  type StreamEvent,
+} from "../streams"
 
 const dispatchCommandSchema = z.object({
   command: z.string().min(1, "command is required"),
@@ -148,28 +154,24 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
       }
 
       if (clientCommandId) {
-        const replayCheck = await withClient(pool, async (client) => {
-          const accessible = (await checkStreamAccess(client, streamId, workspaceId, userId)) != null
-          return {
-            accessible,
-            replay: accessible
-              ? await findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
-              : null,
-          }
+        const replay = await withTransaction(pool, async (client) => {
+          await resolveLockedStreamAuthorities(client, {
+            workspaceId,
+            streamIds: [streamId],
+            principal: { kind: "user", userId },
+          })
+          return findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
         })
-        if (!replayCheck.accessible) {
-          return res.status(404).json({ success: false, error: "Stream not found" })
-        }
-        if (replayCheck.replay) {
+        if (replay) {
           return res.status(202).json({
             success: true,
-            ...replayCheck.replay,
-            event: serializeBigInt(replayCheck.replay.event),
+            ...replay,
+            event: serializeBigInt(replay.event),
           })
         }
       }
 
-      const resolved = await commandAvailabilityService.resolveCommand({
+      const resolved = await commandAvailabilityService.resolveCommandForDispatch({
         workspaceId,
         userId,
         streamId,
@@ -197,6 +199,17 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
 
       if (resolved.executionKind === CommandKinds.SERVER) {
         const dispatch = await withTransaction(pool, async (client) => {
+          const [authority] = await resolveLockedStreamAuthorities(client, {
+            workspaceId,
+            streamIds: [streamId],
+            principal: { kind: "user", userId },
+          })
+          const committedReplay = clientCommandId
+            ? await findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
+            : null
+          if (committedReplay) return committedReplay
+          if (commandRequiresWritableAuthority(parsed.name)) assertViewerStreamWritable(authority.state)
+
           const replay = await claimOrReplayCommandDispatch(client, {
             workspaceId,
             userId,
@@ -206,6 +219,20 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
             eventId: evtId,
           })
           if (replay) return replay
+
+          const current = await commandAvailabilityService.resolveCommandInTransaction(
+            client,
+            {
+              workspaceId,
+              userId,
+              streamId,
+              name: parsed.name,
+            },
+            { includeReadOnlyWorkCommands: true }
+          )
+          if (!current || current.executionKind !== CommandKinds.SERVER) {
+            throw new HttpError("Command is no longer available", { status: 404, code: "COMMAND_NOT_AVAILABLE" })
+          }
 
           const event = await insertCommandDispatchedEvent(client, {
             workspaceId,
@@ -230,6 +257,17 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
       }
 
       const dispatch = await withTransaction(pool, async (client) => {
+        const [authority] = await resolveLockedStreamAuthorities(client, {
+          workspaceId,
+          streamIds: [streamId],
+          principal: { kind: "user", userId },
+        })
+        const committedReplay = clientCommandId
+          ? await findCommandDispatchReplay(client, { workspaceId, userId, streamId, clientCommandId })
+          : null
+        if (committedReplay) return committedReplay
+        if (commandRequiresWritableAuthority(parsed.name)) assertViewerStreamWritable(authority.state)
+
         const replay = await claimOrReplayCommandDispatch(client, {
           workspaceId,
           userId,
@@ -239,6 +277,20 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           eventId: evtId,
         })
         if (replay) return replay
+
+        const current = await commandAvailabilityService.resolveCommandInTransaction(
+          client,
+          {
+            workspaceId,
+            userId,
+            streamId,
+            name: parsed.name,
+          },
+          { includeReadOnlyWorkCommands: true }
+        )
+        if (!current || current.executionKind !== CommandKinds.BOT_RUNTIME) {
+          throw new HttpError("Command is no longer available", { status: 404, code: "COMMAND_NOT_AVAILABLE" })
+        }
 
         const event = await insertCommandDispatchedEvent(client, {
           workspaceId,
@@ -258,20 +310,20 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           name: parsed.name,
           args: parsed.args,
         })
-        const routing = resolveRuntimeInvocationRouting(parsed.name, resolved.runtime.runtimeKind)
+        const routing = resolveRuntimeInvocationRouting(parsed.name, current.runtime.runtimeKind)
         await botRuntimeService.createInvocationInTransaction(client, {
           workspaceId,
-          rootStreamId: resolved.runtime.rootStreamId,
-          activeStreamId: resolved.runtime.activeStreamId,
+          rootStreamId: current.runtime.rootStreamId,
+          activeStreamId: current.runtime.activeStreamId,
           sourceMessageId: cmdId,
-          responseStreamId: resolved.runtime.responseStreamId,
-          actorId: resolved.runtime.botId,
+          responseStreamId: current.runtime.responseStreamId,
+          actorId: current.runtime.botId,
           trigger: routing.trigger,
           requiredCapability: routing.requiredCapability,
           promptMarkdown: `/${parsed.name}${parsed.args ? ` ${parsed.args}` : ""}`,
           authorUserId: userId,
-          targetInstanceId: resolved.runtime.targetInstanceId,
-          targetRuntimeSessionId: resolved.runtime.targetRuntimeSessionId,
+          targetInstanceId: current.runtime.targetInstanceId,
+          targetRuntimeSessionId: current.runtime.targetRuntimeSessionId,
           metadata,
         })
 

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -512,7 +512,7 @@ export function createConversationHandlers({
         return res.status(404).json({ error: "Conversation not found" })
       }
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
-      res.json(await conversationService.regenerateTitle({ workspaceId, conversationId }))
+      res.json(await conversationService.regenerateTitle({ workspaceId, conversationId, actorUserId: userId }))
     },
 
     /**

--- a/apps/backend/src/features/conversations/service.apply-split.test.ts
+++ b/apps/backend/src/features/conversations/service.apply-split.test.ts
@@ -5,6 +5,7 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import * as delivery from "./conversation-delivery"
 import { StreamRepository } from "../streams"
+import * as streamsModule from "../streams"
 import { MessageRepository, type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -68,6 +69,7 @@ function setup(options: { source: Conversation; primaries: Record<string, string
   const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
   spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
     fn(fakeClient)) as typeof dbModule.withTransaction)
+  spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({} as never)
 
   spyOn(StreamRepository, "findById").mockResolvedValue({ id: "chan_1", type: "channel" } as never)
 

--- a/apps/backend/src/features/conversations/service.reassign-messages.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign-messages.test.ts
@@ -5,6 +5,7 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import * as delivery from "./conversation-delivery"
 import { StreamRepository } from "../streams"
+import * as streamsModule from "../streams"
 import { MessageRepository, type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -53,6 +54,7 @@ function messageMap(ids: string[]): Map<string, Message> {
 }
 
 interface Spies {
+  assertStreamWritable: ReturnType<typeof spyOn>
   insert: ReturnType<typeof spyOn>
   removePrimaryMessages: ReturnType<typeof spyOn>
   addPrimaryMessages: ReturnType<typeof spyOn>
@@ -78,6 +80,7 @@ function setup(options: {
   const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
   spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
     fn(fakeClient)) as typeof dbModule.withTransaction)
+  const assertStreamWritable = spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({} as never)
 
   spyOn(StreamRepository, "findById").mockResolvedValue({ id: "chan_1", type: "channel" } as never)
 
@@ -139,6 +142,7 @@ function setup(options: {
   })
 
   return {
+    assertStreamWritable,
     insert,
     removePrimaryMessages: spyOn(ConversationRepository, "removePrimaryMessages").mockResolvedValue(undefined as never),
     addPrimaryMessages: spyOn(ConversationRepository, "addPrimaryMessages").mockResolvedValue(undefined as never),
@@ -351,6 +355,7 @@ describe("ConversationService.reassignMessagesToConversation archived streams", 
           ? { id: "chan_1", type: "thread", rootStreamId: "chan_root" }
           : { id: "chan_root", type: "channel", rootStreamId: null, archivedAt: new Date() }) as never
     )
+    spies.assertStreamWritable.mockRejectedValue(streamsModule.createStreamReadOnlyError("archived"))
 
     await expect(reassign(["m1", "m2"], { kind: "new" })).rejects.toMatchObject({ status: 403 })
     expect(spies.insert).not.toHaveBeenCalled()

--- a/apps/backend/src/features/conversations/service.reassign.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign.test.ts
@@ -5,6 +5,7 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import * as delivery from "./conversation-delivery"
 import { StreamRepository } from "../streams"
+import * as streamsModule from "../streams"
 import { MessageRepository, type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -69,10 +70,19 @@ function setup(options: {
   spyOn(StreamRepository, "findById").mockImplementation(
     async (_c: unknown, id: string) => (STREAMS[id] ?? null) as never
   )
-  spyOn(MessageRepository, "findByIdForUpdate").mockImplementation(async (_c: unknown, id: string) => {
+  spyOn(streamsModule, "assertStreamsWritable").mockImplementation(async (_c, params) => {
+    const denied = params.streamIds
+      .map((id) => STREAMS[id])
+      .find((stream) => stream?.archivedAt || (stream?.rootStreamId && STREAMS[stream.rootStreamId]?.archivedAt))
+    if (denied) throw Object.assign(new Error("read only"), { status: 403, code: "STREAM_READ_ONLY" })
+    return []
+  })
+  const findMessage = async (_c: unknown, id: string) => {
     const base = MESSAGES[id]
     return base ? ({ id, streamId: base.streamId, authorId: base.authorId } as unknown as Message) : null
-  })
+  }
+  spyOn(MessageRepository, "findById").mockImplementation(findMessage)
+  spyOn(MessageRepository, "findByIdForUpdate").mockImplementation(findMessage)
 
   spyOn(ConversationRepository, "findById").mockImplementation(
     async (_c: unknown, id: string) => options.conversations[id] ?? null

--- a/apps/backend/src/features/conversations/service.split.test.ts
+++ b/apps/backend/src/features/conversations/service.split.test.ts
@@ -5,6 +5,7 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import * as delivery from "./conversation-delivery"
 import { StreamRepository } from "../streams"
+import * as streamsModule from "../streams"
 import { MessageRepository, type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import * as dbModule from "../../db"
@@ -83,6 +84,7 @@ function setup(options?: {
   const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
   spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
     fn(fakeClient)) as typeof dbModule.withTransaction)
+  spyOn(streamsModule, "assertStreamsWritable").mockResolvedValue([])
 
   const streams = { ...STREAMS, ...(options?.streamOverrides ?? {}) }
   spyOn(StreamRepository, "findById").mockImplementation(

--- a/apps/backend/src/features/conversations/service.test.ts
+++ b/apps/backend/src/features/conversations/service.test.ts
@@ -39,6 +39,8 @@ describe("ConversationService.updateConversation — user status lock", () => {
   beforeEach(() => {
     spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, cb: (client: unknown) => unknown) =>
       cb({})) as never)
+    spyOn(ConversationRepository, "findById").mockResolvedValue(fakeConversation())
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({} as never)
     updateSpy = spyOn(ConversationRepository, "update").mockResolvedValue(fakeConversation())
     updateTopicSpy = spyOn(ConversationRepository, "updateTopicSummary").mockResolvedValue(
       fakeConversation({ topicSummary: "New title", topicSummarySource: "explicit", topicSummaryRevision: 1 })
@@ -56,7 +58,12 @@ describe("ConversationService.updateConversation — user status lock", () => {
 
   test("locks the status against the extractor when the user sets it (Mark resolved / Reopen)", async () => {
     const service = new ConversationService(POOL)
-    await service.updateConversation({ workspaceId: "ws_1", conversationId: "conv_1", status: "resolved" })
+    await service.updateConversation({
+      workspaceId: "ws_1",
+      conversationId: "conv_1",
+      status: "resolved",
+      actorUserId: "usr_1",
+    })
 
     expect(updateSpy).toHaveBeenCalledWith(
       expect.anything(),
@@ -68,7 +75,12 @@ describe("ConversationService.updateConversation — user status lock", () => {
 
   test("leaves the lock untouched on a rename-only edit (no status change)", async () => {
     const service = new ConversationService(POOL)
-    await service.updateConversation({ workspaceId: "ws_1", conversationId: "conv_1", topicSummary: "New title" })
+    await service.updateConversation({
+      workspaceId: "ws_1",
+      conversationId: "conv_1",
+      topicSummary: "New title",
+      actorUserId: "usr_1",
+    })
 
     expect(updateSpy.mock.calls[0]![3]).toEqual(expect.objectContaining({ statusLockedByUser: undefined }))
     expect(updateTopicSpy).toHaveBeenCalledWith(

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -4,7 +4,14 @@ import { ConversationRepository, distinctAuthors, type Conversation } from "./re
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageConversationStateRepository } from "./settling-repository"
 import { MessageRepository, type Message } from "../messaging"
-import { StreamRepository, applySparseRead, applySparseUnread, type ReadStateSnapshot } from "../streams"
+import {
+  assertStreamWritable,
+  assertStreamsWritable,
+  StreamRepository,
+  applySparseRead,
+  applySparseUnread,
+  type ReadStateSnapshot,
+} from "../streams"
 import { ActivityRepository } from "../activity"
 import { AttachmentRepository, hydrateAttachmentSummaries } from "../attachments"
 import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
@@ -217,28 +224,11 @@ export interface ApplySplitResult {
 }
 
 /**
- * Re-filing a message is a write to its stream, so it obeys the same archived
- * rule as sending one (`StreamService.resolveWritableMessageStream`): the
- * effective root's `archivedAt` seals every thread under it (INV-62), and the
- * anchor's own row seals it directly.
- */
-async function assertStreamNotArchived(client: Querier, streamId: string): Promise<void> {
-  const stream = await StreamRepository.findById(client, streamId)
-  if (stream?.archivedAt) {
-    throw new HttpError("Cannot move messages in an archived stream", { status: 403 })
-  }
-  if (stream?.rootStreamId) {
-    const root = await StreamRepository.findById(client, stream.rootStreamId)
-    if (root?.archivedAt) {
-      throw new HttpError("Cannot move messages in a thread under an archived stream", { status: 403 })
-    }
-  }
-}
-
-/**
  * Public interface for querying conversations.
  * Computes temporal staleness on read.
  */
+class StaleMessagePlacementError extends Error {}
+
 export class ConversationService {
   constructor(private pool: Pool) {}
 
@@ -548,153 +538,166 @@ export class ConversationService {
   async reassignMessage(params: ReassignMessageParams): Promise<ReassignMessageResult> {
     const { workspaceId, conversationId, messageId, userId } = params
 
-    return withTransaction(this.pool, async (client) => {
-      const target = await ConversationRepository.findById(client, conversationId)
-      if (!target || target.workspaceId !== workspaceId) {
-        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
-      }
+    for (let attempt = 0; attempt < 3; attempt++) {
+      let attemptedStreamId: string | null = null
+      try {
+        return await withTransaction(this.pool, async (client) => {
+          const target = await ConversationRepository.findById(client, conversationId)
+          if (!target || target.workspaceId !== workspaceId) {
+            throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+          }
 
-      // Lock-then-read in one statement (INV-20): the same row lock that
-      // serializes us against concurrent boundary extractions also guarantees
-      // the streamId/authorId we validate against can't be changed by a
-      // concurrent message move between read and write.
-      const message = await MessageRepository.findByIdForUpdate(client, messageId)
-      if (!message) {
-        throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
-      }
-      // One-root rule, same as the assigner's `existing` directive: same stream
-      // passes trivially; a cross-stream move between the root and its threads
-      // (the board's "move to sub-topic" re-file) passes; a cross-root move is
-      // rejected. Membership moves only — the message row itself never leaves
-      // its stream (re-file, not relocation).
-      if (message.streamId !== target.streamId) {
-        const [targetRoot, messageRoot] = await Promise.all([
-          effectiveRootId(client, target.streamId),
-          effectiveRootId(client, message.streamId),
-        ])
-        if (targetRoot !== messageRoot) {
-          throw new HttpError("Conversation is in a different root stream", {
-            status: 400,
-            code: "CONVERSATION_NOT_IN_ROOT",
+          const messageSnapshot = await MessageRepository.findById(client, messageId)
+          attemptedStreamId = messageSnapshot?.streamId ?? null
+          if (!messageSnapshot) {
+            throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+          }
+          await assertStreamsWritable(client, {
+            workspaceId,
+            streamIds: [messageSnapshot.streamId, target.streamId],
+            principal: { kind: "user", userId },
           })
-        }
-      }
+          const message = await MessageRepository.findByIdForUpdate(client, messageId)
+          if (!message) throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+          if (message.streamId !== messageSnapshot.streamId) throw new StaleMessagePlacementError()
+          // One-root rule, same as the assigner's `existing` directive: same stream
+          // passes trivially; a cross-stream move between the root and its threads
+          // (the board's "move to sub-topic" re-file) passes; a cross-root move is
+          // rejected. Membership moves only — the message row itself never leaves
+          // its stream (re-file, not relocation).
+          if (message.streamId !== target.streamId) {
+            const [targetRoot, messageRoot] = await Promise.all([
+              effectiveRootId(client, target.streamId),
+              effectiveRootId(client, message.streamId),
+            ])
+            if (targetRoot !== messageRoot) {
+              throw new HttpError("Conversation is in a different root stream", {
+                status: 400,
+                code: "CONVERSATION_NOT_IN_ROOT",
+              })
+            }
+          }
 
-      await assertStreamNotArchived(client, message.streamId)
-      if (target.streamId !== message.streamId) await assertStreamNotArchived(client, target.streamId)
+          const previous = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
+          if (previous?.id === target.id) {
+            // Already where the user wants it — report current state, record nothing.
+            return { conversation: addStalenessFields(target), previousConversation: null }
+          }
 
-      const previous = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
-      if (previous?.id === target.id) {
-        // Already where the user wants it — report current state, record nothing.
-        return { conversation: addStalenessFields(target), previousConversation: null }
-      }
+          if (previous) {
+            await ConversationRepository.removePrimaryMessage(client, workspaceId, previous.id, messageId)
+            // Moving a conversation's only message out leaves an empty shell that
+            // would otherwise stay "active" forever; resolve it. Moving a message
+            // back into it (the undo path) reactivates it below.
+            await ConversationRepository.resolveIfEmpty(client, workspaceId, previous.id)
+          }
+          await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, messageId, message.authorId)
+          // Deliberately unconditional, not just for the undo path: a user moving
+          // a message into ANY resolved conversation is declaring it has activity
+          // again, so it returns to the active lifecycle.
+          await ConversationRepository.reactivateIfInactive(client, workspaceId, target.id)
 
-      if (previous) {
-        await ConversationRepository.removePrimaryMessage(client, workspaceId, previous.id, messageId)
-        // Moving a conversation's only message out leaves an empty shell that
-        // would otherwise stay "active" forever; resolve it. Moving a message
-        // back into it (the undo path) reactivates it below.
-        await ConversationRepository.resolveIfEmpty(client, workspaceId, previous.id)
-      }
-      await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, messageId, message.authorId)
-      // Deliberately unconditional, not just for the undo path: a user moving
-      // a message into ANY resolved conversation is declaring it has activity
-      // again, so it returns to the active lifecycle.
-      await ConversationRepository.reactivateIfInactive(client, workspaceId, target.id)
+          await ConversationFeedbackRepository.insert(client, {
+            id: conversationFeedbackId(),
+            workspaceId,
+            streamId: message.streamId,
+            messageId,
+            fromConversationId: previous?.id ?? null,
+            toConversationId: target.id,
+            userId,
+          })
 
-      await ConversationFeedbackRepository.insert(client, {
-        id: conversationFeedbackId(),
-        workspaceId,
-        streamId: message.streamId,
-        messageId,
-        fromConversationId: previous?.id ?? null,
-        toConversationId: target.id,
-        userId,
-      })
+          // A user re-filing a provisionally-placed message IS the human ruling:
+          // the row follows the message to its new home and settles there, so the
+          // emptied source can never be left holding a settling row.
+          await MessageConversationStateRepository.settleForConversationTarget(
+            client,
+            workspaceId,
+            messageId,
+            target.id,
+            "user"
+          )
 
-      // A user re-filing a provisionally-placed message IS the human ruling:
-      // the row follows the message to its new home and settles there, so the
-      // emptied source can never be left holding a settling row.
-      await MessageConversationStateRepository.settleForConversationTarget(
-        client,
-        workspaceId,
-        messageId,
-        target.id,
-        "user"
-      )
+          const touchedIds = previous ? [previous.id, target.id] : [target.id]
+          await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      const touchedIds = previous ? [previous.id, target.id] : [target.id]
-      await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
+          // `previous` and `target` share one access root (the one-root guard above,
+          // INV-62) but can be anchored in different streams under it — the root and
+          // one of its threads — so delivery is resolved per conversation stream,
+          // mirroring the boundary extractor's cross-stream persist.
+          const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+          const deliveryFor = async (streamId: string) => {
+            let resolved = deliveryByStreamId.get(streamId)
+            if (!resolved) {
+              const stream = await StreamRepository.findById(client, streamId)
+              resolved = await resolveConversationDelivery(client, stream)
+              deliveryByStreamId.set(streamId, resolved)
+            }
+            return resolved
+          }
 
-      // `previous` and `target` share one access root (the one-root guard above,
-      // INV-62) but can be anchored in different streams under it — the root and
-      // one of its threads — so delivery is resolved per conversation stream,
-      // mirroring the boundary extractor's cross-stream persist.
-      const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
-      const deliveryFor = async (streamId: string) => {
-        let resolved = deliveryByStreamId.get(streamId)
-        if (!resolved) {
-          const stream = await StreamRepository.findById(client, streamId)
-          resolved = await resolveConversationDelivery(client, stream)
-          deliveryByStreamId.set(streamId, resolved)
-        }
-        return resolved
-      }
+          const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
+          const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+            client,
+            workspaceId,
+            touchedIds
+          )
+          for (const conv of touched) {
+            const { parentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
+            await OutboxRepository.insert(client, "conversation:updated", {
+              workspaceId,
+              streamId: conv.streamId,
+              conversationId: conv.id,
+              conversation: addStalenessFields(conv),
+              parentStreamId,
+              streamVisibility,
+              settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
+            })
+          }
 
-      const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
-      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
-        client,
-        workspaceId,
-        touchedIds
-      )
-      for (const conv of touched) {
-        const { parentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
-        await OutboxRepository.insert(client, "conversation:updated", {
-          workspaceId,
-          streamId: conv.streamId,
-          conversationId: conv.id,
-          conversation: addStalenessFields(conv),
-          parentStreamId,
-          streamVisibility,
-          settlingMessageIds: settlingByConversation.get(conv.id) ?? [],
+          if (previous) {
+            await OutboxRepository.insert(client, "conversation:message_reassigned", {
+              workspaceId,
+              streamId: message.streamId,
+              messageId,
+              fromConversationId: previous.id,
+              toConversationId: target.id,
+              reason: "user_correction",
+            })
+          } else {
+            await OutboxRepository.insert(client, "conversation:message_assigned", {
+              workspaceId,
+              streamId: message.streamId,
+              parentStreamId: (await deliveryFor(message.streamId)).parentStreamId,
+              messageId,
+              conversationId: target.id,
+              isPrimary: true,
+              reason: "user_correction",
+            })
+          }
+
+          const findTouched = (id: string): Conversation | undefined => touched.find((c) => c.id === id)
+          const updatedTarget = findTouched(target.id)
+          if (!updatedTarget) {
+            // The target row vanished mid-transaction despite the row lock — fail
+            // loudly (INV-11) rather than returning stale membership.
+            throw new Error(`Conversation ${target.id} disappeared during reassignment`)
+          }
+          const updatedPrevious = previous ? findTouched(previous.id) : undefined
+
+          return {
+            conversation: addStalenessFields(updatedTarget),
+            previousConversation: updatedPrevious ? addStalenessFields(updatedPrevious) : null,
+          }
         })
+      } catch (error) {
+        if (attempt === 2) throw error
+        if (error instanceof StaleMessagePlacementError) continue
+        const current = await MessageRepository.findById(this.pool, messageId)
+        if (!current || current.streamId === attemptedStreamId) throw error
       }
-
-      if (previous) {
-        await OutboxRepository.insert(client, "conversation:message_reassigned", {
-          workspaceId,
-          streamId: message.streamId,
-          messageId,
-          fromConversationId: previous.id,
-          toConversationId: target.id,
-          reason: "user_correction",
-        })
-      } else {
-        await OutboxRepository.insert(client, "conversation:message_assigned", {
-          workspaceId,
-          streamId: message.streamId,
-          parentStreamId: (await deliveryFor(message.streamId)).parentStreamId,
-          messageId,
-          conversationId: target.id,
-          isPrimary: true,
-          reason: "user_correction",
-        })
-      }
-
-      const findTouched = (id: string): Conversation | undefined => touched.find((c) => c.id === id)
-      const updatedTarget = findTouched(target.id)
-      if (!updatedTarget) {
-        // The target row vanished mid-transaction despite the row lock — fail
-        // loudly (INV-11) rather than returning stale membership.
-        throw new Error(`Conversation ${target.id} disappeared during reassignment`)
-      }
-      const updatedPrevious = previous ? findTouched(previous.id) : undefined
-
-      return {
-        conversation: addStalenessFields(updatedTarget),
-        previousConversation: updatedPrevious ? addStalenessFields(updatedPrevious) : null,
-      }
-    })
+    }
+    throw new Error("Unreachable")
   }
 
   /**
@@ -711,51 +714,85 @@ export class ConversationService {
   async settleMessage(params: SettleMessageParams): Promise<SettleMessageResult> {
     const { workspaceId, conversationId, messageId, userId } = params
 
-    return withTransaction(this.pool, async (client) => {
-      const conversation = await ConversationRepository.findById(client, conversationId)
-      if (!conversation || conversation.workspaceId !== workspaceId) {
-        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
-      }
+    for (let attempt = 0; attempt < 3; attempt++) {
+      let attemptedStreamId: string | null = null
+      try {
+        return await withTransaction(this.pool, async (client) => {
+          const conversation = await ConversationRepository.findById(client, conversationId)
+          if (!conversation || conversation.workspaceId !== workspaceId) {
+            throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+          }
 
-      const message = await MessageRepository.findById(client, messageId)
-      if (!message || !conversation.messageIds.includes(messageId)) {
-        throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
-      }
+          const message = await MessageRepository.findById(client, messageId)
+          attemptedStreamId = message?.streamId ?? null
+          if (!message || !conversation.messageIds.includes(messageId)) {
+            throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+          }
 
-      const settled = await MessageConversationStateRepository.settle(client, workspaceId, [messageId], "user")
-      if (settled.length > 0) {
-        await ConversationFeedbackRepository.insert(client, {
-          id: conversationFeedbackId(),
-          workspaceId,
-          streamId: message.streamId,
-          messageId,
-          fromConversationId: conversation.id,
-          toConversationId: conversation.id,
-          userId,
+          await assertStreamWritable(client, {
+            workspaceId,
+            streamId: message.streamId,
+            principal: { kind: "user", userId },
+          })
+          const lockedMessage = await MessageRepository.findByIdForUpdate(client, messageId)
+          if (!lockedMessage || lockedMessage.streamId !== message.streamId) throw new StaleMessagePlacementError()
+          const lockedConversation = await ConversationRepository.findByIdForUpdate(client, workspaceId, conversationId)
+          if (!lockedConversation || !lockedConversation.messageIds.includes(messageId)) {
+            throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+          }
+
+          const settled = await MessageConversationStateRepository.settle(client, workspaceId, [messageId], "user")
+          if (settled.length > 0) {
+            await ConversationFeedbackRepository.insert(client, {
+              id: conversationFeedbackId(),
+              workspaceId,
+              streamId: message.streamId,
+              messageId,
+              fromConversationId: conversation.id,
+              toConversationId: conversation.id,
+              userId,
+            })
+            await emitSettledConversationUpdates(client, workspaceId, settled)
+          }
+
+          const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
+            client,
+            workspaceId,
+            [conversation.id]
+          )
+
+          return {
+            conversation: addStalenessFields(lockedConversation),
+            previousConversation: null,
+            settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
+          }
         })
-        await emitSettledConversationUpdates(client, workspaceId, settled)
+      } catch (error) {
+        if (attempt === 2) throw error
+        if (error instanceof StaleMessagePlacementError) continue
+        const current = await MessageRepository.findById(this.pool, messageId)
+        if (!current || current.streamId === attemptedStreamId) throw error
       }
-
-      const settlingByConversation = await MessageConversationStateRepository.listSettlingByConversationIds(
-        client,
-        workspaceId,
-        [conversation.id]
-      )
-
-      return {
-        conversation: addStalenessFields(conversation),
-        previousConversation: null,
-        settlingMessageIds: settlingByConversation.get(conversation.id) ?? [],
-      }
-    })
+    }
+    throw new Error("Unreachable")
   }
 
   async regenerateTitle(params: {
     workspaceId: string
     conversationId: string
+    actorUserId: string
   }): Promise<{ conversation: ConversationWithStaleness; deferred: false }> {
     const { workspaceId, conversationId } = params
     return withTransaction(this.pool, async (client) => {
+      const snapshot = await ConversationRepository.findById(client, conversationId)
+      if (!snapshot || snapshot.workspaceId !== workspaceId) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      await assertStreamWritable(client, {
+        workspaceId,
+        streamId: snapshot.streamId,
+        principal: { kind: "user", userId: params.actorUserId },
+      })
       const locked = await ConversationRepository.findByIdForUpdate(client, workspaceId, conversationId)
       if (!locked) throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
       const stream = await StreamRepository.findById(client, locked.streamId)
@@ -840,6 +877,16 @@ export class ConversationService {
   }): Promise<{ conversation: ConversationWithStaleness }> {
     const { workspaceId, conversationId, topicSummary, status, actorUserId } = params
     return withTransaction(this.pool, async (client) => {
+      const snapshot = await ConversationRepository.findById(client, conversationId)
+      if (!snapshot || snapshot.workspaceId !== workspaceId) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      if (!actorUserId) throw new Error("actorUserId is required for conversation mutation")
+      await assertStreamWritable(client, {
+        workspaceId,
+        streamId: snapshot.streamId,
+        principal: { kind: "user", userId: actorUserId },
+      })
       let updated = await ConversationRepository.update(client, workspaceId, conversationId, {
         status,
         // A user-set status is authoritative — lock it so the extractor's LLM stops
@@ -905,6 +952,15 @@ export class ConversationService {
     const { workspaceId, conversationId, threadStreamId, actorUserId } = params
 
     return withTransaction(this.pool, async (client) => {
+      const snapshot = await ConversationRepository.findById(client, conversationId)
+      if (!snapshot || snapshot.workspaceId !== workspaceId) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      await assertStreamsWritable(client, {
+        workspaceId,
+        streamIds: [snapshot.streamId, threadStreamId],
+        principal: { kind: "user", userId: actorUserId },
+      })
       // Lock the source: any op that removes a primary from it must UPDATE this
       // row, so holding the lock keeps `messageIds` stable through the split and
       // serializes a concurrent split (the loser re-reads an empty move set).
@@ -1087,9 +1143,11 @@ export class ConversationService {
     const { workspaceId, streamId, messageIds, target, actorUserId } = params
 
     return withTransaction(this.pool, async (client) => {
-      // Every moving message and an existing destination are pinned to this
-      // stream below, so one archived check covers the whole batch.
-      await assertStreamNotArchived(client, streamId)
+      await assertStreamWritable(client, {
+        workspaceId,
+        streamId,
+        principal: { kind: "user", userId: actorUserId },
+      })
 
       const uniqueIds = [...new Set(messageIds)]
 
@@ -1379,6 +1437,11 @@ export class ConversationService {
     const { workspaceId, streamId, conversationId, groups, actorUserId } = params
 
     return withTransaction(this.pool, async (client) => {
+      await assertStreamWritable(client, {
+        workspaceId,
+        streamId,
+        principal: { kind: "user", userId: actorUserId },
+      })
       const source = await ConversationRepository.findByIdForUpdate(client, workspaceId, conversationId)
       if (!source) {
         throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1214,7 +1214,11 @@ export function createPublicApiHandlers({
       if (!link) {
         throw new HttpError("No active runtime session link found", { status: 404, code: "NOT_FOUND" })
       }
-      const updated = await streamService.updateStream(link.activeStreamId, { displayName: data.displayName })
+      const updated = await streamService.updateStream(
+        link.activeStreamId,
+        { displayName: data.displayName },
+        { workspaceId: req.workspaceId!, principal: { kind: "bot", botId: req.botApiKey.botId } }
+      )
       if (!updated) {
         throw new HttpError("Linked stream not found", { status: 404, code: "NOT_FOUND" })
       }
@@ -2136,7 +2140,14 @@ export function createPublicApiHandlers({
         throw new HttpError("No API key context", { status: 401, code: "UNAUTHORIZED" })
       }
 
-      const updated = await streamService.updateStream(streamId, { description, actorId, actorType })
+      const principal = req.userApiKey
+        ? { kind: "user" as const, userId: req.user!.id }
+        : { kind: "bot" as const, botId: req.botApiKey!.botId }
+      const updated = await streamService.updateStream(
+        streamId,
+        { description, actorId, actorType },
+        { workspaceId, principal }
+      )
       if (!updated || updated.archivedAt) {
         throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
       }

--- a/apps/backend/src/features/public-api/update-stream.test.ts
+++ b/apps/backend/src/features/public-api/update-stream.test.ts
@@ -90,11 +90,11 @@ describe("public API updateStream", () => {
     const { res, getBody } = createResponse()
     await handlers.updateStream(userRequest({ description: "New blurb" }), res)
 
-    expect(updateStream).toHaveBeenCalledWith("stream_1", {
-      description: "New blurb",
-      actorId: "usr_1",
-      actorType: "user",
-    })
+    expect(updateStream).toHaveBeenCalledWith(
+      "stream_1",
+      { description: "New blurb", actorId: "usr_1", actorType: "user" },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
     expect(getBody()).toMatchObject({ data: { id: "stream_1", description: "New blurb" } })
   })
 
@@ -108,11 +108,11 @@ describe("public API updateStream", () => {
 
     await handlers.updateStream(botRequest({ description: "From a bot" }), createResponse().res)
 
-    expect(updateStream).toHaveBeenCalledWith("stream_1", {
-      description: "From a bot",
-      actorId: "bot_1",
-      actorType: "bot",
-    })
+    expect(updateStream).toHaveBeenCalledWith(
+      "stream_1",
+      { description: "From a bot", actorId: "bot_1", actorType: "bot" },
+      { workspaceId: "ws_1", principal: { kind: "bot", botId: "bot_1" } }
+    )
   })
 
   it("clears the description with an empty string", async () => {
@@ -124,7 +124,11 @@ describe("public API updateStream", () => {
 
     await handlers.updateStream(userRequest({ description: "" }), createResponse().res)
 
-    expect(updateStream).toHaveBeenCalledWith("stream_1", { description: "", actorId: "usr_1", actorType: "user" })
+    expect(updateStream).toHaveBeenCalledWith(
+      "stream_1",
+      { description: "", actorId: "usr_1", actorType: "user" },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
   })
 
   it("rejects with 403 when the stream is not accessible", async () => {

--- a/apps/backend/src/features/scheduled-messages/service.test.ts
+++ b/apps/backend/src/features/scheduled-messages/service.test.ts
@@ -4,6 +4,7 @@ import { CompanionModes, ScheduledMessageStatuses, StreamTypes, Visibilities } f
 import { ScheduledMessagesService } from "./service"
 import { ScheduledMessagesRepository, type ScheduledMessage } from "./repository"
 import { StreamRepository, StreamMemberRepository } from "../streams"
+import * as streamsModule from "../streams"
 import type { EventService } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import { QueueRepository } from "../../lib/queue"
@@ -94,6 +95,9 @@ const fakeEventService = (override: Partial<EventService> = {}): EventService =>
 
 function setupService(eventService: EventService = fakeEventService()) {
   spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as PoolClient))
+  spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({ target: fakeStream() } as never)
+  spyOn(streamsModule, "resolveLockedStreamAuthorities").mockResolvedValue([])
+  spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
   return new ScheduledMessagesService({ pool: {} as any, eventService })
 }
 
@@ -103,6 +107,7 @@ describe("ScheduledMessagesService.schedule", () => {
   it("rejects when the stream isn't in the caller's workspace (workspace-scope guard)", async () => {
     const service = setupService()
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream({ workspaceId: "ws_other" }))
+    spyOn(streamsModule, "assertStreamWritable").mockRejectedValue(new Error("Stream not found"))
 
     await expect(
       service.schedule({
@@ -124,6 +129,9 @@ describe("ScheduledMessagesService.schedule", () => {
   it("refuses to schedule into an E2E stream (server can't seal at fire time) — E2EE-3", async () => {
     const service = setupService()
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream({ e2eEnabled: true }))
+    spyOn(streamsModule, "assertStreamWritable").mockResolvedValue({
+      target: fakeStream({ e2eEnabled: true }),
+    } as never)
     const insertSpy = spyOn(ScheduledMessagesRepository, "insert")
 
     await expect(
@@ -148,6 +156,7 @@ describe("ScheduledMessagesService.schedule", () => {
     const service = setupService()
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream({ visibility: Visibilities.PRIVATE }))
     spyOn(StreamMemberRepository, "isMember").mockResolvedValue(false)
+    spyOn(streamsModule, "assertStreamWritable").mockRejectedValue(new Error("not a member"))
 
     await expect(
       service.schedule({

--- a/apps/backend/src/features/scheduled-messages/service.ts
+++ b/apps/backend/src/features/scheduled-messages/service.ts
@@ -13,8 +13,7 @@ import { HttpError, isUniqueViolation } from "../../lib/errors"
 // the same — see service.ts there for the TDZ explanation).
 import "../workspaces"
 import { OutboxRepository } from "../../lib/outbox"
-import { StreamRepository, StreamMemberRepository, type Stream } from "../streams"
-import { Visibilities } from "@threa/types"
+import { assertStreamWritable, resolveLockedStreamAuthorities, StreamRepository } from "../streams"
 import { MessageRepository } from "../messaging"
 import { EventService } from "../messaging"
 import { scheduledMessageId, scheduledMessageQueueId } from "../../lib/id"
@@ -105,45 +104,56 @@ export class ScheduledMessagesService {
   async schedule(params: ScheduleParams): Promise<ScheduledMessageView> {
     const clamped = clampToFuture(params.scheduledFor)
 
-    return withTransaction(this.pool, async (client) => {
-      if (params.clientMessageId) {
-        const existing = await ScheduledMessagesRepository.findByClientMessageId(
-          client,
-          params.workspaceId,
-          params.userId,
-          params.clientMessageId
-        )
-        if (existing) return toScheduledMessageView(existing)
-      }
-
-      await this.ensureStreamWriteAccess(client, params.workspaceId, params.userId, params.streamId)
-
-      if (params.parentMessageId) {
-        const parent = await MessageRepository.findById(client, params.parentMessageId)
-        if (!parent || parent.deletedAt !== null) {
-          throw new HttpError("Parent message not found", {
-            status: 404,
-            code: "SCHEDULED_MESSAGE_PARENT_UNAVAILABLE",
-          })
+    try {
+      return await withTransaction(this.pool, async (client) => {
+        if (params.clientMessageId) {
+          const existing = await ScheduledMessagesRepository.findByClientMessageId(
+            client,
+            params.workspaceId,
+            params.userId,
+            params.clientMessageId
+          )
+          if (existing) {
+            await resolveLockedStreamAuthorities(client, {
+              workspaceId: params.workspaceId,
+              streamIds: [existing.streamId],
+              principal: { kind: "user", userId: params.userId },
+            })
+            return toScheduledMessageView(existing)
+          }
         }
-        // Workspace-scope check (INV-8): MessageRepository.findById is keyed
-        // by the message PK alone, so we must verify the parent belongs to
-        // the caller's workspace via its stream. Without this, a caller could
-        // attach a foreign workspace's message id and the row would be
-        // accepted (and silently leak workspace boundaries at fire time).
-        const parentStream = await StreamRepository.findById(client, parent.streamId)
-        if (!parentStream || parentStream.workspaceId !== params.workspaceId) {
-          throw new HttpError("Parent message not found", {
-            status: 404,
-            code: "SCHEDULED_MESSAGE_PARENT_UNAVAILABLE",
-          })
-        }
-      }
 
-      const id = scheduledMessageId()
-      let row: ScheduledMessage
-      try {
-        row = await ScheduledMessagesRepository.insert(client, {
+        const authority = await assertStreamWritable(client, {
+          workspaceId: params.workspaceId,
+          streamId: params.streamId,
+          principal: { kind: "user", userId: params.userId },
+        })
+        await this.assertSchedulingTransportSupported(client, authority.target)
+
+        if (params.parentMessageId) {
+          const parent = await MessageRepository.findById(client, params.parentMessageId)
+          if (!parent || parent.deletedAt !== null) {
+            throw new HttpError("Parent message not found", {
+              status: 404,
+              code: "SCHEDULED_MESSAGE_PARENT_UNAVAILABLE",
+            })
+          }
+          // Workspace-scope check (INV-8): MessageRepository.findById is keyed
+          // by the message PK alone, so we must verify the parent belongs to
+          // the caller's workspace via its stream. Without this, a caller could
+          // attach a foreign workspace's message id and the row would be
+          // accepted (and silently leak workspace boundaries at fire time).
+          const parentStream = await StreamRepository.findById(client, parent.streamId)
+          if (!parentStream || parentStream.workspaceId !== params.workspaceId) {
+            throw new HttpError("Parent message not found", {
+              status: 404,
+              code: "SCHEDULED_MESSAGE_PARENT_UNAVAILABLE",
+            })
+          }
+        }
+
+        const id = scheduledMessageId()
+        const row: ScheduledMessage = await ScheduledMessagesRepository.insert(client, {
           id,
           workspaceId: params.workspaceId,
           userId: params.userId,
@@ -157,32 +167,36 @@ export class ScheduledMessagesService {
           scheduledFor: clamped,
           clientMessageId: params.clientMessageId,
         })
-      } catch (err) {
-        // Concurrent duplicate insert with the same client_message_id — refetch
-        // the winner and return it. Same shape the message-create path uses.
-        if (params.clientMessageId && isUniqueViolation(err, "idx_scheduled_messages_client_id")) {
-          const existing = await ScheduledMessagesRepository.findByClientMessageId(
-            client,
-            params.workspaceId,
-            params.userId,
-            params.clientMessageId
-          )
-          if (existing) return toScheduledMessageView(existing)
+
+        const queueId = await this.enqueueSendJob(client, row)
+        const updated = (await ScheduledMessagesRepository.findById(client, params.workspaceId, params.userId, id)) ?? {
+          ...row,
+          queueMessageId: queueId,
         }
-        throw err
-      }
 
-      const queueId = await this.enqueueSendJob(client, row)
-      const updated = (await ScheduledMessagesRepository.findById(client, params.workspaceId, params.userId, id)) ?? {
-        ...row,
-        queueMessageId: queueId,
-      }
+        const view = toScheduledMessageView(updated)
+        await this.publishUpsert(client, view, params.userId)
 
-      const view = toScheduledMessageView(updated)
-      await this.publishUpsert(client, view, params.userId)
-
-      return view
-    })
+        return view
+      })
+    } catch (err) {
+      if (!params.clientMessageId || !isUniqueViolation(err, "idx_scheduled_messages_client_id")) throw err
+      return withTransaction(this.pool, async (client) => {
+        const winner = await ScheduledMessagesRepository.findByClientMessageId(
+          client,
+          params.workspaceId,
+          params.userId,
+          params.clientMessageId!
+        )
+        if (!winner) throw err
+        await resolveLockedStreamAuthorities(client, {
+          workspaceId: params.workspaceId,
+          streamIds: [winner.streamId],
+          principal: { kind: "user", userId: params.userId },
+        })
+        return toScheduledMessageView(winner)
+      })
+    }
   }
 
   async list(params: ListScheduledParams): Promise<{ scheduled: ScheduledMessageView[]; nextCursor: string | null }> {
@@ -273,7 +287,14 @@ export class ScheduledMessagesService {
    */
   async update(params: UpdateScheduledParams): Promise<ScheduledMessageView> {
     return withTransaction(this.pool, async (client) => {
-      const existing = await this.assertPendingOrThrow(client, params)
+      const existing = await this.findOwnedOrThrow(client, params)
+      const authority = await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: existing.streamId,
+        principal: { kind: "user", userId: params.userId },
+      })
+      await this.assertSchedulingTransportSupported(client, authority.target)
+      this.assertRowPending(existing)
 
       const updated = await ScheduledMessagesRepository.update(client, {
         workspaceId: params.workspaceId,
@@ -345,7 +366,14 @@ export class ScheduledMessagesService {
 
   async sendNow(params: { workspaceId: string; userId: string; id: string }): Promise<ScheduledMessageView> {
     return withTransaction(this.pool, async (client) => {
-      const existing = await this.assertPendingOrThrow(client, params)
+      const existing = await this.findOwnedOrThrow(client, params)
+      const authority = await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: existing.streamId,
+        principal: { kind: "user", userId: params.userId },
+      })
+      await this.assertSchedulingTransportSupported(client, authority.target)
+      this.assertRowPending(existing)
 
       // Claim the row atomically (status flip → sending). `force` drops the
       // `scheduled_for <= NOW()` guard so a still-future row fires now, and
@@ -558,10 +586,9 @@ export class ScheduledMessagesService {
    * Use `notPendingMessage` to override the user-visible text per call site
    * (e.g. cancel uses "Cannot cancel sending scheduled message").
    */
-  private async assertPendingOrThrow(
+  private async findOwnedOrThrow(
     client: PoolClient,
-    params: { workspaceId: string; userId: string; id: string },
-    options?: { notPendingMessage?: (status: string) => string }
+    params: { workspaceId: string; userId: string; id: string }
   ): Promise<ScheduledMessage> {
     const existing = await ScheduledMessagesRepository.findById(client, params.workspaceId, params.userId, params.id)
     if (!existing) {
@@ -570,6 +597,13 @@ export class ScheduledMessagesService {
         code: "SCHEDULED_MESSAGE_NOT_FOUND",
       })
     }
+    return existing
+  }
+
+  private assertRowPending(
+    existing: ScheduledMessage,
+    options?: { notPendingMessage?: (status: string) => string }
+  ): void {
     if (existing.status !== ScheduledMessageStatuses.PENDING) {
       const buildMessage = options?.notPendingMessage ?? ((status: string) => `Scheduled message already ${status}`)
       throw new HttpError(buildMessage(existing.status), {
@@ -580,6 +614,15 @@ export class ScheduledMessagesService {
             : "SCHEDULED_MESSAGE_NOT_PENDING",
       })
     }
+  }
+
+  private async assertPendingOrThrow(
+    client: PoolClient,
+    params: { workspaceId: string; userId: string; id: string },
+    options?: { notPendingMessage?: (status: string) => string }
+  ): Promise<ScheduledMessage> {
+    const existing = await this.findOwnedOrThrow(client, params)
+    this.assertRowPending(existing, options)
     return existing
   }
 
@@ -616,59 +659,14 @@ export class ScheduledMessagesService {
     return queueId
   }
 
-  /**
-   * Stream-write authorization. Mirrors the saved-messages stream-access
-   * helper but for write intent: the user must be a member of the stream
-   * (or the stream's root for thread sends), and the workspace must match.
-   * Public streams allow any workspace user to write — same as live message
-   * create.
-   */
-  private async ensureStreamWriteAccess(
-    client: PoolClient,
-    workspaceId: string,
-    userId: string,
-    streamIdParam: string
-  ): Promise<Stream> {
-    const stream = await StreamRepository.findById(client, streamIdParam)
-    if (!stream || stream.workspaceId !== workspaceId) {
-      throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
-    }
-    if (stream.archivedAt) {
-      throw new HttpError("Cannot schedule messages to an archived stream", {
-        status: 403,
-        code: "STREAM_ARCHIVED",
-      })
-    }
-
-    // E2EE-3: the server holds no stream key, so it can never seal a future
-    // message at fire time. Refuse at schedule time with a loud error rather
-    // than accepting plaintext that would either leak into the sealed stream
-    // (now backstopped by the INV-E1 sink) or silently fail to send much later.
-    // `findById` already populates `e2eEnabled` off the e2e_streams join.
-    if (stream.e2eEnabled === true) {
+  private async assertSchedulingTransportSupported(client: PoolClient, stream: { id: string }): Promise<void> {
+    const fresh = await StreamRepository.findById(client, stream.id)
+    if (fresh?.e2eEnabled) {
       throw new HttpError("Cannot schedule messages to an end-to-end-encrypted stream", {
         status: 400,
         code: "E2E_STREAM_SCHEDULING_UNSUPPORTED",
       })
     }
-
-    const accessStreamId = stream.rootStreamId ?? stream.id
-    let accessStream: Stream | null = stream
-    if (stream.rootStreamId) {
-      accessStream = await StreamRepository.findById(client, accessStreamId)
-      if (!accessStream) {
-        throw new HttpError("Parent stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
-      }
-    }
-
-    if (accessStream.visibility === Visibilities.PUBLIC) return stream
-
-    const isMember = await StreamMemberRepository.isMember(client, accessStreamId, userId)
-    if (!isMember) {
-      throw new HttpError("Not a member of this stream", { status: 403, code: "FORBIDDEN" })
-    }
-
-    return stream
   }
 }
 

--- a/apps/backend/src/features/streams/brief-handlers.test.ts
+++ b/apps/backend/src/features/streams/brief-handlers.test.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import { Visibilities } from "@threa/types"
 import { StreamRepository, type Stream } from "./repository"
-import { StreamMemberRepository } from "./member-repository"
+import { HttpError } from "../../lib/errors"
 import { createStreamBriefHandlers } from "./brief-handlers"
 import type { StreamBriefService, UpdateBriefParams } from "./brief-service"
 import type { StreamBrief } from "./brief-repository"
@@ -93,21 +93,34 @@ describe("stream brief handlers", () => {
     expect(res.body).toEqual({ brief: null })
   })
 
-  it("PUT requires membership of the effective root: a non-member who can read a public stream gets 403", async () => {
+  it("PUT delegates public non-member authority to the transactional service", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
-    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(false)
-    const handlers = makeHandlers({})
+    const update = mock(async () => {
+      throw new HttpError("This stream is read-only", {
+        status: 403,
+        code: "STREAM_READ_ONLY",
+        details: { reason: "not_a_member" },
+      })
+    })
+    const handlers = makeHandlers({ update } as unknown as Partial<StreamBriefService>)
 
     const req = fakeReq({ body: { content: "Goal: ship v2", version: 0 } })
     await expect(handlers.put(req, fakeRes())).rejects.toMatchObject({
       status: 403,
-      code: "BRIEF_MEMBERSHIP_REQUIRED",
+      code: "STREAM_READ_ONLY",
+      details: { reason: "not_a_member" },
     })
   })
 
-  it("PUT rejects encrypted streams — a sealed stream's brief would be plaintext the enclave never injects", async () => {
+  it("PUT delegates encrypted-stream ordering to the transactional service", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream({ e2eEnabled: true }))
-    const handlers = makeHandlers({})
+    const update = mock(async () => {
+      throw new HttpError("Briefs are not supported on encrypted streams", {
+        status: 400,
+        code: "BRIEF_E2E_UNSUPPORTED",
+      })
+    })
+    const handlers = makeHandlers({ update } as unknown as Partial<StreamBriefService>)
 
     const req = fakeReq({ body: { content: "Goal: ship v2", version: 0 } })
     await expect(handlers.put(req, fakeRes())).rejects.toMatchObject({
@@ -118,7 +131,6 @@ describe("stream brief handlers", () => {
 
   it("PUT rejects a version beyond pg INT4 range at validation instead of 500ing in the guard query", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
-    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
     const handlers = makeHandlers({})
 
     const req = fakeReq({ body: { content: "x", version: 3_000_000_000 } })
@@ -127,7 +139,6 @@ describe("stream brief handlers", () => {
 
   it("PUT surfaces a lost optimistic-concurrency race as 409 carrying the fresh brief", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
-    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
     const current = fakeBriefServiceUpdateResult({ version: 5 })
     const update = mock(async () => ({ outcome: "version_conflict" as const, current }))
     const handlers = makeHandlers({ update } as unknown as Partial<StreamBriefService>)
@@ -142,7 +153,6 @@ describe("stream brief handlers", () => {
 
   it("PUT writes as the calling user and returns the updated brief", async () => {
     spyOn(StreamRepository, "findById").mockResolvedValue(fakeStream())
-    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
     const brief = fakeBriefServiceUpdateResult({ version: 1 })
     const update = mock(async (_params: UpdateBriefParams) => ({ outcome: "updated" as const, brief }))
     const handlers = makeHandlers({ update } as unknown as Partial<StreamBriefService>)
@@ -157,6 +167,8 @@ describe("stream brief handlers", () => {
       expectedVersion: 0,
       updatedByKind: "user",
       updatedById: "usr_1",
+      principal: { kind: "user", userId: "usr_1" },
+      requestedStreamId: "stream_chan",
     })
     expect(res.body).toEqual({ brief })
   })

--- a/apps/backend/src/features/streams/brief-handlers.ts
+++ b/apps/backend/src/features/streams/brief-handlers.ts
@@ -5,8 +5,7 @@ import { AuthorTypes } from "@threa/types"
 import { HttpError, StreamNotFoundError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
 import { checkStreamAccess } from "./access"
-import { StreamMemberRepository } from "./member-repository"
-import { resolveBriefStreamId, STREAM_BRIEF_MAX_CHARS, type StreamBriefService } from "./brief-service"
+import { resolveBriefStreamId, type StreamBriefService } from "./brief-service"
 
 interface Dependencies {
   pool: Pool
@@ -14,7 +13,7 @@ interface Dependencies {
 }
 
 const putBriefSchema = z.object({
-  content: z.string().max(STREAM_BRIEF_MAX_CHARS),
+  content: z.string(),
   /**
    * The version the client read; 0 when no brief existed yet. Bounded to pg
    * INT4 — an unbounded value would surface as a 500 (Postgres 22003) instead
@@ -54,27 +53,7 @@ export function createStreamBriefHandlers({ pool, streamBriefService }: Dependen
       const stream = await checkStreamAccess(pool, streamId, workspaceId, userId)
       if (!stream) throw new StreamNotFoundError()
 
-      // A sealed stream's brief would be server-stored plaintext that the
-      // enclave prompt never injects — a silent no-op attached to an E2E
-      // surface. Reject until the sealed wire supports briefs (roadmap §4.1
-      // deviation), consistent with E2E parity being deferred across the
-      // roadmap.
-      if (stream.e2eEnabled) {
-        throw new HttpError("Briefs are not supported on encrypted streams", {
-          status: 400,
-          code: "BRIEF_E2E_UNSUPPORTED",
-        })
-      }
-
       const briefStreamId = resolveBriefStreamId(stream)
-      const isMember = await StreamMemberRepository.isMember(pool, briefStreamId, userId)
-      if (!isMember) {
-        throw new HttpError("Only stream members can edit the brief", {
-          status: 403,
-          code: "BRIEF_MEMBERSHIP_REQUIRED",
-        })
-      }
-
       const result = await streamBriefService.update({
         workspaceId,
         streamId: briefStreamId,
@@ -82,6 +61,8 @@ export function createStreamBriefHandlers({ pool, streamBriefService }: Dependen
         expectedVersion: version,
         updatedByKind: AuthorTypes.USER,
         updatedById: userId,
+        principal: { kind: "user", userId },
+        requestedStreamId: streamId,
       })
 
       if (result.outcome === "version_conflict") {

--- a/apps/backend/src/features/streams/brief-service.test.ts
+++ b/apps/backend/src/features/streams/brief-service.test.ts
@@ -50,7 +50,7 @@ describe("StreamBriefService.update", () => {
     const insertFirst = spyOn(StreamBriefRepository, "insertFirstVersion").mockResolvedValue(fakeBrief())
     const insertRevision = spyOn(StreamBriefRepository, "insertRevision").mockResolvedValue(undefined)
 
-    const result = await makeService().update({
+    const result = await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "Goal: ship v2",
@@ -77,7 +77,7 @@ describe("StreamBriefService.update", () => {
     const updateAtVersion = spyOn(StreamBriefRepository, "updateAtVersion").mockResolvedValue(updated)
     const insertRevision = spyOn(StreamBriefRepository, "insertRevision").mockResolvedValue(undefined)
 
-    const result = await makeService().update({
+    const result = await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "Goal: ship v3",
@@ -98,7 +98,7 @@ describe("StreamBriefService.update", () => {
     spyOn(StreamBriefRepository, "updateAtVersion").mockResolvedValue(updated)
     spyOn(StreamBriefRepository, "insertRevision").mockResolvedValue(undefined)
 
-    await makeService().update({
+    await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_root",
       content: "Goal: ship v3",
@@ -123,7 +123,7 @@ describe("StreamBriefService.update", () => {
     spyOn(StreamBriefRepository, "insertFirstVersion").mockResolvedValue(fakeBrief({ version: 1, id: "sbrf_1" }))
     spyOn(StreamBriefRepository, "insertRevision").mockResolvedValue(undefined)
 
-    await makeService().update({
+    await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "Goal: ship v2",
@@ -145,7 +145,7 @@ describe("StreamBriefService.update", () => {
     spyOn(StreamBriefRepository, "updateAtVersion").mockResolvedValue(null)
     spyOn(StreamBriefRepository, "findByStreamId").mockResolvedValue(fakeBrief({ version: 5 }))
 
-    await makeService().update({
+    await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "stale write",
@@ -164,7 +164,7 @@ describe("StreamBriefService.update", () => {
     spyOn(StreamBriefRepository, "findByStreamId").mockResolvedValue(current)
     const insertRevision = spyOn(StreamBriefRepository, "insertRevision").mockResolvedValue(undefined)
 
-    const result = await makeService().update({
+    const result = await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "stale write",
@@ -183,7 +183,7 @@ describe("StreamBriefService.update", () => {
     spyOn(StreamBriefRepository, "insertFirstVersion").mockResolvedValue(null)
     spyOn(StreamBriefRepository, "findByStreamId").mockResolvedValue(current)
 
-    const result = await makeService().update({
+    const result = await makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "late create",
@@ -195,10 +195,11 @@ describe("StreamBriefService.update", () => {
     expect(result).toEqual({ outcome: "version_conflict", current })
   })
 
-  it("rejects content over the cap before touching the database", async () => {
-    const withTransaction = spyOn(dbModule, "withTransaction")
+  it("rejects generated content over the cap inside its transaction before writing", async () => {
+    stubTransaction()
+    const insertFirst = spyOn(StreamBriefRepository, "insertFirstVersion")
 
-    const attempt = makeService().update({
+    const attempt = makeService().updateInternal({
       workspaceId: "ws_1",
       streamId: "stream_1",
       content: "x".repeat(STREAM_BRIEF_MAX_CHARS + 1),
@@ -209,7 +210,7 @@ describe("StreamBriefService.update", () => {
 
     await expect(attempt).rejects.toMatchObject({ status: 400, code: "BRIEF_TOO_LONG" })
     await expect(attempt).rejects.toBeInstanceOf(HttpError)
-    expect(withTransaction).not.toHaveBeenCalled()
+    expect(insertFirst).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/streams/brief-service.ts
+++ b/apps/backend/src/features/streams/brief-service.ts
@@ -5,6 +5,8 @@ import { withTransaction } from "../../db"
 import { HttpError } from "../../lib/errors"
 import { OutboxRepository } from "../../lib/outbox"
 import { StreamEventRepository } from "./event-repository"
+import { StreamRepository } from "./repository"
+import { assertStreamWritable, type StreamWritePrincipal } from "./write-authority"
 import { StreamBriefRepository, type BriefAuthorKind, type StreamBrief } from "./brief-repository"
 
 /**
@@ -36,6 +38,8 @@ export interface UpdateBriefParams {
    * the timeline row carries a null reason.
    */
   reason?: string
+  principal: StreamWritePrincipal
+  requestedStreamId: string
 }
 
 export type UpdateBriefResult =
@@ -64,16 +68,44 @@ export class StreamBriefService {
    * miss an accepted version.
    */
   async update(params: UpdateBriefParams): Promise<UpdateBriefResult> {
+    return this.updateInTransaction(params, true)
+  }
+
+  async updateInternal(params: Omit<UpdateBriefParams, "principal" | "requestedStreamId">): Promise<UpdateBriefResult> {
+    return this.updateInTransaction(params, false)
+  }
+
+  private async updateInTransaction(
+    params: UpdateBriefParams | Omit<UpdateBriefParams, "principal" | "requestedStreamId">,
+    enforceAuthority: boolean
+  ): Promise<UpdateBriefResult> {
     const { workspaceId, streamId, content, expectedVersion, updatedByKind, updatedById, reason } = params
-    if (content.length > STREAM_BRIEF_MAX_CHARS) {
-      throw new HttpError(`Brief exceeds ${STREAM_BRIEF_MAX_CHARS} characters`, {
-        status: 400,
-        code: "BRIEF_TOO_LONG",
-        details: { maxChars: STREAM_BRIEF_MAX_CHARS },
-      })
-    }
 
     return withTransaction(this.pool, async (client) => {
+      if (enforceAuthority) {
+        const request = params as UpdateBriefParams
+        const authority = await assertStreamWritable(client, {
+          workspaceId,
+          streamId: request.requestedStreamId,
+          principal: request.principal,
+        })
+        const effectiveRootId = authority.target.rootStreamId ?? authority.target.id
+        if (effectiveRootId !== streamId) throw new HttpError("Stream not found", { status: 404, code: "NOT_FOUND" })
+        const freshTarget = await StreamRepository.findById(client, request.requestedStreamId)
+        if (freshTarget?.e2eEnabled) {
+          throw new HttpError("Briefs are not supported on encrypted streams", {
+            status: 400,
+            code: "BRIEF_E2E_UNSUPPORTED",
+          })
+        }
+      }
+      if (content.length > STREAM_BRIEF_MAX_CHARS) {
+        throw new HttpError(`Brief exceeds ${STREAM_BRIEF_MAX_CHARS} characters`, {
+          status: 400,
+          code: "BRIEF_TOO_LONG",
+          details: { maxChars: STREAM_BRIEF_MAX_CHARS },
+        })
+      }
       const brief =
         expectedVersion === 0
           ? await StreamBriefRepository.insertFirstVersion(client, {

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -158,7 +158,10 @@ describe("createStreamHandlers.updateToolPolicy", () => {
 
     await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
 
-    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", ["web"])
+    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", ["web"], {
+      kind: "user",
+      userId: "user_owner",
+    })
     expect(captured.body).toEqual({ data: { allowedToolCategories: ["web"] } })
   })
 
@@ -172,12 +175,17 @@ describe("createStreamHandlers.updateToolPolicy", () => {
 
     await handlers.updateToolPolicy(makeReq({ allowedCategories: null }), res)
 
-    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", null)
+    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", null, {
+      kind: "user",
+      userId: "user_owner",
+    })
     expect(captured.body).toEqual({ data: { allowedToolCategories: null } })
   })
 
   it("rejects a non-owner with 403 and never writes", async () => {
-    const setStreamToolPolicy = mock(async () => null)
+    const setStreamToolPolicy = mock(async () => {
+      throw Object.assign(new Error("forbidden"), { status: 403, code: "FORBIDDEN" })
+    })
     const handlers = makeHandlers({
       validateStreamAccess: mock(async () => ({
         ...scratchpad,
@@ -190,11 +198,13 @@ describe("createStreamHandlers.updateToolPolicy", () => {
     await expect(handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)).rejects.toMatchObject({
       status: 403,
     })
-    expect(setStreamToolPolicy).not.toHaveBeenCalled()
+    expect(setStreamToolPolicy).toHaveBeenCalled()
   })
 
   it("rejects a non-scratchpad stream with 400 and never writes", async () => {
-    const setStreamToolPolicy = mock(async () => null)
+    const setStreamToolPolicy = mock(async () => {
+      throw Object.assign(new Error("invalid stream"), { status: 400, code: "INVALID_STREAM_TYPE" })
+    })
     const handlers = makeHandlers({
       validateStreamAccess: mock(async () => ({
         ...scratchpad,
@@ -207,7 +217,7 @@ describe("createStreamHandlers.updateToolPolicy", () => {
     await expect(handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)).rejects.toMatchObject({
       status: 400,
     })
-    expect(setStreamToolPolicy).not.toHaveBeenCalled()
+    expect(setStreamToolPolicy).toHaveBeenCalled()
   })
 })
 
@@ -252,7 +262,10 @@ describe("createStreamHandlers.update — DM memoryMode", () => {
 
     await handlers.update(makeReq({ memoryMode: "off" }), res)
 
-    expect(updateStream).toHaveBeenCalledWith("stream_dm", expect.objectContaining({ memoryMode: "off" }))
+    expect(updateStream).toHaveBeenCalledWith("stream_dm", expect.objectContaining({ memoryMode: "off" }), {
+      workspaceId: "ws_1",
+      principal: { kind: "user", userId: "user_a" },
+    })
     expect(captured.body).toEqual({ stream: expect.objectContaining({ memoryMode: "off" }) })
   })
 

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -722,6 +722,7 @@ export function createStreamHandlers({
 
       const schema = updateSchemaForType(stream.type)
       if (!schema) {
+        await streamService.assertWritable(streamId, workspaceId, { kind: "user", userId })
         throw new HttpError("Cannot update this stream type", { status: 403, code: "STREAM_IMMUTABLE" })
       }
 
@@ -746,16 +747,23 @@ export function createStreamHandlers({
         sealedName = null
       }
 
-      const updated = await streamService.updateStream(streamId, {
-        displayName,
-        slug,
-        description,
-        descriptionJson,
-        actorId: userId,
-        visibility,
-        memoryMode,
-        sealedName,
-      })
+      const updated = await streamService.updateStream(
+        streamId,
+        {
+          displayName,
+          slug,
+          description,
+          descriptionJson,
+          actorId: userId,
+          visibility,
+          memoryMode,
+          sealedName,
+        },
+        {
+          workspaceId,
+          principal: { kind: "user", userId },
+        }
+      )
       res.json({ stream: updated })
     },
 
@@ -769,7 +777,12 @@ export function createStreamHandlers({
         body.sealedNameCiphertext && body.sealedNameEnvelope
           ? { ciphertext: body.sealedNameCiphertext, envelope: body.sealedNameEnvelope }
           : undefined
-      const result = await streamService.regenerateDisplayName(workspaceId, streamId, sealedName)
+      const result = await streamService.regenerateDisplayName(
+        workspaceId,
+        streamId,
+        { kind: "user", userId },
+        sealedName
+      )
       res.json(result)
     },
 
@@ -870,11 +883,6 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const isMember = await streamService.isMember(streamId, userId)
-      if (!isMember) {
-        return res.status(403).json({ error: "Not a member of this stream" })
-      }
-
       const updated = await streamService.updateCompanionMode(
         streamId,
         workspaceId,
@@ -893,23 +901,12 @@ export function createStreamHandlers({
 
       const { allowedCategories } = validateRequest(updateToolPolicySchema, req.body)
 
-      // Scoped to scratchpads, owner-only: the tool policy is a personal
-      // guardrail on a solo surface, not a shared channel admin setting.
-      const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
-      if (stream.type !== StreamTypes.SCRATCHPAD) {
-        throw new HttpError("Tool policy can only be set on a scratchpad", {
-          status: 400,
-          code: "INVALID_STREAM_TYPE",
-        })
-      }
-      if (stream.createdBy !== userId) {
-        throw new HttpError("Only the scratchpad owner can change its tool policy", {
-          status: 403,
-          code: "FORBIDDEN",
-        })
-      }
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const allowedToolCategories = await streamService.setStreamToolPolicy(workspaceId, streamId, allowedCategories)
+      const allowedToolCategories = await streamService.setStreamToolPolicy(workspaceId, streamId, allowedCategories, {
+        kind: "user",
+        userId,
+      })
       res.json({ data: { allowedToolCategories } })
     },
 

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -21,6 +21,10 @@ import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
 
 const mockFindById = spyOn(StreamRepository, "findById")
+spyOn(StreamRepository, "findByIds").mockImplementation(async (client, ids) => {
+  const streams = await Promise.all(ids.map((id) => mockFindById(client, id)))
+  return streams.filter((stream): stream is NonNullable<typeof stream> => stream != null)
+})
 spyOn(StreamRepository, "findByIdsInWorkspace").mockImplementation(async (client, _workspaceId, ids) => {
   const streams = await Promise.all(ids.map((id) => mockFindById(client, id)))
   return streams.filter((stream): stream is NonNullable<typeof stream> => stream != null)
@@ -31,7 +35,9 @@ const mockFindByIdsForUpdateBlocking = spyOn(StreamRepository, "findByIdsForUpda
     return streams.filter((stream): stream is NonNullable<typeof stream> => stream != null)
   }
 )
-const mockLockMemberships = spyOn(StreamMemberRepository, "lockMemberships").mockResolvedValue(new Set())
+const mockLockMemberships = spyOn(StreamMemberRepository, "lockMemberships").mockImplementation(
+  async (_client, streamIds) => new Set(streamIds)
+)
 spyOn(StreamMemberRepository, "lockMemberPairs").mockImplementation(
   async (_client, pairs) => new Set(pairs.map(({ streamId, memberId }) => `${streamId}:${memberId}`))
 )
@@ -2049,10 +2055,14 @@ describe("StreamService.updateStream sealed-name handling", () => {
 
     // Even if a client sends a plaintext displayName alongside the seal, the
     // server must not persist it — the sealed ciphertext is the only name.
-    await service.updateStream("stream_1", {
-      displayName: "leak",
-      sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
-    })
+    await service.updateStream(
+      "stream_1",
+      {
+        displayName: "leak",
+        sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
+      },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockUpdateDisplayName).toHaveBeenCalledWith(
       {},
@@ -2068,13 +2078,18 @@ describe("StreamService.updateStream sealed-name handling", () => {
     const stream = { id: "stream_1", workspaceId: "ws_1", displayName: null } as never
     mockUpdate.mockResolvedValue(stream)
     mockUpdateDisplayName.mockResolvedValue(stream)
+    mockFindById.mockResolvedValue(stream)
     // No e2e_streams row to update — the stream isn't E2E.
     mockUpdateSealedName.mockResolvedValue(false)
 
     await expect(
-      service.updateStream("stream_1", {
-        sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
-      })
+      service.updateStream(
+        "stream_1",
+        {
+          sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
+        },
+        { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+      )
     ).rejects.toMatchObject({ status: 400, code: "STREAM_NOT_E2E" })
 
     // Transaction rolls back; no stream:updated event for a half-applied rename.
@@ -2082,7 +2097,13 @@ describe("StreamService.updateStream sealed-name handling", () => {
   })
 
   test("clearing a sealed name without a displayName is rejected", async () => {
-    await expect(service.updateStream("stream_1", { sealedName: null })).rejects.toMatchObject({
+    await expect(
+      service.updateStream(
+        "stream_1",
+        { sealedName: null },
+        { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+      )
+    ).rejects.toMatchObject({
       status: 400,
       code: "SEALED_NAME_REQUIRES_DISPLAY_NAME",
     })
@@ -2095,7 +2116,11 @@ describe("StreamService.updateStream sealed-name handling", () => {
     mockUpdateDisplayName.mockResolvedValue(stream)
     mockFindById.mockResolvedValue(stream)
 
-    await service.updateStream("stream_1", { displayName: "New name" })
+    await service.updateStream(
+      "stream_1",
+      { displayName: "New name" },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockUpdateDisplayName).toHaveBeenCalledWith(
       {},
@@ -2122,12 +2147,16 @@ describe("StreamService.updateStream description", () => {
     mockUpdate.mockResolvedValue(stream)
     mockFindById.mockResolvedValue(stream)
 
-    await service.updateStream("stream_1", {
-      descriptionJson: {
-        type: "doc",
-        content: [{ type: "paragraph", content: [{ type: "text", text: "About this channel" }] }],
+    await service.updateStream(
+      "stream_1",
+      {
+        descriptionJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "About this channel" }] }],
+        },
       },
-    })
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockUpdate).toHaveBeenCalledWith(
       {},
@@ -2150,7 +2179,11 @@ describe("StreamService.updateStream description", () => {
     mockUpdateDisplayName.mockResolvedValue(stream)
     mockFindById.mockResolvedValue(stream)
 
-    await service.updateStream("stream_1", { displayName: "Renamed" })
+    await service.updateStream(
+      "stream_1",
+      { displayName: "Renamed" },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     const params = mockUpdate.mock.calls[0]![2] as Record<string, unknown>
     expect(params).not.toHaveProperty("description")
@@ -2159,15 +2192,21 @@ describe("StreamService.updateStream description", () => {
 
   test("appends a description_set timeline event + outbox when an actor changes the description", async () => {
     mockUpdate.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
-    // First read = pre-update snapshot; second = the post-update re-read.
+    const authorityStream = { id: "stream_1", workspaceId: "ws_1", type: "channel", visibility: "private" }
     mockFindById
-      .mockResolvedValueOnce({ id: "stream_1", workspaceId: "ws_1", description: "Old" } as never)
-      .mockResolvedValueOnce({ id: "stream_1", workspaceId: "ws_1", description: "New" } as never)
+      .mockResolvedValueOnce(authorityStream as never)
+      .mockResolvedValueOnce(authorityStream as never)
+      .mockResolvedValueOnce({ ...authorityStream, description: "Old" } as never)
+      .mockResolvedValueOnce({ ...authorityStream, description: "New" } as never)
 
-    await service.updateStream("stream_1", {
-      descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "New" }] }] },
-      actorId: "usr_1",
-    })
+    await service.updateStream(
+      "stream_1",
+      {
+        descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "New" }] }] },
+        actorId: "usr_1",
+      },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockInsertEvent).toHaveBeenCalledWith(
       {},
@@ -2189,10 +2228,14 @@ describe("StreamService.updateStream description", () => {
     mockUpdate.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" } as never)
     mockFindById.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1", description: "Same" } as never)
 
-    await service.updateStream("stream_1", {
-      descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Same" }] }] },
-      actorId: "usr_1",
-    })
+    await service.updateStream(
+      "stream_1",
+      {
+        descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Same" }] }] },
+        actorId: "usr_1",
+      },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockInsertEvent).not.toHaveBeenCalled()
   })
@@ -2201,9 +2244,13 @@ describe("StreamService.updateStream description", () => {
     mockUpdate.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1", description: "New" } as never)
     mockFindById.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1", description: "New" } as never)
 
-    await service.updateStream("stream_1", {
-      descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "New" }] }] },
-    })
+    await service.updateStream(
+      "stream_1",
+      {
+        descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "New" }] }] },
+      },
+      { workspaceId: "ws_1", principal: { kind: "user", userId: "usr_1" } }
+    )
 
     expect(mockInsertEvent).not.toHaveBeenCalled()
   })
@@ -2282,16 +2329,18 @@ describe("StreamService.updateCompanionMode persona validation", () => {
 
   test("rejects a companionPersonaId that resolves to no active persona", async () => {
     mockPersonaFindById.mockResolvedValue(null)
-    await expect(service.updateCompanionMode("stream_1", "ws_1", "on", "persona_gone")).rejects.toMatchObject({
-      status: 400,
-      code: "PERSONA_NOT_AVAILABLE",
-    })
+    await expect(service.updateCompanionMode("stream_1", "ws_1", "on", "persona_gone", "user_1")).rejects.toMatchObject(
+      {
+        status: 400,
+        code: "PERSONA_NOT_AVAILABLE",
+      }
+    )
     expect(mockUpdate).not.toHaveBeenCalled()
   })
 
   test("rejects an archived persona", async () => {
     mockPersonaFindById.mockResolvedValue({ id: "persona_x", status: "archived" } as never)
-    await expect(service.updateCompanionMode("stream_1", "ws_1", "on", "persona_x")).rejects.toMatchObject({
+    await expect(service.updateCompanionMode("stream_1", "ws_1", "on", "persona_x", "user_1")).rejects.toMatchObject({
       status: 400,
       code: "PERSONA_NOT_AVAILABLE",
     })
@@ -2299,13 +2348,13 @@ describe("StreamService.updateCompanionMode persona validation", () => {
 
   test("accepts an active persona and writes", async () => {
     mockPersonaFindById.mockResolvedValue({ id: "persona_x", status: "active" } as never)
-    await service.updateCompanionMode("stream_1", "ws_1", "on", "persona_x")
+    await service.updateCompanionMode("stream_1", "ws_1", "on", "persona_x", "user_1")
     expect(mockUpdate).toHaveBeenCalled()
     expect(mockPersonaFindById).toHaveBeenCalledWith(expect.anything(), "persona_x", "ws_1")
   })
 
   test("clearing (null) skips persona validation", async () => {
-    await service.updateCompanionMode("stream_1", "ws_1", "off", null)
+    await service.updateCompanionMode("stream_1", "ws_1", "off", null, "user_1")
     expect(mockPersonaFindById).not.toHaveBeenCalled()
     expect(mockUpdate).toHaveBeenCalled()
   })

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -28,7 +28,13 @@ import {
 } from "../../lib/errors"
 import { formatParticipantNames } from "./display-name"
 import { checkStreamAccess } from "./access"
-import { assertViewerStreamWritable, deriveStreamViewerState, lockEffectiveStreams } from "./write-authority"
+import {
+  assertStreamWritable,
+  assertViewerStreamWritable,
+  deriveStreamViewerState,
+  lockEffectiveStreams,
+  type StreamWritePrincipal,
+} from "./write-authority"
 import { UserRepository } from "../workspaces"
 import { BotChannelAccessRepository } from "../api-keys"
 import {
@@ -237,6 +243,10 @@ export class StreamService {
     const stream = await this.checkAccess(streamId, workspaceId, userId)
     if (!stream) throw new StreamNotFoundError()
     return stream
+  }
+
+  async assertWritable(streamId: string, workspaceId: string, principal: StreamWritePrincipal): Promise<void> {
+    await withTransaction(this.pool, (client) => assertStreamWritable(client, { workspaceId, streamId, principal }))
   }
 
   /** Like {@link validateStreamAccess} but returns null instead of throwing. */
@@ -468,6 +478,7 @@ export class StreamService {
           parentStreamId: params.parentStreamId,
           parentAnchorId,
           createdBy: params.createdBy,
+          principal: { kind: "user", userId: params.createdBy },
         })
       }
       default:
@@ -649,7 +660,18 @@ export class StreamService {
     })
   }
 
-  async createThread(params: CreateThreadParams): Promise<Stream> {
+  async createThread(params: CreateThreadParams & { principal: StreamWritePrincipal }): Promise<Stream> {
+    return withTransaction(this.pool, async (client) => {
+      await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: params.parentStreamId,
+        principal: params.principal,
+      })
+      return this.createThreadOn(client, params)
+    })
+  }
+
+  async createThreadInternal(params: CreateThreadParams): Promise<Stream> {
     return withTransaction(this.pool, (client) => this.createThreadOn(client, params))
   }
 
@@ -846,13 +868,16 @@ export class StreamService {
     streamId: string,
     workspaceId: string,
     companionMode: CompanionMode,
-    companionPersonaId?: string | null,
-    actingUserId?: string
+    companionPersonaId: string | null | undefined,
+    actingUserId: string
   ): Promise<Stream> {
-    // The acting user may pin their own personal persona but not another user's
-    // (user-scoped-personas); the handler threads the caller's id.
-    await assertAssignablePersona(this.pool, companionPersonaId, workspaceId, { callerUserId: actingUserId })
     return withTransaction(this.pool, async (client) => {
+      await assertStreamWritable(client, {
+        workspaceId,
+        streamId,
+        principal: { kind: "user", userId: actingUserId },
+      })
+      await assertAssignablePersona(client, companionPersonaId, workspaceId, { callerUserId: actingUserId })
       const stream = await StreamRepository.update(client, streamId, {
         companionMode,
         companionPersonaId,
@@ -880,10 +905,27 @@ export class StreamService {
   async setStreamToolPolicy(
     workspaceId: string,
     streamId: string,
-    policy: ToolPrivacyPolicy
+    policy: ToolPrivacyPolicy,
+    principal: StreamWritePrincipal
   ): Promise<ToolPrivacyPolicy> {
-    await StreamPoliciesRepository.setToolPolicy(this.pool, workspaceId, streamId, policy)
-    return policy
+    return withTransaction(this.pool, async (client) => {
+      const { target } = await assertStreamWritable(client, { workspaceId, streamId, principal })
+      if (target.type !== StreamTypes.SCRATCHPAD) {
+        throw new HttpError("Tool policy can only be set on a scratchpad", {
+          status: 400,
+          code: "INVALID_STREAM_TYPE",
+        })
+      }
+      const ownerId = principal.kind === "user" ? principal.userId : null
+      if (target.createdBy !== ownerId) {
+        throw new HttpError("Only the scratchpad owner can change its tool policy", {
+          status: 403,
+          code: "FORBIDDEN",
+        })
+      }
+      await StreamPoliciesRepository.setToolPolicy(client, workspaceId, streamId, policy)
+      return policy
+    })
   }
 
   /**
@@ -1030,7 +1072,8 @@ export class StreamService {
        * null so the server never holds the cleartext name at rest.
        */
       sealedName?: { ciphertext: string; envelope: unknown } | null
-    }
+    },
+    authority: { workspaceId: string; principal: StreamWritePrincipal }
   ): Promise<Stream | null> {
     const { sealedName, description, descriptionJson, actorId, actorType, ...rest } = data
     const { displayName, ...nonTitleData } = rest
@@ -1062,6 +1105,11 @@ export class StreamService {
     }
     try {
       return await withTransaction(this.pool, async (client) => {
+        await assertStreamWritable(client, {
+          workspaceId: authority.workspaceId,
+          streamId,
+          principal: authority.principal,
+        })
         // Snapshot the pre-update markdown so we only emit when it really changes
         // (a no-op re-save shouldn't spam the timeline).
         let previousDescription: string | null = null
@@ -1571,9 +1619,11 @@ export class StreamService {
   async regenerateDisplayName(
     workspaceId: string,
     streamId: string,
+    principal: StreamWritePrincipal,
     sealedName?: { ciphertext: string; envelope: unknown }
   ): Promise<{ stream: Stream; deferred: boolean }> {
     return withTransaction(this.pool, async (client) => {
+      await assertStreamWritable(client, { workspaceId, streamId, principal })
       const locked = await StreamRepository.findByIdForUpdateBlocking(client, streamId)
       if (!locked || locked.workspaceId !== workspaceId) {
         throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })

--- a/apps/backend/src/features/streams/stream-read-only-mutation-inventory.test.ts
+++ b/apps/backend/src/features/streams/stream-read-only-mutation-inventory.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const source = (path: string) => readFileSync(resolve(import.meta.dir, path), "utf8")
+
+function methodBody(text: string, name: string): string {
+  const match = new RegExp(`async\\s+${name}\\s*\\(`).exec(text)
+  if (!match) throw new Error(`Missing owned method ${name}`)
+  const nextMethod = text.indexOf("\n  async ", match.index + match[0].length)
+  return text.slice(match.index, nextMethod < 0 ? text.length : nextMethod)
+}
+
+describe("stream read-only mutation source shape", () => {
+  test("source shape only: each owned mutation body mentions its authority helper (behavior is covered in tests/integration/stream-read-only-mutation-matrix.test.ts)", () => {
+    const guarded = [
+      [
+        "../conversations/service.ts",
+        {
+          reassignMessage: "assertStreamsWritable",
+          settleMessage: "assertStreamWritable",
+          regenerateTitle: "assertStreamWritable",
+          updateConversation: "assertStreamWritable",
+          splitThreadIntoConversation: "assertStreamsWritable",
+          reassignMessagesToConversation: "assertStreamWritable",
+          applySplit: "assertStreamWritable",
+        },
+      ],
+      [
+        "service.ts",
+        {
+          createThread: "assertStreamWritable",
+          updateCompanionMode: "assertStreamWritable",
+          setStreamToolPolicy: "assertStreamWritable",
+          updateStream: "assertStreamWritable",
+          regenerateDisplayName: "assertStreamWritable",
+        },
+      ],
+      [
+        "../scheduled-messages/service.ts",
+        { schedule: "assertStreamWritable", update: "assertStreamWritable", sendNow: "assertStreamWritable" },
+      ],
+      ["../commands/handlers.ts", { dispatch: "assertViewerStreamWritable" }],
+      ["../calls/service.ts", { startCall: "assertStreamWritable", joinCall: "assertStreamWritable" }],
+      ["brief-service.ts", { updateInTransaction: "assertStreamWritable" }],
+    ] as const
+
+    for (const [path, methods] of guarded) {
+      const text = source(path)
+      for (const [method, guard] of Object.entries(methods)) expect(methodBody(text, method)).toContain(guard)
+    }
+  })
+})

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -559,7 +559,8 @@ export async function startServer(): Promise<ServerInstance> {
       userId: params.actorId,
       actorType: "persona",
     })
-  const createThread = (params: Parameters<typeof streamService.createThread>[0]) => streamService.createThread(params)
+  const createThread = (params: Parameters<typeof streamService.createThreadInternal>[0]) =>
+    streamService.createThreadInternal(params)
 
   const activityService = new ActivityService({ pool })
   const syncService = new SyncService({ pool })
@@ -990,7 +991,7 @@ export async function startServer(): Promise<ServerInstance> {
     },
     loadFollowUp: ({ workspaceId, followUpId }) => agentFollowUpService.getById({ workspaceId, followUpId }),
     updateBrief: async ({ workspaceId, streamId, personaId, content, reason, expectedVersion }) => {
-      const result = await streamBriefService.update({
+      const result = await streamBriefService.updateInternal({
         workspaceId,
         streamId,
         content,

--- a/apps/backend/tests/integration/access-control.test.ts
+++ b/apps/backend/tests/integration/access-control.test.ts
@@ -449,6 +449,7 @@ describe("Access Control", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Threads inherit visibility from the root stream.
@@ -498,6 +499,7 @@ describe("Access Control", () => {
         parentStreamId: channel.id,
         parentAnchorId: event.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       expect(thread.parentAnchorId).toBe(event.id)
@@ -547,6 +549,7 @@ describe("Access Control", () => {
         parentStreamId: channel.id,
         parentAnchorId: msg1.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const msg2 = await eventService.createMessage({
@@ -562,6 +565,7 @@ describe("Access Control", () => {
         parentStreamId: thread1.id,
         parentAnchorId: msg2.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const msg3 = await eventService.createMessage({
@@ -577,6 +581,7 @@ describe("Access Control", () => {
         parentStreamId: thread2.id,
         parentAnchorId: msg3.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // All threads should have channel as root
@@ -629,6 +634,7 @@ describe("Access Control", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Non-member of channel cannot access thread (even though in workspace)
@@ -679,7 +685,7 @@ describe("Access Control", () => {
         authorType: "user",
         ...testMessageContent("Message that will spawn a thread"),
       })
-      const thread = await streamService.createThread({
+      const thread = await streamService.createThreadInternal({
         workspaceId: wsId,
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
@@ -731,6 +737,7 @@ describe("Access Control", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Initially not a member of either
@@ -997,6 +1004,7 @@ describe("Access Control", () => {
         parentStreamId: memberPrivateChannel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const publicChannel = await streamService.createChannel({

--- a/apps/backend/tests/integration/access-log-http.test.ts
+++ b/apps/backend/tests/integration/access-log-http.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
+import { getTestDatabaseTarget } from "../test-database"
 import {
   TestClient,
   loginAs,
@@ -37,9 +38,7 @@ describe("access-log HTTP capture", () => {
   let pool: Pool
 
   beforeAll(() => {
-    pool = new Pool({
-      connectionString: process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test",
-    })
+    pool = new Pool({ connectionString: getTestDatabaseTarget().connectionUrl })
   })
 
   afterAll(async () => {

--- a/apps/backend/tests/integration/access-log-socket.test.ts
+++ b/apps/backend/tests/integration/access-log-socket.test.ts
@@ -10,6 +10,7 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { io, Socket } from "socket.io-client"
 import { Pool } from "pg"
+import { getTestDatabaseTarget } from "../test-database"
 import {
   TestClient,
   loginAs,
@@ -84,9 +85,7 @@ describe("access-log socket capture", () => {
   let pool: Pool
 
   beforeAll(() => {
-    pool = new Pool({
-      connectionString: process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test",
-    })
+    pool = new Pool({ connectionString: getTestDatabaseTarget().connectionUrl })
   })
 
   afterAll(async () => {

--- a/apps/backend/tests/integration/agent-outcomes-read.test.ts
+++ b/apps/backend/tests/integration/agent-outcomes-read.test.ts
@@ -124,9 +124,8 @@ describe("agent outcomes read path", () => {
       authorType: "user",
       ...testMessageContent("anchor"),
     })
-    const thread = await streamService.create({
+    const thread = await streamService.createThreadInternal({
       workspaceId: wsId,
-      type: StreamTypes.THREAD,
       parentStreamId: channelId,
       parentAnchorId: anchor.id,
       createdBy: outsiderId,

--- a/apps/backend/tests/integration/conversation-reassign.test.ts
+++ b/apps/backend/tests/integration/conversation-reassign.test.ts
@@ -11,7 +11,7 @@ import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test
 import { Pool } from "pg"
 import { withTransaction, addTestMember, setupIsolatedTestDatabase, testMessageContent } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
-import { StreamRepository } from "../../src/features/streams"
+import { StreamMemberRepository, StreamRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
 import { ConversationRepository, ConversationService } from "../../src/features/conversations"
 import { userId, workspaceId, streamId, messageId, conversationId } from "../../src/lib/id"
@@ -49,6 +49,7 @@ describe("ConversationService.reassignMessage", () => {
         companionMode: "off",
         createdBy: testUserId,
       })
+      await StreamMemberRepository.insert(client, testStreamId, testUserId)
     })
 
     service = new ConversationService(pool)
@@ -67,6 +68,55 @@ describe("ConversationService.reassignMessage", () => {
       await client.query(`DELETE FROM streams WHERE id != '${testStreamId}'`)
     })
   })
+
+  async function waitForBlockedStreamLock(): Promise<void> {
+    const deadline = Date.now() + 5_000
+    while (Date.now() < deadline) {
+      const result = await pool.query<{ blocked: boolean }>(`
+        SELECT EXISTS (
+          SELECT 1 FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND pid <> pg_backend_pid()
+            AND wait_event_type = 'Lock'
+            AND query ILIKE '%streams%'
+        ) AS blocked
+      `)
+      if (result.rows[0]?.blocked) return
+      await Bun.sleep(10)
+    }
+    throw new Error("Timed out waiting for production stream lock contention")
+  }
+
+  async function raceMessagePlacement(params: { messageId: string; invoke: () => Promise<unknown> }): Promise<unknown> {
+    const archivedThreadId = streamId()
+    await withTransaction(pool, async (client) => {
+      await StreamRepository.insert(client, {
+        id: archivedThreadId,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+        parentStreamId: testStreamId,
+        rootStreamId: testStreamId,
+      })
+      await client.query("UPDATE streams SET archived_at = NOW() WHERE id = $1", [archivedThreadId])
+    })
+
+    const blocker = await pool.connect()
+    try {
+      await blocker.query("BEGIN")
+      await blocker.query("SELECT id FROM streams WHERE id = $1 FOR UPDATE", [testStreamId])
+      const operation = params.invoke()
+      await waitForBlockedStreamLock()
+      await pool.query("UPDATE messages SET stream_id = $1 WHERE id = $2", [archivedThreadId, params.messageId])
+      await blocker.query("COMMIT")
+      return await operation
+    } finally {
+      await blocker.query("ROLLBACK").catch(() => {})
+      blocker.release()
+    }
+  }
 
   /** Insert two conversations (A owning msg1+msg2, B owning msg0) in the shared test stream. */
   async function seedTwoConversations() {
@@ -323,6 +373,7 @@ describe("ConversationService.reassignMessage", () => {
         companionMode: "off",
         createdBy: testUserId,
       })
+      await StreamMemberRepository.insert(client, otherStreamId, testUserId)
       await MessageRepository.insert(client, {
         id: foreignMsgId,
         streamId: otherStreamId,
@@ -408,6 +459,63 @@ describe("ConversationService.reassignMessage", () => {
     expect(updatedSub?.payload.parentStreamId).toBe(testStreamId)
     expect(updatedA?.payload.parentStreamId).toBeUndefined()
   })
+
+  test("reassign retries stale placement and denies the archived current stream without mutation", async () => {
+    const { convAId, convBId, msg2Id, msg0Id, msg1Id } = await seedTwoConversations()
+    await expect(
+      raceMessagePlacement({
+        messageId: msg2Id,
+        invoke: () =>
+          service.reassignMessage({
+            workspaceId: testWorkspaceId,
+            conversationId: convBId,
+            messageId: msg2Id,
+            userId: testUserId,
+          }),
+      })
+    ).rejects.toMatchObject({
+      status: 403,
+      code: "STREAM_READ_ONLY",
+      details: { reason: "archived" },
+    })
+    const rows = await pool.query("SELECT id, message_ids FROM conversations WHERE id = ANY($1) ORDER BY id", [
+      [convAId, convBId],
+    ])
+    const effects = await pool.query(
+      "SELECT (SELECT COUNT(*)::int FROM conversation_feedback) AS feedback, (SELECT COUNT(*)::int FROM outbox WHERE event_type LIKE 'conversation:%') AS outbox"
+    )
+    expect({ conversations: rows.rows, effects: effects.rows }).toEqual({
+      conversations: expect.arrayContaining([
+        expect.objectContaining({ id: convAId, message_ids: [msg1Id, msg2Id] }),
+        expect.objectContaining({ id: convBId, message_ids: [msg0Id] }),
+      ]),
+      effects: [{ feedback: 0, outbox: 0 }],
+    })
+  }, 15_000)
+
+  test("settle retries stale placement and denies the archived current stream without feedback or outbox", async () => {
+    const { convAId, msg2Id } = await seedTwoConversations()
+    await expect(
+      raceMessagePlacement({
+        messageId: msg2Id,
+        invoke: () =>
+          service.settleMessage({
+            workspaceId: testWorkspaceId,
+            conversationId: convAId,
+            messageId: msg2Id,
+            userId: testUserId,
+          }),
+      })
+    ).rejects.toMatchObject({
+      status: 403,
+      code: "STREAM_READ_ONLY",
+      details: { reason: "archived" },
+    })
+    const effects = await pool.query(
+      "SELECT (SELECT COUNT(*)::int FROM conversation_feedback) AS feedback, (SELECT COUNT(*)::int FROM outbox WHERE event_type LIKE 'conversation:%') AS outbox"
+    )
+    expect(effects.rows).toEqual([{ feedback: 0, outbox: 0 }])
+  }, 15_000)
 
   test("rejects a conversation from a different workspace", async () => {
     const { convBId, msg2Id } = await seedTwoConversations()

--- a/apps/backend/tests/integration/setup.ts
+++ b/apps/backend/tests/integration/setup.ts
@@ -9,24 +9,23 @@ import { createMigrator } from "../../src/db/migrations"
 import { userId } from "../../src/lib/id"
 import type { Querier } from "../../src/db"
 import { UserRepository, type InsertUserParams } from "../../src/features/workspaces"
+import { getTestDatabaseTarget, quoteDatabaseIdentifier } from "../test-database"
 
 // Re-export production helpers for tests that need to persist data
 export { withClient, withTransaction } from "../../src/db"
-
-const ADMIN_DATABASE_URL = "postgresql://threa:threa@localhost:5454/postgres"
-const TEST_DATABASE_URL = "postgresql://threa:threa@localhost:5454/threa_test"
 
 /**
  * Creates the test database if it doesn't exist.
  */
 export async function ensureTestDatabaseExists(): Promise<void> {
-  const adminPool = new Pool({ connectionString: ADMIN_DATABASE_URL })
+  const { adminUrl, databaseName } = getTestDatabaseTarget()
+  const adminPool = new Pool({ connectionString: adminUrl })
 
   try {
-    const result = await adminPool.query("SELECT 1 FROM pg_database WHERE datname = 'threa_test'")
+    const result = await adminPool.query("SELECT 1 FROM pg_database WHERE datname = $1", [databaseName])
 
     if (result.rows.length === 0) {
-      await adminPool.query("CREATE DATABASE threa_test")
+      await adminPool.query(`CREATE DATABASE ${quoteDatabaseIdentifier(databaseName)}`)
     }
   } finally {
     await adminPool.end()
@@ -37,7 +36,7 @@ export async function ensureTestDatabaseExists(): Promise<void> {
  * Creates a pool connected to the test database.
  */
 export function createTestPool(): Pool {
-  return createDatabasePool(process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL)
+  return createDatabasePool(getTestDatabaseTarget().connectionUrl)
 }
 
 /**
@@ -58,19 +57,35 @@ export async function setupIsolatedTestDatabase(label: string): Promise<{ pool: 
     .replaceAll(/[^a-z0-9]/g, "_")
     .slice(0, 24)
   const databaseName = `threa_test_${safeLabel}_${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`
-  const adminPool = new Pool({ connectionString: ADMIN_DATABASE_URL })
-  await adminPool.query(`CREATE DATABASE "${databaseName}"`)
+  const target = getTestDatabaseTarget()
+  const adminPool = new Pool({ connectionString: target.adminUrl })
+  const databaseIdentifier = quoteDatabaseIdentifier(databaseName)
+  let pool: Pool | null = null
+  let databaseCreated = false
 
-  const connectionUrl = new URL(process.env.TEST_DATABASE_URL ?? TEST_DATABASE_URL)
-  connectionUrl.pathname = `/${databaseName}`
-  const pool = createDatabasePool(connectionUrl.toString())
-  await createMigrator(pool).up()
+  try {
+    await adminPool.query(`CREATE DATABASE ${databaseIdentifier}`)
+    databaseCreated = true
 
+    const connectionUrl = new URL(target.connectionUrl)
+    connectionUrl.pathname = `/${databaseName}`
+    pool = createDatabasePool(connectionUrl.toString())
+    await createMigrator(pool).up()
+  } catch (error) {
+    if (pool) await pool.end()
+    if (databaseCreated) await adminPool.query(`DROP DATABASE ${databaseIdentifier} WITH (FORCE)`)
+    await adminPool.end()
+    throw error
+  }
+
+  let cleanedUp = false
   return {
     pool,
     cleanup: async () => {
+      if (cleanedUp) return
+      cleanedUp = true
       await pool.end()
-      await adminPool.query(`DROP DATABASE "${databaseName}" WITH (FORCE)`)
+      await adminPool.query(`DROP DATABASE ${databaseIdentifier} WITH (FORCE)`)
       await adminPool.end()
     },
   }

--- a/apps/backend/tests/integration/stream-context-read.test.ts
+++ b/apps/backend/tests/integration/stream-context-read.test.ts
@@ -85,9 +85,8 @@ describe("stream context read path", () => {
 
     // The thread is created by the OUTSIDER, so the member holds no membership
     // row on it — the case a `stream_members` filter would drop.
-    const thread = await streamService.create({
+    const thread = await streamService.createThreadInternal({
       workspaceId: wsId,
-      type: StreamTypes.THREAD,
       parentStreamId: channelId,
       parentAnchorId: anchor.id,
       createdBy: outsiderId,

--- a/apps/backend/tests/integration/stream-read-only-mutation-matrix.test.ts
+++ b/apps/backend/tests/integration/stream-read-only-mutation-matrix.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { Pool } from "pg"
+import { addTestMember, setupIsolatedTestDatabase, withTransaction } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import {
+  assertStreamWritable,
+  StreamEventRepository,
+  StreamMemberRepository,
+  StreamRepository,
+  StreamService,
+} from "../../src/features/streams"
+import { eventId, streamId, userId, workspaceId } from "../../src/lib/id"
+
+const rejection = (reason: string) => ({ status: 403, code: "STREAM_READ_ONLY", details: { reason } })
+
+describe("synchronous stream read-only mutation matrix", () => {
+  let pool: Pool
+  let cleanup: () => Promise<void>
+  let workspace: string
+  let member: string
+  let outsider: string
+  let otherWorkspace: string
+  let otherMember: string
+
+  beforeAll(async () => {
+    const isolated = await setupIsolatedTestDatabase("stream_read_only_mutation_matrix")
+    pool = isolated.pool
+    cleanup = isolated.cleanup
+    workspace = workspaceId()
+    member = userId()
+    outsider = userId()
+    otherWorkspace = workspaceId()
+    otherMember = userId()
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, { id: workspace, name: "Matrix", slug: workspace, createdBy: member })
+      member = (await addTestMember(client, workspace, member)).id
+      outsider = (await addTestMember(client, workspace, outsider)).id
+      await WorkspaceRepository.insert(client, {
+        id: otherWorkspace,
+        name: "Other Matrix",
+        slug: otherWorkspace,
+        createdBy: otherMember,
+      })
+      otherMember = (await addTestMember(client, otherWorkspace, otherMember)).id
+    })
+  }, 120_000)
+
+  afterAll(async () => cleanup(), 120_000)
+
+  async function seed(overrides: Partial<Parameters<typeof StreamRepository.insert>[1]> = {}) {
+    const id = streamId()
+    await withTransaction(pool, async (client) => {
+      await StreamRepository.insert(client, {
+        id,
+        workspaceId: workspace,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: member,
+        ...overrides,
+      })
+      await StreamMemberRepository.insert(client, id, member)
+    })
+    return id
+  }
+
+  test("real schema returns exact direct, inherited, system, and public nonparticipant reasons", async () => {
+    const direct = await seed()
+    const root = await seed()
+    const thread = await seed({ type: "thread", rootStreamId: root, parentStreamId: root })
+    const system = await seed({ type: "system" })
+    const publicStream = await seed({ visibility: "public" })
+    await pool.query("UPDATE streams SET archived_at = NOW() WHERE id = ANY($1)", [[direct, root]])
+
+    const check = (id: string, principal = member) =>
+      withTransaction(pool, (client) =>
+        assertStreamWritable(client, {
+          workspaceId: workspace,
+          streamId: id,
+          principal: { kind: "user", userId: principal },
+        })
+      )
+    await expect(check(direct)).rejects.toMatchObject(rejection("archived"))
+    await expect(check(thread)).rejects.toMatchObject(rejection("archived"))
+    await expect(check(system)).rejects.toMatchObject(rejection("system_stream"))
+    await expect(check(publicStream, outsider)).rejects.toMatchObject(rejection("not_a_member"))
+  })
+
+  test("private and cross-workspace targets remain hidden and denied metadata writes leave no outbox", async () => {
+    const privateStream = await seed()
+    const archived = await seed()
+    const foreign = streamId()
+    await withTransaction(pool, async (client) => {
+      await StreamRepository.insert(client, {
+        id: foreign,
+        workspaceId: otherWorkspace,
+        type: "channel",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: otherMember,
+      })
+      await StreamMemberRepository.insert(client, foreign, otherMember)
+    })
+    await pool.query("UPDATE streams SET archived_at = NOW() WHERE id = $1", [archived])
+    const service = new StreamService(pool)
+
+    await expect(
+      withTransaction(pool, (client) =>
+        assertStreamWritable(client, {
+          workspaceId: workspace,
+          streamId: privateStream,
+          principal: { kind: "user", userId: outsider },
+        })
+      )
+    ).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    await expect(
+      withTransaction(pool, (client) =>
+        assertStreamWritable(client, {
+          workspaceId: workspace,
+          streamId: foreign,
+          principal: { kind: "user", userId: member },
+        })
+      )
+    ).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
+    await expect(
+      service.updateStream(
+        archived,
+        { displayName: "forbidden" },
+        { workspaceId: workspace, principal: { kind: "user", userId: member } }
+      )
+    ).rejects.toMatchObject(rejection("archived"))
+    const rows = await pool.query("SELECT display_name FROM streams WHERE id = $1", [archived])
+    const outbox = await pool.query("SELECT 1 FROM outbox WHERE payload->>'streamId' = $1", [archived])
+    expect({ displayName: rows.rows[0].display_name, outboxRows: outbox.rowCount }).toEqual({
+      displayName: null,
+      outboxRows: 0,
+    })
+  })
+
+  test("production stream mutation services preserve authority reasons before legacy eligibility", async () => {
+    const archivedScratchpad = await seed({ type: "scratchpad", displayName: "Protected" })
+    const system = await seed({ type: "system", createdBy: outsider })
+    const publicStream = await seed({ visibility: "public" })
+    await pool.query("UPDATE streams SET archived_at = NOW() WHERE id = $1", [archivedScratchpad])
+    const service = new StreamService(pool)
+
+    await expect(
+      service.updateStream(
+        system,
+        { displayName: "forbidden" },
+        { workspaceId: workspace, principal: { kind: "user", userId: member } }
+      )
+    ).rejects.toMatchObject(rejection("system_stream"))
+    await expect(service.updateCompanionMode(publicStream, workspace, "off", null, outsider)).rejects.toMatchObject(
+      rejection("not_a_member")
+    )
+    await expect(
+      service.setStreamToolPolicy(workspace, system, ["web"], { kind: "user", userId: member })
+    ).rejects.toMatchObject(rejection("system_stream"))
+    await expect(
+      service.regenerateDisplayName(workspace, archivedScratchpad, { kind: "user", userId: member })
+    ).rejects.toMatchObject(rejection("archived"))
+
+    const rows = await pool.query(
+      "SELECT id, display_name, companion_mode FROM streams WHERE id = ANY($1) ORDER BY id",
+      [[system, publicStream, archivedScratchpad]]
+    )
+    const policies = await pool.query("SELECT stream_id FROM stream_policies WHERE stream_id = ANY($1)", [
+      [system, publicStream, archivedScratchpad],
+    ])
+    const outbox = await pool.query("SELECT id FROM outbox WHERE payload->>'streamId' = ANY($1)", [
+      [system, publicStream, archivedScratchpad],
+    ])
+    expect({
+      streams: rows.rows,
+      policies: policies.rows,
+      outbox: outbox.rows,
+    }).toEqual({
+      streams: expect.arrayContaining([
+        expect.objectContaining({ id: system, display_name: null }),
+        expect.objectContaining({ id: publicStream, companion_mode: "off" }),
+        expect.objectContaining({ id: archivedScratchpad, display_name: "Protected" }),
+      ]),
+      policies: [],
+      outbox: [],
+    })
+  })
+
+  test("public nonparticipants cannot create threads", async () => {
+    const root = await seed({ visibility: "public" })
+    const anchor = await StreamEventRepository.insert(pool, {
+      id: eventId(),
+      streamId: root,
+      eventType: "delegation:created",
+      payload: {},
+      actorId: member,
+      actorType: "user",
+    })
+
+    await expect(
+      new StreamService(pool).createThread({
+        workspaceId: workspace,
+        parentStreamId: root,
+        parentAnchorId: anchor.id,
+        createdBy: outsider,
+        principal: { kind: "user", userId: outsider },
+      })
+    ).rejects.toMatchObject(rejection("not_a_member"))
+
+    const threads = await pool.query("SELECT id FROM streams WHERE parent_stream_id = $1", [root])
+    const outbox = await pool.query("SELECT id FROM outbox WHERE payload->>'parentStreamId' = $1", [root])
+    expect({ threads: threads.rows, outbox: outbox.rows }).toEqual({ threads: [], outbox: [] })
+  })
+
+  test("archive transition contends with the stable authority lock", async () => {
+    const id = await seed()
+    const locker = await pool.connect()
+    const archiver = await pool.connect()
+    try {
+      await locker.query("BEGIN")
+      await assertStreamWritable(locker, {
+        workspaceId: workspace,
+        streamId: id,
+        principal: { kind: "user", userId: member },
+      })
+      await archiver.query("BEGIN")
+      let finished = false
+      const transition = archiver.query("UPDATE streams SET archived_at = NOW() WHERE id = $1", [id]).then(() => {
+        finished = true
+      })
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(finished).toBe(false)
+      await locker.query("COMMIT")
+      await transition
+      await archiver.query("COMMIT")
+      await expect(
+        withTransaction(pool, (client) =>
+          assertStreamWritable(client, {
+            workspaceId: workspace,
+            streamId: id,
+            principal: { kind: "user", userId: member },
+          })
+        )
+      ).rejects.toMatchObject(rejection("archived"))
+    } finally {
+      await locker.query("ROLLBACK").catch(() => {})
+      await archiver.query("ROLLBACK").catch(() => {})
+      locker.release()
+      archiver.release()
+    }
+  })
+})

--- a/apps/backend/tests/integration/thread-graph.test.ts
+++ b/apps/backend/tests/integration/thread-graph.test.ts
@@ -12,7 +12,12 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
 import { withTestTransaction, addTestMember } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
-import { StreamService, StreamEventRepository, StreamRepository } from "../../src/features/streams"
+import {
+  StreamService,
+  StreamEventRepository,
+  StreamMemberRepository,
+  StreamRepository,
+} from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
 import { setupTestDatabase, testMessageContent } from "./setup"
 import { userId, workspaceId, messageId, eventId, streamId } from "../../src/lib/id"
@@ -71,6 +76,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       expect(thread.type).toBe(StreamTypes.THREAD)
@@ -115,6 +121,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: msg1.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const msg2 = await eventService.createMessage({
@@ -130,6 +137,7 @@ describe("Thread Graph", () => {
         parentStreamId: thread1.id,
         parentAnchorId: msg2.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // thread1's root is channel
@@ -179,6 +187,7 @@ describe("Thread Graph", () => {
           parentStreamId: parentStream.id,
           parentAnchorId: msg.id,
           createdBy: ownerId,
+          principal: { kind: "user", userId: ownerId },
         })
         threads.push(thread)
         parentStream = thread
@@ -233,6 +242,7 @@ describe("Thread Graph", () => {
         parentStreamId: scratchpad.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       expect(thread.parentStreamId).toBe(scratchpad.id)
@@ -275,6 +285,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Creator should be a member
@@ -304,6 +315,7 @@ describe("Thread Graph", () => {
           parentStreamId: "stream_nonexistent",
           parentAnchorId: "msg_nonexistent",
           createdBy: ownerId,
+          principal: { kind: "user", userId: ownerId },
         })
       ).rejects.toThrow("Stream not found")
     })
@@ -346,6 +358,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Create thread second time with same parent message
@@ -354,6 +367,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Should return the same thread
@@ -399,14 +413,18 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
-      // Second user tries to create thread for same message
+      // The second caller must participate at the effective root before this
+      // user operation can resolve the existing thread.
+      await StreamMemberRepository.insert(pool, channel.id, user2Id)
       const thread2 = await streamService.createThread({
         workspaceId: wsId,
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: user2Id,
+        principal: { kind: "user", userId: user2Id },
       })
 
       // Should return same thread
@@ -463,6 +481,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Send a message in the thread
@@ -528,6 +547,7 @@ describe("Thread Graph", () => {
         parentStreamId: channel.id,
         parentAnchorId: channelMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Create message in thread1
@@ -549,6 +569,7 @@ describe("Thread Graph", () => {
         parentStreamId: thread1.id,
         parentAnchorId: thread1Message.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       // Create message in nested thread
@@ -616,6 +637,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: event.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       expect(thread.parentAnchorId).toBe(event.id)
@@ -642,6 +664,7 @@ describe("Thread Graph", () => {
           parentStreamId: channelId,
           parentAnchorId: event.id,
           createdBy: ownerId,
+          principal: { kind: "user", userId: ownerId },
         })
       ).rejects.toMatchObject({ code: "ANCHOR_NOT_THREADABLE" })
     })
@@ -669,6 +692,7 @@ describe("Thread Graph", () => {
           parentStreamId: channelId,
           parentAnchorId: event.id,
           createdBy: ownerId,
+          principal: { kind: "user", userId: ownerId },
         })
       ).rejects.toMatchObject({ code: "ANCHOR_NOT_FOUND" })
     })
@@ -688,6 +712,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: parentMessage.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const persisted = await StreamRepository.findById(pool, thread.id)
@@ -710,12 +735,15 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: event.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
+      await StreamMemberRepository.insert(pool, channelId, actorId)
       const second = await streamService.createThread({
         workspaceId: wsId,
         parentStreamId: channelId,
         parentAnchorId: event.id,
         createdBy: actorId,
+        principal: { kind: "user", userId: actorId },
       })
 
       expect(second.id).toBe(first.id)
@@ -773,6 +801,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: parent.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       const reply = await eventService.createMessage({
@@ -824,6 +853,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: cardEvent.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
 
       await eventService.createMessage({
@@ -864,6 +894,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: parent.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
       await eventService.createMessage({
         workspaceId: wsId,
@@ -886,6 +917,7 @@ describe("Thread Graph", () => {
         parentStreamId: channelId,
         parentAnchorId: cardEvent.id,
         createdBy: ownerId,
+        principal: { kind: "user", userId: ownerId },
       })
       await eventService.createMessage({
         workspaceId: wsId,

--- a/apps/backend/tests/integration/thread-summary.test.ts
+++ b/apps/backend/tests/integration/thread-summary.test.ts
@@ -86,6 +86,7 @@ describe("Thread Summary", () => {
       parentStreamId: channel.id,
       parentAnchorId: parent.id,
       createdBy: ownerId,
+      principal: { kind: "user", userId: ownerId },
     })
 
     // Create replyUserCount distinct user IDs. We don't need actual User
@@ -263,6 +264,7 @@ describe("Thread Summary", () => {
           parentStreamId: channel.id,
           parentAnchorId: parent.id,
           createdBy: ownerId,
+          principal: { kind: "user", userId: ownerId },
         })
         await eventService.createMessage({
           workspaceId: wsId,

--- a/apps/backend/tests/integration/title-regeneration.test.ts
+++ b/apps/backend/tests/integration/title-regeneration.test.ts
@@ -3,7 +3,7 @@ import { Pool } from "pg"
 import { StreamTypes } from "@threa/types"
 import { addTestMember, setupTestDatabase, withTransaction } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
-import { StreamRepository, StreamService } from "../../src/features/streams"
+import { StreamMemberRepository, StreamRepository, StreamService } from "../../src/features/streams"
 import { ConversationRepository, ConversationService } from "../../src/features/conversations"
 import { DynamicNamingStateRepository } from "../../src/features/dynamic-naming"
 import { E2eStreamsRepository } from "../../src/features/e2e-streams"
@@ -41,12 +41,13 @@ describe("title regeneration", () => {
         displayNameSource: "explicit",
         createdBy: ownerId,
       })
+      await StreamMemberRepository.insert(tx, sId, ownerId)
     })
     return { wsId, ownerId, sId }
   }
 
   test("preserves a plaintext stream title while resetting lifecycle and writing the request atomically", async () => {
-    const { wsId, sId } = await fixture()
+    const { wsId, ownerId, sId } = await fixture()
     const state = await DynamicNamingStateRepository.ensure(pool, {
       workspaceId: wsId,
       targetKind: "stream",
@@ -56,7 +57,10 @@ describe("title regeneration", () => {
       state.id,
     ])
 
-    const result = await new StreamService(pool).regenerateDisplayName(wsId, sId)
+    const result = await new StreamService(pool).regenerateDisplayName(wsId, sId, {
+      kind: "user",
+      userId: ownerId,
+    })
 
     expect(result).toMatchObject({
       deferred: false,
@@ -89,6 +93,7 @@ describe("title regeneration", () => {
         slug: `regen-${channelId}`,
         createdBy: ownerId,
       })
+      await StreamMemberRepository.insert(tx, channelId, ownerId)
       await ConversationRepository.insert(tx, {
         id: cId,
         workspaceId: wsId,
@@ -98,7 +103,11 @@ describe("title regeneration", () => {
       })
     })
 
-    const result = await new ConversationService(pool).regenerateTitle({ workspaceId: wsId, conversationId: cId })
+    const result = await new ConversationService(pool).regenerateTitle({
+      workspaceId: wsId,
+      conversationId: cId,
+      actorUserId: ownerId,
+    })
 
     expect(result.conversation).toMatchObject({
       topicSummary: "Migration rollback",
@@ -131,7 +140,12 @@ describe("title regeneration", () => {
     const ciphertext = Buffer.from("freshly-resealed-current-title").toString("base64")
     const envelope = nameEnvelope(sId)
 
-    const result = await new StreamService(pool).regenerateDisplayName(wsId, sId, { ciphertext, envelope })
+    const result = await new StreamService(pool).regenerateDisplayName(
+      wsId,
+      sId,
+      { kind: "user", userId: ownerId },
+      { ciphertext, envelope }
+    )
 
     expect(result).toMatchObject({ deferred: true, stream: { displayName: null, displayNameSource: "generated" } })
     expect(await E2eStreamsRepository.getSealedName(pool, wsId, sId)).toEqual({ ciphertext, envelope })

--- a/apps/backend/tests/test-database.ts
+++ b/apps/backend/tests/test-database.ts
@@ -1,0 +1,32 @@
+const DEFAULT_TEST_DATABASE_URL = "postgresql://threa:threa@localhost:5455/threa_test"
+
+export interface TestDatabaseTarget {
+  connectionUrl: string
+  adminUrl: string
+  databaseName: string
+}
+
+/**
+ * Resolve every test-database connection from the same endpoint. Local test
+ * infrastructure is exposed on port 5455; CI can override the full URL.
+ */
+export function getTestDatabaseTarget(): TestDatabaseTarget {
+  const connectionUrl = process.env.TEST_DATABASE_URL ?? DEFAULT_TEST_DATABASE_URL
+  const parsed = new URL(connectionUrl)
+  const databaseName = decodeURIComponent(parsed.pathname.slice(1))
+  if (!databaseName) throw new Error("TEST_DATABASE_URL must include a database name")
+
+  const admin = new URL(parsed)
+  admin.pathname = "/postgres"
+
+  return {
+    connectionUrl,
+    adminUrl: admin.toString(),
+    databaseName,
+  }
+}
+
+/** PostgreSQL does not support bind parameters for identifiers. */
+export function quoteDatabaseIdentifier(databaseName: string): string {
+  return `"${databaseName.replaceAll('"', '""')}"`
+}

--- a/apps/backend/tests/test-server.ts
+++ b/apps/backend/tests/test-server.ts
@@ -13,6 +13,7 @@
 import { createServer } from "http"
 import { Pool } from "pg"
 import { S3Client, HeadBucketCommand, CreateBucketCommand } from "@aws-sdk/client-s3"
+import { getTestDatabaseTarget, quoteDatabaseIdentifier } from "./test-database"
 
 export interface TestServer {
   url: string
@@ -24,15 +25,14 @@ export interface TestServer {
  * Creates the test database if it doesn't exist.
  */
 async function ensureTestDatabaseExists(): Promise<void> {
-  const adminPool = new Pool({
-    connectionString: "postgresql://threa:threa@localhost:5454/postgres",
-  })
+  const { adminUrl, databaseName } = getTestDatabaseTarget()
+  const adminPool = new Pool({ connectionString: adminUrl })
 
   try {
-    const result = await adminPool.query("SELECT 1 FROM pg_database WHERE datname = 'threa_test'")
+    const result = await adminPool.query("SELECT 1 FROM pg_database WHERE datname = $1", [databaseName])
 
     if (result.rows.length === 0) {
-      await adminPool.query("CREATE DATABASE threa_test")
+      await adminPool.query(`CREATE DATABASE ${quoteDatabaseIdentifier(databaseName)}`)
     }
   } finally {
     await adminPool.end()
@@ -44,7 +44,7 @@ async function ensureTestDatabaseExists(): Promise<void> {
  */
 async function ensureMinioBucketExists(): Promise<void> {
   const bucket = process.env.S3_BUCKET || "threa-test-uploads"
-  const endpoint = process.env.S3_ENDPOINT || "http://localhost:9099"
+  const endpoint = process.env.S3_ENDPOINT || "http://localhost:9002"
 
   const client = new S3Client({
     region: "us-east-1",
@@ -75,9 +75,7 @@ async function ensureMinioBucketExists(): Promise<void> {
  * Cleans up stale jobs from previous test runs to prevent test pollution.
  */
 async function cleanupStaleData(): Promise<void> {
-  const testPool = new Pool({
-    connectionString: process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test",
-  })
+  const testPool = new Pool({ connectionString: getTestDatabaseTarget().connectionUrl })
 
   try {
     // TRUNCATE all mutable tables to prevent test pollution between runs.
@@ -153,7 +151,7 @@ export async function startTestServer(): Promise<TestServer> {
 
   // Configure environment for test server
   process.env.FAST_SHUTDOWN = "true" // Fast shutdown for tests
-  process.env.DATABASE_URL = process.env.TEST_DATABASE_URL || "postgresql://threa:threa@localhost:5454/threa_test"
+  process.env.DATABASE_URL = getTestDatabaseTarget().connectionUrl
   process.env.PORT = String(port)
   process.env.USE_STUB_AUTH = "true"
   process.env.SESSION_COOKIE_NAME = process.env.SESSION_COOKIE_NAME || "wos_session_test"
@@ -183,7 +181,7 @@ export async function startTestServer(): Promise<TestServer> {
 
   // S3/MinIO for e2e
   // - CI (`.github/workflows/ci.yml`) exports MinIO on :9000 — must not override.
-  // - Local dev: Bun loads `.env` with real AWS; force our compose MinIO (:9099) or HeadBucket 403s.
+  // - Local tests: Bun loads `.env` with real AWS; force docker-compose.test.yml MinIO (:9002).
   if (process.env.CI) {
     process.env.S3_BUCKET = process.env.S3_BUCKET || "threa-test-uploads"
     process.env.S3_REGION = process.env.S3_REGION || "us-east-1"
@@ -195,7 +193,7 @@ export async function startTestServer(): Promise<TestServer> {
     process.env.S3_REGION = "us-east-1"
     process.env.S3_ACCESS_KEY_ID = "minioadmin"
     process.env.S3_SECRET_ACCESS_KEY = "minioadmin"
-    process.env.S3_ENDPOINT = "http://localhost:9099"
+    process.env.S3_ENDPOINT = "http://localhost:9002"
   }
 
   // Ensure MinIO bucket exists


### PR DESCRIPTION
## Problem

Message writes now serialize with stream lifecycle transitions, but other synchronous mutations still use archive checks, membership checks, or readable access as write authority. Conversation refiles, metadata, briefs, scheduled acceptance, commands, and calls can therefore disagree with the core transaction gate or expose legacy errors instead of `STREAM_READ_ONLY`.

## Solution

Route the remaining request-time shared writes through the central principal authority.

- Conversation reassign, settle, split, title, summary, and status mutations lock all relevant streams before conversation and message rows. Reassign and settle retry when a concurrent move invalidates their placement snapshot.
- Thread creation, stream metadata, companion settings, tool policy, title regeneration, and briefs check user or bot authority in the mutation transaction. Brief storage remains on the effective root while authority applies to the requested target.
- Scheduled create, update, and send-now check authority before status or E2E errors. Own idempotent retries recheck current read access, including the post-rollback unique-race winner.
- Command dispatch separates listing from intrinsic command resolution. Fresh work commands lock writability before the idempotency claim; `invite`, `stop`, and `status` remain available as lifecycle/read controls.
- Call start and join check the host stream before call, participant, endpoint, event, or outbox writes. Leave and termination controls remain available.

This is PR 3 of the stream read-only stack. Deferred worker and generated-output checks follow in PR 4. Plan visualization: https://seer.build/ws_vbyzjvdg6g/b/threa-stream-read-only-plan/

## Files

| Area | Change |
| --- | --- |
| `features/conversations/{handlers,service}.ts` | Principal authority and stale-placement recovery for topology writes |
| `features/streams/{service,handlers,brief-*}.ts` | Guarded thread, metadata, companion, policy, regeneration, and brief mutations |
| `features/scheduled-messages/service.ts` | Authority, replay privacy, status ordering, and E2E recheck |
| `features/commands/{availability,handlers}.ts` | Dispatch-time authority, replay locking, and narrow exceptions |
| `features/calls/service.ts` | Host-stream authority for call start and join |
| `features/public-api/handlers.ts` | User and bot principals for metadata and runtime-session rename |
| Mutation inventory and integration tests | Method-level guard inventory, exact reasons, privacy, lock contention, and move races |

## Test plan

- [x] focused touched backend unit suites: 272 tests
- [x] real-schema mutation-matrix and conversation suites: 16 tests
- [x] call lifecycle integration: 5 tests
- [x] pre-commit repository lint, monorepo typecheck, migration validation, and generated API-doc check

## Known coverage gap

The real-schema matrix covers central reasons, cross-workspace hiding, selected production stream services, archive contention, and conversation placement races. It does not yet instantiate every owned adapter, including brief, scheduled-message, principal thread-create, and call start/join services, in one end-to-end matrix. Focused unit suites cover those gates; the full production-path inventory remains for PR review and the final whole-stack pass.

<details>
<summary>📋 Full implementation plan</summary>

# Stream read-only state — implementation plan

## Baseline and scope

- Plan against `origin/main` / `abe0bb1a` (the inspected worktree is identical to that ref).
- This is a cross-layer authorization feature, not an archive-only UI cleanup. The server is authoritative; client state is a hint that suppresses impossible actions and explains denials.
- No database migration. Viewer state is derived from existing stream, root-stream, human-membership, and bot-channel-grant rows. IndexedDB fields are optional and unindexed, so no Dexie schema version is needed.
- Do not put viewer-relative fields on repository `Stream` rows or shared outbox/socket payloads. Add explicit viewer DTOs and project them only at request/bootstrap boundaries.
- Do not add a generic broadcast `stream_read_only_changed` event. Archive events remain shared facts; membership/grant changes remain scoped facts. Recipients recompute their own overlay.

## Binding state model

### Shared contract

Follow the repository’s existing constants SSOT pattern in `packages/types/src/constants.ts` and re-export it from `packages/types/src/index.ts`:

```ts
export const STREAM_READ_ONLY_REASONS = ["archived", "system_stream", "not_a_member"] as const
export type StreamReadOnlyReason = (typeof STREAM_READ_ONLY_REASONS)[number]

export const StreamReadOnlyReasons = {
  ARCHIVED: "archived",
  SYSTEM_STREAM: "system_stream",
  NOT_A_MEMBER: "not_a_member",
} as const satisfies Record<string, StreamReadOnlyReason>

export const StreamErrorCodes = {
  READ_ONLY: "STREAM_READ_ONLY",
} as const
```

`system_stream` is the sole wire value; never serialize, compare, or document `system` as a read-only reason. Define `StreamViewerState`, `ViewerStream`, and `ViewerStreamWithPreview` in `packages/types/src/domain.ts` using the constants type:

```ts
export interface StreamViewerState {
  readOnly: boolean
  readOnlyReason: StreamReadOnlyReason | null
}

export type ViewerStream = Stream & StreamViewerState
export type ViewerStreamWithPreview = StreamWithPreview & StreamViewerState
```

Use `ViewerStream`/`ViewerStreamWithPreview` in viewer-facing response types in `packages/types/src/api.ts`: `WorkspaceBootstrap.streams`, `StreamBootstrap.stream`, app stream list/get/create/update/archive responses, and any nested fresh stream response. Keep `Stream`, `StreamCreatedPayload`, `StreamUpdatedPayload`, archive events, outbox payloads, and internal repository types principal-free.

Add the generic overlay in parallel with existing archive-specific projections:

- Keep `StreamBootstrap.rootArchivedAt`. It is a distinct archive-inheritance fact used by existing archive behavior; generic viewer state does not replace it in this feature.
- Keep `BoardPost.rootArchived`. Board archive filtering specifically needs root archive state and must not filter on generic `streamReadOnly` (which would incorrectly filter system streams and public non-member rows).
- Add `BoardPost.streamReadOnly` and `streamReadOnlyReason` alongside `rootArchived` as the viewer-scoped effective state of the stream receiving the post/reply.
- Add required `readOnly` and nullable `readOnlyReason` properties to the public API `WireStream` schema in `apps/backend/src/features/public-api/routes.ts`.
- Defer removal of either archive-specific field until a separate cleanup proves every inheritance/filter consumer has an equivalent archive-specific source; that cleanup is not part of this stack.

### Truth table and precedence

First resolve access using the existing effective-root model. A missing stream, cross-workspace stream, dangling root, or private stream whose principal lacks effective-root participation/grant remains inaccessible and must not produce a read-only DTO. Preserve the current 404/non-disclosure behavior for those cases.

For every accessible target, derive exactly one state in this order:

| Condition | `readOnly` | `readOnlyReason` |
|---|---:|---|
| Target is archived, or its effective root is archived | `true` | `"archived"` |
| Otherwise target type is `system` | `true` | `"system_stream"` |
| Otherwise the principal lacks participation at the effective root | `true` | `"not_a_member"` |
| Otherwise | `false` | `null` |

Consequences that must be encoded in tests rather than left implicit:

- A public channel/thread remains readable without participation, but is `not_a_member` and cannot perform shared writes.
- A private channel/thread without participation is hidden/revoked, not returned as `not_a_member`.
- A target archive beats `system_stream` and `not_a_member`; `system_stream` beats `not_a_member`.
- Root archive state applies to descendants. A child’s own archive state also seals the child.
- Human participation is the effective-root `stream_members` row. API-key bot participation is the effective-root bot-channel grant. A user-scoped public API key uses its human principal; a bot key uses its bot principal.
- A persona/event actor is presentation identity, not write authority. Deferred work must retain and recheck the initiating human/bot principal.
- Unknown future reason strings received by the frontend still mean read-only and use generic copy.

### Backend authority API

Create `apps/backend/src/features/streams/write-authority.ts` and centralize both projection and mutation checks there; do not grow another collection of handler-local archive/member checks.

The module should expose:

1. A pure `deriveStreamViewerState({ target, root, participates })` implementing the table above.
2. User and API-principal single/batch projection functions. Batch functions load all required roots and participation/grant rows once and return new DTO objects; they never mutate repository rows.
3. A transaction-only `assertStreamWritable(client, { workspaceId, streamId, principal })` that locks, resolves, and returns the target/root plus writable authority, or throws the structured denial below.
4. A narrowly scoped trusted lifecycle capability for writes that exist to record state transitions (for example stream/member/archive system events and system-stream activity). It must be a non-forgeable exported token/constructor accepted only by the low-level mutation API—not a widely propagated `bypassReadOnly: boolean`.

Represent authorization principal separately from event actor:

```ts
type StreamWritePrincipal =
  | { kind: "user"; userId: string }
  | { kind: "bot"; botId: string }
```

Persona, companion, command, scheduled, delegation, enclave, and worker code must pass the initiating user/bot principal at execution time. Trusted lifecycle capability is not a fallback for missing principal data.

For an accessible but read-only target, throw:

```ts
new HttpError("This stream is read-only", {
  status: 403,
  code: "STREAM_READ_ONLY",
  details: { reason },
})
```

Use the same shape through app and public API error middleware. Keep privacy/E2E/validation failures distinct; do not wrap them as read-only. Inaccessible private targets remain 404. Export the error code in the relevant shared error constants so frontend, CLI, and tests do not compare message text.

### Lock protocol and linearization point

All archive/unarchive, leave/remove, and guarded stream mutation paths must use one deterministic protocol:

1. Begin a transaction.
2. Resolve target and effective-root ids in the workspace.
3. Lock stream rows with `SELECT ... FOR UPDATE` in stable id order (effective root and target; one lock if identical).
4. Lock the principal’s participation row/grant at the effective root. Membership removal locks that same row; membership insertion uses the same stream lock before inserting. Bot grants follow the same ordering.
5. Recompute access and read-only state from the locked rows.
6. Perform the mutation and insert its event/outbox records before commit.

Add repository methods in `apps/backend/src/features/streams/repository.ts`, `member-repository.ts`, and the bot channel access repository to support those locks. Do not perform a handler/service precheck and mutate in a later `EventService` transaction. Refactor `EventService` to accept an existing `PoolClient` (or add transaction-scoped variants) so its sequence/event/outbox operations share the authority transaction.

Archive/unarchive and leave/remove are not themselves blocked by the resulting read-only state. They acquire the same locks and serialize against writes. If a write gets the lock first it may commit before the transition; if the transition gets it first the write deterministically fails. Join/invite/remove/leave, unarchive, and stop/cancel controls remain available subject to their existing role/ownership rules.

### Event transitions and recipient-local recomputation

| Durable fact transition | Delivery | Recipient result |
|---|---|---|
| Target/root archived or unarchived | Reuse existing archive/unarchive causal event and shared stream delivery | Recompute target plus cached descendants. Archive produces `archived`; unarchive reveals `system_stream`, `not_a_member`, or writable according to current facts. |
| Current user self-joins or is added | Persist the membership delta with `OutboxRepository`; make `resolveDeliveryGroups` include the existing `userGroup(affectedUserId)` so `BroadcastHandler` writes it to `sync_log` and emits it live | Add effective-root participation, fetch a fresh viewer stream/bootstrap only if the stream is absent, then recompute target/descendants. |
| Current user leaves or is removed | Persist the removal delta and make `resolveDeliveryGroups` include `userGroup(affectedUserId)` as well as any existing `streamGroup(streamId)` lifecycle audience | Public root: retain readable cache and become `not_a_member`. Private root: revoke access and purge server-derived cache. |
| Bot grant added/removed | Persist the bot grant transition; public API bot requests derive from current grant rows | A subsequent list/get/write reflects the new bot overlay; do not broadcast bot-relative viewer state to humans. |

The affected-user membership delta contains only the identifiers/action needed to update participation; it does not carry `readOnly`, `readOnlyReason`, or another viewer’s projection. If the existing `stream:member_added` timeline envelope must retain its canonical `stream`/`event` payload for the stream audience, split the affected-user sync delta from that envelope rather than copying the full timeline payload into a new viewer hint. Offline/reconnect catch-up consumes durable `userGroup` deltas, then fresh bootstrap remains the reconciliation backstop. Shared canonical archive/stream events and viewer-scoped membership deltas must be safe in either arrival order because the client resolver applies precedence from facts.

## Current drifts this stack must remove

- `StreamService.resolveWritableMessageStream` performs an out-of-transaction archive/member check, has legacy text errors, and does not cover system streams.
- App and public message handlers authorize readability separately from `EventService` mutation; public non-members and bot keys without grants can currently reach writes on public streams.
- Edit/delete/reaction paths, message movement, and conversation assignment/merge/split use different or incomplete checks.
- Stream metadata, brief, companion settings, command dispatch, scheduling, and call start/join mostly gate on readability or local archive checks.
- Scheduled, command, companion/persona, delegation, bot-runtime, follow-up, and enclave output can be accepted before a state transition and execute afterward without a common execution-time recheck.
- `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, and `useEffectiveArchived` correctly model archive-specific behavior but do not model system-stream or participation read-only state; they must remain available while generic state is added in parallel.
- Shared stream events cannot safely carry viewer state; current client membership removal drops a private stream shell but does not comprehensively purge its cached event tree.
- `useMessageQueue` retries ordinary 403s. A stale `STREAM_READ_ONLY` rejection must become a terminal, editable failed message rather than an endless retry.

## Stacked delivery plan

Each branch is based on the preceding branch. The ordering intentionally lands server enforcement before advertising a complete viewer contract, and separates the lifecycle race fix from the broad mutation sweep.

### PR 1 — Contract and centralized resolver

- **Branch:** `feat/stream-readonly-contract`
- **base_ref:** `origin/main`
- **Owns:** Shared vocabulary, pure derivation, principal model, structured error, and projection primitives. It does not change endpoint responses or mutation behavior yet.

Changes:

- Add `STREAM_READ_ONLY_REASONS`, `StreamReadOnlyReason`, `StreamReadOnlyReasons`, and `StreamErrorCodes` to the SSOT in `packages/types/src/constants.ts` and export them through `packages/types/src/index.ts`; define `StreamViewerState` and viewer DTO aliases in `domain.ts`. PR 5, not this latent contract PR, switches `api.ts` response properties to those aliases so this PR remains type-correct without endpoint projection.
- Add `apps/backend/src/features/streams/write-authority.ts` with the truth-table function, user/bot participation adapters, single/batch projection helpers, and structured denial helper.
- Reuse effective-root resolution from `apps/backend/src/features/streams/access.ts`; consolidate duplicate root/membership semantics rather than creating a conflicting resolver. Keep read access and write authority as separate methods sharing the same intrinsic facts.
- Add batch queries to `member-repository.ts` and `apps/backend/src/features/public-api/bot-channel-service.ts`/its grant repository so workspace and public list projection will not become N+1.
- Add unit tests covering every precedence/access row, root inheritance, human vs bot principal, public/private behavior, and no mutation of canonical rows.

Acceptance:

- Pure resolver exhaustively matches the table.
- Private non-participants never receive a viewer state from the access+projection facade.
- Repository rows and shared payload types contain no viewer fields.

Focused gates (new test path is created by this PR):

```bash
bun run --cwd packages/types test
bun scripts/test-silent.ts backend-unit src/features/streams/write-authority.test.ts src/features/streams/access.test.ts
bun run --cwd packages/types typecheck
bun run --cwd apps/backend typecheck
```

Exclusions / compatibility / rollout:

- No endpoint projection, mutation enforcement, socket behavior, or UI change. The constants/resolver are latent and safe to deploy alone.
- PR 2 owns transaction enforcement; PR 5 owns response shapes; PRs 6–7 own client consumption.

### PR 2 — Core writes and transition locking

- **Branch:** `feat/stream-readonly-core-writes`
- **base_ref:** `feat/stream-readonly-contract`
- **Owns:** The transaction boundary, sequence of locks, and the highest-risk content mutations/transitions.

Changes:

- Add stable-order stream/member/bot-grant `FOR UPDATE` repository methods and transaction-scoped event mutation support.
- Move archive/unarchive permission checks and updates into one locked transaction in `apps/backend/src/features/streams/service.ts`; retain their lifecycle event/outbox emission through the trusted capability.
- Move join, leave, add, and remove membership/grant transitions onto the same lock protocol. Preserve public content access after human leave; preserve private revocation semantics.
- Replace `resolveWritableMessageStream` and handler-local checks with `assertStreamWritable` inside the transaction that creates a message.
- Guard app create/edit/delete/reaction paths and public API create/edit/delete paths in `apps/backend/src/features/messaging/event-service.ts`, `messaging/handlers.ts`, and `public-api/handlers.ts`. Resolve the API key into a user/bot write principal explicitly; the public API currently has no reaction operations to guard.
- Guard movement/refiling primitives that mutate message placement. Replace archive-specific `assertStreamNotArchived` in `conversations/service.ts` with authority checks for every source/destination stream in stable id order.
- Use the lifecycle capability only for stream-created/member/archive/system activity records. Ordinary user/bot messages into system streams must fail with reason `system_stream`.

Tests:

- Integration tests with two clients/connections coordinate on advisory barriers: write vs archive, write vs root archive, write vs self-leave, write vs admin removal, reaction/edit/delete vs transition, and bot write vs grant removal. Assert serializable outcomes and that no post-transition content event committed.
- Endpoint tests assert exact 403 code/details for all three reasons, app/public parity for both user-key and bot-key principals, public read still succeeds, private removal returns 404, and E2E/privacy errors retain their own codes.
- Existing archive/member event tests prove the trusted lifecycle records still commit.

Acceptance:

- No message/reaction/refile mutation can commit based on an authority snapshot older than a committed archive/member/grant transition.
- Public non-member reads still work; writes fail with `not_a_member`.
- Existing retry/idempotency behavior remains intact for non-read-only failures.

Focused gates (start the repository test database before integration/E2E commands):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/streams/write-authority.test.ts src/features/streams/service.test.ts src/features/public-api/handlers.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-locking.test.ts tests/integration/message-move.test.ts
bun scripts/test-silent.ts backend-e2e tests/e2e/stream-read-only-core.test.ts tests/e2e/public-api-crud.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not yet guard the PR 3 synchronous surfaces, deferred execution, or add response/UI hints. Older clients may first encounter structured 403s on core writes; that is the intended authoritative fallback.
- Existing error parsers that ignore `code/details` still receive a normal 403. PRs 5–7 add richer consumers only after enforcement exists.

### PR 3 — Remaining synchronous mutation boundaries

- **Branch:** `feat/stream-readonly-shared-writes`
- **base_ref:** `feat/stream-readonly-core-writes`
- **Owns:** Complete synchronous API coverage, without worker/agent execution paths.

Changes:

- Guard conversation assignment/unassignment, title/summary edits, merge/split, thread creation/branching, and other shared topology operations in `apps/backend/src/features/conversations/{handlers,service}.ts` and stream thread creation paths. Multi-stream operations lock all effective roots/targets in sorted order before any write.
- Guard shared stream metadata, visibility/name/description/memory/companion changes and stream brief writes in `streams/{handlers,service,brief-handlers,brief-service}.ts`. Keep archive/unarchive and membership management as explicit lifecycle exceptions. Keep personal safety/organization operations—mute, save, local drafts, notification/sidebar settings, and agent/call stop/cancel—outside this guard.
- Guard schedule creation and send-now acceptance in `scheduled-messages/service.ts`; cancellation remains available.
- Guard command dispatch/acceptance in `commands/{availability,handlers}.ts`.
- Guard call start/join in `calls/{access,handlers,service,signaling-gateway}.ts`; leave/end/stop remains available so read-only transitions cannot trap an active participant.
- Route each operation through a transaction-scoped authority check; remove legacy archive/member denial text and readability-as-write checks.

Tests:

- Add a mutation matrix test keyed by operation × reason × root/target to prevent uncovered endpoints.
- Add focused multi-stream lock-order tests for conversation merge/split/move.
- Verify lifecycle/personal exceptions remain callable while read-only and still enforce their pre-existing ownership rules.

Acceptance:

- A repository search for mutation endpoints finds either `assertStreamWritable`, a lower-level guarded service call, or a documented lifecycle/personal exception.
- No handler relies on client hints or an earlier readability check as write authorization.

Focused gates (new matrix path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/conversations/service.test.ts src/features/streams/brief-service.test.ts src/features/scheduled-messages/service.test.ts src/features/commands/handlers.test.ts src/features/calls/service.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-mutation-matrix.test.ts tests/integration/message-move.test.ts tests/integration/calls-leave-end.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not claim worker/agent execution-time safety; PR 4 owns already-queued work. Does not expose DTO hints or change sync/UI.
- Deploying this PR without later layers is safe: synchronous attempts fail authoritatively, while existing clients display their generic 403 handling.

### PR 4 — Deferred work and generated output

- **Branch:** `feat/stream-readonly-deferred-work`
- **base_ref:** `feat/stream-readonly-shared-writes`
- **Owns:** Execution-time authority for work accepted before a state transition.

Changes:

- In `scheduled-messages/worker.ts`, recheck the schedule creator’s principal immediately before sending. On read-only, move the row to the existing terminal/failed outcome with the structured reason; do not retry forever. Cancellation remains possible.
- In `commands/worker.ts`, recheck `requestedBy` before execution and before any eventual stream output. Emit the existing command-failed terminal event using the lifecycle capability; do not execute the command body after denial.
- Thread the initiating principal, distinct from persona actor, through `agents/persona-agent.ts`, companion session/context paths, follow-up service, delegation service, bot-runtime invocation handler, and enclave session handlers. Guard new/retry/steer/claim work acceptance before provider execution where that action starts new work, and recheck immediately before every eventual stream mutation. Stop/cancel/fail bookkeeping remains exempt.
- Route agent tools that mutate shared state (`send_message`, `react_to_message`, follow-up scheduling, `update_stream_brief`, and `delegate_task`) through the same authority service rather than relying only on the enclosing session’s initial check.
- Bot-runtime/public callbacks use the bot grant principal. Companion/persona/delegation/enclave work caused by a human action uses that human principal even when the resulting event actor is a persona.
- Permit only required bookkeeping/terminal status/system activity through the trusted capability; it must not publish generated user-visible content into a read-only target.
- Make denial idempotent and terminal. Preserve transport/provider/E2E failures as separate retry/error classes.

Tests:

- Deterministic tests pause each worker after dequeue/acceptance, archive/remove the principal, resume, and assert no generated content plus one terminal status/failure record.
- Cover human leave from a public channel, private removal, bot grant removal, root archive while targeting a thread, and system stream output.
- Assert stop/cancel and terminal bookkeeping still work after the transition.

Acceptance:

- There is no generic “system” escape hatch available to ordinary generated output.
- Every deferred row/session can identify an existing initiating user/bot principal at execution time; absent identity fails closed rather than being inferred from the presentation actor.

Focused gates (new integration path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/agents/persona-agent-worker.test.ts src/features/agents/follow-up-service.test.ts src/features/scheduled-messages/service.test.ts src/features/public-api/handlers.test.ts
bun scripts/test-silent.ts backend-integration tests/integration/stream-read-only-deferred.test.ts tests/integration/agent-session-effects.test.ts
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- No viewer projection, membership delivery, IndexedDB, or affordance changes. PR 5 advertises state only after synchronous and deferred enforcement are complete.
- Terminal denial must use existing job/session terminal states; no schema migration or retry-policy redesign is included.

### PR 5 — Viewer projections, public contract, and CLI/MCP

- **Branch:** `feat/stream-readonly-projections`
- **base_ref:** `feat/stream-readonly-deferred-work`
- **Owns:** Fresh response coverage and the external API contract after server enforcement is complete.

Changes:

- Project viewer DTOs in workspace bootstrap (`workspaces/handlers.ts`), stream list/get/create/update/archive responses and stream bootstrap (`streams/handlers.ts`/service), and every public API stream list/get response. Use batch projection for lists/bootstrap.
- Keep `rootArchivedAt` in stream bootstrap and add effective `readOnly`/`readOnlyReason` on `stream` in parallel.
- In conversation/board bootstrap projection, populate `BoardPost.streamReadOnly` and `streamReadOnlyReason` using one batch keyed by target stream/effective root. Preserve `rootArchived` and its archive-only query/projection semantics for board filtering; optimize the two projections together only if tests prove both values remain distinct and correct.
- Update public Zod/OpenAPI schemas and examples in `public-api/routes.ts`.
- **Header-versioning policy:** the additive stream fields alone do not require a dated API version and must reach every supported pin, so do not add a downgrade response/spec that strips them. The authorization change is behaviorally breaking, however, so add one new date later than current `2026-07-24` to `packages/types/src/api-versions.ts` and a `VERSION_CHANGES` entry in `public-api/versions/index.ts`. Its operation set must enumerate the public routes whose behavior actually changed after the PR 2–4 inventory—expected stream-writing ids are `sendMessage`, `updateMessage`, `deleteMessage`, `updateStream`, `completeBotInvocation`, `completeBotInvocationSealed`, `sendBotInvocationSealedMessage`, and `completeDelegation`; add/remove an id only if its handler test proves it does/does not cross the guarded stream mutation boundary. Give the entry no downgrade transform: per the binding decision, older pins are documented as behind the behavior change but are not grandfathered into the write bypass. The generated changelog must explicitly say the date marks universal enforcement while `readOnly`/`readOnlyReason` are additive on every pin.
- Regenerate all committed OpenAPI artifacts with `bun run generate:api-docs`; do not hand-edit generated files.
- Update `packages/cli/src/commands/streams.ts` and `tools/streams.ts` response schemas/types. Extend `ThreaApiError` in `packages/cli/src/api-client.ts` to retain structured `details.reason`, so CLI and MCP callers can distinguish read-only from auth/scope failures.

Tests:

- Response-shape tests assert fields are present (including `false`/`null`) in every fresh app/public stream surface and board row.
- Query-count tests cover large workspace/public/board lists and reject N+1 projection.
- Public API version/OpenAPI snapshots verify old pins receive the additive fields and structured denial.
- CLI tests verify JSON/MCP schemas and error detail retention.

Acceptance:

- Fresh viewer stream/board responses include generic fields while retaining the independent archive-only fields and their consumers.
- No viewer-relative fields appear in a shared outbox payload or another principal’s response.
- `bun run generate:api-docs:check` is clean.

Focused gates (new projection path is created by this PR):

```bash
bun run test:db:start
bun scripts/test-silent.ts backend-unit src/features/public-api/versions/index.test.ts src/features/public-api/handlers.test.ts src/features/streams/handlers.test.ts
bun scripts/test-silent.ts backend-e2e tests/e2e/stream-read-only-projection.test.ts tests/e2e/public-api-versioning.test.ts tests/e2e/public-api-openapi.test.ts tests/e2e/stream-bootstrap.test.ts
bun run --cwd packages/cli test
bun run generate:api-docs:check
bun run --cwd packages/types typecheck
bun run --cwd packages/cli typecheck
bun run --cwd apps/backend typecheck
bun run test:db:stop
```

Exclusions / compatibility / rollout:

- Does not change shared events, IndexedDB reconciliation, or frontend controls; PRs 6–7 own those layers.
- Old app/CLI clients ignore additive fields. Every public API pin receives the fields and enforcement; the new date documents the universal behavioral break rather than preserving the bypass.
- Keep `rootArchivedAt`/`rootArchived` wire fields and archive filters unchanged; their removal is deferred beyond this stack.

### PR 6 — Live delivery and persisted client state

- **Branch:** `feat/stream-readonly-live-state`
- **base_ref:** `feat/stream-readonly-projections`
- **Owns:** One frontend source of truth across HTTP, IndexedDB, socket deltas, and reconnects.

Changes:

- Add optional `readOnly`/`readOnlyReason` to cached viewer stream rows in `apps/frontend/src/db/database.ts`; persist fresh workspace/stream bootstrap fields in `workspace-sync.ts` and `stream-sync.ts`. Preserve the cold-load overlay when applying principal-free shared `stream_created`/`stream_updated` payloads.
- Add a frontend pure resolver (for example `apps/frontend/src/lib/stream-read-only.ts`) with the same precedence, runtime normalization, and reason-to-copy mapping. Unknown non-null reason disables writes with generic copy.
- Add `useStreamWriteState` and generalize callers onto it while retaining `useEffectiveArchived` as an archive-specific compatibility wrapper. Draft streams remain writable. Fresh DTO/board fields are cold-load fallbacks; once live target/root/membership facts are present, those facts win. A missing legacy optional field must not override known archive/system-stream/non-member facts.
- On `stream_archived`/`stream_unarchived`, recompute and persist the affected target and all cached descendants/board generic fields atomically, while updating `rootArchivedAt`/`rootArchived` through their existing archive-specific paths.
- On current-user `stream_member_added`, persist the minimal membership delta, fetch a fresh viewer stream/bootstrap if no canonical stream is cached, recompute descendants/board generic fields, subscribe, and turn `not_a_member` into writable unless a higher-precedence reason remains.
- On current-user leave/removal, delete membership/read-state. For public roots, retain readable cached streams/events/board content and recompute them to `not_a_member`. For private roots, purge the root/descendant stream rows and server-derived events, slots, board conversations/posts, read/unread state, and query caches; unsubscribe. Keep canonical event payloads unchanged.
- Reconciliation after reconnect/bootstrap must overwrite stale local overlays from fresh viewer DTOs and membership rows.
- Teach `useMessageQueue.ts` and `operation-queue.ts` to classify `STREAM_READ_ONLY` as terminal. Preserve/edit the pending message body and failed optimistic row; remove impossible optimistic mutations for reactions/metadata/schedules. Never auto-retry read-only. A later join/unarchive may let the user explicitly retry.

Tests:

- Pure resolver parity table including unknown reason.
- Workspace/stream bootstrap persistence and principal-free socket merge tests.
- Live archive/unarchive, public leave/join, private removal/re-add, root-to-thread propagation, offline `sync_log` catch-up/reconnect-gap, and two-tab IndexedDB convergence tests.
- Queue tests prove stale submissions preserve authored content, become terminal, do not retry, and can be explicitly retried after writable state returns.

Acceptance:

- Public leave does not make readable content disappear; private removal leaves no server-derived content cache.
- No refresh is needed for archive/membership transitions.
- Draft/pending authored content survives a hint/server race.

Focused gates (new resolver path is created by this PR):

```bash
bun scripts/test-silent.ts frontend src/lib/stream-read-only.test.ts src/hooks/use-effective-archived.test.ts src/hooks/use-message-queue.test.ts src/sync/operation-queue.test.ts src/sync/workspace-sync.test.ts src/sync/stream-sync.test.ts
bun run --cwd apps/frontend typecheck
```

Exclusions / compatibility / rollout:

- Does not claim the complete mutation-affordance sweep; PR 7 owns component wiring and browser coverage.
- Legacy IndexedDB rows without generic fields remain supported through target/root/membership derivation and cold refetch. Live facts override cold DTO/board fallbacks.
- No Dexie schema bump and no product-database migration.

### PR 7 — Complete frontend affordance sweep and adversarial coverage

- **Branch:** `feat/stream-readonly-ui`
- **base_ref:** `feat/stream-readonly-live-state`
- **Owns:** Consistent UX across all mutation surfaces and final whole-feature regression coverage.

Changes:

- Replace archive-only **shared-mutation gating** in `timeline/stream-content.tsx`, `timeline/message-input.tsx`, `thread/stream-panel.tsx`, `conversations/conversation-panel.tsx`, `board/board-card.tsx`, and stream page/header/menu code with `useStreamWriteState` or projected board state. Keep archive inheritance/display/filter consumers on `rootArchivedAt`/`rootArchived`.
- Use one `ComposerDisabledNotice`/copy mapper everywhere:
  - archived: explain that the stream/root is archived;
  - `system_stream`: explain that the system stream is read-only;
  - not member: explain that joining is required and show Join only for a readable public channel when existing permissions allow it;
  - unknown: generic read-only copy.
- Disable or remove mutation affordances for sends/quick replies, reactions, edit/delete, pins/shared message state, thread/branch creation, conversation assignment/merge/split/title edits, shared stream/brief/companion metadata, schedule create/send-now, command dispatch, and call start/join. Destination state governs cross-stream actions; reading/copying/sharing from a read-only source is allowed only when the operation does not mutate that source and the destination is writable.
- Keep readable history, navigation, search, copy, saves, mutes, sidebar/notification preferences, local drafts, join/invite/remove/leave, archive/unarchive, schedule/agent cancellation, and call leave/end/stop controls available under their existing permission rules.
- If state flips while a composer/dialog is open, close or disable the action without clearing its draft/form. If a stale submit reaches the server, show reason-specific feedback and keep editable authored content.
- Keep `use-effective-archived.ts`, `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, and archive-filter tests in this stack. Any removal is a separately reviewed cleanup gated on proof that archive inheritance and board archive filtering are unchanged.

Tests:

- Component tests for each reason and unknown fallback on timeline, thread, conversation panel, board quick reply, message action menu, schedule/command controls, and call controls.
- Browser tests for: public non-member browse → denied write → join → write; public member leave without content loss; private removal with immediate cache/navigation revocation; root archive while a thread/board/conversation composer is open; system stream readability; stale send preserving content; cancel/leave/unarchive exceptions.
- Final endpoint inventory test/review pairs every server mutation route with a guarded service or explicit exception, and every frontend mutating control with generic write state.

Acceptance:

- No user-visible shared mutation appears enabled when the client knows the stream is read-only.
- The server still returns `STREAM_READ_ONLY` correctly when hints are stale or bypassed.
- Existing readable/public and lifecycle escape hatches remain usable.

Focused gates (new browser path is created by this PR):

```bash
bun scripts/test-silent.ts frontend src/components/timeline/message-input.test.tsx src/components/conversations/conversation-panel.test.tsx src/components/board/board-card.test.tsx src/components/call/call-start-menu.test.tsx src/components/composer/scheduled-messages-picker.test.tsx src/components/composer/use-composer-command-send.test.tsx
bun scripts/test-silent.ts browser tests/browser/stream-read-only.spec.ts
bun run --cwd apps/frontend typecheck
```

Exclusions / compatibility / rollout:

- No removal of archive-specific DTO fields, board filtering, hook wrapper, or tests. That cleanup is explicitly deferred.
- UI hints may be stale or absent; all controls still surface the server’s structured denial without discarding authored content.

## Validation gates

The commands below were audited against the root and workspace `package.json` scripts. Run from the repository root. `test:integration` and `test:e2e` require the repository test database; the browser script uses the repository Playwright harness. The per-PR focused commands above invoke the documented `scripts/test-silent.ts` path selector directly and are runnable once that PR’s named new test file exists.

```bash
bun run test:db:start
bun run --cwd packages/types test
bun run --cwd packages/cli test
bun run --cwd apps/backend test:unit
bun run --cwd apps/backend test:integration
bun run --cwd apps/backend test:e2e
bun run --cwd apps/frontend test
bun run typecheck
bun run lint
bun run generate:api-docs:check
bun run test:browser
bun run test:db:stop
```

Focused proof required before merge:

1. Resolver truth table is identical in backend projection, backend denial details, and frontend copy/state.
2. Concurrency tests prove the lock linearization behavior rather than merely sending requests sequentially.
3. Shared outbox/socket fixture snapshots contain no `readOnly` or `readOnlyReason` fields.
4. Public non-member reads survive; private non-member data is absent and purged.
5. Every accepted/deferred operation is rechecked at execution and terminates cleanly after denial.
6. Queue/browser tests prove no authored draft is silently lost and no terminal 403 retries forever.
7. OpenAPI, changelog, CLI, and MCP expose the additive fields and structured error details across supported API pins.

## Explicit non-goals / edge rules

- No persisted `read_only` column and no backfill.
- No admin-configured/custom reasons in this feature.
- No generic viewer-state broadcast and no principal-specific data in shared events/outbox rows.
- Do not conflate read-only with read access: inaccessible private streams remain hidden; public non-members remain readers.
- Do not block recovery/exit/safety operations (join/leave, member management, archive/unarchive, cancel/stop/end) merely because the target is read-only; their existing authorization still applies.
- Visibility changes that revoke private access must continue to use existing access-revocation behavior; they do not introduce a fourth read-only reason.
- Removal of `StreamBootstrap.rootArchivedAt`, `BoardPost.rootArchived`, `useEffectiveArchived`, or archive-only board filtering is deferred to a separate proven cleanup.

## Final plan-conformance checklist

- [ ] Constants SSOT is in `packages/types/src/constants.ts` with exactly `archived | system_stream | not_a_member`; no read-only reason uses `system`.
- [ ] Fresh viewer DTOs always include `readOnly` and `readOnlyReason`, with reason non-null iff read-only and precedence archived → system stream → missing effective-root participation.
- [ ] `StreamBootstrap.rootArchivedAt` and `BoardPost.rootArchived` remain in parallel; board archive filtering still uses `rootArchived`, never generic read-only.
- [ ] State is derived with no product migration/column; canonical repository rows and shared stream/workspace outbox payloads remain principal-free.
- [ ] Effective-root access rules hold: public non-members remain readable/read-only; private non-members remain hidden/revoked; target and root archive both seal descendants.
- [ ] User-key and bot-key public list/get/write paths use the correct human membership or bot grant principal, with no pinned-version authorization bypass.
- [ ] Every shared mutation entry point is either transactionally guarded through the central resolver or listed as an intentional lifecycle/personal/stop-cancel exemption.
- [ ] Archive/unarchive, membership/grant transitions, and writes use the same deterministic stream→participation lock order and have real concurrent race tests.
- [ ] Deferred scheduled/command/persona/companion/delegation/bot/enclave outputs preserve the initiating principal and recheck at execution; trusted capabilities cover only lifecycle/system notifications.
- [ ] `STREAM_READ_ONLY` is 403 with `{ details: { reason } }`; E2E/privacy/transport errors remain distinct and private revocation remains non-disclosing.
- [ ] Archive events are reused; self-join/add/remove/leave reach the affected `userGroup` durably via outbox/sync; no generic read-only event exists.
- [ ] Cold DTO/board generic fields are fallbacks, live target/root/membership facts win, offline catch-up and multi-tab ordering converge, and legacy cache rows stay safe.
- [ ] Public leave retains readable cache; private removal purges server-derived cache; stale rejects become terminal without retry loops and preserve editable drafts/pending content.
- [ ] Public API date is justified by the behavioral authorization break, not additive fields; additive fields appear in every pin’s runtime/spec, and the generated changelog states universal enforcement.
- [ ] CLI/MCP retain the additive fields and structured error reason; frontend copy is centralized and unknown future reasons fail closed with generic copy.
- [ ] Every PR uses the stated branch/base_ref, has focused runnable gates, remains deployable with its exclusions, and leaves later-layer ownership explicit.
- [ ] Stack-tip typecheck, lint, docs check, unit/integration/E2E/frontend/browser suites, mutation inventory, race tests, and adversarial scenarios all pass.


</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788792071&installation_model_id=20758&pr_number=1818&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1818&signature=f431efb8e537ab339f83c55d4288f5847a8f2f9ff0acb5cbf7b27e88b33a42a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->