### PR TITLE
feat: drag composer pills into place

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -534,7 +534,7 @@ The composer is **TipTap (ProseMirror)** wrapped by:
 - Text structure: `doc`, `paragraph`, `text`, `hardBreak`, `heading`, `blockquote`, `horizontalRule`, and `codeBlock`.
 - Lists and tables: `bulletList`, `orderedList`, `listItem`, `table`, `tableRow`, `tableHeader`, and `tableCell`.
 - Inline atoms: `mention` (`attrs.slug`), `channelLink` (`attrs.slug`), `slashCommand` (`attrs.name`), `emoji`, `attachmentReference`, `memoEmbed`, `inAppLink`, and `giphyEmbed`.
-- Pill atoms (every inline atom above except `emoji`) reorder by drag: 6px mouse activation or the shared 500ms touch hold. The source stays in place while a gold caret previews the drop; release commits one undoable move.
+- Pill atoms (every inline atom above except `emoji`) reorder by drag: 6px mouse activation or the shared 500ms touch hold. The source greys in place while a gold caret snaps between words; touch mirrors that slot in a contextual loupe above the thumb and pulses haptics as the target changes. Release commits one undoable move.
 - Block atoms: `quoteReply` and `sharedMessage`.
 
 The mobile collapsed bar and board draft affordances both use

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -534,6 +534,7 @@ The composer is **TipTap (ProseMirror)** wrapped by:
 - Text structure: `doc`, `paragraph`, `text`, `hardBreak`, `heading`, `blockquote`, `horizontalRule`, and `codeBlock`.
 - Lists and tables: `bulletList`, `orderedList`, `listItem`, `table`, `tableRow`, `tableHeader`, and `tableCell`.
 - Inline atoms: `mention` (`attrs.slug`), `channelLink` (`attrs.slug`), `slashCommand` (`attrs.name`), `emoji`, `attachmentReference`, `memoEmbed`, `inAppLink`, and `giphyEmbed`.
+- Pill atoms (every inline atom above except `emoji`) reorder by drag: 6px mouse activation or the shared 500ms touch hold. The source stays in place while a gold caret previews the drop; release commits one undoable move.
 - Block atoms: `quoteReply` and `sharedMessage`.
 
 The mobile collapsed bar and board draft affordances both use

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.test.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { fireEvent } from "@testing-library/react"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@threa/types"
+import { createEditorExtensions } from "./editor-extensions"
+import {
+  COMPOSER_PILL_NODE_NAMES,
+  composerPillDropPoint,
+  createComposerPillMoveTransaction,
+  isComposerPillNode,
+} from "./composer-pill-drag-extension"
+
+const openEditors: Editor[] = []
+
+afterEach(() => {
+  while (openEditors.length > 0) openEditors.pop()?.destroy()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+function pill(type: "mention" | "channelLink" | "slashCommand"): JSONContent {
+  if (type === "mention") return { type, attrs: { id: "usr_1", slug: "alice", mentionType: "user" } }
+  if (type === "channelLink") return { type, attrs: { id: "stream_1", slug: "design" } }
+  return { type, attrs: { name: "invite", clientActionId: null } }
+}
+
+function createPillEditor(content: JSONContent[] = [pill("mention"), pill("channelLink"), pill("slashCommand")]) {
+  const editor = new Editor({
+    element: document.createElement("div"),
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content: { type: "doc", content: [{ type: "paragraph", content }] },
+  })
+  openEditors.push(editor)
+  return editor
+}
+
+function nodePos(editor: Editor, type: string): number {
+  let result = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (result === -1 && node.type.name === type) result = pos
+  })
+  if (result === -1) throw new Error(`${type} not found`)
+  return result
+}
+
+function childTypes(editor: Editor): string[] {
+  return editor.state.doc.firstChild?.content.content.map((node) => node.type.name) ?? []
+}
+
+function touch(identifier: number, clientX: number, clientY: number): Touch {
+  return { identifier, clientX, clientY } as Touch
+}
+
+describe("composer pill moves", () => {
+  it("covers every inline composer chip while leaving emoji text atoms out", () => {
+    const editor = createPillEditor()
+
+    expect(COMPOSER_PILL_NODE_NAMES).toEqual([
+      "mention",
+      "channelLink",
+      "slashCommand",
+      "attachmentReference",
+      "memoEmbed",
+      "inAppLink",
+      "giphyEmbed",
+    ])
+    expect(isComposerPillNode(editor.state.schema.nodes.mention.create())).toBe(true)
+    expect(isComposerPillNode(editor.state.schema.nodes.emoji.create())).toBe(false)
+  })
+
+  it("builds one transaction that leaves the document unchanged until dispatch", () => {
+    const editor = createPillEditor()
+    const sourcePos = nodePos(editor, "mention")
+    const dropPos = nodePos(editor, "slashCommand") + 1
+    const tr = createComposerPillMoveTransaction(editor.state, sourcePos, dropPos)
+
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+    expect(tr).not.toBeNull()
+
+    editor.view.dispatch(tr!)
+    expect(childTypes(editor)).toEqual(["channelLink", "slashCommand", "mention"])
+
+    editor.commands.undo()
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+  })
+
+  it("can insert the pill at a text caret, not only between other atoms", () => {
+    const editor = createPillEditor([pill("mention"), { type: "text", text: "hello" }])
+    const tr = createComposerPillMoveTransaction(editor.state, nodePos(editor, "mention"), 5)
+
+    expect(tr).not.toBeNull()
+    editor.view.dispatch(tr!)
+    expect(editor.getJSON().content?.[0]?.content).toEqual([
+      { type: "text", text: "hel" },
+      pill("mention"),
+      { type: "text", text: "lo" },
+    ])
+  })
+
+  it("treats either edge of the source pill as a no-op", () => {
+    const editor = createPillEditor()
+    const sourcePos = nodePos(editor, "mention")
+
+    expect(createComposerPillMoveTransaction(editor.state, sourcePos, sourcePos)).toBeNull()
+    expect(createComposerPillMoveTransaction(editor.state, sourcePos, sourcePos + 1)).toBeNull()
+  })
+
+  it("does not offer an inline pill cursor inside a code block", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createEditorExtensions({ placeholder: "" }),
+      content: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [pill("mention")] },
+          { type: "codeBlock", attrs: { language: "plaintext" }, content: [{ type: "text", text: "code" }] },
+        ],
+      },
+    })
+    openEditors.push(editor)
+    const source = editor.state.doc.nodeAt(nodePos(editor, "mention"))!
+    const codePos = nodePos(editor, "codeBlock") + 1
+
+    expect(composerPillDropPoint(editor.state.doc, codePos, source)).toBeNull()
+  })
+})
+
+describe("composer pill drag gestures", () => {
+  it("shows only source state and an insertion cursor while a mouse drag is in flight", () => {
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    const dropPos = nodePos(editor, "slashCommand") + 1
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: dropPos, inside: -1 })
+
+    fireEvent.mouseDown(source, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 18, clientY: 10 })
+
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+    expect(editor.view.dom.querySelector(".composer-pill-drop-cursor")).not.toBeNull()
+
+    fireEvent.mouseUp(document, { button: 0, clientX: 18, clientY: 10 })
+
+    expect(childTypes(editor)).toEqual(["channelLink", "slashCommand", "mention"])
+    expect(editor.view.dom.querySelector(".composer-pill-drop-cursor")).toBeNull()
+  })
+
+  it("drags attachment React node views through the same path", () => {
+    const editor = createPillEditor([
+      {
+        type: "attachmentReference",
+        attrs: {
+          id: "att_1",
+          filename: "image.png",
+          mimeType: "image/png",
+          sizeBytes: 42,
+          status: "uploaded",
+          imageIndex: 1,
+          error: null,
+        },
+      },
+      pill("mention"),
+    ])
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="attachment-reference"]')!
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: nodePos(editor, "mention") + 1, inside: -1 })
+
+    fireEvent.mouseDown(source, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 18, clientY: 10 })
+
+    expect(source).toHaveClass("composer-pill-dragging")
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+  })
+
+  it("requires a stationary long press before touch dragging, then commits only on release", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    const dropPos = nodePos(editor, "slashCommand") + 1
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: dropPos, inside: -1 })
+
+    fireEvent.touchStart(source, { touches: [touch(7, 10, 10)] })
+    vi.advanceTimersByTime(499)
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+
+    vi.advanceTimersByTime(1)
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+
+    fireEvent.touchMove(document, { touches: [touch(7, 20, 10)] })
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+
+    fireEvent.touchEnd(document, { touches: [], changedTouches: [touch(7, 20, 10)] })
+    expect(childTypes(editor)).toEqual(["channelLink", "slashCommand", "mention"])
+  })
+
+  it("cancels an active drag when a second finger lands outside the editor", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.touchStart(source, { touches: [touch(3, 10, 10)] })
+    vi.advanceTimersByTime(500)
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+
+    fireEvent.touchStart(document.body, { touches: [touch(3, 10, 10), touch(4, 50, 50)] })
+    fireEvent.touchEnd(document, { touches: [touch(4, 50, 50)], changedTouches: [touch(3, 10, 10)] })
+
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+  })
+
+  it("leaves touch scrolling alone when the finger moves before the long-press threshold", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.touchStart(source, { touches: [touch(3, 10, 10)] })
+    fireEvent.touchMove(document, { touches: [touch(3, 10, 21)] })
+    vi.advanceTimersByTime(500)
+
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.test.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.test.ts
@@ -11,9 +11,20 @@ import {
 } from "./composer-pill-drag-extension"
 
 const openEditors: Editor[] = []
+let originalVibrateDescriptor: PropertyDescriptor | undefined
+let vibrateMocked = false
 
 afterEach(() => {
   while (openEditors.length > 0) openEditors.pop()?.destroy()
+  if (vibrateMocked) {
+    if (originalVibrateDescriptor) {
+      Object.defineProperty(window.navigator, "vibrate", originalVibrateDescriptor)
+    } else {
+      delete (window.navigator as unknown as { vibrate?: Navigator["vibrate"] }).vibrate
+    }
+    originalVibrateDescriptor = undefined
+    vibrateMocked = false
+  }
   vi.useRealTimers()
   vi.restoreAllMocks()
 })
@@ -51,6 +62,14 @@ function touch(identifier: number, clientX: number, clientY: number): Touch {
   return { identifier, clientX, clientY } as Touch
 }
 
+function mockVibrate() {
+  originalVibrateDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "vibrate")
+  vibrateMocked = true
+  const vibrate = vi.fn((_pattern: number | number[]) => true)
+  Object.defineProperty(window.navigator, "vibrate", { configurable: true, value: vibrate })
+  return vibrate
+}
+
 describe("composer pill moves", () => {
   it("covers every inline composer chip while leaving emoji text atoms out", () => {
     const editor = createPillEditor()
@@ -84,17 +103,32 @@ describe("composer pill moves", () => {
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
   })
 
-  it("can insert the pill at a text caret, not only between other atoms", () => {
-    const editor = createPillEditor([pill("mention"), { type: "text", text: "hello" }])
-    const tr = createComposerPillMoveTransaction(editor.state, nodePos(editor, "mention"), 5)
+  it("snaps a text drop to whitespace instead of splitting a word", () => {
+    const editor = createPillEditor([pill("mention"), { type: "text", text: "hello world" }])
+    const sourcePos = nodePos(editor, "mention")
+    const source = editor.state.doc.nodeAt(sourcePos)!
+
+    expect(composerPillDropPoint(editor.state.doc, 5, source)).toBe(7)
+    const tr = createComposerPillMoveTransaction(editor.state, sourcePos, 5)
 
     expect(tr).not.toBeNull()
     editor.view.dispatch(tr!)
     expect(editor.getJSON().content?.[0]?.content).toEqual([
-      { type: "text", text: "hel" },
+      { type: "text", text: "hello" },
       pill("mention"),
-      { type: "text", text: "lo" },
+      { type: "text", text: " world" },
     ])
+  })
+
+  it("does not treat a text mark boundary inside a word as a drop slot", () => {
+    const editor = createPillEditor([
+      pill("mention"),
+      { type: "text", text: "hel", marks: [{ type: "bold" }] },
+      { type: "text", text: "lo world" },
+    ])
+    const source = editor.state.doc.nodeAt(nodePos(editor, "mention"))!
+
+    expect(composerPillDropPoint(editor.state.doc, 5, source)).toBe(7)
   })
 
   it("treats either edge of the source pill as a no-op", () => {
@@ -138,6 +172,7 @@ describe("composer pill drag gestures", () => {
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
     expect(editor.view.dom.querySelector(".composer-pill-drop-cursor")).not.toBeNull()
+    expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
 
     fireEvent.mouseUp(document, { button: 0, clientX: 18, clientY: 10 })
 
@@ -172,8 +207,9 @@ describe("composer pill drag gestures", () => {
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
   })
 
-  it("requires a stationary long press before touch dragging, then commits only on release", () => {
+  it("uses a contextual touch guide and haptics after the stationary long press", () => {
     vi.useFakeTimers()
+    const vibrate = mockVibrate()
     const editor = createPillEditor()
     const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
     const dropPos = nodePos(editor, "slashCommand") + 1
@@ -185,12 +221,74 @@ describe("composer pill drag gestures", () => {
 
     vi.advanceTimersByTime(1)
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+    expect(document.querySelector(".composer-pill-touch-guide")).toHaveTextContent("@alice")
 
     fireEvent.touchMove(document, { touches: [touch(7, 20, 10)] })
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
+    expect(document.querySelector(".composer-pill-touch-guide")).toHaveTextContent("/invite")
 
     fireEvent.touchEnd(document, { touches: [], changedTouches: [touch(7, 20, 10)] })
     expect(childTypes(editor)).toEqual(["channelLink", "slashCommand", "mention"])
+    expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
+    expect(vibrate.mock.calls.map(([pattern]) => pattern)).toEqual([10, 10, [10, 20, 10]])
+  })
+
+  it("shows words across formatting-isolated whitespace in the touch guide", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor([
+      pill("mention"),
+      { type: "text", text: "hello", marks: [{ type: "bold" }] },
+      { type: "text", text: " ", marks: [{ type: "italic" }] },
+      { type: "text", text: "world" },
+    ])
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 7, inside: -1 })
+
+    fireEvent.touchStart(source, { touches: [touch(2, 10, 100)] })
+    vi.advanceTimersByTime(500)
+    fireEvent.touchMove(document, { touches: [touch(2, 20, 100)] })
+
+    const context = Array.from(document.querySelectorAll(".composer-pill-touch-guide__context"))
+    expect(context.map((element) => element.textContent)).toEqual(["hello", "world"])
+
+    fireEvent.touchCancel(document)
+    expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
+  })
+
+  it("refreshes touch-guide context when an inline node updates during the drag", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor([
+      pill("mention"),
+      { type: "text", text: "hello " },
+      {
+        type: "attachmentReference",
+        attrs: {
+          id: "att_1",
+          filename: "old.txt",
+          mimeType: "text/plain",
+          sizeBytes: 42,
+          status: "uploaded",
+          imageIndex: null,
+          error: null,
+        },
+      },
+    ])
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    const attachmentPos = nodePos(editor, "attachmentReference")
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: attachmentPos, inside: -1 })
+
+    fireEvent.touchStart(source, { touches: [touch(5, 10, 100)] })
+    vi.advanceTimersByTime(500)
+    fireEvent.touchMove(document, { touches: [touch(5, 20, 100)] })
+    expect(document.querySelector(".composer-pill-touch-guide")).toHaveTextContent("old.txt")
+
+    const attachment = editor.state.doc.nodeAt(attachmentPos)!
+    editor.view.dispatch(
+      editor.state.tr.setNodeMarkup(attachmentPos, undefined, { ...attachment.attrs, filename: "new.txt" })
+    )
+    expect(document.querySelector(".composer-pill-touch-guide")).toHaveTextContent("new.txt")
+
+    fireEvent.touchCancel(document)
   })
 
   it("cancels an active drag when a second finger lands outside the editor", () => {
@@ -207,6 +305,7 @@ describe("composer pill drag gestures", () => {
 
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+    expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
   })
 
   it("leaves touch scrolling alone when the finger moves before the long-press threshold", () => {
@@ -220,5 +319,6 @@ describe("composer pill drag gestures", () => {
 
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+    expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
   })
 })

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey, Selection, type EditorState, type Transaction } from
 import { dropPoint } from "@tiptap/pm/transform"
 import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view"
 import { LONG_PRESS_MOVE_TOLERANCE_PX, LONG_PRESS_THRESHOLD_MS } from "@/hooks/use-long-press"
+import { ComposerPillTouchGuide } from "./composer-pill-touch-guide"
 
 export const COMPOSER_PILL_NODE_NAMES = [
   "mention",
@@ -18,6 +19,9 @@ export const COMPOSER_PILL_NODE_NAMES = [
 const COMPOSER_PILL_NODE_NAME_SET = new Set<string>(COMPOSER_PILL_NODE_NAMES)
 const MOUSE_DRAG_THRESHOLD_PX = 6
 const COMPATIBILITY_CLICK_WINDOW_MS = 400
+const TOUCH_ACTIVATION_HAPTIC_MS = 10
+const TOUCH_TARGET_HAPTIC_MS = 10
+const TOUCH_DROP_HAPTIC_PATTERN_MS = [10, 20, 10]
 
 interface ComposerPillDragState {
   sourcePos: number
@@ -43,11 +47,72 @@ function pillSlice(node: ProseMirrorNode): Slice {
   return new Slice(Fragment.from(node), 0, 0)
 }
 
+/**
+ * Keep pill drops between lexical tokens. Text-node boundaries alone are not
+ * enough because marks can split one word into several nodes; only whitespace,
+ * non-text inline nodes, and the parent edges form real insertion slots.
+ */
+const INLINE_TOKEN_BOUNDARY_CACHE = new WeakMap<ProseMirrorNode, readonly number[]>()
+
+function inlineTokenBoundaryOffsets(parent: ProseMirrorNode): readonly number[] {
+  const cached = INLINE_TOKEN_BOUNDARY_CACHE.get(parent)
+  if (cached) return cached
+
+  const candidates = new Set<number>([0, parent.content.size])
+  parent.forEach((child, offset) => {
+    if (!child.isText) {
+      if (child.isInline) {
+        candidates.add(offset)
+        candidates.add(offset + child.nodeSize)
+      }
+      return
+    }
+
+    const text = child.text ?? ""
+    for (let index = 0; index < text.length; index++) {
+      if (!/\s/u.test(text[index] ?? "")) continue
+      candidates.add(offset + index)
+      candidates.add(offset + index + 1)
+    }
+  })
+
+  const result = [...candidates].sort((left, right) => left - right)
+  INLINE_TOKEN_BOUNDARY_CACHE.set(parent, result)
+  return result
+}
+
+function nearestInlineTokenBoundary(doc: ProseMirrorNode, pos: number): number {
+  const $pos = doc.resolve(pos)
+  const parent = $pos.parent
+  if (!parent.inlineContent) return pos
+
+  const parentStart = $pos.start()
+  const relativePos = pos - parentStart
+  const candidates = inlineTokenBoundaryOffsets(parent)
+  let low = 0
+  let high = candidates.length
+  while (low < high) {
+    const middle = (low + high) >> 1
+    if ((candidates[middle] ?? 0) < relativePos) low = middle + 1
+    else high = middle
+  }
+
+  const before = candidates[Math.max(0, low - 1)]
+  const after = candidates[Math.min(low, candidates.length - 1)]
+  if (before === undefined) return parentStart + (after ?? relativePos)
+  if (after === undefined) return parentStart + before
+  return parentStart + (relativePos - before <= after - relativePos ? before : after)
+}
+
 export function composerPillDropPoint(doc: ProseMirrorNode, rawPos: number, node: ProseMirrorNode): number | null {
   if (rawPos < 0 || rawPos > doc.content.size) return null
-  const point = dropPoint(doc, rawPos, pillSlice(node))
+  const slice = pillSlice(node)
+  const point = dropPoint(doc, rawPos, slice)
   if (point === null || !doc.resolve(point).parent.inlineContent) return null
-  return point
+
+  const snappedPoint = dropPoint(doc, nearestInlineTokenBoundary(doc, point), slice)
+  if (snappedPoint === null || !doc.resolve(snappedPoint).parent.inlineContent) return null
+  return snappedPoint
 }
 
 export function createComposerPillMoveTransaction(
@@ -194,6 +259,14 @@ function touchById(list: TouchList, id: number): Touch | null {
   return null
 }
 
+function vibrate(win: Window, pattern: number | number[]) {
+  try {
+    win.navigator.vibrate?.(pattern)
+  } catch {
+    // Vibration is optional feedback.
+  }
+}
+
 class ComposerPillDragController {
   private view: EditorView
   private readonly doc: Document
@@ -201,6 +274,7 @@ class ComposerPillDragController {
   private pending: PendingDrag | null = null
   private longPressTimer: number | null = null
   private suppressClickUntil = 0
+  private touchGuide: ComposerPillTouchGuide | null = null
 
   constructor(view: EditorView) {
     this.view = view
@@ -213,12 +287,18 @@ class ComposerPillDragController {
     view.dom.addEventListener("dragstart", this.onNativeDragStart, true)
   }
 
-  update(view: EditorView) {
+  update(view: EditorView, previousState?: EditorState) {
     this.view = view
     const dragState = ComposerPillDragPluginKey.getState(view.state)
     const active = dragState !== null && dragState !== undefined
     view.dom.classList.toggle("composer-pill-drag-active", active)
-    if (this.pending?.active && !active) this.clearPending()
+    if (this.pending?.active && !active) {
+      this.clearPending()
+      return
+    }
+    if (previousState?.doc !== view.state.doc && this.pending?.kind === "touch" && this.pending.active && dragState) {
+      this.touchGuide?.refresh(view.state.doc, dragState.dropPos)
+    }
   }
 
   destroy() {
@@ -250,12 +330,6 @@ class ComposerPillDragController {
     this.longPressTimer = this.win.setTimeout(() => {
       if (!this.pending || this.pending.kind !== "touch") return
       this.activate()
-      if (!this.pending?.active) return
-      try {
-        this.win.navigator.vibrate?.(10)
-      } catch {
-        // Vibration is optional feedback.
-      }
     }, LONG_PRESS_THRESHOLD_MS)
   }
 
@@ -270,6 +344,10 @@ class ComposerPillDragController {
       this.view.state.doc.nodeAt(drag.sourcePos)!
     )
     this.setDragState({ sourcePos: drag.sourcePos, dropPos })
+    if (drag.kind === "touch") {
+      this.updateTouchGuide(drag.startX, drag.startY, dropPos)
+      vibrate(this.win, TOUCH_ACTIVATION_HAPTIC_MS)
+    }
   }
 
   private updateDrop(x: number, y: number) {
@@ -280,7 +358,12 @@ class ComposerPillDragController {
       this.clearPending()
       return
     }
-    this.setDragState({ ...current, dropPos: dropPositionAt(this.view, x, y) })
+    const dropPos = dropPositionAt(this.view, x, y)
+    if (drag.kind === "touch") {
+      this.updateTouchGuide(x, y, dropPos)
+      if (dropPos !== null && dropPos !== current.dropPos) vibrate(this.win, TOUCH_TARGET_HAPTIC_MS)
+    }
+    this.setDragState({ ...current, dropPos })
   }
 
   private finish(x: number, y: number) {
@@ -297,10 +380,12 @@ class ComposerPillDragController {
         ? null
         : createComposerPillMoveTransaction(this.view.state, current.sourcePos, current.dropPos)
 
+    const touchDrop = drag.kind === "touch"
     this.suppressClickUntil = Date.now() + COMPATIBILITY_CLICK_WINDOW_MS
     this.clearPending()
     if (tr) {
       this.view.dispatch(tr.setMeta(ComposerPillDragPluginKey, null).setMeta("uiEvent", "drop"))
+      if (touchDrop) vibrate(this.win, TOUCH_DROP_HAPTIC_PATTERN_MS)
     } else {
       this.clearDragState()
     }
@@ -325,7 +410,19 @@ class ComposerPillDragController {
     this.doc.removeEventListener("touchcancel", this.onTouchCancel, true)
     this.doc.removeEventListener("keydown", this.onKeyDown, true)
     this.win.removeEventListener("blur", this.onWindowBlur)
+    this.removeTouchGuide()
     this.pending = null
+  }
+
+  private updateTouchGuide(x: number, y: number, dropPos: number | null) {
+    if (this.pending?.kind !== "touch" || !this.pending.active) return
+    this.touchGuide ??= new ComposerPillTouchGuide(this.doc, this.win)
+    this.touchGuide.update(this.view.state.doc, dropPos, x, y)
+  }
+
+  private removeTouchGuide() {
+    this.touchGuide?.destroy()
+    this.touchGuide = null
   }
 
   private setDragState(next: ComposerPillDragState) {
@@ -464,7 +561,7 @@ export const ComposerPillDragExtension = Extension.create({
         view(view) {
           const controller = new ComposerPillDragController(view)
           return {
-            update: (updatedView) => controller.update(updatedView),
+            update: (updatedView, previousState) => controller.update(updatedView, previousState),
             destroy: () => controller.destroy(),
           }
         },

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
@@ -1,0 +1,474 @@
+import { Extension } from "@tiptap/core"
+import { Fragment, Slice, type Node as ProseMirrorNode } from "@tiptap/pm/model"
+import { Plugin, PluginKey, Selection, type EditorState, type Transaction } from "@tiptap/pm/state"
+import { dropPoint } from "@tiptap/pm/transform"
+import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view"
+import { LONG_PRESS_MOVE_TOLERANCE_PX, LONG_PRESS_THRESHOLD_MS } from "@/hooks/use-long-press"
+
+export const COMPOSER_PILL_NODE_NAMES = [
+  "mention",
+  "channelLink",
+  "slashCommand",
+  "attachmentReference",
+  "memoEmbed",
+  "inAppLink",
+  "giphyEmbed",
+] as const
+
+const COMPOSER_PILL_NODE_NAME_SET = new Set<string>(COMPOSER_PILL_NODE_NAMES)
+const MOUSE_DRAG_THRESHOLD_PX = 6
+const COMPATIBILITY_CLICK_WINDOW_MS = 400
+
+interface ComposerPillDragState {
+  sourcePos: number
+  dropPos: number | null
+}
+
+interface PendingDrag {
+  kind: "mouse" | "touch"
+  id: number
+  sourcePos: number
+  startX: number
+  startY: number
+  active: boolean
+}
+
+export const ComposerPillDragPluginKey = new PluginKey<ComposerPillDragState | null>("composerPillDrag")
+
+export function isComposerPillNode(node: ProseMirrorNode | null | undefined): node is ProseMirrorNode {
+  return Boolean(node?.isInline && node.isAtom && COMPOSER_PILL_NODE_NAME_SET.has(node.type.name))
+}
+
+function pillSlice(node: ProseMirrorNode): Slice {
+  return new Slice(Fragment.from(node), 0, 0)
+}
+
+export function composerPillDropPoint(doc: ProseMirrorNode, rawPos: number, node: ProseMirrorNode): number | null {
+  if (rawPos < 0 || rawPos > doc.content.size) return null
+  const point = dropPoint(doc, rawPos, pillSlice(node))
+  if (point === null || !doc.resolve(point).parent.inlineContent) return null
+  return point
+}
+
+export function createComposerPillMoveTransaction(
+  state: EditorState,
+  sourcePos: number,
+  requestedDropPos: number
+): Transaction | null {
+  const node = state.doc.nodeAt(sourcePos)
+  if (!isComposerPillNode(node)) return null
+
+  const dropPos = composerPillDropPoint(state.doc, requestedDropPos, node)
+  if (dropPos === null || dropPos === sourcePos || dropPos === sourcePos + node.nodeSize) return null
+
+  const insertPos = dropPos > sourcePos ? dropPos - node.nodeSize : dropPos
+  const tr = state.tr.delete(sourcePos, sourcePos + node.nodeSize)
+  const $insert = tr.doc.resolve(insertPos)
+  if (
+    !$insert.parent.inlineContent ||
+    !$insert.parent.canReplaceWith($insert.index(), $insert.index(), node.type, node.marks)
+  ) {
+    return null
+  }
+
+  tr.insert(insertPos, node)
+  tr.setSelection(Selection.near(tr.doc.resolve(insertPos + node.nodeSize), 1))
+  return tr
+}
+
+function dragDecorations(state: EditorState): DecorationSet | null {
+  const drag = ComposerPillDragPluginKey.getState(state)
+  if (!drag) return null
+  const source = state.doc.nodeAt(drag.sourcePos)
+  if (!isComposerPillNode(source)) return null
+
+  const decorations: Decoration[] = [
+    Decoration.node(drag.sourcePos, drag.sourcePos + source.nodeSize, {
+      class: "composer-pill-dragging",
+      "data-composer-pill-dragging": "true",
+    }),
+  ]
+
+  if (drag.dropPos !== null) {
+    decorations.push(
+      Decoration.widget(
+        drag.dropPos,
+        () => {
+          const cursor = document.createElement("span")
+          cursor.className = "composer-pill-drop-cursor"
+          cursor.setAttribute("aria-hidden", "true")
+          return cursor
+        },
+        {
+          key: "composer-pill-drop-cursor",
+          side: drag.dropPos <= drag.sourcePos ? -1 : 1,
+          ignoreSelection: true,
+        }
+      )
+    )
+  }
+
+  return DecorationSet.create(state.doc, decorations)
+}
+
+function mappedDragState(tr: Transaction, current: ComposerPillDragState | null): ComposerPillDragState | null {
+  const meta = tr.getMeta(ComposerPillDragPluginKey) as ComposerPillDragState | null | undefined
+  if (meta !== undefined) return meta
+  if (!current || !tr.docChanged) return current
+
+  const sourcePos = tr.mapping.map(current.sourcePos, 1)
+  const dropAssociation = current.dropPos !== null && current.dropPos <= current.sourcePos ? -1 : 1
+  const dropPos = current.dropPos === null ? null : tr.mapping.map(current.dropPos, dropAssociation)
+  return isComposerPillNode(tr.doc.nodeAt(sourcePos)) ? { sourcePos, dropPos } : null
+}
+
+function pillAtPosition(doc: ProseMirrorNode, pos: number): { node: ProseMirrorNode; pos: number } | null {
+  for (const candidate of [pos, pos - 1]) {
+    if (candidate < 0) continue
+    const node = doc.nodeAt(candidate)
+    if (isComposerPillNode(node)) return { node, pos: candidate }
+  }
+  return null
+}
+
+function eventElement(target: EventTarget | null): Element | null {
+  if (!target) return null
+  if (target instanceof Element) return target
+  return target instanceof Node ? target.parentElement : null
+}
+
+function pillFromDom(view: EditorView, target: EventTarget | null): { element: Element; pos: number } | null {
+  let element = eventElement(target)
+  while (element && element !== view.dom) {
+    if (element.hasAttribute("data-type")) {
+      try {
+        const found = pillAtPosition(view.state.doc, view.posAtDOM(element, 0))
+        if (found) return { element, pos: found.pos }
+      } catch {
+        // A nested React node-view element may not map directly; its wrapper does.
+      }
+    }
+    element = element.parentElement
+  }
+  return null
+}
+
+function dropPositionAt(view: EditorView, x: number, y: number): number | null {
+  const sourceState = ComposerPillDragPluginKey.getState(view.state)
+  if (!sourceState) return null
+  const sourceNode = view.state.doc.nodeAt(sourceState.sourcePos)
+  if (!isComposerPillNode(sourceNode)) return null
+
+  const hit = view.dom.ownerDocument.elementFromPoint(x, y)
+  if (hit && hit !== view.dom && !view.dom.contains(hit)) return null
+
+  const hoveredPill = pillFromDom(view, hit)
+  let rawPos: number | null = null
+  if (hoveredPill) {
+    const hoveredNode = view.state.doc.nodeAt(hoveredPill.pos)
+    if (hoveredNode) {
+      const rect = hoveredPill.element.getBoundingClientRect()
+      rawPos = x < rect.left + rect.width / 2 ? hoveredPill.pos : hoveredPill.pos + hoveredNode.nodeSize
+    }
+  }
+
+  if (rawPos === null) rawPos = view.posAtCoords({ left: x, top: y })?.pos ?? null
+  return rawPos === null ? null : composerPillDropPoint(view.state.doc, rawPos, sourceNode)
+}
+
+function distanceFromStart(drag: PendingDrag, x: number, y: number): number {
+  return Math.hypot(x - drag.startX, y - drag.startY)
+}
+
+function movedBeyondLongPressTolerance(drag: PendingDrag, x: number, y: number): boolean {
+  return (
+    Math.abs(x - drag.startX) > LONG_PRESS_MOVE_TOLERANCE_PX || Math.abs(y - drag.startY) > LONG_PRESS_MOVE_TOLERANCE_PX
+  )
+}
+
+function touchById(list: TouchList, id: number): Touch | null {
+  for (let index = 0; index < list.length; index++) {
+    const touch = list[index]
+    if (touch?.identifier === id) return touch
+  }
+  return null
+}
+
+class ComposerPillDragController {
+  private view: EditorView
+  private readonly doc: Document
+  private readonly win: Window
+  private pending: PendingDrag | null = null
+  private longPressTimer: number | null = null
+  private suppressClickUntil = 0
+
+  constructor(view: EditorView) {
+    this.view = view
+    this.doc = view.dom.ownerDocument
+    this.win = this.doc.defaultView ?? window
+    view.dom.addEventListener("mousedown", this.onMouseDown, true)
+    view.dom.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true })
+    view.dom.addEventListener("click", this.onClick, true)
+    view.dom.addEventListener("contextmenu", this.onContextMenu, true)
+    view.dom.addEventListener("dragstart", this.onNativeDragStart, true)
+  }
+
+  update(view: EditorView) {
+    this.view = view
+    const dragState = ComposerPillDragPluginKey.getState(view.state)
+    const active = dragState !== null && dragState !== undefined
+    view.dom.classList.toggle("composer-pill-drag-active", active)
+    if (this.pending?.active && !active) this.clearPending()
+  }
+
+  destroy() {
+    this.view.dom.removeEventListener("mousedown", this.onMouseDown, true)
+    this.view.dom.removeEventListener("touchstart", this.onTouchStart, true)
+    this.view.dom.removeEventListener("click", this.onClick, true)
+    this.view.dom.removeEventListener("contextmenu", this.onContextMenu, true)
+    this.view.dom.removeEventListener("dragstart", this.onNativeDragStart, true)
+    this.clearPending()
+    this.view.dom.classList.remove("composer-pill-drag-active")
+  }
+
+  private begin(drag: PendingDrag) {
+    this.cancel()
+    this.pending = drag
+    this.doc.addEventListener("keydown", this.onKeyDown, true)
+    this.win.addEventListener("blur", this.onWindowBlur)
+
+    if (drag.kind === "mouse") {
+      this.doc.addEventListener("mousemove", this.onMouseMove, true)
+      this.doc.addEventListener("mouseup", this.onMouseUp, true)
+      return
+    }
+
+    this.doc.addEventListener("touchstart", this.onAdditionalTouchStart, true)
+    this.doc.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false })
+    this.doc.addEventListener("touchend", this.onTouchEnd, true)
+    this.doc.addEventListener("touchcancel", this.onTouchCancel, true)
+    this.longPressTimer = this.win.setTimeout(() => {
+      if (!this.pending || this.pending.kind !== "touch") return
+      this.activate()
+      if (!this.pending?.active) return
+      try {
+        this.win.navigator.vibrate?.(10)
+      } catch {
+        // Vibration is optional feedback.
+      }
+    }, LONG_PRESS_THRESHOLD_MS)
+  }
+
+  private activate() {
+    const drag = this.pending
+    if (!drag || drag.active || !isComposerPillNode(this.view.state.doc.nodeAt(drag.sourcePos))) return
+    drag.active = true
+    this.win.getSelection()?.removeAllRanges()
+    const dropPos = composerPillDropPoint(
+      this.view.state.doc,
+      drag.sourcePos,
+      this.view.state.doc.nodeAt(drag.sourcePos)!
+    )
+    this.setDragState({ sourcePos: drag.sourcePos, dropPos })
+  }
+
+  private updateDrop(x: number, y: number) {
+    const drag = this.pending
+    if (!drag?.active) return
+    const current = ComposerPillDragPluginKey.getState(this.view.state)
+    if (!current) {
+      this.clearPending()
+      return
+    }
+    this.setDragState({ ...current, dropPos: dropPositionAt(this.view, x, y) })
+  }
+
+  private finish(x: number, y: number) {
+    const drag = this.pending
+    if (!drag?.active) {
+      this.cancel()
+      return
+    }
+
+    this.updateDrop(x, y)
+    const current = ComposerPillDragPluginKey.getState(this.view.state)
+    const tr =
+      current?.dropPos === null || current?.dropPos === undefined
+        ? null
+        : createComposerPillMoveTransaction(this.view.state, current.sourcePos, current.dropPos)
+
+    this.suppressClickUntil = Date.now() + COMPATIBILITY_CLICK_WINDOW_MS
+    this.clearPending()
+    if (tr) {
+      this.view.dispatch(tr.setMeta(ComposerPillDragPluginKey, null).setMeta("uiEvent", "drop"))
+    } else {
+      this.clearDragState()
+    }
+  }
+
+  private cancel = () => {
+    const wasActive = this.pending?.active === true
+    this.clearPending()
+    if (wasActive) this.clearDragState()
+  }
+
+  private clearPending() {
+    if (this.longPressTimer !== null) {
+      this.win.clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
+    this.doc.removeEventListener("mousemove", this.onMouseMove, true)
+    this.doc.removeEventListener("mouseup", this.onMouseUp, true)
+    this.doc.removeEventListener("touchstart", this.onAdditionalTouchStart, true)
+    this.doc.removeEventListener("touchmove", this.onTouchMove, true)
+    this.doc.removeEventListener("touchend", this.onTouchEnd, true)
+    this.doc.removeEventListener("touchcancel", this.onTouchCancel, true)
+    this.doc.removeEventListener("keydown", this.onKeyDown, true)
+    this.win.removeEventListener("blur", this.onWindowBlur)
+    this.pending = null
+  }
+
+  private setDragState(next: ComposerPillDragState) {
+    const current = ComposerPillDragPluginKey.getState(this.view.state)
+    if (current?.sourcePos === next.sourcePos && current.dropPos === next.dropPos) return
+    this.view.dispatch(this.view.state.tr.setMeta(ComposerPillDragPluginKey, next).setMeta("addToHistory", false))
+  }
+
+  private clearDragState() {
+    const dragState = ComposerPillDragPluginKey.getState(this.view.state)
+    if (dragState === null || dragState === undefined) return
+    this.view.dispatch(this.view.state.tr.setMeta(ComposerPillDragPluginKey, null).setMeta("addToHistory", false))
+  }
+
+  private onMouseDown = (event: MouseEvent) => {
+    if (!this.view.editable || event.button !== 0) return
+    const pill = pillFromDom(this.view, event.target)
+    if (!pill) return
+    this.begin({
+      kind: "mouse",
+      id: 0,
+      sourcePos: pill.pos,
+      startX: event.clientX,
+      startY: event.clientY,
+      active: false,
+    })
+  }
+
+  private onMouseMove = (event: MouseEvent) => {
+    const drag = this.pending
+    if (!drag || drag.kind !== "mouse") return
+    if (!drag.active && distanceFromStart(drag, event.clientX, event.clientY) < MOUSE_DRAG_THRESHOLD_PX) return
+    if (!drag.active) this.activate()
+    if (!this.pending?.active) return
+    event.preventDefault()
+    event.stopPropagation()
+    this.updateDrop(event.clientX, event.clientY)
+  }
+
+  private onMouseUp = (event: MouseEvent) => {
+    const drag = this.pending
+    if (!drag || drag.kind !== "mouse") return
+    if (drag.active) event.preventDefault()
+    this.finish(event.clientX, event.clientY)
+  }
+
+  private onTouchStart = (event: TouchEvent) => {
+    if (!this.view.editable || event.touches.length !== 1) {
+      this.cancel()
+      return
+    }
+    const pill = pillFromDom(this.view, event.target)
+    const touch = event.touches[0]
+    if (!pill || !touch) return
+    this.begin({
+      kind: "touch",
+      id: touch.identifier,
+      sourcePos: pill.pos,
+      startX: touch.clientX,
+      startY: touch.clientY,
+      active: false,
+    })
+  }
+
+  private onAdditionalTouchStart = (event: TouchEvent) => {
+    if (this.pending?.kind === "touch" && event.touches.length > 1) this.cancel()
+  }
+
+  private onTouchMove = (event: TouchEvent) => {
+    const drag = this.pending
+    if (!drag || drag.kind !== "touch") return
+    if (event.touches.length > 1) {
+      this.cancel()
+      return
+    }
+    const touch = touchById(event.touches, drag.id)
+    if (!touch) return
+    if (!drag.active) {
+      if (movedBeyondLongPressTolerance(drag, touch.clientX, touch.clientY)) this.cancel()
+      return
+    }
+    if (event.cancelable) event.preventDefault()
+    event.stopPropagation()
+    this.updateDrop(touch.clientX, touch.clientY)
+  }
+
+  private onTouchEnd = (event: TouchEvent) => {
+    const drag = this.pending
+    if (!drag || drag.kind !== "touch") return
+    const touch = touchById(event.changedTouches, drag.id)
+    if (!touch) return
+    if (drag.active && event.cancelable) event.preventDefault()
+    this.finish(touch.clientX, touch.clientY)
+  }
+
+  private onTouchCancel = () => this.cancel()
+
+  private onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return
+    event.preventDefault()
+    this.cancel()
+  }
+
+  private onWindowBlur = () => this.cancel()
+
+  private onClick = (event: MouseEvent) => {
+    if (Date.now() > this.suppressClickUntil) return
+    this.suppressClickUntil = 0
+    event.preventDefault()
+    event.stopImmediatePropagation()
+  }
+
+  private onContextMenu = (event: MouseEvent) => {
+    if (this.pending?.kind === "touch") event.preventDefault()
+  }
+
+  private onNativeDragStart = (event: DragEvent) => {
+    if (pillFromDom(this.view, event.target)) event.preventDefault()
+  }
+}
+
+export const ComposerPillDragExtension = Extension.create({
+  name: "composerPillDrag",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<ComposerPillDragState | null>({
+        key: ComposerPillDragPluginKey,
+        state: {
+          init: () => null,
+          apply: mappedDragState,
+        },
+        props: {
+          decorations: dragDecorations,
+        },
+        view(view) {
+          const controller = new ComposerPillDragController(view)
+          return {
+            update: (updatedView) => controller.update(updatedView),
+            destroy: () => controller.destroy(),
+          }
+        },
+      }),
+    ]
+  },
+})

--- a/apps/frontend/src/components/editor/composer-pill-touch-guide.ts
+++ b/apps/frontend/src/components/editor/composer-pill-touch-guide.ts
@@ -1,0 +1,217 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+
+const GUIDE_GAP_PX = 40
+const GUIDE_VIEWPORT_MARGIN_PX = 12
+const GUIDE_LABEL_MAX_LENGTH = 18
+
+interface DropGuideContext {
+  before: string
+  after: string
+}
+
+const DROP_GUIDE_CONTEXT_CACHE = new WeakMap<ProseMirrorNode, Map<number, DropGuideContext>>()
+
+function truncateGuideLabel(label: string, fromEnd: boolean): string {
+  const characters = Array.from(label)
+  if (characters.length <= GUIDE_LABEL_MAX_LENGTH) return label
+  const kept = GUIDE_LABEL_MAX_LENGTH - 1
+  return fromEnd ? `…${characters.slice(-kept).join("")}` : `${characters.slice(0, kept).join("")}…`
+}
+
+function guideLabelForText(text: string, fromEnd: boolean, rangeStart = 0, rangeEnd = text.length): string {
+  let start = Math.max(0, rangeStart)
+  let end = Math.min(text.length, rangeEnd)
+  if (fromEnd) {
+    while (end > start && /\s/u.test(text[end - 1] ?? "")) end--
+    start = end
+    while (start > rangeStart && !/\s/u.test(text[start - 1] ?? "")) start--
+  } else {
+    while (start < end && /\s/u.test(text[start] ?? "")) start++
+    end = start
+    while (end < rangeEnd && !/\s/u.test(text[end] ?? "")) end++
+  }
+  return truncateGuideLabel(text.slice(start, end), fromEnd)
+}
+
+function guideLabelForNode(node: ProseMirrorNode | null, fromEnd: boolean): string {
+  if (!node) return ""
+  if (node.isText) return guideLabelForText(node.text ?? "", fromEnd)
+
+  let label = ""
+  switch (node.type.name) {
+    case "mention":
+      label = typeof node.attrs.slug === "string" ? `@${node.attrs.slug}` : "Mention"
+      break
+    case "channelLink":
+      label = typeof node.attrs.slug === "string" ? `#${node.attrs.slug}` : "Stream"
+      break
+    case "slashCommand":
+      label = typeof node.attrs.name === "string" ? `/${node.attrs.name}` : "Command"
+      break
+    case "attachmentReference":
+      label = typeof node.attrs.filename === "string" ? node.attrs.filename : "File"
+      break
+    case "memoEmbed":
+      label = typeof node.attrs.title === "string" && node.attrs.title ? node.attrs.title : "Memory"
+      break
+    case "inAppLink":
+      label = typeof node.attrs.name === "string" && node.attrs.name ? node.attrs.name : "Link"
+      break
+    case "giphyEmbed":
+      label = typeof node.attrs.title === "string" && node.attrs.title ? node.attrs.title : "GIF"
+      break
+    case "emoji":
+      label = typeof node.attrs.emoji === "string" ? node.attrs.emoji : "Emoji"
+      break
+  }
+  return truncateGuideLabel(label, fromEnd)
+}
+
+function guideLabelBefore(parent: ProseMirrorNode, parentOffset: number): string {
+  let searchOffset = parentOffset
+  while (searchOffset > 0) {
+    const { node, offset } = parent.childBefore(searchOffset)
+    if (!node) return ""
+    let label = ""
+    if (node.isText) {
+      label = guideLabelForText(node.text ?? "", true, 0, Math.min(node.nodeSize, searchOffset - offset))
+    } else if (offset + node.nodeSize <= searchOffset) {
+      label = guideLabelForNode(node, true)
+    }
+    if (label) return label
+    if (offset >= searchOffset) return ""
+    searchOffset = offset
+  }
+  return ""
+}
+
+function guideLabelAfter(parent: ProseMirrorNode, parentOffset: number): string {
+  let searchOffset = parentOffset
+  while (searchOffset < parent.content.size) {
+    const { node, offset } = parent.childAfter(searchOffset)
+    if (!node) return ""
+    let label = ""
+    if (node.isText) {
+      label = guideLabelForText(node.text ?? "", false, Math.max(0, searchOffset - offset))
+    } else if (offset >= searchOffset) {
+      label = guideLabelForNode(node, false)
+    }
+    if (label) return label
+    const nextOffset = offset + node.nodeSize
+    if (nextOffset <= searchOffset) return ""
+    searchOffset = nextOffset
+  }
+  return ""
+}
+
+function dropGuideContext(doc: ProseMirrorNode, pos: number): DropGuideContext {
+  const $pos = doc.resolve(pos)
+  let parentCache = DROP_GUIDE_CONTEXT_CACHE.get($pos.parent)
+  if (!parentCache) {
+    parentCache = new Map()
+    DROP_GUIDE_CONTEXT_CACHE.set($pos.parent, parentCache)
+  }
+  const cached = parentCache.get($pos.parentOffset)
+  if (cached) return cached
+
+  const context = {
+    before: guideLabelBefore($pos.parent, $pos.parentOffset),
+    after: guideLabelAfter($pos.parent, $pos.parentOffset),
+  }
+  parentCache.set($pos.parentOffset, context)
+  return context
+}
+
+/** Fixed contextual loupe that mirrors a touch drag's real document caret. */
+export class ComposerPillTouchGuide {
+  private guide: HTMLDivElement | null = null
+  private before: HTMLSpanElement | null = null
+  private after: HTMLSpanElement | null = null
+  private contextKey = ""
+  private width = 0
+  private height = 32
+  private x: number | null = null
+  private y: number | null = null
+
+  constructor(
+    private readonly doc: Document,
+    private readonly win: Window
+  ) {}
+
+  update(editorDoc: ProseMirrorNode, dropPos: number | null, x: number, y: number) {
+    this.x = x
+    this.y = y
+    const guide = this.ensureGuide()
+    if (dropPos === null) {
+      guide.classList.add("composer-pill-touch-guide--hidden")
+      return
+    }
+
+    const context = dropGuideContext(editorDoc, dropPos)
+    const contextKey = `${context.before.length}:${context.before}${context.after}`
+    const contextChanged = contextKey !== this.contextKey
+    if (contextChanged) {
+      this.before!.textContent = context.before
+      this.after!.textContent = context.after
+      this.contextKey = contextKey
+    }
+    guide.classList.remove("composer-pill-touch-guide--hidden")
+    guide.style.left = `${x}px`
+
+    if (this.width === 0 || contextChanged) {
+      const rect = guide.getBoundingClientRect()
+      this.width = rect.width
+      this.height = rect.height || 32
+    }
+    const viewportWidth = this.win.innerWidth || this.doc.documentElement.clientWidth
+    if (this.width > 0 && viewportWidth > 0) {
+      const halfWidth = Math.min(this.width / 2, Math.max(0, (viewportWidth - GUIDE_VIEWPORT_MARGIN_PX * 2) / 2))
+      const left = Math.max(
+        GUIDE_VIEWPORT_MARGIN_PX + halfWidth,
+        Math.min(x, viewportWidth - GUIDE_VIEWPORT_MARGIN_PX - halfWidth)
+      )
+      guide.style.left = `${left}px`
+    }
+
+    const placeBelow = y < this.height + GUIDE_GAP_PX + GUIDE_VIEWPORT_MARGIN_PX
+    guide.classList.toggle("composer-pill-touch-guide--below", placeBelow)
+    guide.style.top = `${placeBelow ? y + GUIDE_GAP_PX : y - GUIDE_GAP_PX}px`
+  }
+
+  refresh(editorDoc: ProseMirrorNode, dropPos: number | null) {
+    if (this.x === null || this.y === null) return
+    this.update(editorDoc, dropPos, this.x, this.y)
+  }
+
+  destroy() {
+    this.guide?.remove()
+    this.guide = null
+    this.before = null
+    this.after = null
+    this.contextKey = ""
+    this.width = 0
+    this.height = 32
+    this.x = null
+    this.y = null
+  }
+
+  private ensureGuide(): HTMLDivElement {
+    if (this.guide) return this.guide
+
+    const guide = this.doc.createElement("div")
+    guide.className = "composer-pill-touch-guide"
+    guide.setAttribute("aria-hidden", "true")
+    const before = this.doc.createElement("span")
+    before.className = "composer-pill-touch-guide__context"
+    const cursor = this.doc.createElement("span")
+    cursor.className = "composer-pill-touch-guide__cursor"
+    const after = this.doc.createElement("span")
+    after.className = "composer-pill-touch-guide__context"
+    guide.append(before, cursor, after)
+    this.doc.body.appendChild(guide)
+    this.guide = guide
+    this.before = before
+    this.after = after
+    return guide
+  }
+}

--- a/apps/frontend/src/components/editor/editor-extensions.ts
+++ b/apps/frontend/src/components/editor/editor-extensions.ts
@@ -36,6 +36,7 @@ import { GiphyEmbedExtension } from "./giphy-embed-extension"
 import { MemoSearchExtension, type MemoSearchOptions } from "./triggers/memo-search-extension"
 import { DictationPreview } from "./dictation-preview-extension"
 import { DictationChunkExtension } from "./dictation-chunk-extension"
+import { ComposerPillDragExtension } from "./composer-pill-drag-extension"
 
 const lowlight = createLowlight(common)
 
@@ -131,6 +132,8 @@ export function createEditorExtensions(options: CreateEditorExtensionsOptions | 
     InAppLinkExtension,
 
     GiphyEmbedExtension,
+
+    ComposerPillDragExtension,
 
     // Live dictation hypothesis ghost (inert unless actively dictating)
     DictationPreview,

--- a/apps/frontend/src/hooks/use-long-press.ts
+++ b/apps/frontend/src/hooks/use-long-press.ts
@@ -1,5 +1,8 @@
 import { useRef, useCallback, useState, useEffect } from "react"
 
+export const LONG_PRESS_THRESHOLD_MS = 500
+export const LONG_PRESS_MOVE_TOLERANCE_PX = 10
+
 interface UseLongPressOptions {
   /** Duration in ms before long press fires (default: 500) */
   threshold?: number
@@ -47,7 +50,7 @@ interface UseLongPressReturn {
 }
 
 export function useLongPress({
-  threshold = 500,
+  threshold = LONG_PRESS_THRESHOLD_MS,
   onLongPress,
   triggerOnTouchEnd = false,
   enabled = true,
@@ -138,8 +141,8 @@ export function useLongPress({
       }
       const dx = touch.clientX - startPos.current.x
       const dy = touch.clientY - startPos.current.y
-      // Cancel if moved more than 10px (user is scrolling)
-      if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+      // Cancel once movement reads as scrolling rather than a held touch.
+      if (Math.abs(dx) > LONG_PRESS_MOVE_TOLERANCE_PX || Math.abs(dy) > LONG_PRESS_MOVE_TOLERANCE_PX) {
         clear()
       }
     },

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -690,8 +690,83 @@ html[data-input="mouse"]
 
 .ProseMirror .composer-pill-dragging {
   border-radius: 0.375rem;
-  outline: 2px solid hsl(var(--primary) / 0.55);
+  opacity: 0.42;
+  filter: grayscale(1) saturate(0.2);
+  outline: 1px dashed hsl(var(--muted-foreground) / 0.5);
   outline-offset: 2px;
+}
+
+/* Touch keeps the real caret in the document and mirrors its immediate context
+   in a compact loupe above the thumb. The overlay is fixed and pointer-less, so
+   it never shifts the composer or steals the active gesture (INV-21). */
+.composer-pill-touch-guide {
+  position: fixed;
+  z-index: 80;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100vw - 24px);
+  min-height: 32px;
+  padding: 6px 9px;
+  color: hsl(var(--foreground));
+  font-size: 13px;
+  line-height: 1;
+  white-space: nowrap;
+  background: hsl(var(--popover) / 0.96);
+  border: 1px solid hsl(var(--primary) / 0.42);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px hsl(var(--foreground) / 0.16);
+  pointer-events: none;
+  transform: translate(-50%, -100%);
+}
+
+.composer-pill-touch-guide::after {
+  content: "";
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background: hsl(var(--popover));
+  border-right: 1px solid hsl(var(--primary) / 0.42);
+  border-bottom: 1px solid hsl(var(--primary) / 0.42);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.composer-pill-touch-guide--below {
+  transform: translate(-50%, 0);
+}
+
+.composer-pill-touch-guide--below::after {
+  top: -5px;
+  bottom: auto;
+  border: 0;
+  border-top: 1px solid hsl(var(--primary) / 0.42);
+  border-left: 1px solid hsl(var(--primary) / 0.42);
+}
+
+.composer-pill-touch-guide--hidden {
+  display: none;
+}
+
+.composer-pill-touch-guide__context {
+  max-width: 7rem;
+  overflow: hidden;
+  color: hsl(var(--muted-foreground));
+  text-overflow: ellipsis;
+}
+
+.composer-pill-touch-guide__context:empty {
+  display: none;
+}
+
+.composer-pill-touch-guide__cursor {
+  width: 2px;
+  height: 20px;
+  flex: 0 0 2px;
+  border-radius: 999px;
+  background: hsl(var(--primary));
+  box-shadow: 0 0 0 1px hsl(var(--background) / 0.7);
 }
 
 .composer-pill-drop-cursor {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -640,6 +640,79 @@ html[data-input="mouse"] .message-hover-wash:hover {
   background-color: hsl(var(--primary) / 0.08);
 }
 
+/* Composer atoms drag without a floating clone: source stays put and this
+   zero-size widget previews the eventual insertion point (INV-21). */
+.ProseMirror
+  :is(
+    [data-type="mention"],
+    [data-type="channelLink"],
+    [data-type="slashCommand"],
+    [data-type="attachment-reference"],
+    [data-type="memo-embed"],
+    [data-type="in-app-link"],
+    [data-type="giphy-embed"]
+  ) {
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+html[data-input="mouse"]
+  .ProseMirror
+  :is(
+    [data-type="mention"],
+    [data-type="channelLink"],
+    [data-type="slashCommand"],
+    [data-type="attachment-reference"],
+    [data-type="memo-embed"],
+    [data-type="in-app-link"],
+    [data-type="giphy-embed"]
+  ),
+html[data-input="mouse"]
+  .ProseMirror
+  :is(
+    [data-type="mention"],
+    [data-type="channelLink"],
+    [data-type="slashCommand"],
+    [data-type="attachment-reference"],
+    [data-type="memo-embed"],
+    [data-type="in-app-link"],
+    [data-type="giphy-embed"]
+  )
+  * {
+  cursor: grab;
+}
+
+.ProseMirror.composer-pill-drag-active,
+.ProseMirror.composer-pill-drag-active * {
+  cursor: grabbing !important;
+}
+
+.ProseMirror .composer-pill-dragging {
+  border-radius: 0.375rem;
+  outline: 2px solid hsl(var(--primary) / 0.55);
+  outline-offset: 2px;
+}
+
+.composer-pill-drop-cursor {
+  position: relative;
+  display: inline;
+  pointer-events: none;
+}
+
+.composer-pill-drop-cursor::after {
+  content: "";
+  position: absolute;
+  bottom: -0.35em;
+  left: -1px;
+  z-index: 2;
+  width: 2px;
+  height: 1.7em;
+  border-radius: 999px;
+  background: hsl(var(--primary));
+  box-shadow: 0 0 0 1px hsl(var(--background) / 0.75);
+}
+
 .ProseMirror > *:not(.ProseMirror-gapcursor) + *:not(.ProseMirror-gapcursor) {
   @apply mt-2;
 }


### PR DESCRIPTION
## Problem

Composer pill atoms—mentions, stream/message links, commands, attachments, memories, and GIFs—were difficult to reposition, especially on touch. The initial drag interaction also allowed mid-word drops, kept the source visually live, and placed the only target caret beneath the user's thumb.

## Solution

Add `ComposerPillDragExtension`, a ProseMirror interaction that keeps the document fixed during drag and commits one undoable move on release.

- Mouse drag activates after 6px; touch uses the shared 500ms/10px long-press contract.
- Drop positions snap to paragraph edges, whitespace around words, and inline-atom edges. Formatting boundaries inside a word are not targets.
- The source stays fixed but greys into a ghost; a zero-size gold caret marks the real insertion slot.
- Touch mirrors the words or pills beside that slot in a compact loupe 40px above the thumb. It clamps to the viewport and moves below the finger near the top edge.
- Touch haptics pulse on activation, each changed valid target, and successful commit. Unsupported browsers remain a silent no-op.
- Escape, blur, gesture cancellation, and multi-touch clear without moving content. Pre-activation movement remains native scrolling.
- Standard editor selection/cut/paste remains the keyboard route; this adds no separate keyboard lift mode.

## Files

| File | Change |
| ---- | ------ |
| `composer-pill-drag-extension.ts` | Mouse/touch sensors, cached word-boundary snapping, mapped plugin state, and atomic move (**new**) |
| `composer-pill-touch-guide.ts` | Viewport-aware contextual loupe for touch placement (**new**) |
| `composer-pill-drag-extension.test.ts` | Mouse, long-press, snapping, haptics, loupe lifecycle, async node-update, invalid-drop, and undo coverage (**new**) |
| `editor-extensions.ts` | Registers pill dragging on every rich editor |
| `use-long-press.ts` | Exposes the existing touch threshold and movement tolerance |
| `index.css` | Grab/ghost affordances, layout-neutral drop caret, and touch loupe |
| `DESIGN.md` | Records the shipped interaction |

## Test plan

- [x] `bun run test --run src/components/editor src/components/composer src/components/timeline/pending-attachments.test.tsx` — 619 passed
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [ ] Full frontend suite — follow-up commit is running in CI; focused editor/composer regressions pass locally

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788799622&installation_model_id=20758&pr_number=1822&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1822&signature=7fbe6fa20340d0e59ccce3e3c58e1cb3b4c3e25718653baffb3d54f7e0fe05d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
