### PR TITLE
feat: activate bounded dictation client protocol

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -221,7 +221,9 @@ describe("MessageComposer", () => {
       ref: ForwardedRef<{ abort: () => void; prepareSendAsIs: () => void }>
     ) {
       useImperativeHandle(ref, () => ({ abort: vi.fn(), prepareSendAsIs: vi.fn() }))
-      useEffect(() => props.onInsertText("lo", { joinPrevious: true }), [props])
+      useEffect(() => {
+        props.onInsertText("lo", { joinPrevious: true })
+      }, [props])
       return null
     })
     spyOnExport(micButtonModule, "MicButton").mockReturnValue(

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -17,6 +17,7 @@ import { queueComposerCommandRequest } from "@/stores/composer-command-request-s
 let isMobileMockValue = false
 const mockRichEditorFocus = vi.fn()
 const mockInsertFiles = vi.fn(() => true)
+const mockInsertTranscribedText = vi.fn()
 const mockInsertDictationChunk = vi.fn()
 
 type MockEditorInstance = {
@@ -35,6 +36,7 @@ const MockRichEditor = forwardRef<
     insertEmoji: () => void
     openSnippetEditor: () => void
     insertFiles: (files: File[]) => boolean
+    insertTranscribedText: (text: string, options?: { joinPrevious?: boolean }) => void
     insertDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => void
     getEditor: () => MockEditorInstance | null
   },
@@ -75,6 +77,7 @@ const MockRichEditor = forwardRef<
       insertEmoji: () => undefined,
       openSnippetEditor: () => undefined,
       insertFiles: mockInsertFiles,
+      insertTranscribedText: mockInsertTranscribedText,
       insertDictationChunk: mockInsertDictationChunk,
       getEditor: () => editorInstance,
     }),
@@ -150,6 +153,7 @@ describe("MessageComposer", () => {
     vi.restoreAllMocks()
     mockRichEditorFocus.mockClear()
     mockInsertFiles.mockClear()
+    mockInsertTranscribedText.mockClear()
     mockInsertDictationChunk.mockClear()
     isMobileMockValue = false
     vi.useRealTimers()
@@ -209,6 +213,24 @@ describe("MessageComposer", () => {
       chunkId: "local_recovery_1",
       contentJson: recovered,
     })
+  })
+
+  it("forwards hard-join recovery through the plain committed-text editor seam", async () => {
+    const MockMicButton = forwardRef(function MockMicButton(
+      props: { onInsertText: (text: string, options?: { joinPrevious?: boolean }) => void },
+      ref: ForwardedRef<{ abort: () => void; prepareSendAsIs: () => void }>
+    ) {
+      useImperativeHandle(ref, () => ({ abort: vi.fn(), prepareSendAsIs: vi.fn() }))
+      useEffect(() => props.onInsertText("lo", { joinPrevious: true }), [props])
+      return null
+    })
+    spyOnExport(micButtonModule, "MicButton").mockReturnValue(
+      MockMicButton as unknown as typeof micButtonModule.MicButton
+    )
+
+    render(<MessageComposer {...defaultProps} workspaceId="ws_1" />)
+
+    await waitFor(() => expect(mockInsertTranscribedText).toHaveBeenCalledWith("lo", { joinPrevious: true }))
   })
 
   it("aborts active dictation when a nonempty draft is cleared", async () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -757,7 +757,10 @@ export function MessageComposer({
 
   // Always available on workspace surfaces so dictation can be resumed after the
   // composer already has text — appended at the caret like committed speech.
-  const insertTranscribedText = useCallback((text: string) => richEditorRef.current?.insertTranscribedText(text), [])
+  const insertTranscribedText = useCallback(
+    (text: string, options?: { joinPrevious?: boolean }) => richEditorRef.current?.insertTranscribedText(text, options),
+    []
+  )
   const setDictationInterim = useCallback((text: string) => richEditorRef.current?.setDictationInterim(text), [])
   // Polished-chunk wiring: the editor tracks each polished chunk by id so a
   // session-wide toggle can swap them in-place between polished and raw.

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -40,7 +40,12 @@ import { COLLAPSED_COMPOSER_ROW, COLLAPSED_COMPOSER_SHADOW } from "@/components/
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { collapsedComposerPreview } from "@/lib/drafts/collapsed-composer-preview"
 import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
-import { DEFAULT_USER_PREFERENCES, type MessageSendMode, type JSONContent } from "@threa/types"
+import {
+  DEFAULT_USER_PREFERENCES,
+  type MessageSendMode,
+  type JSONContent,
+  type VoiceTranscriptReplacementV4,
+} from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import type { Editor } from "@tiptap/react"
 import { consumeComposerCommandRequest, subscribeComposerCommandRequest } from "@/stores/composer-command-request-store"
@@ -757,12 +762,22 @@ export function MessageComposer({
   // Polished-chunk wiring: the editor tracks each polished chunk by id so a
   // session-wide toggle can swap them in-place between polished and raw.
   const insertPolishedDictationChunk = useCallback(
-    (args: { chunkId: string; contentJson: JSONContent }) => richEditorRef.current?.insertDictationChunk(args),
+    (args: { chunkId: string; contentJson: JSONContent; afterChunkId?: string; joinPrevious?: boolean }) =>
+      richEditorRef.current?.insertDictationChunk(args) ?? false,
     []
   )
   const swapDictationChunk = useCallback(
     (args: { chunkId: string; contentJson: JSONContent }) =>
       richEditorRef.current?.replaceDictationChunk?.(args) ?? false,
+    []
+  )
+  const replaceDictationChunks = useCallback(
+    (args: { sources: VoiceTranscriptReplacementV4["sources"]; resultChunkId: string; contentJson: JSONContent }) =>
+      richEditorRef.current?.replaceDictationChunks?.(args) ?? "missing",
+    []
+  )
+  const lockDictationChunk = useCallback(
+    (args: { chunkId: string }) => richEditorRef.current?.lockDictationChunk(args),
     []
   )
   const lockAllDictationChunks = useCallback(() => richEditorRef.current?.lockAllDictationChunks(), [])
@@ -782,8 +797,8 @@ export function MessageComposer({
     const { doc, selection } = editor.state
     return getDictationMarkdownContext(doc, selection, VOICE_DRAFT_CONTEXT_MAX_CHARS)
   }, [])
-  // Keyed by scopeId so navigating to a different stream remounts the button, tearing down any
-  // in-flight dictation session (the unmount cleanup aborts the take) instead of carrying it over.
+  // Keyed by scopeId so navigation ends the old take after its layout cleanup
+  // has preserved any visible interim in the composer.
   const micButton = workspaceId ? (
     <MicButton
       key={`mic-${scopeId ?? ""}`}
@@ -794,6 +809,8 @@ export function MessageComposer({
       onActiveChange={setVoiceActive}
       onInsertPolishedChunk={insertPolishedDictationChunk}
       onChunkSwap={swapDictationChunk}
+      onChunksReplace={replaceDictationChunks}
+      onLockChunk={lockDictationChunk}
       onLockAllChunks={lockAllDictationChunks}
       onGetChunkContent={getDictationChunkContent}
       onGetDraftContext={getDictationDraftContext}
@@ -810,6 +827,8 @@ export function MessageComposer({
       onActiveChange={setVoiceActive}
       onInsertPolishedChunk={insertPolishedDictationChunk}
       onChunkSwap={swapDictationChunk}
+      onChunksReplace={replaceDictationChunks}
+      onLockChunk={lockDictationChunk}
       onLockAllChunks={lockAllDictationChunks}
       onGetChunkContent={getDictationChunkContent}
       onGetDraftContext={getDictationDraftContext}

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -1,4 +1,4 @@
-import type { JSONContent } from "@threa/types"
+import type { JSONContent, VoiceReplacementAckStatus, VoiceTranscriptReplacementSourceV4 } from "@threa/types"
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 import { Mic, Loader2, AlertTriangle, Sparkles, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -69,14 +69,25 @@ interface MicButtonProps {
   /** Reports whether a take is in flight, so the host can keep its chrome (and this button) mounted while dictating. */
   onActiveChange?: (active: boolean) => void
   /**
-   * Insert a polished chunk into the editor with tracking so a later toggle can
-   * swap it. When omitted, the polished pipeline is essentially disabled from
-   * the editor's POV (the backend still emits the events, but nothing tracks
-   * them) — surfaces that don't support inline swap can leave this off.
+   * Insert a transcript chunk with tracking so a later formatter operation can
+   * replace it. Surfaces without inline tracking may omit this; finals then use
+   * the committed-text path and formatter operations acknowledge `missing`.
    */
-  onInsertPolishedChunk?: (args: { chunkId: string; contentJson: JSONContent }) => void
+  onInsertPolishedChunk?: (args: {
+    chunkId: string
+    contentJson: JSONContent
+    afterChunkId?: string
+    joinPrevious?: boolean
+  }) => boolean
   /** Swap a tracked chunk's text. Returns false if the user edited inside it. */
   onChunkSwap?: (args: { chunkId: string; contentJson: JSONContent }) => boolean
+  onChunksReplace?: (args: {
+    sources: VoiceTranscriptReplacementSourceV4[]
+    resultChunkId: string
+    contentJson: JSONContent
+  }) => VoiceReplacementAckStatus
+  /** Lock one locally recovered raw chunk without affecting accepted chunks. */
+  onLockChunk?: (args: { chunkId: string }) => void
   /** Drop tracking for every chunk (post-session lock, or starting a new take). */
   onLockAllChunks?: () => void
   /**
@@ -105,6 +116,8 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     onActiveChange,
     onInsertPolishedChunk,
     onChunkSwap,
+    onChunksReplace,
+    onLockChunk,
     onLockAllChunks,
     onGetChunkContent,
     onGetDraftContext,
@@ -139,6 +152,8 @@ export const MicButton = forwardRef<MicButtonHandle, MicButtonProps>(function Mi
     onCommittedText: onInsertText,
     onPolishedChunkInserted: onInsertPolishedChunk,
     onChunkSwap,
+    onChunksReplace,
+    onLockChunk,
     onLockAllChunks,
     onGetChunkContent,
     onGetDraftContext,

--- a/apps/frontend/src/components/composer/mic-button.tsx
+++ b/apps/frontend/src/components/composer/mic-button.tsx
@@ -63,7 +63,7 @@ export interface MicButtonHandle {
 interface MicButtonProps {
   workspaceId: string
   /** Insert a committed transcript span into the editor at the caret. */
-  onInsertText: (text: string) => void
+  onInsertText: (text: string, options?: { joinPrevious?: boolean }) => void
   /** Live (uncommitted) transcript hypothesis, pushed as it grows and cleared ("") when a segment commits or the take ends. */
   onInterimText?: (text: string) => void
   /** Reports whether a take is in flight, so the host can keep its chrome (and this button) mounted while dictating. */

--- a/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
+++ b/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
@@ -326,8 +326,7 @@ describe("structured dictation chunks", () => {
       contentJson: paragraph("combined"),
       onResult: (result) => (status = result),
     })
-    expect(status).not.toBe("applied")
-    expect(editor.getJSON()).toEqual(edited)
+    expect({ status, doc: editor.getJSON() }).toEqual({ status: "locked", doc: edited })
   })
 
   it("keeps a locked predecessor and appends the next independent source after it", () => {

--- a/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
+++ b/apps/frontend/src/components/editor/dictation-chunk-extension.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest"
 import { Editor } from "@tiptap/core"
 import type { JSONContent } from "@tiptap/react"
 import { createEditorExtensions } from "./editor-extensions"
+import { getDictationChunkPositions } from "./dictation-chunk-extension"
 
 const paragraph = (text: string): JSONContent => ({
   type: "doc",
@@ -119,6 +120,236 @@ describe("structured dictation chunks", () => {
     })
   })
 
+  it("inserts after a tracked chunk independent of the moved caret and hard-joins scalar splits", () => {
+    editor = make(paragraph("typed"))
+    editor.commands.setTextSelection(6)
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("hel") })
+    editor.commands.setTextSelection(1)
+    editor.commands.insertDictationChunk({
+      chunkId: "b",
+      afterChunkId: "a",
+      joinPrevious: true,
+      contentJson: paragraph("lo"),
+    })
+    expect(editor.getText()).toBe("typed hello")
+  })
+
+  it("atomically collapses two adjacent chunks and tracks the result", () => {
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("one") })
+    editor.commands.insertDictationChunk({ chunkId: "b", afterChunkId: "a", contentJson: paragraph("two") })
+    let status = ""
+    expect(
+      editor.commands.replaceDictationChunks({
+        sources: [
+          { chunkId: "a", throughRevision: 1 },
+          { chunkId: "b", throughRevision: 2 },
+        ],
+        resultChunkId: "ab",
+        contentJson: paragraph("combined"),
+        onResult: (result) => (status = result),
+      })
+    ).toBe(true)
+    expect({ status, text: editor.getText() }).toEqual({ status: "applied", text: "combined" })
+    expect(editor.commands.replaceDictationChunk({ chunkId: "ab", contentJson: paragraph("toggle") })).toBe(true)
+    expect(editor.getText()).toBe("toggle")
+  })
+
+  it("tracks structurally fitted list sources and atomically replaces their complete span", () => {
+    editor = make(paragraph("Typed"))
+    editor.commands.setTextSelection(6)
+    expect(editor.commands.insertDictationChunk({ chunkId: "accepted-list", contentJson: list })).toBe(true)
+    expect(
+      editor.commands.insertDictationChunk({
+        chunkId: "raw-tail",
+        afterChunkId: "accepted-list",
+        contentJson: paragraph("tail"),
+      })
+    ).toBe(true)
+    const sources = getDictationChunkPositions(editor.state)
+    expect(sources.map(({ chunkId, from, to }) => ({ chunkId, nonempty: from < to }))).toEqual([
+      { chunkId: "accepted-list", nonempty: true },
+      { chunkId: "raw-tail", nonempty: true },
+    ])
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Typed" }] },
+        ...list.content!,
+        { type: "paragraph", content: [{ type: "text", text: "tail" }] },
+      ],
+    })
+
+    let status = ""
+    expect(
+      editor.commands.replaceDictationChunks({
+        sources: [
+          { chunkId: "accepted-list", throughRevision: 1 },
+          { chunkId: "raw-tail", throughRevision: 2 },
+        ],
+        resultChunkId: "combined",
+        contentJson: list,
+        onResult: (result) => (status = result),
+      })
+    ).toBe(true)
+    expect(status).toBe("applied")
+    expect(editor.getJSON()).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Typed" }] }, ...list.content!],
+    })
+    expect(
+      getDictationChunkPositions(editor.state).map(({ chunkId, from, to }) => ({ chunkId, nonempty: from < to }))
+    ).toEqual([{ chunkId: "combined", nonempty: true }])
+    expect(editor.commands.replaceDictationChunk({ chunkId: "combined", contentJson: paragraph("toggle") })).toBe(true)
+    expect(editor.getText()).toBe("Typed toggle")
+  })
+
+  it("keeps exactly one outer space for one-source and hard-joined two-source v4 replacements", () => {
+    editor = make(paragraph("Typed"))
+    editor.commands.setTextSelection(6)
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("hel") })
+    let status = ""
+    editor.commands.replaceDictationChunks({
+      sources: [{ chunkId: "a", throughRevision: 1 }],
+      resultChunkId: "a",
+      contentJson: paragraph("hello"),
+      onResult: (result) => (status = result),
+    })
+    expect({ status, text: editor.getText() }).toEqual({ status: "applied", text: "Typed hello" })
+
+    editor.commands.insertDictationChunk({
+      chunkId: "b",
+      afterChunkId: "a",
+      joinPrevious: true,
+      contentJson: paragraph("world"),
+    })
+    editor.commands.replaceDictationChunks({
+      sources: [
+        { chunkId: "a", throughRevision: 1 },
+        { chunkId: "b", throughRevision: 2 },
+      ],
+      resultChunkId: "ab",
+      contentJson: paragraph("helloworld"),
+      onResult: (result) => (status = result),
+    })
+    expect({ status, text: editor.getText() }).toEqual({ status: "applied", text: "Typed helloworld" })
+    expect(editor.commands.replaceDictationChunk({ chunkId: "ab", contentJson: paragraph("rawtoggle") })).toBe(true)
+    expect(editor.getText()).toBe("Typed rawtoggle")
+  })
+
+  it("rejects reversed, missing, duplicate, and invalid replacements without partial content changes", () => {
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("one") })
+    editor.commands.insertDictationChunk({ chunkId: "b", afterChunkId: "a", contentJson: paragraph("two") })
+    const before = editor.getJSON()
+    const attempt = (sources: Array<{ chunkId: string; throughRevision: number }>, contentJson = paragraph("bad")) => {
+      let status = ""
+      editor.commands.replaceDictationChunks({
+        sources,
+        resultChunkId: "result",
+        contentJson,
+        onResult: (s) => (status = s),
+      })
+      return status
+    }
+    expect(
+      attempt([
+        { chunkId: "b", throughRevision: 2 },
+        { chunkId: "a", throughRevision: 1 },
+      ])
+    ).toBe("non_contiguous")
+    expect(attempt([{ chunkId: "missing", throughRevision: 1 }])).toBe("missing")
+    expect(
+      attempt([
+        { chunkId: "a", throughRevision: 1 },
+        { chunkId: "a", throughRevision: 1 },
+      ])
+    ).toBe("invalid")
+    expect(attempt([{ chunkId: "a", throughRevision: 1 }], { type: "nope" })).toBe("invalid")
+    expect(editor.getJSON()).toEqual(before)
+  })
+
+  it("reports malformed runtime sources invalid exactly once without throwing or mutating tracking", () => {
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("one") })
+    const before = editor.getJSON()
+    const malformed: unknown[] = [null, {}, [null], [{ chunkId: "a", throughRevision: 1.5 }]]
+    for (const sources of malformed) {
+      const statuses: string[] = []
+      expect(() =>
+        editor.commands.replaceDictationChunks({
+          sources: sources as never,
+          resultChunkId: "result",
+          contentJson: paragraph("bad"),
+          onResult: (status) => statuses.push(status),
+        })
+      ).not.toThrow()
+      expect({ statuses, doc: editor.getJSON() }).toEqual({ statuses: ["invalid"], doc: before })
+    }
+    const contentStatuses: string[] = []
+    expect(() =>
+      editor.commands.replaceDictationChunks({
+        sources: [{ chunkId: "a", throughRevision: 1 }],
+        resultChunkId: "result",
+        contentJson: null as never,
+        onResult: (status) => contentStatuses.push(status),
+      })
+    ).not.toThrow()
+    expect({ contentStatuses, doc: editor.getJSON() }).toEqual({ contentStatuses: ["invalid"], doc: before })
+    expect(editor.commands.replaceDictationChunk({ chunkId: "a", contentJson: paragraph("still tracked") })).toBe(true)
+  })
+
+  it("rejects result collisions and intervening user content without partial mutation", () => {
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("one") })
+    editor.commands.insertDictationChunk({ chunkId: "b", afterChunkId: "a", contentJson: paragraph("two") })
+    editor.commands.insertDictationChunk({ chunkId: "independent", afterChunkId: "b", contentJson: paragraph("three") })
+    const beforeCollision = editor.getJSON()
+    let status = ""
+    editor.commands.replaceDictationChunks({
+      sources: [{ chunkId: "a", throughRevision: 1 }],
+      resultChunkId: "independent",
+      contentJson: paragraph("bad"),
+      onResult: (result) => (status = result),
+    })
+    expect({ status, doc: editor.getJSON() }).toEqual({ status: "invalid", doc: beforeCollision })
+
+    editor.commands.setTextSelection(5)
+    editor.commands.insertContent("USER")
+    const edited = editor.getJSON()
+    editor.commands.replaceDictationChunks({
+      sources: [
+        { chunkId: "a", throughRevision: 1 },
+        { chunkId: "b", throughRevision: 2 },
+      ],
+      resultChunkId: "ab",
+      contentJson: paragraph("combined"),
+      onResult: (result) => (status = result),
+    })
+    expect(status).not.toBe("applied")
+    expect(editor.getJSON()).toEqual(edited)
+  })
+
+  it("keeps a locked predecessor and appends the next independent source after it", () => {
+    editor = make(paragraph(""))
+    editor.commands.insertDictationChunk({ chunkId: "a", contentJson: paragraph("raw") })
+    editor.commands.setTextSelection(2)
+    editor.commands.insertContent("EDIT ")
+    const edited = editor.getText()
+    expect(
+      editor.commands.insertDictationChunk({ chunkId: "b", afterChunkId: "a", contentJson: paragraph("next") })
+    ).toBe(true)
+    expect(
+      editor.commands.insertDictationChunk({ chunkId: "c", afterChunkId: "b", contentJson: paragraph("independent") })
+    ).toBe(true)
+    expect(editor.getText()).toBe(`${edited} next independent`)
+    expect(editor.commands.replaceDictationChunk({ chunkId: "a", contentJson: paragraph("overwrite") })).toBe(false)
+    expect(editor.commands.replaceDictationChunk({ chunkId: "b", contentJson: paragraph("polished next") })).toBe(true)
+    expect(
+      editor.commands.replaceDictationChunk({ chunkId: "c", contentJson: paragraph("polished independent") })
+    ).toBe(true)
+  })
+
   it("maps adjacent edits but tombstones a chunk after an inside edit", () => {
     editor = make(paragraph("typed"))
     editor.commands.setTextSelection(6)
@@ -131,8 +362,10 @@ describe("structured dictation chunks", () => {
     editor.commands.insertContent("E")
     const edited = editor.getText()
     expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: list })).toBe(false)
-    expect(editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("resurrected") })).toBe(false)
+    expect(editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("continued") })).toBe(true)
+    expect(editor.commands.insertDictationChunk({ chunkId: "take", contentJson: paragraph("again") })).toBe(true)
     expect(editor.getText()).not.toBe(beforeEdit)
-    expect(editor.getText()).toBe(edited)
+    expect(editor.getText()).toBe(`${edited} continued again`)
+    expect(editor.commands.replaceDictationChunk({ chunkId: "take", contentJson: paragraph("overwrite") })).toBe(false)
   })
 })

--- a/apps/frontend/src/components/editor/dictation-chunk-extension.ts
+++ b/apps/frontend/src/components/editor/dictation-chunk-extension.ts
@@ -1,8 +1,8 @@
 import { Extension } from "@tiptap/core"
 import { Node as ProseMirrorNode } from "@tiptap/pm/model"
-import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state"
+import { Plugin, PluginKey, type EditorState, type Transaction } from "@tiptap/pm/state"
 import { Decoration, DecorationSet } from "@tiptap/pm/view"
-import type { JSONContent } from "@threa/types"
+import type { JSONContent, VoiceReplacementAckStatus, VoiceTranscriptReplacementSourceV4 } from "@threa/types"
 import { canonicalContentSlice } from "./multiline-blocks"
 
 export interface DictationChunkInfo {
@@ -14,7 +14,10 @@ export interface DictationChunkInfo {
 
 type Chunk = { chunkId: string; from: number; to: number; expectedContentJson: JSONContent; locked: boolean }
 type ChunkState = Map<string, Chunk>
-type ChunkMeta = { type: "set"; chunk: Chunk } | { type: "lock"; chunkId: string } | { type: "removeAll" }
+type ChunkMeta =
+  | { type: "set"; chunk: Chunk; removeChunkIds?: string[] }
+  | { type: "lock"; chunkId: string }
+  | { type: "removeAll" }
 
 const DictationChunkPluginKey = new PluginKey<ChunkState>("dictationChunk")
 
@@ -24,6 +27,50 @@ function sliceJson(doc: ProseMirrorNode, from: number, to: number): JSONContent 
 
 function equalJson(a: JSONContent, b: JSONContent): boolean {
   return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function isCanonicalDoc(contentJson: unknown): contentJson is JSONContent {
+  return (
+    typeof contentJson === "object" &&
+    contentJson !== null &&
+    (contentJson as JSONContent).type === "doc" &&
+    Array.isArray((contentJson as JSONContent).content) &&
+    (contentJson as JSONContent).content!.length > 0
+  )
+}
+
+function replacementSpan(
+  tr: Transaction,
+  firstStep: number,
+  requestedFrom: number,
+  requestedTo: number
+): { from: number; to: number } | null {
+  let oldFrom = requestedFrom
+  let oldTo = requestedTo
+  for (let index = firstStep; index < tr.steps.length; index++) {
+    const map = tr.steps[index]!.getMap()
+    let newFrom: number | undefined
+    let newTo: number | undefined
+    map.forEach((stepOldFrom, stepOldTo, stepNewFrom, stepNewTo) => {
+      if (stepOldFrom <= oldFrom && stepOldTo >= oldTo && stepNewTo > stepNewFrom) {
+        newFrom = stepNewFrom
+        newTo = stepNewTo
+      }
+    })
+    if (newFrom !== undefined && newTo !== undefined) {
+      let from = newFrom
+      let to = newTo
+      for (let later = index + 1; later < tr.steps.length; later++) {
+        const laterMap = tr.steps[later]!.getMap()
+        from = laterMap.map(from, -1)
+        to = laterMap.map(to, 1)
+      }
+      return from < to ? { from, to } : null
+    }
+    oldFrom = map.map(oldFrom, -1)
+    oldTo = map.map(oldTo, 1)
+  }
+  return null
 }
 
 function withBoundarySpace(state: EditorState, from: number, contentJson: JSONContent): JSONContent {
@@ -41,8 +88,19 @@ function withBoundarySpace(state: EditorState, from: number, contentJson: JSONCo
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     dictationChunk: {
-      insertDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => ReturnType
+      insertDictationChunk: (args: {
+        chunkId: string
+        contentJson: JSONContent
+        afterChunkId?: string
+        joinPrevious?: boolean
+      }) => ReturnType
       replaceDictationChunk: (args: { chunkId: string; contentJson: JSONContent }) => ReturnType
+      replaceDictationChunks: (args: {
+        sources: VoiceTranscriptReplacementSourceV4[]
+        resultChunkId: string
+        contentJson: JSONContent
+        onResult: (status: VoiceReplacementAckStatus) => void
+      }) => ReturnType
       lockDictationChunk: (args: { chunkId: string }) => ReturnType
       lockAllDictationChunks: () => ReturnType
     }
@@ -55,27 +113,33 @@ export const DictationChunkExtension = Extension.create({
   addCommands() {
     return {
       insertDictationChunk:
-        ({ chunkId, contentJson }) =>
+        ({ chunkId, contentJson, afterChunkId, joinPrevious }) =>
         ({ state, tr, dispatch }) => {
-          const existing = DictationChunkPluginKey.getState(state)?.get(chunkId)
-          if (existing?.locked) return false
-          const from = existing?.to ?? state.selection.from
-          const to = existing?.to ?? state.selection.to
-          const normalized = withBoundarySpace(state, from, contentJson)
+          const chunks = DictationChunkPluginKey.getState(state)
+          const existing = chunks?.get(chunkId)
+          const predecessor = afterChunkId ? chunks?.get(afterChunkId) : undefined
+          if (afterChunkId && !predecessor) return false
+          if (!isCanonicalDoc(contentJson)) return false
+          const from = existing?.to ?? predecessor?.to ?? state.selection.from
+          const to = existing?.to ?? predecessor?.to ?? state.selection.to
+          const normalized = joinPrevious ? contentJson : withBoundarySpace(state, from, contentJson)
           const slice = canonicalContentSlice(state.schema, normalized)
           if (!slice) return false
+          const firstStep = tr.steps.length
           tr.replaceRange(from, to, slice)
-          const insertedFrom = tr.mapping.map(from, -1)
-          const insertedTo = tr.mapping.map(to, 1)
-          const chunkFrom = existing?.from ?? insertedFrom
+          const inserted = replacementSpan(tr, firstStep, from, to)
+          if (!inserted) return false
+          const chunkFrom = existing?.from ?? inserted.from
+          const chunkTo = inserted.to
+          if (chunkFrom >= chunkTo) return false
           tr.setMeta(DictationChunkPluginKey, {
             type: "set",
             chunk: {
               chunkId,
               from: chunkFrom,
-              to: insertedTo,
-              expectedContentJson: sliceJson(tr.doc, chunkFrom, insertedTo),
-              locked: false,
+              to: chunkTo,
+              expectedContentJson: sliceJson(tr.doc, chunkFrom, chunkTo),
+              locked: existing?.locked ?? false,
             },
           } satisfies ChunkMeta)
           dispatch?.(tr.scrollIntoView())
@@ -87,6 +151,7 @@ export const DictationChunkExtension = Extension.create({
         ({ state, tr, dispatch }) => {
           const chunk = DictationChunkPluginKey.getState(state)?.get(chunkId)
           if (!chunk || chunk.locked) return false
+          if (!isCanonicalDoc(contentJson)) return false
           const normalized = withBoundarySpace(state, chunk.from, contentJson)
           const slice = canonicalContentSlice(state.schema, normalized)
           if (!slice) return false
@@ -95,15 +160,85 @@ export const DictationChunkExtension = Extension.create({
             dispatch?.(tr)
             return false
           }
+          const firstStep = tr.steps.length
           tr.replaceRange(chunk.from, chunk.to, slice)
-          const from = tr.mapping.map(chunk.from, -1)
-          const to = tr.mapping.map(chunk.to, 1)
+          const inserted = replacementSpan(tr, firstStep, chunk.from, chunk.to)
+          if (!inserted) return false
+          const { from, to } = inserted
           tr.setMeta(DictationChunkPluginKey, {
             type: "set",
             chunk: { chunkId, from, to, expectedContentJson: sliceJson(tr.doc, from, to), locked: false },
           } satisfies ChunkMeta)
           dispatch?.(tr)
           return true
+        },
+
+      replaceDictationChunks:
+        ({ sources, resultChunkId, contentJson, onResult }) =>
+        ({ state, tr, dispatch }) => {
+          const finish = (status: VoiceReplacementAckStatus) => {
+            onResult(status)
+            return status === "applied"
+          }
+          if (
+            !isCanonicalDoc(contentJson) ||
+            typeof resultChunkId !== "string" ||
+            resultChunkId.length === 0 ||
+            !Array.isArray(sources) ||
+            sources.length < 1 ||
+            sources.length > 2 ||
+            sources.some(
+              (source) =>
+                !source ||
+                typeof source !== "object" ||
+                typeof source.chunkId !== "string" ||
+                source.chunkId.length === 0 ||
+                !Number.isSafeInteger(source.throughRevision) ||
+                source.throughRevision < 0
+            ) ||
+            new Set(sources.map((source) => source.chunkId)).size !== sources.length
+          )
+            return finish("invalid")
+          const chunks = DictationChunkPluginKey.getState(state)
+          if (chunks?.has(resultChunkId) && !sources.some((source) => source.chunkId === resultChunkId))
+            return finish("invalid")
+          const resolved = sources.map((source) => chunks?.get(source.chunkId))
+          if (resolved.some((chunk) => !chunk)) return finish("missing")
+          const concrete = resolved as Chunk[]
+          const locked = concrete.find((chunk) => chunk.locked)
+          if (locked) return finish("locked")
+          for (const chunk of concrete) {
+            if (!equalJson(sliceJson(state.doc, chunk.from, chunk.to), chunk.expectedContentJson)) {
+              tr.setMeta(DictationChunkPluginKey, { type: "lock", chunkId: chunk.chunkId } satisfies ChunkMeta)
+              dispatch?.(tr)
+              return finish("locked")
+            }
+          }
+          if (concrete.some((chunk, index) => index > 0 && concrete[index - 1].to !== chunk.from))
+            return finish("non_contiguous")
+          const first = concrete[0]
+          const last = concrete.at(-1)!
+          const normalized = withBoundarySpace(state, first.from, contentJson)
+          const slice = canonicalContentSlice(state.schema, normalized)
+          if (!slice) return finish("invalid")
+          const firstStep = tr.steps.length
+          tr.replaceRange(first.from, last.to, slice)
+          const inserted = replacementSpan(tr, firstStep, first.from, last.to)
+          if (!inserted) return finish("invalid")
+          const { from, to } = inserted
+          tr.setMeta(DictationChunkPluginKey, {
+            type: "set",
+            removeChunkIds: sources.map((source) => source.chunkId),
+            chunk: {
+              chunkId: resultChunkId,
+              from,
+              to,
+              expectedContentJson: sliceJson(tr.doc, from, to),
+              locked: false,
+            },
+          } satisfies ChunkMeta)
+          dispatch?.(tr)
+          return finish("applied")
         },
 
       lockDictationChunk:
@@ -135,7 +270,7 @@ export const DictationChunkExtension = Extension.create({
             if (meta?.type === "removeAll") return new Map()
             const next = new Map<string, Chunk>()
             for (const [id, chunk] of previous) {
-              if (meta?.type === "set" && meta.chunk.chunkId === id) continue
+              if (meta?.type === "set" && (meta.chunk.chunkId === id || meta.removeChunkIds?.includes(id))) continue
               const from = tr.mapping.map(chunk.from, 1)
               const to = tr.mapping.map(chunk.to, -1)
               let locked = chunk.locked || (meta?.type === "lock" && meta.chunkId === id)

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -79,7 +79,7 @@ export interface RichEditorHandle {
   /** Upload files and insert their reference chips at the current selection. */
   insertFiles(files: File[]): boolean
   /** Append a committed dictation span at the caret. */
-  insertTranscribedText(text: string): void
+  insertTranscribedText(text: string, options?: { joinPrevious?: boolean }): void
   /** Show the live (uncommitted) dictation hypothesis as a caret ghost; empty string clears it. */
   setDictationInterim(text: string): void
   /**
@@ -1117,13 +1117,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   }, [handleTriggerClick])
 
   const insertTranscribedText = useCallback(
-    (text: string) => {
+    (text: string, options?: { joinPrevious?: boolean }) => {
       if (!editor || editor.isDestroyed || !text) return
-      // Separate consecutive committed spans with a space when the caret isn't
-      // already on whitespace, so words don't run together.
+      // Separate independent committed spans, but preserve a backend-declared
+      // hard split when tracked insertion has to fall back to this plain path.
       const { from } = editor.state.selection
       const charBefore = from > 0 ? editor.state.doc.textBetween(from - 1, from) : ""
-      const prefix = charBefore && !/\s/.test(charBefore) ? " " : ""
+      const prefix = !options?.joinPrevious && charBefore && !/\s/.test(charBefore) ? " " : ""
       editor.chain().focus().insertContent(`${prefix}${text}`).run()
     },
     [editor]

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -60,7 +60,12 @@ import { usePreferences } from "@/contexts"
 import { getEffectiveEditorBindings } from "@/lib/keyboard-shortcuts"
 import type { UploadResult } from "@/hooks/use-attachments"
 import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
-import type { MessageSendMode, JSONContent } from "@threa/types"
+import type {
+  MessageSendMode,
+  JSONContent,
+  VoiceReplacementAckStatus,
+  VoiceTranscriptReplacementSourceV4,
+} from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 
 export interface RichEditorHandle {
@@ -82,13 +87,23 @@ export interface RichEditorHandle {
    * later be swapped (Show original / Show polished) or locked when the user
    * edits inside it.
    */
-  insertDictationChunk(args: { chunkId: string; contentJson: JSONContent }): void
+  insertDictationChunk(args: {
+    chunkId: string
+    contentJson: JSONContent
+    afterChunkId?: string
+    joinPrevious?: boolean
+  }): boolean
   /**
    * Swap a tracked chunk's text in place. Returns true if the swap happened,
    * false if the chunk was missing or the user edited inside it (the chunk is
    * locked in that case and the swap is skipped).
    */
   replaceDictationChunk?(args: { chunkId: string; contentJson: JSONContent }): boolean
+  replaceDictationChunks?(args: {
+    sources: VoiceTranscriptReplacementSourceV4[]
+    resultChunkId: string
+    contentJson: JSONContent
+  }): VoiceReplacementAckStatus
   /** Drop tracking for a single chunk (leaves its text in the doc). */
   lockDictationChunk(args: { chunkId: string }): void
   /** Drop tracking for every chunk. */
@@ -1123,9 +1138,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   )
 
   const insertDictationChunk = useCallback(
-    ({ chunkId, contentJson }: { chunkId: string; contentJson: JSONContent }) => {
-      if (!editor || editor.isDestroyed) return
-      editor.chain().focus().insertDictationChunk({ chunkId, contentJson }).run()
+    (args: { chunkId: string; contentJson: JSONContent; afterChunkId?: string; joinPrevious?: boolean }) => {
+      if (!editor || editor.isDestroyed) return false
+      return editor.chain().focus().insertDictationChunk(args).run()
     },
     [editor]
   )
@@ -1134,6 +1149,20 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     ({ chunkId, contentJson }: { chunkId: string; contentJson: JSONContent }) => {
       if (!editor || editor.isDestroyed) return false
       return editor.chain().replaceDictationChunk({ chunkId, contentJson }).run()
+    },
+    [editor]
+  )
+
+  const replaceDictationChunks = useCallback(
+    (args: {
+      sources: VoiceTranscriptReplacementSourceV4[]
+      resultChunkId: string
+      contentJson: JSONContent
+    }): VoiceReplacementAckStatus => {
+      if (!editor || editor.isDestroyed) return "missing"
+      let status: VoiceReplacementAckStatus = "invalid"
+      editor.commands.replaceDictationChunks({ ...args, onResult: (result) => (status = result) })
+      return status
     },
     [editor]
   )
@@ -1173,6 +1202,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       setDictationInterim,
       insertDictationChunk,
       replaceDictationChunk,
+      replaceDictationChunks,
       lockDictationChunk,
       lockAllDictationChunks,
       getDictationChunkContent,
@@ -1190,6 +1220,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       setDictationInterim,
       insertDictationChunk,
       replaceDictationChunk,
+      replaceDictationChunks,
       lockDictationChunk,
       lockAllDictationChunks,
       getDictationChunkContent,

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -447,43 +447,70 @@ describe("useVoiceDictation lifecycle", () => {
     expect(harness.sockets[0].stopPayloads).toEqual([{ mode: "abort" }])
   })
 
-  it("commits and locks only the v4 recovery chunk on unexpected disconnect", async () => {
+  it("commits only the v4 recovery chunk immediately and locks accepted chunks after terminal grace", async () => {
     const inserted = vi.fn(() => true)
     const lockChunk = vi.fn()
     const lockAll = vi.fn()
     const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
       onPolishedChunkInserted: inserted,
+      onChunksReplace: () => "applied",
       onLockChunk: lockChunk,
       onLockAllChunks: lockAll,
     })
     act(() => harness.result.current.start())
     await waitFor(() => expect(harness.result.current.state).toBe("recording"))
-    act(() => {
-      harness.sockets[0].fire("voice:transcript:delta", {
-        protocolVersion: 4,
-        voiceSessionId: "voicesess_1",
-        revision: 1,
-        text: "visible v4 tail",
-        isFinal: false,
+    vi.useFakeTimers()
+    try {
+      act(() => {
+        harness.sockets[0].fire("voice:transcript:delta", {
+          protocolVersion: 4,
+          voiceSessionId: "voicesess_1",
+          revision: 1,
+          text: "accepted raw",
+          isFinal: true,
+          chunkId: "accepted",
+          contentJson: paragraph("accepted raw"),
+        })
+        harness.sockets[0].fire("voice:transcript:polished", {
+          protocolVersion: 4,
+          operationId: "accepted-operation",
+          voiceSessionId: "voicesess_1",
+          authoritative: false,
+          resultChunkId: "accepted",
+          throughRevision: 1,
+          sources: [{ chunkId: "accepted", throughRevision: 1 }],
+          raw: "accepted raw",
+          polished: "Accepted polished.",
+          rawContentJson: paragraph("accepted raw"),
+          polishedContentJson: paragraph("Accepted polished."),
+        })
+        harness.sockets[0].fire("voice:transcript:delta", {
+          protocolVersion: 4,
+          voiceSessionId: "voicesess_1",
+          revision: 1,
+          text: "visible v4 tail",
+          isFinal: false,
+        })
+        harness.sockets[0].fire("disconnect", undefined)
+        harness.sockets[0].fire("disconnect", undefined)
       })
-      harness.sockets[0].fire("disconnect", undefined)
-      harness.sockets[0].fire("disconnect", undefined)
-    })
 
-    expect(inserted).toHaveBeenCalledOnce()
-    expect(inserted).toHaveBeenCalledWith({
-      chunkId: "local_recovery_1",
-      contentJson: {
-        type: "doc",
-        content: [{ type: "paragraph", content: [{ type: "text", text: "visible v4 tail" }] }],
-      },
-    })
-    expect(lockChunk).toHaveBeenCalledOnce()
-    expect(lockChunk).toHaveBeenCalledWith({ chunkId: "local_recovery_1" })
-    // Starting the take clears previous tracking; disconnect itself must not
-    // globally lock already accepted v4 chunks.
-    expect(lockAll).toHaveBeenCalledOnce()
-    expect(harness.result.current.error).toBe("Dictation connection lost")
+      expect(inserted).toHaveBeenCalledTimes(2)
+      expect(inserted).toHaveBeenLastCalledWith({
+        chunkId: "local_recovery_1",
+        contentJson: paragraph("visible v4 tail"),
+      })
+      expect(lockChunk).toHaveBeenCalledWith({ chunkId: "local_recovery_1" })
+      expect(lockAll).toHaveBeenCalledOnce()
+      expect(harness.result.current.chunks.size).toBe(1)
+      expect(harness.result.current.error).toBe("Dictation connection lost")
+
+      act(() => vi.advanceTimersByTime(8_001))
+      expect(lockAll).toHaveBeenCalledTimes(2)
+      expect(harness.result.current.chunks.size).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("canonically inserts send-as-is interim recovery synchronously before the composer snapshot", async () => {

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -12,18 +12,22 @@ import {
 } from "./use-voice-dictation"
 
 class FakeSocket {
-  handlers = new Map<string, (payload: unknown) => void>()
+  handlers = new Map<string, (...args: unknown[]) => void>()
+  startPayloads: unknown[] = []
   stopCallbacks: Array<() => void> = []
   stopPayloads: unknown[] = []
   disconnected = false
   private timeoutMs: number | null = null
   constructor(private readonly ack: VoiceStartAck) {}
-  on(event: string, callback: (payload: unknown) => void) {
+  on(event: string, callback: (...args: unknown[]) => void) {
     this.handlers.set(event, callback)
     return this
   }
   emit(event: string, ...args: unknown[]) {
-    if (event === "voice:start") (args[1] as (ack: VoiceStartAck) => void)(this.ack)
+    if (event === "voice:start") {
+      this.startPayloads.push(args[0])
+      ;(args[1] as (ack: VoiceStartAck) => void)(this.ack)
+    }
     if (event === "voice:stop") {
       this.stopPayloads.push(args[0])
       const callback = args.at(-1)
@@ -42,8 +46,8 @@ class FakeSocket {
     this.disconnected = true
     return this
   }
-  fire(event: string, payload: unknown) {
-    this.handlers.get(event)?.(payload)
+  fire(event: string, ...args: unknown[]) {
+    this.handlers.get(event)?.(...args)
   }
 }
 
@@ -278,7 +282,7 @@ describe("useVoiceDictation lifecycle", () => {
     ["transport disconnect", "disconnect", undefined],
     ["upstream error", "voice:transcription:error", { code: "UPSTREAM_CLOSED" }],
   ])("commits the exact visible interim once before teardown on %s", async (_label, event, payload) => {
-    const inserted = vi.fn()
+    const inserted = vi.fn(() => true)
     const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
     act(() => harness.result.current.start())
     await waitFor(() => expect(harness.result.current.state).toBe("recording"))
@@ -313,7 +317,10 @@ describe("useVoiceDictation lifecycle", () => {
 
   it("flushes visible interim before a terminal provider outcome locks tracking", async () => {
     const order: string[] = []
-    const inserted = vi.fn(() => order.push("insert"))
+    const inserted = vi.fn(() => {
+      order.push("insert")
+      return true
+    })
     const lockAll = vi.fn(() => order.push("lock"))
     const harness = hookHarness([{ ok: true, protocolVersion: 3 }], {
       onPolishedChunkInserted: inserted,
@@ -351,7 +358,7 @@ describe("useVoiceDictation lifecycle", () => {
   })
 
   it("preserves visible interim as-is when the page is backgrounded", async () => {
-    const inserted = vi.fn()
+    const inserted = vi.fn(() => true)
     const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
     act(() => harness.result.current.start())
     await waitFor(() => expect(harness.result.current.state).toBe("recording"))
@@ -386,7 +393,7 @@ describe("useVoiceDictation lifecycle", () => {
   })
 
   it("commits visible interim when scope navigation unmounts the active take", async () => {
-    const inserted = vi.fn()
+    const inserted = vi.fn(() => true)
     const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
     act(() => harness.result.current.start())
     await waitFor(() => expect(harness.result.current.state).toBe("recording"))
@@ -431,6 +438,45 @@ describe("useVoiceDictation lifecycle", () => {
     expect(harness.sockets[0].stopPayloads).toEqual([{ mode: "abort" }])
   })
 
+  it("commits and locks only the v4 recovery chunk on unexpected disconnect", async () => {
+    const inserted = vi.fn(() => true)
+    const lockChunk = vi.fn()
+    const lockAll = vi.fn()
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
+      onPolishedChunkInserted: inserted,
+      onLockChunk: lockChunk,
+      onLockAllChunks: lockAll,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "visible v4 tail",
+        isFinal: false,
+      })
+      harness.sockets[0].fire("disconnect", undefined)
+      harness.sockets[0].fire("disconnect", undefined)
+    })
+
+    expect(inserted).toHaveBeenCalledOnce()
+    expect(inserted).toHaveBeenCalledWith({
+      chunkId: "local_recovery_1",
+      contentJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "visible v4 tail" }] }],
+      },
+    })
+    expect(lockChunk).toHaveBeenCalledOnce()
+    expect(lockChunk).toHaveBeenCalledWith({ chunkId: "local_recovery_1" })
+    // Starting the take clears previous tracking; disconnect itself must not
+    // globally lock already accepted v4 chunks.
+    expect(lockAll).toHaveBeenCalledOnce()
+    expect(harness.result.current.error).toBe("Dictation connection lost")
+  })
+
   it("canonically inserts send-as-is interim recovery synchronously before the composer snapshot", async () => {
     const order: string[] = []
     const inserted = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
@@ -439,6 +485,7 @@ describe("useVoiceDictation lifecycle", () => {
         type: "doc",
         content: [{ type: "paragraph", content: [{ type: "text", marks: [{ type: "bold" }], text: "recovered" }] }],
       })
+      return true
     })
     const harness = hookHarness([{ ok: true, protocolVersion: 3 }], { onPolishedChunkInserted: inserted })
     act(() => harness.result.current.start())
@@ -461,10 +508,127 @@ describe("useVoiceDictation lifecycle", () => {
     expect(harness.committed).not.toHaveBeenCalled()
   })
 
+  it("preserves failed tracked final and interim insertions once and ACKs unavailable v4 sources missing", async () => {
+    const inserted = vi.fn(() => false)
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    const contentJson: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "final" }] }],
+    }
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "final",
+        isFinal: true,
+        chunkId: "a",
+        contentJson,
+      })
+    )
+    const acknowledgements: unknown[] = []
+    act(() =>
+      harness.sockets[0].fire(
+        "voice:transcript:polished",
+        {
+          protocolVersion: 4,
+          operationId: "missing-operation",
+          voiceSessionId: "voicesess_1",
+          authoritative: true,
+          resultChunkId: "a",
+          throughRevision: 1,
+          sources: [{ chunkId: "a", throughRevision: 1 }],
+          raw: "final",
+          polished: "Final.",
+          rawContentJson: contentJson,
+          polishedContentJson: contentJson,
+        },
+        (ack: unknown) => acknowledgements.push(ack)
+      )
+    )
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 2,
+        text: "interim",
+        isFinal: false,
+        chunkId: "b",
+        contentJson,
+      })
+    )
+    act(() => harness.result.current.prepareSendAsIs())
+
+    expect(harness.committed.mock.calls.map(([text]) => text)).toEqual(["final", "interim"])
+    expect(acknowledgements).toEqual([{ operationId: "missing-operation", status: "missing" }])
+  })
+
+  it("negotiates v4, applies sealed per-source operations, and ACKs duplicate delivery exactly once", async () => {
+    const inserted = vi.fn((_args: { chunkId: string }) => true)
+    const replaced = vi.fn(() => "applied" as const)
+    const acknowledgements: unknown[] = []
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
+      onPolishedChunkInserted: inserted,
+      onChunksReplace: replaced,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    expect(harness.sockets[0].startPayloads[0]).toMatchObject({ maxProtocolVersion: 4 })
+    const contentJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "raw" }] }] }
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "raw",
+        isFinal: true,
+        chunkId: "a",
+        contentJson,
+      })
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 2,
+        text: "newer other chunk",
+        isFinal: true,
+        chunkId: "b",
+        afterChunkId: "a",
+        contentJson,
+      })
+    })
+    const operation = {
+      protocolVersion: 4,
+      operationId: "operation_1",
+      voiceSessionId: "voicesess_1",
+      authoritative: true,
+      resultChunkId: "a",
+      throughRevision: 1,
+      sources: [{ chunkId: "a", throughRevision: 1 }],
+      raw: "raw",
+      polished: "polished",
+      rawContentJson: contentJson,
+      polishedContentJson: contentJson,
+    } as const
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:polished", operation, (ack: unknown) => acknowledgements.push(ack))
+      harness.sockets[0].fire("voice:transcript:polished", operation, (ack: unknown) => acknowledgements.push(ack))
+    })
+
+    expect(inserted.mock.calls.map(([args]) => args.chunkId)).toEqual(["a", "b"])
+    expect(replaced).toHaveBeenCalledTimes(1)
+    expect(acknowledgements).toEqual([
+      { operationId: "operation_1", status: "applied" },
+      { operationId: "operation_1", status: "applied" },
+    ])
+  })
+
   it("normalizes v2 Markdown and preserves exact v3 raw and polished JSON payloads", async () => {
     let current: JSONContent | null = null
     const inserted = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
       current = contentJson
+      return true
     })
     const swapped = vi.fn(({ contentJson }: { contentJson: JSONContent }) => {
       current = contentJson
@@ -525,6 +689,7 @@ describe("useVoiceDictation lifecycle", () => {
     const harness = hookHarness([{ ok: true, protocolVersion: 2 }], {
       onPolishedChunkInserted: ({ contentJson }) => {
         chunkContent = contentJson
+        return true
       },
       onGetChunkContent: () => chunkContent,
       onChunkSwap: ({ contentJson }) => {

--- a/apps/frontend/src/hooks/use-voice-dictation.test.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.test.ts
@@ -79,6 +79,15 @@ const stream = {
   getTracks: () => [{ stop: () => {} }],
 }
 
+const paragraph = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+function contentText(contentJson: JSONContent): string {
+  return `${contentJson.text ?? ""}${(contentJson.content ?? []).map(contentText).join("")}`
+}
+
 beforeEach(() => {
   localStorage.setItem("threa-ws-config:ws_1", JSON.stringify({ region: "test", wsUrl: "https://voice.test" }))
   Object.defineProperty(window, "AudioContext", { configurable: true, value: FakeAudioContext })
@@ -563,6 +572,312 @@ describe("useVoiceDictation lifecycle", () => {
 
     expect(harness.committed.mock.calls.map(([text]) => text)).toEqual(["final", "interim"])
     expect(acknowledgements).toEqual([{ operationId: "missing-operation", status: "missing" }])
+  })
+
+  it("preserves hard-join semantics when a tracked continuation falls back to committed text", async () => {
+    const inserted = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false)
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], { onPolishedChunkInserted: inserted })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "hel",
+        isFinal: true,
+        chunkId: "a",
+        contentJson: paragraph("hel"),
+      })
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 2,
+        text: "lo",
+        isFinal: true,
+        chunkId: "b",
+        afterChunkId: "a",
+        joinPrevious: true,
+        contentJson: paragraph("lo"),
+      })
+    })
+    const acknowledgements: unknown[] = []
+    act(() =>
+      harness.sockets[0].fire(
+        "voice:transcript:polished",
+        {
+          protocolVersion: 4,
+          operationId: "missing-hard-split",
+          voiceSessionId: "voicesess_1",
+          authoritative: true,
+          resultChunkId: "b",
+          throughRevision: 2,
+          sources: [{ chunkId: "b", throughRevision: 2 }],
+          raw: "lo",
+          polished: "lo",
+          rawContentJson: paragraph("lo"),
+          polishedContentJson: paragraph("lo"),
+        },
+        (ack: unknown) => acknowledgements.push(ack)
+      )
+    )
+
+    expect(harness.committed.mock.calls).toEqual([["lo", { joinPrevious: true }]])
+    expect(acknowledgements).toEqual([{ operationId: "missing-hard-split", status: "missing" }])
+  })
+
+  it("ACKs a changed source revision stale without invoking the editor", async () => {
+    const replaced = vi.fn(() => "applied" as const)
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
+      onPolishedChunkInserted: () => true,
+      onChunksReplace: replaced,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      for (const [revision, text] of [
+        [1, "first"],
+        [2, "newer"],
+      ] as const)
+        harness.sockets[0].fire("voice:transcript:delta", {
+          protocolVersion: 4,
+          voiceSessionId: "voicesess_1",
+          revision,
+          text,
+          isFinal: true,
+          chunkId: "a",
+          contentJson: paragraph(text),
+        })
+    })
+    const acknowledgements: unknown[] = []
+    act(() =>
+      harness.sockets[0].fire(
+        "voice:transcript:polished",
+        {
+          protocolVersion: 4,
+          operationId: "stale-operation",
+          voiceSessionId: "voicesess_1",
+          authoritative: false,
+          resultChunkId: "a",
+          throughRevision: 1,
+          sources: [{ chunkId: "a", throughRevision: 1 }],
+          raw: "first",
+          polished: "First.",
+          rawContentJson: paragraph("first"),
+          polishedContentJson: paragraph("First."),
+        },
+        (ack: unknown) => acknowledgements.push(ack)
+      )
+    )
+
+    expect({ acknowledgements, editorCalls: replaced.mock.calls }).toEqual({
+      acknowledgements: [{ operationId: "stale-operation", status: "stale" }],
+      editorCalls: [],
+    })
+  })
+
+  it("reconciles only an edited source after a locked ACK and keeps independent chunks toggleable", async () => {
+    const replaced = vi.fn(({ resultChunkId }: { resultChunkId: string }) =>
+      resultChunkId === "ab" ? ("locked" as const) : ("applied" as const)
+    )
+    const swapped = vi.fn((_args: { chunkId: string; contentJson: JSONContent }) => true)
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
+      onPolishedChunkInserted: () => true,
+      onChunksReplace: replaced,
+      onGetChunkContent: (chunkId) => (chunkId === "a" ? null : paragraph(`editor ${chunkId}`)),
+      onChunkSwap: swapped,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() => {
+      for (const [index, chunkId] of ["a", "b", "c"].entries())
+        harness.sockets[0].fire("voice:transcript:delta", {
+          protocolVersion: 4,
+          voiceSessionId: "voicesess_1",
+          revision: index + 1,
+          text: chunkId,
+          isFinal: true,
+          chunkId,
+          ...(index ? { afterChunkId: ["a", "b"][index - 1] } : {}),
+          contentJson: paragraph(chunkId),
+        })
+    })
+    const acknowledgements: unknown[] = []
+    const apply = (
+      operationId: string,
+      resultChunkId: string,
+      sources: Array<{ chunkId: string; throughRevision: number }>
+    ) =>
+      harness.sockets[0].fire(
+        "voice:transcript:polished",
+        {
+          protocolVersion: 4,
+          operationId,
+          voiceSessionId: "voicesess_1",
+          authoritative: false,
+          resultChunkId,
+          throughRevision: Math.max(...sources.map((source) => source.throughRevision)),
+          sources,
+          raw: sources.map((source) => source.chunkId).join(" "),
+          polished: sources.map((source) => source.chunkId.toUpperCase()).join(" "),
+          rawContentJson: paragraph(sources.map((source) => source.chunkId).join(" ")),
+          polishedContentJson: paragraph(sources.map((source) => source.chunkId.toUpperCase()).join(" ")),
+        },
+        (ack: unknown) => acknowledgements.push(ack)
+      )
+    act(() => {
+      apply("accept-a", "a", [{ chunkId: "a", throughRevision: 1 }])
+      apply("accept-b", "b", [{ chunkId: "b", throughRevision: 2 }])
+      apply("accept-c", "c", [{ chunkId: "c", throughRevision: 3 }])
+      apply("lock-ab", "ab", [
+        { chunkId: "a", throughRevision: 1 },
+        { chunkId: "b", throughRevision: 2 },
+      ])
+    })
+
+    expect(acknowledgements).toEqual([
+      { operationId: "accept-a", status: "applied" },
+      { operationId: "accept-b", status: "applied" },
+      { operationId: "accept-c", status: "applied" },
+      { operationId: "lock-ab", status: "locked" },
+    ])
+    expect([...harness.result.current.chunks].map(([chunkId, record]) => ({ chunkId, locked: record.locked }))).toEqual(
+      [
+        { chunkId: "a", locked: true },
+        { chunkId: "b", locked: false },
+        { chunkId: "c", locked: false },
+      ]
+    )
+    act(() => harness.result.current.setShowOriginal(true))
+    expect(swapped.mock.calls.map(([args]) => args.chunkId)).toEqual(["b", "c"])
+  })
+
+  it("appends alias-chain deltas once and keeps canonical raw and polished whitespace in sync", async () => {
+    const inserted = vi.fn((_args: { chunkId: string; afterChunkId?: string; contentJson: JSONContent }) => true)
+    const swapped = vi.fn((_args: { chunkId: string; contentJson: JSONContent }) => true)
+    const replaced = vi.fn(() => "applied" as const)
+    const harness = hookHarness([{ ok: true, protocolVersion: 4 }], {
+      onPolishedChunkInserted: inserted,
+      onChunksReplace: replaced,
+      onChunkSwap: swapped,
+    })
+    act(() => harness.result.current.start())
+    await waitFor(() => expect(harness.result.current.state).toBe("recording"))
+    act(() =>
+      harness.sockets[0].fire("voice:transcript:delta", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        revision: 1,
+        text: "base",
+        isFinal: true,
+        chunkId: "a",
+        contentJson: paragraph("base"),
+      })
+    )
+    const deliverOperation = (args: {
+      operationId: string
+      sourceId: string
+      throughRevision: number
+      resultChunkId: string
+      raw: string
+      polished: string
+      rawContentJson: JSONContent
+      polishedContentJson: JSONContent
+    }) => {
+      const { sourceId, ...operation } = args
+      harness.sockets[0].fire("voice:transcript:polished", {
+        protocolVersion: 4,
+        voiceSessionId: "voicesess_1",
+        authoritative: false,
+        sources: [{ chunkId: sourceId, throughRevision: operation.throughRevision }],
+        ...operation,
+      })
+    }
+    act(() =>
+      deliverOperation({
+        operationId: "a-to-r",
+        sourceId: "a",
+        throughRevision: 1,
+        resultChunkId: "r",
+        raw: "base ",
+        polished: "Polished ",
+        rawContentJson: paragraph("base "),
+        polishedContentJson: paragraph("Polished "),
+      })
+    )
+    const tailDelta = {
+      protocolVersion: 4,
+      voiceSessionId: "voicesess_1",
+      revision: 2,
+      text: "tail",
+      isFinal: true,
+      chunkId: "a",
+      contentJson: paragraph("tail"),
+    } as const
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", tailDelta)
+      harness.sockets[0].fire("voice:transcript:delta", tailDelta)
+    })
+    const firstRecord = harness.result.current.chunks.get("r")!
+    expect({
+      raw: firstRecord.raw,
+      rawJson: contentText(firstRecord.rawContentJson!),
+      polished: firstRecord.polished,
+      polishedJson: contentText(firstRecord.polishedContentJson!),
+    }).toEqual({ raw: "base tail", rawJson: "base tail", polished: "Polished tail", polishedJson: "Polished tail" })
+
+    act(() =>
+      deliverOperation({
+        operationId: "r-to-s",
+        sourceId: "r",
+        throughRevision: 2,
+        resultChunkId: "s",
+        raw: "base tail",
+        polished: "Polished tail",
+        rawContentJson: paragraph("base tail"),
+        polishedContentJson: paragraph("Polished tail"),
+      })
+    )
+    act(() => {
+      harness.sockets[0].fire("voice:transcript:delta", {
+        ...tailDelta,
+        revision: 3,
+        text: "again",
+        contentJson: paragraph("again"),
+      })
+      harness.sockets[0].fire("voice:transcript:delta", {
+        ...tailDelta,
+        revision: 4,
+        text: "next",
+        chunkId: "b",
+        afterChunkId: "a",
+        contentJson: paragraph("next"),
+      })
+    })
+
+    const finalRecord = harness.result.current.chunks.get("s")!
+    expect({
+      raw: finalRecord.raw,
+      rawJson: contentText(finalRecord.rawContentJson!),
+      polished: finalRecord.polished,
+      polishedJson: contentText(finalRecord.polishedContentJson!),
+      insertions: inserted.mock.calls.map(([args]) => ({ chunkId: args.chunkId, afterChunkId: args.afterChunkId })),
+    }).toEqual({
+      raw: "base tail again",
+      rawJson: "base tail again",
+      polished: "Polished tail again",
+      polishedJson: "Polished tail again",
+      insertions: [
+        { chunkId: "a", afterChunkId: undefined },
+        { chunkId: "r", afterChunkId: undefined },
+        { chunkId: "s", afterChunkId: undefined },
+        { chunkId: "b", afterChunkId: "s" },
+      ],
+    })
+    act(() => harness.result.current.setShowOriginal(true))
+    expect(contentText(swapped.mock.calls.at(-1)![0].contentJson)).toBe("base tail again")
+    act(() => harness.result.current.setShowOriginal(false))
+    expect(contentText(swapped.mock.calls.at(-1)![0].contentJson)).toBe("Polished tail again")
   })
 
   it("negotiates v4, applies sealed per-source operations, and ACKs duplicate delivery exactly once", async () => {

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { io, type Socket } from "socket.io-client"
 import {
+  VOICE_PROTOCOL_VERSION,
+  type VoiceReplacementAckStatus,
   type VoiceStartAck,
   type VoiceStoppedPayload,
-  type VoiceTranscriptDeltaV3,
-  type VoiceTranscriptPolishedV3,
+  type VoiceTranscriptDelta,
+  type VoiceTranscriptPolished,
+  type VoiceTranscriptReplacementV4,
 } from "@threa/types"
 import { voiceApi } from "@/api/voice"
 import { parseMarkdown } from "@threa/prosemirror"
@@ -13,11 +16,6 @@ import { getCachedWsConfig } from "@/lib/cached-ws-config"
 import { useDictationCoordinator, isDictationExternalHeld } from "@/contexts"
 
 export type VoiceDictationState = "idle" | "connecting" | "recording" | "stopping" | "error"
-
-// This PR keeps the current client pinned to negotiated v3. The v4 event
-// consumers replace these aliases when multi-chunk activation lands.
-type VoiceDelta = VoiceTranscriptDeltaV3
-type VoicePolishedChunk = VoiceTranscriptPolishedV3
 
 export interface DictationChunkRecord {
   /** Cumulative raw text the chunk would revert to if the toggle flips to "Show original". */
@@ -61,13 +59,25 @@ interface UseVoiceDictationOptions {
    * can swap it back to raw. The text passed is whatever the toggle currently
    * resolves to (polished by default).
    */
-  onPolishedChunkInserted?: (args: { chunkId: string; contentJson: JSONContent }) => void
+  onPolishedChunkInserted?: (args: {
+    chunkId: string
+    contentJson: JSONContent
+    afterChunkId?: string
+    joinPrevious?: boolean
+  }) => boolean
   /**
    * Swap a tracked chunk's text in the editor. Must return true if the swap
    * landed cleanly, false if the chunk was missing or the user edited inside
    * it (the hook then locks that chunk locally so the toggle stops touching it).
    */
   onChunkSwap?: (args: { chunkId: string; contentJson: JSONContent }) => boolean
+  onChunksReplace?: (args: {
+    sources: VoiceTranscriptReplacementV4["sources"]
+    resultChunkId: string
+    contentJson: JSONContent
+  }) => VoiceReplacementAckStatus
+  /** Lock one locally recovered raw chunk without affecting accepted chunks. */
+  onLockChunk?: (args: { chunkId: string }) => void
   /** Drop tracking for all polished chunks (e.g. session-expired or new take starting). */
   onLockAllChunks?: () => void
   /**
@@ -231,6 +241,26 @@ export function noAudioWarningMessage(args: { deviceLabel: string | null; everHa
     : `We're not hearing audio from ${device} — try a different input device`
 }
 
+function appendTranscriptText(base: string, suffix: string, joinPrevious: boolean): string {
+  if (!base || !suffix || joinPrevious || /\s$/u.test(base) || /^\s/u.test(suffix)) return `${base}${suffix}`
+  return `${base} ${suffix}`
+}
+
+function appendCanonicalContent(base: JSONContent, suffix: JSONContent, joinPrevious: boolean): JSONContent {
+  const before = [...(base.content ?? [])]
+  const after = [...(suffix.content ?? [])]
+  const last = before.at(-1)
+  const first = after[0]
+  if (last?.type === "paragraph" && first?.type === "paragraph") {
+    const left = [...(last.content ?? [])]
+    const right = [...(first.content ?? [])]
+    if (!joinPrevious && left.length && right.length) left.push({ type: "text", text: " " })
+    before[before.length - 1] = { ...last, content: [...left, ...right] }
+    after.shift()
+  }
+  return { type: "doc", content: [...before, ...after] }
+}
+
 function detectSupport(): { supported: boolean; reason: string | null } {
   if (typeof window === "undefined") return { supported: false, reason: "Voice input is unavailable here" }
   if (!navigator.mediaDevices?.getUserMedia) {
@@ -284,6 +314,8 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     onCommittedText,
     onPolishedChunkInserted,
     onChunkSwap,
+    onChunksReplace,
+    onLockChunk,
     onLockAllChunks,
     onGetChunkContent,
     onGetDraftContext,
@@ -346,6 +378,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   onPolishedChunkInsertedRef.current = onPolishedChunkInserted
   const onChunkSwapRef = useRef(onChunkSwap)
   onChunkSwapRef.current = onChunkSwap
+  const onChunksReplaceRef = useRef(onChunksReplace)
+  onChunksReplaceRef.current = onChunksReplace
+  const onLockChunkRef = useRef(onLockChunk)
+  onLockChunkRef.current = onLockChunk
   const onLockAllChunksRef = useRef(onLockAllChunks)
   onLockAllChunksRef.current = onLockAllChunks
   const onGetChunkContentRef = useRef(onGetChunkContent)
@@ -366,6 +402,28 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
   // The session-wide chunkId for the active take, set on the first final
   // delta the backend tags. Reset when a new take starts.
   const sessionChunkIdRef = useRef<string | null>(null)
+  const latestRawRevisionByChunkRef = useRef(new Map<string, number>())
+  const operationStatusesRef = useRef(new Map<string, VoiceReplacementAckStatus>())
+  const chunkAliasesRef = useRef(new Map<string, { resultChunkId: string; throughRevision: number }>())
+  const unavailableV4ChunksRef = useRef(new Set<string>())
+
+  const resetV4State = useCallback(() => {
+    latestRawRevisionByChunkRef.current.clear()
+    operationStatusesRef.current.clear()
+    chunkAliasesRef.current.clear()
+    unavailableV4ChunksRef.current.clear()
+  }, [])
+  const resolveChunkAlias = useCallback((chunkId: string): string => {
+    const seen = new Set<string>()
+    let current = chunkId
+    while (!seen.has(current)) {
+      seen.add(current)
+      const alias = chunkAliasesRef.current.get(current)
+      if (!alias) break
+      current = alias.resultChunkId
+    }
+    return current
+  }, [])
 
   // Only one take dictates at a time across all composers. Starting a take stops
   // whichever was active first (flushing its tail). `coordinatedStop` is a stable
@@ -392,14 +450,13 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       updateInterim("")
       return false
     }
-    if (onPolishedChunkInsertedRef.current) {
-      onPolishedChunkInsertedRef.current({
-        chunkId: `local_recovery_${++recoveryChunkSequenceRef.current}`,
-        contentJson: parseMarkdown(pending),
-      })
-    } else {
-      onCommittedTextRef.current(pending)
-    }
+    const chunkId = `local_recovery_${++recoveryChunkSequenceRef.current}`
+    const inserted = onPolishedChunkInsertedRef.current?.({
+      chunkId,
+      contentJson: parseMarkdown(pending),
+    })
+    if (inserted) onLockChunkRef.current?.({ chunkId })
+    else onCommittedTextRef.current(pending)
     updateInterim("")
     return true
   }, [updateInterim])
@@ -498,10 +555,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     socketRef.current?.disconnect()
     socketRef.current = null
     sessionIdRef.current = null
+    resetV4State()
     setMaxDurationMs(null)
     updateInterim("")
     coordinator.deactivate(coordinatedStop)
-  }, [teardownAudio, updateInterim, coordinator, coordinatedStop])
+  }, [teardownAudio, updateInterim, coordinator, coordinatedStop, resetV4State])
 
   // Drop tracking for every polished chunk: tell the editor to drop its
   // decorations, clear our local map, and reset the toggle. Used by the
@@ -517,20 +575,26 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     sessionChunkIdRef.current = null
   }, [])
 
+  const scheduleChunkLock = useCallback(() => {
+    if (lockTimerRef.current !== null) return
+    lockTimerRef.current = setTimeout(() => {
+      lockTimerRef.current = null
+      lockAllChunks()
+    }, POST_SESSION_LOCK_MS)
+  }, [lockAllChunks])
+
   const fail = useCallback(
     (message: string) => {
       // The preview is view-only editor decoration. Commit it to the document
       // before teardown clears the decoration so a transport/provider failure
       // can never erase words the user was already looking at.
       flushInterim()
-      // Recovery chunks have no raw/polished pair to toggle. Drop editor and
-      // hook tracking while leaving every inserted character in the document.
-      lockAllChunks()
       setError(message)
       setState("error")
       teardown()
+      scheduleChunkLock()
     },
-    [flushInterim, lockAllChunks, teardown]
+    [flushInterim, teardown, scheduleChunkLock]
   )
 
   const start = useCallback(() => {
@@ -541,6 +605,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     if (isDictationExternalHeld()) return
 
     resetVoiceTakeProtocol({ acceptedRevision: acceptedRevisionRef, protocolVersion: protocolVersionRef })
+    resetV4State()
 
     // Take the single active slot, flushing+stopping any other composer's take.
     coordinator.activate(coordinatedStop)
@@ -684,10 +749,66 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
         })
         socketRef.current = socket
 
-        socket.on("voice:transcript:delta", (delta: VoiceDelta) => {
+        socket.on("voice:transcript:delta", (delta: VoiceTranscriptDelta) => {
+          if (delta.voiceSessionId !== sessionIdRef.current) return
+          if (protocolVersionRef.current >= 4 && "protocolVersion" in delta && delta.protocolVersion === 4) {
+            if (!delta.isFinal) {
+              updateInterim(delta.text)
+              return
+            }
+            const alias = chunkAliasesRef.current.get(delta.chunkId)
+            if (alias && delta.revision <= alias.throughRevision) return
+            const chunkId = resolveChunkAlias(delta.chunkId)
+            const observedRevision = latestRawRevisionByChunkRef.current.get(chunkId)
+            if (observedRevision !== undefined && delta.revision <= observedRevision) return
+            const afterChunkId = delta.afterChunkId ? resolveChunkAlias(delta.afterChunkId) : undefined
+            const inserted =
+              onPolishedChunkInsertedRef.current?.({
+                chunkId,
+                afterChunkId,
+                joinPrevious: delta.joinPrevious,
+                contentJson: delta.contentJson,
+              }) ?? false
+            if (!inserted) {
+              onCommittedTextRef.current(delta.text)
+              latestRawRevisionByChunkRef.current.set(chunkId, delta.revision)
+              unavailableV4ChunksRef.current.add(delta.chunkId)
+              unavailableV4ChunksRef.current.add(chunkId)
+              updateInterim("")
+              return
+            }
+            latestRawRevisionByChunkRef.current.set(chunkId, delta.revision)
+            if (alias) {
+              setChunks((prev) => {
+                const record = prev.get(chunkId)
+                if (!record) return prev
+                const rawContentJson = appendCanonicalContent(
+                  record.rawContentJson!,
+                  delta.contentJson,
+                  !!delta.joinPrevious
+                )
+                const polishedContentJson = appendCanonicalContent(
+                  record.polishedContentJson!,
+                  delta.contentJson,
+                  !!delta.joinPrevious
+                )
+                const next = new Map(prev)
+                next.set(chunkId, {
+                  ...record,
+                  raw: appendTranscriptText(record.raw, delta.text, !!delta.joinPrevious),
+                  polished: appendTranscriptText(record.polished, delta.text, !!delta.joinPrevious),
+                  rawContentJson,
+                  polishedContentJson,
+                })
+                return next
+              })
+            }
+            updateInterim("")
+            return
+          }
           // Ignore deltas from a session we've already moved past so a stale
           // socket can't leak text into a new take (plan §3).
-          if (delta.voiceSessionId !== sessionIdRef.current || delta.revision < acceptedRevisionRef.current) return
+          if (delta.revision < acceptedRevisionRef.current) return
           acceptedRevisionRef.current = delta.revision
           if (!delta.isFinal) {
             // Running hypothesis for the current segment — each partial replaces
@@ -707,70 +828,165 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
             // decoration is the source of truth and we read it via
             // onGetChunkText when we need the canonical expectedText.
             if (!sessionChunkIdRef.current) sessionChunkIdRef.current = delta.chunkId
-            onPolishedChunkInsertedRef.current?.({
+            const inserted = onPolishedChunkInsertedRef.current?.({
               chunkId: delta.chunkId,
               contentJson: delta.contentJson ?? parseMarkdown(delta.text),
             })
+            if (!inserted) onCommittedTextRef.current(delta.text)
           } else if (delta.text) {
             onCommittedTextRef.current(delta.text)
           }
           updateInterim("")
         })
-        socket.on("voice:transcript:polished", (chunk: VoicePolishedChunk) => {
-          // Stale chunk from a previous take — ignore it so polishing latency
-          // can't leak text into a new session.
-          if (chunk.voiceSessionId !== sessionIdRef.current || chunk.revision < acceptedRevisionRef.current) return
-          acceptedRevisionRef.current = chunk.revision
-          if (chunk.chunkId !== sessionChunkIdRef.current) return
-          // Swap the editor's session chunk to whichever mode the toggle is
-          // showing right now (the toggle can be flipped mid-session). If the
-          // editor accepts, update bookkeeping; if it rejects (the user edited
-          // inside the chunk), lock and forget — the user's edit wins.
-          //
-          // The expectedText comes from the editor itself rather than a
-          // hook-side prediction: ProseMirror's mapping is the source of
-          // truth for what's currently inside the tracked range (including
-          // any spaces the extension absorbed when extending the chunk).
-          const rawContentJson = chunk.rawContentJson ?? parseMarkdown(chunk.raw)
-          const polishedContentJson = chunk.polishedContentJson ?? parseMarkdown(chunk.polished)
-          const target = showOriginalRef.current ? rawContentJson : polishedContentJson
-          const current = onGetChunkContentRef.current?.(chunk.chunkId) ?? null
-          let accepted = current !== null
-          if (accepted && JSON.stringify(target) !== JSON.stringify(current)) {
-            accepted = onChunkSwapRef.current?.({ chunkId: chunk.chunkId, contentJson: target }) ?? false
-          }
-          setChunks((prev) => {
-            const next = new Map(prev)
-            if (!accepted) {
-              const existing = prev.get(chunk.chunkId)
-              if (existing) next.set(chunk.chunkId, { ...existing, locked: true })
-              return next
+        socket.on(
+          "voice:transcript:polished",
+          (
+            chunk: VoiceTranscriptPolished,
+            acknowledge?: (ack: { operationId: string; status: VoiceReplacementAckStatus }) => void
+          ) => {
+            if ("protocolVersion" in chunk && chunk.protocolVersion === 4) {
+              const reply = (status: VoiceReplacementAckStatus) =>
+                acknowledge?.({ operationId: chunk.operationId, status })
+              const recorded = operationStatusesRef.current.get(chunk.operationId)
+              if (recorded) {
+                reply(recorded)
+                return
+              }
+              let status: VoiceReplacementAckStatus = "stale"
+              if (chunk.voiceSessionId === sessionIdRef.current && protocolVersionRef.current >= 4) {
+                const unavailable = chunk.sources.some(
+                  (source) =>
+                    unavailableV4ChunksRef.current.has(source.chunkId) ||
+                    unavailableV4ChunksRef.current.has(resolveChunkAlias(source.chunkId))
+                )
+                if (unavailable) status = "missing"
+                const exact =
+                  !unavailable &&
+                  chunk.sources.every(
+                    (source) =>
+                      latestRawRevisionByChunkRef.current.get(resolveChunkAlias(source.chunkId)) ===
+                      source.throughRevision
+                  )
+                if (exact) {
+                  const target = showOriginalRef.current ? chunk.rawContentJson : chunk.polishedContentJson
+                  status =
+                    onChunksReplaceRef.current?.({
+                      sources: chunk.sources.map((source) => ({
+                        ...source,
+                        chunkId: resolveChunkAlias(source.chunkId),
+                      })),
+                      resultChunkId: chunk.resultChunkId,
+                      contentJson: target,
+                    }) ?? "missing"
+                  if (status === "locked" && onGetChunkContentRef.current) {
+                    const sourceIds = chunk.sources.map((source) => resolveChunkAlias(source.chunkId))
+                    setChunks((prev) => {
+                      const next = new Map(prev)
+                      for (const sourceId of sourceIds) {
+                        const record = next.get(sourceId)
+                        if (record && !onGetChunkContentRef.current?.(sourceId))
+                          next.set(sourceId, { ...record, locked: true })
+                      }
+                      return next
+                    })
+                  }
+                  if (status === "applied") {
+                    const nextRecord: DictationChunkRecord = {
+                      raw: chunk.raw,
+                      rawContentJson: chunk.rawContentJson,
+                      polished: chunk.polished,
+                      polishedContentJson: chunk.polishedContentJson,
+                      currentlyShowing: showOriginalRef.current ? "raw" : "polished",
+                      locked: false,
+                    }
+                    const sourceIds = chunk.sources.map((source) => resolveChunkAlias(source.chunkId))
+                    for (const [index, source] of chunk.sources.entries()) {
+                      const sourceId = sourceIds[index]
+                      chunkAliasesRef.current.set(source.chunkId, {
+                        resultChunkId: chunk.resultChunkId,
+                        throughRevision: source.throughRevision,
+                      })
+                      chunkAliasesRef.current.set(sourceId, {
+                        resultChunkId: chunk.resultChunkId,
+                        throughRevision: source.throughRevision,
+                      })
+                      latestRawRevisionByChunkRef.current.delete(sourceId)
+                    }
+                    latestRawRevisionByChunkRef.current.set(chunk.resultChunkId, chunk.throughRevision)
+                    setChunks((prev) => {
+                      const next = new Map(prev)
+                      for (const sourceId of sourceIds) next.delete(sourceId)
+                      next.set(chunk.resultChunkId, nextRecord)
+                      return next
+                    })
+                  }
+                }
+              }
+              operationStatusesRef.current.set(chunk.operationId, status)
+              reply(status)
+              return
             }
-            next.set(chunk.chunkId, {
-              raw: chunk.raw,
-              rawContentJson,
-              polished: chunk.polished,
-              polishedContentJson,
-              currentlyShowing: showOriginalRef.current ? "raw" : "polished",
-              locked: false,
+            const legacyChunk = chunk as Exclude<VoiceTranscriptPolished, VoiceTranscriptReplacementV4>
+            // Stale chunk from a previous take — ignore it so polishing latency
+            // can't leak text into a new session.
+            if (
+              legacyChunk.voiceSessionId !== sessionIdRef.current ||
+              legacyChunk.revision < acceptedRevisionRef.current
+            )
+              return
+            acceptedRevisionRef.current = legacyChunk.revision
+            if (legacyChunk.chunkId !== sessionChunkIdRef.current) return
+            // Swap the editor's session chunk to whichever mode the toggle is
+            // showing right now (the toggle can be flipped mid-session). If the
+            // editor accepts, update bookkeeping; if it rejects (the user edited
+            // inside the chunk), lock and forget — the user's edit wins.
+            //
+            // The expectedText comes from the editor itself rather than a
+            // hook-side prediction: ProseMirror's mapping is the source of
+            // truth for what's currently inside the tracked range (including
+            // any spaces the extension absorbed when extending the chunk).
+            const rawContentJson = legacyChunk.rawContentJson ?? parseMarkdown(legacyChunk.raw)
+            const polishedContentJson = legacyChunk.polishedContentJson ?? parseMarkdown(legacyChunk.polished)
+            const target = showOriginalRef.current ? rawContentJson : polishedContentJson
+            const current = onGetChunkContentRef.current?.(legacyChunk.chunkId) ?? null
+            let accepted = current !== null
+            if (accepted && JSON.stringify(target) !== JSON.stringify(current)) {
+              accepted = onChunkSwapRef.current?.({ chunkId: legacyChunk.chunkId, contentJson: target }) ?? false
+            }
+            setChunks((prev) => {
+              const next = new Map(prev)
+              if (!accepted) {
+                const existing = prev.get(legacyChunk.chunkId)
+                if (existing) next.set(legacyChunk.chunkId, { ...existing, locked: true })
+                return next
+              }
+              next.set(legacyChunk.chunkId, {
+                raw: legacyChunk.raw,
+                rawContentJson,
+                polished: legacyChunk.polished,
+                polishedContentJson,
+                currentlyShowing: showOriginalRef.current ? "raw" : "polished",
+                locked: false,
+              })
+              return next
             })
-            return next
-          })
-          if (!accepted) sessionChunkIdRef.current = null
-        })
+            if (!accepted) sessionChunkIdRef.current = null
+          }
+        )
         socket.on("voice:transcription:error", (e: { code?: string }) => {
           if (socketRef.current === socket) fail(friendlyTranscriptionError(e?.code))
         })
         socket.on("voice:stopped", (payload: VoiceStoppedPayload) => {
           if (socketRef.current !== socket) return
-          // A provider/relay terminal event is allowed to arrive without a
-          // final delta. Preserve the last visible hypothesis before teardown.
-          // On the normal path the final delta already cleared this, so the
-          // flush is an idempotent no-op rather than a duplicate insertion.
-          const recoveredInterim = flushInterim()
-          if (recoveredInterim || (payload.outcome !== "success" && payload.outcome !== "empty_input")) lockAllChunks()
+          // A provider/relay terminal event can arrive without a final delta.
+          // Preserve the visible hypothesis first; a normal final already
+          // cleared it, making this an idempotent no-op.
+          flushInterim()
+          if (protocolVersionRef.current < 4 && payload.outcome !== "success" && payload.outcome !== "empty_input")
+            lockAllChunks()
           teardown()
           setState("idle")
+          scheduleChunkLock()
         })
         socket.on("disconnect", () => {
           if (socketRef.current === socket && workletRef.current) fail("Dictation connection lost")
@@ -787,7 +1003,13 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
 
         socket.emit(
           "voice:start",
-          { workspaceId, voiceSessionId: session.voiceSessionId, draftBefore, draftAfter },
+          {
+            workspaceId,
+            voiceSessionId: session.voiceSessionId,
+            draftBefore,
+            draftAfter,
+            maxProtocolVersion: VOICE_PROTOCOL_VERSION,
+          },
           (result: VoiceStartAck) => {
             // The user stopped (or we tore down) while this ACK was in flight —
             // don't resurrect a dead take into the "recording" state.
@@ -854,9 +1076,10 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       // The ack callback fires on the server's confirmation or on the timeout —
       // either way we disconnect and return to idle so the UI never wedges.
       const recover = () => {
-        if (flushInterim()) lockAllChunks()
+        flushInterim()
         teardown()
         setState("idle")
+        scheduleChunkLock()
       }
       if (protocolVersionRef.current >= 2)
         socket.timeout(FORMAT_STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "format" }, recover)
@@ -864,18 +1087,11 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     } else {
       // Defensive local recovery for a take whose socket disappeared before
       // stop could be emitted. The visible preview still belongs to the user.
-      if (flushInterim()) lockAllChunks()
+      flushInterim()
       setState("idle")
+      scheduleChunkLock()
     }
-    // The take is over — start the post-session lock countdown. The user gets a
-    // grace window to flip the toggle and read what landed before the chunks
-    // freeze as plain text. A new take or another stop resets the timer.
-    if (lockTimerRef.current !== null) clearTimeout(lockTimerRef.current)
-    lockTimerRef.current = setTimeout(() => {
-      lockTimerRef.current = null
-      lockAllChunks()
-    }, POST_SESSION_LOCK_MS)
-  }, [state, teardownAudio, flushInterim, teardown, coordinator, coordinatedStop, lockAllChunks])
+  }, [state, teardownAudio, flushInterim, teardown, coordinator, coordinatedStop, scheduleChunkLock])
   // Keep the stable coordinator handle pointed at the latest stop().
   stopRef.current = stop
 
@@ -944,6 +1160,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       const socket = socketRef.current
       socketRef.current = null
       sessionIdRef.current = null
+      resetV4State()
       if (socket) {
         if (protocolVersionRef.current >= 2) {
           socket.timeout(STOP_ACK_TIMEOUT_MS).emit("voice:stop", { mode: "send_as_is" }, () => socket.disconnect())
@@ -961,7 +1178,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
       lockTimerRef.current !== null
     )
       lockAllChunks()
-  }, [state, flushInterim, teardownAudio, coordinator, coordinatedStop, lockAllChunks])
+  }, [state, flushInterim, teardownAudio, coordinator, coordinatedStop, lockAllChunks, resetV4State])
 
   const abort = useCallback(() => {
     startGenerationRef.current++
@@ -971,6 +1188,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     const sessionId = sessionIdRef.current
     socketRef.current = null
     sessionIdRef.current = null
+    resetV4State()
     if (socket) {
       if (protocolVersionRef.current >= 2) socket.emit("voice:stop", { mode: "abort" })
       socket.disconnect()
@@ -980,7 +1198,16 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
     coordinator.deactivate(coordinatedStop)
     lockAllChunks()
     setState("idle")
-  }, [teardownAudio, updateInterim, workspaceId, coordinator, coordinatedStop, dependencies, lockAllChunks])
+  }, [
+    teardownAudio,
+    updateInterim,
+    workspaceId,
+    coordinator,
+    coordinatedStop,
+    dependencies,
+    lockAllChunks,
+    resetV4State,
+  ])
 
   // Backgrounding the tab throttles the rAF meter and can suspend capture or
   // networking entirely. Preserve the visible hypothesis synchronously and end

--- a/apps/frontend/src/hooks/use-voice-dictation.ts
+++ b/apps/frontend/src/hooks/use-voice-dictation.ts
@@ -53,7 +53,7 @@ interface UseVoiceDictationOptions {
    * this session. When polish is ON, `onPolishedChunkInserted` is called
    * instead and this never fires for that chunk.
    */
-  onCommittedText: (text: string) => void
+  onCommittedText: (text: string, options?: { joinPrevious?: boolean }) => void
   /**
    * Insert a polished chunk into the editor with tracking, so a later toggle
    * can swap it back to raw. The text passed is whatever the toggle currently
@@ -254,7 +254,10 @@ function appendCanonicalContent(base: JSONContent, suffix: JSONContent, joinPrev
   if (last?.type === "paragraph" && first?.type === "paragraph") {
     const left = [...(last.content ?? [])]
     const right = [...(first.content ?? [])]
-    if (!joinPrevious && left.length && right.length) left.push({ type: "text", text: " " })
+    const endsWithWhitespace = /\s$/u.test(left.at(-1)?.text ?? "")
+    const startsWithWhitespace = /^\s/u.test(right[0]?.text ?? "")
+    if (!joinPrevious && left.length && right.length && !endsWithWhitespace && !startsWithWhitespace)
+      left.push({ type: "text", text: " " })
     before[before.length - 1] = { ...last, content: [...left, ...right] }
     after.shift()
   }
@@ -770,7 +773,7 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
                 contentJson: delta.contentJson,
               }) ?? false
             if (!inserted) {
-              onCommittedTextRef.current(delta.text)
+              onCommittedTextRef.current(delta.text, { joinPrevious: delta.joinPrevious })
               latestRawRevisionByChunkRef.current.set(chunkId, delta.revision)
               unavailableV4ChunksRef.current.add(delta.chunkId)
               unavailableV4ChunksRef.current.add(chunkId)
@@ -783,12 +786,12 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
                 const record = prev.get(chunkId)
                 if (!record) return prev
                 const rawContentJson = appendCanonicalContent(
-                  record.rawContentJson!,
+                  record.rawContentJson ?? parseMarkdown(record.raw),
                   delta.contentJson,
                   !!delta.joinPrevious
                 )
                 const polishedContentJson = appendCanonicalContent(
-                  record.polishedContentJson!,
+                  record.polishedContentJson ?? parseMarkdown(record.polished),
                   delta.contentJson,
                   !!delta.joinPrevious
                 )
@@ -879,13 +882,15 @@ export function useVoiceDictation(options: UseVoiceDictationOptions): UseVoiceDi
                       contentJson: target,
                     }) ?? "missing"
                   if (status === "locked" && onGetChunkContentRef.current) {
-                    const sourceIds = chunk.sources.map((source) => resolveChunkAlias(source.chunkId))
+                    const getChunkContent = onGetChunkContentRef.current
+                    const unavailableSourceIds = chunk.sources
+                      .map((source) => resolveChunkAlias(source.chunkId))
+                      .filter((sourceId) => !getChunkContent(sourceId))
                     setChunks((prev) => {
                       const next = new Map(prev)
-                      for (const sourceId of sourceIds) {
+                      for (const sourceId of unavailableSourceIds) {
                         const record = next.get(sourceId)
-                        if (record && !onGetChunkContentRef.current?.(sourceId))
-                          next.set(sourceId, { ...record, locked: true })
+                        if (record) next.set(sourceId, { ...record, locked: true })
                       }
                       return next
                     })


### PR DESCRIPTION
## Problem

Protocol v3 treats a dictation take as one cumulative editor range. Long takes therefore keep reformatting an ever-growing transcript, and the client cannot safely accept bounded one- or two-window replacements without risking stale edits, partial replacements, or lost raw speech during failure and teardown.

## Solution

Activate the backend's negotiated protocol v4 path in the frontend. Raw finals enter the editor immediately as independently tracked canonical chunks. Formatter operations name exact chunk IDs and revisions, replace one or two contiguous sources atomically, and receive a synchronous typed acknowledgement. Legacy v2/v3 sessions retain their existing single-chunk behavior.

Visible speech remains non-destructive: failed tracked insertion falls back synchronously to committed text, editor rejection preserves every source, and unexpected termination commits the last visible interim. Only explicit abort may discard it.

### Key design decisions

1. **Stable IDs instead of editor positions.** Socket payloads carry chunk IDs and revisions; ProseMirror positions stay private to the editor plugin and continue mapping through outside edits.
2. **Canonical editor boundary.** Both raw and polished Markdown are parsed before transport; only validated `contentJson` is inserted or swapped.
3. **Atomic, exactly-once replacement.** One operation replaces one or two exact, unique, contiguous tracked sources in one transaction and returns `applied`, `stale`, `locked`, `missing`, `non_contiguous`, or `invalid` exactly once.
4. **User edits and visible raw speech win.** An inside edit locks only that source. Raw suffixes targeting consumed aliases append once to the latest result and remain present in both original and polished toggle forms.
5. **Terminal grace starts at completion.** The eight-second post-session toggle window begins after the terminal event/recovery, not when format stop starts; the existing 12-second format-stop acknowledgement budget remains intact.

## Files changed

| File | Change |
| --- | --- |
| `apps/frontend/src/hooks/use-voice-dictation.ts` | Negotiate v4; manage per-take revisions, operation dedupe, aliases, unavailable sources, ACKs, recovery, and grace timing. |
| `apps/frontend/src/hooks/use-voice-dictation.test.ts` | Cover negotiation, lifecycle recovery, stale/duplicate operations, insertion fallback, and v4 failure paths. |
| `apps/frontend/src/components/editor/dictation-chunk-extension.ts` | Track chunk ranges and perform validated one-/two-source atomic replacements. |
| `apps/frontend/src/components/editor/dictation-chunk-extension.test.ts` | Cover structural list/paragraph fitting, spacing, mapping, locking, malformed input, collisions, and no-partial replacement. |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Expose typed chunk insertion, replacement, lookup, and locking callbacks. |
| `apps/frontend/src/components/composer/mic-button.tsx` | Connect negotiated dictation state and editor callbacks without changing the UI. |
| `apps/frontend/src/components/composer/message-composer.tsx` | Wire editor operations and preserve active interim synchronously before submit or scope teardown. |
| `apps/frontend/src/components/composer/message-composer.test.tsx` | Verify synchronous recovery ordering and hard-join fallback forwarding through the composer seam. |

## Test plan

- [x] Focused hook/editor/composer tests: 87 passed
- [x] Full frontend suite: 6,525 passed on a clean deterministic rerun
- [x] Root backend unit suite: 4,005 passed
- [x] Focused backend protocol/incremental e2e suite: 58 passed
- [x] Frontend and monorepo TypeScript checks
- [x] Frontend and monorepo lint checks
- [x] Dockerfile, migration, API-doc, and `git diff --check` gates
- [x] One bounded `/code-review` pass: 7/7, no findings
- [x] Whole-stack adversarial review completed; both accepted findings have regressions and fixes in their owning PRs
- [x] Throwaway Playwright visual pass at 1,440×900 and 390×844; screenshots inspected, temporary spec removed
- [x] All CodeRabbit threads across PR #1813 and PR #1826 explicitly dispositioned, replied to, and resolved
- [x] Refreshed GitHub CI complete

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Activate bounded incremental dictation formatting in the client while preserving canonical Markdown-to-ProseMirror conversion, legacy protocol behavior, user-edit-wins semantics, immediate send, flush-on-stop, and the invariant that visible speech is never discarded except by explicit abort.

## What Was Built

### Negotiated protocol and per-take state

The hook sends `maxProtocolVersion: 4` and branches only on the server's negotiated acknowledgement. Negotiated v1/v2/v3 sessions continue through the prior cumulative path. V4 sessions maintain separate maps for latest raw revision, operation status, consumed-source aliases, and unavailable tracked sources; all reset on start and teardown.

Raw v4 finals are inserted immediately under their server-provided chunk ID. A sealed source's exact operation may still apply after a newer chunk begins, while a changed revision of the same source returns `stale`. Duplicate operations return the recorded status without reapplying.

**Files:**
- `apps/frontend/src/hooks/use-voice-dictation.ts`
- `apps/frontend/src/hooks/use-voice-dictation.test.ts`

### Alias-safe raw continuation and toggles

After a one- or two-source operation applies, aliases map consumed sources to the latest result chunk. New raw speech naming a consumed source appends once to that result, and `afterChunkId` resolves through the same alias chain. Raw and polished strings and canonical documents both retain the suffix, so toggling cannot hide later speech.

Tracked insertion absence/failure falls back synchronously to `onCommittedText` and marks that source unavailable. Any operation touching it acknowledges `missing` rather than pretending that an editor replacement happened.

### Atomic ProseMirror operations

The editor extension resolves source IDs to mapped ranges, validates one or two unique sources in exact order, verifies expected canonical content, requires contiguity, and replaces the complete span in one transaction. Success removes source tracking and installs one result range. Missing, invalid, reversed, non-contiguous, locked, or edited sources never partially mutate document content.

The range calculation follows structural fitting for paragraphs and lists rather than predicting inserted length. Contextual outer spacing is retained, while `joinPrevious` avoids inventing whitespace for same-final hard splits.

**Files:**
- `apps/frontend/src/components/editor/dictation-chunk-extension.ts`
- `apps/frontend/src/components/editor/dictation-chunk-extension.test.ts`
- `apps/frontend/src/components/editor/rich-editor.tsx`

### Lifecycle and composer integration

The composer and mic pass synchronous insertion/replacement/lock callbacks to the hook. Send-as-is commits visible interim before the composer snapshot and invalidates late formatter work. Unexpected disconnect, provider termination, timeout, backgrounding, and navigation preserve the last visible interim exactly once. Explicit abort remains the only path that intentionally drops interim speech.

A locally recovered raw chunk is locked immediately without globally locking accepted chunks. V4 terminal failure leaves accepted chunks independently toggleable until the post-terminal eight-second grace expires.

**Files:**
- `apps/frontend/src/components/composer/message-composer.tsx`
- `apps/frontend/src/components/composer/mic-button.tsx`
- `apps/frontend/src/hooks/use-voice-dictation.ts`

## Design Decisions

### IDs and synchronous typed ACKs

**Chose:** Exact source chunk IDs/revisions and synchronous `{ operationId, status }` callbacks.

**Why:** Numeric editor positions cannot survive local mapping, and server state must reuse only output the editor actually applied.

### Canonical JSON as the editor contract

**Chose:** Store and swap parsed `contentJson`; keep Markdown only as model/wire and toggle metadata.

**Why:** This preserves the established structured-content invariant and prevents raw model Markdown from entering ProseMirror.

### Non-destructive fallback

**Chose:** Preserve existing accepted content plus visible raw continuation on every formatter, scope, socket, insertion, replacement, or ACK failure.

**Why:** A formatting enhancement must never become a transcript-loss path. Explicit abort is the sole destructive lifecycle action.

### Source-local locking

**Chose:** Lock only the chunk proven edited or locally recovered; keep unrelated chunks independently replaceable and toggleable.

**Why:** One user edit should not disable formatting or hide subsequent speech elsewhere in the take.

## Design Evolution

- **Cumulative take replacement → bounded chunks:** Production evidence showed authoritative full-take formatting timing out on a long take while smaller cumulative calls succeeded. The new client activates the backend's fixed-size windows rather than changing model or deadlines.
- **Global failure lock → local recovery lock:** The merged transcript-loss hotfix (#1820) established that visible interim must be committed before teardown. V4 retains that behavior while locking only the recovery chunk so accepted results remain independently toggleable.
- **Wire `joinPrevious` → exact backend separator metadata:** The backend prerequisite in PR #1813 now distinguishes same-STT-final pieces from ordinary window boundaries, preserving exact hard and whitespace splits through widening/collapse. The client also carries the hard-join hint through the plain committed-text fallback when tracked insertion fails.
- **Post-flush delta acceptance → explicit terminal gate:** The final stack review found that a provider final arriving after flush timeout could duplicate promoted interim while authoritative formatting ran. PR #1813 now closes delta acceptance when the flush contract settles.

## Schema Changes

None.

## What's NOT Included

- No settings or visual redesign
- No model, prompt, timeout, STT provider, or audio-pipeline change
- No persisted chunk metadata, reconnect replay, or database migration
- No correction beyond the immediate predecessor window
- No manual reformat UI or protocol-v3 removal

## Status

- [x] Protocol-v4 negotiation and legacy downgrade
- [x] Stable multi-chunk editor tracking
- [x] Atomic one-/two-source replacement and typed ACKs
- [x] Alias continuation, canonical toggles, and source-local locking
- [x] Failure/teardown raw preservation
- [x] Focused and broad deterministic local gates
- [x] PR and whole-stack external reviews complete
- [x] Refreshed GitHub CI complete

</details>

---

🤖 Generated with [Codex](https://github.com/openai/codex)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788817981&installation_model_id=20758&pr_number=1826&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1826&signature=86abed74d86c36142ffc13494accaa4d742ee5500d220cb307af33d0e6195436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


