### PR TITLE
fix: preserve visible dictation on failures

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -17,6 +17,7 @@ import { queueComposerCommandRequest } from "@/stores/composer-command-request-s
 let isMobileMockValue = false
 const mockRichEditorFocus = vi.fn()
 const mockInsertFiles = vi.fn(() => true)
+const mockInsertDictationChunk = vi.fn()
 
 type MockEditorInstance = {
   id: string
@@ -34,6 +35,7 @@ const MockRichEditor = forwardRef<
     insertEmoji: () => void
     openSnippetEditor: () => void
     insertFiles: (files: File[]) => boolean
+    insertDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => void
     getEditor: () => MockEditorInstance | null
   },
   {
@@ -73,6 +75,7 @@ const MockRichEditor = forwardRef<
       insertEmoji: () => undefined,
       openSnippetEditor: () => undefined,
       insertFiles: mockInsertFiles,
+      insertDictationChunk: mockInsertDictationChunk,
       getEditor: () => editorInstance,
     }),
     [editorInstance]
@@ -147,6 +150,7 @@ describe("MessageComposer", () => {
     vi.restoreAllMocks()
     mockRichEditorFocus.mockClear()
     mockInsertFiles.mockClear()
+    mockInsertDictationChunk.mockClear()
     isMobileMockValue = false
     vi.useRealTimers()
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileMockValue)
@@ -173,6 +177,39 @@ describe("MessageComposer", () => {
     onSubmit: vi.fn(),
     canSubmit: false,
   }
+
+  it("preserves active interim before the composer and editor refs unmount", () => {
+    const recovered: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "visible interim" }] }],
+    }
+    const prepareSendAsIs = vi.fn()
+    const MockMicButton = forwardRef(function MockMicButton(
+      props: { onInsertPolishedChunk: (args: { chunkId: string; contentJson: JSONContent }) => void },
+      ref: ForwardedRef<{ abort: () => void; prepareSendAsIs: () => void }>
+    ) {
+      useImperativeHandle(ref, () => ({
+        abort: vi.fn(),
+        prepareSendAsIs: () => {
+          prepareSendAsIs()
+          props.onInsertPolishedChunk({ chunkId: "local_recovery_1", contentJson: recovered })
+        },
+      }))
+      return null
+    })
+    spyOnExport(micButtonModule, "MicButton").mockReturnValue(
+      MockMicButton as unknown as typeof micButtonModule.MicButton
+    )
+
+    const { unmount } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" scopeId="stream_a" />)
+    unmount()
+
+    expect(prepareSendAsIs).toHaveBeenCalledOnce()
+    expect(mockInsertDictationChunk).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: recovered,
+    })
+  })
 
   it("aborts active dictation when a nonempty draft is cleared", async () => {
     const abort = vi.fn()

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   useEffect,
   useId,
+  useLayoutEffect,
 } from "react"
 import { flushSync } from "react-dom"
 import { ArrowUp, X, Plus, AtSign, Slash, Paperclip } from "lucide-react"
@@ -381,6 +382,12 @@ export function MessageComposer({
   // dictation take when it sends or clears the draft (drops the polish toggle
   // and any warning chrome rather than letting them ride out a timer).
   const micRef = useRef<MicButtonHandle | null>(null)
+  // Preserve a live ghost while both the mic and editor refs are still mounted.
+  // Hook-level passive cleanup is too late when the whole composer unmounts:
+  // React has already detached the RichEditor imperative ref by then.
+  useLayoutEffect(() => {
+    return () => micRef.current?.prepareSendAsIs()
+  }, [scopeId])
   // Edge-detect the composer emptying (send-clear, manual delete, stash) so we
   // tear down the dictation session exactly once on the non-empty → empty transition.
   const wasEmptyRef = useRef(isEmptyContent(content))

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -339,6 +339,13 @@ describe("useVoiceDictation lifecycle", () => {
 
     expect(order).toEqual(["insert", "lock"])
     expect(inserted).toHaveBeenCalledOnce()
+    expect(inserted).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "keep this tail" }] }],
+      },
+    })
     expect(harness.result.current.interimText).toBe("")
     expect(harness.result.current.state).toBe("idle")
   })
@@ -367,6 +374,13 @@ describe("useVoiceDictation lifecycle", () => {
     }
 
     expect(inserted).toHaveBeenCalledOnce()
+    expect(inserted).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "survive the network switch" }] }],
+      },
+    })
     expect(harness.sockets[0].stopPayloads).toEqual([{ mode: "send_as_is" }])
     expect(harness.result.current.state).toBe("idle")
   })

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -274,6 +274,149 @@ describe("useVoiceDictation lifecycle", () => {
     expect(harness.sockets).toHaveLength(0)
   })
 
+  it.each([
+    ["transport disconnect", "disconnect", undefined],
+    ["upstream error", "voice:transcription:error", { code: "UPSTREAM_CLOSED" }],
+  ])("commits the exact visible interim once before teardown on %s", async (_label, event, payload) => {
+    const inserted = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "the last visible words",
+        isFinal: false,
+      })
+    )
+
+    act(() => {
+      harness.sockets[0].fire(event, payload)
+      // A provider error can be followed by both terminal and disconnect
+      // notifications. Detached callbacks must not recover the same text twice.
+      harness.sockets[0].fire("voice:stopped", { reason: "stopped", revision: 1, outcome: "provider_error" })
+      harness.sockets[0].fire("disconnect", undefined)
+    })
+
+    expect(inserted).toHaveBeenCalledOnce()
+    expect(inserted).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "the last visible words" }] }],
+      },
+    })
+    expect(harness.result.current.interimText).toBe("")
+    expect(harness.result.current.state).toBe("error")
+  })
+
+  it("flushes visible interim before a terminal provider outcome locks tracking", async () => {
+    const order: string[] = []
+    const inserted = vi.fn(() => order.push("insert"))
+    const lockAll = vi.fn(() => order.push("lock"))
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], {
+      onPolishedChunkInserted: inserted,
+      onLockAllChunks: lockAll,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    lockAll.mockClear()
+    order.length = 0
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "keep this tail",
+        isFinal: false,
+      })
+      harness.sockets[0].fire("voice:stopped", {
+        reason: "stopped",
+        revision: 1,
+        outcome: "provider_error",
+      })
+    })
+
+    expect(order).toEqual(["insert", "lock"])
+    expect(inserted).toHaveBeenCalledOnce()
+    expect(harness.result.current.interimText).toBe("")
+    expect(harness.result.current.state).toBe("idle")
+  })
+
+  it("preserves visible interim as-is when the page is backgrounded", async () => {
+    const inserted = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "survive the network switch",
+        isFinal: false,
+      })
+    )
+
+    const previous = Object.getOwnPropertyDescriptor(document, "visibilityState")
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" })
+    try {
+      act(() => document.dispatchEvent(new Event("visibilitychange")))
+    } finally {
+      if (previous) Object.defineProperty(document, "visibilityState", previous)
+      else delete (document as unknown as { visibilityState?: string }).visibilityState
+    }
+
+    expect(inserted).toHaveBeenCalledOnce()
+    expect(harness.sockets[0].stopPayloads).toEqual([{ mode: "send_as_is" }])
+    expect(harness.result.current.state).toBe("idle")
+  })
+
+  it("commits visible interim when scope navigation unmounts the active take", async () => {
+    const inserted = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "keep this across navigation",
+        isFinal: false,
+      })
+    )
+
+    harness.unmount()
+
+    expect(inserted).toHaveBeenCalledOnce()
+    expect(inserted).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "keep this across navigation" }] }],
+      },
+    })
+  })
+
+  it("keeps explicit abort as the only terminal path that discards interim", async () => {
+    const inserted = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "discard intentionally",
+        isFinal: false,
+      })
+      harness.result.current.abort()
+    })
+
+    expect(inserted).not.toHaveBeenCalled()
+    expect(harness.committed).not.toHaveBeenCalled()
+    expect(harness.sockets[0].stopPayloads).toEqual([{ mode: "abort" }])
+  })
+
   it("canonically inserts send-as-is interim recovery synchronously before the composer snapshot", async () => {
     const order: string[] = []
     const inserted = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -384,19 +384,22 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // a take ends before the upstream emits a final delta (manual stop, error, or a
   // dropped connection) so the words the user already saw are kept rather than
   // silently discarded.
-  const flushInterim = useCallback(() => {
+  const flushInterim = useCallback((): boolean => {
     const pending = interimRef.current
-    if (pending) {
-      if (onPolishedChunkInsertedRef.current) {
-        onPolishedChunkInsertedRef.current({
-          chunkId: `local_recovery_${++recoveryChunkSequenceRef.current}`,
-          contentJson: parseMarkdown(pending),
-        })
-      } else {
-        onCommittedTextRef.current(pending)
-      }
+    if (!pending) {
+      updateInterim("")
+      return false
+    }
+    if (onPolishedChunkInsertedRef.current) {
+      onPolishedChunkInsertedRef.current({
+        chunkId: `local_recovery_${++recoveryChunkSequenceRef.current}`,
+        contentJson: parseMarkdown(pending),
+      })
+    } else {
+      onCommittedTextRef.current(pending)
     }
     updateInterim("")
+    return true
   }, [updateInterim])
 
   const teardownAudio = useCallback(() => {
@@ -518,11 +521,14 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       // before teardown clears the decoration so a transport/provider failure
       // can never erase words the user was already looking at.
       flushInterim()
+      // Recovery chunks have no raw/polished pair to toggle. Drop editor and
+      // hook tracking while leaving every inserted character in the document.
+      lockAllChunks()
       setError(message)
       setState("error")
       teardown()
     },
-    [flushInterim, teardown]
+    [flushInterim, lockAllChunks, teardown]
   )
 
   const start = useCallback(() => {
@@ -759,8 +765,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
           // final delta. Preserve the last visible hypothesis before teardown.
           // On the normal path the final delta already cleared this, so the
           // flush is an idempotent no-op rather than a duplicate insertion.
-          flushInterim()
-          if (payload.outcome !== "success" && payload.outcome !== "empty_input") lockAllChunks()
+          const recoveredInterim = flushInterim()
+          if (recoveredInterim || (payload.outcome !== "success" && payload.outcome !== "empty_input")) lockAllChunks()
           teardown()
           setState("idle")
         })
@@ -846,7 +852,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       // The ack callback fires on the server's confirmation or on the timeout —
       // either way we disconnect and return to idle so the UI never wedges.
       const recover = () => {
-        flushInterim()
+        if (flushInterim()) lockAllChunks()
         teardown()
         setState("idle")
       }
@@ -856,7 +862,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     } else {
       // Defensive local recovery for a take whose socket disappeared before
       // stop could be emitted. The visible preview still belongs to the user.
-      flushInterim()
+      if (flushInterim()) lockAllChunks()
       setState("idle")
     }
     // The take is over — start the post-session lock countdown. The user gets a
@@ -928,8 +934,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   }, [])
 
   const prepareSendAsIs = useCallback(() => {
+    let recoveredInterim = false
     if (state === "recording" || state === "connecting" || state === "stopping") {
-      flushInterim()
+      recoveredInterim = flushInterim()
       startGenerationRef.current++
       teardownAudio()
       const socket = socketRef.current
@@ -945,7 +952,12 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       coordinator.deactivate(coordinatedStop)
       setState("idle")
     }
-    if (chunksRef.current.size > 0 || sessionChunkIdRef.current !== null || lockTimerRef.current !== null)
+    if (
+      recoveredInterim ||
+      chunksRef.current.size > 0 ||
+      sessionChunkIdRef.current !== null ||
+      lockTimerRef.current !== null
+    )
       lockAllChunks()
   }, [state, flushInterim, teardownAudio, coordinator, coordinatedStop, lockAllChunks])
 
@@ -989,7 +1001,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     return () => {
       const sessionId = sessionIdRef.current
       const hadSocket = socketRef.current !== null
-      flushInterim()
+      if (flushInterim()) lockAllChunks()
       teardown()
       if (lockTimerRef.current !== null) {
         clearTimeout(lockTimerRef.current)
@@ -999,7 +1011,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         void dependencies.abortSession(workspaceId, sessionId).catch(() => {})
       }
     }
-  }, [flushInterim, teardown, workspaceId, dependencies])
+  }, [flushInterim, lockAllChunks, teardown, workspaceId, dependencies])
 
   let hasUnlockedChunks = false
   for (const record of chunks.values()) {

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -514,14 +514,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
 
   const fail = useCallback(
     (message: string) => {
-      // Don't throw away words the user already saw mid-segment — commit the
-      // pending hypothesis before tearing the failed take down.
-      updateInterim("")
+      // The preview is view-only editor decoration. Commit it to the document
+      // before teardown clears the decoration so a transport/provider failure
+      // can never erase words the user was already looking at.
+      flushInterim()
       setError(message)
       setState("error")
       teardown()
     },
-    [teardown, updateInterim]
+    [flushInterim, teardown]
   )
 
   const start = useCallback(() => {
@@ -754,6 +755,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         })
         socket.on("voice:stopped", (payload: VoiceStoppedPayload) => {
           if (socketRef.current !== socket) return
+          // A provider/relay terminal event is allowed to arrive without a
+          // final delta. Preserve the last visible hypothesis before teardown.
+          // On the normal path the final delta already cleared this, so the
+          // flush is an idempotent no-op rather than a duplicate insertion.
+          flushInterim()
           if (payload.outcome !== "success" && payload.outcome !== "empty_input") lockAllChunks()
           teardown()
           setState("idle")
@@ -814,6 +820,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     workspaceId,
     language,
     fail,
+    flushInterim,
     teardown,
     runMeter,
     coordinator,
@@ -847,6 +854,9 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         socket.timeout(FORMAT_STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "format" }, recover)
       else socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", recover)
     } else {
+      // Defensive local recovery for a take whose socket disappeared before
+      // stop could be emitted. The visible preview still belongs to the user.
+      flushInterim()
       setState("idle")
     }
     // The take is over — start the post-session lock countdown. The user gets a
@@ -958,27 +968,28 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     setState("idle")
   }, [teardownAudio, updateInterim, workspaceId, coordinator, coordinatedStop, dependencies, lockAllChunks])
 
-  // Backgrounding the tab throttles the rAF meter and (on mobile) suspends audio
-  // capture, so a take left "recording" would silently record nothing while the
-  // UI still says it's live. End it cleanly on hide instead: stop() flushes the
-  // in-flight hypothesis and commits the landed text, so the user returns to
-  // their words and an idle mic rather than a dead one they think is recording.
+  // Backgrounding the tab throttles the rAF meter and can suspend capture or
+  // networking entirely. Preserve the visible hypothesis synchronously and end
+  // as-is; `abort()` is intentionally reserved for explicit discard actions.
   useEffect(() => {
     const onVisibilityChange = () => {
-      if (document.visibilityState === "hidden") abort()
+      if (document.visibilityState === "hidden") prepareSendAsIs()
     }
     document.addEventListener("visibilitychange", onVisibilityChange)
     return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [abort])
+  }, [prepareSendAsIs])
 
-  // Abort a still-open session on unmount: disconnecting the socket makes the
-  // gateway finalize it as aborted; if the socket never opened, abort over HTTP
-  // so it doesn't linger until the max-duration guard. Also clear the lock
-  // timer so it doesn't fire against a torn-down editor handle.
+  // Preserve any visible hypothesis before unmount. Scope navigation remounts
+  // the mic while leaving the composer/editor alive, so treating cleanup as an
+  // implicit abort would erase the ghost before the draft can retain it.
+  // Disconnecting then makes the gateway finalize the session as aborted; if
+  // the socket never opened, abort over HTTP so it doesn't linger until the
+  // max-duration guard. Also clear the lock timer.
   useEffect(() => {
     return () => {
       const sessionId = sessionIdRef.current
       const hadSocket = socketRef.current !== null
+      flushInterim()
       teardown()
       if (lockTimerRef.current !== null) {
         clearTimeout(lockTimerRef.current)
@@ -988,7 +999,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         void dependencies.abortSession(workspaceId, sessionId).catch(() => {})
       }
     }
-  }, [teardown, workspaceId, dependencies])
+  }, [flushInterim, teardown, workspaceId, dependencies])
 
   let hasUnlockedChunks = false
   for (const record of chunks.values()) {


### PR DESCRIPTION
## Problem

The dictation failure handler claimed to preserve the visible interim transcript but called `updateInterim("")`, deleting the editor’s view-only ghost before it entered the document. Provider termination, transport loss, page backgrounding, and composer/scope unmount could therefore erase several minutes of visible speech.

## Solution

Make explicit `abort` the only discard path:

- `fail()` and `voice:stopped` commit an unfinalized tail before teardown; finalized stops remain idempotent because their interim is already empty.
- Backgrounding ends with `send_as_is`, and missing-socket/stop-timeout paths recover locally.
- `MessageComposer` uses layout cleanup to flush while both mic and editor refs remain mounted; hook cleanup remains a fallback.
- Recovered raw chunks immediately drop editor/hook tracking, preserving content without a stale dotted or swappable decoration.
- Duplicate terminal/disconnect events remain harmless because the first flush clears the interim ref synchronously.

Explicit `abort` still discards interim text by design.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-voice-dictation.ts` | Preserve and finalize visible interim text across every non-abort terminal path. |
| `apps/frontend/src/hooks/use-voice-dictation.test.ts` | Regress disconnect, provider error, terminal ordering, backgrounding, hook unmount, dedupe, and explicit abort. |
| `apps/frontend/src/components/composer/message-composer.tsx` | Flush before child editor refs detach. |
| `apps/frontend/src/components/composer/message-composer.test.tsx` | Verify whole-composer teardown can still insert through the live editor handle. |

## Test plan

- [x] Focused hook + composer suites — 64 passed
- [x] Frontend typecheck
- [x] Frontend lint
- [x] Full pre-commit monorepo lint, typecheck, Dockerfile, migration, and API-doc checks
- [x] Full frontend suite before the post-review teardown fix — 6,483 passed
- [ ] Final full frontend rerun — timed out under concurrent worktree test load; affected final suites passed and CI will rerun the full shard matrix

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
