### PR TITLE
fix: stash target drafts before message sharing

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import type { ReactNode } from "react"
+import { StrictMode, type ReactNode } from "react"
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter, useSearchParams } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { toast } from "sonner"
 import * as contextsModule from "@/contexts"
 import * as hooksModule from "@/hooks"
 import * as useAttachmentsModule from "@/hooks/use-attachments"
@@ -18,11 +19,12 @@ import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
 import * as streamCommandsModule from "@/hooks/use-stream-commands"
 import { spyOnExport } from "@/test"
-import { upsertLoadedDraft, stashLoadedDraft } from "@/hooks/use-draft-message"
+import * as draftMessageModule from "@/hooks/use-draft-message"
 import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
 import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 import { resetApplyWindow } from "@/stores/apply-window"
 import { setComposerTarget } from "@/hooks/use-composer-target"
+import { peekShareHandoff, queueShareHandoff, resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 // eslint-disable-next-line no-restricted-imports -- seeds/asserts the real draft + composer-target rows
 import { db } from "@/db"
 import { MessageInput } from "./message-input"
@@ -58,14 +60,17 @@ let lastActiveStreamId = streamId
 let e2eEnabled = false
 let openPanelSpy = vi.fn()
 let renderedBodies: string[] = []
+let editorRunResult = true
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+const { upsertLoadedDraft, stashLoadedDraft } = draftMessageModule
 
 beforeEach(async () => {
   vi.restoreAllMocks()
   resetApplyWindow()
   resetDraftStoreCache()
   resetDraftResolutionGuard()
+  resetShareHandoffStoreCache()
   localStorage.clear()
   await db.drafts.clear()
   await db.composerLoaded.clear()
@@ -78,6 +83,7 @@ beforeEach(async () => {
   e2eEnabled = false
   openPanelSpy = vi.fn()
   renderedBodies = []
+  editorRunResult = true
 
   vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
   vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
@@ -193,16 +199,35 @@ beforeEach(async () => {
   }) => {
     renderedBodies.push(docText(content))
     if (composerRef) {
+      const chain = {
+        nextContent: content,
+        setContent(nextContent: JSONContent) {
+          this.nextContent = nextContent
+          return this
+        },
+        focus() {
+          return this
+        },
+        run() {
+          if (editorRunResult) onContentChange(this.nextContent)
+          return editorRunResult
+        },
+      }
       composerRef.current = {
         focus: vi.fn(),
         focusAfterQuoteReply: vi.fn(),
-        getEditor: () => null,
+        getEditor: () => ({
+          isDestroyed: false,
+          getJSON: () => content,
+          chain: () => chain,
+        }),
         openSnippetEditor: vi.fn(),
       }
     }
     return (
       <div>
         <span data-testid="editor-body">{docText(content)}</span>
+        <span data-testid="editor-json">{JSON.stringify(content)}</span>
         <button onClick={() => onContentChange(makeDoc("typed here"))}>type</button>
         <button onClick={() => onContentChange({ type: "doc", content: [{ type: "paragraph" }] })}>clear</button>
       </div>
@@ -215,8 +240,8 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-function mount(initialEntries: string[] = ["/"], mountStreamId: string = streamId) {
-  return render(
+function mount(initialEntries: string[] = ["/"], mountStreamId: string = streamId, strict = false) {
+  const tree = (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
         <MessageInput workspaceId={workspaceId} streamId={mountStreamId} />
@@ -224,6 +249,7 @@ function mount(initialEntries: string[] = ["/"], mountStreamId: string = streamI
       </MemoryRouter>
     </QueryClientProvider>
   )
+  return render(strict ? <StrictMode>{tree}</StrictMode> : tree)
 }
 
 /** The same tree with a different stream — `MessageInput` is NOT remounted per
@@ -266,6 +292,196 @@ async function bodyOf(scope: string): Promise<string> {
 }
 
 describe("the timeline composer's durable target", () => {
+  it("stashes the target's live draft before a shared message takes over the composer", async () => {
+    const original = await upsertLoadedDraft(workspaceId, hostScope, {
+      contentJson: makeDoc("keep this"),
+      attachments: [
+        {
+          id: "attach_keep",
+          filename: "keep.txt",
+          mimeType: "text/plain",
+          sizeBytes: 12,
+        },
+      ],
+    })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("keep this"))
+    await userEvent.click(screen.getByRole("button", { name: "type" }))
+
+    queueShareHandoff(streamId, {
+      messageId: "msg_shared",
+      streamId: "stream_source",
+      authorName: "Ada",
+      authorId: "usr_ada",
+      actorType: "user",
+    })
+
+    await waitFor(() => expect(screen.getByTestId("editor-json")).toHaveTextContent('"type":"sharedMessage"'), {
+      timeout: 7000,
+    })
+    await waitFor(
+      async () => {
+        const loadedId = (await db.composerLoaded.get(hostScope))?.draftId
+        expect(loadedId).toBeDefined()
+        expect(loadedId).not.toBe(original.id)
+      },
+      { timeout: 7000 }
+    )
+
+    expect(await db.drafts.get(original.id)).toMatchObject({
+      contentJson: makeDoc("typed here"),
+      attachments: [{ id: "attach_keep", filename: "keep.txt", mimeType: "text/plain", sizeBytes: 12 }],
+      stashedAt: expect.any(Number),
+    })
+    const loadedId = (await db.composerLoaded.get(hostScope))?.draftId
+    expect(await db.drafts.get(loadedId!)).toMatchObject({
+      contentJson: {
+        type: "doc",
+        content: [
+          {
+            type: "sharedMessage",
+            attrs: {
+              messageId: "msg_shared",
+              streamId: "stream_source",
+              authorName: "Ada",
+              authorId: "usr_ada",
+              actorType: "user",
+            },
+          },
+          { type: "paragraph" },
+        ],
+      },
+    })
+  }, 10_000)
+
+  it("keeps the draft and handoff when the destination cannot be stashed", async () => {
+    const original = await upsertLoadedDraft(workspaceId, hostScope, {
+      contentJson: makeDoc("keep this"),
+      attachments: [],
+    })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("keep this"))
+
+    vi.spyOn(draftMessageModule, "stashLoadedDraft").mockRejectedValueOnce(new Error("IDB unavailable"))
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const toastSpy = vi.spyOn(toast, "error").mockImplementation(() => "toast-id")
+    queueShareHandoff(streamId, {
+      messageId: "msg_retry",
+      streamId: "stream_source",
+      authorName: "Ada",
+      authorId: "usr_ada",
+      actorType: "user",
+    })
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith("Couldn't prepare this composer for sharing. Your draft was kept.")
+    )
+    expect(screen.getByTestId("editor-body")).toHaveTextContent("keep this")
+    expect((await db.composerLoaded.get(hostScope))?.draftId).toBe(original.id)
+    expect((await db.drafts.get(original.id))?.stashedAt).toBeUndefined()
+    expect(peekShareHandoff(streamId)?.messageId).toBe("msg_retry")
+    expect(errorSpy).toHaveBeenCalled()
+  }, 10_000)
+
+  it("keeps the handoff when the destination editor rejects insertion", async () => {
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    mount()
+    editorRunResult = false
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const toastSpy = vi.spyOn(toast, "error").mockImplementation(() => "toast-id")
+    queueShareHandoff(streamId, {
+      messageId: "msg_rejected",
+      streamId: "stream_source",
+      authorName: "Ada",
+      authorId: "usr_ada",
+      actorType: "user",
+    })
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith("Couldn't prepare this composer for sharing. Your draft was kept.")
+    )
+    expect(screen.getByTestId("editor-json")).not.toHaveTextContent('"messageId":"msg_rejected"')
+    expect(peekShareHandoff(streamId)?.messageId).toBe("msg_rejected")
+    expect(await db.composerLoaded.get(hostScope)).toBeUndefined()
+    expect(errorSpy).toHaveBeenCalled()
+  }, 10_000)
+
+  it("keeps the handoff through StrictMode's throwaway effect", async () => {
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    queueShareHandoff(streamId, {
+      messageId: "msg_strict",
+      streamId: "stream_source",
+      authorName: "Ada",
+      authorId: "usr_ada",
+      actorType: "user",
+    })
+
+    mount(["/"], streamId, true)
+
+    await waitFor(() => expect(screen.getByTestId("editor-json")).toHaveTextContent('"messageId":"msg_strict"'), {
+      timeout: 7000,
+    })
+    await waitFor(async () => expect((await db.composerLoaded.get(hostScope))?.draftId).toBeDefined(), {
+      timeout: 7000,
+    })
+    expect(screen.getByTestId("editor-json").textContent?.match(/msg_strict/g)).toHaveLength(1)
+  }, 10_000)
+
+  it("hydrates the destination before stashing when navigation reuses the composer", async () => {
+    const targetStreamId = "stream_target"
+    const targetScope = `stream:${targetStreamId}`
+    const source = await upsertLoadedDraft(workspaceId, hostScope, {
+      contentJson: makeDoc("source body"),
+      attachments: [],
+    })
+    const target = await upsertLoadedDraft(workspaceId, targetScope, {
+      contentJson: makeDoc("target body"),
+      attachments: [],
+    })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    const view = mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toHaveTextContent("source body"))
+    queueShareHandoff(targetStreamId, {
+      messageId: "msg_target",
+      streamId: "stream_source",
+      authorName: "Ada",
+      authorId: "usr_ada",
+      actorType: "user",
+    })
+    rerenderAtStream(view, targetStreamId)
+
+    await waitFor(() => expect(screen.getByTestId("editor-json")).toHaveTextContent('"messageId":"msg_target"'), {
+      timeout: 7000,
+    })
+    await waitFor(
+      async () => {
+        const loadedId = (await db.composerLoaded.get(targetScope))?.draftId
+        expect(loadedId).toBeDefined()
+        expect(loadedId).not.toBe(target.id)
+      },
+      { timeout: 7000 }
+    )
+
+    expect(await db.drafts.get(source.id)).toMatchObject({ contentJson: makeDoc("source body") })
+    expect(await db.drafts.get(target.id)).toMatchObject({
+      contentJson: makeDoc("target body"),
+      stashedAt: expect.any(Number),
+    })
+  }, 10_000)
+
   it("edits the targeted board draft, not the stream's own — and a keystroke lands there", async () => {
     await seedDrafts()
     await setComposerTarget(workspaceId, hostScope, boardScope)
@@ -288,15 +504,19 @@ describe("the timeline composer's durable target", () => {
     await userEvent.click(screen.getByRole("button", { name: "type" }))
     await waitFor(async () => expect(await bodyOf(hostScope)).toBe("typed here"))
     await act(async () => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
-    await waitFor(async () => expect((await db.composerTarget.get(hostScope))?.scope).toBe(boardScope))
-    expect((await db.composerLoaded.get(boardScope))?.draftId).toBe(stableDraftId)
+    await waitFor(async () => {
+      expect((await db.composerTarget.get(hostScope))?.scope).toBe(boardScope)
+      expect((await db.composerLoaded.get(boardScope))?.draftId).toBe(stableDraftId)
+    })
 
     const secondScope = "board:reply:conv_2"
     renderedBodies = []
     await act(async () => registeredConversationReplyHandler?.({ conversationId: "conv_2" }))
-    await waitFor(async () => expect((await db.composerTarget.get(hostScope))?.scope).toBe(secondScope))
+    await waitFor(async () => {
+      expect((await db.composerTarget.get(hostScope))?.scope).toBe(secondScope)
+      expect((await db.composerLoaded.get(secondScope))?.draftId).toBe(stableDraftId)
+    })
 
-    expect((await db.composerLoaded.get(secondScope))?.draftId).toBe(stableDraftId)
     expect(await db.drafts.get(stableDraftId!)).toMatchObject({
       id: stableDraftId,
       scope: secondScope,

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -869,7 +869,7 @@ describe("MessageInput", () => {
         </Wrapper>
       )
       await arm("conv_1")
-      expect(mockComposerFocus).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(mockComposerFocus).toHaveBeenCalledTimes(1))
       expect(mockOpenPanel).not.toHaveBeenCalled()
 
       vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -44,7 +44,12 @@ import { useConversationBoardPost } from "@/hooks/use-conversations"
 import { boardPostLastActiveStreamId } from "@/lib/board/reply-plan"
 import { boardReplyDraftKey, parseBoardDraftKey } from "@/lib/board/draft-keys"
 import { usePanel, createConversationPanelId } from "@/contexts"
-import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
+import {
+  acknowledgeShareHandoffBatch,
+  peekShareHandoffBatch,
+  subscribeShareHandoff,
+  type ShareHandoffBatch,
+} from "@/stores/share-handoff-store"
 import { consumeSnippetRequest, subscribeSnippetRequest } from "@/stores/snippet-request-store"
 import { requestConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { useComposerCommandSend } from "@/components/composer/use-composer-command-send"
@@ -409,11 +414,15 @@ function MessageInputComponent({
   // Use a ref so the handler always reads fresh composer state without
   // re-registering on every render (composer object is not memoized).
   const composerRef = useRef(composer)
+  const stashRef = useRef(stash)
+  const draftKeyRef = useRef(draftKey)
   const armConversationPendingRef = useRef(false)
   const removeConversationFilingPendingRef = useRef(false)
   const mobileChromeOpenRef = useRef(false)
   const [preserveConversationStripSpace, setPreserveConversationStripSpace] = useState(false)
   composerRef.current = composer
+  stashRef.current = stash
+  draftKeyRef.current = draftKey
 
   // Imperative handle for programmatic focus from outside (e.g. quote reply insertion)
   const composerFocusRef = useRef<ComposerControlHandle | null>(null)
@@ -564,115 +573,146 @@ function MessageInputComponent({
     else redirectReplyToPanel(armedConversationId)
   }, [armedConversationId, conversationReplyLastActiveStreamId, redirectReplyToPanel, streamId, hostScope])
 
-  // Consume any pending share handoff for this stream, pre-inserting the
-  // shared-message pointer into the composer and leaving the cursor after it.
-  // We drive this through the editor directly (not React state) so the cursor
-  // positioning lands atomically with the content change — going through the
-  // useState path meant setContent committed one frame after the focus call,
-  // and TipTap would reset the selection to 0 in the process.
-  //
-  // Two trigger paths: (a) on mount / streamId change, pick up any handoff
-  // queued before this composer existed; (b) subscribe to the store so a
-  // share queued while we're already mounted (e.g. share-to-parent fired
-  // from a thread panel of the parent we're already viewing) reaches us
-  // without a remount.
+  // A share gets a fresh composer. Keep the handoff queued until the destination
+  // draft is stashed, then replace the editor with the share and a typing line.
   useEffect(() => {
-    let pendingRaf: number | null = null
-    // Buffer of share nodes consumed from the store but not yet inserted
-    // into the editor (editor not mounted, RAF retry pending). A second
-    // handoff arriving mid-retry appends to this buffer and the RAF inserts
-    // both in one chain — previously, cancelling the retry dropped the
-    // first share's already-consumed payload from the closure. Order is
-    // preserved: first queued ends up first in the doc.
-    const buffered: JSONContent[] = []
+    let pendingFrame: { id: number; resolve: (active: boolean) => void } | null = null
+    let processing = false
+    let cancelled = false
 
-    const cancelPendingRaf = () => {
-      if (pendingRaf !== null) {
-        cancelAnimationFrame(pendingRaf)
-        pendingRaf = null
-      }
-    }
-
-    const tryConsume = () => {
-      const pending = consumeShareHandoff(streamId)
-      if (pending) {
-        buffered.push({
-          type: "sharedMessage",
-          attrs: pending as unknown as Record<string, unknown>,
+    const hasPending = () => peekShareHandoffBatch(streamId) !== null
+    const waitForFrame = () =>
+      new Promise<boolean>((resolve) => {
+        const id = requestAnimationFrame(() => {
+          if (pendingFrame?.id === id) pendingFrame = null
+          resolve(!cancelled)
         })
-      }
-      // A message shared OUT of an E2E scratchpad: the decrypted plaintext was
-      // captured (behind a confirmation) and is inserted as a public blockquote,
-      // not a sealed pointer recipients couldn't open.
-      const pendingPlaintext = consumePlaintextShareHandoff(streamId)
-      if (pendingPlaintext) {
-        const parsed = parseMarkdown(pendingPlaintext.markdown)
-        const inner = parsed.content && parsed.content.length > 0 ? parsed.content : [{ type: "paragraph" }]
-        buffered.push({ type: "blockquote", content: inner })
-      }
-      if (buffered.length === 0) return
-
-      // Reset any in-flight retry — we'll restart it below covering the
-      // updated buffer. Safe because the retry's only side-effect is
-      // requestAnimationFrame; the editor write only happens inside
-      // `insert()` which we re-run on the new RAF.
-      cancelPendingRaf()
-
-      const insert = (): boolean => {
-        const editor = composerFocusRef.current?.getEditor?.()
-        if (!editor || editor.isDestroyed) return false
-
-        const currentDoc = editor.getJSON() as JSONContent
-        const existingBlocks = currentDoc.content ?? []
-        const trimmedBlocks = [...existingBlocks]
-        while (
-          trimmedBlocks.length > 0 &&
-          trimmedBlocks[trimmedBlocks.length - 1].type === "paragraph" &&
-          (trimmedBlocks[trimmedBlocks.length - 1].content?.length ?? 0) === 0
-        ) {
-          trimmedBlocks.pop()
-        }
-
-        // Drain the buffer atomically with the setContent so a notification
-        // arriving between getJSON and setContent doesn't double-insert.
-        const nodesToInsert = buffered.splice(0)
-        editor
-          .chain()
-          .setContent({
-            type: "doc",
-            content: [...trimmedBlocks, ...nodesToInsert, { type: "paragraph" }],
-          })
-          .focus("end")
-          .run()
-        pendingRaf = null
-        return true
-      }
-
-      if (insert()) return
-
-      // Editor not mounted yet on the first tick after a route change —
-      // retry on the next frame until it lands. Bound the chain with a
-      // deadline so a permanently-unmounted host (e.g. the
-      // `disabled && disabledReason` early return below) doesn't burn
-      // a frame per tick forever and silently swallow the share. Mirrors
-      // the deadline pattern on `triggerEditLast` further down.
-      const deadline = performance.now() + 1500
-      pendingRaf = requestAnimationFrame(function retry() {
-        if (insert()) return
-        if (performance.now() >= deadline) {
-          pendingRaf = null
-          return
-        }
-        pendingRaf = requestAnimationFrame(retry)
+        pendingFrame = { id, resolve }
       })
+    const nodesForBatch = (batch: ShareHandoffBatch): JSONContent[] =>
+      batch.handoffs.map((handoff) => {
+        if (handoff.kind === "pointer") {
+          return { type: "sharedMessage", attrs: handoff.attrs as unknown as Record<string, unknown> }
+        }
+        const parsed = parseMarkdown(handoff.markdown)
+        return {
+          type: "blockquote",
+          content: parsed.content && parsed.content.length > 0 ? parsed.content : [{ type: "paragraph" }],
+        }
+      })
+
+    const processPending = async () => {
+      if (processing || !hasPending()) return
+      processing = true
+      let failed = false
+      const deadline = performance.now() + 5000
+      let readyScope: string | null = null
+      const retry = async (message: string) => {
+        if (cancelled) return false
+        if (performance.now() >= deadline) throw new Error(message)
+        return waitForFrame()
+      }
+
+      try {
+        while (!cancelled && hasPending()) {
+          const scope = draftKeyRef.current
+          const current = composerRef.current
+          const editor = composerFocusRef.current?.getEditor?.()
+          if (!current.isLoaded || !editor || editor.isDestroyed) {
+            readyScope = null
+            if (!(await retry("destination composer did not become ready"))) return
+            continue
+          }
+          // Route changes reuse this component; wait for the destination draft's
+          // state update instead of reading the previous stream's editor document.
+          if (readyScope !== scope) {
+            readyScope = scope
+            if (!(await retry("destination draft did not hydrate"))) return
+            continue
+          }
+
+          const attachments = current.getPendingAttachmentsSnapshot()
+          if (attachments.some((attachment) => attachment.status === "error")) {
+            throw new Error("destination composer has a failed attachment")
+          }
+          if (attachments.some((attachment) => attachment.id.startsWith("temp_"))) {
+            if (!(await retry("destination attachment was not reserved in time"))) return
+            continue
+          }
+
+          const liveContent = editor.getJSON() as JSONContent
+          const hadLivePayload = hasDocContent(liveContent) || attachments.length > 0 || current.contextRefs.length > 0
+          const stashed = await stashRef.current.handleStashBeforeReplace(liveContent)
+          if (cancelled) return
+          if (draftKeyRef.current !== scope) {
+            readyScope = null
+            continue
+          }
+          if (hadLivePayload && !stashed) throw new Error("destination draft could not be persisted")
+
+          if (stashed) {
+            // A second clear frame lets the pointer-null transition finish before
+            // insertion; its late reset would otherwise erase the new share.
+            let clearFrames = 0
+            while (!cancelled && draftKeyRef.current === scope) {
+              const reset = composerRef.current
+              const resetEditor = composerFocusRef.current?.getEditor?.()
+              const isClear =
+                resetEditor &&
+                !resetEditor.isDestroyed &&
+                !hasDocContent(reset.content) &&
+                !hasDocContent(resetEditor.getJSON() as JSONContent) &&
+                reset.getPendingAttachmentsSnapshot().length === 0 &&
+                reset.contextRefs.length === 0
+              clearFrames = isClear ? clearFrames + 1 : 0
+              if (clearFrames >= 2) break
+              if (!(await retry("destination composer did not clear"))) return
+            }
+            if (cancelled) return
+            if (draftKeyRef.current !== scope) {
+              readyScope = null
+              continue
+            }
+          }
+
+          const destinationEditor = composerFocusRef.current?.getEditor?.()
+          if (!destinationEditor || destinationEditor.isDestroyed) {
+            readyScope = null
+            if (!(await retry("destination composer was removed"))) return
+            continue
+          }
+          const batch = peekShareHandoffBatch(streamId)
+          if (!batch) return
+          const shareContent: JSONContent = {
+            type: "doc",
+            content: [...nodesForBatch(batch), { type: "paragraph" }],
+          }
+          const inserted = destinationEditor.chain().setContent(shareContent).focus("end").run()
+          if (!inserted) throw new Error("destination editor rejected the share")
+          acknowledgeShareHandoffBatch(streamId, batch)
+          const persisted = await composerRef.current.flushDraftWithResult({ contentJson: shareContent })
+          if (!persisted) toast.error("Couldn't save the shared message as a draft. Keep this composer open.")
+        }
+      } catch (err) {
+        failed = true
+        console.error("[composer] failed to prepare share handoff", err)
+        toast.error("Couldn't prepare this composer for sharing. Your draft was kept.")
+      } finally {
+        processing = false
+        if (!cancelled && !failed && hasPending()) void processPending()
+      }
     }
 
-    tryConsume()
-    const unsubscribe = subscribeShareHandoff(streamId, tryConsume)
-
+    void processPending()
+    const unsubscribe = subscribeShareHandoff(streamId, () => void processPending())
     return () => {
+      cancelled = true
       unsubscribe()
-      cancelPendingRaf()
+      const frame = pendingFrame
+      if (!frame) return
+      cancelAnimationFrame(frame.id)
+      pendingFrame = null
+      frame.resolve(false)
     }
   }, [streamId])
 

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -169,7 +169,9 @@ export interface DraftComposerState {
    * stash/restore calls avoid the empty→delete path; filing-only scope moves may
    * preserve an existing row after the user deliberately cleared its body.
    */
-  flushDraft: (options?: { keepEmpty?: boolean }) => Promise<void>
+  flushDraft: (options?: { keepEmpty?: boolean; contentJson?: JSONContent }) => Promise<void>
+  /** Same flush, reporting false when a payload was present but could not be persisted. */
+  flushDraftWithResult: (options?: { keepEmpty?: boolean; contentJson?: JSONContent }) => Promise<boolean>
   /**
    * Re-run the composer's init from whatever draft is now loaded for the scope.
    * Called after a stash/restore pointer move so the editor re-reads (and, for
@@ -311,18 +313,24 @@ export function useDraftComposer({
   // while the editor is still mid-hydration (transiently empty) — taking the
   // empty→delete path then would silently destroy the loaded draft. An
   // intentional clear is handled by the debounced save, never here.
-  const flushDraft = useCallback(
-    async (options?: { keepEmpty?: boolean }) => {
+  const flushDraftWithResult = useCallback(
+    async (options?: { keepEmpty?: boolean; contentJson?: JSONContent }) => {
+      const contentJson = options?.contentJson ?? contentRef.current
       const attachments = persistableAttachments(getPendingAttachmentsSnapshot())
       if (options?.keepEmpty) {
-        await saveDraft(contentRef.current, attachments, undefined, options)
-      } else if (hasDocContent(contentRef.current)) {
-        await saveDraft(contentRef.current)
-      } else if (attachments.length > 0) {
-        await saveDraft(contentRef.current, attachments)
+        return (await saveDraft(contentJson, attachments, undefined, { keepEmpty: true })) !== null
       }
+      if (hasDocContent(contentJson)) return (await saveDraft(contentJson)) !== null
+      if (attachments.length > 0) return (await saveDraft(contentJson, attachments)) !== null
+      return true
     },
     [getPendingAttachmentsSnapshot, saveDraft]
+  )
+  const flushDraft = useCallback(
+    async (options?: { keepEmpty?: boolean; contentJson?: JSONContent }) => {
+      await flushDraftWithResult(options)
+    },
+    [flushDraftWithResult]
   )
 
   // Blank the composer to an un-initialized state so the init effect below
@@ -721,6 +729,7 @@ export function useDraftComposer({
 
     // Flush / re-hydrate (used by stash + restore)
     flushDraft,
+    flushDraftWithResult,
     markNeedsRehydrate: resetForReinit,
 
     // Clear helpers

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -136,6 +136,29 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
     await waitFor(() => expect(result.current.stash.drafts.some((d) => d.id === ambientId)).toBe(true))
   })
 
+  it("does not detach a loaded draft when the live payload cannot be persisted", async () => {
+    const { ambientId } = await seedStashAndAmbient()
+    const detachSpy = vi.spyOn(draftMessageModule, "stashLoadedDraft")
+
+    function useFailedFlushHarness() {
+      const composer = useDraftComposer({ workspaceId, draftKey, scopeId: streamId })
+      const wrapped = { ...composer, flushDraftWithResult: async () => false }
+      const stash = useStashComposer(wrapped as never, workspaceId, draftKey)
+      return { composer, stash }
+    }
+
+    const { result } = renderHook(() => useFailedFlushHarness(), { wrapper })
+    await waitFor(() => expect(result.current.composer.content).toEqual(AMBIENT_BODY))
+
+    await act(async () => {
+      expect(await result.current.stash.handleStashBeforeReplace(BIG_BODY)).toBe(false)
+    })
+
+    expect(detachSpy).not.toHaveBeenCalled()
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(ambientId)
+    expect(result.current.composer.content).toEqual(AMBIENT_BODY)
+  })
+
   it("refuses to restore a foreign row into a host whose home stream is unresolvable", async () => {
     const { bigId } = await seedStashAndAmbient()
     const restoreSpy = vi.spyOn(draftMessageModule, "restoreStashedDraftToComposer")

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { useLiveQuery } from "dexie-react-hooks"
+import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import {
@@ -103,6 +104,8 @@ export interface UseStashComposerResult {
   setPileOpen: (open: boolean) => void
   /** Snapshot the current composer content into the stash, clear the editor. Empty composer → silent no-op. */
   handleStashDraft: () => Promise<void>
+  /** Stash any loaded draft before programmatic composer replacement. Returns whether a row was preserved. */
+  handleStashBeforeReplace: (contentJson: JSONContent) => Promise<boolean>
   /** Swap: stash current content first (if any), then bring the chosen pile row here — adopting or moving it as {@link planDraftRestore} decides. Refusals come back as data for the caller to surface. */
   handleRestoreStashed: (id: string) => Promise<DraftRestoreResult>
   /** Delete a stashed row without restoring. */
@@ -170,25 +173,33 @@ export function useStashComposer(
   const targetHost = host?.targetHost ?? null
   const disarmTarget = host?.disarmTarget ?? null
 
+  const stashCurrentDraft = useCallback(
+    async (contentJson?: JSONContent): Promise<boolean> => {
+      if (!scope) return false
+      const persisted = await composer.flushDraftWithResult(contentJson ? { contentJson } : undefined)
+      if (!persisted) return false
+      const stashedId = await stashLoadedDraft(workspaceId, scope)
+      if (!stashedId) return false
+      syncEngine?.kickOperationQueue()
+      composer.markNeedsRehydrate()
+      return true
+    },
+    [composer, workspaceId, scope, syncEngine]
+  )
+
   const handleStashDraft = useCallback(async () => {
-    if (!scope) return
     // Nothing worth stashing → silent no-op (parity with the picker's disabled
     // button and the product brief). Attachments alone count as content.
     const hasContent = !isEmptyContent(composer.content)
     const hasAttachments = composer.uploadedIds.length > 0
     if (!hasContent && !hasAttachments) return
+    await stashCurrentDraft()
+  }, [composer.content, composer.uploadedIds.length, stashCurrentDraft])
 
-    // Flush the live editor into its row first (sealed for E2E, E2EE-4) so the
-    // stash entry carries exactly what the user was typing, then detach it. The
-    // flush never deletes (it no-ops on empty), so it can't destroy the draft.
-    await composer.flushDraft()
-    const stashedId = await stashLoadedDraft(workspaceId, scope)
-    if (!stashedId) return
-    // The durable stash marker rides the row — drain it promptly.
-    syncEngine?.kickOperationQueue()
-    // Re-init the (now draft-less) composer so the editor blanks out.
-    composer.markNeedsRehydrate()
-  }, [composer, workspaceId, scope, syncEngine])
+  const handleStashBeforeReplace = useCallback(
+    (contentJson: JSONContent) => stashCurrentDraft(contentJson),
+    [stashCurrentDraft]
+  )
 
   const { canHostForeignDraft, describeScope } = stashedDrafts
 
@@ -389,6 +400,7 @@ export function useStashComposer(
     originByDraftId: stashedDrafts.originByDraftId,
     setPileOpen: stashedDrafts.setPileOpen,
     handleStashDraft,
+    handleStashBeforeReplace,
     handleRestoreStashed: restoreDraftHere,
     handleDeleteStashed: stashedDrafts.deleteStashedDraft,
   }

--- a/apps/frontend/src/stores/share-handoff-store.test.ts
+++ b/apps/frontend/src/stores/share-handoff-store.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   __resetShareHandoffStoreForTesting,
+  acknowledgeShareHandoffBatch,
   consumeShareHandoff,
   consumePlaintextShareHandoff,
   peekShareHandoff,
+  peekPlaintextShareHandoff,
+  peekShareHandoffBatch,
   queueShareHandoff,
   queuePlaintextShareHandoff,
   subscribeShareHandoff,
@@ -37,8 +40,36 @@ describe("share handoff store", () => {
     queuePlaintextShareHandoff("stream_a", "the secret plan", sampleAttrs)
     // The pointer channel is untouched by a plaintext queue.
     expect(consumeShareHandoff("stream_a")).toBeNull()
+    expect(peekPlaintextShareHandoff("stream_a")).toMatchObject({ markdown: "the secret plan", attrs: sampleAttrs })
     expect(consumePlaintextShareHandoff("stream_a")).toMatchObject({ markdown: "the secret plan", attrs: sampleAttrs })
     expect(consumePlaintextShareHandoff("stream_a")).toBeNull()
+  })
+
+  it("keeps multiple handoffs queued while the destination composer prepares", () => {
+    queueShareHandoff("stream_a", { ...sampleAttrs, messageId: "msg_1" })
+    queueShareHandoff("stream_a", { ...sampleAttrs, messageId: "msg_2" })
+
+    expect(consumeShareHandoff("stream_a")?.messageId).toBe("msg_1")
+    expect(consumeShareHandoff("stream_a")?.messageId).toBe("msg_2")
+    expect(consumeShareHandoff("stream_a")).toBeNull()
+  })
+
+  it("snapshots mixed handoffs in FIFO order and acknowledges only that batch", () => {
+    queuePlaintextShareHandoff("stream_a", "first", { ...sampleAttrs, messageId: "msg_plain" })
+    queueShareHandoff("stream_a", { ...sampleAttrs, messageId: "msg_pointer" })
+
+    const batch = peekShareHandoffBatch("stream_a")!
+    expect(batch.handoffs).toEqual([
+      { kind: "plaintext", markdown: "first", attrs: { ...sampleAttrs, messageId: "msg_plain" } },
+      { kind: "pointer", attrs: { ...sampleAttrs, messageId: "msg_pointer" } },
+    ])
+    expect(peekPlaintextShareHandoff("stream_a")?.markdown).toBe("first")
+
+    queueShareHandoff("stream_a", { ...sampleAttrs, messageId: "msg_later" })
+    acknowledgeShareHandoffBatch("stream_a", batch)
+
+    expect(consumePlaintextShareHandoff("stream_a")).toBeNull()
+    expect(consumeShareHandoff("stream_a")?.messageId).toBe("msg_later")
   })
 
   it("queues independently per target stream", () => {

--- a/apps/frontend/src/stores/share-handoff-store.ts
+++ b/apps/frontend/src/stores/share-handoff-store.ts
@@ -23,11 +23,48 @@ export interface PlaintextShareHandoffEntry {
   expiresAt: number
 }
 
+export type PendingShareHandoff =
+  | { kind: "pointer"; attrs: SharedMessageAttrs }
+  | { kind: "plaintext"; markdown: string; attrs: SharedMessageAttrs }
+
+export interface ShareHandoffBatch {
+  ids: readonly number[]
+  handoffs: readonly PendingShareHandoff[]
+}
+
+type QueuedShareHandoff =
+  | ({ queueId: number; kind: "pointer" } & ShareHandoffEntry)
+  | ({ queueId: number; kind: "plaintext" } & PlaintextShareHandoffEntry)
+
 const HANDOFF_TTL_MS = 5 * 60 * 1000
 
-const cache = new Map<string, ShareHandoffEntry>()
-const plaintextCache = new Map<string, PlaintextShareHandoffEntry>()
+let nextQueueId = 0
+const cache = new Map<string, QueuedShareHandoff[]>()
 const listeners = new Map<string, Set<() => void>>()
+
+function liveQueue(streamId: string): QueuedShareHandoff[] {
+  const queued = cache.get(streamId)
+  if (!queued) return []
+  const now = Date.now()
+  for (let index = queued.length - 1; index >= 0; index--) {
+    if (queued[index].expiresAt < now) queued.splice(index, 1)
+  }
+  if (queued.length === 0) cache.delete(streamId)
+  return queued
+}
+
+function consumeKind(streamId: string, kind: QueuedShareHandoff["kind"]): QueuedShareHandoff | null {
+  const queued = liveQueue(streamId)
+  const index = queued.findIndex((entry) => entry.kind === kind)
+  if (index < 0) return null
+  const [entry] = queued.splice(index, 1)
+  if (queued.length === 0) cache.delete(streamId)
+  return entry
+}
+
+function peekKind(streamId: string, kind: QueuedShareHandoff["kind"]): QueuedShareHandoff | null {
+  return liveQueue(streamId).find((entry) => entry.kind === kind) ?? null
+}
 
 /**
  * Queue a share node for the target stream's composer. A composer already
@@ -36,10 +73,9 @@ const listeners = new Map<string, Set<() => void>>()
  * user is already viewing).
  */
 export function queueShareHandoff(targetStreamId: string, attrs: SharedMessageAttrs): void {
-  cache.set(targetStreamId, {
-    attrs,
-    expiresAt: Date.now() + HANDOFF_TTL_MS,
-  })
+  const queued = cache.get(targetStreamId) ?? []
+  queued.push({ queueId: ++nextQueueId, kind: "pointer", attrs, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  cache.set(targetStreamId, queued)
   const subs = listeners.get(targetStreamId)
   if (subs) {
     for (const listener of subs) listener()
@@ -52,20 +88,56 @@ export function queueShareHandoff(targetStreamId: string, attrs: SharedMessageAt
  * pointer hand-off; consumed via {@link consumePlaintextShareHandoff}.
  */
 export function queuePlaintextShareHandoff(targetStreamId: string, markdown: string, attrs: SharedMessageAttrs): void {
-  plaintextCache.set(targetStreamId, { markdown, attrs, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  const queued = cache.get(targetStreamId) ?? []
+  queued.push({
+    queueId: ++nextQueueId,
+    kind: "plaintext",
+    markdown,
+    attrs,
+    expiresAt: Date.now() + HANDOFF_TTL_MS,
+  })
+  cache.set(targetStreamId, queued)
   const subs = listeners.get(targetStreamId)
   if (subs) {
     for (const listener of subs) listener()
   }
 }
 
-/** Read + clear a pending plaintext (decrypted E2E) share for the stream. */
+/** Read + clear the oldest pending plaintext (decrypted E2E) share for the stream. */
 export function consumePlaintextShareHandoff(targetStreamId: string): PlaintextShareHandoffEntry | null {
-  const entry = plaintextCache.get(targetStreamId)
-  if (!entry) return null
-  plaintextCache.delete(targetStreamId)
-  if (entry.expiresAt < Date.now()) return null
-  return entry
+  const entry = consumeKind(targetStreamId, "plaintext")
+  if (!entry || entry.kind !== "plaintext") return null
+  return { markdown: entry.markdown, attrs: entry.attrs, expiresAt: entry.expiresAt }
+}
+
+/** Non-consuming read of the oldest pending plaintext share. */
+export function peekPlaintextShareHandoff(targetStreamId: string): PlaintextShareHandoffEntry | null {
+  const entry = peekKind(targetStreamId, "plaintext")
+  if (!entry || entry.kind !== "plaintext") return null
+  return { markdown: entry.markdown, attrs: entry.attrs, expiresAt: entry.expiresAt }
+}
+
+/** Snapshot every pending handoff in queue order without consuming it. */
+export function peekShareHandoffBatch(targetStreamId: string): ShareHandoffBatch | null {
+  const queued = liveQueue(targetStreamId)
+  if (queued.length === 0) return null
+  return {
+    ids: queued.map((entry) => entry.queueId),
+    handoffs: queued.map((entry) => {
+      if (entry.kind === "pointer") return { kind: "pointer", attrs: entry.attrs }
+      return { kind: "plaintext", markdown: entry.markdown, attrs: entry.attrs }
+    }),
+  }
+}
+
+/** Remove only the entries represented by a previously-read batch. */
+export function acknowledgeShareHandoffBatch(targetStreamId: string, batch: ShareHandoffBatch): void {
+  const queued = cache.get(targetStreamId)
+  if (!queued) return
+  const acknowledged = new Set(batch.ids)
+  const remaining = queued.filter((entry) => !acknowledged.has(entry.queueId))
+  if (remaining.length > 0) cache.set(targetStreamId, remaining)
+  else cache.delete(targetStreamId)
 }
 
 /**
@@ -94,11 +166,8 @@ export function subscribeShareHandoff(targetStreamId: string, listener: () => vo
  * nothing is queued or the entry has expired (and evicts it).
  */
 export function consumeShareHandoff(targetStreamId: string): SharedMessageAttrs | null {
-  const entry = cache.get(targetStreamId)
-  if (!entry) return null
-  cache.delete(targetStreamId)
-  if (entry.expiresAt < Date.now()) return null
-  return entry.attrs
+  const entry = consumeKind(targetStreamId, "pointer")
+  return entry?.attrs ?? null
 }
 
 /**
@@ -106,13 +175,7 @@ export function consumeShareHandoff(targetStreamId: string): SharedMessageAttrs 
  * stream. Mostly for tests and debug panels.
  */
 export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | null {
-  const entry = cache.get(targetStreamId)
-  if (!entry) return null
-  if (entry.expiresAt < Date.now()) {
-    cache.delete(targetStreamId)
-    return null
-  }
-  return entry.attrs
+  return peekKind(targetStreamId, "pointer")?.attrs ?? null
 }
 
 /**
@@ -122,7 +185,6 @@ export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | n
  */
 export function resetShareHandoffStoreCache(): void {
   cache.clear()
-  plaintextCache.clear()
   listeners.clear()
 }
 


### PR DESCRIPTION
## Problem

Sharing a message into another stream could replace that stream's active composer before its draft had settled. Text and attachments already in the destination could disappear instead of remaining available as a draft.

## Solution

Preserve the destination draft before installing the share:

- `MessageInput` waits for destination hydration, flushes the live editor payload, stashes the loaded draft, and waits for the pointer reset before inserting the share into a fresh composer.
- The new share is flushed immediately as the active draft. Failed persistence blocks detachment; failed preparation or rejected insertion leaves the handoff queued and shows an error.
- Pointer and decrypted-plaintext handoffs now share one FIFO queue. Snapshot/acknowledge semantics consume only entries the editor accepted, including when another share arrives during preparation.
- Integration coverage pins unsaved text and attachments, route reuse, StrictMode, persistence failure, rejected insertion, and mixed handoff ordering.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-input.tsx` | Stash-before-share orchestration and failure handling |
| `apps/frontend/src/components/timeline/message-input.composer-target.test.tsx` | End-to-end draft preservation and handoff lifecycle coverage |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | Stabilize asynchronous focus assertion |
| `apps/frontend/src/hooks/use-draft-composer.ts` | Result-aware immediate draft flush |
| `apps/frontend/src/hooks/use-stash-composer.ts` | Refuse detachment when live content cannot persist |
| `apps/frontend/src/hooks/use-stash-composer.test.ts` | Failed-persistence coverage |
| `apps/frontend/src/stores/share-handoff-store.ts` | Unified FIFO queue with snapshot acknowledgment |
| `apps/frontend/src/stores/share-handoff-store.test.ts` | Queue ordering and acknowledgment coverage |

## Test plan

- [x] Targeted frontend tests: 78 passed
- [x] Repository pre-commit gates: lint, monorepo typecheck, API docs, Docker workspace checks, and 259 migration checks
- [x] Combined Sol/high review; 3 findings fixed and targeted recheck marked all `FIXED`
- [ ] Full frontend suite: exceeded the 15-minute local harness limit

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788799048&installation_model_id=20758&pr_number=1821&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1821&signature=18f769944855587c3a583ccf18a8661a4668aceab0a32ff4cac36b8d5dd814c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->