### PR TITLE
refactor: drop the eventWriteChunking flag

### DIFF
--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -3,9 +3,8 @@ import { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   EVENT_BULK_PUT_LIMIT,
-  isEventWriteChunkingEnabled,
   isSharedStreamRegistrationEnabledSync,
-  readEventWriteFlagsFresh,
+  isSinglePreviewWriterEnabled,
   primeEventWriteFlags,
   primeEventWriteFlagsIfAbsent,
   putEventsBounded,
@@ -62,27 +61,27 @@ describe("putEventsBounded", () => {
     const rows = makePage("stream_a", 50)
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, rows, true)
+    await putEventsBounded(db.events, rows)
 
     expect(bulkPut).toHaveBeenCalledTimes(2)
     expect(bulkPut.mock.calls.map((call) => (call[0] as CachedEvent[]).length)).toEqual([EVENT_BULK_PUT_LIMIT, 1])
     expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
   })
 
-  it("writes a single bulkPut when chunking is off", async () => {
+  it("a page at the limit is written as one bulkPut", async () => {
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, makePage("stream_a", 50), false)
+    await putEventsBounded(db.events, makePage("stream_a", EVENT_BULK_PUT_LIMIT))
 
     expect(bulkPut).toHaveBeenCalledTimes(1)
-    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
+    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(EVENT_BULK_PUT_LIMIT)
   })
 })
 
 describe("skipNoOpEventRewrites", () => {
   it("re-writing an identical page writes nothing", async () => {
     const rows = makePage("stream_a", 50)
-    await putEventsBounded(db.events, rows, true)
+    await putEventsBounded(db.events, rows)
 
     const existingRows = await db.events.bulkGet(rows.map((row) => row.id))
     const existingById = new Map(
@@ -91,7 +90,7 @@ describe("skipNoOpEventRewrites", () => {
     const candidates = rows.map((row) => ({ ...row, _cachedAt: 999 }))
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates), true)
+    await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates))
 
     expect(bulkPut).toHaveBeenCalledTimes(0)
     const after = await db.events.where("streamId").equals("stream_a").toArray()
@@ -154,23 +153,26 @@ describe("live-query wake set (D1)", () => {
   }
 
   it("a 50-row page does not wake a live query ranged on another stream", async () => {
-    const chunkedEmissions = await countEmissions(async () => {
-      await putEventsBounded(db.events, makePage("stream_b", 50), true)
+    const boundedEmissions = await countEmissions(async () => {
+      await putEventsBounded(db.events, makePage("stream_b", 50))
     })
-    expect(chunkedEmissions).toBe(0)
+    expect(boundedEmissions).toBe(0)
 
     await db.events.clear()
 
-    const unchunkedEmissions = await countEmissions(async () => {
-      await putEventsBounded(db.events, makePage("stream_b", 50), false)
+    // Control: the same page through a single bulkPut is what trips Dexie's
+    // FULL_RANGE marking, so a 0 above means the slicing worked, not that the
+    // subscription was deaf.
+    const singlePutEmissions = await countEmissions(async () => {
+      await db.events.bulkPut(makePage("stream_b", 50))
     })
-    expect(unchunkedEmissions).toBeGreaterThan(0)
+    expect(singlePutEmissions).toBeGreaterThan(0)
   })
 
   it("a page written inside one wrapping transaction still does not wake another stream's query", async () => {
     const emissions = await countEmissions(async () => {
       await db.transaction("rw", [db.events], async () => {
-        await putEventsBounded(db.events, makePage("stream_b", 50), true)
+        await putEventsBounded(db.events, makePage("stream_b", 50))
       })
     })
 
@@ -182,57 +184,54 @@ describe("live-query wake set (D1)", () => {
     await db.events.put(makeRow("stream_a", 0))
 
     const emissions = await countEmissions(async () => {
-      await putEventsBounded(
-        db.events,
-        [makeRow("stream_a", 0, { payload: { messageId: "evt_stream_a_0", contentMarkdown: "edited" } })],
-        true
-      )
+      await putEventsBounded(db.events, [
+        makeRow("stream_a", 0, { payload: { messageId: "evt_stream_a_0", contentMarkdown: "edited" } }),
+      ])
     })
 
     expect(emissions).toBeGreaterThan(0)
   })
 })
 
-describe("isEventWriteChunkingEnabled", () => {
+describe("the primed flag cache", () => {
   it("resolves a persisted layered row and caches it", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "on" }, user: {} })
     const get = vi.spyOn(db.workspaceMetadata, "get")
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
     expect(get).toHaveBeenCalledTimes(1)
   })
 
   it("a pre-#1455 flat row neither throws nor overrides the registry default", async () => {
     // A flat legacy row is IGNORED (coerced away), so the resolved value is the
-    // registry default — "on" since the go-live flip — never the flat row's own
-    // field, and never a crash.
-    await putMetadata({ eventWriteChunking: "off" })
+    // registry default, never the flat row's own field, and never a crash.
+    await putMetadata({ singlePreviewWriter: "on" })
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
   })
 
   it("a primed value wins without reading the row", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
     const get = vi.spyOn(db.workspaceMetadata, "get")
-    primeEventWriteFlags("ws_1", { workspace: {}, user: { eventWriteChunking: "on" } })
+    primeEventWriteFlags("ws_1", { workspace: {}, user: { singlePreviewWriter: "on" } })
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
     expect(get).not.toHaveBeenCalled()
   })
 
   it("resetEventWriteFlags clears the primed value", async () => {
-    // Primed "off" (an explicit override), then reset: with no persisted row
-    // the resolve falls back to the registry default "on" — proving the primed
-    // override was dropped, not retained.
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
+    // Primed "on" (an explicit override), then reset: with no persisted row the
+    // resolve falls back to the registry default — proving the primed override
+    // was dropped, not retained.
+    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
     resetEventWriteFlags()
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
   })
 
   it("a prime landing mid-read wins over the older persisted row", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
     let release: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
       release = resolve
@@ -241,36 +240,12 @@ describe("isEventWriteChunkingEnabled", () => {
     vi.spyOn(db.workspaceMetadata, "get").mockImplementation(((key: string) =>
       gate.then(() => real(key))) as unknown as typeof db.workspaceMetadata.get)
 
-    const inFlight = isEventWriteChunkingEnabled(db, "ws_1")
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    const inFlight = isSinglePreviewWriterEnabled(db, "ws_1")
+    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
     release()
 
     expect(await inFlight).toBe(true)
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
-  })
-
-  it("readEventWriteFlagsFresh ignores the cache and re-reads the row every call", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
-
-    const first = await readEventWriteFlagsFresh(db, "ws_1")
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
-    const second = await readEventWriteFlagsFresh(db, "ws_1")
-
-    expect({ first, second }).toEqual({
-      first: {
-        chunking: true,
-        sharedStreamRegistration: false,
-        singlePreviewWriter: false,
-        coalescedLiveCommit: false,
-      },
-      second: {
-        chunking: false,
-        sharedStreamRegistration: false,
-        singlePreviewWriter: false,
-        coalescedLiveCommit: false,
-      },
-    })
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
   })
 })
 

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -15,13 +15,13 @@ type EventTable = EntityTable<CachedEvent, "id">
 const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
 
 /**
- * Writes events in slices below Dexie's FULL_RANGE threshold when `chunked`,
- * and as today's single `bulkPut` when not. Opens no transaction of its own —
- * the caller's transaction is what makes the slices atomic.
+ * Writes events in slices below Dexie's FULL_RANGE threshold. Opens no
+ * transaction of its own — the caller's transaction is what makes the slices
+ * atomic.
  */
-export async function putEventsBounded(table: EventTable, rows: CachedEvent[], chunked: boolean): Promise<void> {
+export async function putEventsBounded(table: EventTable, rows: CachedEvent[]): Promise<void> {
   if (rows.length === 0) return
-  if (!chunked || rows.length <= EVENT_BULK_PUT_LIMIT) {
+  if (rows.length <= EVENT_BULK_PUT_LIMIT) {
     await table.bulkPut(rows)
     return
   }
@@ -73,7 +73,6 @@ export function skipNoOpEventRewrites(
 // event write costs more than the write. Resolve once per workspace per module
 // instance instead, primed from the network bootstrap and socket flag flips.
 type EventWriteFlags = {
-  chunking: boolean
   sharedStreamRegistration: boolean
   singlePreviewWriter: boolean
   coalescedLiveCommit: boolean
@@ -101,7 +100,6 @@ export function getAccountGeneration(): number {
 function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
   return {
-    chunking: resolved.eventWriteChunking === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
     singlePreviewWriter: resolved.singlePreviewWriter === "on",
     coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
@@ -144,27 +142,6 @@ async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string):
   if (primeGeneration !== generation) return flagsByWorkspace.get(workspaceId) ?? flags
   flagsByWorkspace.set(workspaceId, flags)
   return flags
-}
-
-/**
- * The viewer's `eventWriteChunking` value — the primed value when one exists,
- * otherwise resolved once from the layers persisted for a warm start. Tolerates
- * the pre-#1455 flat `featureFlags` shape rather than throwing on it.
- */
-export async function isEventWriteChunkingEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).chunking
-}
-
-/**
- * The chunking flag read straight from the persisted row, bypassing the module
- * cache. The service worker runs its own module instance that nothing primes
- * and nothing resets, so a cached value there would outlive an account switch
- * and hide a backoffice flip until the worker restarts; the per-account
- * `database` handle makes a fresh read account-correct by construction.
- */
-export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
-  const metadata = await database.workspaceMetadata.get(workspaceId)
-  return resolveEventWriteFlags(metadata?.featureFlags)
 }
 
 /** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -3,7 +3,7 @@ import { useStreamBootstrap } from "./use-streams"
 import { useStreamService } from "@/contexts"
 import { useQueryClient, useInfiniteQuery } from "@tanstack/react-query"
 import { db, sequenceToNum } from "@/db"
-import { isEventWriteChunkingEnabled, putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
+import { putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
@@ -281,7 +281,6 @@ export async function cacheToIndexedDB(
   carrier?: SlotCarrier
 ) {
   const now = Date.now()
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   await db.transaction("rw", [db.events, db.slots], async () => {
     if (events.length > 0) {
       const existingRows = await db.events.bulkGet(events.map((e) => e.id))
@@ -304,7 +303,7 @@ export async function cacheToIndexedDB(
           _patchedAt: existing._patchedAt,
         }
       })
-      await putEventsBounded(db.events, chunked ? skipNoOpEventRewrites(existingById, candidates) : candidates, chunked)
+      await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates))
     }
     // Persist the page's slot carrier alongside its events so pointers in pages
     // older than the bootstrap window hydrate from the store (Amendment A2).

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -1,6 +1,6 @@
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import type { CachedEvent, ThreaDatabase } from "../db/database"
-import { putEventsBounded, readEventWriteFlagsFresh } from "../db/event-writes"
+import { putEventsBounded } from "../db/event-writes"
 import { writeSlotCarrier } from "../stores/slot-store"
 
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
@@ -142,7 +142,6 @@ async function prefetchEventsAround(
     if (data?.events?.length > 0) {
       const now = Date.now()
       const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
-      const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
       await db.transaction("rw", [db.events, db.slots], async () => {
         await putEventsBounded(
           db.events,
@@ -151,8 +150,7 @@ async function prefetchEventsAround(
             workspaceId,
             _sequenceNum: sequenceToNum(e.sequence as string),
             _cachedAt: now,
-          })) as CachedEvent[],
-          chunked
+          })) as CachedEvent[]
         )
         // Warm the pointer slots this prefetch exists to preserve; an
         // events-around window merges (it is not an authoritative snapshot).
@@ -192,7 +190,6 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
     // sink the stream into "Other". Merge via update() so lastMessagePreview
     // and membership-derived fields (notificationLevel) from
     // applyWorkspaceBootstrap survive.
-    const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       await putEventsBounded(
         db.events,
@@ -201,8 +198,7 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
           workspaceId,
           _sequenceNum: sequenceToNum(e.sequence),
           _cachedAt: now,
-        })),
-        chunked
+        }))
       )
 
       // Warm the bootstrap's pointer slots in the same transaction; a cold

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,7 +1,6 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
 import {
-  isEventWriteChunkingEnabled,
   isSinglePreviewWriterEnabled,
   isNoOpRewrite,
   isSharedStreamRegistrationEnabledSync,
@@ -118,7 +117,7 @@ export function toCachedStreamBootstrap(
   }
 }
 
-async function resolveUnknownOptimisticAnchors(streamId: string, chunked: boolean): Promise<void> {
+async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> {
   const unresolved = (await db.events.where("_status").anyOf(["pending", "failed", "editing"]).toArray()).filter(
     (event) => event.streamId === streamId && event._anchorSequenceNum == null
   )
@@ -142,7 +141,7 @@ async function resolveUnknownOptimisticAnchors(streamId: string, chunked: boolea
       anchor ?? Math.max(0, Math.min(...persistedEvents.map((persisted) => persisted._sequenceNum)) - 1)
     return [{ ...event, _anchorSequenceNum: resolvedAnchor, _cachedAt: now }]
   })
-  await putEventsBounded(db.events, resolved, chunked)
+  await putEventsBounded(db.events, resolved)
 }
 
 export async function bumpLaterOptimisticAnchors(
@@ -287,7 +286,6 @@ async function writeBootstrapEventsAndStream(
   streamId: string,
   bootstrap: StreamBootstrap,
   now: number,
-  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<StreamReadFrontier | undefined> {
   await cleanupStaleOptimisticEvents(streamId)
@@ -447,8 +445,8 @@ async function writeBootstrapEventsAndStream(
       }
     }
 
-    await putEventsBounded(db.events, toWrite, chunked)
-    await resolveUnknownOptimisticAnchors(streamId, chunked)
+    await putEventsBounded(db.events, toWrite)
+    await resolveUnknownOptimisticAnchors(streamId)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
@@ -694,7 +692,6 @@ export async function applyStreamBootstrap(
   options?: StreamBootstrapApplyOptions
 ): Promise<void> {
   const now = Date.now()
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   let preservedReadState: StreamReadFrontier | undefined
   await db.transaction(
     "rw",
@@ -705,7 +702,6 @@ export async function applyStreamBootstrap(
         streamId,
         bootstrap,
         now,
-        chunked,
         options?.fetchStartedAt
       )
     }
@@ -747,10 +743,9 @@ export async function applyStreamBootstrapInCurrentTransaction(
   streamId: string,
   bootstrap: StreamBootstrap,
   now = Date.now(),
-  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<void> {
-  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
+  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, fetchStartedAt)
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 
@@ -1219,7 +1214,6 @@ function bindStreamSocketHandlers(
       // after the transaction commits so the backfill never runs inside it.
       let gapAfterSequence: string | null = null
 
-      const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
       // Same primed map, so this resolves without a second IDB read.
       const singlePreviewWriter = await isSinglePreviewWriterEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
@@ -1285,7 +1279,7 @@ function bindStreamSocketHandlers(
             _sequenceNum: sequenceToNum(newEvent.sequence),
             _cachedAt: now,
           })
-          await resolveUnknownOptimisticAnchors(streamId, chunked)
+          await resolveUnknownOptimisticAnchors(streamId)
 
           if (newPayload.clientMessageId) {
             if (optimistic) {
@@ -1479,7 +1473,6 @@ function bindStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1517,8 +1510,7 @@ function bindStreamSocketHandlers(
             workspaceId,
             _sequenceNum: sequenceToNum(event.sequence),
             _cachedAt: now,
-          })),
-          chunked
+          }))
         )
         // B3: the moved messages' pointer cards would skeleton in the
         // destination panel (cross-stream sources aren't in the local event
@@ -1696,7 +1688,6 @@ function bindStreamSocketHandlers(
     // Set when this event's sequence reveals missed events behind it; reported
     // after the transaction commits so the backfill never runs inside it.
     let gapAfterSequence: string | null = null
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     // Same transactional shape as handleMessageCreated: dedupe, gap-read, and
     // put must be atomic, or a concurrent append can land between the gap read
     // and this write and make the cursor lie in either direction.
@@ -1719,7 +1710,7 @@ function bindStreamSocketHandlers(
         _sequenceNum: sequenceToNum(payload.event.sequence),
         _cachedAt: now,
       })
-      await resolveUnknownOptimisticAnchors(streamId, chunked)
+      await resolveUnknownOptimisticAnchors(streamId)
       if (commandClientId && optimisticCommand) {
         await bumpLaterOptimisticAnchors(
           streamId,

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -112,7 +112,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isCoalescedLiveCommitEnabledSync, isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
+import { isCoalescedLiveCommitEnabledSync, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -3184,7 +3184,6 @@ export async function applyReconnectBootstrapBatch(
   })
 
   primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -3466,7 +3465,7 @@ export async function applyReconnectBootstrapBatch(
         // Carry the fetch window so a per-stream envelope's stale `readState`
         // never clobbers a frontier touched during the reconnect (same rule
         // the workspace map merge above applies).
-        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
+        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, fetchStartedAt)
       }
 
       if (terminalStreamIds.size > 0) {

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -59,7 +59,6 @@ export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
-  eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.


### PR DESCRIPTION
## Problem

`eventWriteChunking` has been on by default since #1761 and healthy in production. Its off arm is a single `bulkPut` of the whole page, which is exactly what trips Dexie's FULL_RANGE marking at ≥50 rows (`dexie.js:5199-5226`) and wakes every live query mounted on `db.events` app-wide. The flag was threaded as a `chunked` boolean through `putEventsBounded`, three bootstrap-apply functions, and the service-worker prefetch.

It also gated something unrelated to chunking: `cacheToIndexedDB` only skipped no-op rewrites when the flag was on.

## Solution

Bounded writes unconditionally.

- `putEventsBounded(table, rows)` — the `chunked` argument is gone. Pages at or below `EVENT_BULK_PUT_LIMIT` still go out as one `bulkPut`; larger ones slice.
- `chunked` stops being threaded through `writeBootstrapEventsAndStream`, `applyStreamBootstrapInCurrentTransaction` and `resolveUnknownOptimisticAnchors`.
- `cacheToIndexedDB` always filters no-op rewrites.
- `readEventWriteFlagsFresh` existed for the SW prefetch's chunking read only, so it goes with it (INV-38).

The primed-cache tests (prime wins over the persisted row, reset drops it, a prime landing mid-read wins, a pre-#1455 flat row is coerced not honoured) moved to a flag that still exists rather than being deleted — that machinery outlives this PR by one layer.

The live-query wake test lost its flag-off control arm; it now compares against a direct `db.events.bulkPut`, which is the same write shape and keeps the assertion falsifiable.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/event-writes.ts` | `chunked` argument, chunking flag reader and `readEventWriteFlagsFresh` removed |
| `apps/frontend/src/sync/stream-sync.ts`, `workspace-sync.ts` | `chunked` unthreaded from the bootstrap apply path |
| `apps/frontend/src/hooks/use-events.ts` | no-op rewrite skipping is unconditional |
| `apps/frontend/src/lib/sw-bootstrap-prefetch.ts` | drops its two fresh flag reads |
| `packages/types/src/feature-flags.ts` | registry key removed |

## Test plan

- [x] `event-writes.test.ts`, `use-events.test.ts`, `stream-sync.test.ts`, `workspace-sync.test.ts`, `stream-sync.perf.test.ts`, `sw-bootstrap-prefetch.test.ts` — 329 pass
- [x] monorepo lint + typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788854946&installation_model_id=20758&pr_number=1831&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1831&signature=f27b3fe89bdd19ad29c1523e86033a9835fa7c2d1b8d98ed102f1b2d977ef9b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->