### PR TITLE
refactor: drop the indexedMessagePatch flag

### DIFF
--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1590,9 +1590,7 @@ export class ThreaDatabase extends Dexie {
     // the index over existing rows; no row is rewritten.
     // One-way door: once a client has opened at v47, code declaring only v46
     // cannot open the database (IndexedDB refuses a version downgrade), so a
-    // revert of this bump is not available — reverting means a v48. The
-    // *lookup* that uses the index is flag-gated (`indexedMessagePatch`)
-    // instead, and that is what a rollback turns off.
+    // revert of this bump is not available — reverting means a v48.
     this.version(47).stores({
       events:
         "id, workspaceId, streamId, sequence, [streamId+sequence], [streamId+_sequenceNum], eventType, [streamId+eventType], _clientId, _cachedAt, _status, payload.messageId",

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -250,24 +250,22 @@ describe("isEventWriteChunkingEnabled", () => {
   })
 
   it("readEventWriteFlagsFresh ignores the cache and re-reads the row every call", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on", indexedMessagePatch: "on" }, user: {} })
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off", indexedMessagePatch: "off" }, user: {} })
+    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
 
     const first = await readEventWriteFlagsFresh(db, "ws_1")
-    await putMetadata({ workspace: { eventWriteChunking: "off", indexedMessagePatch: "on" }, user: {} })
+    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
     const second = await readEventWriteFlagsFresh(db, "ws_1")
 
     expect({ first, second }).toEqual({
       first: {
         chunking: true,
-        indexedMessagePatch: true,
         sharedStreamRegistration: false,
         singlePreviewWriter: false,
         coalescedLiveCommit: false,
       },
       second: {
         chunking: false,
-        indexedMessagePatch: true,
         sharedStreamRegistration: false,
         singlePreviewWriter: false,
         coalescedLiveCommit: false,

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -74,7 +74,6 @@ export function skipNoOpEventRewrites(
 // instance instead, primed from the network bootstrap and socket flag flips.
 type EventWriteFlags = {
   chunking: boolean
-  indexedMessagePatch: boolean
   sharedStreamRegistration: boolean
   singlePreviewWriter: boolean
   coalescedLiveCommit: boolean
@@ -103,7 +102,6 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
   return {
     chunking: resolved.eventWriteChunking === "on",
-    indexedMessagePatch: resolved.indexedMessagePatch === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
     singlePreviewWriter: resolved.singlePreviewWriter === "on",
     coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
@@ -167,11 +165,6 @@ export async function isEventWriteChunkingEnabled(database: ThreaDatabase, works
 export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
   const metadata = await database.workspaceMetadata.get(workspaceId)
   return resolveEventWriteFlags(metadata?.featureFlags)
-}
-
-/** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
-export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch
 }
 
 /** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -126,7 +126,7 @@ async function promoteDraft(
   // re-increment here.
   const anchorId = creation.parentAnchorId ?? creation.parentMessageId
   if (creation.type === StreamTypes.THREAD && creation.parentStreamId && anchorId) {
-    setParentThreadId(next.workspaceId, creation.parentStreamId, anchorId, realStreamId).catch(() => {})
+    setParentThreadId(creation.parentStreamId, anchorId, realStreamId).catch(() => {})
   }
 
   // Clean up draft data (no-ops gracefully for non-scratchpad drafts).

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -264,12 +264,7 @@ export function useQueueDraftMessage(workspaceId: string) {
       const anchorId = params.streamCreation?.parentAnchorId ?? params.streamCreation?.parentMessageId
       if (params.streamCreation?.type === StreamTypes.THREAD && params.streamCreation.parentStreamId && anchorId) {
         const draftPanelId = createDraftPanelId(params.streamCreation.parentStreamId, anchorId)
-        await optimisticReplyCountUpdate(
-          params.workspaceId,
-          params.streamCreation.parentStreamId,
-          anchorId,
-          draftPanelId
-        ).catch(() => {})
+        await optimisticReplyCountUpdate(params.streamCreation.parentStreamId, anchorId, draftPanelId).catch(() => {})
       }
 
       notifyQueue()

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1209,7 +1209,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: Date.now(),
     })
 
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
 
     const event = await db.events.get("evt_1")
     expect((event?.payload as Record<string, unknown>).replyCount).toBe(5)
@@ -1226,7 +1226,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: before - 10000,
     })
 
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
 
     const event = await db.events.get("evt_patched")
     expect(event?._patchedAt).toBeDefined()
@@ -1248,12 +1248,12 @@ describe("updateMessageEvent", () => {
     // concurrently. With the old read-then-update implementation the last
     // write would overwrite earlier ones and lose fields.
     await Promise.all([
-      updateMessageEvent(false, streamId, messageId, (p) => ({
+      updateMessageEvent(streamId, messageId, (p) => ({
         ...p,
         replyCount: 3,
         threadSummary: { lastReplyContentMarkdown: "hi", participantIds: ["u1"] },
       })),
-      updateMessageEvent(false, streamId, messageId, (p) => ({
+      updateMessageEvent(streamId, messageId, (p) => ({
         ...p,
         threadId: "thread_123",
       })),
@@ -1267,7 +1267,7 @@ describe("updateMessageEvent", () => {
   })
 })
 
-describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessagePatch)", () => {
+describe("updateMessageEvent — indexed payload.messageId lookup", () => {
   function seedRow(overrides: {
     id: string
     streamId: string
@@ -1370,18 +1370,12 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     await seedLargeStream(streamId, 1000, messageId)
 
     const indexed = trackCursor()
-    await updateMessageEvent(true, streamId, messageId, (p) => ({ ...p, reactions: ["👍"] }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, reactions: ["👍"] }))
     expect(indexed.indexes).toEqual(["payload.messageId"])
     expect({ filtered: indexed.filtered, visited: indexed.visited }).toEqual({ filtered: 0, visited: 1 })
-    vi.restoreAllMocks()
-
-    const scanned = trackCursor()
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, reactions: ["👍", "🎉"] }))
-    expect(scanned.indexes).toEqual(["[streamId+eventType]"])
-    expect({ filtered: scanned.filtered, visited: scanned.visited }).toEqual({ filtered: 1000, visited: 1 })
 
     const patched = await db.events.get("evt_bulk_998")
-    expect((patched?.payload as Record<string, unknown>).reactions).toEqual(["👍", "🎉"])
+    expect((patched?.payload as Record<string, unknown>).reactions).toEqual(["👍"])
   }, 20000)
 
   it("a patch for a message in another stream is not applied", async () => {
@@ -1392,7 +1386,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     ])
 
     const counts = trackCursor()
-    await updateMessageEvent(true, "stream_here", messageId, (p) => ({ ...p, replyCount: 7 }))
+    await updateMessageEvent("stream_here", messageId, (p) => ({ ...p, replyCount: 7 }))
 
     const here = await db.events.get("evt_here")
     const there = await db.events.get("evt_there")
@@ -1419,7 +1413,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     ])
 
     const counts = trackCursor()
-    await updateMessageEvent(true, "stream_typed", messageId, (p) => ({ ...p, replyCount: 9 }))
+    await updateMessageEvent("stream_typed", messageId, (p) => ({ ...p, replyCount: 9 }))
 
     const created = await db.events.get("evt_created")
     const edited = await db.events.get("evt_edited")
@@ -1439,8 +1433,8 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     )
 
     await Promise.all([
-      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, replyCount: 3 })),
-      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, threadId: "thread_1" })),
+      updateMessageEvent("stream_race", messageId, (p) => ({ ...p, replyCount: 3 })),
+      updateMessageEvent("stream_race", messageId, (p) => ({ ...p, threadId: "thread_1" })),
     ])
 
     const event = await db.events.get("evt_race_indexed")
@@ -1464,7 +1458,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       }),
     ])
 
-    await updateMessageEvent(true, "stream_sparse", "msg_sparse", (p) => ({ ...p, replyCount: 1 }))
+    await updateMessageEvent("stream_sparse", "msg_sparse", (p) => ({ ...p, replyCount: 1 }))
 
     const untouched = await db.events.get("evt_no_message_id")
     const patched = await db.events.get("evt_with_message_id")
@@ -1486,7 +1480,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       seedRow({ id: "evt_new_stream", streamId: "stream_new", sequence: "1", payload: { messageId, tag: "new" } }),
     ])
 
-    await updateMessageEvent(true, "stream_new", messageId, (p) => ({ ...p, tag: "patched" }))
+    await updateMessageEvent("stream_new", messageId, (p) => ({ ...p, tag: "patched" }))
 
     const rows = await db.events.bulkGet(["evt_old_stream", "evt_new_stream"])
     expect(rows.map((row) => (row?.payload as Record<string, unknown>).tag)).toEqual(["old", "patched"])
@@ -1510,13 +1504,13 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       }),
     ])
 
-    await updateMessageEvent(true, streamId, "msg_edit", (p) => ({ ...p, contentMarkdown: "edited", editedAt: "t" }))
-    await updateMessageEvent(true, streamId, "msg_delete", (p) => ({ ...p, deletedAt: "t" }))
-    await updateMessageEvent(true, streamId, "msg_move", (p) => ({ ...p, movedToStreamId: "stream_other" }))
-    await updateMessageEvent(true, streamId, "msg_reaction", (p) => ({ ...p, reactions: ["👍"] }))
-    await updateMessageEvent(true, streamId, "msg_preview", (p) => ({ ...p, linkPreviews: [{ url: "u" }] }))
-    await updateEventByAnchor(true, streamId, "msg_heal", (p) => ({ ...p, threadId: "thread_healed" }))
-    await updateEventByAnchor(true, streamId, "evt_card", (p) => ({ ...p, threadId: "thread_card" }))
+    await updateMessageEvent(streamId, "msg_edit", (p) => ({ ...p, contentMarkdown: "edited", editedAt: "t" }))
+    await updateMessageEvent(streamId, "msg_delete", (p) => ({ ...p, deletedAt: "t" }))
+    await updateMessageEvent(streamId, "msg_move", (p) => ({ ...p, movedToStreamId: "stream_other" }))
+    await updateMessageEvent(streamId, "msg_reaction", (p) => ({ ...p, reactions: ["👍"] }))
+    await updateMessageEvent(streamId, "msg_preview", (p) => ({ ...p, linkPreviews: [{ url: "u" }] }))
+    await updateEventByAnchor(streamId, "msg_heal", (p) => ({ ...p, threadId: "thread_healed" }))
+    await updateEventByAnchor(streamId, "evt_card", (p) => ({ ...p, threadId: "thread_card" }))
 
     const rows = await db.events.bulkGet([
       "evt_edit",

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -2,7 +2,6 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
 import {
   isEventWriteChunkingEnabled,
-  isIndexedMessagePatchEnabled,
   isSinglePreviewWriterEnabled,
   isNoOpRewrite,
   isSharedStreamRegistrationEnabledSync,
@@ -932,7 +931,6 @@ export async function updateMemoEmbedSummary(streamId: string, summary: MemoEmbe
 }
 
 export async function updateMessageEvent(
-  indexed: boolean,
   streamId: string,
   messageId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
@@ -953,30 +951,19 @@ export async function updateMessageEvent(
     event._patchedAt = now
   }
 
-  if (indexed) {
-    // The `payload.messageId` sparse index (v47) makes this a direct lookup.
-    // The stream/type guard stays inside the cursor so a message that moved
-    // streams is still not patched in its old stream — today's semantics.
-    // `false` (not a bare return) is what tells Dexie to SKIP the row: any
-    // other return value re-puts it, which would fire observability for every
-    // same-id row in another stream.
-    await db.events
-      .where("payload.messageId")
-      .equals(messageId)
-      .modify((event) => {
-        if (event.streamId !== streamId || event.eventType !== "message_created") return false
-        patch(event)
-      })
-    return
-  }
-
-  // Use compound index to narrow to message_created events for this stream,
-  // then filter by messageId in the payload (not indexed but over a small set).
+  // The `payload.messageId` sparse index (v47) makes this a direct lookup.
+  // The stream/type guard stays inside the cursor so a message that moved
+  // streams is still not patched in its old stream — today's semantics.
+  // `false` (not a bare return) is what tells Dexie to SKIP the row: any
+  // other return value re-puts it, which would fire observability for every
+  // same-id row in another stream.
   await db.events
-    .where("[streamId+eventType]")
-    .equals([streamId, "message_created"])
-    .filter((e) => (e.payload as { messageId?: string })?.messageId === messageId)
-    .modify(patch)
+    .where("payload.messageId")
+    .equals(messageId)
+    .modify((event) => {
+      if (event.streamId !== streamId || event.eventType !== "message_created") return false
+      patch(event)
+    })
 }
 
 /**
@@ -987,13 +974,12 @@ export async function updateMessageEvent(
  * for messages, event id for cards).
  */
 export async function updateEventByAnchor(
-  indexed: boolean,
   streamId: string,
   anchorId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
 ): Promise<void> {
   if (anchorId.startsWith("msg_")) {
-    await updateMessageEvent(indexed, streamId, anchorId, updater)
+    await updateMessageEvent(streamId, anchorId, updater)
     return
   }
   await db.events
@@ -1018,13 +1004,11 @@ export async function updateEventByAnchor(
  * anchor's canonical id so event-anchored (card) threads bump too.
  */
 export async function optimisticReplyCountUpdate(
-  workspaceId: string,
   parentStreamId: string,
   anchorId: string,
   threadId: string
 ): Promise<void> {
-  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
+  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
     replyCount: ((p.replyCount as number) ?? 0) + 1,
@@ -1040,14 +1024,8 @@ export async function optimisticReplyCountUpdate(
  * created, we swap the threadId to the server-assigned one so navigation
  * targets the real thread.
  */
-export async function setParentThreadId(
-  workspaceId: string,
-  parentStreamId: string,
-  anchorId: string,
-  threadId: string
-): Promise<void> {
-  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
+export async function setParentThreadId(parentStreamId: string, anchorId: string, threadId: string): Promise<void> {
+  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
   }))
@@ -1425,9 +1403,8 @@ function bindStreamSocketHandlers(
     }
 
     const now = Date.now()
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.slots], async () => {
-      await updateMessageEvent(indexed, streamId, editPayload.messageId, (p) => ({
+      await updateMessageEvent(streamId, editPayload.messageId, (p) => ({
         ...p,
         contentJson: editPayload.contentJson,
         contentMarkdown: editPayload.contentMarkdown,
@@ -1483,8 +1460,7 @@ function bindStreamSocketHandlers(
 
   const handleMessageDeleted = async (payload: MessageDeletedPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
+    await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
       deletedAt: payload.deletedAt,
     }))
@@ -1503,10 +1479,7 @@ function bindStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
-    const [chunked, indexed] = await Promise.all([
-      isEventWriteChunkingEnabled(db, workspaceId),
-      isIndexedMessagePatchEnabled(db, workspaceId),
-    ])
+    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1528,7 +1501,7 @@ function bindStreamSocketHandlers(
         // identical result. This makes `messages:moved` self-sufficient:
         // the thread card surfaces with the right count even if
         // `thread:updated` is delayed or lost.
-        await updateMessageEvent(indexed, streamId, payload.targetMessageId, (p) => ({
+        await updateMessageEvent(streamId, payload.targetMessageId, (p) => ({
           ...p,
           threadId: payload.thread.id,
           replyCount: payload.parentReplyCount,
@@ -1611,8 +1584,7 @@ function bindStreamSocketHandlers(
 
   const handleReactionAdded = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
+    await updateMessageEvent(streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       const existing = reactions[payload.emoji] || []
       if (!existing.includes(payload.userId)) {
@@ -1631,8 +1603,7 @@ function bindStreamSocketHandlers(
 
   const handleReactionRemoved = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
+    await updateMessageEvent(streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       if (reactions[payload.emoji]) {
         reactions[payload.emoji] = reactions[payload.emoji].filter((id) => id !== payload.userId)
@@ -1664,8 +1635,7 @@ function bindStreamSocketHandlers(
     const anchorId = stream.parentAnchorId
     if (!anchorId) return
 
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateEventByAnchor(indexed, streamId, anchorId, (p) => ({
+    await updateEventByAnchor(streamId, anchorId, (p) => ({
       ...p,
       threadId: stream.id,
     }))
@@ -1696,8 +1666,7 @@ function bindStreamSocketHandlers(
     // Heal only the fields the patch carries: the edit path omits replyCount
     // (summary-only refresh) so it can't overwrite a concurrent create/delete's
     // authoritative count.
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateEventByAnchor(indexed, streamId, payload.anchorId, (p) => ({
+    await updateEventByAnchor(streamId, payload.anchorId, (p) => ({
       ...p,
       ...(payload.replyCount !== undefined ? { replyCount: payload.replyCount } : {}),
       ...(payload.threadSummary !== undefined ? { threadSummary: payload.threadSummary } : {}),
@@ -1830,8 +1799,7 @@ function bindStreamSocketHandlers(
 
   const handleLinkPreviewReady = async (payload: LinkPreviewReadyPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
+    await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
       linkPreviews: preserveBakedInAppData(payload.previews, p.linkPreviews as LinkPreviewSummary[] | undefined),
     }))

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -60,7 +60,6 @@ export const FEATURE_FLAGS = {
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
-  indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.


### PR DESCRIPTION
## Problem

`indexedMessagePatch` shipped in #1745 and has been on by default since #1761. Both arms of the message patch lookup are still in the tree: the `payload.messageId` sparse index (v47) and the pre-index `[streamId+eventType]` cursor that filters the whole `message_created` range per patch. The flag is threaded through eleven call sites and two exported helpers, and two optimistic helpers carry a `workspaceId` argument whose only use is resolving it.

Kris has been running every perf flag enabled for several days with nothing misbehaving and asked for the cleanup.

## Solution

Delete the flag and the scan arm.

- `updateMessageEvent` / `updateEventByAnchor` lose the leading `indexed: boolean` and keep only the indexed lookup. The stream/type guard stays inside the cursor, so a message that moved streams is still not patched in its old one.
- `optimisticReplyCountUpdate` / `setParentThreadId` lose `workspaceId`; the two callers in `use-queue-draft-message` and `use-message-queue` drop it.
- `handleMessagesMoved` no longer needs its `Promise.all` — one flag read remains there.
- The registry key goes, so any lingering DB override row is inert at read time (INV-38).

The v47 comment kept its one-way-door note (an IndexedDB version bump cannot be reverted) but lost the sentence claiming a rollback turns the lookup off — there is nothing left to turn off.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/stream-sync.ts` | scan arm deleted, `indexed` unthreaded from 11 sites |
| `apps/frontend/src/db/event-writes.ts` | `isIndexedMessagePatchEnabled` and its flag field removed |
| `apps/frontend/src/db/database.ts` | v47 comment drops the flag-rollback claim |
| `apps/frontend/src/hooks/use-message-queue.ts`, `use-queue-draft-message.ts` | `workspaceId` argument dropped |
| `packages/types/src/feature-flags.ts` | registry key removed |
| `apps/frontend/src/sync/stream-sync.test.ts` | the two describe blocks merge onto the one surviving path |

## Test plan

- [x] `stream-sync.test.ts`, `event-writes.test.ts`, `use-queue-draft-message.test.ts`, `use-message-queue.test.ts`, `stream-sync.perf.test.ts` — 183 pass
- [x] monorepo lint + typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788854928&installation_model_id=20758&pr_number=1830&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1830&signature=ba9afe4b7a5cc68155684a72b5482d37ae9c27f2129cd0ac3bcd9580fd65d879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->