### PR TITLE
refactor: drop the bootstrapDiff and boundedTimelineRead flags

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -925,7 +925,6 @@ describe("CoordinatedLoadingProvider store publication", () => {
     bootstrapBase = {
       ...makeWorkspaceBootstrap(),
       workspace: { id: WS, name: "CLP", slug: "clp", createdBy: "user_1", createdAt: now, updatedAt: now },
-      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
       users: [
         {
           id: "user_1",

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -6,7 +6,6 @@ import { db, sequenceToNum } from "@/db"
 import { putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { isTerminalBootstrapError, shouldSuppressBootstrapError } from "@/lib/query-load-state"
 import { computeTimelineHoles, holesSignature, type TimelineHole } from "@/sync/contiguity"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
@@ -454,12 +453,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   // cap for bounded initial load.
   const idbFloor = useMemo(() => getDisplayFloor(bootstrapFloor, olderFloor), [bootstrapFloor, olderFloor])
   const idbFloorNum = idbFloor !== null ? Number(idbFloor) : null
-  // The flag is resolved here — inside the providers, off the feature-flag hook
-  // layer — rather than in the store hook, so the four floorless `useStreamEvents`
-  // call sites keep their provider-free contract. `useStreamEvents` latches the
-  // value per (streamId, floor) window.
-  const boundedRead = useFeatureFlag(workspaceId, "boundedTimelineRead") === "on"
-  const idbEvents = useStreamEvents(streamId, idbFloorNum, { boundedRead })
+  const idbEvents = useStreamEvents(streamId, idbFloorNum)
 
   const idbResolved = idbEvents !== undefined
   const hasIdbEvents = idbResolved && idbEvents.length > 0

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -918,10 +918,9 @@ describe("useStreamEvents with the bounded read armed", () => {
 
     const { ranges, restore } = recordRanges()
     try {
-      const { result, rerender } = renderHook(
-        ({ floor }: { floor: number }) => useStreamEvents(STREAM, floor, { boundedRead: true }),
-        { initialProps: { floor: 200 } }
-      )
+      const { result, rerender } = renderHook(({ floor }: { floor: number }) => useStreamEvents(STREAM, floor), {
+        initialProps: { floor: 200 },
+      })
       await waitFor(() => expect(result.current?.length).toBe(101))
 
       const tailRanges = ranges.filter((args) => Array.isArray(args[1]) && (args[1] as unknown[])[1] === Dexie.maxKey)
@@ -956,7 +955,7 @@ describe("useStreamEvents with the bounded read armed", () => {
       const seen: (CachedEvent[] | undefined)[] = []
       const { result, rerender } = renderHook(
         ({ floor }: { floor: number }) => {
-          const events = useStreamEvents(STREAM, floor, { boundedRead: true })
+          const events = useStreamEvents(STREAM, floor)
           seen.push(events)
           return events
         },
@@ -1006,7 +1005,7 @@ describe("useStreamEvents with the bounded read armed", () => {
     const seen: (CachedEvent[] | undefined)[] = []
     const { result, rerender } = renderHook(
       ({ streamId }: { streamId: string }) => {
-        const events = useStreamEvents(streamId, 1, { boundedRead: true })
+        const events = useStreamEvents(streamId, 1)
         seen.push(events)
         return events
       },

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -305,17 +305,12 @@ interface TailAnchor {
  */
 export function useStreamEvents(
   streamId: string | undefined,
-  fromSequenceNum?: number | null,
-  options?: { boundedRead?: boolean }
+  fromSequenceNum?: number | null
 ): CachedEvent[] | undefined {
   const floor = fromSequenceNum ?? null
   // Floorless callers keep the single capped read: their bound is the count cap,
-  // and a tail/prefix split there would change what that cap means. The flag
-  // resolves at the caller and can arrive after the first render (cold direct
-  // link), so it is read every render rather than latched — a flip re-arms the
-  // window, which costs one extra read and cannot mis-render because both arms
-  // mount the same two hooks.
-  const bounded = options?.boundedRead === true && floor !== null
+  // and a tail/prefix split there would change what that cap means.
+  const bounded = floor !== null
 
   const [anchor, setAnchor] = useState<TailAnchor | null>(null)
   // The tail floor is latched ONCE per stream and never moves while the stream

--- a/apps/frontend/src/sync/bootstrap-diff.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.ts
@@ -94,10 +94,6 @@ export function diffRows<T extends { id: string }>(
   return { toWrite, merged, skipped }
 }
 
-export function writeAllRows<T extends { id: string }>(candidates: T[]): RowDiff<T> {
-  return { toWrite: candidates, merged: candidates, skipped: 0 }
-}
-
 export function diffSingleton<T>(
   existing: T | undefined,
   candidate: T,

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -2202,7 +2202,7 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
   })
 })
 
-describe("SyncEngine bootstrap query-cache identity (bootstrapDiff)", () => {
+describe("SyncEngine bootstrap query-cache identity", () => {
   beforeEach(async () => {
     resetRevealGate()
     resetApplyWindow()
@@ -2232,7 +2232,6 @@ describe("SyncEngine bootstrap query-cache identity (bootstrapDiff)", () => {
   function diffOnBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
     diffBase ??= {
       ...makeWorkspaceBootstrap(),
-      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
       streams: [
         {
           ...makeStreamBootstrap("stream_id_1").stream,

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -793,7 +793,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
   })
 
-  describe("bootstrapDiff", () => {
+  describe("the bootstrap row diff", () => {
     interface DiffTable {
       name: string
       toArray: () => Promise<Array<{ id: string; _cachedAt: number }>>
@@ -838,7 +838,6 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     function diffBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
       diffBase ??= makeBootstrap({
-        featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
         users: [makeWorkspaceUser()],
         streams: [
           { ...makeStream("stream_d1"), lastMessagePreview: null },
@@ -1105,16 +1104,9 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       expect(await cachedAtSnapshot()).toEqual(before)
     })
 
-    async function warmThenOlderReconnect(
-      flagOn: boolean,
-      reconnectOverrides: Partial<WorkspaceBootstrap>
-    ): Promise<void> {
-      const flags: WorkspaceBootstrap["featureFlags"] = flagOn
-        ? { workspace: { bootstrapDiff: "on" }, user: {} }
-        : { workspace: {}, user: {} }
+    async function warmThenOlderReconnect(reconnectOverrides: Partial<WorkspaceBootstrap>): Promise<void> {
       const warm = (): WorkspaceBootstrap =>
         diffBootstrap({
-          featureFlags: flags,
           streamReadState: {
             stream_d1: { lastReadEventId: "evt_9", lastReadSequence: "9", lastReadAt: "2026-01-02T00:00:00Z" },
           },
@@ -1127,7 +1119,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
       await applyReconnectBootstrapBatch(
         "ws_1",
-        diffBootstrap({ featureFlags: flags, ...reconnectOverrides }),
+        diffBootstrap({ ...reconnectOverrides }),
         new Map(),
         new Set(),
         new Set(),
@@ -1153,17 +1145,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
 
     it("a reconnect carrying an older frontier cannot regress a row the diff just confirmed", async () => {
-      await warmThenOlderReconnect(true, {
-        streamReadState: {
-          stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
-        },
-      })
-
-      expect((await db.streamReadState.get("ws_1:stream_d1"))?.lastReadSequence).toBe("9")
-    })
-
-    it("with bootstrapDiff off, an older reconnect frontier still loses to the freshly written row", async () => {
-      await warmThenOlderReconnect(false, {
+      await warmThenOlderReconnect({
         streamReadState: {
           stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
         },
@@ -1174,7 +1156,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     it("a reconnect carrying an older displayName cannot clobber a stream row the diff just confirmed", async () => {
       const base = diffBootstrap()
-      await warmThenOlderReconnect(true, {
+      await warmThenOlderReconnect({
         streams: base.streams.map((s) => (s.id === "stream_d1" ? { ...s, displayName: "Older Name" } : s)),
       })
 
@@ -1182,7 +1164,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
 
     it("a reconnect carrying an older notificationLevel cannot clobber a membership row the diff just confirmed", async () => {
-      await warmThenOlderReconnect(true, {
+      await warmThenOlderReconnect({
         streamMemberships: [
           {
             streamId: "stream_d1",
@@ -1259,21 +1241,6 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
 
       expect(getCachedWorkspaceTables("ws_1").streams).toBe(first)
-    })
-
-    it("with bootstrapDiff off, every row is rewritten", async () => {
-      // Explicit off override — the registry default is "on" since the go-live
-      // flip, so empty layers no longer select this arm.
-      const off = (): WorkspaceBootstrap =>
-        diffBootstrap({ featureFlags: { workspace: { bootstrapDiff: "off" }, user: {} } })
-      await applyWorkspaceBootstrap("ws_1", off(), Date.now() - 5000)
-      await stampCachedAt(1)
-
-      await applyWorkspaceBootstrap("ws_1", off(), Date.now())
-
-      const snapshot = await cachedAtSnapshot()
-      expect(Object.keys(snapshot).length).toBeGreaterThan(0)
-      expect(Object.entries(snapshot).filter(([, value]) => value === 1)).toEqual([])
     })
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -14,7 +14,6 @@ import {
 } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { mergeConversationByTitleRevision, mergeStreamByTitleRevision } from "@/lib/title-merge"
-import { resolveFeatureFlags } from "@threa/types"
 import {
   diffRows,
   diffSingleton,
@@ -23,7 +22,6 @@ import {
   removeRowConfirmations,
   semanticEqual,
   SERVER_STAMP_IGNORED_KEYS,
-  writeAllRows,
 } from "./bootstrap-diff"
 import { getCachedWorkspaceTables, seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import {
@@ -2543,8 +2541,6 @@ async function upsertStreamRow(stream: Stream): Promise<void> {
   })
 }
 
-const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
-
 function byId<T extends { id: string }>(rows: T[]): Map<string, T> {
   return new Map(rows.map((row) => [row.id, row]))
 }
@@ -2690,7 +2686,6 @@ export async function applyWorkspaceBootstrap(
   const now = Date.now()
   const capture = getPerfCapture()
   primeEventWriteFlags(workspaceId, bootstrap.featureFlags)
-  const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -2811,19 +2806,17 @@ export async function applyWorkspaceBootstrap(
         existingLabels,
         existingLabelAssignments,
         existingMetadata,
-      ] = diffEnabled
-        ? await Promise.all([
-            db.workspaces.get(workspaceId),
-            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
-            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
-            db.personas.where("workspaceId").equals(workspaceId).toArray(),
-            db.bots.where("workspaceId").equals(workspaceId).toArray(),
-            db.labels.where("workspaceId").equals(workspaceId).toArray(),
-            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
-            db.workspaceMetadata.get(workspaceId),
-          ])
-        : [undefined, [], [], [], [], [], [], [], undefined]
+      ] = await Promise.all([
+        db.workspaces.get(workspaceId),
+        db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+        db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+        db.personas.where("workspaceId").equals(workspaceId).toArray(),
+        db.bots.where("workspaceId").equals(workspaceId).toArray(),
+        db.labels.where("workspaceId").equals(workspaceId).toArray(),
+        db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+        db.workspaceMetadata.get(workspaceId),
+      ])
       stopPreRead()
 
       const stopDiff = capture.time("bootstrap.diff")
@@ -2846,24 +2839,16 @@ export async function applyWorkspaceBootstrap(
         ...mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now),
       ])
 
-      const workspaceDiff = diffEnabled
-        ? diffSingleton(existingWorkspace, workspaceRow)
-        : { write: true, merged: workspaceRow }
-      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
-      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, streamCandidates) : writeAllRows(streamCandidates)
-      const membershipsDiff = diffEnabled
-        ? diffRows(byId(existingMemberships), membershipRows)
-        : writeAllRows(membershipRows)
-      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
-      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
-      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
-      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
-      const labelAssignmentsDiff = diffEnabled
-        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
-        : writeAllRows(labelAssignmentRows)
-      const metadataDiff = diffEnabled
-        ? diffSingleton(existingMetadata, metadataRow)
-        : { write: true, merged: metadataRow }
+      const workspaceDiff = diffSingleton(existingWorkspace, workspaceRow)
+      const usersDiff = diffRows(byId(existingUsers), userRows)
+      const streamsDiff = diffRows(existingByStreamId, streamCandidates)
+      const membershipsDiff = diffRows(byId(existingMemberships), membershipRows)
+      const dmPeersDiff = diffRows(byId(existingDmPeers), dmPeerRows)
+      const personasDiff = diffRows(byId(existingPersonas), personaRows)
+      const botsDiff = diffRows(byId(existingBots), botRows)
+      const labelsDiff = diffRows(byId(existingLabels), labelRows)
+      const labelAssignmentsDiff = diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+      const metadataDiff = diffSingleton(existingMetadata, metadataRow)
       stopDiff()
 
       mergedWorkspace = workspaceDiff.merged
@@ -2931,7 +2916,7 @@ export async function applyWorkspaceBootstrap(
       const existingUnread = await db.unreadState.get(workspaceId)
       effectiveUnread = mergeBootstrapUnreadFields(bootstrap, existingUnread, fetchStartedAt)
       const unreadRow = { id: workspaceId, workspaceId, ...effectiveUnread, _cachedAt: now }
-      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
+      const unreadDiff = diffSingleton(existingUnread, unreadRow)
       if (unreadDiff.write) {
         rowsWritten += 1
         await db.unreadState.put(unreadRow)
@@ -2978,9 +2963,7 @@ export async function applyWorkspaceBootstrap(
             _cachedAt: now,
           })
         }
-        const readStateDiff = diffEnabled
-          ? diffRows(new Map(existingRows.map((row) => [row.id, row])), serverRows)
-          : writeAllRows(serverRows)
+        const readStateDiff = diffRows(new Map(existingRows.map((row) => [row.id, row])), serverRows)
         if (readStateDiff.toWrite.length > 0) {
           await db.streamReadState.bulkPut(readStateDiff.toWrite)
         }
@@ -2999,7 +2982,7 @@ export async function applyWorkspaceBootstrap(
           workspaceId,
           _cachedAt: now,
         }
-        if (diffEnabled && existingPrefs && semanticEqual(existingPrefs, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
+        if (existingPrefs && semanticEqual(existingPrefs, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
           rowsSkipped += 1
         } else {
           rowsWritten += 1
@@ -3015,7 +2998,7 @@ export async function applyWorkspaceBootstrap(
           config: bootstrap.sidebarConfig,
           _cachedAt: now,
         }
-        if (diffEnabled && existingSidebar && semanticEqual(existingSidebar, sidebarRow)) {
+        if (existingSidebar && semanticEqual(existingSidebar, sidebarRow)) {
           rowsSkipped += 1
         } else {
           rowsWritten += 1
@@ -3184,7 +3167,6 @@ export async function applyReconnectBootstrapBatch(
   })
 
   primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
-  const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 
@@ -3311,51 +3293,39 @@ export async function applyReconnectBootstrapBatch(
         existingLabelAssignments,
         existingUnread,
         existingMetadata,
-      ] = diffEnabled
-        ? await Promise.all([
-            db.workspaces.get(workspaceId),
-            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
-            db.streams.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
-            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
-            db.personas.where("workspaceId").equals(workspaceId).toArray(),
-            db.bots.where("workspaceId").equals(workspaceId).toArray(),
-            db.labels.where("workspaceId").equals(workspaceId).toArray(),
-            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
-            db.unreadState.get(workspaceId),
-            db.workspaceMetadata.get(workspaceId),
-          ])
-        : [undefined, [], [], [], [], [], [], [], [], [], undefined, undefined]
+      ] = await Promise.all([
+        db.workspaces.get(workspaceId),
+        db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+        db.streams.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
+        db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+        db.personas.where("workspaceId").equals(workspaceId).toArray(),
+        db.bots.where("workspaceId").equals(workspaceId).toArray(),
+        db.labels.where("workspaceId").equals(workspaceId).toArray(),
+        db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+        db.unreadState.get(workspaceId),
+        db.workspaceMetadata.get(workspaceId),
+      ])
 
       const stopDiff = capture.time("bootstrap.diff")
-      const workspaceDiff = diffEnabled
-        ? diffSingleton(existingWorkspace, workspaceRow)
-        : { write: true, merged: workspaceRow }
-      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
+      const workspaceDiff = diffSingleton(existingWorkspace, workspaceRow)
+      const usersDiff = diffRows(byId(existingUsers), userRows)
       const existingByStreamId = byId(existingStreams)
       const mergedStreamRows = streamRows.map((incoming) => {
         const existing = existingByStreamId.get(incoming.id)
         return existing ? mergeStreamByTitleRevision(existing, incoming) : incoming
       })
-      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, mergedStreamRows) : writeAllRows(mergedStreamRows)
-      const membershipsDiff = diffEnabled
-        ? diffRows(byId(existingMemberships), membershipRows)
-        : writeAllRows(membershipRows)
-      const readStatesDiff = diffEnabled
-        ? diffRows(byId(existingReadStates), readStateRows)
-        : writeAllRows(readStateRows)
-      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
-      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
-      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
-      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
-      const labelAssignmentsDiff = diffEnabled
-        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
-        : writeAllRows(labelAssignmentRows)
-      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
-      const metadataDiff = diffEnabled
-        ? diffSingleton(existingMetadata, metadataRow)
-        : { write: true, merged: metadataRow }
+      const streamsDiff = diffRows(existingByStreamId, mergedStreamRows)
+      const membershipsDiff = diffRows(byId(existingMemberships), membershipRows)
+      const readStatesDiff = diffRows(byId(existingReadStates), readStateRows)
+      const dmPeersDiff = diffRows(byId(existingDmPeers), dmPeerRows)
+      const personasDiff = diffRows(byId(existingPersonas), personaRows)
+      const botsDiff = diffRows(byId(existingBots), botRows)
+      const labelsDiff = diffRows(byId(existingLabels), labelRows)
+      const labelAssignmentsDiff = diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+      const unreadDiff = diffSingleton(existingUnread, unreadRow)
+      const metadataDiff = diffSingleton(existingMetadata, metadataRow)
       stopDiff()
 
       mergedWorkspace = workspaceDiff.merged
@@ -3431,11 +3401,7 @@ export async function applyReconnectBootstrapBatch(
           workspaceId,
           _cachedAt: now,
         }
-        if (
-          !diffEnabled ||
-          !existingUserPreferences ||
-          !semanticEqual(existingUserPreferences, prefsRow, SERVER_STAMP_IGNORED_KEYS)
-        ) {
+        if (!existingUserPreferences || !semanticEqual(existingUserPreferences, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
           rowsWritten += 1
           await db.userPreferences.put(prefsRow)
         } else {
@@ -3451,7 +3417,7 @@ export async function applyReconnectBootstrapBatch(
           config: finalBootstrap.sidebarConfig,
           _cachedAt: now,
         }
-        if (!diffEnabled || !existingSidebarConfig || !semanticEqual(existingSidebarConfig, sidebarRow)) {
+        if (!existingSidebarConfig || !semanticEqual(existingSidebarConfig, sidebarRow)) {
           rowsWritten += 1
           await db.sidebarConfigs.put(sidebarRow)
         } else {
@@ -3599,7 +3565,7 @@ export async function applyReconnectBootstrapBatch(
 }
 
 // Every keep-set below derives from the BOOTSTRAP PAYLOAD, never from the set of
-// rows the apply actually wrote. Under `bootstrapDiff` a row present in the
+// rows the apply actually wrote: a row present in the
 // payload can be skipped and keep an old `_cachedAt` — narrowing these sets to
 // "the ids we wrote" would sweep exactly those rows. Presence in the payload is
 // the protection; `_cachedAt >= now` only shields rows the payload never

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -101,13 +101,12 @@ stream page, twenty-four or more on the board — so a sample cannot be attribut
 to one timeline. Disambiguating would mean a per-caller mark name and the
 registry is closed on purpose (D15), so read them as a page total.
 
-They are also not like-for-like across arms: with `boundedTimelineRead` on, only
-the prefix read emits `liveQuery.rerun`/`liveQuery.load`, so an on-vs-off
-comparison is prefix-only after against whole-read before. That is the intended
-reading of the win (the tail is what the arriving message wakes), but it is not a
-measurement of the same population. `timeline.tailLoad` is emitted by the bounded
-tail read alone: it exists in the on arm only, so its presence is what proves the
-flag armed, and its duration is the cost of the read a live arrival triggers.
+They also cover only part of a floored read: the window is split into an
+immutable tail and a widening prefix, and only the prefix emits
+`liveQuery.rerun`/`liveQuery.load`. `timeline.tailLoad` is the tail read's own
+mark — its duration is the cost of the read a live arrival triggers. Any
+comparison against a capture taken before the split (pre-#1745) is prefix-only
+after against whole-read before, not the same population.
 
 ### Reading `stream.idbTransaction` / `stream.activityApply` (scenarios 4, 15)
 
@@ -143,20 +142,17 @@ total work halves. Compare sample counts × mean, not means.
 
 `workspace-wide` is the only profile that crosses Dexie's 50-row threshold in
 `streams` and `streamMemberships`, which is the amplifier the bootstrap diff
-removes. Run it as an A/B on one device, same fixture and same workspace in both
-arms — `bootstrapDiff` defaults to `off`, so the arms are a flag flip, not a
-build swap:
+removes. The diff is now unconditional, so this is a single-arm reading — load,
+hard-refresh, hard-refresh again, then idle, and read `bootstrap.preRead`,
+`bootstrap.diff` and the written/skipped row counts on the third load:
 
 ```bash
-# BEFORE — flag off (the default). Load, hard-refresh, hard-refresh again, then idle.
 open 'http://localhost:4004/w/<workspaceId>?perfCapture=1'
 #    devtools console, on the third load: copy(JSON.stringify(__threaPerfCapture.export()))
-
-# AFTER — open the backoffice the stack recipe already boots on :4006, pick the
-# workspace, Feature flags → bootstrapDiff = on (it propagates live), then repeat
-# the three loads above unchanged. Set it back to off before re-running BEFORE.
-open 'http://localhost:4006'
 ```
+
+A before/after against the pre-diff behaviour needs a build swap (the flag that
+used to provide it was deleted once the rollout finished).
 
 What to read — the _third_ load's samples. Load 2 still writes: the first load's
 read watermark and `counterTouchedAt` settle against the previous fetch window,

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,8 +54,6 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
-  bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
-  boundedTimelineRead: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),


### PR DESCRIPTION
## Problem

Two more flags from #1745, both on by default since #1761 and healthy in production.

`bootstrapDiff` gated ~20 ternaries across the two bootstrap applies: with it off, the pre-read `Promise.all` is skipped entirely and every table takes `writeAllRows` — every row rewritten on every apply, which is the amplifier the diff exists to remove.

`boundedTimelineRead` gated the tail/prefix split in `useStreamEvents`, plumbed from `use-events` as an options bag because the flag had to resolve inside the providers.

## Solution

- `applyWorkspaceBootstrap` and `applyReconnectBootstrapBatch` always pre-read and diff. `writeAllRows` loses its last caller and is deleted from `bootstrap-diff.ts`.
- `useStreamEvents` derives `bounded` from having a floor, so the `options?: { boundedRead?: boolean }` parameter and its plumbing disappear. Floorless callers still take the single capped read — their bound is the count cap, and splitting there would change what that cap means.
- `docs/perf/reproduction-matrix.md`: scenario 13 and the `liveQuery.rerun` note lose their flag-flip A/B recipes. Scenario 13 is a single-arm reading now; a before/after against the pre-diff behaviour needs a build swap, and the doc says so rather than implying the flag is still there.

Two `workspace-sync` tests pinned the deleted arm — "with bootstrapDiff off, every row is rewritten" is gone, and the reconnect-frontier pair collapses to the one case (both arms asserted the same outcome, only the flag differed).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/workspace-sync.ts` | diff is unconditional; both `diffEnabled` locals removed |
| `apps/frontend/src/sync/bootstrap-diff.ts` | `writeAllRows` deleted |
| `apps/frontend/src/stores/stream-store.ts` | `bounded` derives from the floor |
| `apps/frontend/src/hooks/use-events.ts` | options bag and flag read dropped |
| `packages/types/src/feature-flags.ts` | two registry keys removed |
| `docs/perf/reproduction-matrix.md` | flag-flip recipes replaced |

## Test plan

- [x] `workspace-sync.test.ts`, `stream-store.test.ts`, `use-events.test.ts`, `sync-engine.test.ts`, `coordinated-loading-context.test.tsx`, `workspace-table-registry.test.tsx` — 310 pass
- [x] monorepo lint + typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788854963&installation_model_id=20758&pr_number=1832&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1832&signature=ed6e88a8bed623537071b27d6c977c842226ea03d87b5b294c4a7777a809352d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->