### PR TITLE
fix(composer): keep multi-file chips complete and sequential

### DIFF
--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { Editor } from "@tiptap/core"
 import { DOMParser as PMDOMParser, DOMSerializer, type Slice } from "@tiptap/pm/model"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
@@ -102,6 +102,30 @@ describe("attachment reference insertion", () => {
       beforeChip: editor.state.doc.textBetween(0, at),
       afterChip: editor.state.doc.textBetween(at + 1, at + 2),
     }).toEqual({ beforeChip: expectedBeforeChip, afterChip: " " })
+  })
+
+  it("inserts a picked batch atomically", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+      content: { type: "doc", content: [{ type: "paragraph" }] },
+    })
+    openEditors.push(editor)
+    const onUpdate = vi.fn()
+    editor.on("update", onUpdate)
+
+    editor.commands.insertAttachmentReferences(
+      ["temp_1", "temp_2", "temp_3"].map((id) => ({ ...CHIP_ATTRS, id, status: "uploading" }))
+    )
+    const ids: string[] = []
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === "attachmentReference") ids.push(node.attrs.id as string)
+    })
+
+    expect({ ids, updateCalls: onUpdate.mock.calls.length }).toEqual({
+      ids: ["temp_1", "temp_2", "temp_3"],
+      updateCalls: 1,
+    })
   })
 
   it("does not add a leading space after a hard break", () => {

--- a/apps/frontend/src/components/editor/attachment-reference-extension.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.ts
@@ -29,6 +29,10 @@ declare module "@tiptap/core" {
        */
       insertAttachmentReference: (attrs: AttachmentReferenceAttrs) => ReturnType
       /**
+       * Insert attachment references together in one editor transaction.
+       */
+      insertAttachmentReferences: (attrs: AttachmentReferenceAttrs[]) => ReturnType
+      /**
        * Update an attachment reference by its temp ID
        */
       updateAttachmentReference: (tempId: string, updates: Partial<AttachmentReferenceAttrs>) => ReturnType
@@ -128,7 +132,14 @@ export const AttachmentReferenceExtension = Node.create({
     return {
       insertAttachmentReference:
         (attrs) =>
+        ({ commands }) =>
+          commands.insertAttachmentReferences([attrs]),
+
+      insertAttachmentReferences:
+        (references) =>
         ({ chain, state }) => {
+          if (references.length === 0) return false
+
           // Get marks at current position to preserve styling
           const { $from } = state.selection
           const { storedMarks } = state
@@ -147,8 +158,10 @@ export const AttachmentReferenceExtension = Node.create({
           return chain()
             .insertContent([
               ...(needsLeadingSpace ? [{ type: "text", text: " ", marks }] : []),
-              { type: "attachmentReference", attrs, marks },
-              { type: "text", text: " ", marks },
+              ...references.flatMap((attrs) => [
+                { type: "attachmentReference", attrs, marks },
+                { type: "text", text: " ", marks },
+              ]),
             ])
             .run()
         },

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -508,71 +508,75 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     }
   }, [shouldBeVisible])
 
-  // Helper to handle file insertion from paste or drop
-  const handleFileInsert = useCallback(async (file: File, editorInstance: ReturnType<typeof useEditor>) => {
-    const uploadFn = onFileUploadRef.current
-    if (!uploadFn || !editorInstance) return
-    const uploadScopeVersion = uploadScopeVersionRef.current
-
-    const isImage = file.type.startsWith("image/")
-    const tempId = `temp_${Date.now()}_${Math.random().toString(36).slice(2)}`
-
-    const placeholderAttrs: AttachmentReferenceAttrs = {
-      id: tempId,
-      filename: file.name,
-      mimeType: file.type || "application/octet-stream",
-      sizeBytes: file.size,
-      status: "uploading",
-      imageIndex: null, // Will be set after upload
-      error: null,
-    }
-
-    editorInstance.commands.insertAttachmentReference(placeholderAttrs)
-
-    // Caller is fire-and-forget (paste/drop loops), so swallow the rejection
-    // here and surface it through the placeholder's error state instead of
-    // leaving the node stuck in "uploading" indefinitely.
-    const isStillTargeting = () =>
-      uploadScopeVersion === uploadScopeVersionRef.current &&
-      !editorInstance.isDestroyed &&
-      editorRef.current === editorInstance
-
-    try {
-      const result = await uploadFn(file)
-      if (!isStillTargeting()) return
-      // uploadFn resolves once the id is RESERVED — the bytes may still be
-      // streaming in the background. The node is a reference marker, so it
-      // settles to "uploaded" here (live transfer state renders on the chip
-      // row, and stored content never persists "uploading" — see
-      // materializePendingAttachmentReferences).
-      editorInstance.commands.updateAttachmentReference(tempId, {
-        id: result.attachment.id,
-        status: result.attachment.status === "error" ? "error" : "uploaded",
-        imageIndex: isImage ? result.imageIndex : null,
-        error: result.attachment.error || null,
+  const handleFilesInsert = useCallback(
+    (files: File[], editorInstance: ReturnType<typeof useEditor> | null): boolean => {
+      const uploadFn = onFileUploadRef.current
+      if (!uploadFn || !editorInstance || editorInstance.isDestroyed || files.length === 0) return false
+      const uploadScopeVersion = uploadScopeVersionRef.current
+      const batchId = `${Date.now()}_${Math.random().toString(36).slice(2)}`
+      const insertions = files.map((file, index) => {
+        const tempId = `temp_${batchId}_${index}`
+        const attrs: AttachmentReferenceAttrs = {
+          id: tempId,
+          filename: file.name,
+          mimeType: file.type || "application/octet-stream",
+          sizeBytes: file.size,
+          status: "uploading",
+          imageIndex: null,
+          error: null,
+        }
+        return { file, tempId, isImage: file.type.startsWith("image/"), attrs }
       })
-    } catch (err) {
-      if (!isStillTargeting()) return
-      editorInstance.commands.updateAttachmentReference(tempId, {
-        status: "error",
-        error: err instanceof Error ? err.message : "Upload failed",
-      })
-    }
-  }, [])
 
-  const insertFiles = useCallback(
-    (files: File[]): boolean => {
-      const editorInstance = editorRef.current
-      if (!editorInstance || editorInstance.isDestroyed || !onFileUploadRef.current) return false
-      for (const file of files) void handleFileInsert(file, editorInstance)
+      // A picked batch must reach the controlled editor as one document update;
+      // intermediate renders can otherwise overwrite one placeholder while the
+      // near-simultaneous reservations settle.
+      if (!editorInstance.commands.insertAttachmentReferences(insertions.map(({ attrs }) => attrs))) return false
+
+      for (const { file, tempId, isImage } of insertions) {
+        void (async () => {
+          const isStillTargeting = () =>
+            uploadScopeVersion === uploadScopeVersionRef.current &&
+            !editorInstance.isDestroyed &&
+            editorRef.current === editorInstance
+
+          try {
+            const result = await uploadFn(file)
+            if (!isStillTargeting()) return
+            // uploadFn resolves once the id is RESERVED — the bytes may still be
+            // streaming in the background. The node is a reference marker, so it
+            // settles to "uploaded" here (live transfer state renders on the chip
+            // row, and stored content never persists "uploading" — see
+            // materializePendingAttachmentReferences).
+            editorInstance.commands.updateAttachmentReference(tempId, {
+              id: result.attachment.id,
+              status: result.attachment.status === "error" ? "error" : "uploaded",
+              imageIndex: isImage ? result.imageIndex : null,
+              error: result.attachment.error || null,
+            })
+          } catch (err) {
+            if (!isStillTargeting()) return
+            editorInstance.commands.updateAttachmentReference(tempId, {
+              status: "error",
+              error: err instanceof Error ? err.message : "Upload failed",
+            })
+          }
+        })()
+      }
+
       return true
     },
-    [handleFileInsert]
+    []
+  )
+
+  const insertFiles = useCallback(
+    (files: File[]): boolean => handleFilesInsert(files, editorRef.current),
+    [handleFilesInsert]
   )
 
   // Save the snippet editor's contents as a text attachment, inserting the chip
   // back at the caret position the paste happened at. Reuses the same
-  // upload-and-insert path as pasted images/files (handleFileInsert), so E2E
+  // upload-and-insert path as pasted images/files (handleFilesInsert), so E2E
   // encryption, scope-drift guarding, and the inline chip all come for free.
   const handleSnippetSave = useCallback(
     ({ text, filename }: { text: string; filename: string }) => {
@@ -596,9 +600,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       }
       chain.run()
 
-      void handleFileInsert(file, editorInstance)
+      handleFilesInsert([file], editorInstance)
     },
-    [handleFileInsert]
+    [handleFilesInsert]
   )
 
   // Insert the chosen GIF as an inline embed rendered straight from Giphy's CDN
@@ -683,20 +687,16 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
         const files = event.clipboardData?.files
         if (files && files.length > 0 && onFileUploadRef.current && editorRef.current) {
           event.preventDefault()
-          const fileArray = Array.from(files)
           let pasteImageOffset = 0
-          for (const file of fileArray) {
-            let fileToInsert = file
-            // Rename pasted images to sequential names (pasted-image-1.png, etc.)
-            if (file.type.startsWith("image/")) {
-              pasteImageOffset++
-              const nextIndex = imageCountRef.current + pasteImageOffset
-              const ext = file.name.split(".").pop() || "png"
-              const newName = `pasted-image-${nextIndex}.${ext}`
-              fileToInsert = new File([file], newName, { type: file.type })
-            }
-            handleFileInsert(fileToInsert, editorRef.current)
-          }
+          const filesToInsert = Array.from(files).map((file) => {
+            if (!file.type.startsWith("image/")) return file
+            pasteImageOffset++
+            const nextIndex = imageCountRef.current + pasteImageOffset
+            const ext = file.name.split(".").pop() || "png"
+            const newName = `pasted-image-${nextIndex}.${ext}`
+            return new File([file], newName, { type: file.type })
+          })
+          handleFilesInsert(filesToInsert, editorRef.current)
           return true
         }
 
@@ -812,9 +812,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
         const files = event.dataTransfer?.files
         if (files && files.length > 0 && onFileUploadRef.current && editorRef.current) {
           event.preventDefault()
-          for (const file of Array.from(files)) {
-            handleFileInsert(file, editorRef.current)
-          }
+          handleFilesInsert(Array.from(files), editorRef.current)
           return true
         }
         return false

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -1116,6 +1116,47 @@ describe("MessageInput", () => {
       ).toEqual(content)
     })
 
+    it("keeps IDs and picked ordinals when repeated filenames lose the middle placeholder", () => {
+      const imageReference = (id: string, filename: string, imageIndex: number): JSONContent => ({
+        type: "attachmentReference",
+        attrs: {
+          id,
+          filename,
+          mimeType: "image/jpeg",
+          sizeBytes: 1,
+          status: "uploaded",
+          imageIndex,
+          error: null,
+        },
+      })
+      const content: JSONContent = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [imageReference("attach_1", "photo.jpg", 1), imageReference("attach_3", "photo.jpg", 3)],
+          },
+        ],
+      }
+
+      expect(
+        materializePendingAttachmentReferences(content, [
+          { id: "attach_1", filename: "photo.jpg", mimeType: "image/jpeg", sizeBytes: 1, status: "uploaded" },
+          { id: "attach_2", filename: "photo.jpg", mimeType: "image/jpeg", sizeBytes: 1, status: "uploaded" },
+          { id: "attach_3", filename: "photo.jpg", mimeType: "image/jpeg", sizeBytes: 1, status: "uploaded" },
+        ])
+      ).toEqual({
+        ...content,
+        content: [
+          ...(content.content ?? []),
+          {
+            type: "paragraph",
+            content: [imageReference("attach_2", "photo.jpg", 2)],
+          },
+        ],
+      })
+    })
+
     it("materializes a still-uploading reserved attachment with persisted status 'uploaded'", () => {
       // Stored contentJson is never revisited when the bytes land, so the node
       // must not freeze a transient "uploading" into the message (it would

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -112,6 +112,10 @@ export function materializePendingAttachmentReferences(
   pendingAttachments: PendingAttachment[]
 ): JSONContent {
   const uploadedQueues = new Map<string, PendingAttachment[]>()
+  const materializableAttachments: PendingAttachment[] = []
+  const materializableAttachmentById = new Map<string, PendingAttachment>()
+  const imageIndexByAttachment = new Map<PendingAttachment, number>()
+  let pickedImageIndex = 1
   for (const attachment of pendingAttachments) {
     // Reserved-but-still-uploading attachments materialize like uploaded ones
     // (send-while-uploading): their id is real and the message binds it while
@@ -122,6 +126,11 @@ export function materializePendingAttachmentReferences(
     // state rides the message's attachment summaries instead. Errors and
     // still-reserving (temp-id) files stay out of the message.
     if (attachment.status === "error" || attachment.id.startsWith("temp_")) continue
+    materializableAttachments.push(attachment)
+    materializableAttachmentById.set(attachment.id, attachment)
+    if (attachment.mimeType.startsWith("image/")) {
+      imageIndexByAttachment.set(attachment, pickedImageIndex++)
+    }
     const key = attachmentMatchKey(attachment)
     const queue = uploadedQueues.get(key)
     if (queue) {
@@ -131,7 +140,15 @@ export function materializePendingAttachmentReferences(
     }
   }
 
-  let nextImageIndex = 1
+  const matchedAttachments = new Set<PendingAttachment>()
+  const takeUnmatchedAttachment = (key: string): PendingAttachment | undefined => {
+    const queue = uploadedQueues.get(key)
+    let attachment = queue?.shift()
+    while (attachment && matchedAttachments.has(attachment)) {
+      attachment = queue?.shift()
+    }
+    return attachment
+  }
 
   const visitNode = (node: JSONContent): JSONContent => {
     if (node.type === "attachmentReference") {
@@ -141,16 +158,18 @@ export function materializePendingAttachmentReferences(
           ? node.attrs.mimeType
           : "application/octet-stream"
       const isImage = mimeType.startsWith("image/")
-      const matchedUpload = uploadedQueues.get(attachmentMatchKey({ filename, mimeType }))?.shift()
-      let imageIndex = node.attrs?.imageIndex
-      if (isImage && typeof node.attrs?.imageIndex === "number" && node.attrs.imageIndex > 0) {
-        imageIndex = node.attrs.imageIndex
-      } else if (isImage && matchedUpload) {
-        imageIndex = nextImageIndex
-      }
+      const nodeId = typeof node.attrs?.id === "string" ? node.attrs.id : ""
+      const hasRealId = nodeId.length > 0 && !nodeId.startsWith("temp_")
+      const matchedUpload = hasRealId
+        ? materializableAttachmentById.get(nodeId)
+        : takeUnmatchedAttachment(attachmentMatchKey({ filename, mimeType }))
+      const existingImageIndex =
+        isImage && typeof node.attrs?.imageIndex === "number" && node.attrs.imageIndex > 0
+          ? node.attrs.imageIndex
+          : null
 
       if (matchedUpload) {
-        if (isImage) nextImageIndex += 1
+        matchedAttachments.add(matchedUpload)
         return {
           ...node,
           attrs: {
@@ -160,14 +179,10 @@ export function materializePendingAttachmentReferences(
             mimeType: matchedUpload.mimeType,
             sizeBytes: matchedUpload.sizeBytes,
             status: "uploaded",
-            imageIndex: isImage ? imageIndex : null,
+            imageIndex: isImage ? (existingImageIndex ?? imageIndexByAttachment.get(matchedUpload) ?? null) : null,
             error: null,
           },
         }
-      }
-
-      if (isImage && typeof imageIndex === "number" && imageIndex > 0) {
-        nextImageIndex = Math.max(nextImageIndex, imageIndex + 1)
       }
     }
 
@@ -182,7 +197,7 @@ export function materializePendingAttachmentReferences(
   }
 
   const materializedContent = visitNode(content)
-  const remainingAttachments = Array.from(uploadedQueues.values()).flatMap((queue) => queue)
+  const remainingAttachments = materializableAttachments.filter((attachment) => !matchedAttachments.has(attachment))
   if (remainingAttachments.length === 0) {
     return materializedContent
   }
@@ -191,7 +206,9 @@ export function materializePendingAttachmentReferences(
     type: "paragraph",
     content: remainingAttachments.flatMap((attachment, index) => {
       const isImage = attachment.mimeType.startsWith("image/")
-      const imageIndex = isImage ? nextImageIndex++ : null
+      // The pending list preserves picker order even when an inline placeholder
+      // is lost, so the send-time fallback keeps that original image ordinal.
+      const imageIndex = isImage ? (imageIndexByAttachment.get(attachment) ?? null) : null
 
       const nodes: JSONContent[] = [
         {

--- a/apps/frontend/src/hooks/use-attachments.test.ts
+++ b/apps/frontend/src/hooks/use-attachments.test.ts
@@ -268,6 +268,23 @@ describe("useAttachments", () => {
       expect(doc!.imageIndex).toBeNull()
       expect(second!.imageIndex).toBe(2)
     })
+
+    it("assigns distinct indices when a picker starts multiple image uploads together", async () => {
+      mockReserve()
+      vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 201, body: {} })
+
+      const { result } = renderHook(() => useAttachments(workspaceId))
+      let uploads: Awaited<ReturnType<typeof result.current.uploadFile>>[] = []
+      await act(async () => {
+        uploads = await Promise.all([
+          result.current.uploadFile(createFile("image1.png", "image/png")),
+          result.current.uploadFile(createFile("image2.png", "image/png")),
+          result.current.uploadFile(createFile("pasted.png", "image/png")),
+        ])
+      })
+
+      expect(uploads.map((upload) => upload.imageIndex)).toEqual([1, 2, 3])
+    })
   })
 
   describe("restore", () => {

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -163,6 +163,28 @@ test.describe("Inline File Uploads", () => {
     await expect(page.getByText("pasted-image-2.png")).toBeVisible({ timeout: 5000 })
   })
 
+  test("should keep a mobile multi-pick inline with sequential image numbers", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    const editor = page.locator("[contenteditable='true']")
+    if (!(await editor.isVisible())) {
+      await page.getByText("Type a message...").evaluate((element: HTMLElement) => element.click())
+    }
+    await expect(editor).toBeVisible({ timeout: 5000 })
+
+    const imageBuffer = createTestImage()
+    await page.locator('input[type="file"][multiple]').setInputFiles([
+      { name: "one.png", mimeType: "image/png", buffer: imageBuffer },
+      { name: "two.png", mimeType: "image/png", buffer: imageBuffer },
+      { name: "three.png", mimeType: "image/png", buffer: imageBuffer },
+    ])
+
+    const references = editor.locator("span[data-type='attachment-reference']")
+    await expect(references).toHaveCount(3, { timeout: 10000 })
+    await expect(references.nth(0)).toContainText("[Image #1]", { timeout: 10000 })
+    await expect(references.nth(1)).toContainText("[Image #2]", { timeout: 10000 })
+    await expect(references.nth(2)).toContainText("[Image #3]", { timeout: 10000 })
+  })
+
   test("should open lightbox when clicking image link in sent message", async ({ page }) => {
     const editor = page.locator("[contenteditable='true']")
     await editor.click()


### PR DESCRIPTION
## Problem

Mobile multi-file picks inserted each attachment chip in a separate TipTap transaction. Near-simultaneous reservation updates could let the controlled editor lose an intermediate placeholder: a three-image pick rendered `Image #1` and `Image #3` while all three files remained attached. Send-time reconciliation then appended the missing file with a duplicate `Image #3` label.

## Solution

Insert each picked batch as one editor transaction, then settle every reservation independently.

- `insertAttachmentReferences` preserves current marks and spacing while dispatching one update for the whole batch; picker, paste, drop, and snippet paths share it.
- Reservation completion retains the existing scope/version guard and updates each placeholder by its batch-unique temp id.
- Send-time materialization takes image ordinals from pending attachment order and matches authoritative real attachment ids before filename/MIME fallback, including repeated filenames.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/attachment-reference-extension.ts` | Add atomic multi-reference insertion command. |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Insert file batches atomically; keep uploads independently settled. |
| `apps/frontend/src/components/timeline/message-input.tsx` | Preserve picked ordinals and reconcile existing chips by attachment id. |
| Frontend unit/browser tests | Cover one-transaction insertion, concurrent indices, missing-middle recovery, repeated filenames, and mobile three-file selection. |

## Test plan

- [x] Mobile browser regression: baseline rendered 2 of 3 chips; patched branch renders `Image #1`, `Image #2`, `Image #3` — 1 passed
- [x] Relevant frontend suites — 579 passed
- [x] Repository commit gates — lint, monorepo typecheck, migration/Dockerfile checks, and OpenAPI drift check passed

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788793767&installation_model_id=20758&pr_number=1819&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1819&signature=157c121e42a76c86db8db818cf2186ab473ced3c6d21964d3d83bfaf8853d0d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->