### PR TITLE
refactor: drop the last three perf flags and the primed flag cache

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -10,7 +10,7 @@ import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { resetActorLookups } from "@/stores/actor-lookup"
-import { bumpAccountGeneration, resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration } from "@/db/event-writes"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -81,7 +81,6 @@ function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
   resetWorkspaceTableRegistry()
   resetActorLookups()
-  resetEventWriteFlags()
   // The `db` proxy is repointed on a switch, so any write deferred past this
   // point would land in the new account's database — deferred writers capture
   // this generation and bail when it moves.

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -1,16 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import {
-  EVENT_BULK_PUT_LIMIT,
-  isSharedStreamRegistrationEnabledSync,
-  isSinglePreviewWriterEnabled,
-  primeEventWriteFlags,
-  primeEventWriteFlagsIfAbsent,
-  putEventsBounded,
-  resetEventWriteFlags,
-  skipNoOpEventRewrites,
-} from "./event-writes"
+import { EVENT_BULK_PUT_LIMIT, putEventsBounded, skipNoOpEventRewrites } from "./event-writes"
 
 function makeRow(streamId: string, index: number, overrides: Partial<CachedEvent> = {}): CachedEvent {
   const sequence = String(1000 + index)
@@ -35,22 +26,9 @@ function makePage(streamId: string, count: number): CachedEvent[] {
 }
 
 beforeEach(async () => {
-  resetEventWriteFlags()
   await db.events.clear()
   await db.workspaceMetadata.clear()
 })
-
-async function putMetadata(featureFlags: unknown): Promise<void> {
-  await db.workspaceMetadata.put({
-    id: "ws_1",
-    workspaceId: "ws_1",
-    emojis: [],
-    emojiWeights: {},
-    commands: [],
-    featureFlags,
-    _cachedAt: 1,
-  } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
-}
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -190,76 +168,5 @@ describe("live-query wake set (D1)", () => {
     })
 
     expect(emissions).toBeGreaterThan(0)
-  })
-})
-
-describe("the primed flag cache", () => {
-  it("resolves a persisted layered row and caches it", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "on" }, user: {} })
-    const get = vi.spyOn(db.workspaceMetadata, "get")
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(get).toHaveBeenCalledTimes(1)
-  })
-
-  it("a pre-#1455 flat row neither throws nor overrides the registry default", async () => {
-    // A flat legacy row is IGNORED (coerced away), so the resolved value is the
-    // registry default, never the flat row's own field, and never a crash.
-    await putMetadata({ singlePreviewWriter: "on" })
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
-  })
-
-  it("a primed value wins without reading the row", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
-    const get = vi.spyOn(db.workspaceMetadata, "get")
-    primeEventWriteFlags("ws_1", { workspace: {}, user: { singlePreviewWriter: "on" } })
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(get).not.toHaveBeenCalled()
-  })
-
-  it("resetEventWriteFlags clears the primed value", async () => {
-    // Primed "on" (an explicit override), then reset: with no persisted row the
-    // resolve falls back to the registry default — proving the primed override
-    // was dropped, not retained.
-    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
-    resetEventWriteFlags()
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
-  })
-
-  it("a prime landing mid-read wins over the older persisted row", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
-    let release: () => void = () => {}
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const real = db.workspaceMetadata.get.bind(db.workspaceMetadata)
-    vi.spyOn(db.workspaceMetadata, "get").mockImplementation(((key: string) =>
-      gate.then(() => real(key))) as unknown as typeof db.workspaceMetadata.get)
-
-    const inFlight = isSinglePreviewWriterEnabled(db, "ws_1")
-    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
-    release()
-
-    expect(await inFlight).toBe(true)
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-  })
-})
-
-describe("primeEventWriteFlagsIfAbsent", () => {
-  it("primeEventWriteFlagsIfAbsent fills an empty cache", () => {
-    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
-
-    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
-  })
-
-  it("primeEventWriteFlagsIfAbsent never overwrites a value already primed", () => {
-    primeEventWriteFlags("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
-    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "off" }, user: {} })
-
-    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
   })
 })

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -1,6 +1,5 @@
-import { coerceLayers, resolveFeatureFlags, type FeatureFlagLayers } from "@threa/types"
 import type { EntityTable } from "dexie"
-import type { CachedEvent, ThreaDatabase } from "@/db/database"
+import type { CachedEvent } from "@/db/database"
 
 /**
  * Dexie 4.4.2 registers precise changed keys for a `bulkPut` of fewer than 50
@@ -11,8 +10,6 @@ import type { CachedEvent, ThreaDatabase } from "@/db/database"
 export const EVENT_BULK_PUT_LIMIT = 49
 
 type EventTable = EntityTable<CachedEvent, "id">
-
-const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
 
 /**
  * Writes events in slices below Dexie's FULL_RANGE threshold. Opens no
@@ -68,18 +65,6 @@ export function skipNoOpEventRewrites(
   })
 }
 
-// The `workspaceMetadata` row carries the workspace emoji list — hundreds of KB
-// that Dexie must deserialize per read — so resolving the flag from it on every
-// event write costs more than the write. Resolve once per workspace per module
-// instance instead, primed from the network bootstrap and socket flag flips.
-type EventWriteFlags = {
-  sharedStreamRegistration: boolean
-  singlePreviewWriter: boolean
-  coalescedLiveCommit: boolean
-}
-
-const flagsByWorkspace = new Map<string, EventWriteFlags>()
-let primeGeneration = 0
 let accountGeneration = 0
 
 /**
@@ -95,77 +80,4 @@ export function bumpAccountGeneration(): void {
 /** The current account generation — capture it before deferring a write. */
 export function getAccountGeneration(): number {
   return accountGeneration
-}
-
-function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
-  const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
-  return {
-    sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
-    singlePreviewWriter: resolved.singlePreviewWriter === "on",
-    coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
-  }
-}
-
-/** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
-export function primeEventWriteFlags(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
-  primeGeneration += 1
-  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
-}
-
-/**
- * Seed the cache from the persisted workspace row on a warm start, where
- * registration can run before any network prime. If-absent, not prime: the
- * persisted row is only a warm-start fallback and must never overwrite a
- * network prime that landed while the IDB reads were in flight (same freshness
- * rule as {@link getEventWriteFlags}).
- */
-export function primeEventWriteFlagsIfAbsent(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
-  if (flagsByWorkspace.has(workspaceId)) return
-  primeGeneration += 1
-  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
-}
-
-/** Test-only: drop the cache so each case resolves from its own prime/IDB row. */
-export function resetEventWriteFlags(): void {
-  primeGeneration += 1
-  flagsByWorkspace.clear()
-}
-
-async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
-  const cached = flagsByWorkspace.get(workspaceId)
-  if (cached !== undefined) return cached
-  // The persisted row is the warm-start fallback, so a prime that lands while
-  // this read is in flight is strictly newer and must win (INV-20).
-  const generation = primeGeneration
-  const metadata = await database.workspaceMetadata.get(workspaceId)
-  const flags = resolveEventWriteFlags(metadata?.featureFlags)
-  if (primeGeneration !== generation) return flagsByWorkspace.get(workspaceId) ?? flags
-  flagsByWorkspace.set(workspaceId, flags)
-  return flags
-}
-
-/** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */
-export async function isSinglePreviewWriterEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).singlePreviewWriter
-}
-
-/**
- * The viewer's `coalescedLiveCommit` value, read only from the primed map so the
- * synchronous commit seams can re-read it per event. A backoffice flip re-primes
- * the map, so arming and disarming both take effect on the next event; an
- * unprimed read takes the immediate path rather than guessing.
- */
-export function isCoalescedLiveCommitEnabledSync(workspaceId: string): boolean {
-  return flagsByWorkspace.get(workspaceId)?.coalescedLiveCommit ?? false
-}
-
-/**
- * The viewer's `sharedStreamRegistration` value, read only from the primed map.
- * Handler registration is synchronous, so there is no await in which to resolve
- * the persisted row: an unprimed read falls back to the unshared path rather
- * than guessing. A miss costs the optimization for that registration, never
- * correctness — two unshared registrations behave exactly as they do today.
- */
-export function isSharedStreamRegistrationEnabledSync(workspaceId: string): boolean {
-  return flagsByWorkspace.get(workspaceId)?.sharedStreamRegistration ?? false
 }

--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import type { StreamEvent } from "@threa/types"
 import { db, type CachedEvent } from "@/db"
-import { resetEventWriteFlags } from "@/db/event-writes"
 import { loadStreamPrefix, loadStreamTail, unionStreamRanges } from "@/stores/stream-store"
 import {
   computeTimelineLoadState,
@@ -232,7 +231,6 @@ describe("getEffectiveEvents", () => {
 
 describe("cacheToIndexedDB with eventWriteChunking on", () => {
   beforeEach(async () => {
-    resetEventWriteFlags()
     await db.events.clear()
     await db.workspaceMetadata.clear()
     await db.workspaceMetadata.put({

--- a/apps/frontend/src/stores/workspace-store.publication.test.ts
+++ b/apps/frontend/src/stores/workspace-store.publication.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, type CachedWorkspace, type CachedWorkspaceUser } from "@/db"
-import { isSharedStreamRegistrationEnabledSync, resetEventWriteFlags } from "@/db/event-writes"
 import {
   getCachedWorkspaceTables,
   resetWorkspaceStoreCache,
@@ -97,24 +96,6 @@ describe("seedWorkspaceCache publication gating", () => {
     await idbSeed
 
     expect(getCachedWorkspaceTables(WS).users?.map((u) => u.name)).toEqual(["Fresh"])
-  })
-
-  it("a warm start primes the stream-registration flag before any bootstrap", async () => {
-    resetEventWriteFlags()
-    await db.workspaces.put(makeWorkspace())
-    await db.workspaceMetadata.put({
-      id: WS,
-      workspaceId: WS,
-      emojis: [],
-      emojiWeights: {},
-      commands: [],
-      featureFlags: { workspace: { sharedStreamRegistration: "on" }, user: {} },
-      _cachedAt: Date.now(),
-    } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
-
-    expect(await seedCacheFromIdb(WS)).toBe(true)
-
-    expect(isSharedStreamRegistrationEnabledSync(WS)).toBe(true)
   })
 
   it("a publishing seed notifies exactly once", () => {

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -6,7 +6,6 @@ import {
   type WorkspaceTableKey,
   type WorkspaceTableRowTypes,
 } from "./workspace-table-registry"
-import { primeEventWriteFlagsIfAbsent } from "@/db/event-writes"
 // Namespace import so the shared overlay memo below is spy-able against the
 // module (INV-48) — the "once per workspace, not once per consumer" property is
 // only assertable through the real call.
@@ -216,8 +215,6 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     publishWorkspaceCache(workspaceId)
     return true
   }
-
-  primeEventWriteFlagsIfAbsent(workspaceId, metadata?.featureFlags)
 
   seedWorkspaceCache(workspaceId, {
     workspace,

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -156,7 +156,6 @@ export class LiveCommitBatch {
   /** Flushes run one at a time and in schedule order, so an awaited `flush()`
    *  drains everything buffered before it (the catch-up window's guarantee). */
   private chain: Promise<void> = Promise.resolve()
-  private flushing = false
 
   constructor(
     private readonly queryClient: QueryClient,
@@ -194,20 +193,6 @@ export class LiveCommitBatch {
     this.schedule()
   }
 
-  /** Whether anything is buffered and not yet committed. Callers taking the
-   *  immediate path (the flag flipped off mid-task) drain first, so a pending
-   *  fold can't land on top of a newer immediate commit. */
-  hasPending(): boolean {
-    return this.counterMutators.length > 0 || this.streamPreviews.size > 0 || this.readAllSnapshots.length > 0
-  }
-
-  /** Whether a commit has emptied the buffers but not yet published. Immediate
-   *  callers drain on this too: `hasPending()` alone is false in that window, so
-   *  an older in-flight fold would publish on top of a newer direct commit. */
-  isFlushing(): boolean {
-    return this.flushing
-  }
-
   /** Commit everything buffered so far. Awaited by the engine when a catch-up
    *  window opens, so a live fold can never interleave into a replay fold. */
   flush(): Promise<void> {
@@ -218,24 +203,6 @@ export class LiveCommitBatch {
     // throwing inside publish) would poison every later flush permanently.
     this.chain = attempt.catch(this.logFlushFailure)
     return attempt
-  }
-
-  /** Drain, then run `fn` — on the batch's OWN chain, so anything buffered after
-   *  this call queues BEHIND `fn` instead of racing it. Branching off `flush()`'s
-   *  returned promise inverts order: that promise settles when its drain runs,
-   *  and that drain commits whatever was buffered by then, which can be newer
-   *  than `fn`. */
-  runAfterDrain(fn: () => void): void {
-    this.scheduled = false
-    // Taken NOW, not when the drain runs: a commit that re-reads the buffers at
-    // execution time would sweep up whatever was buffered after this call and
-    // publish it BEFORE `fn`.
-    const drained = this.takePending()
-    this.chain = this.chain
-      .then(() => this.commit(drained))
-      .catch(this.logFlushFailure)
-      .then(fn)
-      .catch(this.logFlushFailure)
   }
 
   private readonly logFlushFailure = (error: unknown): void => {
@@ -273,13 +240,8 @@ export class LiveCommitBatch {
     return pending
   }
 
-  private async commit(pending?: PendingFold): Promise<void> {
-    this.flushing = true
-    try {
-      await this.runCommit(pending ?? this.takePending())
-    } finally {
-      this.flushing = false
-    }
+  private async commit(): Promise<void> {
+    await this.runCommit(this.takePending())
   }
 
   private async runCommit({ mutators, previews, snapshots }: PendingFold): Promise<void> {

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -11,7 +11,7 @@ import {
 import type { Socket } from "socket.io-client"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { bumpAccountGeneration, primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration } from "@/db/event-writes"
 import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
@@ -200,14 +200,10 @@ type Harness = {
   setCatchUpBatch: (batch: CatchUpBatch | null) => void
 }
 
-/** Registers the workspace handlers exactly as the SyncEngine does, with the
- *  flag primed. `commitCounter`/`commitPreview` read the flag synchronously per
- *  event, so a mid-task flip takes effect on the next event with no reconnect. */
+/** Registers the workspace handlers exactly as the SyncEngine does. `coalesced`
+ *  false withholds the batch — the per-event path handlers built without an
+ *  engine still take, and the baseline the folded arm is compared against. */
 async function register(queryClient: QueryClient, coalesced: boolean): Promise<Harness> {
-  primeEventWriteFlags(WORKSPACE_ID, {
-    workspace: { coalescedLiveCommit: coalesced ? "on" : "off" },
-    user: {},
-  })
   const liveBatch = new LiveCommitBatch(queryClient, WORKSPACE_ID)
   let catchUpBatch: CatchUpBatch | null = null
   const { socket, emit } = createTestSocket()
@@ -216,7 +212,7 @@ async function register(queryClient: QueryClient, coalesced: boolean): Promise<H
     getCurrentUser: () => ({ id: "workos_1" }),
     subscribeStream: vi.fn(),
     getCatchUpBatch: () => catchUpBatch,
-    getLiveCommitBatch: () => liveBatch,
+    getLiveCommitBatch: () => (coalesced ? liveBatch : null),
   })
   return {
     emit,
@@ -242,12 +238,10 @@ function bootstrapOf(queryClient: QueryClient): WorkspaceBootstrap | undefined {
 
 describe("LiveCommitBatch", () => {
   beforeEach(async () => {
-    resetEventWriteFlags()
     await Promise.all([db.streams.clear(), db.unreadState.clear()])
   })
 
   afterEach(() => {
-    resetEventWriteFlags()
     vi.restoreAllMocks()
   })
 
@@ -276,24 +270,6 @@ describe("LiveCommitBatch", () => {
       unread: 1,
       cachePreview: "message 6",
       idbPreview: "message 6",
-    })
-
-    harness.cleanup()
-  })
-
-  it("the flag off keeps today's two transactions and two publications", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-    const harness = await register(queryClient, false)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 2,
-      publications: 2,
     })
 
     harness.cleanup()
@@ -345,7 +321,6 @@ describe("LiveCommitBatch", () => {
 
     await db.streams.clear()
     await db.unreadState.clear()
-    resetEventWriteFlags()
 
     const immediateClient = new QueryClient()
     await seedFixture(immediateClient, ["stream_1", "stream_2"])
@@ -488,53 +463,6 @@ describe("LiveCommitBatch", () => {
     batch.destroy()
   })
 
-  it("flipping the flag off disarms the coalescing on the next event, with no reconnect", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    // What a `feature_flags:updated` socket event does to the module map.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 2,
-      publications: 2,
-    })
-
-    harness.cleanup()
-  })
-
-  it("flipping the flag on arms the coalescing on the next event, with no reconnect", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, false)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 1,
-      publications: 1,
-    })
-
-    harness.cleanup()
-  })
-
   it("the activity path's stream.idbTransaction count falls from two to one", async () => {
     const counts = async (coalesced: boolean): Promise<number> => {
       const queryClient = new QueryClient()
@@ -554,7 +482,7 @@ describe("LiveCommitBatch", () => {
     expect({ off: await counts(false), on: await counts(true) }).toEqual({ off: 2, on: 1 })
   })
 
-  it("the fold has its own mark: stream.activityApply stays one handler sample per event in both arms", async () => {
+  it("the fold has its own mark: stream.activityApply stays one handler sample per event with or without the batch", async () => {
     const marks = async (coalesced: boolean) => {
       const queryClient = new QueryClient()
       await seedFixture(queryClient, ["stream_1"])
@@ -668,98 +596,6 @@ describe("LiveCommitBatch", () => {
 
     expect({ afterFirst, total: onFlushFailed.mock.calls.length }).toEqual({ afterFirst: 1, total: 2 })
     batch.destroy()
-  })
-
-  it("flipping the flag off drains the pending fold before the next immediate commit", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    // Buffered under the armed flag; the flip lands in the same task, so the
-    // newer immediate commit must not be overwritten by the older fold.
-    harness.emit("stream:activity", activity("stream_1", 6))
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
-
-    harness.cleanup()
-  })
-
-  it("flipping the flag off drains a fold that is already in flight", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const realTransaction = Dexie.prototype.transaction
-    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
-      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
-      return gate.then(() => running) as never
-    })
-
-    // A is buffered and its commit begins: the buffers are already empty and the
-    // transaction is awaiting, so `hasPending()` alone reads false here.
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    expect({ pending: harness.liveBatch.hasPending(), flushing: harness.liveBatch.isFlushing() }).toEqual({
-      pending: false,
-      flushing: true,
-    })
-
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    release()
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
-
-    harness.cleanup()
-  })
-
-  it("an off-then-on flip during an in-flight fold still lands the newest commit last", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const realTransaction = Dexie.prototype.transaction
-    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
-      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
-      return gate.then(() => running) as never
-    })
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await new Promise((resolve) => setTimeout(resolve, 0))
-
-    // Off: #7 takes the deferred immediate arm while #6's commit is in flight.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    // Back on: #8 buffers, and must publish AFTER the deferred #7.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 8))
-    release()
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 8", idbPreview: "message 8" })
-
-    harness.cleanup()
   })
 
   it("a fold buffered before an account switch writes nothing after it", async () => {

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -7,7 +7,6 @@ import type { Socket } from "socket.io-client"
 import { CatchUpBatch, commitCounterMutation } from "./catch-up-batch"
 import { registerStreamSocketHandlers } from "./stream-sync"
 import { registerWorkspaceSocketHandlers } from "./workspace-sync"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 import { applyStreamsReadAllOrdinals } from "./unread-counters"
 import {
   applyReadStateSnapshotsIdb,
@@ -640,12 +639,7 @@ describe("replayed message:created entries and the preview write", () => {
     }
   }
 
-  async function replay(streamId: string, singlePreviewWriter: boolean): Promise<number> {
-    resetEventWriteFlags()
-    primeEventWriteFlags("ws_1", {
-      workspace: { singlePreviewWriter: singlePreviewWriter ? "on" : "off" },
-      user: {},
-    })
+  async function replay(streamId: string): Promise<number> {
     await db.events.clear()
     await db.streams.clear()
     await db.streams.put({
@@ -666,11 +660,8 @@ describe("replayed message:created entries and the preview write", () => {
     return calls
   }
 
-  it("live message:created delivery writes no preview when the single writer is on", async () => {
-    const on = await replay("stream_replay_on", true)
-    const off = await replay("stream_replay_off", false)
-    expect({ on, off }).toEqual({ on: 0, off: 3 })
-    resetEventWriteFlags()
+  it("live message:created delivery writes no preview — stream:activity is the only writer", async () => {
+    expect(await replay("stream_replay_on")).toBe(0)
   })
 
   it("a catch-up replay's batched stream:activity previews land on flush, last write winning", async () => {

--- a/apps/frontend/src/sync/stream-sync.perf.test.ts
+++ b/apps/frontend/src/sync/stream-sync.perf.test.ts
@@ -5,7 +5,6 @@ import type { PerformanceSample, StreamEvent } from "@threa/types"
 import { db } from "@/db"
 import { NO_CAPTURE, PerfCapture, armPerfCapture, getPerfCapture } from "@/lib/perf/capture"
 import { registerStreamSocketHandlers } from "./stream-sync"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 
 function createTestSocket() {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
@@ -84,25 +83,22 @@ async function resetTables(): Promise<void> {
 
 beforeEach(async () => {
   await resetTables()
-  primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "off" }, user: {} })
 })
 
 afterEach(() => {
   armPerfCapture(NO_CAPTURE)
-  resetEventWriteFlags()
 })
 
 describe("message:created sub-marks", () => {
-  it("an applied message records one eventTx and one previewWrite sample", async () => {
+  it("an applied message records one eventTx and one contextRows sample", async () => {
     const capture = new PerfCapture()
     armPerfCapture(capture)
 
     await deliver("stream_perf", ["evt_1"])
 
     expect(samplesNamed(capture, "stream.eventTx")).toHaveLength(1)
-    expect(samplesNamed(capture, "stream.previewWrite")).toHaveLength(1)
     expect(samplesNamed(capture, "stream.contextRows")).toHaveLength(1)
-    for (const name of ["stream.eventTx", "stream.previewWrite", "stream.contextRows"] as const) {
+    for (const name of ["stream.eventTx", "stream.contextRows"] as const) {
       expect(samplesNamed(capture, name)[0].value).toBeTypeOf("number")
     }
     expect(samplesNamed(capture, "stream.eventDuplicate")).toEqual([])

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -19,7 +19,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { sharedMessageSlotKey } from "@threa/types"
 import type {
   AttachmentSummary,
@@ -4360,17 +4360,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     }
   }
 
-  function enableSharing(enabled: boolean) {
-    primeEventWriteFlags("ws_1", {
-      // `singlePreviewWriter` is pinned off, not inherited: these cases count
-      // `db.streams.update` calls to tell one apply from two, and that writer
-      // only exists on this arm. Inheriting a default scheduled to flip would
-      // silently retarget the assertion at nothing.
-      workspace: { sharedStreamRegistration: enabled ? "on" : "off", singlePreviewWriter: "off" },
-      user: {},
-    })
-  }
-
   function messageCreated(streamId: string, id: string, sequence: string, extraPayload: Record<string, unknown> = {}) {
     return {
       workspaceId: "ws_1",
@@ -4407,16 +4396,13 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     await db.streamContextItems.clear()
     await db.pendingMessages.clear()
     clearDecryptCache()
-    resetEventWriteFlags()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    resetEventWriteFlags()
   })
 
   it("two registrations against one event source bind the listener set once", async () => {
-    enableSharing(true)
     const streamId = "stream_shared_once"
     await db.streams.put({
       id: streamId,
@@ -4426,8 +4412,8 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     } as never)
 
     const { socket, emit } = createCountingSocket()
+    // One scope read per apply — two bindings would read twice.
     const scopeReads = vi.spyOn(db.streams, "get")
-    const previewWrites = vi.spyOn(db.streams, "update")
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
@@ -4437,45 +4423,14 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
 
     expect({
       scopeReads: scopeReads.mock.calls.length,
-      previewWrites: previewWrites.mock.calls.length,
       persisted: (await db.events.get("evt_shared"))?.sequence,
-    }).toEqual({ scopeReads: 1, previewWrites: 1, persisted: "10" })
-
-    releaseA()
-    releaseB()
-  })
-
-  it("binds the listener set twice and applies twice when the flag is off", async () => {
-    enableSharing(false)
-    const streamId = "stream_unshared"
-    await db.streams.put({
-      id: streamId,
-      workspaceId: "ws_1",
-      rootStreamId: streamId,
-      _cachedAt: Date.now(),
-    } as never)
-
-    const { socket, emit } = createCountingSocket()
-    const scopeReads = vi.spyOn(db.streams, "get")
-    const previewWrites = vi.spyOn(db.streams, "update")
-    const queryClient = new QueryClient()
-
-    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    await emit("message:created", messageCreated(streamId, "evt_unshared", "10"))
-
-    expect({
-      scopeReads: scopeReads.mock.calls.length,
-      previewWrites: previewWrites.mock.calls.length,
-    }).toEqual({ scopeReads: 2, previewWrites: 2 })
+    }).toEqual({ scopeReads: 1, persisted: "10" })
 
     releaseA()
     releaseB()
   })
 
   it("the listeners survive until the last release", async () => {
-    enableSharing(true)
     const streamId = "stream_last_release"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4493,7 +4448,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("releasing twice does not tear down a live registration", async () => {
-    enableSharing(true)
     const streamId = "stream_strictmode"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4511,7 +4465,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a registration without an engine is not shared with the gated one", async () => {
-    enableSharing(true)
     const streamId = "stream_two_sources"
     const gated = createCountingSocket()
     const raw = createCountingSocket()
@@ -4531,7 +4484,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a second registrant with mismatched wiring throws", () => {
-    enableSharing(true)
     const streamId = "stream_mismatch"
     const { socket } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4550,7 +4502,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("every registrant's gap callback fires, and a released one stops", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_fanout"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4587,7 +4538,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("two registrants sharing ONE callback reference keep the survivor's subscription", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_same_reference"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4609,7 +4559,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a registrant that joins a gap-less registration still receives gaps", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_late_join"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4630,7 +4579,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("an E2E self-send seeds the decrypt cache exactly once", async () => {
-    enableSharing(true)
     const streamId = "stream_e2e_shared"
     const plaintextJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "secret" }] }] }
     await db.events.put({
@@ -4649,7 +4597,10 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     })
 
     const { socket, emit } = createCountingSocket()
-    const previewWrites = vi.spyOn(db.streams, "update")
+    // One `stream.eventApply` sample per handler run — the direct count of how
+    // many times the shared binding applied this event.
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
@@ -4670,15 +4621,15 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     expect({
       status: cached?.status,
       markdown: cached?.value?.contentMarkdown,
-      applies: previewWrites.mock.calls.length,
+      applies: capture.snapshot().filter((sample) => sample.name === "stream.eventApply").length,
     }).toEqual({ status: "decrypted", markdown: "secret", applies: 1 })
 
+    armPerfCapture(NO_CAPTURE)
     releaseA()
     releaseB()
   })
 
   it("the registry drops its entry when the last holder releases", async () => {
-    enableSharing(true)
     const streamId = "stream_registry_drop"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4722,13 +4673,6 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
         await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
       },
     }
-  }
-
-  function enableSinglePreviewWriter(enabled: boolean) {
-    primeEventWriteFlags("ws_1", {
-      workspace: { singlePreviewWriter: enabled ? "on" : "off" },
-      user: {},
-    })
   }
 
   const contentJson = {
@@ -4776,16 +4720,13 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
     await db.streamContextItems.clear()
     await db.pendingMessages.clear()
     await db.slots.clear()
-    resetEventWriteFlags()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    resetEventWriteFlags()
   })
 
   it("a live message writes no preview and no bootstrap cache entry", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_single_writer"
     await seedStream(streamId)
 
@@ -4809,38 +4750,7 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
     cleanup()
   })
 
-  it("the flag off writes the preview exactly as today", async () => {
-    enableSinglePreviewWriter(false)
-    const streamId = "stream_single_writer_off"
-    await seedStream(streamId)
-
-    const queryClient = new QueryClient()
-    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
-      streams: [{ id: streamId, lastMessagePreview: bootstrapPreview }],
-    } as unknown as WorkspaceBootstrap)
-
-    const { socket, emit } = createTestSocket()
-    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    await emit("message:created", messageCreated(streamId, "evt_single_off", "10"))
-
-    const written = {
-      authorId: "user_7",
-      authorType: "user",
-      content: contentJson,
-      createdAt: "2026-08-04T10:00:00.000Z",
-    }
-    expect({
-      preview: (await db.streams.get(streamId))?.lastMessagePreview,
-      cached: queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streams[0]
-        .lastMessagePreview,
-    }).toEqual({ preview: written, cached: written })
-
-    cleanup()
-  })
-
   it("a message:created applied without a SyncEngine still writes the event and does not throw", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_no_engine"
     const queryClient = new QueryClient()
 
@@ -4861,7 +4771,6 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
   })
 
   it("the share-fallback invalidation still fires for a map-less share-bearing event", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_share_fallback"
     await seedStream(streamId)
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,11 +1,6 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
-import {
-  isSinglePreviewWriterEnabled,
-  isNoOpRewrite,
-  isSharedStreamRegistrationEnabledSync,
-  putEventsBounded,
-} from "@/db/event-writes"
+import { isNoOpRewrite, putEventsBounded } from "@/db/event-writes"
 import {
   StreamTypes,
   THREAD_ANCHORABLE_EVENT_TYPES,
@@ -13,7 +8,6 @@ import {
   type Stream,
   type StreamBootstrap,
   type StreamReadFrontier,
-  type LastMessagePreview,
   type LinkPreviewSummary,
   type MemoEmbedSummary,
   type ThreadSummary,
@@ -1214,8 +1208,6 @@ function bindStreamSocketHandlers(
       // after the transaction commits so the backfill never runs inside it.
       let gapAfterSequence: string | null = null
 
-      // Same primed map, so this resolves without a second IDB read.
-      const singlePreviewWriter = await isSinglePreviewWriterEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
       // Read after the transaction only: the `return` it drives stays inside the
       // callback, so the write path's control flow is unchanged.
@@ -1320,41 +1312,6 @@ function bindStreamSocketHandlers(
       // ciphertext); for plaintext sends the render path ignores the cache.
       if (optimisticPlaintext && isEncryptedPayload(newEvent.payload)) {
         seedDecryption(newEvent.id, optimisticPlaintext)
-      }
-
-      // `stream:activity` is emitted in the same backend transaction as this
-      // event and carries the server markdown, so it is the single preview
-      // writer; this arm only exists as the kill switch.
-      if (!singlePreviewWriter) {
-        // Update sidebar preview in both TanStack cache and IDB so the sort order
-        // and preview text survive cold starts (offline-first).
-        const newPreview: LastMessagePreview = {
-          authorId: newEvent.actorId ?? "",
-          authorType: newEvent.actorType ?? "user",
-          content: newPayload.contentJson as string,
-          createdAt: newEvent.createdAt,
-        }
-
-        const stopPreviewWrite = getPerfCapture().time("stream.previewWrite")
-        try {
-          await db.streams.update(streamId, {
-            lastMessagePreview: newPreview,
-            _cachedAt: Date.now(),
-          })
-
-          queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-            if (!old) return old
-            return {
-              ...old,
-              streams: old.streams.map((stream) => {
-                if (stream.id !== streamId) return stream
-                return { ...stream, lastMessagePreview: newPreview }
-              }),
-            }
-          })
-        } finally {
-          stopPreviewWrite()
-        }
       }
 
       if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(newPayload.contentJson)) {
@@ -2005,10 +1962,10 @@ function describeSignatureConflicts(
 
 /**
  * Registers the stream handler set, sharing one binding per
- * `(eventSource, streamId)` when `sharedStreamRegistration` is on. The open
- * stream is registered twice — once per membership by the SyncEngine, once by
- * `useStreamSocket` — through the same event gate, so without sharing every
- * handler runs twice for every event on that stream.
+ * `(eventSource, streamId)`. The open stream is registered twice — once per
+ * membership by the SyncEngine, once by `useStreamSocket` — through the same
+ * event gate, so without sharing every handler runs twice for every event on
+ * that stream.
  */
 export function registerStreamSocketHandlers(
   socket: SyncEventSource,
@@ -2021,10 +1978,6 @@ export function registerStreamSocketHandlers(
   // A fresh wrapper per registration: two registrants may pass the same
   // function reference, and a release must remove only its own listener.
   const listener: SequenceGapListener | null = onSequenceGap ? (gap) => onSequenceGap(gap) : null
-
-  if (!isSharedStreamRegistrationEnabledSync(workspaceId)) {
-    return bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, new Set(listener ? [listener] : []))
-  }
 
   const signature = { workspaceId, queryClient }
   let byStream = streamRegistrations.get(socket)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -110,7 +110,6 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isCoalescedLiveCommitEnabledSync, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -693,9 +692,9 @@ export function registerWorkspaceSocketHandlers(
      *  and sidebar order never flicker through intermediate replay values.
      *  Absent → live, write-immediately. */
     getCatchUpBatch?: () => CatchUpBatch | null
-    /** The engine's live-commit batch, used when `coalescedLiveCommit` is on:
-     *  one task's counter and preview writes fold into one transaction and one
-     *  cache publication instead of two of each per event. */
+    /** The engine's live-commit batch: one task's counter and preview writes
+     *  fold into one transaction and one cache publication instead of two of
+     *  each per event. Absent only for handlers built without an engine. */
     getLiveCommitBatch?: () => LiveCommitBatch | null
   }
 ): () => void {
@@ -705,50 +704,24 @@ export function registerWorkspaceSocketHandlers(
   // batch when one is active, else commit immediately (live). Read-pointer
   // mirrors and feed invalidations are not coalesced — they stay on their own
   // immediate paths in the handlers below.
-  /** The live batch when the flag is armed, else null. Re-read per event: a
-   *  backoffice flip re-primes the flag map, so arming and disarming both take
-   *  effect on the next event. */
-  const armedLiveBatch = (): LiveCommitBatch | null =>
-    isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
-
-  /** Run an immediate (unbatched) commit, draining a still-pending fold first.
-   *  Without this, an off-flip mid-task lets an older buffered preview flush
-   *  AFTER a newer immediate commit and overwrite it in cache and IDB. */
-  const commitImmediate = (commit: () => void): void => {
-    const pending = refs.getLiveCommitBatch?.() ?? null
-    if (pending?.hasPending() || pending?.isFlushing()) {
-      pending.runAfterDrain(commit)
-      return
-    }
-    commit()
-  }
+  const liveBatch = (): LiveCommitBatch | null => refs.getLiveCommitBatch?.() ?? null
 
   const commitCounter = (mutate: CounterMutator): void => {
-    const batch = refs.getCatchUpBatch?.() ?? null
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.applyCounter(mutate)
       return
     }
-    const live = armedLiveBatch()
-    if (live) {
-      live.applyCounter(mutate)
-      return
-    }
-    commitImmediate(() => commitCounterMutation(queryClient, workspaceId, mutate))
+    commitCounterMutation(queryClient, workspaceId, mutate)
   }
 
   const commitPreview = (streamId: string, preview: LastMessagePreview | null): void => {
-    const batch = refs.getCatchUpBatch?.() ?? null
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.setStreamPreview(streamId, preview)
       return
     }
-    const live = armedLiveBatch()
-    if (live) {
-      live.setStreamPreview(streamId, preview)
-      return
-    }
-    commitImmediate(() => commitStreamPreview(queryClient, workspaceId, streamId, preview))
+    commitStreamPreview(queryClient, workspaceId, streamId, preview)
   }
 
   // Activity-feed invalidation seam. During catch-up it marks the feed stale on
@@ -1212,12 +1185,12 @@ export function registerWorkspaceSocketHandlers(
     // commit from ONE ordered buffer: routing it around the batch would open its
     // transaction at handler time and drop held rows BEFORE the buffered fold
     // inserts them, resurrecting an already-read mention.
-    const batch = refs.getCatchUpBatch?.() ?? armedLiveBatch()
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.applyCounter((state) => applyStreamsReadAllOrdinals(state, payload.reads))
       batch.applyReadAllFrontiers(payload.frontiers)
     } else {
-      commitImmediate(() => void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers))
+      void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers)
     }
 
     // Standalone frontier (read cutover): read_all carries ordinals, no event
@@ -1784,10 +1757,7 @@ export function registerWorkspaceSocketHandlers(
     }))
     if (!patched) return
     const layers = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.featureFlags
-    if (layers) {
-      primeEventWriteFlags(workspaceId, layers)
-      void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
-    }
+    if (layers) void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
   }
 
   const handleFeatureFlagsUpdated = (payload: FeatureFlagsUpdatedPayload) => {
@@ -2685,7 +2655,6 @@ export async function applyWorkspaceBootstrap(
 ): Promise<AppliedWorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
-  primeEventWriteFlags(workspaceId, bootstrap.featureFlags)
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -3165,8 +3134,6 @@ export async function applyReconnectBootstrapBatch(
     localUnreadState: localUnreadState ?? undefined,
     fetchStartedAt,
   })
-
-  primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -92,7 +92,7 @@ there is no gap to catch up on.
 | 12  | Restore → switch stream → return → navigate away and back | `--profile drafts` plus `--profile large-stream`                                               | `editor.externalSync`, `stream.subscriptions`, `liveQuery.rerun`, `bootstrap.publish`                                                                                                                                                                         |
 | 13  | Unchanged warm refresh, wide workspace                    | `--profile workspace-wide`, then hard-refresh twice with no new messages (read the third load) | `bootstrap.preRead` + `bootstrap.tx` (the comparable number), `bootstrap.rowsWritten`, `bootstrap.rowsSkipped`, `bootstrap.diff`, `bootstrap.storePublish`, `bootstrap.cachePublish`, `bootstrap.cleanup`                                                     |
 | 14  | One incoming message into a deep scroll-back window       | `--profile large-stream`, scroll up ten pages, then post from a second client                  | `timeline.tailLoad` (bounded and flat as the scroll-back deepens), `liveQuery.load`, `timeline.derive` (samples sum to the whole derivation chain — one per memo in it), `timeline.windowItems` (identical between arms — a change here is a correctness bug) |
-| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.previewWrite`, `stream.activityApply`, `stream.liveCommitFold`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                         |
+| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.activityApply`, `stream.liveCommitFold`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                                                |
 
 ### Reading `liveQuery.rerun` / `liveQuery.load` (scenarios 7, 8, 14)
 
@@ -112,31 +112,26 @@ after against whole-read before, not the same population.
 
 `stream.idbTransaction` counts the per-message write transactions the sync path
 opens: the event-write transaction (`stream-sync.ts`), the local context-row
-transaction (`putLocalContextRows`), and the counter and preview commits
-(`commitCounterMutation`, `commitStreamPreview`, or the single
-`LiveCommitBatch.commit` that replaces both when `coalescedLiveCommit` is on).
-It does not count catch-up flushes — those are per window, not per message — so
-read it only in a live-delivery scenario.
+transaction (`putLocalContextRows`), and the single `LiveCommitBatch.commit`
+that carries the counter and preview together. It does not count catch-up
+flushes — those are per window, not per message — so read it only in a
+live-delivery scenario.
 
-`stream.activityApply` is the handler body in BOTH arms — one sample per
-`stream:activity`. It is not the same work in each: with `coalescedLiveCommit`
-off it covers two synchronous `setQueryData` calls plus the _setup_ of two
-fire-and-forget IDB transactions (`void db.transaction(...)` — the sample stops
-before the persist settles); with the flag on those calls are replaced by two
-buffer pushes, so the sample is near zero. Read it as "what the handler costs
-the task", never as the cost of the write.
+`stream.activityApply` is the handler body — one sample per `stream:activity`,
+covering two buffer pushes, so it is near zero. Read it as "what the handler
+costs the task", never as the cost of the write.
 
-The fold has its own name, `stream.liveCommitFold`, emitted only in the on arm —
-one sample per flush, covering the awaited transaction and the single bootstrap
-publication. Its presence proves the flag armed; its count against the
-`stream.activityApply` count is the coalescing ratio. The two names are separate
-populations on purpose: mixed under one name, N near-zero handler samples plus
-one awaited fold sample makes the arm look faster or slower depending on which
-statistic the reader takes.
+The fold has its own name, `stream.liveCommitFold` — one sample per flush,
+covering the awaited transaction and the single bootstrap publication. Its count
+against the `stream.activityApply` count is the coalescing ratio. The two names
+are separate populations on purpose: mixed under one name, N near-zero handler
+samples plus one awaited fold sample makes the path look faster or slower
+depending on which statistic the reader takes.
 
-Caveat for scenario 15 with `sharedStreamRegistration` on: the cheap duplicate
-apply disappears, so the mean of `stream.eventApply` **rises** even though the
-total work halves. Compare sample counts × mean, not means.
+Caveat for scenario 15: one binding per (event source, stream) means the cheap
+duplicate apply is gone, so the mean of `stream.eventApply` reads **higher** than
+a pre-#1764 capture even though the total work halved. Compare sample counts ×
+mean, not means.
 
 ### Scenario 13 — reading the unchanged warm refresh
 
@@ -185,7 +180,7 @@ Three caveats, all load-bearing:
 
 `stream.eventApply` is wall clock around a handler that awaits, so it includes
 main-thread contention from the renders its own writes wake — its samples do not
-sum from `stream.eventTx` + `stream.contextRows` + `stream.previewWrite`.
+sum from `stream.eventTx` + `stream.contextRows`.
 
 Three things to check before reading a scenario-15 capture, each of which
 otherwise produces a confident wrong conclusion:

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -55,14 +55,11 @@ export function defineFlag<
  */
 export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
-  coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
-  sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  singlePreviewWriter: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -34,7 +34,6 @@ export const PERF_MARK_NAMES = [
   "stream.idbTransaction",
   "stream.eventTx",
   "stream.contextRows",
-  "stream.previewWrite",
   "stream.activityApply",
   "stream.liveCommitFold",
   "stream.eventDuplicate",


### PR DESCRIPTION
## Problem

The three flags from Stack #1765 (`sharedStreamRegistration`, `singlePreviewWriter`, `coalescedLiveCommit`) merged default-off as kill switches. They have now run enabled in production for several days with nothing misbehaving, so their off arms — and the whole primed flag cache that existed to resolve them without an IDB read per event — are dead weight.

## Solution

- **`sharedStreamRegistration`**: `registerStreamSocketHandlers` always shares one binding per `(eventSource, streamId)`. The unshared front door is gone.
- **`singlePreviewWriter`**: `message:created` no longer writes a sidebar preview. `stream:activity` is emitted in the same backend transaction and carries the server markdown, so it is the only writer. The `stream.previewWrite` mark now has no emitter and is retired from `PERF_MARK_NAMES`.
- **`coalescedLiveCommit`**: `commitCounter`, `commitPreview` and the `read_all` seam always fold into the live batch.
- **The primed flag cache**: with no readers left, `flagsByWorkspace`, `primeEventWriteFlags`, `primeEventWriteFlagsIfAbsent`, `resetEventWriteFlags`, `getEventWriteFlags` and `resolveEventWriteFlags` go. `event-writes.ts` keeps only the account generation (`bumpAccountGeneration` / `getAccountGeneration`), which the batch's account guard still reads. 201 → 83 lines.

**The drain deletion is the one worth checking.** `commitImmediate` drained a pending or in-flight fold before running a direct commit, because an off-flip mid-task could otherwise let an older buffered preview publish on top of a newer immediate one — the hole CodeRabbit found in #1770. With no flag, the batch cannot disarm mid-task: `commitCounter`/`commitPreview` reach the immediate path only when `getLiveCommitBatch` is absent, in which case there is no batch to drain. So `hasPending`, `isFlushing`, `runAfterDrain` and the `flushing` field are unreachable and go with it.

Handlers built without an engine (tests) still take the immediate path, and `live-commit-batch.test.ts` now uses that — withholding the batch — as the baseline its folded arm is compared against, instead of a flag-off prime.

Two shared-registration tests counted `db.streams.update` calls to tell one apply from two; removing the preview write zeroes that counter. They now count the scope read and `stream.eventApply` samples. **Both were verified red under a neutralised binding** before being accepted.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/event-writes.ts` | flag cache deleted; account generation kept |
| `apps/frontend/src/sync/stream-sync.ts` | sharing unconditional; preview write removed |
| `apps/frontend/src/sync/workspace-sync.ts` | seams always fold into the live batch |
| `apps/frontend/src/sync/catch-up-batch.ts` | drain API and `flushing` removed |
| `apps/frontend/src/stores/workspace-store.ts`, `auth/account-scope.tsx` | prime/reset calls dropped |
| `packages/types/src/feature-flags.ts`, `performance-capture.ts` | three keys and `stream.previewWrite` removed |
| 7 test files | off arms and flip cases removed |

Registry after this stack: `calls`, `composeTraces`, `perfDiagnostics` — no rollout gates left.

## Test plan

- [x] `src/sync/`, `src/db/`, `src/stores/`, `src/hooks/`, `src/auth/` — 1949 pass
- [x] `packages/types` + backend + control-plane feature-flag suites — 31 pass
- [x] neutralisation check: unsharing the binding turns both rewritten registration tests red
- [x] monorepo lint + typecheck (pre-commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788855006&installation_model_id=20758&pr_number=1834&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1834&signature=884e763502f0c6bdc06007914f22f88bbd6024eb2d20458f8c360fa69c522ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->