### PR TITLE
refactor: drop the sharedWorkspaceReads flag and the private read mode

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
 import * as useMobileModule from "@/hooks/use-mobile"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
 import {
@@ -143,6 +144,7 @@ function enterConnectedCall(roster: CallRosterParticipant[]) {
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   localStorage.clear()
   __resetCallPrefsForTests()
   // Default resolves to the floating square now; pin the sidebar dock so the dock-

--- a/apps/frontend/src/components/call/call-start-menu.test.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.test.tsx
@@ -5,6 +5,7 @@ import * as authModule from "@/auth"
 import { clearCallState, setCallSession, setCallPhase } from "@/stores/call-store"
 import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls-store"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import type { CallController } from "@/calls/call-manager"
 import { CallStartMenu } from "./call-start-menu"
 import { CallManagerProvider } from "./call-manager-context"
@@ -40,6 +41,7 @@ beforeEach(() => {
   clearCallState()
   __resetActiveCallsStore()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   // The menu reads viewer identity to tell "join" from "take over".
   vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
 })

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent } from "@testing-library/react"
 import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import {
   clearCallState,
   setCallSession,
@@ -145,6 +146,7 @@ const TWO_PEERS: CallRosterParticipant[] = [
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   localStorage.clear()
   __resetCallPrefsForTests()
   seedUsers()

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -21,10 +21,8 @@ import { useStreamFromStore } from "@/stores/stream-store"
 import { resetActorLookups } from "@/stores/actor-lookup"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
 } from "@/stores/workspace-table-registry"
 import { EditLastMessageContext } from "./edit-last-message-context"
@@ -680,7 +678,6 @@ describe("row-tree read fan-out", () => {
     // The real lookup, not the suite's stub: this test is about what the row
     // tree reads from IDB.
     vi.spyOn(hooksModule, "useActors").mockRestore()
-    setWorkspaceReadMode("shared")
     const where = vi.spyOn(workspaceUsersTable(), "where")
 
     render(
@@ -694,24 +691,6 @@ describe("row-tree read fan-out", () => {
     await screen.findAllByText("row 0")
 
     expect(where).toHaveBeenCalledTimes(1)
-  })
-
-  it("fifty rows open one users read per consumer when sharing is off", async () => {
-    vi.spyOn(hooksModule, "useActors").mockRestore()
-    setWorkspaceReadMode("off")
-    const where = vi.spyOn(workspaceUsersTable(), "where")
-
-    render(
-      <>
-        {rowEvents.map((event) => (
-          <MessageEvent key={event.id} event={event} workspaceId={workspaceId} streamId={streamId} />
-        ))}
-      </>,
-      { wrapper: Wrapper }
-    )
-    await screen.findAllByText("row 0")
-
-    expect(where.mock.calls.length).toBeGreaterThan(50)
   })
 
   // Runs under the suite's stubbed `useActors`, so it covers the pre-existing
@@ -762,9 +741,8 @@ describe("MessageEvent stream-row reads", () => {
   const rootStreamId = "stream_root"
 
   async function primeStreamRegistry(): Promise<() => void> {
-    const token = allocateWorkspaceTableToken()
-    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
-    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams")).toBeDefined())
     return unsubscribe
   }
 
@@ -795,7 +773,6 @@ describe("MessageEvent stream-row reads", () => {
     await clearWorkspaceActorTables()
     await seedWorkspaceUser(workspaceId, "member_123")
     await clearStreams()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act, waitFor } from "@testing-library/react"
 import { StreamTypes, type StreamType } from "@threa/types"
 import { db, type CachedStream } from "@/db"
 import { resetWorkspaceStoreCache, seedWorkspaceCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
 import { useSealedNamePendingResolver, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
@@ -113,6 +114,7 @@ async function seedSealedStream() {
 
 beforeEach(async () => {
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   clearStreamNameCache()
   await db.streams.clear()
   vi.spyOn(workspaces, "useWorkspaceUserId").mockReturnValue("user_1")

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -62,8 +62,6 @@ import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { isServerStreamId } from "@/lib/stream-ids"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
-import { setWorkspaceReadMode } from "@/stores/workspace-table-registry"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { SyncEngine, SyncEngineContext, isSyncEngineCurrent } from "@/sync/sync-engine"
 import { draftsApi, messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
@@ -343,21 +341,6 @@ function MessageQueueHandler() {
   return null
 }
 
-/**
- * Pushes the `sharedWorkspaceReads` flag into the workspace-table registry. The
- * flag flips sharing only — the hook shape is identical in both arms — so it can
- * arrive late or change mid-session without changing a single hook count (D5).
- */
-function WorkspaceReadModeSync({ workspaceId }: { workspaceId: string }) {
-  const shared = useFeatureFlag(workspaceId, "sharedWorkspaceReads") === "on"
-
-  useEffect(() => {
-    setWorkspaceReadMode(shared ? "shared" : "off")
-  }, [shared])
-
-  return null
-}
-
 function StreamNameDecryptor({ workspaceId }: { workspaceId: string }) {
   useDecryptStreamNames(workspaceId)
   return null
@@ -497,7 +480,6 @@ export function WorkspaceLayout() {
             <AppUpdateChecker />
             <FreshnessWatchers />
             <MessageQueueHandler />
-            <WorkspaceReadModeSync workspaceId={workspaceId} />
             <StreamNameDecryptor workspaceId={workspaceId} />
             <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={coordinatedStreamIds}>
               <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>

--- a/apps/frontend/src/stores/actor-lookup.test.tsx
+++ b/apps/frontend/src/stores/actor-lookup.test.tsx
@@ -6,7 +6,7 @@ import * as perfCapture from "@/lib/perf/capture"
 import { useActors } from "@/hooks/use-actors"
 import { useWorkspaceStreams, resetWorkspaceStoreCache, upsertWorkspacePersonaCache } from "./workspace-store"
 import { resetActorLookups } from "./actor-lookup"
-import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
+import { resetWorkspaceTableRegistry } from "./workspace-table-registry"
 
 const WORKSPACE = "ws_1"
 
@@ -103,7 +103,6 @@ describe("actor lookup", () => {
     await db.bots.clear()
     await db.workspaceMetadata.clear()
     await db.streams.clear()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {
@@ -175,8 +174,7 @@ describe("actor lookup", () => {
     await waitFor(() => expect(result.current.getActorName("persona_1", "persona")).toBe("Ariadne"))
   })
 
-  it("each consumer keeps its own lookup identity across a re-render when sharing is off", async () => {
-    setWorkspaceReadMode("off")
+  it("a consumer keeps its lookup identity across a re-render", async () => {
     await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
     await db.workspaceMetadata.put(makeMetadata())
     const seen: Array<[unknown, unknown]> = []
@@ -198,7 +196,6 @@ describe("actor lookup", () => {
   })
 
   it("the lookup build count is bounded by the consumer count and does not grow on re-render", async () => {
-    setWorkspaceReadMode("off")
     await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
     await db.workspaceMetadata.put(makeMetadata())
     const time = vi.fn((_name: string) => () => {})
@@ -219,12 +216,11 @@ describe("actor lookup", () => {
     rerender(<TwoConsumers tick={2} seen={seen} />)
     await findByText("Ada-Ada-2")
 
-    // One sample per emoji-index build (the only producer): two consumers each
-    // build their own while the rows resolve — a per-consumer constant, not a
-    // per-render one.
+    // One sample per emoji-index build (the only producer): both consumers read
+    // the one shared entry, so the index is built once while the rows resolve —
+    // a constant, not a per-render or per-consumer cost.
     expect({ settled, grew: builds() - settled }).toEqual({ settled, grew: 0 })
-    // One emoji-index build per consumer, and nothing else samples this timer.
-    expect(settled).toBe(2)
+    expect(settled).toBe(1)
   })
 
   it("an unknown actor id falls back exactly as before", async () => {

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import Dexie, { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { computeTimelineHoles } from "@/sync/contiguity"
@@ -17,10 +17,8 @@ import {
   useStreamFromStore,
 } from "./stream-store"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
 } from "./workspace-table-registry"
 import { makeCachedStream } from "@/test/workspace-rows"
@@ -452,9 +450,8 @@ describe("useStreamFromStore", () => {
 
   /** Bring up the shared registry entry the fast path reads, and wait for its first emission. */
   async function primeRegistry(workspaceId: string): Promise<() => void> {
-    const token = allocateWorkspaceTableToken()
-    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
-    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams")).toBeDefined())
     return unsubscribe
   }
 
@@ -479,7 +476,6 @@ describe("useStreamFromStore", () => {
   beforeEach(async () => {
     resetWorkspaceTableRegistry()
     await db.streams.clear()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {
@@ -579,38 +575,6 @@ describe("useStreamFromStore", () => {
       expect(typeof value).toBe("object")
       expect((value as CachedStream).id).toBe("stream_a")
     }
-  })
-
-  it("an on→off flip holds the resolved row and opens no whole-table read per reader", async () => {
-    await db.streams.put(makeStream("stream_a", REGISTRY_WORKSPACE, { displayName: "Held Channel" }))
-    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
-
-    const observed: (CachedStream | undefined)[] = []
-    const readers = [0, 1, 2].map(() =>
-      renderHook(() => {
-        const row = useStreamFromStore("stream_a")
-        observed.push(row)
-        return row
-      })
-    )
-    for (const reader of readers) await waitFor(() => expect(reader.result.current?.id).toBe("stream_a"))
-    const held = readers.map((reader) => reader.result.current)
-
-    const where = vi.spyOn(db.streams, "where")
-    await act(async () => {
-      setWorkspaceReadMode("off")
-    })
-
-    readers.forEach((reader, index) => expect(reader.result.current).toBe(held[index]))
-    for (const reader of readers) {
-      await waitFor(() => expect(reader.result.current?.displayName).toBe("Held Channel"))
-    }
-    expect(observed).not.toContain(undefined)
-    // The flip must not migrate the readers' row registrations into private
-    // entries: that opens one whole-table streams query PER READER — the cost the
-    // kill switch exists to remove. The one expected call is the table
-    // subscriber's own re-key.
-    expect(where.mock.calls.length).toBe(1)
   })
 })
 

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
 import {
-  allocateWorkspaceTableToken,
   findSharedRowWorkspace,
   getWorkspaceTableRow,
   hasResolvedSharedEntry,
@@ -452,37 +451,30 @@ type StreamRowFallback = CachedStream | typeof REGISTRY_OWNED_ROW | undefined
  * ran ~4× the rendered window on every write before.
  *
  * Fallback (D7, fail-open): an id no shared entry holds — a socket write that
- * landed before bootstrap, or the `sharedWorkspaceReads=off` arm, where entries
- * are private to a token this hook does not have and the fast path therefore
- * misses by design — resolves through today's per-key `db.streams.get`. Both
- * paths mount the same hooks unconditionally; only the work inside them differs.
+ * landed before bootstrap — resolves through today's per-key `db.streams.get`.
+ * Both paths mount the same hooks unconditionally; only the work inside them
+ * differs.
  *
  * `undefined` means "genuinely not resolved anywhere". `resolveDecryptContext`
  * reads that as "hold, never attempt", and a decrypt attempted against an
  * unhydrated row caches its failure forever — so a value already resolved on
- * either path is held across a registry flip rather than flickering to
+ * either path is held across an ownership change rather than flickering to
  * `undefined`.
  */
 export function useStreamFromStore(streamId: string | undefined): CachedStream | undefined {
-  const tokenRef = useRef<number | null>(null)
-  tokenRef.current ??= allocateWorkspaceTableToken()
-  const token = tokenRef.current
-
   const registryWorkspaceId = streamId ? findSharedRowWorkspace("streams", streamId) : undefined
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (!streamId || !registryWorkspaceId) return () => {}
-      return subscribeWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token, onStoreChange)
+      return subscribeWorkspaceTableRow(registryWorkspaceId, "streams", streamId, onStoreChange)
     },
-    [streamId, registryWorkspaceId, token]
+    [streamId, registryWorkspaceId]
   )
   const readRegistryRow = useCallback(
     () =>
-      streamId && registryWorkspaceId
-        ? getWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token)
-        : undefined,
-    [streamId, registryWorkspaceId, token]
+      streamId && registryWorkspaceId ? getWorkspaceTableRow(registryWorkspaceId, "streams", streamId) : undefined,
+    [streamId, registryWorkspaceId]
   )
   const registryRow = useSyncExternalStore(subscribe, readRegistryRow, readRegistryRow)
 

--- a/apps/frontend/src/stores/workspace-store.test.tsx
+++ b/apps/frontend/src/stores/workspace-store.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act, render, waitFor } from "@testing-library/react"
 import { LabelableResourceTypes } from "@threa/types"
 import { db, type CachedLabelAssignment, type CachedStream, type CachedWorkspaceUser } from "@/db"
 import * as streamNameCache from "@/lib/crypto/stream-name-cache"
-import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
+import { resetWorkspaceTableRegistry } from "./workspace-table-registry"
 import {
   resetWorkspaceStoreCache,
   seedWorkspaceCache,
@@ -240,7 +240,6 @@ describe("workspace store cache subscriptions", () => {
     // Same contract as the case above, re-asserted through the shared registry:
     // an emptied IDB must win over the bootstrap cache, or a socket unassign is
     // masked until the next bootstrap.
-    setWorkspaceReadMode("shared")
     await db.labelAssignments.clear()
     const assignment: CachedLabelAssignment = {
       id: "workspace_1:stream:stream_9:label_9:user_1",
@@ -284,7 +283,6 @@ describe("workspace store cache subscriptions", () => {
   })
 
   it("the decrypted-name overlay is applied once per workspace, not once per consumer", async () => {
-    setWorkspaceReadMode("shared")
     await db.streams.clear()
     const stream: CachedStream = {
       id: "stream_overlay",

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -1,7 +1,6 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { useBatchedValue } from "./apply-window"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   subscribeWorkspaceTable,
   type WorkspaceTableKey,
@@ -350,25 +349,17 @@ export function upsertWorkspaceUserInCache(workspaceId: string, user: CachedWork
 // on the returned reference) for the whole pre-resolution window.
 const EMPTY_ROWS: never[] = []
 
-function useWorkspaceTableToken(): number {
-  const token = useRef<number | null>(null)
-  if (token.current === null) token.current = allocateWorkspaceTableToken()
-  return token.current
-}
-
 function useWorkspaceTable<K extends WorkspaceTableKey>(
   workspaceId: string | undefined,
   tableKey: K
 ): WorkspaceTableRowTypes[K][] | undefined {
-  const token = useWorkspaceTableToken()
   const subscribe = useCallback(
-    (listener: () => void) =>
-      workspaceId ? subscribeWorkspaceTable(workspaceId, tableKey, token, listener) : () => {},
-    [workspaceId, tableKey, token]
+    (listener: () => void) => (workspaceId ? subscribeWorkspaceTable(workspaceId, tableKey, listener) : () => {}),
+    [workspaceId, tableKey]
   )
   const getSnapshot = useCallback(
-    () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey, token) : undefined),
-    [workspaceId, tableKey, token]
+    () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey) : undefined),
+    [workspaceId, tableKey]
   )
   const live = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
   useWorkspaceCacheSignal(workspaceId, live === undefined)

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -1,16 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render, renderHook, waitFor } from "@testing-library/react"
-import { useState, useSyncExternalStore } from "react"
+import { useSyncExternalStore } from "react"
 import { db, type CachedWorkspaceUser } from "@/db"
 import * as perfCapture from "@/lib/perf/capture"
 import { resetWorkspaceStoreCache, useWorkspaceUsers } from "./workspace-store"
 import {
   activeWorkspaceSubscriptionCount,
-  allocateWorkspaceTableToken,
   getWorkspaceTableRow,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
   subscribeWorkspaceTableRow,
 } from "./workspace-table-registry"
@@ -55,11 +53,11 @@ function ManyConsumers({ count }: { count: number }) {
   return <div data-testid="rows">{rows[0].length}</div>
 }
 
-function useRegistryRows(workspaceId: string, token: number): CachedWorkspaceUser[] | undefined {
+function useRegistryRows(workspaceId: string): CachedWorkspaceUser[] | undefined {
   return useSyncExternalStore(
-    (listener) => subscribeWorkspaceTable(workspaceId, "users", token, listener),
-    () => getWorkspaceTableSnapshot(workspaceId, "users", token),
-    () => getWorkspaceTableSnapshot(workspaceId, "users", token)
+    (listener) => subscribeWorkspaceTable(workspaceId, "users", listener),
+    () => getWorkspaceTableSnapshot(workspaceId, "users"),
+    () => getWorkspaceTableSnapshot(workspaceId, "users")
   )
 }
 
@@ -77,7 +75,6 @@ describe("workspace table registry", () => {
 
   it("twenty consumers of useWorkspaceUsers open one IDB read", async () => {
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    setWorkspaceReadMode("shared")
     const where = vi.spyOn(db.workspaceUsers, "where")
 
     const { findByText } = render(<ManyConsumers count={20} />)
@@ -87,23 +84,9 @@ describe("workspace table registry", () => {
     expect(activeWorkspaceSubscriptionCount()).toBe(1)
   })
 
-  it("mode off creates one subscription per consumer", async () => {
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    setWorkspaceReadMode("off")
-    const where = vi.spyOn(db.workspaceUsers, "where")
-
-    const { findByText } = render(<ManyConsumers count={20} />)
-    await findByText("2")
-
-    expect(where).toHaveBeenCalledTimes(20)
-    expect(activeWorkspaceSubscriptionCount()).toBe(20)
-  })
-
   it("an unchanged row keeps its object identity across emissions", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.put(makeUser("user_1"))
-    const token = allocateWorkspaceTableToken()
-    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE))
     await waitFor(() => expect(result.current).toHaveLength(1))
     const first = result.current![0]
 
@@ -116,16 +99,14 @@ describe("workspace table registry", () => {
   })
 
   it("a change to one row does not re-render a consumer reading another row", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
     const renders = { user_1: 0, user_2: 0 }
 
     function RowProbe({ rowId }: { rowId: "user_1" | "user_2" }) {
-      const [token] = useState(allocateWorkspaceTableToken)
       const row = useSyncExternalStore(
-        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", rowId, token, listener),
-        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token),
-        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token)
+        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", rowId, listener),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId)
       )
       renders[rowId] += 1
       return <span data-testid={rowId}>{row?.name ?? "-"}</span>
@@ -151,43 +132,19 @@ describe("workspace table registry", () => {
     }).toEqual({ user_1: 0, user_2: true })
   })
 
-  it("a private entry tears down at zero grace after its consumer unmounts", async () => {
-    // The 5s grace exists so a SHARED entry survives a remount; a token-keyed
-    // entry has exactly one consumer, so retaining its whole-table liveQuery
-    // for 5s per unmount doubled the off-arm's subscriptions on navigation
-    // (whole-stack finding). Zero delay still absorbs a same-task remount.
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      setWorkspaceReadMode("off")
-      await db.workspaceUsers.put(makeUser("user_1"))
-      const { findByText, unmount } = render(<ManyConsumers count={2} />)
-      await findByText("1")
-      const mounted = activeWorkspaceSubscriptionCount()
-      unmount()
-      await act(async () => {
-        vi.advanceTimersByTime(0)
-      })
-      expect({ mounted, afterUnmount: activeWorkspaceSubscriptionCount() }).toEqual({ mounted: 2, afterUnmount: 0 })
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
   it("the last unsubscribe tears the query down after the grace window, and a re-subscribe inside it reuses the entry", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
-      setWorkspaceReadMode("shared")
       await db.workspaceUsers.put(makeUser("user_1"))
-      const token = allocateWorkspaceTableToken()
       const noop = () => {}
-      const unsubscribe = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
-      await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1))
+      const unsubscribe = subscribeWorkspaceTable(WORKSPACE, "users", noop)
+      await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users")).toHaveLength(1))
 
       unsubscribe()
       expect(activeWorkspaceSubscriptionCount()).toBe(1)
 
-      const again = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
-      expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1)
+      const again = subscribeWorkspaceTable(WORKSPACE, "users", noop)
+      expect(getWorkspaceTableSnapshot(WORKSPACE, "users")).toHaveLength(1)
       expect(activeWorkspaceSubscriptionCount()).toBe(1)
 
       again()
@@ -201,10 +158,8 @@ describe("workspace table registry", () => {
   })
 
   it("a subscriber that mounts after the first emission gets the current snapshot synchronously", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.put(makeUser("user_1"))
-    const token = allocateWorkspaceTableToken()
-    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE))
     await waitFor(() => expect(result.current).toHaveLength(1))
 
     const seen: (number | undefined)[] = []
@@ -219,7 +174,6 @@ describe("workspace table registry", () => {
   })
 
   it("switching workspaces does not leak the previous workspace's rows", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_other", { workspaceId: OTHER_WORKSPACE })])
 
     const { result, rerender } = renderHook(({ workspaceId }) => useWorkspaceUsers(workspaceId), {
@@ -229,104 +183,6 @@ describe("workspace table registry", () => {
 
     rerender({ workspaceId: OTHER_WORKSPACE })
     await waitFor(() => expect(result.current.map((row) => row.id)).toEqual(["user_other"]))
-  })
-
-  it("a flip after mount leaks no listener and tears down cleanly", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      setWorkspaceReadMode("off")
-      await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-
-      const { findByText, unmount } = render(<ManyConsumers count={5} />)
-      await findByText("2")
-
-      act(() => {
-        setWorkspaceReadMode("shared")
-      })
-      expect(activeWorkspaceSubscriptionCount()).toBe(1)
-
-      unmount()
-      await act(async () => {
-        vi.advanceTimersByTime(6_000)
-      })
-
-      expect(activeWorkspaceSubscriptionCount()).toBe(0)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it("a flip preserves the resolved snapshot and does not notify unchanged consumers", async () => {
-    setWorkspaceReadMode("off")
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    let renders = 0
-    const seen: (CachedWorkspaceUser[] | undefined)[] = []
-
-    function Consumer() {
-      const [token] = useState(allocateWorkspaceTableToken)
-      const rows = useRegistryRows(WORKSPACE, token)
-      renders += 1
-      seen.push(rows)
-      return <span data-testid="count">{rows?.length ?? "-"}</span>
-    }
-
-    const { findByText } = render(<Consumer />)
-    await findByText("2")
-    const before = seen[seen.length - 1]!
-    const rendersBefore = renders
-
-    act(() => {
-      setWorkspaceReadMode("shared")
-    })
-
-    expect({
-      rows: seen[seen.length - 1],
-      extraRenders: renders - rendersBefore,
-      ids: seen[seen.length - 1]!.map((row) => row.id),
-    }).toEqual({ rows: before, extraRenders: 0, ids: ["user_1", "user_2"] })
-  })
-
-  it("a row registration survives a flip, but a re-subscribe in off mode mints nothing", async () => {
-    setWorkspaceReadMode("shared")
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    const token = allocateWorkspaceTableToken()
-    const notify = vi.fn()
-
-    let unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
-    const sharedEntries = activeWorkspaceSubscriptionCount()
-
-    act(() => {
-      setWorkspaceReadMode("off")
-    })
-
-    // The reader's effect re-runs after the flip: the new subscribe must be a
-    // no-op, and the consumer reads undefined and falls back to its own query.
-    unsubscribe()
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-    const afterDrop = activeWorkspaceSubscriptionCount()
-    const noop = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    noop()
-
-    expect({
-      minted: activeWorkspaceSubscriptionCount() - afterDrop,
-      row: getWorkspaceTableRow(WORKSPACE, "users", "user_1", token),
-    }).toEqual({ minted: 0, row: undefined })
-
-    act(() => {
-      setWorkspaceReadMode("shared")
-    })
-    unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
-    expect(activeWorkspaceSubscriptionCount()).toBe(sharedEntries)
-
-    await act(async () => {
-      await db.workspaceUsers.put(makeUser("user_1", { name: "Renamed" }))
-    })
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("Renamed"))
-    unsubscribe()
   })
 
   it("the subscription-count mark tracks entry lifecycle", async () => {
@@ -339,20 +195,11 @@ describe("workspace table registry", () => {
         flush: async () => {},
       } as unknown as ReturnType<typeof perfCapture.getPerfCapture>)
 
-      // The mark measures the shared-arm economy only: in `off` mode the count
-      // tracks consumer mounts and would flood the capture ring, so nothing is
-      // emitted there (whole-stack finding).
-      setWorkspaceReadMode("off")
       await db.workspaceUsers.put(makeUser("user_1"))
 
       const { findByText, unmount } = render(<ManyConsumers count={3} />)
       await findByText("1")
       const afterMount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
-
-      act(() => {
-        setWorkspaceReadMode("shared")
-      })
-      const afterFlip = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
 
       unmount()
       await act(async () => {
@@ -360,40 +207,12 @@ describe("workspace table registry", () => {
       })
       const afterUnmount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
 
-      expect({ afterMount: afterMount?.[1], afterFlip: afterFlip?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
-        afterMount: undefined,
-        afterFlip: 1,
+      expect({ afterMount: afterMount?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
+        afterMount: 1,
         afterUnmount: 0,
       })
     } finally {
       vi.useRealTimers()
     }
-  })
-
-  it("an off to shared flip seeds the shared entry from the freshest private snapshot", async () => {
-    let dataset: CachedWorkspaceUser[] = [makeUser("user_1")]
-    vi.spyOn(db.workspaceUsers, "where").mockReturnValue({
-      equals: () => ({ toArray: async () => [...dataset] }),
-    } as unknown as ReturnType<typeof db.workspaceUsers.where>)
-
-    setWorkspaceReadMode("off")
-    const noop = () => {}
-    const staleToken = allocateWorkspaceTableToken()
-    subscribeWorkspaceTable(WORKSPACE, "users", staleToken, noop)
-    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)).toHaveLength(1))
-
-    dataset = [makeUser("user_1"), makeUser("user_2")]
-    const freshToken = allocateWorkspaceTableToken()
-    subscribeWorkspaceTable(WORKSPACE, "users", freshToken, noop)
-    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", freshToken)).toHaveLength(2))
-
-    setWorkspaceReadMode("shared")
-
-    // Synchronously after the flip: the shared entry's own query has not emitted
-    // yet, so this reads exactly what the migration seeded.
-    expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)?.map((row) => row.id)).toEqual([
-      "user_1",
-      "user_2",
-    ])
   })
 })

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -67,17 +67,9 @@ const WORKSPACE_TABLE_QUERIES: Record<WorkspaceTableKey, TableQuery> = {
   metadata: async (workspaceId) => oneRow(await db.workspaceMetadata.get(workspaceId)),
 }
 
-/** `shared` = one live query per (workspace, table); `off` = one per subscriber, as before the registry. */
-export type WorkspaceReadMode = "shared" | "off"
-
 interface WorkspaceTableEntry {
   workspaceId: string
   tableKey: WorkspaceTableKey
-  // Set from the key form at creation, not re-derived from the current mode: a
-  // token-keyed entry can outlive an off→shared flip inside the teardown grace,
-  // and `findSharedRowWorkspace` must not report ownership under a key a
-  // tokenless reader cannot resolve.
-  shared: boolean
   rows: IdentifiedRow[] | undefined
   byId: Map<string, IdentifiedRow>
   resolved: boolean
@@ -92,7 +84,6 @@ interface WorkspaceTableEntry {
 interface RegistrationBase {
   workspaceId: string
   tableKey: WorkspaceTableKey
-  token: number
   listener: () => void
   entryKey: string
 }
@@ -107,18 +98,14 @@ type Registration = (RegistrationBase & { kind: "table" }) | (RegistrationBase &
 // rows. A context provider would re-render its whole subtree on every table
 // change — which is the cost this exists to remove.
 const entries = new Map<string, WorkspaceTableEntry>()
-// Keyed by an internal registration id, not by the consumer token: one token can
-// hold several registrations, and `unsubscribe` must resolve ITS entry key here
-// at call time — a captured key goes stale the moment a mode flip re-keys it,
-// which leaks the listener and pins `refCount` for the session.
+// Keyed by an internal registration id: one consumer can hold several
+// registrations, and `unsubscribe` must resolve ITS entry here at call time.
 const registrations = new Map<number, Registration>()
 
 // Matches `RAIL_TEARDOWN_GRACE_MS`: a remount unsubscribes before it
 // re-subscribes, and tearing the query down in between would re-read the table.
 const TABLE_TEARDOWN_GRACE_MS = 5_000
 
-let mode: WorkspaceReadMode = "off"
-let nextToken = 1
 let nextRegistrationId = 1
 let lastMarkedLiveEntries = -1
 
@@ -130,41 +117,15 @@ let lastMarkedLiveEntries = -1
  */
 const COMPARE_ALL_KEYS: ReadonlySet<string> = new Set()
 
-/** A stable token for one consumer, so the `off` mode can key a private entry per subscriber. */
-export function allocateWorkspaceTableToken(): number {
-  return nextToken++
-}
-
 let emissionCounter = 0
 
-function sharedEntryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey): string {
+function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey): string {
   return `${workspaceId}|${tableKey}`
-}
-
-function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey, token: number): string {
-  return mode === "shared" ? sharedEntryKeyFor(workspaceId, tableKey) : `${workspaceId}|${tableKey}|${token}`
 }
 
 function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
   const entry = entries.get(entryKey)
   if (!entry) return
-
-  // Private (token-keyed) entries have exactly one consumer and match the
-  // pre-registry useLiveQuery behaviour: fresh rows, notify on every emission.
-  // The per-row semantic compare would be pure added cost there — for the
-  // metadata singleton it deep-walks the ~356KB emoji row once per consumer
-  // per reaction, and the rows genuinely changed so everyone re-renders anyway.
-  if (entryKey.split("|").length === 3) {
-    entry.byId = new Map(incoming.map((row) => [row.id, row]))
-    entry.rows = incoming
-    entry.resolved = true
-    entry.emissionSeq = ++emissionCounter
-    for (const notify of entry.listeners) notify()
-    for (const keyed of entry.keyListeners.values()) {
-      for (const notify of keyed) notify()
-    }
-    return
-  }
 
   const previous = entry.rows
   const byId = new Map<string, IdentifiedRow>()
@@ -217,23 +178,13 @@ function liveEntryCount(): number {
 }
 
 function markLiveEntries(): void {
-  // The mark measures the shared-arm subscription economy. In `off` mode the
-  // count tracks consumer mounts (~700 per window) — emitting it would flood
-  // the 2000-sample capture ring and evict the marks the A/B compares, and
-  // liveEntryCount() itself is O(entries) on a hot path.
-  if (mode !== "shared") return
   const count = liveEntryCount()
   if (count === lastMarkedLiveEntries) return
   lastMarkedLiveEntries = count
   perfCapture.getPerfCapture().mark("store.tableSubscriptions", count)
 }
 
-function ensureEntry(
-  entryKey: string,
-  workspaceId: string,
-  tableKey: WorkspaceTableKey,
-  seed?: WorkspaceTableEntry
-): WorkspaceTableEntry {
+function ensureEntry(entryKey: string, workspaceId: string, tableKey: WorkspaceTableKey): WorkspaceTableEntry {
   const existing = entries.get(entryKey)
   if (existing) {
     if (existing.teardown) {
@@ -247,7 +198,6 @@ function ensureEntry(
   const created: WorkspaceTableEntry = {
     workspaceId,
     tableKey,
-    shared: entryKey === sharedEntryKeyFor(workspaceId, tableKey),
     rows: undefined,
     byId: new Map(),
     resolved: false,
@@ -261,12 +211,6 @@ function ensureEntry(
   // Register BEFORE subscribing so a synchronous first emission finds the entry;
   // the callback re-reads it from the map, so a late emission after teardown is
   // a no-op.
-  if (seed?.resolved) {
-    created.rows = seed.rows
-    created.byId = new Map(seed.byId)
-    created.resolved = true
-    created.emissionSeq = seed.emissionSeq
-  }
   entries.set(entryKey, created)
   created.subscription = liveQuery(() => WORKSPACE_TABLE_QUERIES[tableKey](workspaceId)).subscribe((rows) =>
     applyEmission(entryKey, rows)
@@ -275,57 +219,33 @@ function ensureEntry(
   return created
 }
 
-function releaseEntry(entryKey: string, immediate: boolean): void {
+function releaseEntry(entryKey: string): void {
   const entry = entries.get(entryKey)
   if (!entry) return
   if (entry.refCount > 0 || entry.listeners.size > 0 || entry.keyListeners.size > 0) return
-  // Private (token-keyed) entries tear down immediately: their one consumer is
-  // gone, nobody else can adopt them, and the grace window would keep a
-  // whole-table liveQuery re-reading for 5s per unmounted consumer — a
-  // behaviour change vs the pre-registry useLiveQuery cleanup in the arm every
-  // user ships with. A StrictMode remount just re-creates the private query.
-  if (immediate) {
-    if (entry.teardown) clearTimeout(entry.teardown)
-    entry.subscription.unsubscribe()
-    entries.delete(entryKey)
-    markLiveEntries()
-    return
-  }
   if (entry.teardown) return
-  // Private (token-keyed) entries get a zero-delay grace: their one consumer is
-  // gone and nobody else can adopt them, so the 5s window would keep a
-  // whole-table liveQuery re-reading per unmounted consumer — a behaviour
-  // change vs the pre-registry useLiveQuery cleanup in the default arm. Zero
-  // delay still absorbs a same-task unsubscribe/resubscribe (StrictMode
-  // remount): the callback re-checks liveness and aborts.
-  const graceMs = entryKey.split("|").length === 3 ? 0 : TABLE_TEARDOWN_GRACE_MS
   entry.teardown = setTimeout(() => {
     const live = entries.get(entryKey)
     if (!live || live.refCount > 0 || live.listeners.size > 0 || live.keyListeners.size > 0) return
     live.subscription.unsubscribe()
     entries.delete(entryKey)
     markLiveEntries()
-  }, graceMs)
+  }, TABLE_TEARDOWN_GRACE_MS)
   markLiveEntries()
 }
 
-/**
- * Subscribe one consumer to a workspace table. `token` comes from
- * {@link allocateWorkspaceTableToken} and must be stable for the consumer's
- * lifetime — in `off` mode it is what keeps the subscription private.
- */
+/** Subscribe one consumer to a workspace table. */
 export function subscribeWorkspaceTable(
   workspaceId: string,
   tableKey: WorkspaceTableKey,
-  token: number,
   listener: () => void
 ): () => void {
-  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entryKey = entryKeyFor(workspaceId, tableKey)
   const entry = ensureEntry(entryKey, workspaceId, tableKey)
   entry.listeners.add(listener)
   entry.refCount += 1
   const registrationId = nextRegistrationId++
-  registrations.set(registrationId, { kind: "table", workspaceId, tableKey, token, listener, entryKey })
+  registrations.set(registrationId, { kind: "table", workspaceId, tableKey, listener, entryKey })
 
   return () => {
     const registration = registrations.get(registrationId)
@@ -335,24 +255,18 @@ export function subscribeWorkspaceTable(
     if (!current) return
     current.listeners.delete(listener)
     current.refCount -= 1
-    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+    if (current.refCount <= 0) releaseEntry(registration.entryKey)
   }
 }
 
-/** Subscribe to one row of a shared table, so a change to row X wakes only X's readers (D6). */
+/** Subscribe to one row of a table, so a change to row X wakes only X's readers (D6). */
 export function subscribeWorkspaceTableRow(
   workspaceId: string,
   tableKey: WorkspaceTableKey,
   rowId: string,
-  token: number,
   listener: () => void
 ): () => void {
-  // Row reads are a shared-mode feature: a shared→off flip landing between a
-  // reader's render and this subscribe effect would otherwise mint one private
-  // whole-table query per reader that no drop machinery unwinds. The off arm's
-  // consumer falls back to its own live query.
-  if (mode !== "shared") return () => {}
-  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entryKey = entryKeyFor(workspaceId, tableKey)
   const entry = ensureEntry(entryKey, workspaceId, tableKey)
   let keyed = entry.keyListeners.get(rowId)
   if (!keyed) {
@@ -362,7 +276,7 @@ export function subscribeWorkspaceTableRow(
   keyed.add(listener)
   entry.refCount += 1
   const registrationId = nextRegistrationId++
-  registrations.set(registrationId, { kind: "row", workspaceId, tableKey, rowId, token, listener, entryKey })
+  registrations.set(registrationId, { kind: "row", workspaceId, tableKey, rowId, listener, entryKey })
 
   return () => {
     const registration = registrations.get(registrationId)
@@ -376,43 +290,35 @@ export function subscribeWorkspaceTableRow(
       if (set.size === 0) current.keyListeners.delete(rowId)
     }
     current.refCount -= 1
-    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+    if (current.refCount <= 0) releaseEntry(registration.entryKey)
   }
 }
 
 /** The table's rows, or `undefined` while the first read is in flight (`useLiveQuery`'s contract). */
 export function getWorkspaceTableSnapshot<K extends WorkspaceTableKey>(
   workspaceId: string,
-  tableKey: K,
-  token: number
+  tableKey: K
 ): WorkspaceTableRowTypes[K][] | undefined {
-  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
   return entry?.rows as WorkspaceTableRowTypes[K][] | undefined
 }
 
 export function getWorkspaceTableRow<K extends WorkspaceTableKey>(
   workspaceId: string,
   tableKey: K,
-  rowId: string,
-  token: number
+  rowId: string
 ): WorkspaceTableRowTypes[K] | undefined {
-  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
   return entry?.byId.get(rowId) as WorkspaceTableRowTypes[K] | undefined
 }
 
 /**
- * The workspace whose **shared** entry currently holds `rowId`, or `undefined`.
+ * The workspace whose entry currently holds `rowId`, or `undefined`.
  *
  * For consumers that know a row id but not its workspace (`useStreamFromStore`).
- * Only shared entries qualify: with the mode `off` an entry is keyed by its
- * subscriber's token, so a tokenless consumer would open a private live query of
- * its own — the very cost the fast path removes — and the caller must fall back
- * to a per-key read instead (D5, D7).
  */
 export function findSharedRowWorkspace(tableKey: WorkspaceTableKey, rowId: string): string | undefined {
-  if (mode !== "shared") return undefined
   for (const entry of entries.values()) {
-    if (!entry.shared) continue
     if (entry.tableKey !== tableKey) continue
     if (entry.byId.has(rowId)) return entry.workspaceId
   }
@@ -420,116 +326,15 @@ export function findSharedRowWorkspace(tableKey: WorkspaceTableKey, rowId: strin
 }
 
 /**
- * True when the shared (workspace, table) entry is live and has resolved.
+ * True when the (workspace, table) entry is live and has resolved.
  *
  * Lets a reader tell a row's genuine removal — that entry still answering, just
- * without the id — from an ownership drop (mode flip, teardown), where the row
- * is unchanged and only the reader's route to it went away.
+ * without the id — from a teardown, where the row is unchanged and only the
+ * reader's route to it went away.
  */
 export function hasResolvedSharedEntry(workspaceId: string, tableKey: WorkspaceTableKey): boolean {
-  if (mode !== "shared") return false
-  const entry = entries.get(sharedEntryKeyFor(workspaceId, tableKey))
-  return Boolean(entry?.shared && entry.resolved && !entry.teardown)
-}
-
-function detach(entry: WorkspaceTableEntry, registration: Registration): void {
-  if (registration.kind === "table") {
-    entry.listeners.delete(registration.listener)
-  } else {
-    const set = entry.keyListeners.get(registration.rowId)
-    if (set) {
-      set.delete(registration.listener)
-      if (set.size === 0) entry.keyListeners.delete(registration.rowId)
-    }
-  }
-  entry.refCount -= 1
-}
-
-function attach(entry: WorkspaceTableEntry, registration: Registration): void {
-  if (registration.kind === "table") {
-    entry.listeners.add(registration.listener)
-  } else {
-    let keyed = entry.keyListeners.get(registration.rowId)
-    if (!keyed) {
-      keyed = new Set()
-      entry.keyListeners.set(registration.rowId, keyed)
-    }
-    keyed.add(registration.listener)
-  }
-  entry.refCount += 1
-}
-
-function visibleSnapshot(entry: WorkspaceTableEntry | undefined, registration: Registration): unknown {
-  if (!entry) return undefined
-  return registration.kind === "table" ? entry.rows : entry.byId.get(registration.rowId)
-}
-
-/**
- * Flip sharing on or off. Every live **table** registration is moved to its new
- * entry key synchronously, so the flag can arrive or change mid-session without
- * a single hook count changing (D5).
- *
- * Row registrations are DROPPED instead of moved. They belong to readers that
- * found the entry by id rather than by token (`useStreamFromStore`), and there
- * are several per rendered message row — migrating them would open one private
- * whole-table live query per registration on the very flip that exists to kill
- * whole-table reads, and the seeded rows being identity-equal means no listener
- * would ever fire to unwind it. Each dropped listener is fired unconditionally
- * so its reader re-renders, finds no shared owner, and falls back to its own
- * per-key read; the registration is deleted, so its `unsubscribe` closure is a
- * no-op and a fresh subscribe from the same reader starts clean.
- *
- * The new entry is seeded from the most recently emitted resolved predecessor
- * for the same (workspace, table): the query is identical, but private entries
- * emit independently, so an older resolved snapshot can still be sitting in the
- * map and would republish rolled-back rows. Publishing an unresolved entry
- * instead would regress every consumer to its bootstrap-era cache fallback for a frame — and the flag itself is read
- * through this registry, so an unresolved metadata entry would flip the mode back
- * and loop.
- */
-export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
-  if (next === mode) return
-  const all = [...registrations.entries()]
-  const active = all.filter(([, registration]) => registration.kind === "table")
-  const dropped = all.filter(([, registration]) => registration.kind === "row")
-  const before = new Map<number, unknown>()
-  const seeds = new Map<string, WorkspaceTableEntry>()
-
-  for (const [id, registration] of all) {
-    const entry = entries.get(registration.entryKey)
-    before.set(id, visibleSnapshot(entry, registration))
-    if (!entry) continue
-    detach(entry, registration)
-  }
-  for (const [id] of dropped) registrations.delete(id)
-  for (const entry of entries.values()) {
-    const seedKey = `${entry.workspaceId}|${entry.tableKey}`
-    if (!entry.resolved) continue
-    const held = seeds.get(seedKey)
-    if (!held || entry.emissionSeq > held.emissionSeq) seeds.set(seedKey, entry)
-  }
-
-  mode = next
-
-  for (const [id, registration] of active) {
-    const entryKey = entryKeyFor(registration.workspaceId, registration.tableKey, registration.token)
-    const entry = ensureEntry(
-      entryKey,
-      registration.workspaceId,
-      registration.tableKey,
-      seeds.get(`${registration.workspaceId}|${registration.tableKey}`)
-    )
-    attach(entry, registration)
-    registrations.set(id, { ...registration, entryKey })
-  }
-  for (const [, registration] of all) releaseEntry(registration.entryKey, true)
-
-  for (const [id] of active) {
-    const current = registrations.get(id)
-    if (!current) continue
-    if (visibleSnapshot(entries.get(current.entryKey), current) !== before.get(id)) current.listener()
-  }
-  for (const [, registration] of dropped) registration.listener()
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
+  return Boolean(entry?.resolved && !entry.teardown)
 }
 
 /** Live Dexie subscriptions on workspace tables, teardown-grace ones included. */
@@ -544,6 +349,5 @@ export function resetWorkspaceTableRegistry(): void {
   }
   entries.clear()
   registrations.clear()
-  mode = "off"
   lastMarkedLiveEntries = -1
 }

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -62,7 +62,6 @@ export const FEATURE_FLAGS = {
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
   sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   singlePreviewWriter: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 


### PR DESCRIPTION
## Problem

`sharedWorkspaceReads` is not a branch — it is a second read mode. With it off, `workspace-table-registry` keys every entry by a per-subscriber token, so each consumer opens its own whole-table `liveQuery`; row-level subscriptions are refused outright and readers fall back to per-key reads. Keeping that arm alive costs a flip migration (`setWorkspaceReadMode`, ~50 lines of attach/detach/re-key/seed), a private-entry branch in `applyEmission`, a zero-grace teardown path, a mode guard on four public functions, and a `token` parameter threaded through the whole registry API to serve nothing else.

The flag has been on by default since #1761 and healthy in production.

## Solution

One live query per `(workspace, table)` is the only shape.

- Deleted: `WorkspaceReadMode`, `setWorkspaceReadMode`, `allocateWorkspaceTableToken`, `attach`/`detach`/`visibleSnapshot`, the `entry.shared` field, the private-entry emission branch, and the token-keyed teardown grace. 549 → 353 lines.
- `subscribeWorkspaceTable`, `subscribeWorkspaceTableRow`, `getWorkspaceTableSnapshot`, `getWorkspaceTableRow` lose the `token` parameter; `useWorkspaceTable` and `useStreamFromStore` lose their token refs.
- `WorkspaceReadModeSync` is removed from `workspace-layout`.

One behaviour change is visible in a test rather than in the diff: `actor-lookup` asserted **2** emoji-index builds for two consumers, because it ran the off arm. Sharing makes it 1. That is the win the flag was gating, so the expectation moves rather than the code.

Tests that only existed to exercise the removed arm or a flip are deleted (off-mode subscription counts, private-entry teardown, the four flip-migration cases, the seed-from-freshest-private-snapshot case). Everything asserting shared-mode behaviour is kept.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/stores/workspace-table-registry.ts` | mode machinery and tokens deleted |
| `apps/frontend/src/stores/workspace-store.ts`, `stream-store.ts` | token refs dropped |
| `apps/frontend/src/pages/workspace-layout.tsx` | `WorkspaceReadModeSync` removed |
| `packages/types/src/feature-flags.ts` | registry key removed |
| 5 test files | off-arm and flip cases removed; the actor-lookup bound is now 1 |

## Test plan

- [x] `src/stores/` (23 files) + `message-event.test.tsx` — 260 pass
- [x] monorepo lint + typecheck (pre-commit)

## Residual risk

`hasResolvedSharedEntry` and `findSharedRowWorkspace` no longer have a mode to refuse on, so they answer purely from entry presence. That is the same answer they gave in the shipped arm — but if a caller ever relied on `undefined` meaning "sharing is off" rather than "no entry holds this row", that distinction is gone.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788854983&installation_model_id=20758&pr_number=1833&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1833&signature=d885e8dee05242b15ec8db31171bf0d7ab0e6f1ff011e63d6c224fb5a6732b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

**Follow-up commits (found by a full-CI probe, not by the local runs):** three call suites and the sealed-name loading tests seed only the in-memory workspace cache and never write to IDB. A shared entry outlives its consumer by the 5s teardown grace where the per-token entries it replaces tore down at zero, so a later case in the same file adopts an entry that already resolved to `[]` — and `live ?? cached` prefers a resolved empty array over the seed. Test-only fix: they reset the store cache already and never meant to exercise the registry. No production path constructs that state; IDB and the memory seed are written by the same bootstrap apply.
