### PR TITLE
chore: CI probe for the flag-cleanup stack (do not merge)

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -10,7 +10,7 @@ import { makeQueryClient } from "@/contexts/query-client"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { resetActorLookups } from "@/stores/actor-lookup"
-import { bumpAccountGeneration, resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration } from "@/db/event-writes"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
@@ -81,7 +81,6 @@ function flushModuleStoreCaches(): void {
   resetWorkspaceStoreCache()
   resetWorkspaceTableRegistry()
   resetActorLookups()
-  resetEventWriteFlags()
   // The `db` proxy is repointed on a switch, so any write deferred past this
   // point would land in the new account's database — deferred writers capture
   // this generation and bail when it moves.

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
 import * as useMobileModule from "@/hooks/use-mobile"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 
 type CachedWorkspaceUser = Parameters<typeof seedWorkspaceCache>[1]["users"][number]
 import {
@@ -143,6 +144,7 @@ function enterConnectedCall(roster: CallRosterParticipant[]) {
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   localStorage.clear()
   __resetCallPrefsForTests()
   // Default resolves to the floating square now; pin the sidebar dock so the dock-

--- a/apps/frontend/src/components/call/call-start-menu.test.tsx
+++ b/apps/frontend/src/components/call/call-start-menu.test.tsx
@@ -5,6 +5,7 @@ import * as authModule from "@/auth"
 import { clearCallState, setCallSession, setCallPhase } from "@/stores/call-store"
 import { upsertActiveCall, __resetActiveCallsStore } from "@/stores/active-calls-store"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import type { CallController } from "@/calls/call-manager"
 import { CallStartMenu } from "./call-start-menu"
 import { CallManagerProvider } from "./call-manager-context"
@@ -40,6 +41,7 @@ beforeEach(() => {
   clearCallState()
   __resetActiveCallsStore()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   // The menu reads viewer identity to tell "join" from "take over".
   vi.spyOn(authModule, "useUser").mockReturnValue({ id: "workos_self" } as ReturnType<typeof authModule.useUser>)
 })

--- a/apps/frontend/src/components/call/floating-call-square.test.tsx
+++ b/apps/frontend/src/components/call/floating-call-square.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent } from "@testing-library/react"
 import { render, screen, userEvent } from "@/test"
 import * as authModule from "@/auth"
 import { seedWorkspaceCache, resetWorkspaceStoreCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import {
   clearCallState,
   setCallSession,
@@ -145,6 +146,7 @@ const TWO_PEERS: CallRosterParticipant[] = [
 beforeEach(() => {
   clearCallState()
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   localStorage.clear()
   __resetCallPrefsForTests()
   seedUsers()

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -21,10 +21,8 @@ import { useStreamFromStore } from "@/stores/stream-store"
 import { resetActorLookups } from "@/stores/actor-lookup"
 import { resetWorkspaceStoreCache } from "@/stores/workspace-store"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
 } from "@/stores/workspace-table-registry"
 import { EditLastMessageContext } from "./edit-last-message-context"
@@ -680,7 +678,6 @@ describe("row-tree read fan-out", () => {
     // The real lookup, not the suite's stub: this test is about what the row
     // tree reads from IDB.
     vi.spyOn(hooksModule, "useActors").mockRestore()
-    setWorkspaceReadMode("shared")
     const where = vi.spyOn(workspaceUsersTable(), "where")
 
     render(
@@ -694,24 +691,6 @@ describe("row-tree read fan-out", () => {
     await screen.findAllByText("row 0")
 
     expect(where).toHaveBeenCalledTimes(1)
-  })
-
-  it("fifty rows open one users read per consumer when sharing is off", async () => {
-    vi.spyOn(hooksModule, "useActors").mockRestore()
-    setWorkspaceReadMode("off")
-    const where = vi.spyOn(workspaceUsersTable(), "where")
-
-    render(
-      <>
-        {rowEvents.map((event) => (
-          <MessageEvent key={event.id} event={event} workspaceId={workspaceId} streamId={streamId} />
-        ))}
-      </>,
-      { wrapper: Wrapper }
-    )
-    await screen.findAllByText("row 0")
-
-    expect(where.mock.calls.length).toBeGreaterThan(50)
   })
 
   // Runs under the suite's stubbed `useActors`, so it covers the pre-existing
@@ -762,9 +741,8 @@ describe("MessageEvent stream-row reads", () => {
   const rootStreamId = "stream_root"
 
   async function primeStreamRegistry(): Promise<() => void> {
-    const token = allocateWorkspaceTableToken()
-    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
-    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams")).toBeDefined())
     return unsubscribe
   }
 
@@ -795,7 +773,6 @@ describe("MessageEvent stream-row reads", () => {
     await clearWorkspaceActorTables()
     await seedWorkspaceUser(workspaceId, "member_123")
     await clearStreams()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {

--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -925,7 +925,6 @@ describe("CoordinatedLoadingProvider store publication", () => {
     bootstrapBase = {
       ...makeWorkspaceBootstrap(),
       workspace: { id: WS, name: "CLP", slug: "clp", createdBy: "user_1", createdAt: now, updatedAt: now },
-      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
       users: [
         {
           id: "user_1",

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1590,9 +1590,7 @@ export class ThreaDatabase extends Dexie {
     // the index over existing rows; no row is rewritten.
     // One-way door: once a client has opened at v47, code declaring only v46
     // cannot open the database (IndexedDB refuses a version downgrade), so a
-    // revert of this bump is not available — reverting means a v48. The
-    // *lookup* that uses the index is flag-gated (`indexedMessagePatch`)
-    // instead, and that is what a rollback turns off.
+    // revert of this bump is not available — reverting means a v48.
     this.version(47).stores({
       events:
         "id, workspaceId, streamId, sequence, [streamId+sequence], [streamId+_sequenceNum], eventType, [streamId+eventType], _clientId, _cachedAt, _status, payload.messageId",

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -250,24 +250,22 @@ describe("isEventWriteChunkingEnabled", () => {
   })
 
   it("readEventWriteFlagsFresh ignores the cache and re-reads the row every call", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on", indexedMessagePatch: "on" }, user: {} })
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off", indexedMessagePatch: "off" }, user: {} })
+    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
+    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
 
     const first = await readEventWriteFlagsFresh(db, "ws_1")
-    await putMetadata({ workspace: { eventWriteChunking: "off", indexedMessagePatch: "on" }, user: {} })
+    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
     const second = await readEventWriteFlagsFresh(db, "ws_1")
 
     expect({ first, second }).toEqual({
       first: {
         chunking: true,
-        indexedMessagePatch: true,
         sharedStreamRegistration: false,
         singlePreviewWriter: false,
         coalescedLiveCommit: false,
       },
       second: {
         chunking: false,
-        indexedMessagePatch: true,
         sharedStreamRegistration: false,
         singlePreviewWriter: false,
         coalescedLiveCommit: false,

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -1,16 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
-import {
-  EVENT_BULK_PUT_LIMIT,
-  isSharedStreamRegistrationEnabledSync,
-  isSinglePreviewWriterEnabled,
-  primeEventWriteFlags,
-  primeEventWriteFlagsIfAbsent,
-  putEventsBounded,
-  resetEventWriteFlags,
-  skipNoOpEventRewrites,
-} from "./event-writes"
+import { EVENT_BULK_PUT_LIMIT, putEventsBounded, skipNoOpEventRewrites } from "./event-writes"
 
 function makeRow(streamId: string, index: number, overrides: Partial<CachedEvent> = {}): CachedEvent {
   const sequence = String(1000 + index)
@@ -35,22 +26,9 @@ function makePage(streamId: string, count: number): CachedEvent[] {
 }
 
 beforeEach(async () => {
-  resetEventWriteFlags()
   await db.events.clear()
   await db.workspaceMetadata.clear()
 })
-
-async function putMetadata(featureFlags: unknown): Promise<void> {
-  await db.workspaceMetadata.put({
-    id: "ws_1",
-    workspaceId: "ws_1",
-    emojis: [],
-    emojiWeights: {},
-    commands: [],
-    featureFlags,
-    _cachedAt: 1,
-  } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
-}
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -190,76 +168,5 @@ describe("live-query wake set (D1)", () => {
     })
 
     expect(emissions).toBeGreaterThan(0)
-  })
-})
-
-describe("the primed flag cache", () => {
-  it("resolves a persisted layered row and caches it", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "on" }, user: {} })
-    const get = vi.spyOn(db.workspaceMetadata, "get")
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(get).toHaveBeenCalledTimes(1)
-  })
-
-  it("a pre-#1455 flat row neither throws nor overrides the registry default", async () => {
-    // A flat legacy row is IGNORED (coerced away), so the resolved value is the
-    // registry default, never the flat row's own field, and never a crash.
-    await putMetadata({ singlePreviewWriter: "on" })
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
-  })
-
-  it("a primed value wins without reading the row", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
-    const get = vi.spyOn(db.workspaceMetadata, "get")
-    primeEventWriteFlags("ws_1", { workspace: {}, user: { singlePreviewWriter: "on" } })
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-    expect(get).not.toHaveBeenCalled()
-  })
-
-  it("resetEventWriteFlags clears the primed value", async () => {
-    // Primed "on" (an explicit override), then reset: with no persisted row the
-    // resolve falls back to the registry default — proving the primed override
-    // was dropped, not retained.
-    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
-    resetEventWriteFlags()
-
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
-  })
-
-  it("a prime landing mid-read wins over the older persisted row", async () => {
-    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
-    let release: () => void = () => {}
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const real = db.workspaceMetadata.get.bind(db.workspaceMetadata)
-    vi.spyOn(db.workspaceMetadata, "get").mockImplementation(((key: string) =>
-      gate.then(() => real(key))) as unknown as typeof db.workspaceMetadata.get)
-
-    const inFlight = isSinglePreviewWriterEnabled(db, "ws_1")
-    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
-    release()
-
-    expect(await inFlight).toBe(true)
-    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
-  })
-})
-
-describe("primeEventWriteFlagsIfAbsent", () => {
-  it("primeEventWriteFlagsIfAbsent fills an empty cache", () => {
-    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
-
-    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
-  })
-
-  it("primeEventWriteFlagsIfAbsent never overwrites a value already primed", () => {
-    primeEventWriteFlags("ws_1", { workspace: { sharedStreamRegistration: "on" }, user: {} })
-    primeEventWriteFlagsIfAbsent("ws_1", { workspace: { sharedStreamRegistration: "off" }, user: {} })
-
-    expect(isSharedStreamRegistrationEnabledSync("ws_1")).toBe(true)
   })
 })

--- a/apps/frontend/src/db/event-writes.test.ts
+++ b/apps/frontend/src/db/event-writes.test.ts
@@ -3,9 +3,8 @@ import { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import {
   EVENT_BULK_PUT_LIMIT,
-  isEventWriteChunkingEnabled,
   isSharedStreamRegistrationEnabledSync,
-  readEventWriteFlagsFresh,
+  isSinglePreviewWriterEnabled,
   primeEventWriteFlags,
   primeEventWriteFlagsIfAbsent,
   putEventsBounded,
@@ -62,27 +61,27 @@ describe("putEventsBounded", () => {
     const rows = makePage("stream_a", 50)
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, rows, true)
+    await putEventsBounded(db.events, rows)
 
     expect(bulkPut).toHaveBeenCalledTimes(2)
     expect(bulkPut.mock.calls.map((call) => (call[0] as CachedEvent[]).length)).toEqual([EVENT_BULK_PUT_LIMIT, 1])
     expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
   })
 
-  it("writes a single bulkPut when chunking is off", async () => {
+  it("a page at the limit is written as one bulkPut", async () => {
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, makePage("stream_a", 50), false)
+    await putEventsBounded(db.events, makePage("stream_a", EVENT_BULK_PUT_LIMIT))
 
     expect(bulkPut).toHaveBeenCalledTimes(1)
-    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(50)
+    expect(await db.events.where("streamId").equals("stream_a").count()).toBe(EVENT_BULK_PUT_LIMIT)
   })
 })
 
 describe("skipNoOpEventRewrites", () => {
   it("re-writing an identical page writes nothing", async () => {
     const rows = makePage("stream_a", 50)
-    await putEventsBounded(db.events, rows, true)
+    await putEventsBounded(db.events, rows)
 
     const existingRows = await db.events.bulkGet(rows.map((row) => row.id))
     const existingById = new Map(
@@ -91,7 +90,7 @@ describe("skipNoOpEventRewrites", () => {
     const candidates = rows.map((row) => ({ ...row, _cachedAt: 999 }))
     const bulkPut = vi.spyOn(db.events, "bulkPut")
 
-    await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates), true)
+    await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates))
 
     expect(bulkPut).toHaveBeenCalledTimes(0)
     const after = await db.events.where("streamId").equals("stream_a").toArray()
@@ -154,23 +153,26 @@ describe("live-query wake set (D1)", () => {
   }
 
   it("a 50-row page does not wake a live query ranged on another stream", async () => {
-    const chunkedEmissions = await countEmissions(async () => {
-      await putEventsBounded(db.events, makePage("stream_b", 50), true)
+    const boundedEmissions = await countEmissions(async () => {
+      await putEventsBounded(db.events, makePage("stream_b", 50))
     })
-    expect(chunkedEmissions).toBe(0)
+    expect(boundedEmissions).toBe(0)
 
     await db.events.clear()
 
-    const unchunkedEmissions = await countEmissions(async () => {
-      await putEventsBounded(db.events, makePage("stream_b", 50), false)
+    // Control: the same page through a single bulkPut is what trips Dexie's
+    // FULL_RANGE marking, so a 0 above means the slicing worked, not that the
+    // subscription was deaf.
+    const singlePutEmissions = await countEmissions(async () => {
+      await db.events.bulkPut(makePage("stream_b", 50))
     })
-    expect(unchunkedEmissions).toBeGreaterThan(0)
+    expect(singlePutEmissions).toBeGreaterThan(0)
   })
 
   it("a page written inside one wrapping transaction still does not wake another stream's query", async () => {
     const emissions = await countEmissions(async () => {
       await db.transaction("rw", [db.events], async () => {
-        await putEventsBounded(db.events, makePage("stream_b", 50), true)
+        await putEventsBounded(db.events, makePage("stream_b", 50))
       })
     })
 
@@ -182,57 +184,54 @@ describe("live-query wake set (D1)", () => {
     await db.events.put(makeRow("stream_a", 0))
 
     const emissions = await countEmissions(async () => {
-      await putEventsBounded(
-        db.events,
-        [makeRow("stream_a", 0, { payload: { messageId: "evt_stream_a_0", contentMarkdown: "edited" } })],
-        true
-      )
+      await putEventsBounded(db.events, [
+        makeRow("stream_a", 0, { payload: { messageId: "evt_stream_a_0", contentMarkdown: "edited" } }),
+      ])
     })
 
     expect(emissions).toBeGreaterThan(0)
   })
 })
 
-describe("isEventWriteChunkingEnabled", () => {
+describe("the primed flag cache", () => {
   it("resolves a persisted layered row and caches it", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "on" }, user: {} })
     const get = vi.spyOn(db.workspaceMetadata, "get")
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
     expect(get).toHaveBeenCalledTimes(1)
   })
 
   it("a pre-#1455 flat row neither throws nor overrides the registry default", async () => {
     // A flat legacy row is IGNORED (coerced away), so the resolved value is the
-    // registry default — "on" since the go-live flip — never the flat row's own
-    // field, and never a crash.
-    await putMetadata({ eventWriteChunking: "off" })
+    // registry default, never the flat row's own field, and never a crash.
+    await putMetadata({ singlePreviewWriter: "on" })
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
   })
 
   it("a primed value wins without reading the row", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
     const get = vi.spyOn(db.workspaceMetadata, "get")
-    primeEventWriteFlags("ws_1", { workspace: {}, user: { eventWriteChunking: "on" } })
+    primeEventWriteFlags("ws_1", { workspace: {}, user: { singlePreviewWriter: "on" } })
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
     expect(get).not.toHaveBeenCalled()
   })
 
   it("resetEventWriteFlags clears the primed value", async () => {
-    // Primed "off" (an explicit override), then reset: with no persisted row
-    // the resolve falls back to the registry default "on" — proving the primed
-    // override was dropped, not retained.
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
+    // Primed "on" (an explicit override), then reset: with no persisted row the
+    // resolve falls back to the registry default — proving the primed override
+    // was dropped, not retained.
+    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
     resetEventWriteFlags()
 
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(false)
   })
 
   it("a prime landing mid-read wins over the older persisted row", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
+    await putMetadata({ workspace: { singlePreviewWriter: "off" }, user: {} })
     let release: () => void = () => {}
     const gate = new Promise<void>((resolve) => {
       release = resolve
@@ -241,36 +240,12 @@ describe("isEventWriteChunkingEnabled", () => {
     vi.spyOn(db.workspaceMetadata, "get").mockImplementation(((key: string) =>
       gate.then(() => real(key))) as unknown as typeof db.workspaceMetadata.get)
 
-    const inFlight = isEventWriteChunkingEnabled(db, "ws_1")
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "on" }, user: {} })
+    const inFlight = isSinglePreviewWriterEnabled(db, "ws_1")
+    primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "on" }, user: {} })
     release()
 
     expect(await inFlight).toBe(true)
-    expect(await isEventWriteChunkingEnabled(db, "ws_1")).toBe(true)
-  })
-
-  it("readEventWriteFlagsFresh ignores the cache and re-reads the row every call", async () => {
-    await putMetadata({ workspace: { eventWriteChunking: "on" }, user: {} })
-    primeEventWriteFlags("ws_1", { workspace: { eventWriteChunking: "off" }, user: {} })
-
-    const first = await readEventWriteFlagsFresh(db, "ws_1")
-    await putMetadata({ workspace: { eventWriteChunking: "off" }, user: {} })
-    const second = await readEventWriteFlagsFresh(db, "ws_1")
-
-    expect({ first, second }).toEqual({
-      first: {
-        chunking: true,
-        sharedStreamRegistration: false,
-        singlePreviewWriter: false,
-        coalescedLiveCommit: false,
-      },
-      second: {
-        chunking: false,
-        sharedStreamRegistration: false,
-        singlePreviewWriter: false,
-        coalescedLiveCommit: false,
-      },
-    })
+    expect(await isSinglePreviewWriterEnabled(db, "ws_1")).toBe(true)
   })
 })
 

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -1,6 +1,5 @@
-import { coerceLayers, resolveFeatureFlags, type FeatureFlagLayers } from "@threa/types"
 import type { EntityTable } from "dexie"
-import type { CachedEvent, ThreaDatabase } from "@/db/database"
+import type { CachedEvent } from "@/db/database"
 
 /**
  * Dexie 4.4.2 registers precise changed keys for a `bulkPut` of fewer than 50
@@ -11,8 +10,6 @@ import type { CachedEvent, ThreaDatabase } from "@/db/database"
 export const EVENT_BULK_PUT_LIMIT = 49
 
 type EventTable = EntityTable<CachedEvent, "id">
-
-const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
 
 /**
  * Writes events in slices below Dexie's FULL_RANGE threshold. Opens no
@@ -68,18 +65,6 @@ export function skipNoOpEventRewrites(
   })
 }
 
-// The `workspaceMetadata` row carries the workspace emoji list — hundreds of KB
-// that Dexie must deserialize per read — so resolving the flag from it on every
-// event write costs more than the write. Resolve once per workspace per module
-// instance instead, primed from the network bootstrap and socket flag flips.
-type EventWriteFlags = {
-  sharedStreamRegistration: boolean
-  singlePreviewWriter: boolean
-  coalescedLiveCommit: boolean
-}
-
-const flagsByWorkspace = new Map<string, EventWriteFlags>()
-let primeGeneration = 0
 let accountGeneration = 0
 
 /**
@@ -95,77 +80,4 @@ export function bumpAccountGeneration(): void {
 /** The current account generation — capture it before deferring a write. */
 export function getAccountGeneration(): number {
   return accountGeneration
-}
-
-function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
-  const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
-  return {
-    sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
-    singlePreviewWriter: resolved.singlePreviewWriter === "on",
-    coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
-  }
-}
-
-/** Seed the cache from freshly delivered layers (bootstrap response or flag-flip socket event). */
-export function primeEventWriteFlags(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
-  primeGeneration += 1
-  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
-}
-
-/**
- * Seed the cache from the persisted workspace row on a warm start, where
- * registration can run before any network prime. If-absent, not prime: the
- * persisted row is only a warm-start fallback and must never overwrite a
- * network prime that landed while the IDB reads were in flight (same freshness
- * rule as {@link getEventWriteFlags}).
- */
-export function primeEventWriteFlagsIfAbsent(workspaceId: string, layers: FeatureFlagLayers | null | undefined): void {
-  if (flagsByWorkspace.has(workspaceId)) return
-  primeGeneration += 1
-  flagsByWorkspace.set(workspaceId, resolveEventWriteFlags(layers))
-}
-
-/** Test-only: drop the cache so each case resolves from its own prime/IDB row. */
-export function resetEventWriteFlags(): void {
-  primeGeneration += 1
-  flagsByWorkspace.clear()
-}
-
-async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
-  const cached = flagsByWorkspace.get(workspaceId)
-  if (cached !== undefined) return cached
-  // The persisted row is the warm-start fallback, so a prime that lands while
-  // this read is in flight is strictly newer and must win (INV-20).
-  const generation = primeGeneration
-  const metadata = await database.workspaceMetadata.get(workspaceId)
-  const flags = resolveEventWriteFlags(metadata?.featureFlags)
-  if (primeGeneration !== generation) return flagsByWorkspace.get(workspaceId) ?? flags
-  flagsByWorkspace.set(workspaceId, flags)
-  return flags
-}
-
-/** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */
-export async function isSinglePreviewWriterEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).singlePreviewWriter
-}
-
-/**
- * The viewer's `coalescedLiveCommit` value, read only from the primed map so the
- * synchronous commit seams can re-read it per event. A backoffice flip re-primes
- * the map, so arming and disarming both take effect on the next event; an
- * unprimed read takes the immediate path rather than guessing.
- */
-export function isCoalescedLiveCommitEnabledSync(workspaceId: string): boolean {
-  return flagsByWorkspace.get(workspaceId)?.coalescedLiveCommit ?? false
-}
-
-/**
- * The viewer's `sharedStreamRegistration` value, read only from the primed map.
- * Handler registration is synchronous, so there is no await in which to resolve
- * the persisted row: an unprimed read falls back to the unshared path rather
- * than guessing. A miss costs the optimization for that registration, never
- * correctness — two unshared registrations behave exactly as they do today.
- */
-export function isSharedStreamRegistrationEnabledSync(workspaceId: string): boolean {
-  return flagsByWorkspace.get(workspaceId)?.sharedStreamRegistration ?? false
 }

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -15,13 +15,13 @@ type EventTable = EntityTable<CachedEvent, "id">
 const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
 
 /**
- * Writes events in slices below Dexie's FULL_RANGE threshold when `chunked`,
- * and as today's single `bulkPut` when not. Opens no transaction of its own —
- * the caller's transaction is what makes the slices atomic.
+ * Writes events in slices below Dexie's FULL_RANGE threshold. Opens no
+ * transaction of its own — the caller's transaction is what makes the slices
+ * atomic.
  */
-export async function putEventsBounded(table: EventTable, rows: CachedEvent[], chunked: boolean): Promise<void> {
+export async function putEventsBounded(table: EventTable, rows: CachedEvent[]): Promise<void> {
   if (rows.length === 0) return
-  if (!chunked || rows.length <= EVENT_BULK_PUT_LIMIT) {
+  if (rows.length <= EVENT_BULK_PUT_LIMIT) {
     await table.bulkPut(rows)
     return
   }
@@ -73,7 +73,6 @@ export function skipNoOpEventRewrites(
 // event write costs more than the write. Resolve once per workspace per module
 // instance instead, primed from the network bootstrap and socket flag flips.
 type EventWriteFlags = {
-  chunking: boolean
   sharedStreamRegistration: boolean
   singlePreviewWriter: boolean
   coalescedLiveCommit: boolean
@@ -101,7 +100,6 @@ export function getAccountGeneration(): number {
 function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): EventWriteFlags {
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
   return {
-    chunking: resolved.eventWriteChunking === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
     singlePreviewWriter: resolved.singlePreviewWriter === "on",
     coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
@@ -144,27 +142,6 @@ async function getEventWriteFlags(database: ThreaDatabase, workspaceId: string):
   if (primeGeneration !== generation) return flagsByWorkspace.get(workspaceId) ?? flags
   flagsByWorkspace.set(workspaceId, flags)
   return flags
-}
-
-/**
- * The viewer's `eventWriteChunking` value — the primed value when one exists,
- * otherwise resolved once from the layers persisted for a warm start. Tolerates
- * the pre-#1455 flat `featureFlags` shape rather than throwing on it.
- */
-export async function isEventWriteChunkingEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).chunking
-}
-
-/**
- * The chunking flag read straight from the persisted row, bypassing the module
- * cache. The service worker runs its own module instance that nothing primes
- * and nothing resets, so a cached value there would outlive an account switch
- * and hide a backoffice flip until the worker restarts; the per-account
- * `database` handle makes a fresh read account-correct by construction.
- */
-export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
-  const metadata = await database.workspaceMetadata.get(workspaceId)
-  return resolveEventWriteFlags(metadata?.featureFlags)
 }
 
 /** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */

--- a/apps/frontend/src/db/event-writes.ts
+++ b/apps/frontend/src/db/event-writes.ts
@@ -74,7 +74,6 @@ export function skipNoOpEventRewrites(
 // instance instead, primed from the network bootstrap and socket flag flips.
 type EventWriteFlags = {
   chunking: boolean
-  indexedMessagePatch: boolean
   sharedStreamRegistration: boolean
   singlePreviewWriter: boolean
   coalescedLiveCommit: boolean
@@ -103,7 +102,6 @@ function resolveEventWriteFlags(layers: FeatureFlagLayers | null | undefined): E
   const resolved = resolveFeatureFlags(coerceLayers(layers ?? null) ?? EMPTY_FLAG_LAYERS)
   return {
     chunking: resolved.eventWriteChunking === "on",
-    indexedMessagePatch: resolved.indexedMessagePatch === "on",
     sharedStreamRegistration: resolved.sharedStreamRegistration === "on",
     singlePreviewWriter: resolved.singlePreviewWriter === "on",
     coalescedLiveCommit: resolved.coalescedLiveCommit === "on",
@@ -167,11 +165,6 @@ export async function isEventWriteChunkingEnabled(database: ThreaDatabase, works
 export async function readEventWriteFlagsFresh(database: ThreaDatabase, workspaceId: string): Promise<EventWriteFlags> {
   const metadata = await database.workspaceMetadata.get(workspaceId)
   return resolveEventWriteFlags(metadata?.featureFlags)
-}
-
-/** The viewer's `indexedMessagePatch` value, resolved through the same primed cache. */
-export async function isIndexedMessagePatchEnabled(database: ThreaDatabase, workspaceId: string): Promise<boolean> {
-  return (await getEventWriteFlags(database, workspaceId)).indexedMessagePatch
 }
 
 /** The viewer's `singlePreviewWriter` value, resolved through the same primed cache. */

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act, waitFor } from "@testing-library/react"
 import { StreamTypes, type StreamType } from "@threa/types"
 import { db, type CachedStream } from "@/db"
 import { resetWorkspaceStoreCache, seedWorkspaceCache } from "@/stores/workspace-store"
+import { resetWorkspaceTableRegistry } from "@/stores/workspace-table-registry"
 import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
 import { useSealedNamePendingResolver, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
@@ -113,6 +114,7 @@ async function seedSealedStream() {
 
 beforeEach(async () => {
   resetWorkspaceStoreCache()
+  resetWorkspaceTableRegistry()
   clearStreamNameCache()
   await db.streams.clear()
   vi.spyOn(workspaces, "useWorkspaceUserId").mockReturnValue("user_1")

--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import type { StreamEvent } from "@threa/types"
 import { db, type CachedEvent } from "@/db"
-import { resetEventWriteFlags } from "@/db/event-writes"
 import { loadStreamPrefix, loadStreamTail, unionStreamRanges } from "@/stores/stream-store"
 import {
   computeTimelineLoadState,
@@ -232,7 +231,6 @@ describe("getEffectiveEvents", () => {
 
 describe("cacheToIndexedDB with eventWriteChunking on", () => {
   beforeEach(async () => {
-    resetEventWriteFlags()
     await db.events.clear()
     await db.workspaceMetadata.clear()
     await db.workspaceMetadata.put({

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -3,7 +3,7 @@ import { useStreamBootstrap } from "./use-streams"
 import { useStreamService } from "@/contexts"
 import { useQueryClient, useInfiniteQuery } from "@tanstack/react-query"
 import { db, sequenceToNum } from "@/db"
-import { isEventWriteChunkingEnabled, putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
+import { putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useFeatureFlag } from "@/hooks/use-feature-flags"
@@ -281,7 +281,6 @@ export async function cacheToIndexedDB(
   carrier?: SlotCarrier
 ) {
   const now = Date.now()
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   await db.transaction("rw", [db.events, db.slots], async () => {
     if (events.length > 0) {
       const existingRows = await db.events.bulkGet(events.map((e) => e.id))
@@ -304,7 +303,7 @@ export async function cacheToIndexedDB(
           _patchedAt: existing._patchedAt,
         }
       })
-      await putEventsBounded(db.events, chunked ? skipNoOpEventRewrites(existingById, candidates) : candidates, chunked)
+      await putEventsBounded(db.events, skipNoOpEventRewrites(existingById, candidates))
     }
     // Persist the page's slot carrier alongside its events so pointers in pages
     // older than the bootstrap window hydrate from the store (Amendment A2).

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -6,7 +6,6 @@ import { db, sequenceToNum } from "@/db"
 import { putEventsBounded, skipNoOpEventRewrites } from "@/db/event-writes"
 import { EVENT_PAGE_SIZE } from "@/lib/constants"
 import { useStreamEvents } from "@/stores/stream-store"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { isTerminalBootstrapError, shouldSuppressBootstrapError } from "@/lib/query-load-state"
 import { computeTimelineHoles, holesSignature, type TimelineHole } from "@/sync/contiguity"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
@@ -454,12 +453,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   // cap for bounded initial load.
   const idbFloor = useMemo(() => getDisplayFloor(bootstrapFloor, olderFloor), [bootstrapFloor, olderFloor])
   const idbFloorNum = idbFloor !== null ? Number(idbFloor) : null
-  // The flag is resolved here — inside the providers, off the feature-flag hook
-  // layer — rather than in the store hook, so the four floorless `useStreamEvents`
-  // call sites keep their provider-free contract. `useStreamEvents` latches the
-  // value per (streamId, floor) window.
-  const boundedRead = useFeatureFlag(workspaceId, "boundedTimelineRead") === "on"
-  const idbEvents = useStreamEvents(streamId, idbFloorNum, { boundedRead })
+  const idbEvents = useStreamEvents(streamId, idbFloorNum)
 
   const idbResolved = idbEvents !== undefined
   const hasIdbEvents = idbResolved && idbEvents.length > 0

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -126,7 +126,7 @@ async function promoteDraft(
   // re-increment here.
   const anchorId = creation.parentAnchorId ?? creation.parentMessageId
   if (creation.type === StreamTypes.THREAD && creation.parentStreamId && anchorId) {
-    setParentThreadId(next.workspaceId, creation.parentStreamId, anchorId, realStreamId).catch(() => {})
+    setParentThreadId(creation.parentStreamId, anchorId, realStreamId).catch(() => {})
   }
 
   // Clean up draft data (no-ops gracefully for non-scratchpad drafts).

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -264,12 +264,7 @@ export function useQueueDraftMessage(workspaceId: string) {
       const anchorId = params.streamCreation?.parentAnchorId ?? params.streamCreation?.parentMessageId
       if (params.streamCreation?.type === StreamTypes.THREAD && params.streamCreation.parentStreamId && anchorId) {
         const draftPanelId = createDraftPanelId(params.streamCreation.parentStreamId, anchorId)
-        await optimisticReplyCountUpdate(
-          params.workspaceId,
-          params.streamCreation.parentStreamId,
-          anchorId,
-          draftPanelId
-        ).catch(() => {})
+        await optimisticReplyCountUpdate(params.streamCreation.parentStreamId, anchorId, draftPanelId).catch(() => {})
       }
 
       notifyQueue()

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -1,6 +1,6 @@
 import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import type { CachedEvent, ThreaDatabase } from "../db/database"
-import { putEventsBounded, readEventWriteFlagsFresh } from "../db/event-writes"
+import { putEventsBounded } from "../db/event-writes"
 import { writeSlotCarrier } from "../stores/slot-store"
 
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
@@ -142,7 +142,6 @@ async function prefetchEventsAround(
     if (data?.events?.length > 0) {
       const now = Date.now()
       const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
-      const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
       await db.transaction("rw", [db.events, db.slots], async () => {
         await putEventsBounded(
           db.events,
@@ -151,8 +150,7 @@ async function prefetchEventsAround(
             workspaceId,
             _sequenceNum: sequenceToNum(e.sequence as string),
             _cachedAt: now,
-          })) as CachedEvent[],
-          chunked
+          })) as CachedEvent[]
         )
         // Warm the pointer slots this prefetch exists to preserve; an
         // events-around window merges (it is not an authoritative snapshot).
@@ -192,7 +190,6 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
     // sink the stream into "Other". Merge via update() so lastMessagePreview
     // and membership-derived fields (notificationLevel) from
     // applyWorkspaceBootstrap survive.
-    const { chunking: chunked } = await readEventWriteFlagsFresh(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       await putEventsBounded(
         db.events,
@@ -201,8 +198,7 @@ async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string
           workspaceId,
           _sequenceNum: sequenceToNum(e.sequence),
           _cachedAt: now,
-        })),
-        chunked
+        }))
       )
 
       // Warm the bootstrap's pointer slots in the same transaction; a cold

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -62,8 +62,6 @@ import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { isServerStreamId } from "@/lib/stream-ids"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
-import { setWorkspaceReadMode } from "@/stores/workspace-table-registry"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { SyncEngine, SyncEngineContext, isSyncEngineCurrent } from "@/sync/sync-engine"
 import { draftsApi, messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
@@ -343,21 +341,6 @@ function MessageQueueHandler() {
   return null
 }
 
-/**
- * Pushes the `sharedWorkspaceReads` flag into the workspace-table registry. The
- * flag flips sharing only — the hook shape is identical in both arms — so it can
- * arrive late or change mid-session without changing a single hook count (D5).
- */
-function WorkspaceReadModeSync({ workspaceId }: { workspaceId: string }) {
-  const shared = useFeatureFlag(workspaceId, "sharedWorkspaceReads") === "on"
-
-  useEffect(() => {
-    setWorkspaceReadMode(shared ? "shared" : "off")
-  }, [shared])
-
-  return null
-}
-
 function StreamNameDecryptor({ workspaceId }: { workspaceId: string }) {
   useDecryptStreamNames(workspaceId)
   return null
@@ -497,7 +480,6 @@ export function WorkspaceLayout() {
             <AppUpdateChecker />
             <FreshnessWatchers />
             <MessageQueueHandler />
-            <WorkspaceReadModeSync workspaceId={workspaceId} />
             <StreamNameDecryptor workspaceId={workspaceId} />
             <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={coordinatedStreamIds}>
               <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>

--- a/apps/frontend/src/stores/actor-lookup.test.tsx
+++ b/apps/frontend/src/stores/actor-lookup.test.tsx
@@ -6,7 +6,7 @@ import * as perfCapture from "@/lib/perf/capture"
 import { useActors } from "@/hooks/use-actors"
 import { useWorkspaceStreams, resetWorkspaceStoreCache, upsertWorkspacePersonaCache } from "./workspace-store"
 import { resetActorLookups } from "./actor-lookup"
-import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
+import { resetWorkspaceTableRegistry } from "./workspace-table-registry"
 
 const WORKSPACE = "ws_1"
 
@@ -103,7 +103,6 @@ describe("actor lookup", () => {
     await db.bots.clear()
     await db.workspaceMetadata.clear()
     await db.streams.clear()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {
@@ -175,8 +174,7 @@ describe("actor lookup", () => {
     await waitFor(() => expect(result.current.getActorName("persona_1", "persona")).toBe("Ariadne"))
   })
 
-  it("each consumer keeps its own lookup identity across a re-render when sharing is off", async () => {
-    setWorkspaceReadMode("off")
+  it("a consumer keeps its lookup identity across a re-render", async () => {
     await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
     await db.workspaceMetadata.put(makeMetadata())
     const seen: Array<[unknown, unknown]> = []
@@ -198,7 +196,6 @@ describe("actor lookup", () => {
   })
 
   it("the lookup build count is bounded by the consumer count and does not grow on re-render", async () => {
-    setWorkspaceReadMode("off")
     await db.workspaceUsers.put(makeUser("usr_1", "Ada"))
     await db.workspaceMetadata.put(makeMetadata())
     const time = vi.fn((_name: string) => () => {})
@@ -219,12 +216,11 @@ describe("actor lookup", () => {
     rerender(<TwoConsumers tick={2} seen={seen} />)
     await findByText("Ada-Ada-2")
 
-    // One sample per emoji-index build (the only producer): two consumers each
-    // build their own while the rows resolve — a per-consumer constant, not a
-    // per-render one.
+    // One sample per emoji-index build (the only producer): both consumers read
+    // the one shared entry, so the index is built once while the rows resolve —
+    // a constant, not a per-render or per-consumer cost.
     expect({ settled, grew: builds() - settled }).toEqual({ settled, grew: 0 })
-    // One emoji-index build per consumer, and nothing else samples this timer.
-    expect(settled).toBe(2)
+    expect(settled).toBe(1)
   })
 
   it("an unknown actor id falls back exactly as before", async () => {

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -918,10 +918,9 @@ describe("useStreamEvents with the bounded read armed", () => {
 
     const { ranges, restore } = recordRanges()
     try {
-      const { result, rerender } = renderHook(
-        ({ floor }: { floor: number }) => useStreamEvents(STREAM, floor, { boundedRead: true }),
-        { initialProps: { floor: 200 } }
-      )
+      const { result, rerender } = renderHook(({ floor }: { floor: number }) => useStreamEvents(STREAM, floor), {
+        initialProps: { floor: 200 },
+      })
       await waitFor(() => expect(result.current?.length).toBe(101))
 
       const tailRanges = ranges.filter((args) => Array.isArray(args[1]) && (args[1] as unknown[])[1] === Dexie.maxKey)
@@ -956,7 +955,7 @@ describe("useStreamEvents with the bounded read armed", () => {
       const seen: (CachedEvent[] | undefined)[] = []
       const { result, rerender } = renderHook(
         ({ floor }: { floor: number }) => {
-          const events = useStreamEvents(STREAM, floor, { boundedRead: true })
+          const events = useStreamEvents(STREAM, floor)
           seen.push(events)
           return events
         },
@@ -1006,7 +1005,7 @@ describe("useStreamEvents with the bounded read armed", () => {
     const seen: (CachedEvent[] | undefined)[] = []
     const { result, rerender } = renderHook(
       ({ streamId }: { streamId: string }) => {
-        const events = useStreamEvents(streamId, 1, { boundedRead: true })
+        const events = useStreamEvents(streamId, 1)
         seen.push(events)
         return events
       },

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import Dexie, { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { computeTimelineHoles } from "@/sync/contiguity"
@@ -17,10 +17,8 @@ import {
   useStreamFromStore,
 } from "./stream-store"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
 } from "./workspace-table-registry"
 import { makeCachedStream } from "@/test/workspace-rows"
@@ -452,9 +450,8 @@ describe("useStreamFromStore", () => {
 
   /** Bring up the shared registry entry the fast path reads, and wait for its first emission. */
   async function primeRegistry(workspaceId: string): Promise<() => void> {
-    const token = allocateWorkspaceTableToken()
-    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", token, () => {})
-    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams", token)).toBeDefined())
+    const unsubscribe = subscribeWorkspaceTable(workspaceId, "streams", () => {})
+    await waitFor(() => expect(getWorkspaceTableSnapshot(workspaceId, "streams")).toBeDefined())
     return unsubscribe
   }
 
@@ -479,7 +476,6 @@ describe("useStreamFromStore", () => {
   beforeEach(async () => {
     resetWorkspaceTableRegistry()
     await db.streams.clear()
-    setWorkspaceReadMode("shared")
   })
 
   afterEach(() => {
@@ -579,38 +575,6 @@ describe("useStreamFromStore", () => {
       expect(typeof value).toBe("object")
       expect((value as CachedStream).id).toBe("stream_a")
     }
-  })
-
-  it("an on→off flip holds the resolved row and opens no whole-table read per reader", async () => {
-    await db.streams.put(makeStream("stream_a", REGISTRY_WORKSPACE, { displayName: "Held Channel" }))
-    releaseRegistry = await primeRegistry(REGISTRY_WORKSPACE)
-
-    const observed: (CachedStream | undefined)[] = []
-    const readers = [0, 1, 2].map(() =>
-      renderHook(() => {
-        const row = useStreamFromStore("stream_a")
-        observed.push(row)
-        return row
-      })
-    )
-    for (const reader of readers) await waitFor(() => expect(reader.result.current?.id).toBe("stream_a"))
-    const held = readers.map((reader) => reader.result.current)
-
-    const where = vi.spyOn(db.streams, "where")
-    await act(async () => {
-      setWorkspaceReadMode("off")
-    })
-
-    readers.forEach((reader, index) => expect(reader.result.current).toBe(held[index]))
-    for (const reader of readers) {
-      await waitFor(() => expect(reader.result.current?.displayName).toBe("Held Channel"))
-    }
-    expect(observed).not.toContain(undefined)
-    // The flip must not migrate the readers' row registrations into private
-    // entries: that opens one whole-table streams query PER READER — the cost the
-    // kill switch exists to remove. The one expected call is the table
-    // subscriber's own re-key.
-    expect(where.mock.calls.length).toBe(1)
   })
 })
 

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -305,17 +305,12 @@ interface TailAnchor {
  */
 export function useStreamEvents(
   streamId: string | undefined,
-  fromSequenceNum?: number | null,
-  options?: { boundedRead?: boolean }
+  fromSequenceNum?: number | null
 ): CachedEvent[] | undefined {
   const floor = fromSequenceNum ?? null
   // Floorless callers keep the single capped read: their bound is the count cap,
-  // and a tail/prefix split there would change what that cap means. The flag
-  // resolves at the caller and can arrive after the first render (cold direct
-  // link), so it is read every render rather than latched — a flip re-arms the
-  // window, which costs one extra read and cannot mis-render because both arms
-  // mount the same two hooks.
-  const bounded = options?.boundedRead === true && floor !== null
+  // and a tail/prefix split there would change what that cap means.
+  const bounded = floor !== null
 
   const [anchor, setAnchor] = useState<TailAnchor | null>(null)
   // The tail floor is latched ONCE per stream and never moves while the stream

--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
 import {
-  allocateWorkspaceTableToken,
   findSharedRowWorkspace,
   getWorkspaceTableRow,
   hasResolvedSharedEntry,
@@ -452,37 +451,30 @@ type StreamRowFallback = CachedStream | typeof REGISTRY_OWNED_ROW | undefined
  * ran ~4× the rendered window on every write before.
  *
  * Fallback (D7, fail-open): an id no shared entry holds — a socket write that
- * landed before bootstrap, or the `sharedWorkspaceReads=off` arm, where entries
- * are private to a token this hook does not have and the fast path therefore
- * misses by design — resolves through today's per-key `db.streams.get`. Both
- * paths mount the same hooks unconditionally; only the work inside them differs.
+ * landed before bootstrap — resolves through today's per-key `db.streams.get`.
+ * Both paths mount the same hooks unconditionally; only the work inside them
+ * differs.
  *
  * `undefined` means "genuinely not resolved anywhere". `resolveDecryptContext`
  * reads that as "hold, never attempt", and a decrypt attempted against an
  * unhydrated row caches its failure forever — so a value already resolved on
- * either path is held across a registry flip rather than flickering to
+ * either path is held across an ownership change rather than flickering to
  * `undefined`.
  */
 export function useStreamFromStore(streamId: string | undefined): CachedStream | undefined {
-  const tokenRef = useRef<number | null>(null)
-  tokenRef.current ??= allocateWorkspaceTableToken()
-  const token = tokenRef.current
-
   const registryWorkspaceId = streamId ? findSharedRowWorkspace("streams", streamId) : undefined
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (!streamId || !registryWorkspaceId) return () => {}
-      return subscribeWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token, onStoreChange)
+      return subscribeWorkspaceTableRow(registryWorkspaceId, "streams", streamId, onStoreChange)
     },
-    [streamId, registryWorkspaceId, token]
+    [streamId, registryWorkspaceId]
   )
   const readRegistryRow = useCallback(
     () =>
-      streamId && registryWorkspaceId
-        ? getWorkspaceTableRow(registryWorkspaceId, "streams", streamId, token)
-        : undefined,
-    [streamId, registryWorkspaceId, token]
+      streamId && registryWorkspaceId ? getWorkspaceTableRow(registryWorkspaceId, "streams", streamId) : undefined,
+    [streamId, registryWorkspaceId]
   )
   const registryRow = useSyncExternalStore(subscribe, readRegistryRow, readRegistryRow)
 

--- a/apps/frontend/src/stores/workspace-store.publication.test.ts
+++ b/apps/frontend/src/stores/workspace-store.publication.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { db, type CachedWorkspace, type CachedWorkspaceUser } from "@/db"
-import { isSharedStreamRegistrationEnabledSync, resetEventWriteFlags } from "@/db/event-writes"
 import {
   getCachedWorkspaceTables,
   resetWorkspaceStoreCache,
@@ -97,24 +96,6 @@ describe("seedWorkspaceCache publication gating", () => {
     await idbSeed
 
     expect(getCachedWorkspaceTables(WS).users?.map((u) => u.name)).toEqual(["Fresh"])
-  })
-
-  it("a warm start primes the stream-registration flag before any bootstrap", async () => {
-    resetEventWriteFlags()
-    await db.workspaces.put(makeWorkspace())
-    await db.workspaceMetadata.put({
-      id: WS,
-      workspaceId: WS,
-      emojis: [],
-      emojiWeights: {},
-      commands: [],
-      featureFlags: { workspace: { sharedStreamRegistration: "on" }, user: {} },
-      _cachedAt: Date.now(),
-    } as unknown as Parameters<typeof db.workspaceMetadata.put>[0])
-
-    expect(await seedCacheFromIdb(WS)).toBe(true)
-
-    expect(isSharedStreamRegistrationEnabledSync(WS)).toBe(true)
   })
 
   it("a publishing seed notifies exactly once", () => {

--- a/apps/frontend/src/stores/workspace-store.test.tsx
+++ b/apps/frontend/src/stores/workspace-store.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act, render, waitFor } from "@testing-library/react"
 import { LabelableResourceTypes } from "@threa/types"
 import { db, type CachedLabelAssignment, type CachedStream, type CachedWorkspaceUser } from "@/db"
 import * as streamNameCache from "@/lib/crypto/stream-name-cache"
-import { resetWorkspaceTableRegistry, setWorkspaceReadMode } from "./workspace-table-registry"
+import { resetWorkspaceTableRegistry } from "./workspace-table-registry"
 import {
   resetWorkspaceStoreCache,
   seedWorkspaceCache,
@@ -240,7 +240,6 @@ describe("workspace store cache subscriptions", () => {
     // Same contract as the case above, re-asserted through the shared registry:
     // an emptied IDB must win over the bootstrap cache, or a socket unassign is
     // masked until the next bootstrap.
-    setWorkspaceReadMode("shared")
     await db.labelAssignments.clear()
     const assignment: CachedLabelAssignment = {
       id: "workspace_1:stream:stream_9:label_9:user_1",
@@ -284,7 +283,6 @@ describe("workspace store cache subscriptions", () => {
   })
 
   it("the decrypted-name overlay is applied once per workspace, not once per consumer", async () => {
-    setWorkspaceReadMode("shared")
     await db.streams.clear()
     const stream: CachedStream = {
       id: "stream_overlay",

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -1,7 +1,6 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { useBatchedValue } from "./apply-window"
 import {
-  allocateWorkspaceTableToken,
   getWorkspaceTableSnapshot,
   subscribeWorkspaceTable,
   type WorkspaceTableKey,
@@ -350,25 +349,17 @@ export function upsertWorkspaceUserInCache(workspaceId: string, user: CachedWork
 // on the returned reference) for the whole pre-resolution window.
 const EMPTY_ROWS: never[] = []
 
-function useWorkspaceTableToken(): number {
-  const token = useRef<number | null>(null)
-  if (token.current === null) token.current = allocateWorkspaceTableToken()
-  return token.current
-}
-
 function useWorkspaceTable<K extends WorkspaceTableKey>(
   workspaceId: string | undefined,
   tableKey: K
 ): WorkspaceTableRowTypes[K][] | undefined {
-  const token = useWorkspaceTableToken()
   const subscribe = useCallback(
-    (listener: () => void) =>
-      workspaceId ? subscribeWorkspaceTable(workspaceId, tableKey, token, listener) : () => {},
-    [workspaceId, tableKey, token]
+    (listener: () => void) => (workspaceId ? subscribeWorkspaceTable(workspaceId, tableKey, listener) : () => {}),
+    [workspaceId, tableKey]
   )
   const getSnapshot = useCallback(
-    () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey, token) : undefined),
-    [workspaceId, tableKey, token]
+    () => (workspaceId ? getWorkspaceTableSnapshot(workspaceId, tableKey) : undefined),
+    [workspaceId, tableKey]
   )
   const live = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
   useWorkspaceCacheSignal(workspaceId, live === undefined)

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -6,7 +6,6 @@ import {
   type WorkspaceTableKey,
   type WorkspaceTableRowTypes,
 } from "./workspace-table-registry"
-import { primeEventWriteFlagsIfAbsent } from "@/db/event-writes"
 // Namespace import so the shared overlay memo below is spy-able against the
 // module (INV-48) — the "once per workspace, not once per consumer" property is
 // only assertable through the real call.
@@ -216,8 +215,6 @@ export async function seedCacheFromIdb(workspaceId: string): Promise<boolean> {
     publishWorkspaceCache(workspaceId)
     return true
   }
-
-  primeEventWriteFlagsIfAbsent(workspaceId, metadata?.featureFlags)
 
   seedWorkspaceCache(workspaceId, {
     workspace,

--- a/apps/frontend/src/stores/workspace-table-registry.test.tsx
+++ b/apps/frontend/src/stores/workspace-table-registry.test.tsx
@@ -1,16 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render, renderHook, waitFor } from "@testing-library/react"
-import { useState, useSyncExternalStore } from "react"
+import { useSyncExternalStore } from "react"
 import { db, type CachedWorkspaceUser } from "@/db"
 import * as perfCapture from "@/lib/perf/capture"
 import { resetWorkspaceStoreCache, useWorkspaceUsers } from "./workspace-store"
 import {
   activeWorkspaceSubscriptionCount,
-  allocateWorkspaceTableToken,
   getWorkspaceTableRow,
   getWorkspaceTableSnapshot,
   resetWorkspaceTableRegistry,
-  setWorkspaceReadMode,
   subscribeWorkspaceTable,
   subscribeWorkspaceTableRow,
 } from "./workspace-table-registry"
@@ -55,11 +53,11 @@ function ManyConsumers({ count }: { count: number }) {
   return <div data-testid="rows">{rows[0].length}</div>
 }
 
-function useRegistryRows(workspaceId: string, token: number): CachedWorkspaceUser[] | undefined {
+function useRegistryRows(workspaceId: string): CachedWorkspaceUser[] | undefined {
   return useSyncExternalStore(
-    (listener) => subscribeWorkspaceTable(workspaceId, "users", token, listener),
-    () => getWorkspaceTableSnapshot(workspaceId, "users", token),
-    () => getWorkspaceTableSnapshot(workspaceId, "users", token)
+    (listener) => subscribeWorkspaceTable(workspaceId, "users", listener),
+    () => getWorkspaceTableSnapshot(workspaceId, "users"),
+    () => getWorkspaceTableSnapshot(workspaceId, "users")
   )
 }
 
@@ -77,7 +75,6 @@ describe("workspace table registry", () => {
 
   it("twenty consumers of useWorkspaceUsers open one IDB read", async () => {
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    setWorkspaceReadMode("shared")
     const where = vi.spyOn(db.workspaceUsers, "where")
 
     const { findByText } = render(<ManyConsumers count={20} />)
@@ -87,23 +84,9 @@ describe("workspace table registry", () => {
     expect(activeWorkspaceSubscriptionCount()).toBe(1)
   })
 
-  it("mode off creates one subscription per consumer", async () => {
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    setWorkspaceReadMode("off")
-    const where = vi.spyOn(db.workspaceUsers, "where")
-
-    const { findByText } = render(<ManyConsumers count={20} />)
-    await findByText("2")
-
-    expect(where).toHaveBeenCalledTimes(20)
-    expect(activeWorkspaceSubscriptionCount()).toBe(20)
-  })
-
   it("an unchanged row keeps its object identity across emissions", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.put(makeUser("user_1"))
-    const token = allocateWorkspaceTableToken()
-    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE))
     await waitFor(() => expect(result.current).toHaveLength(1))
     const first = result.current![0]
 
@@ -116,16 +99,14 @@ describe("workspace table registry", () => {
   })
 
   it("a change to one row does not re-render a consumer reading another row", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
     const renders = { user_1: 0, user_2: 0 }
 
     function RowProbe({ rowId }: { rowId: "user_1" | "user_2" }) {
-      const [token] = useState(allocateWorkspaceTableToken)
       const row = useSyncExternalStore(
-        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", rowId, token, listener),
-        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token),
-        () => getWorkspaceTableRow(WORKSPACE, "users", rowId, token)
+        (listener) => subscribeWorkspaceTableRow(WORKSPACE, "users", rowId, listener),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId),
+        () => getWorkspaceTableRow(WORKSPACE, "users", rowId)
       )
       renders[rowId] += 1
       return <span data-testid={rowId}>{row?.name ?? "-"}</span>
@@ -151,43 +132,19 @@ describe("workspace table registry", () => {
     }).toEqual({ user_1: 0, user_2: true })
   })
 
-  it("a private entry tears down at zero grace after its consumer unmounts", async () => {
-    // The 5s grace exists so a SHARED entry survives a remount; a token-keyed
-    // entry has exactly one consumer, so retaining its whole-table liveQuery
-    // for 5s per unmount doubled the off-arm's subscriptions on navigation
-    // (whole-stack finding). Zero delay still absorbs a same-task remount.
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      setWorkspaceReadMode("off")
-      await db.workspaceUsers.put(makeUser("user_1"))
-      const { findByText, unmount } = render(<ManyConsumers count={2} />)
-      await findByText("1")
-      const mounted = activeWorkspaceSubscriptionCount()
-      unmount()
-      await act(async () => {
-        vi.advanceTimersByTime(0)
-      })
-      expect({ mounted, afterUnmount: activeWorkspaceSubscriptionCount() }).toEqual({ mounted: 2, afterUnmount: 0 })
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
   it("the last unsubscribe tears the query down after the grace window, and a re-subscribe inside it reuses the entry", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
-      setWorkspaceReadMode("shared")
       await db.workspaceUsers.put(makeUser("user_1"))
-      const token = allocateWorkspaceTableToken()
       const noop = () => {}
-      const unsubscribe = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
-      await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1))
+      const unsubscribe = subscribeWorkspaceTable(WORKSPACE, "users", noop)
+      await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users")).toHaveLength(1))
 
       unsubscribe()
       expect(activeWorkspaceSubscriptionCount()).toBe(1)
 
-      const again = subscribeWorkspaceTable(WORKSPACE, "users", token, noop)
-      expect(getWorkspaceTableSnapshot(WORKSPACE, "users", token)).toHaveLength(1)
+      const again = subscribeWorkspaceTable(WORKSPACE, "users", noop)
+      expect(getWorkspaceTableSnapshot(WORKSPACE, "users")).toHaveLength(1)
       expect(activeWorkspaceSubscriptionCount()).toBe(1)
 
       again()
@@ -201,10 +158,8 @@ describe("workspace table registry", () => {
   })
 
   it("a subscriber that mounts after the first emission gets the current snapshot synchronously", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.put(makeUser("user_1"))
-    const token = allocateWorkspaceTableToken()
-    const { result } = renderHook(() => useRegistryRows(WORKSPACE, token))
+    const { result } = renderHook(() => useRegistryRows(WORKSPACE))
     await waitFor(() => expect(result.current).toHaveLength(1))
 
     const seen: (number | undefined)[] = []
@@ -219,7 +174,6 @@ describe("workspace table registry", () => {
   })
 
   it("switching workspaces does not leak the previous workspace's rows", async () => {
-    setWorkspaceReadMode("shared")
     await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_other", { workspaceId: OTHER_WORKSPACE })])
 
     const { result, rerender } = renderHook(({ workspaceId }) => useWorkspaceUsers(workspaceId), {
@@ -229,104 +183,6 @@ describe("workspace table registry", () => {
 
     rerender({ workspaceId: OTHER_WORKSPACE })
     await waitFor(() => expect(result.current.map((row) => row.id)).toEqual(["user_other"]))
-  })
-
-  it("a flip after mount leaks no listener and tears down cleanly", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      setWorkspaceReadMode("off")
-      await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-
-      const { findByText, unmount } = render(<ManyConsumers count={5} />)
-      await findByText("2")
-
-      act(() => {
-        setWorkspaceReadMode("shared")
-      })
-      expect(activeWorkspaceSubscriptionCount()).toBe(1)
-
-      unmount()
-      await act(async () => {
-        vi.advanceTimersByTime(6_000)
-      })
-
-      expect(activeWorkspaceSubscriptionCount()).toBe(0)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it("a flip preserves the resolved snapshot and does not notify unchanged consumers", async () => {
-    setWorkspaceReadMode("off")
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    let renders = 0
-    const seen: (CachedWorkspaceUser[] | undefined)[] = []
-
-    function Consumer() {
-      const [token] = useState(allocateWorkspaceTableToken)
-      const rows = useRegistryRows(WORKSPACE, token)
-      renders += 1
-      seen.push(rows)
-      return <span data-testid="count">{rows?.length ?? "-"}</span>
-    }
-
-    const { findByText } = render(<Consumer />)
-    await findByText("2")
-    const before = seen[seen.length - 1]!
-    const rendersBefore = renders
-
-    act(() => {
-      setWorkspaceReadMode("shared")
-    })
-
-    expect({
-      rows: seen[seen.length - 1],
-      extraRenders: renders - rendersBefore,
-      ids: seen[seen.length - 1]!.map((row) => row.id),
-    }).toEqual({ rows: before, extraRenders: 0, ids: ["user_1", "user_2"] })
-  })
-
-  it("a row registration survives a flip, but a re-subscribe in off mode mints nothing", async () => {
-    setWorkspaceReadMode("shared")
-    await db.workspaceUsers.bulkPut([makeUser("user_1"), makeUser("user_2")])
-    const token = allocateWorkspaceTableToken()
-    const notify = vi.fn()
-
-    let unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
-    const sharedEntries = activeWorkspaceSubscriptionCount()
-
-    act(() => {
-      setWorkspaceReadMode("off")
-    })
-
-    // The reader's effect re-runs after the flip: the new subscribe must be a
-    // no-op, and the consumer reads undefined and falls back to its own query.
-    unsubscribe()
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
-    })
-    const afterDrop = activeWorkspaceSubscriptionCount()
-    const noop = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    noop()
-
-    expect({
-      minted: activeWorkspaceSubscriptionCount() - afterDrop,
-      row: getWorkspaceTableRow(WORKSPACE, "users", "user_1", token),
-    }).toEqual({ minted: 0, row: undefined })
-
-    act(() => {
-      setWorkspaceReadMode("shared")
-    })
-    unsubscribe = subscribeWorkspaceTableRow(WORKSPACE, "users", "user_1", token, notify)
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("user_1"))
-    expect(activeWorkspaceSubscriptionCount()).toBe(sharedEntries)
-
-    await act(async () => {
-      await db.workspaceUsers.put(makeUser("user_1", { name: "Renamed" }))
-    })
-    await waitFor(() => expect(getWorkspaceTableRow(WORKSPACE, "users", "user_1", token)?.name).toBe("Renamed"))
-    unsubscribe()
   })
 
   it("the subscription-count mark tracks entry lifecycle", async () => {
@@ -339,20 +195,11 @@ describe("workspace table registry", () => {
         flush: async () => {},
       } as unknown as ReturnType<typeof perfCapture.getPerfCapture>)
 
-      // The mark measures the shared-arm economy only: in `off` mode the count
-      // tracks consumer mounts and would flood the capture ring, so nothing is
-      // emitted there (whole-stack finding).
-      setWorkspaceReadMode("off")
       await db.workspaceUsers.put(makeUser("user_1"))
 
       const { findByText, unmount } = render(<ManyConsumers count={3} />)
       await findByText("1")
       const afterMount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
-
-      act(() => {
-        setWorkspaceReadMode("shared")
-      })
-      const afterFlip = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
 
       unmount()
       await act(async () => {
@@ -360,40 +207,12 @@ describe("workspace table registry", () => {
       })
       const afterUnmount = mark.mock.calls.filter(([name]) => name === "store.tableSubscriptions").pop()
 
-      expect({ afterMount: afterMount?.[1], afterFlip: afterFlip?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
-        afterMount: undefined,
-        afterFlip: 1,
+      expect({ afterMount: afterMount?.[1], afterUnmount: afterUnmount?.[1] }).toEqual({
+        afterMount: 1,
         afterUnmount: 0,
       })
     } finally {
       vi.useRealTimers()
     }
-  })
-
-  it("an off to shared flip seeds the shared entry from the freshest private snapshot", async () => {
-    let dataset: CachedWorkspaceUser[] = [makeUser("user_1")]
-    vi.spyOn(db.workspaceUsers, "where").mockReturnValue({
-      equals: () => ({ toArray: async () => [...dataset] }),
-    } as unknown as ReturnType<typeof db.workspaceUsers.where>)
-
-    setWorkspaceReadMode("off")
-    const noop = () => {}
-    const staleToken = allocateWorkspaceTableToken()
-    subscribeWorkspaceTable(WORKSPACE, "users", staleToken, noop)
-    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)).toHaveLength(1))
-
-    dataset = [makeUser("user_1"), makeUser("user_2")]
-    const freshToken = allocateWorkspaceTableToken()
-    subscribeWorkspaceTable(WORKSPACE, "users", freshToken, noop)
-    await vi.waitFor(() => expect(getWorkspaceTableSnapshot(WORKSPACE, "users", freshToken)).toHaveLength(2))
-
-    setWorkspaceReadMode("shared")
-
-    // Synchronously after the flip: the shared entry's own query has not emitted
-    // yet, so this reads exactly what the migration seeded.
-    expect(getWorkspaceTableSnapshot(WORKSPACE, "users", staleToken)?.map((row) => row.id)).toEqual([
-      "user_1",
-      "user_2",
-    ])
   })
 })

--- a/apps/frontend/src/stores/workspace-table-registry.ts
+++ b/apps/frontend/src/stores/workspace-table-registry.ts
@@ -67,17 +67,9 @@ const WORKSPACE_TABLE_QUERIES: Record<WorkspaceTableKey, TableQuery> = {
   metadata: async (workspaceId) => oneRow(await db.workspaceMetadata.get(workspaceId)),
 }
 
-/** `shared` = one live query per (workspace, table); `off` = one per subscriber, as before the registry. */
-export type WorkspaceReadMode = "shared" | "off"
-
 interface WorkspaceTableEntry {
   workspaceId: string
   tableKey: WorkspaceTableKey
-  // Set from the key form at creation, not re-derived from the current mode: a
-  // token-keyed entry can outlive an off→shared flip inside the teardown grace,
-  // and `findSharedRowWorkspace` must not report ownership under a key a
-  // tokenless reader cannot resolve.
-  shared: boolean
   rows: IdentifiedRow[] | undefined
   byId: Map<string, IdentifiedRow>
   resolved: boolean
@@ -92,7 +84,6 @@ interface WorkspaceTableEntry {
 interface RegistrationBase {
   workspaceId: string
   tableKey: WorkspaceTableKey
-  token: number
   listener: () => void
   entryKey: string
 }
@@ -107,18 +98,14 @@ type Registration = (RegistrationBase & { kind: "table" }) | (RegistrationBase &
 // rows. A context provider would re-render its whole subtree on every table
 // change — which is the cost this exists to remove.
 const entries = new Map<string, WorkspaceTableEntry>()
-// Keyed by an internal registration id, not by the consumer token: one token can
-// hold several registrations, and `unsubscribe` must resolve ITS entry key here
-// at call time — a captured key goes stale the moment a mode flip re-keys it,
-// which leaks the listener and pins `refCount` for the session.
+// Keyed by an internal registration id: one consumer can hold several
+// registrations, and `unsubscribe` must resolve ITS entry here at call time.
 const registrations = new Map<number, Registration>()
 
 // Matches `RAIL_TEARDOWN_GRACE_MS`: a remount unsubscribes before it
 // re-subscribes, and tearing the query down in between would re-read the table.
 const TABLE_TEARDOWN_GRACE_MS = 5_000
 
-let mode: WorkspaceReadMode = "off"
-let nextToken = 1
 let nextRegistrationId = 1
 let lastMarkedLiveEntries = -1
 
@@ -130,41 +117,15 @@ let lastMarkedLiveEntries = -1
  */
 const COMPARE_ALL_KEYS: ReadonlySet<string> = new Set()
 
-/** A stable token for one consumer, so the `off` mode can key a private entry per subscriber. */
-export function allocateWorkspaceTableToken(): number {
-  return nextToken++
-}
-
 let emissionCounter = 0
 
-function sharedEntryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey): string {
+function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey): string {
   return `${workspaceId}|${tableKey}`
-}
-
-function entryKeyFor(workspaceId: string, tableKey: WorkspaceTableKey, token: number): string {
-  return mode === "shared" ? sharedEntryKeyFor(workspaceId, tableKey) : `${workspaceId}|${tableKey}|${token}`
 }
 
 function applyEmission(entryKey: string, incoming: IdentifiedRow[]): void {
   const entry = entries.get(entryKey)
   if (!entry) return
-
-  // Private (token-keyed) entries have exactly one consumer and match the
-  // pre-registry useLiveQuery behaviour: fresh rows, notify on every emission.
-  // The per-row semantic compare would be pure added cost there — for the
-  // metadata singleton it deep-walks the ~356KB emoji row once per consumer
-  // per reaction, and the rows genuinely changed so everyone re-renders anyway.
-  if (entryKey.split("|").length === 3) {
-    entry.byId = new Map(incoming.map((row) => [row.id, row]))
-    entry.rows = incoming
-    entry.resolved = true
-    entry.emissionSeq = ++emissionCounter
-    for (const notify of entry.listeners) notify()
-    for (const keyed of entry.keyListeners.values()) {
-      for (const notify of keyed) notify()
-    }
-    return
-  }
 
   const previous = entry.rows
   const byId = new Map<string, IdentifiedRow>()
@@ -217,23 +178,13 @@ function liveEntryCount(): number {
 }
 
 function markLiveEntries(): void {
-  // The mark measures the shared-arm subscription economy. In `off` mode the
-  // count tracks consumer mounts (~700 per window) — emitting it would flood
-  // the 2000-sample capture ring and evict the marks the A/B compares, and
-  // liveEntryCount() itself is O(entries) on a hot path.
-  if (mode !== "shared") return
   const count = liveEntryCount()
   if (count === lastMarkedLiveEntries) return
   lastMarkedLiveEntries = count
   perfCapture.getPerfCapture().mark("store.tableSubscriptions", count)
 }
 
-function ensureEntry(
-  entryKey: string,
-  workspaceId: string,
-  tableKey: WorkspaceTableKey,
-  seed?: WorkspaceTableEntry
-): WorkspaceTableEntry {
+function ensureEntry(entryKey: string, workspaceId: string, tableKey: WorkspaceTableKey): WorkspaceTableEntry {
   const existing = entries.get(entryKey)
   if (existing) {
     if (existing.teardown) {
@@ -247,7 +198,6 @@ function ensureEntry(
   const created: WorkspaceTableEntry = {
     workspaceId,
     tableKey,
-    shared: entryKey === sharedEntryKeyFor(workspaceId, tableKey),
     rows: undefined,
     byId: new Map(),
     resolved: false,
@@ -261,12 +211,6 @@ function ensureEntry(
   // Register BEFORE subscribing so a synchronous first emission finds the entry;
   // the callback re-reads it from the map, so a late emission after teardown is
   // a no-op.
-  if (seed?.resolved) {
-    created.rows = seed.rows
-    created.byId = new Map(seed.byId)
-    created.resolved = true
-    created.emissionSeq = seed.emissionSeq
-  }
   entries.set(entryKey, created)
   created.subscription = liveQuery(() => WORKSPACE_TABLE_QUERIES[tableKey](workspaceId)).subscribe((rows) =>
     applyEmission(entryKey, rows)
@@ -275,57 +219,33 @@ function ensureEntry(
   return created
 }
 
-function releaseEntry(entryKey: string, immediate: boolean): void {
+function releaseEntry(entryKey: string): void {
   const entry = entries.get(entryKey)
   if (!entry) return
   if (entry.refCount > 0 || entry.listeners.size > 0 || entry.keyListeners.size > 0) return
-  // Private (token-keyed) entries tear down immediately: their one consumer is
-  // gone, nobody else can adopt them, and the grace window would keep a
-  // whole-table liveQuery re-reading for 5s per unmounted consumer — a
-  // behaviour change vs the pre-registry useLiveQuery cleanup in the arm every
-  // user ships with. A StrictMode remount just re-creates the private query.
-  if (immediate) {
-    if (entry.teardown) clearTimeout(entry.teardown)
-    entry.subscription.unsubscribe()
-    entries.delete(entryKey)
-    markLiveEntries()
-    return
-  }
   if (entry.teardown) return
-  // Private (token-keyed) entries get a zero-delay grace: their one consumer is
-  // gone and nobody else can adopt them, so the 5s window would keep a
-  // whole-table liveQuery re-reading per unmounted consumer — a behaviour
-  // change vs the pre-registry useLiveQuery cleanup in the default arm. Zero
-  // delay still absorbs a same-task unsubscribe/resubscribe (StrictMode
-  // remount): the callback re-checks liveness and aborts.
-  const graceMs = entryKey.split("|").length === 3 ? 0 : TABLE_TEARDOWN_GRACE_MS
   entry.teardown = setTimeout(() => {
     const live = entries.get(entryKey)
     if (!live || live.refCount > 0 || live.listeners.size > 0 || live.keyListeners.size > 0) return
     live.subscription.unsubscribe()
     entries.delete(entryKey)
     markLiveEntries()
-  }, graceMs)
+  }, TABLE_TEARDOWN_GRACE_MS)
   markLiveEntries()
 }
 
-/**
- * Subscribe one consumer to a workspace table. `token` comes from
- * {@link allocateWorkspaceTableToken} and must be stable for the consumer's
- * lifetime — in `off` mode it is what keeps the subscription private.
- */
+/** Subscribe one consumer to a workspace table. */
 export function subscribeWorkspaceTable(
   workspaceId: string,
   tableKey: WorkspaceTableKey,
-  token: number,
   listener: () => void
 ): () => void {
-  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entryKey = entryKeyFor(workspaceId, tableKey)
   const entry = ensureEntry(entryKey, workspaceId, tableKey)
   entry.listeners.add(listener)
   entry.refCount += 1
   const registrationId = nextRegistrationId++
-  registrations.set(registrationId, { kind: "table", workspaceId, tableKey, token, listener, entryKey })
+  registrations.set(registrationId, { kind: "table", workspaceId, tableKey, listener, entryKey })
 
   return () => {
     const registration = registrations.get(registrationId)
@@ -335,24 +255,18 @@ export function subscribeWorkspaceTable(
     if (!current) return
     current.listeners.delete(listener)
     current.refCount -= 1
-    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+    if (current.refCount <= 0) releaseEntry(registration.entryKey)
   }
 }
 
-/** Subscribe to one row of a shared table, so a change to row X wakes only X's readers (D6). */
+/** Subscribe to one row of a table, so a change to row X wakes only X's readers (D6). */
 export function subscribeWorkspaceTableRow(
   workspaceId: string,
   tableKey: WorkspaceTableKey,
   rowId: string,
-  token: number,
   listener: () => void
 ): () => void {
-  // Row reads are a shared-mode feature: a shared→off flip landing between a
-  // reader's render and this subscribe effect would otherwise mint one private
-  // whole-table query per reader that no drop machinery unwinds. The off arm's
-  // consumer falls back to its own live query.
-  if (mode !== "shared") return () => {}
-  const entryKey = entryKeyFor(workspaceId, tableKey, token)
+  const entryKey = entryKeyFor(workspaceId, tableKey)
   const entry = ensureEntry(entryKey, workspaceId, tableKey)
   let keyed = entry.keyListeners.get(rowId)
   if (!keyed) {
@@ -362,7 +276,7 @@ export function subscribeWorkspaceTableRow(
   keyed.add(listener)
   entry.refCount += 1
   const registrationId = nextRegistrationId++
-  registrations.set(registrationId, { kind: "row", workspaceId, tableKey, rowId, token, listener, entryKey })
+  registrations.set(registrationId, { kind: "row", workspaceId, tableKey, rowId, listener, entryKey })
 
   return () => {
     const registration = registrations.get(registrationId)
@@ -376,43 +290,35 @@ export function subscribeWorkspaceTableRow(
       if (set.size === 0) current.keyListeners.delete(rowId)
     }
     current.refCount -= 1
-    if (current.refCount <= 0) releaseEntry(registration.entryKey, false)
+    if (current.refCount <= 0) releaseEntry(registration.entryKey)
   }
 }
 
 /** The table's rows, or `undefined` while the first read is in flight (`useLiveQuery`'s contract). */
 export function getWorkspaceTableSnapshot<K extends WorkspaceTableKey>(
   workspaceId: string,
-  tableKey: K,
-  token: number
+  tableKey: K
 ): WorkspaceTableRowTypes[K][] | undefined {
-  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
   return entry?.rows as WorkspaceTableRowTypes[K][] | undefined
 }
 
 export function getWorkspaceTableRow<K extends WorkspaceTableKey>(
   workspaceId: string,
   tableKey: K,
-  rowId: string,
-  token: number
+  rowId: string
 ): WorkspaceTableRowTypes[K] | undefined {
-  const entry = entries.get(entryKeyFor(workspaceId, tableKey, token))
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
   return entry?.byId.get(rowId) as WorkspaceTableRowTypes[K] | undefined
 }
 
 /**
- * The workspace whose **shared** entry currently holds `rowId`, or `undefined`.
+ * The workspace whose entry currently holds `rowId`, or `undefined`.
  *
  * For consumers that know a row id but not its workspace (`useStreamFromStore`).
- * Only shared entries qualify: with the mode `off` an entry is keyed by its
- * subscriber's token, so a tokenless consumer would open a private live query of
- * its own — the very cost the fast path removes — and the caller must fall back
- * to a per-key read instead (D5, D7).
  */
 export function findSharedRowWorkspace(tableKey: WorkspaceTableKey, rowId: string): string | undefined {
-  if (mode !== "shared") return undefined
   for (const entry of entries.values()) {
-    if (!entry.shared) continue
     if (entry.tableKey !== tableKey) continue
     if (entry.byId.has(rowId)) return entry.workspaceId
   }
@@ -420,116 +326,15 @@ export function findSharedRowWorkspace(tableKey: WorkspaceTableKey, rowId: strin
 }
 
 /**
- * True when the shared (workspace, table) entry is live and has resolved.
+ * True when the (workspace, table) entry is live and has resolved.
  *
  * Lets a reader tell a row's genuine removal — that entry still answering, just
- * without the id — from an ownership drop (mode flip, teardown), where the row
- * is unchanged and only the reader's route to it went away.
+ * without the id — from a teardown, where the row is unchanged and only the
+ * reader's route to it went away.
  */
 export function hasResolvedSharedEntry(workspaceId: string, tableKey: WorkspaceTableKey): boolean {
-  if (mode !== "shared") return false
-  const entry = entries.get(sharedEntryKeyFor(workspaceId, tableKey))
-  return Boolean(entry?.shared && entry.resolved && !entry.teardown)
-}
-
-function detach(entry: WorkspaceTableEntry, registration: Registration): void {
-  if (registration.kind === "table") {
-    entry.listeners.delete(registration.listener)
-  } else {
-    const set = entry.keyListeners.get(registration.rowId)
-    if (set) {
-      set.delete(registration.listener)
-      if (set.size === 0) entry.keyListeners.delete(registration.rowId)
-    }
-  }
-  entry.refCount -= 1
-}
-
-function attach(entry: WorkspaceTableEntry, registration: Registration): void {
-  if (registration.kind === "table") {
-    entry.listeners.add(registration.listener)
-  } else {
-    let keyed = entry.keyListeners.get(registration.rowId)
-    if (!keyed) {
-      keyed = new Set()
-      entry.keyListeners.set(registration.rowId, keyed)
-    }
-    keyed.add(registration.listener)
-  }
-  entry.refCount += 1
-}
-
-function visibleSnapshot(entry: WorkspaceTableEntry | undefined, registration: Registration): unknown {
-  if (!entry) return undefined
-  return registration.kind === "table" ? entry.rows : entry.byId.get(registration.rowId)
-}
-
-/**
- * Flip sharing on or off. Every live **table** registration is moved to its new
- * entry key synchronously, so the flag can arrive or change mid-session without
- * a single hook count changing (D5).
- *
- * Row registrations are DROPPED instead of moved. They belong to readers that
- * found the entry by id rather than by token (`useStreamFromStore`), and there
- * are several per rendered message row — migrating them would open one private
- * whole-table live query per registration on the very flip that exists to kill
- * whole-table reads, and the seeded rows being identity-equal means no listener
- * would ever fire to unwind it. Each dropped listener is fired unconditionally
- * so its reader re-renders, finds no shared owner, and falls back to its own
- * per-key read; the registration is deleted, so its `unsubscribe` closure is a
- * no-op and a fresh subscribe from the same reader starts clean.
- *
- * The new entry is seeded from the most recently emitted resolved predecessor
- * for the same (workspace, table): the query is identical, but private entries
- * emit independently, so an older resolved snapshot can still be sitting in the
- * map and would republish rolled-back rows. Publishing an unresolved entry
- * instead would regress every consumer to its bootstrap-era cache fallback for a frame — and the flag itself is read
- * through this registry, so an unresolved metadata entry would flip the mode back
- * and loop.
- */
-export function setWorkspaceReadMode(next: WorkspaceReadMode): void {
-  if (next === mode) return
-  const all = [...registrations.entries()]
-  const active = all.filter(([, registration]) => registration.kind === "table")
-  const dropped = all.filter(([, registration]) => registration.kind === "row")
-  const before = new Map<number, unknown>()
-  const seeds = new Map<string, WorkspaceTableEntry>()
-
-  for (const [id, registration] of all) {
-    const entry = entries.get(registration.entryKey)
-    before.set(id, visibleSnapshot(entry, registration))
-    if (!entry) continue
-    detach(entry, registration)
-  }
-  for (const [id] of dropped) registrations.delete(id)
-  for (const entry of entries.values()) {
-    const seedKey = `${entry.workspaceId}|${entry.tableKey}`
-    if (!entry.resolved) continue
-    const held = seeds.get(seedKey)
-    if (!held || entry.emissionSeq > held.emissionSeq) seeds.set(seedKey, entry)
-  }
-
-  mode = next
-
-  for (const [id, registration] of active) {
-    const entryKey = entryKeyFor(registration.workspaceId, registration.tableKey, registration.token)
-    const entry = ensureEntry(
-      entryKey,
-      registration.workspaceId,
-      registration.tableKey,
-      seeds.get(`${registration.workspaceId}|${registration.tableKey}`)
-    )
-    attach(entry, registration)
-    registrations.set(id, { ...registration, entryKey })
-  }
-  for (const [, registration] of all) releaseEntry(registration.entryKey, true)
-
-  for (const [id] of active) {
-    const current = registrations.get(id)
-    if (!current) continue
-    if (visibleSnapshot(entries.get(current.entryKey), current) !== before.get(id)) current.listener()
-  }
-  for (const [, registration] of dropped) registration.listener()
+  const entry = entries.get(entryKeyFor(workspaceId, tableKey))
+  return Boolean(entry?.resolved && !entry.teardown)
 }
 
 /** Live Dexie subscriptions on workspace tables, teardown-grace ones included. */
@@ -544,6 +349,5 @@ export function resetWorkspaceTableRegistry(): void {
   }
   entries.clear()
   registrations.clear()
-  mode = "off"
   lastMarkedLiveEntries = -1
 }

--- a/apps/frontend/src/sync/bootstrap-diff.ts
+++ b/apps/frontend/src/sync/bootstrap-diff.ts
@@ -94,10 +94,6 @@ export function diffRows<T extends { id: string }>(
   return { toWrite, merged, skipped }
 }
 
-export function writeAllRows<T extends { id: string }>(candidates: T[]): RowDiff<T> {
-  return { toWrite: candidates, merged: candidates, skipped: 0 }
-}
-
 export function diffSingleton<T>(
   existing: T | undefined,
   candidate: T,

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -156,7 +156,6 @@ export class LiveCommitBatch {
   /** Flushes run one at a time and in schedule order, so an awaited `flush()`
    *  drains everything buffered before it (the catch-up window's guarantee). */
   private chain: Promise<void> = Promise.resolve()
-  private flushing = false
 
   constructor(
     private readonly queryClient: QueryClient,
@@ -194,20 +193,6 @@ export class LiveCommitBatch {
     this.schedule()
   }
 
-  /** Whether anything is buffered and not yet committed. Callers taking the
-   *  immediate path (the flag flipped off mid-task) drain first, so a pending
-   *  fold can't land on top of a newer immediate commit. */
-  hasPending(): boolean {
-    return this.counterMutators.length > 0 || this.streamPreviews.size > 0 || this.readAllSnapshots.length > 0
-  }
-
-  /** Whether a commit has emptied the buffers but not yet published. Immediate
-   *  callers drain on this too: `hasPending()` alone is false in that window, so
-   *  an older in-flight fold would publish on top of a newer direct commit. */
-  isFlushing(): boolean {
-    return this.flushing
-  }
-
   /** Commit everything buffered so far. Awaited by the engine when a catch-up
    *  window opens, so a live fold can never interleave into a replay fold. */
   flush(): Promise<void> {
@@ -218,24 +203,6 @@ export class LiveCommitBatch {
     // throwing inside publish) would poison every later flush permanently.
     this.chain = attempt.catch(this.logFlushFailure)
     return attempt
-  }
-
-  /** Drain, then run `fn` — on the batch's OWN chain, so anything buffered after
-   *  this call queues BEHIND `fn` instead of racing it. Branching off `flush()`'s
-   *  returned promise inverts order: that promise settles when its drain runs,
-   *  and that drain commits whatever was buffered by then, which can be newer
-   *  than `fn`. */
-  runAfterDrain(fn: () => void): void {
-    this.scheduled = false
-    // Taken NOW, not when the drain runs: a commit that re-reads the buffers at
-    // execution time would sweep up whatever was buffered after this call and
-    // publish it BEFORE `fn`.
-    const drained = this.takePending()
-    this.chain = this.chain
-      .then(() => this.commit(drained))
-      .catch(this.logFlushFailure)
-      .then(fn)
-      .catch(this.logFlushFailure)
   }
 
   private readonly logFlushFailure = (error: unknown): void => {
@@ -273,13 +240,8 @@ export class LiveCommitBatch {
     return pending
   }
 
-  private async commit(pending?: PendingFold): Promise<void> {
-    this.flushing = true
-    try {
-      await this.runCommit(pending ?? this.takePending())
-    } finally {
-      this.flushing = false
-    }
+  private async commit(): Promise<void> {
+    await this.runCommit(this.takePending())
   }
 
   private async runCommit({ mutators, previews, snapshots }: PendingFold): Promise<void> {

--- a/apps/frontend/src/sync/live-commit-batch.test.ts
+++ b/apps/frontend/src/sync/live-commit-batch.test.ts
@@ -11,7 +11,7 @@ import {
 import type { Socket } from "socket.io-client"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { bumpAccountGeneration, primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { bumpAccountGeneration } from "@/db/event-writes"
 import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
@@ -200,14 +200,10 @@ type Harness = {
   setCatchUpBatch: (batch: CatchUpBatch | null) => void
 }
 
-/** Registers the workspace handlers exactly as the SyncEngine does, with the
- *  flag primed. `commitCounter`/`commitPreview` read the flag synchronously per
- *  event, so a mid-task flip takes effect on the next event with no reconnect. */
+/** Registers the workspace handlers exactly as the SyncEngine does. `coalesced`
+ *  false withholds the batch — the per-event path handlers built without an
+ *  engine still take, and the baseline the folded arm is compared against. */
 async function register(queryClient: QueryClient, coalesced: boolean): Promise<Harness> {
-  primeEventWriteFlags(WORKSPACE_ID, {
-    workspace: { coalescedLiveCommit: coalesced ? "on" : "off" },
-    user: {},
-  })
   const liveBatch = new LiveCommitBatch(queryClient, WORKSPACE_ID)
   let catchUpBatch: CatchUpBatch | null = null
   const { socket, emit } = createTestSocket()
@@ -216,7 +212,7 @@ async function register(queryClient: QueryClient, coalesced: boolean): Promise<H
     getCurrentUser: () => ({ id: "workos_1" }),
     subscribeStream: vi.fn(),
     getCatchUpBatch: () => catchUpBatch,
-    getLiveCommitBatch: () => liveBatch,
+    getLiveCommitBatch: () => (coalesced ? liveBatch : null),
   })
   return {
     emit,
@@ -242,12 +238,10 @@ function bootstrapOf(queryClient: QueryClient): WorkspaceBootstrap | undefined {
 
 describe("LiveCommitBatch", () => {
   beforeEach(async () => {
-    resetEventWriteFlags()
     await Promise.all([db.streams.clear(), db.unreadState.clear()])
   })
 
   afterEach(() => {
-    resetEventWriteFlags()
     vi.restoreAllMocks()
   })
 
@@ -276,24 +270,6 @@ describe("LiveCommitBatch", () => {
       unread: 1,
       cachePreview: "message 6",
       idbPreview: "message 6",
-    })
-
-    harness.cleanup()
-  })
-
-  it("the flag off keeps today's two transactions and two publications", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-    const harness = await register(queryClient, false)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 2,
-      publications: 2,
     })
 
     harness.cleanup()
@@ -345,7 +321,6 @@ describe("LiveCommitBatch", () => {
 
     await db.streams.clear()
     await db.unreadState.clear()
-    resetEventWriteFlags()
 
     const immediateClient = new QueryClient()
     await seedFixture(immediateClient, ["stream_1", "stream_2"])
@@ -488,53 +463,6 @@ describe("LiveCommitBatch", () => {
     batch.destroy()
   })
 
-  it("flipping the flag off disarms the coalescing on the next event, with no reconnect", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    // What a `feature_flags:updated` socket event does to the module map.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 2,
-      publications: 2,
-    })
-
-    harness.cleanup()
-  })
-
-  it("flipping the flag on arms the coalescing on the next event, with no reconnect", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, false)
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await settle()
-
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
-    const transaction = vi.spyOn(Dexie.prototype, "transaction")
-    const setQueryData = vi.spyOn(queryClient, "setQueryData")
-
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({ transactions: transaction.mock.calls.length, publications: setQueryData.mock.calls.length }).toEqual({
-      transactions: 1,
-      publications: 1,
-    })
-
-    harness.cleanup()
-  })
-
   it("the activity path's stream.idbTransaction count falls from two to one", async () => {
     const counts = async (coalesced: boolean): Promise<number> => {
       const queryClient = new QueryClient()
@@ -554,7 +482,7 @@ describe("LiveCommitBatch", () => {
     expect({ off: await counts(false), on: await counts(true) }).toEqual({ off: 2, on: 1 })
   })
 
-  it("the fold has its own mark: stream.activityApply stays one handler sample per event in both arms", async () => {
+  it("the fold has its own mark: stream.activityApply stays one handler sample per event with or without the batch", async () => {
     const marks = async (coalesced: boolean) => {
       const queryClient = new QueryClient()
       await seedFixture(queryClient, ["stream_1"])
@@ -668,98 +596,6 @@ describe("LiveCommitBatch", () => {
 
     expect({ afterFirst, total: onFlushFailed.mock.calls.length }).toEqual({ afterFirst: 1, total: 2 })
     batch.destroy()
-  })
-
-  it("flipping the flag off drains the pending fold before the next immediate commit", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    // Buffered under the armed flag; the flip lands in the same task, so the
-    // newer immediate commit must not be overwritten by the older fold.
-    harness.emit("stream:activity", activity("stream_1", 6))
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
-
-    harness.cleanup()
-  })
-
-  it("flipping the flag off drains a fold that is already in flight", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const realTransaction = Dexie.prototype.transaction
-    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
-      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
-      return gate.then(() => running) as never
-    })
-
-    // A is buffered and its commit begins: the buffers are already empty and the
-    // transaction is awaiting, so `hasPending()` alone reads false here.
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    expect({ pending: harness.liveBatch.hasPending(), flushing: harness.liveBatch.isFlushing() }).toEqual({
-      pending: false,
-      flushing: true,
-    })
-
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    release()
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 7", idbPreview: "message 7" })
-
-    harness.cleanup()
-  })
-
-  it("an off-then-on flip during an in-flight fold still lands the newest commit last", async () => {
-    const queryClient = new QueryClient()
-    await seedFixture(queryClient, ["stream_1"])
-    const harness = await register(queryClient, true)
-
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const realTransaction = Dexie.prototype.transaction
-    vi.spyOn(Dexie.prototype, "transaction").mockImplementationOnce(function (this: Dexie, ...args: unknown[]) {
-      const running = (realTransaction as (...a: unknown[]) => Promise<unknown>).apply(this, args)
-      return gate.then(() => running) as never
-    })
-
-    harness.emit("stream:activity", activity("stream_1", 6))
-    await new Promise((resolve) => setTimeout(resolve, 0))
-
-    // Off: #7 takes the deferred immediate arm while #6's commit is in flight.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "off" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 7))
-    // Back on: #8 buffers, and must publish AFTER the deferred #7.
-    primeEventWriteFlags(WORKSPACE_ID, { workspace: { coalescedLiveCommit: "on" }, user: {} })
-    harness.emit("stream:activity", activity("stream_1", 8))
-    release()
-    await settle()
-
-    expect({
-      cachePreview: bootstrapOf(queryClient)?.streams.find((s) => s.id === "stream_1")?.lastMessagePreview?.content,
-      idbPreview: (await db.streams.get("stream_1"))?.lastMessagePreview?.content,
-    }).toEqual({ cachePreview: "message 8", idbPreview: "message 8" })
-
-    harness.cleanup()
   })
 
   it("a fold buffered before an account switch writes nothing after it", async () => {

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -7,7 +7,6 @@ import type { Socket } from "socket.io-client"
 import { CatchUpBatch, commitCounterMutation } from "./catch-up-batch"
 import { registerStreamSocketHandlers } from "./stream-sync"
 import { registerWorkspaceSocketHandlers } from "./workspace-sync"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 import { applyStreamsReadAllOrdinals } from "./unread-counters"
 import {
   applyReadStateSnapshotsIdb,
@@ -640,12 +639,7 @@ describe("replayed message:created entries and the preview write", () => {
     }
   }
 
-  async function replay(streamId: string, singlePreviewWriter: boolean): Promise<number> {
-    resetEventWriteFlags()
-    primeEventWriteFlags("ws_1", {
-      workspace: { singlePreviewWriter: singlePreviewWriter ? "on" : "off" },
-      user: {},
-    })
+  async function replay(streamId: string): Promise<number> {
     await db.events.clear()
     await db.streams.clear()
     await db.streams.put({
@@ -666,11 +660,8 @@ describe("replayed message:created entries and the preview write", () => {
     return calls
   }
 
-  it("live message:created delivery writes no preview when the single writer is on", async () => {
-    const on = await replay("stream_replay_on", true)
-    const off = await replay("stream_replay_off", false)
-    expect({ on, off }).toEqual({ on: 0, off: 3 })
-    resetEventWriteFlags()
+  it("live message:created delivery writes no preview — stream:activity is the only writer", async () => {
+    expect(await replay("stream_replay_on")).toBe(0)
   })
 
   it("a catch-up replay's batched stream:activity previews land on flush, last write winning", async () => {

--- a/apps/frontend/src/sync/stream-sync.perf.test.ts
+++ b/apps/frontend/src/sync/stream-sync.perf.test.ts
@@ -5,7 +5,6 @@ import type { PerformanceSample, StreamEvent } from "@threa/types"
 import { db } from "@/db"
 import { NO_CAPTURE, PerfCapture, armPerfCapture, getPerfCapture } from "@/lib/perf/capture"
 import { registerStreamSocketHandlers } from "./stream-sync"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
 
 function createTestSocket() {
   const handlers = new Map<string, Set<(payload: unknown) => void>>()
@@ -84,25 +83,22 @@ async function resetTables(): Promise<void> {
 
 beforeEach(async () => {
   await resetTables()
-  primeEventWriteFlags("ws_1", { workspace: { singlePreviewWriter: "off" }, user: {} })
 })
 
 afterEach(() => {
   armPerfCapture(NO_CAPTURE)
-  resetEventWriteFlags()
 })
 
 describe("message:created sub-marks", () => {
-  it("an applied message records one eventTx and one previewWrite sample", async () => {
+  it("an applied message records one eventTx and one contextRows sample", async () => {
     const capture = new PerfCapture()
     armPerfCapture(capture)
 
     await deliver("stream_perf", ["evt_1"])
 
     expect(samplesNamed(capture, "stream.eventTx")).toHaveLength(1)
-    expect(samplesNamed(capture, "stream.previewWrite")).toHaveLength(1)
     expect(samplesNamed(capture, "stream.contextRows")).toHaveLength(1)
-    for (const name of ["stream.eventTx", "stream.previewWrite", "stream.contextRows"] as const) {
+    for (const name of ["stream.eventTx", "stream.contextRows"] as const) {
       expect(samplesNamed(capture, name)[0].value).toBeTypeOf("number")
     }
     expect(samplesNamed(capture, "stream.eventDuplicate")).toEqual([])

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -19,7 +19,7 @@ import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
-import { primeEventWriteFlags, resetEventWriteFlags } from "@/db/event-writes"
+import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
 import { sharedMessageSlotKey } from "@threa/types"
 import type {
   AttachmentSummary,
@@ -4360,17 +4360,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     }
   }
 
-  function enableSharing(enabled: boolean) {
-    primeEventWriteFlags("ws_1", {
-      // `singlePreviewWriter` is pinned off, not inherited: these cases count
-      // `db.streams.update` calls to tell one apply from two, and that writer
-      // only exists on this arm. Inheriting a default scheduled to flip would
-      // silently retarget the assertion at nothing.
-      workspace: { sharedStreamRegistration: enabled ? "on" : "off", singlePreviewWriter: "off" },
-      user: {},
-    })
-  }
-
   function messageCreated(streamId: string, id: string, sequence: string, extraPayload: Record<string, unknown> = {}) {
     return {
       workspaceId: "ws_1",
@@ -4407,16 +4396,13 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     await db.streamContextItems.clear()
     await db.pendingMessages.clear()
     clearDecryptCache()
-    resetEventWriteFlags()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    resetEventWriteFlags()
   })
 
   it("two registrations against one event source bind the listener set once", async () => {
-    enableSharing(true)
     const streamId = "stream_shared_once"
     await db.streams.put({
       id: streamId,
@@ -4426,8 +4412,8 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     } as never)
 
     const { socket, emit } = createCountingSocket()
+    // One scope read per apply — two bindings would read twice.
     const scopeReads = vi.spyOn(db.streams, "get")
-    const previewWrites = vi.spyOn(db.streams, "update")
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
@@ -4437,45 +4423,14 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
 
     expect({
       scopeReads: scopeReads.mock.calls.length,
-      previewWrites: previewWrites.mock.calls.length,
       persisted: (await db.events.get("evt_shared"))?.sequence,
-    }).toEqual({ scopeReads: 1, previewWrites: 1, persisted: "10" })
-
-    releaseA()
-    releaseB()
-  })
-
-  it("binds the listener set twice and applies twice when the flag is off", async () => {
-    enableSharing(false)
-    const streamId = "stream_unshared"
-    await db.streams.put({
-      id: streamId,
-      workspaceId: "ws_1",
-      rootStreamId: streamId,
-      _cachedAt: Date.now(),
-    } as never)
-
-    const { socket, emit } = createCountingSocket()
-    const scopeReads = vi.spyOn(db.streams, "get")
-    const previewWrites = vi.spyOn(db.streams, "update")
-    const queryClient = new QueryClient()
-
-    const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-    const releaseB = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    await emit("message:created", messageCreated(streamId, "evt_unshared", "10"))
-
-    expect({
-      scopeReads: scopeReads.mock.calls.length,
-      previewWrites: previewWrites.mock.calls.length,
-    }).toEqual({ scopeReads: 2, previewWrites: 2 })
+    }).toEqual({ scopeReads: 1, persisted: "10" })
 
     releaseA()
     releaseB()
   })
 
   it("the listeners survive until the last release", async () => {
-    enableSharing(true)
     const streamId = "stream_last_release"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4493,7 +4448,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("releasing twice does not tear down a live registration", async () => {
-    enableSharing(true)
     const streamId = "stream_strictmode"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4511,7 +4465,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a registration without an engine is not shared with the gated one", async () => {
-    enableSharing(true)
     const streamId = "stream_two_sources"
     const gated = createCountingSocket()
     const raw = createCountingSocket()
@@ -4531,7 +4484,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a second registrant with mismatched wiring throws", () => {
-    enableSharing(true)
     const streamId = "stream_mismatch"
     const { socket } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4550,7 +4502,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("every registrant's gap callback fires, and a released one stops", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_fanout"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4587,7 +4538,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("two registrants sharing ONE callback reference keep the survivor's subscription", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_same_reference"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4609,7 +4559,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("a registrant that joins a gap-less registration still receives gaps", async () => {
-    enableSharing(true)
     const streamId = "stream_gap_late_join"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4630,7 +4579,6 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
   })
 
   it("an E2E self-send seeds the decrypt cache exactly once", async () => {
-    enableSharing(true)
     const streamId = "stream_e2e_shared"
     const plaintextJson = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "secret" }] }] }
     await db.events.put({
@@ -4649,7 +4597,10 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     })
 
     const { socket, emit } = createCountingSocket()
-    const previewWrites = vi.spyOn(db.streams, "update")
+    // One `stream.eventApply` sample per handler run — the direct count of how
+    // many times the shared binding applied this event.
+    const capture = new PerfCapture()
+    armPerfCapture(capture)
     const queryClient = new QueryClient()
 
     const releaseA = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
@@ -4670,15 +4621,15 @@ describe("registerStreamSocketHandlers — one handler set per (event source, st
     expect({
       status: cached?.status,
       markdown: cached?.value?.contentMarkdown,
-      applies: previewWrites.mock.calls.length,
+      applies: capture.snapshot().filter((sample) => sample.name === "stream.eventApply").length,
     }).toEqual({ status: "decrypted", markdown: "secret", applies: 1 })
 
+    armPerfCapture(NO_CAPTURE)
     releaseA()
     releaseB()
   })
 
   it("the registry drops its entry when the last holder releases", async () => {
-    enableSharing(true)
     const streamId = "stream_registry_drop"
     const { socket, emit } = createCountingSocket()
     const queryClient = new QueryClient()
@@ -4722,13 +4673,6 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
         await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
       },
     }
-  }
-
-  function enableSinglePreviewWriter(enabled: boolean) {
-    primeEventWriteFlags("ws_1", {
-      workspace: { singlePreviewWriter: enabled ? "on" : "off" },
-      user: {},
-    })
   }
 
   const contentJson = {
@@ -4776,16 +4720,13 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
     await db.streamContextItems.clear()
     await db.pendingMessages.clear()
     await db.slots.clear()
-    resetEventWriteFlags()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
-    resetEventWriteFlags()
   })
 
   it("a live message writes no preview and no bootstrap cache entry", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_single_writer"
     await seedStream(streamId)
 
@@ -4809,38 +4750,7 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
     cleanup()
   })
 
-  it("the flag off writes the preview exactly as today", async () => {
-    enableSinglePreviewWriter(false)
-    const streamId = "stream_single_writer_off"
-    await seedStream(streamId)
-
-    const queryClient = new QueryClient()
-    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
-      streams: [{ id: streamId, lastMessagePreview: bootstrapPreview }],
-    } as unknown as WorkspaceBootstrap)
-
-    const { socket, emit } = createTestSocket()
-    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
-
-    await emit("message:created", messageCreated(streamId, "evt_single_off", "10"))
-
-    const written = {
-      authorId: "user_7",
-      authorType: "user",
-      content: contentJson,
-      createdAt: "2026-08-04T10:00:00.000Z",
-    }
-    expect({
-      preview: (await db.streams.get(streamId))?.lastMessagePreview,
-      cached: queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.streams[0]
-        .lastMessagePreview,
-    }).toEqual({ preview: written, cached: written })
-
-    cleanup()
-  })
-
   it("a message:created applied without a SyncEngine still writes the event and does not throw", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_no_engine"
     const queryClient = new QueryClient()
 
@@ -4861,7 +4771,6 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
   })
 
   it("the share-fallback invalidation still fires for a map-less share-bearing event", async () => {
-    enableSinglePreviewWriter(true)
     const streamId = "stream_share_fallback"
     await seedStream(streamId)
 

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1209,7 +1209,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: Date.now(),
     })
 
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 5 }))
 
     const event = await db.events.get("evt_1")
     expect((event?.payload as Record<string, unknown>).replyCount).toBe(5)
@@ -1226,7 +1226,7 @@ describe("updateMessageEvent", () => {
       _cachedAt: before - 10000,
     })
 
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, replyCount: 1 }))
 
     const event = await db.events.get("evt_patched")
     expect(event?._patchedAt).toBeDefined()
@@ -1248,12 +1248,12 @@ describe("updateMessageEvent", () => {
     // concurrently. With the old read-then-update implementation the last
     // write would overwrite earlier ones and lose fields.
     await Promise.all([
-      updateMessageEvent(false, streamId, messageId, (p) => ({
+      updateMessageEvent(streamId, messageId, (p) => ({
         ...p,
         replyCount: 3,
         threadSummary: { lastReplyContentMarkdown: "hi", participantIds: ["u1"] },
       })),
-      updateMessageEvent(false, streamId, messageId, (p) => ({
+      updateMessageEvent(streamId, messageId, (p) => ({
         ...p,
         threadId: "thread_123",
       })),
@@ -1267,7 +1267,7 @@ describe("updateMessageEvent", () => {
   })
 })
 
-describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessagePatch)", () => {
+describe("updateMessageEvent — indexed payload.messageId lookup", () => {
   function seedRow(overrides: {
     id: string
     streamId: string
@@ -1370,18 +1370,12 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     await seedLargeStream(streamId, 1000, messageId)
 
     const indexed = trackCursor()
-    await updateMessageEvent(true, streamId, messageId, (p) => ({ ...p, reactions: ["👍"] }))
+    await updateMessageEvent(streamId, messageId, (p) => ({ ...p, reactions: ["👍"] }))
     expect(indexed.indexes).toEqual(["payload.messageId"])
     expect({ filtered: indexed.filtered, visited: indexed.visited }).toEqual({ filtered: 0, visited: 1 })
-    vi.restoreAllMocks()
-
-    const scanned = trackCursor()
-    await updateMessageEvent(false, streamId, messageId, (p) => ({ ...p, reactions: ["👍", "🎉"] }))
-    expect(scanned.indexes).toEqual(["[streamId+eventType]"])
-    expect({ filtered: scanned.filtered, visited: scanned.visited }).toEqual({ filtered: 1000, visited: 1 })
 
     const patched = await db.events.get("evt_bulk_998")
-    expect((patched?.payload as Record<string, unknown>).reactions).toEqual(["👍", "🎉"])
+    expect((patched?.payload as Record<string, unknown>).reactions).toEqual(["👍"])
   }, 20000)
 
   it("a patch for a message in another stream is not applied", async () => {
@@ -1392,7 +1386,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     ])
 
     const counts = trackCursor()
-    await updateMessageEvent(true, "stream_here", messageId, (p) => ({ ...p, replyCount: 7 }))
+    await updateMessageEvent("stream_here", messageId, (p) => ({ ...p, replyCount: 7 }))
 
     const here = await db.events.get("evt_here")
     const there = await db.events.get("evt_there")
@@ -1419,7 +1413,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     ])
 
     const counts = trackCursor()
-    await updateMessageEvent(true, "stream_typed", messageId, (p) => ({ ...p, replyCount: 9 }))
+    await updateMessageEvent("stream_typed", messageId, (p) => ({ ...p, replyCount: 9 }))
 
     const created = await db.events.get("evt_created")
     const edited = await db.events.get("evt_edited")
@@ -1439,8 +1433,8 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
     )
 
     await Promise.all([
-      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, replyCount: 3 })),
-      updateMessageEvent(true, "stream_race", messageId, (p) => ({ ...p, threadId: "thread_1" })),
+      updateMessageEvent("stream_race", messageId, (p) => ({ ...p, replyCount: 3 })),
+      updateMessageEvent("stream_race", messageId, (p) => ({ ...p, threadId: "thread_1" })),
     ])
 
     const event = await db.events.get("evt_race_indexed")
@@ -1464,7 +1458,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       }),
     ])
 
-    await updateMessageEvent(true, "stream_sparse", "msg_sparse", (p) => ({ ...p, replyCount: 1 }))
+    await updateMessageEvent("stream_sparse", "msg_sparse", (p) => ({ ...p, replyCount: 1 }))
 
     const untouched = await db.events.get("evt_no_message_id")
     const patched = await db.events.get("evt_with_message_id")
@@ -1486,7 +1480,7 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       seedRow({ id: "evt_new_stream", streamId: "stream_new", sequence: "1", payload: { messageId, tag: "new" } }),
     ])
 
-    await updateMessageEvent(true, "stream_new", messageId, (p) => ({ ...p, tag: "patched" }))
+    await updateMessageEvent("stream_new", messageId, (p) => ({ ...p, tag: "patched" }))
 
     const rows = await db.events.bulkGet(["evt_old_stream", "evt_new_stream"])
     expect(rows.map((row) => (row?.payload as Record<string, unknown>).tag)).toEqual(["old", "patched"])
@@ -1510,13 +1504,13 @@ describe("updateMessageEvent — indexed payload.messageId lookup (indexedMessag
       }),
     ])
 
-    await updateMessageEvent(true, streamId, "msg_edit", (p) => ({ ...p, contentMarkdown: "edited", editedAt: "t" }))
-    await updateMessageEvent(true, streamId, "msg_delete", (p) => ({ ...p, deletedAt: "t" }))
-    await updateMessageEvent(true, streamId, "msg_move", (p) => ({ ...p, movedToStreamId: "stream_other" }))
-    await updateMessageEvent(true, streamId, "msg_reaction", (p) => ({ ...p, reactions: ["👍"] }))
-    await updateMessageEvent(true, streamId, "msg_preview", (p) => ({ ...p, linkPreviews: [{ url: "u" }] }))
-    await updateEventByAnchor(true, streamId, "msg_heal", (p) => ({ ...p, threadId: "thread_healed" }))
-    await updateEventByAnchor(true, streamId, "evt_card", (p) => ({ ...p, threadId: "thread_card" }))
+    await updateMessageEvent(streamId, "msg_edit", (p) => ({ ...p, contentMarkdown: "edited", editedAt: "t" }))
+    await updateMessageEvent(streamId, "msg_delete", (p) => ({ ...p, deletedAt: "t" }))
+    await updateMessageEvent(streamId, "msg_move", (p) => ({ ...p, movedToStreamId: "stream_other" }))
+    await updateMessageEvent(streamId, "msg_reaction", (p) => ({ ...p, reactions: ["👍"] }))
+    await updateMessageEvent(streamId, "msg_preview", (p) => ({ ...p, linkPreviews: [{ url: "u" }] }))
+    await updateEventByAnchor(streamId, "msg_heal", (p) => ({ ...p, threadId: "thread_healed" }))
+    await updateEventByAnchor(streamId, "evt_card", (p) => ({ ...p, threadId: "thread_card" }))
 
     const rows = await db.events.bulkGet([
       "evt_edit",

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -2,7 +2,6 @@ import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
 import {
   isEventWriteChunkingEnabled,
-  isIndexedMessagePatchEnabled,
   isSinglePreviewWriterEnabled,
   isNoOpRewrite,
   isSharedStreamRegistrationEnabledSync,
@@ -932,7 +931,6 @@ export async function updateMemoEmbedSummary(streamId: string, summary: MemoEmbe
 }
 
 export async function updateMessageEvent(
-  indexed: boolean,
   streamId: string,
   messageId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
@@ -953,30 +951,19 @@ export async function updateMessageEvent(
     event._patchedAt = now
   }
 
-  if (indexed) {
-    // The `payload.messageId` sparse index (v47) makes this a direct lookup.
-    // The stream/type guard stays inside the cursor so a message that moved
-    // streams is still not patched in its old stream — today's semantics.
-    // `false` (not a bare return) is what tells Dexie to SKIP the row: any
-    // other return value re-puts it, which would fire observability for every
-    // same-id row in another stream.
-    await db.events
-      .where("payload.messageId")
-      .equals(messageId)
-      .modify((event) => {
-        if (event.streamId !== streamId || event.eventType !== "message_created") return false
-        patch(event)
-      })
-    return
-  }
-
-  // Use compound index to narrow to message_created events for this stream,
-  // then filter by messageId in the payload (not indexed but over a small set).
+  // The `payload.messageId` sparse index (v47) makes this a direct lookup.
+  // The stream/type guard stays inside the cursor so a message that moved
+  // streams is still not patched in its old stream — today's semantics.
+  // `false` (not a bare return) is what tells Dexie to SKIP the row: any
+  // other return value re-puts it, which would fire observability for every
+  // same-id row in another stream.
   await db.events
-    .where("[streamId+eventType]")
-    .equals([streamId, "message_created"])
-    .filter((e) => (e.payload as { messageId?: string })?.messageId === messageId)
-    .modify(patch)
+    .where("payload.messageId")
+    .equals(messageId)
+    .modify((event) => {
+      if (event.streamId !== streamId || event.eventType !== "message_created") return false
+      patch(event)
+    })
 }
 
 /**
@@ -987,13 +974,12 @@ export async function updateMessageEvent(
  * for messages, event id for cards).
  */
 export async function updateEventByAnchor(
-  indexed: boolean,
   streamId: string,
   anchorId: string,
   updater: (payload: Record<string, unknown>) => Record<string, unknown>
 ): Promise<void> {
   if (anchorId.startsWith("msg_")) {
-    await updateMessageEvent(indexed, streamId, anchorId, updater)
+    await updateMessageEvent(streamId, anchorId, updater)
     return
   }
   await db.events
@@ -1018,13 +1004,11 @@ export async function updateEventByAnchor(
  * anchor's canonical id so event-anchored (card) threads bump too.
  */
 export async function optimisticReplyCountUpdate(
-  workspaceId: string,
   parentStreamId: string,
   anchorId: string,
   threadId: string
 ): Promise<void> {
-  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
+  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
     replyCount: ((p.replyCount as number) ?? 0) + 1,
@@ -1040,14 +1024,8 @@ export async function optimisticReplyCountUpdate(
  * created, we swap the threadId to the server-assigned one so navigation
  * targets the real thread.
  */
-export async function setParentThreadId(
-  workspaceId: string,
-  parentStreamId: string,
-  anchorId: string,
-  threadId: string
-): Promise<void> {
-  const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-  await updateEventByAnchor(indexed, parentStreamId, anchorId, (p) => ({
+export async function setParentThreadId(parentStreamId: string, anchorId: string, threadId: string): Promise<void> {
+  await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
   }))
@@ -1425,9 +1403,8 @@ function bindStreamSocketHandlers(
     }
 
     const now = Date.now()
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.slots], async () => {
-      await updateMessageEvent(indexed, streamId, editPayload.messageId, (p) => ({
+      await updateMessageEvent(streamId, editPayload.messageId, (p) => ({
         ...p,
         contentJson: editPayload.contentJson,
         contentMarkdown: editPayload.contentMarkdown,
@@ -1483,8 +1460,7 @@ function bindStreamSocketHandlers(
 
   const handleMessageDeleted = async (payload: MessageDeletedPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
+    await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
       deletedAt: payload.deletedAt,
     }))
@@ -1503,10 +1479,7 @@ function bindStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
-    const [chunked, indexed] = await Promise.all([
-      isEventWriteChunkingEnabled(db, workspaceId),
-      isIndexedMessagePatchEnabled(db, workspaceId),
-    ])
+    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1528,7 +1501,7 @@ function bindStreamSocketHandlers(
         // identical result. This makes `messages:moved` self-sufficient:
         // the thread card surfaces with the right count even if
         // `thread:updated` is delayed or lost.
-        await updateMessageEvent(indexed, streamId, payload.targetMessageId, (p) => ({
+        await updateMessageEvent(streamId, payload.targetMessageId, (p) => ({
           ...p,
           threadId: payload.thread.id,
           replyCount: payload.parentReplyCount,
@@ -1611,8 +1584,7 @@ function bindStreamSocketHandlers(
 
   const handleReactionAdded = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
+    await updateMessageEvent(streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       const existing = reactions[payload.emoji] || []
       if (!existing.includes(payload.userId)) {
@@ -1631,8 +1603,7 @@ function bindStreamSocketHandlers(
 
   const handleReactionRemoved = async (payload: ReactionPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => {
+    await updateMessageEvent(streamId, payload.messageId, (p) => {
       const reactions = { ...((p.reactions as Record<string, string[]>) ?? {}) }
       if (reactions[payload.emoji]) {
         reactions[payload.emoji] = reactions[payload.emoji].filter((id) => id !== payload.userId)
@@ -1664,8 +1635,7 @@ function bindStreamSocketHandlers(
     const anchorId = stream.parentAnchorId
     if (!anchorId) return
 
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateEventByAnchor(indexed, streamId, anchorId, (p) => ({
+    await updateEventByAnchor(streamId, anchorId, (p) => ({
       ...p,
       threadId: stream.id,
     }))
@@ -1696,8 +1666,7 @@ function bindStreamSocketHandlers(
     // Heal only the fields the patch carries: the edit path omits replyCount
     // (summary-only refresh) so it can't overwrite a concurrent create/delete's
     // authoritative count.
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateEventByAnchor(indexed, streamId, payload.anchorId, (p) => ({
+    await updateEventByAnchor(streamId, payload.anchorId, (p) => ({
       ...p,
       ...(payload.replyCount !== undefined ? { replyCount: payload.replyCount } : {}),
       ...(payload.threadSummary !== undefined ? { threadSummary: payload.threadSummary } : {}),
@@ -1830,8 +1799,7 @@ function bindStreamSocketHandlers(
 
   const handleLinkPreviewReady = async (payload: LinkPreviewReadyPayload) => {
     if (payload.streamId !== streamId) return
-    const indexed = await isIndexedMessagePatchEnabled(db, workspaceId)
-    await updateMessageEvent(indexed, streamId, payload.messageId, (p) => ({
+    await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
       linkPreviews: preserveBakedInAppData(payload.previews, p.linkPreviews as LinkPreviewSummary[] | undefined),
     }))

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,7 +1,6 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
 import {
-  isEventWriteChunkingEnabled,
   isSinglePreviewWriterEnabled,
   isNoOpRewrite,
   isSharedStreamRegistrationEnabledSync,
@@ -118,7 +117,7 @@ export function toCachedStreamBootstrap(
   }
 }
 
-async function resolveUnknownOptimisticAnchors(streamId: string, chunked: boolean): Promise<void> {
+async function resolveUnknownOptimisticAnchors(streamId: string): Promise<void> {
   const unresolved = (await db.events.where("_status").anyOf(["pending", "failed", "editing"]).toArray()).filter(
     (event) => event.streamId === streamId && event._anchorSequenceNum == null
   )
@@ -142,7 +141,7 @@ async function resolveUnknownOptimisticAnchors(streamId: string, chunked: boolea
       anchor ?? Math.max(0, Math.min(...persistedEvents.map((persisted) => persisted._sequenceNum)) - 1)
     return [{ ...event, _anchorSequenceNum: resolvedAnchor, _cachedAt: now }]
   })
-  await putEventsBounded(db.events, resolved, chunked)
+  await putEventsBounded(db.events, resolved)
 }
 
 export async function bumpLaterOptimisticAnchors(
@@ -287,7 +286,6 @@ async function writeBootstrapEventsAndStream(
   streamId: string,
   bootstrap: StreamBootstrap,
   now: number,
-  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<StreamReadFrontier | undefined> {
   await cleanupStaleOptimisticEvents(streamId)
@@ -447,8 +445,8 @@ async function writeBootstrapEventsAndStream(
       }
     }
 
-    await putEventsBounded(db.events, toWrite, chunked)
-    await resolveUnknownOptimisticAnchors(streamId, chunked)
+    await putEventsBounded(db.events, toWrite)
+    await resolveUnknownOptimisticAnchors(streamId)
 
     // Real rows are in place (bulkPut above, or already present via a skipped
     // rewrite) — now drop the optimistic copies and their outbox entries so a
@@ -694,7 +692,6 @@ export async function applyStreamBootstrap(
   options?: StreamBootstrapApplyOptions
 ): Promise<void> {
   const now = Date.now()
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   let preservedReadState: StreamReadFrontier | undefined
   await db.transaction(
     "rw",
@@ -705,7 +702,6 @@ export async function applyStreamBootstrap(
         streamId,
         bootstrap,
         now,
-        chunked,
         options?.fetchStartedAt
       )
     }
@@ -747,10 +743,9 @@ export async function applyStreamBootstrapInCurrentTransaction(
   streamId: string,
   bootstrap: StreamBootstrap,
   now = Date.now(),
-  chunked: boolean,
   fetchStartedAt?: number
 ): Promise<void> {
-  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
+  await writeBootstrapEventsAndStream(workspaceId, streamId, bootstrap, now, fetchStartedAt)
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }
 
@@ -1219,7 +1214,6 @@ function bindStreamSocketHandlers(
       // after the transaction commits so the backfill never runs inside it.
       let gapAfterSequence: string | null = null
 
-      const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
       // Same primed map, so this resolves without a second IDB read.
       const singlePreviewWriter = await isSinglePreviewWriterEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
@@ -1285,7 +1279,7 @@ function bindStreamSocketHandlers(
             _sequenceNum: sequenceToNum(newEvent.sequence),
             _cachedAt: now,
           })
-          await resolveUnknownOptimisticAnchors(streamId, chunked)
+          await resolveUnknownOptimisticAnchors(streamId)
 
           if (newPayload.clientMessageId) {
             if (optimistic) {
@@ -1479,7 +1473,6 @@ function bindStreamSocketHandlers(
     if (payload.sourceStreamId !== streamId && payload.destinationStreamId !== streamId) return
 
     const now = Date.now()
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     await db.transaction("rw", [db.events, db.streams, db.slots], async () => {
       if (payload.sourceStreamId === streamId) {
         await db.events.bulkDelete(payload.removedEventIds)
@@ -1517,8 +1510,7 @@ function bindStreamSocketHandlers(
             workspaceId,
             _sequenceNum: sequenceToNum(event.sequence),
             _cachedAt: now,
-          })),
-          chunked
+          }))
         )
         // B3: the moved messages' pointer cards would skeleton in the
         // destination panel (cross-stream sources aren't in the local event
@@ -1696,7 +1688,6 @@ function bindStreamSocketHandlers(
     // Set when this event's sequence reveals missed events behind it; reported
     // after the transaction commits so the backfill never runs inside it.
     let gapAfterSequence: string | null = null
-    const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
     // Same transactional shape as handleMessageCreated: dedupe, gap-read, and
     // put must be atomic, or a concurrent append can land between the gap read
     // and this write and make the cursor lie in either direction.
@@ -1719,7 +1710,7 @@ function bindStreamSocketHandlers(
         _sequenceNum: sequenceToNum(payload.event.sequence),
         _cachedAt: now,
       })
-      await resolveUnknownOptimisticAnchors(streamId, chunked)
+      await resolveUnknownOptimisticAnchors(streamId)
       if (commandClientId && optimisticCommand) {
         await bumpLaterOptimisticAnchors(
           streamId,

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -1,11 +1,6 @@
 import { db, sequenceToNum, type CachedEvent } from "@/db"
 import { mergeStreamByTitleRevision } from "@/lib/title-merge"
-import {
-  isSinglePreviewWriterEnabled,
-  isNoOpRewrite,
-  isSharedStreamRegistrationEnabledSync,
-  putEventsBounded,
-} from "@/db/event-writes"
+import { isNoOpRewrite, putEventsBounded } from "@/db/event-writes"
 import {
   StreamTypes,
   THREAD_ANCHORABLE_EVENT_TYPES,
@@ -13,7 +8,6 @@ import {
   type Stream,
   type StreamBootstrap,
   type StreamReadFrontier,
-  type LastMessagePreview,
   type LinkPreviewSummary,
   type MemoEmbedSummary,
   type ThreadSummary,
@@ -1214,8 +1208,6 @@ function bindStreamSocketHandlers(
       // after the transaction commits so the backfill never runs inside it.
       let gapAfterSequence: string | null = null
 
-      // Same primed map, so this resolves without a second IDB read.
-      const singlePreviewWriter = await isSinglePreviewWriterEnabled(db, workspaceId)
       getPerfCapture().count("stream.idbTransaction")
       // Read after the transaction only: the `return` it drives stays inside the
       // callback, so the write path's control flow is unchanged.
@@ -1320,41 +1312,6 @@ function bindStreamSocketHandlers(
       // ciphertext); for plaintext sends the render path ignores the cache.
       if (optimisticPlaintext && isEncryptedPayload(newEvent.payload)) {
         seedDecryption(newEvent.id, optimisticPlaintext)
-      }
-
-      // `stream:activity` is emitted in the same backend transaction as this
-      // event and carries the server markdown, so it is the single preview
-      // writer; this arm only exists as the kill switch.
-      if (!singlePreviewWriter) {
-        // Update sidebar preview in both TanStack cache and IDB so the sort order
-        // and preview text survive cold starts (offline-first).
-        const newPreview: LastMessagePreview = {
-          authorId: newEvent.actorId ?? "",
-          authorType: newEvent.actorType ?? "user",
-          content: newPayload.contentJson as string,
-          createdAt: newEvent.createdAt,
-        }
-
-        const stopPreviewWrite = getPerfCapture().time("stream.previewWrite")
-        try {
-          await db.streams.update(streamId, {
-            lastMessagePreview: newPreview,
-            _cachedAt: Date.now(),
-          })
-
-          queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
-            if (!old) return old
-            return {
-              ...old,
-              streams: old.streams.map((stream) => {
-                if (stream.id !== streamId) return stream
-                return { ...stream, lastMessagePreview: newPreview }
-              }),
-            }
-          })
-        } finally {
-          stopPreviewWrite()
-        }
       }
 
       if (!(payload.slots || payload.sharedMessages) && contentHasSharedMessage(newPayload.contentJson)) {
@@ -2005,10 +1962,10 @@ function describeSignatureConflicts(
 
 /**
  * Registers the stream handler set, sharing one binding per
- * `(eventSource, streamId)` when `sharedStreamRegistration` is on. The open
- * stream is registered twice — once per membership by the SyncEngine, once by
- * `useStreamSocket` — through the same event gate, so without sharing every
- * handler runs twice for every event on that stream.
+ * `(eventSource, streamId)`. The open stream is registered twice — once per
+ * membership by the SyncEngine, once by `useStreamSocket` — through the same
+ * event gate, so without sharing every handler runs twice for every event on
+ * that stream.
  */
 export function registerStreamSocketHandlers(
   socket: SyncEventSource,
@@ -2021,10 +1978,6 @@ export function registerStreamSocketHandlers(
   // A fresh wrapper per registration: two registrants may pass the same
   // function reference, and a release must remove only its own listener.
   const listener: SequenceGapListener | null = onSequenceGap ? (gap) => onSequenceGap(gap) : null
-
-  if (!isSharedStreamRegistrationEnabledSync(workspaceId)) {
-    return bindStreamSocketHandlers(socket, workspaceId, streamId, queryClient, new Set(listener ? [listener] : []))
-  }
 
   const signature = { workspaceId, queryClient }
   let byStream = streamRegistrations.get(socket)

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -2202,7 +2202,7 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
   })
 })
 
-describe("SyncEngine bootstrap query-cache identity (bootstrapDiff)", () => {
+describe("SyncEngine bootstrap query-cache identity", () => {
   beforeEach(async () => {
     resetRevealGate()
     resetApplyWindow()
@@ -2232,7 +2232,6 @@ describe("SyncEngine bootstrap query-cache identity (bootstrapDiff)", () => {
   function diffOnBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
     diffBase ??= {
       ...makeWorkspaceBootstrap(),
-      featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
       streams: [
         {
           ...makeStreamBootstrap("stream_id_1").stream,

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -793,7 +793,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
   })
 
-  describe("bootstrapDiff", () => {
+  describe("the bootstrap row diff", () => {
     interface DiffTable {
       name: string
       toArray: () => Promise<Array<{ id: string; _cachedAt: number }>>
@@ -838,7 +838,6 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     function diffBootstrap(overrides: Partial<WorkspaceBootstrap> = {}): WorkspaceBootstrap {
       diffBase ??= makeBootstrap({
-        featureFlags: { workspace: { bootstrapDiff: "on" }, user: {} },
         users: [makeWorkspaceUser()],
         streams: [
           { ...makeStream("stream_d1"), lastMessagePreview: null },
@@ -1105,16 +1104,9 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       expect(await cachedAtSnapshot()).toEqual(before)
     })
 
-    async function warmThenOlderReconnect(
-      flagOn: boolean,
-      reconnectOverrides: Partial<WorkspaceBootstrap>
-    ): Promise<void> {
-      const flags: WorkspaceBootstrap["featureFlags"] = flagOn
-        ? { workspace: { bootstrapDiff: "on" }, user: {} }
-        : { workspace: {}, user: {} }
+    async function warmThenOlderReconnect(reconnectOverrides: Partial<WorkspaceBootstrap>): Promise<void> {
       const warm = (): WorkspaceBootstrap =>
         diffBootstrap({
-          featureFlags: flags,
           streamReadState: {
             stream_d1: { lastReadEventId: "evt_9", lastReadSequence: "9", lastReadAt: "2026-01-02T00:00:00Z" },
           },
@@ -1127,7 +1119,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
       await applyReconnectBootstrapBatch(
         "ws_1",
-        diffBootstrap({ featureFlags: flags, ...reconnectOverrides }),
+        diffBootstrap({ ...reconnectOverrides }),
         new Map(),
         new Set(),
         new Set(),
@@ -1153,17 +1145,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
 
     it("a reconnect carrying an older frontier cannot regress a row the diff just confirmed", async () => {
-      await warmThenOlderReconnect(true, {
-        streamReadState: {
-          stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
-        },
-      })
-
-      expect((await db.streamReadState.get("ws_1:stream_d1"))?.lastReadSequence).toBe("9")
-    })
-
-    it("with bootstrapDiff off, an older reconnect frontier still loses to the freshly written row", async () => {
-      await warmThenOlderReconnect(false, {
+      await warmThenOlderReconnect({
         streamReadState: {
           stream_d1: { lastReadEventId: "evt_2", lastReadSequence: "2", lastReadAt: "2026-01-01T00:00:00Z" },
         },
@@ -1174,7 +1156,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
 
     it("a reconnect carrying an older displayName cannot clobber a stream row the diff just confirmed", async () => {
       const base = diffBootstrap()
-      await warmThenOlderReconnect(true, {
+      await warmThenOlderReconnect({
         streams: base.streams.map((s) => (s.id === "stream_d1" ? { ...s, displayName: "Older Name" } : s)),
       })
 
@@ -1182,7 +1164,7 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
     })
 
     it("a reconnect carrying an older notificationLevel cannot clobber a membership row the diff just confirmed", async () => {
-      await warmThenOlderReconnect(true, {
+      await warmThenOlderReconnect({
         streamMemberships: [
           {
             streamId: "stream_d1",
@@ -1259,21 +1241,6 @@ describe("applyWorkspaceBootstrap (real IndexedDB)", () => {
       await applyWorkspaceBootstrap("ws_1", diffBootstrap(), Date.now())
 
       expect(getCachedWorkspaceTables("ws_1").streams).toBe(first)
-    })
-
-    it("with bootstrapDiff off, every row is rewritten", async () => {
-      // Explicit off override — the registry default is "on" since the go-live
-      // flip, so empty layers no longer select this arm.
-      const off = (): WorkspaceBootstrap =>
-        diffBootstrap({ featureFlags: { workspace: { bootstrapDiff: "off" }, user: {} } })
-      await applyWorkspaceBootstrap("ws_1", off(), Date.now() - 5000)
-      await stampCachedAt(1)
-
-      await applyWorkspaceBootstrap("ws_1", off(), Date.now())
-
-      const snapshot = await cachedAtSnapshot()
-      expect(Object.keys(snapshot).length).toBeGreaterThan(0)
-      expect(Object.entries(snapshot).filter(([, value]) => value === 1)).toEqual([])
     })
   })
 })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -14,7 +14,6 @@ import {
 } from "@/db"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { mergeConversationByTitleRevision, mergeStreamByTitleRevision } from "@/lib/title-merge"
-import { resolveFeatureFlags } from "@threa/types"
 import {
   diffRows,
   diffSingleton,
@@ -23,7 +22,6 @@ import {
   removeRowConfirmations,
   semanticEqual,
   SERVER_STAMP_IGNORED_KEYS,
-  writeAllRows,
 } from "./bootstrap-diff"
 import { getCachedWorkspaceTables, seedWorkspaceCache, upsertWorkspaceUserInCache } from "@/stores/workspace-store"
 import {
@@ -2543,8 +2541,6 @@ async function upsertStreamRow(stream: Stream): Promise<void> {
   })
 }
 
-const EMPTY_FLAG_LAYERS: FeatureFlagLayers = { workspace: {}, user: {} }
-
 function byId<T extends { id: string }>(rows: T[]): Map<string, T> {
   return new Map(rows.map((row) => [row.id, row]))
 }
@@ -2690,7 +2686,6 @@ export async function applyWorkspaceBootstrap(
   const now = Date.now()
   const capture = getPerfCapture()
   primeEventWriteFlags(workspaceId, bootstrap.featureFlags)
-  const diffEnabled = resolveFeatureFlags(bootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -2811,19 +2806,17 @@ export async function applyWorkspaceBootstrap(
         existingLabels,
         existingLabelAssignments,
         existingMetadata,
-      ] = diffEnabled
-        ? await Promise.all([
-            db.workspaces.get(workspaceId),
-            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
-            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
-            db.personas.where("workspaceId").equals(workspaceId).toArray(),
-            db.bots.where("workspaceId").equals(workspaceId).toArray(),
-            db.labels.where("workspaceId").equals(workspaceId).toArray(),
-            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
-            db.workspaceMetadata.get(workspaceId),
-          ])
-        : [undefined, [], [], [], [], [], [], [], undefined]
+      ] = await Promise.all([
+        db.workspaces.get(workspaceId),
+        db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+        db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+        db.personas.where("workspaceId").equals(workspaceId).toArray(),
+        db.bots.where("workspaceId").equals(workspaceId).toArray(),
+        db.labels.where("workspaceId").equals(workspaceId).toArray(),
+        db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+        db.workspaceMetadata.get(workspaceId),
+      ])
       stopPreRead()
 
       const stopDiff = capture.time("bootstrap.diff")
@@ -2846,24 +2839,16 @@ export async function applyWorkspaceBootstrap(
         ...mapArchivedStreamRows(bootstrap.archivedStreams ?? [], existingByStreamId, now),
       ])
 
-      const workspaceDiff = diffEnabled
-        ? diffSingleton(existingWorkspace, workspaceRow)
-        : { write: true, merged: workspaceRow }
-      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
-      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, streamCandidates) : writeAllRows(streamCandidates)
-      const membershipsDiff = diffEnabled
-        ? diffRows(byId(existingMemberships), membershipRows)
-        : writeAllRows(membershipRows)
-      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
-      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
-      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
-      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
-      const labelAssignmentsDiff = diffEnabled
-        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
-        : writeAllRows(labelAssignmentRows)
-      const metadataDiff = diffEnabled
-        ? diffSingleton(existingMetadata, metadataRow)
-        : { write: true, merged: metadataRow }
+      const workspaceDiff = diffSingleton(existingWorkspace, workspaceRow)
+      const usersDiff = diffRows(byId(existingUsers), userRows)
+      const streamsDiff = diffRows(existingByStreamId, streamCandidates)
+      const membershipsDiff = diffRows(byId(existingMemberships), membershipRows)
+      const dmPeersDiff = diffRows(byId(existingDmPeers), dmPeerRows)
+      const personasDiff = diffRows(byId(existingPersonas), personaRows)
+      const botsDiff = diffRows(byId(existingBots), botRows)
+      const labelsDiff = diffRows(byId(existingLabels), labelRows)
+      const labelAssignmentsDiff = diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+      const metadataDiff = diffSingleton(existingMetadata, metadataRow)
       stopDiff()
 
       mergedWorkspace = workspaceDiff.merged
@@ -2931,7 +2916,7 @@ export async function applyWorkspaceBootstrap(
       const existingUnread = await db.unreadState.get(workspaceId)
       effectiveUnread = mergeBootstrapUnreadFields(bootstrap, existingUnread, fetchStartedAt)
       const unreadRow = { id: workspaceId, workspaceId, ...effectiveUnread, _cachedAt: now }
-      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
+      const unreadDiff = diffSingleton(existingUnread, unreadRow)
       if (unreadDiff.write) {
         rowsWritten += 1
         await db.unreadState.put(unreadRow)
@@ -2978,9 +2963,7 @@ export async function applyWorkspaceBootstrap(
             _cachedAt: now,
           })
         }
-        const readStateDiff = diffEnabled
-          ? diffRows(new Map(existingRows.map((row) => [row.id, row])), serverRows)
-          : writeAllRows(serverRows)
+        const readStateDiff = diffRows(new Map(existingRows.map((row) => [row.id, row])), serverRows)
         if (readStateDiff.toWrite.length > 0) {
           await db.streamReadState.bulkPut(readStateDiff.toWrite)
         }
@@ -2999,7 +2982,7 @@ export async function applyWorkspaceBootstrap(
           workspaceId,
           _cachedAt: now,
         }
-        if (diffEnabled && existingPrefs && semanticEqual(existingPrefs, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
+        if (existingPrefs && semanticEqual(existingPrefs, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
           rowsSkipped += 1
         } else {
           rowsWritten += 1
@@ -3015,7 +2998,7 @@ export async function applyWorkspaceBootstrap(
           config: bootstrap.sidebarConfig,
           _cachedAt: now,
         }
-        if (diffEnabled && existingSidebar && semanticEqual(existingSidebar, sidebarRow)) {
+        if (existingSidebar && semanticEqual(existingSidebar, sidebarRow)) {
           rowsSkipped += 1
         } else {
           rowsWritten += 1
@@ -3184,7 +3167,6 @@ export async function applyReconnectBootstrapBatch(
   })
 
   primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
-  const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 
@@ -3311,51 +3293,39 @@ export async function applyReconnectBootstrapBatch(
         existingLabelAssignments,
         existingUnread,
         existingMetadata,
-      ] = diffEnabled
-        ? await Promise.all([
-            db.workspaces.get(workspaceId),
-            db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
-            db.streams.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
-            db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
-            db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
-            db.personas.where("workspaceId").equals(workspaceId).toArray(),
-            db.bots.where("workspaceId").equals(workspaceId).toArray(),
-            db.labels.where("workspaceId").equals(workspaceId).toArray(),
-            db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
-            db.unreadState.get(workspaceId),
-            db.workspaceMetadata.get(workspaceId),
-          ])
-        : [undefined, [], [], [], [], [], [], [], [], [], undefined, undefined]
+      ] = await Promise.all([
+        db.workspaces.get(workspaceId),
+        db.workspaceUsers.where("workspaceId").equals(workspaceId).toArray(),
+        db.streams.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamMemberships.where("workspaceId").equals(workspaceId).toArray(),
+        db.streamReadState.where("workspaceId").equals(workspaceId).toArray(),
+        db.dmPeers.where("workspaceId").equals(workspaceId).toArray(),
+        db.personas.where("workspaceId").equals(workspaceId).toArray(),
+        db.bots.where("workspaceId").equals(workspaceId).toArray(),
+        db.labels.where("workspaceId").equals(workspaceId).toArray(),
+        db.labelAssignments.where("workspaceId").equals(workspaceId).toArray(),
+        db.unreadState.get(workspaceId),
+        db.workspaceMetadata.get(workspaceId),
+      ])
 
       const stopDiff = capture.time("bootstrap.diff")
-      const workspaceDiff = diffEnabled
-        ? diffSingleton(existingWorkspace, workspaceRow)
-        : { write: true, merged: workspaceRow }
-      const usersDiff = diffEnabled ? diffRows(byId(existingUsers), userRows) : writeAllRows(userRows)
+      const workspaceDiff = diffSingleton(existingWorkspace, workspaceRow)
+      const usersDiff = diffRows(byId(existingUsers), userRows)
       const existingByStreamId = byId(existingStreams)
       const mergedStreamRows = streamRows.map((incoming) => {
         const existing = existingByStreamId.get(incoming.id)
         return existing ? mergeStreamByTitleRevision(existing, incoming) : incoming
       })
-      const streamsDiff = diffEnabled ? diffRows(existingByStreamId, mergedStreamRows) : writeAllRows(mergedStreamRows)
-      const membershipsDiff = diffEnabled
-        ? diffRows(byId(existingMemberships), membershipRows)
-        : writeAllRows(membershipRows)
-      const readStatesDiff = diffEnabled
-        ? diffRows(byId(existingReadStates), readStateRows)
-        : writeAllRows(readStateRows)
-      const dmPeersDiff = diffEnabled ? diffRows(byId(existingDmPeers), dmPeerRows) : writeAllRows(dmPeerRows)
-      const personasDiff = diffEnabled ? diffRows(byId(existingPersonas), personaRows) : writeAllRows(personaRows)
-      const botsDiff = diffEnabled ? diffRows(byId(existingBots), botRows) : writeAllRows(botRows)
-      const labelsDiff = diffEnabled ? diffRows(byId(existingLabels), labelRows) : writeAllRows(labelRows)
-      const labelAssignmentsDiff = diffEnabled
-        ? diffRows(byId(existingLabelAssignments), labelAssignmentRows)
-        : writeAllRows(labelAssignmentRows)
-      const unreadDiff = diffEnabled ? diffSingleton(existingUnread, unreadRow) : { write: true, merged: unreadRow }
-      const metadataDiff = diffEnabled
-        ? diffSingleton(existingMetadata, metadataRow)
-        : { write: true, merged: metadataRow }
+      const streamsDiff = diffRows(existingByStreamId, mergedStreamRows)
+      const membershipsDiff = diffRows(byId(existingMemberships), membershipRows)
+      const readStatesDiff = diffRows(byId(existingReadStates), readStateRows)
+      const dmPeersDiff = diffRows(byId(existingDmPeers), dmPeerRows)
+      const personasDiff = diffRows(byId(existingPersonas), personaRows)
+      const botsDiff = diffRows(byId(existingBots), botRows)
+      const labelsDiff = diffRows(byId(existingLabels), labelRows)
+      const labelAssignmentsDiff = diffRows(byId(existingLabelAssignments), labelAssignmentRows)
+      const unreadDiff = diffSingleton(existingUnread, unreadRow)
+      const metadataDiff = diffSingleton(existingMetadata, metadataRow)
       stopDiff()
 
       mergedWorkspace = workspaceDiff.merged
@@ -3431,11 +3401,7 @@ export async function applyReconnectBootstrapBatch(
           workspaceId,
           _cachedAt: now,
         }
-        if (
-          !diffEnabled ||
-          !existingUserPreferences ||
-          !semanticEqual(existingUserPreferences, prefsRow, SERVER_STAMP_IGNORED_KEYS)
-        ) {
+        if (!existingUserPreferences || !semanticEqual(existingUserPreferences, prefsRow, SERVER_STAMP_IGNORED_KEYS)) {
           rowsWritten += 1
           await db.userPreferences.put(prefsRow)
         } else {
@@ -3451,7 +3417,7 @@ export async function applyReconnectBootstrapBatch(
           config: finalBootstrap.sidebarConfig,
           _cachedAt: now,
         }
-        if (!diffEnabled || !existingSidebarConfig || !semanticEqual(existingSidebarConfig, sidebarRow)) {
+        if (!existingSidebarConfig || !semanticEqual(existingSidebarConfig, sidebarRow)) {
           rowsWritten += 1
           await db.sidebarConfigs.put(sidebarRow)
         } else {
@@ -3599,7 +3565,7 @@ export async function applyReconnectBootstrapBatch(
 }
 
 // Every keep-set below derives from the BOOTSTRAP PAYLOAD, never from the set of
-// rows the apply actually wrote. Under `bootstrapDiff` a row present in the
+// rows the apply actually wrote: a row present in the
 // payload can be skipped and keep an old `_cachedAt` — narrowing these sets to
 // "the ids we wrote" would sweep exactly those rows. Presence in the payload is
 // the protection; `_cachedAt >= now` only shields rows the payload never

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -110,7 +110,6 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isCoalescedLiveCommitEnabledSync, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -693,9 +692,9 @@ export function registerWorkspaceSocketHandlers(
      *  and sidebar order never flicker through intermediate replay values.
      *  Absent → live, write-immediately. */
     getCatchUpBatch?: () => CatchUpBatch | null
-    /** The engine's live-commit batch, used when `coalescedLiveCommit` is on:
-     *  one task's counter and preview writes fold into one transaction and one
-     *  cache publication instead of two of each per event. */
+    /** The engine's live-commit batch: one task's counter and preview writes
+     *  fold into one transaction and one cache publication instead of two of
+     *  each per event. Absent only for handlers built without an engine. */
     getLiveCommitBatch?: () => LiveCommitBatch | null
   }
 ): () => void {
@@ -705,50 +704,24 @@ export function registerWorkspaceSocketHandlers(
   // batch when one is active, else commit immediately (live). Read-pointer
   // mirrors and feed invalidations are not coalesced — they stay on their own
   // immediate paths in the handlers below.
-  /** The live batch when the flag is armed, else null. Re-read per event: a
-   *  backoffice flip re-primes the flag map, so arming and disarming both take
-   *  effect on the next event. */
-  const armedLiveBatch = (): LiveCommitBatch | null =>
-    isCoalescedLiveCommitEnabledSync(workspaceId) ? (refs.getLiveCommitBatch?.() ?? null) : null
-
-  /** Run an immediate (unbatched) commit, draining a still-pending fold first.
-   *  Without this, an off-flip mid-task lets an older buffered preview flush
-   *  AFTER a newer immediate commit and overwrite it in cache and IDB. */
-  const commitImmediate = (commit: () => void): void => {
-    const pending = refs.getLiveCommitBatch?.() ?? null
-    if (pending?.hasPending() || pending?.isFlushing()) {
-      pending.runAfterDrain(commit)
-      return
-    }
-    commit()
-  }
+  const liveBatch = (): LiveCommitBatch | null => refs.getLiveCommitBatch?.() ?? null
 
   const commitCounter = (mutate: CounterMutator): void => {
-    const batch = refs.getCatchUpBatch?.() ?? null
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.applyCounter(mutate)
       return
     }
-    const live = armedLiveBatch()
-    if (live) {
-      live.applyCounter(mutate)
-      return
-    }
-    commitImmediate(() => commitCounterMutation(queryClient, workspaceId, mutate))
+    commitCounterMutation(queryClient, workspaceId, mutate)
   }
 
   const commitPreview = (streamId: string, preview: LastMessagePreview | null): void => {
-    const batch = refs.getCatchUpBatch?.() ?? null
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.setStreamPreview(streamId, preview)
       return
     }
-    const live = armedLiveBatch()
-    if (live) {
-      live.setStreamPreview(streamId, preview)
-      return
-    }
-    commitImmediate(() => commitStreamPreview(queryClient, workspaceId, streamId, preview))
+    commitStreamPreview(queryClient, workspaceId, streamId, preview)
   }
 
   // Activity-feed invalidation seam. During catch-up it marks the feed stale on
@@ -1212,12 +1185,12 @@ export function registerWorkspaceSocketHandlers(
     // commit from ONE ordered buffer: routing it around the batch would open its
     // transaction at handler time and drop held rows BEFORE the buffered fold
     // inserts them, resurrecting an already-read mention.
-    const batch = refs.getCatchUpBatch?.() ?? armedLiveBatch()
+    const batch = refs.getCatchUpBatch?.() ?? liveBatch()
     if (batch) {
       batch.applyCounter((state) => applyStreamsReadAllOrdinals(state, payload.reads))
       batch.applyReadAllFrontiers(payload.frontiers)
     } else {
-      commitImmediate(() => void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers))
+      void commitReadAll(queryClient, workspaceId, payload.reads, payload.frontiers)
     }
 
     // Standalone frontier (read cutover): read_all carries ordinals, no event
@@ -1784,10 +1757,7 @@ export function registerWorkspaceSocketHandlers(
     }))
     if (!patched) return
     const layers = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.featureFlags
-    if (layers) {
-      primeEventWriteFlags(workspaceId, layers)
-      void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
-    }
+    if (layers) void db.workspaceMetadata.update(workspaceId, { featureFlags: layers })
   }
 
   const handleFeatureFlagsUpdated = (payload: FeatureFlagsUpdatedPayload) => {
@@ -2685,7 +2655,6 @@ export async function applyWorkspaceBootstrap(
 ): Promise<AppliedWorkspaceBootstrap> {
   const now = Date.now()
   const capture = getPerfCapture()
-  primeEventWriteFlags(workspaceId, bootstrap.featureFlags)
 
   // Build membership lookup for O(1) access when merging onto streams
   const membershipByStream = new Map(bootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -3165,8 +3134,6 @@ export async function applyReconnectBootstrapBatch(
     localUnreadState: localUnreadState ?? undefined,
     fetchStartedAt,
   })
-
-  primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -112,7 +112,7 @@ import {
   Visibilities,
   normalizeSidebarConfig,
 } from "@threa/types"
-import { isCoalescedLiveCommitEnabledSync, isEventWriteChunkingEnabled, primeEventWriteFlags } from "@/db/event-writes"
+import { isCoalescedLiveCommitEnabledSync, primeEventWriteFlags } from "@/db/event-writes"
 import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { deleteStreamSlots, deleteSlotsForStreams } from "@/stores/slot-store"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
@@ -3184,7 +3184,6 @@ export async function applyReconnectBootstrapBatch(
   })
 
   primeEventWriteFlags(workspaceId, finalBootstrap.featureFlags)
-  const chunked = await isEventWriteChunkingEnabled(db, workspaceId)
   const diffEnabled = resolveFeatureFlags(finalBootstrap.featureFlags ?? EMPTY_FLAG_LAYERS).bootstrapDiff === "on"
 
   const membershipByStream = new Map(finalBootstrap.streamMemberships.map((sm) => [sm.streamId, sm]))
@@ -3466,7 +3465,7 @@ export async function applyReconnectBootstrapBatch(
         // Carry the fetch window so a per-stream envelope's stale `readState`
         // never clobbers a frontier touched during the reconnect (same rule
         // the workspace map merge above applies).
-        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, chunked, fetchStartedAt)
+        await applyStreamBootstrapInCurrentTransaction(workspaceId, streamId, bootstrap, now, fetchStartedAt)
       }
 
       if (terminalStreamIds.size > 0) {

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -101,13 +101,12 @@ stream page, twenty-four or more on the board — so a sample cannot be attribut
 to one timeline. Disambiguating would mean a per-caller mark name and the
 registry is closed on purpose (D15), so read them as a page total.
 
-They are also not like-for-like across arms: with `boundedTimelineRead` on, only
-the prefix read emits `liveQuery.rerun`/`liveQuery.load`, so an on-vs-off
-comparison is prefix-only after against whole-read before. That is the intended
-reading of the win (the tail is what the arriving message wakes), but it is not a
-measurement of the same population. `timeline.tailLoad` is emitted by the bounded
-tail read alone: it exists in the on arm only, so its presence is what proves the
-flag armed, and its duration is the cost of the read a live arrival triggers.
+They also cover only part of a floored read: the window is split into an
+immutable tail and a widening prefix, and only the prefix emits
+`liveQuery.rerun`/`liveQuery.load`. `timeline.tailLoad` is the tail read's own
+mark — its duration is the cost of the read a live arrival triggers. Any
+comparison against a capture taken before the split (pre-#1745) is prefix-only
+after against whole-read before, not the same population.
 
 ### Reading `stream.idbTransaction` / `stream.activityApply` (scenarios 4, 15)
 
@@ -143,20 +142,17 @@ total work halves. Compare sample counts × mean, not means.
 
 `workspace-wide` is the only profile that crosses Dexie's 50-row threshold in
 `streams` and `streamMemberships`, which is the amplifier the bootstrap diff
-removes. Run it as an A/B on one device, same fixture and same workspace in both
-arms — `bootstrapDiff` defaults to `off`, so the arms are a flag flip, not a
-build swap:
+removes. The diff is now unconditional, so this is a single-arm reading — load,
+hard-refresh, hard-refresh again, then idle, and read `bootstrap.preRead`,
+`bootstrap.diff` and the written/skipped row counts on the third load:
 
 ```bash
-# BEFORE — flag off (the default). Load, hard-refresh, hard-refresh again, then idle.
 open 'http://localhost:4004/w/<workspaceId>?perfCapture=1'
 #    devtools console, on the third load: copy(JSON.stringify(__threaPerfCapture.export()))
-
-# AFTER — open the backoffice the stack recipe already boots on :4006, pick the
-# workspace, Feature flags → bootstrapDiff = on (it propagates live), then repeat
-# the three loads above unchanged. Set it back to off before re-running BEFORE.
-open 'http://localhost:4006'
 ```
+
+A before/after against the pre-diff behaviour needs a build swap (the flag that
+used to provide it was deleted once the rollout finished).
 
 What to read — the _third_ load's samples. Load 2 still writes: the first load's
 read watermark and `counterTouchedAt` settle against the previous fetch window,

--- a/docs/perf/reproduction-matrix.md
+++ b/docs/perf/reproduction-matrix.md
@@ -92,7 +92,7 @@ there is no gap to catch up on.
 | 12  | Restore → switch stream → return → navigate away and back | `--profile drafts` plus `--profile large-stream`                                               | `editor.externalSync`, `stream.subscriptions`, `liveQuery.rerun`, `bootstrap.publish`                                                                                                                                                                         |
 | 13  | Unchanged warm refresh, wide workspace                    | `--profile workspace-wide`, then hard-refresh twice with no new messages (read the third load) | `bootstrap.preRead` + `bootstrap.tx` (the comparable number), `bootstrap.rowsWritten`, `bootstrap.rowsSkipped`, `bootstrap.diff`, `bootstrap.storePublish`, `bootstrap.cachePublish`, `bootstrap.cleanup`                                                     |
 | 14  | One incoming message into a deep scroll-back window       | `--profile large-stream`, scroll up ten pages, then post from a second client                  | `timeline.tailLoad` (bounded and flat as the scroll-back deepens), `liveQuery.load`, `timeline.derive` (samples sum to the whole derivation chain — one per memo in it), `timeline.windowItems` (identical between arms — a change here is a correctness bug) |
-| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.previewWrite`, `stream.activityApply`, `stream.liveCommitFold`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                         |
+| 15  | One incoming message into an open member stream           | `--profile large-stream`, open the channel, then post from a second client (phone)             | `stream.eventApply`, `stream.eventTx`, `stream.contextRows`, `stream.activityApply`, `stream.liveCommitFold`, `stream.eventDuplicate`, `stream.idbTransaction`                                                                                                |
 
 ### Reading `liveQuery.rerun` / `liveQuery.load` (scenarios 7, 8, 14)
 
@@ -112,31 +112,26 @@ after against whole-read before, not the same population.
 
 `stream.idbTransaction` counts the per-message write transactions the sync path
 opens: the event-write transaction (`stream-sync.ts`), the local context-row
-transaction (`putLocalContextRows`), and the counter and preview commits
-(`commitCounterMutation`, `commitStreamPreview`, or the single
-`LiveCommitBatch.commit` that replaces both when `coalescedLiveCommit` is on).
-It does not count catch-up flushes — those are per window, not per message — so
-read it only in a live-delivery scenario.
+transaction (`putLocalContextRows`), and the single `LiveCommitBatch.commit`
+that carries the counter and preview together. It does not count catch-up
+flushes — those are per window, not per message — so read it only in a
+live-delivery scenario.
 
-`stream.activityApply` is the handler body in BOTH arms — one sample per
-`stream:activity`. It is not the same work in each: with `coalescedLiveCommit`
-off it covers two synchronous `setQueryData` calls plus the _setup_ of two
-fire-and-forget IDB transactions (`void db.transaction(...)` — the sample stops
-before the persist settles); with the flag on those calls are replaced by two
-buffer pushes, so the sample is near zero. Read it as "what the handler costs
-the task", never as the cost of the write.
+`stream.activityApply` is the handler body — one sample per `stream:activity`,
+covering two buffer pushes, so it is near zero. Read it as "what the handler
+costs the task", never as the cost of the write.
 
-The fold has its own name, `stream.liveCommitFold`, emitted only in the on arm —
-one sample per flush, covering the awaited transaction and the single bootstrap
-publication. Its presence proves the flag armed; its count against the
-`stream.activityApply` count is the coalescing ratio. The two names are separate
-populations on purpose: mixed under one name, N near-zero handler samples plus
-one awaited fold sample makes the arm look faster or slower depending on which
-statistic the reader takes.
+The fold has its own name, `stream.liveCommitFold` — one sample per flush,
+covering the awaited transaction and the single bootstrap publication. Its count
+against the `stream.activityApply` count is the coalescing ratio. The two names
+are separate populations on purpose: mixed under one name, N near-zero handler
+samples plus one awaited fold sample makes the path look faster or slower
+depending on which statistic the reader takes.
 
-Caveat for scenario 15 with `sharedStreamRegistration` on: the cheap duplicate
-apply disappears, so the mean of `stream.eventApply` **rises** even though the
-total work halves. Compare sample counts × mean, not means.
+Caveat for scenario 15: one binding per (event source, stream) means the cheap
+duplicate apply is gone, so the mean of `stream.eventApply` reads **higher** than
+a pre-#1764 capture even though the total work halved. Compare sample counts ×
+mean, not means.
 
 ### Scenario 13 — reading the unchanged warm refresh
 
@@ -185,7 +180,7 @@ Three caveats, all load-bearing:
 
 `stream.eventApply` is wall clock around a handler that awaits, so it includes
 main-thread contention from the renders its own writes wake — its samples do not
-sum from `stream.eventTx` + `stream.contextRows` + `stream.previewWrite`.
+sum from `stream.eventTx` + `stream.contextRows`.
 
 Three things to check before reading a scenario-15 capture, each of which
 otherwise produces a confident wrong conclusion:

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -62,7 +62,6 @@ export const FEATURE_FLAGS = {
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
   sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  sharedWorkspaceReads: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   singlePreviewWriter: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -55,14 +55,11 @@ export function defineFlag<
  */
 export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
-  coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.
   perfDiagnostics: defineFlag({ values: ["off", "available"], scopes: ["workspace", "user"], default: "off" }),
-  sharedStreamRegistration: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
-  singlePreviewWriter: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
 } as const satisfies FeatureFlagRegistry
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -60,7 +60,6 @@ export const FEATURE_FLAGS = {
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
-  indexedMessagePatch: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -59,7 +59,6 @@ export const FEATURE_FLAGS = {
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
-  eventWriteChunking: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The
   // user's own opt-in preference is the consent, and the upload path re-checks
   // both server-side.

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,8 +54,6 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
-  bootstrapDiff: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
-  boundedTimelineRead: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   coalescedLiveCommit: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "off" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),

--- a/packages/types/src/performance-capture.ts
+++ b/packages/types/src/performance-capture.ts
@@ -34,7 +34,6 @@ export const PERF_MARK_NAMES = [
   "stream.idbTransaction",
   "stream.eventTx",
   "stream.contextRows",
-  "stream.previewWrite",
   "stream.activityApply",
   "stream.liveCommitFold",
   "stream.eventDuplicate",


### PR DESCRIPTION
Throwaway. `ci.yml` triggers on `pull_request: branches: [main]`, so the four stacked PRs in Stack #1835 never run unit/lint/typecheck — only browser-tests. This runs the full matrix against the combined diff. Closing once it settles.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788855624&installation_model_id=20758&pr_number=1836&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1836&signature=7523dbfd0a35270adba1177330ab412df5d020604fda023e4bb04e1d379b6d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->