### PR TITLE
fix: five mobile annoyances (popover drift, back-to-close, z-order, tables, toast taps)

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -285,8 +285,11 @@ export function AppShell({ sidebar, children }: AppShellProps) {
       <div ref={pullRef} className="relative flex flex-1 flex-col overflow-hidden">
         {/* Workspace-wide loading indicator — hairline along the bottom of the
              sidebar/page header row (h-12). Spans the full viewport so it links
-             the two headers visually now that the top bar is gone. */}
-        <div className="pointer-events-none absolute left-0 right-0 top-12 z-[55]">
+             the two headers visually now that the top bar is gone. Above the
+             sidebar column (z-40), below the z-50 overlay layer: no ancestor
+             here opens a stacking context, so anything higher paints the
+             hairline over dialogs, drawers and menus portalled to the body. */}
+        <div className="pointer-events-none absolute left-0 right-0 top-12 z-[45]">
           <TopbarLoadingIndicator visible={showLoadingIndicator} />
         </div>
 

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -2,9 +2,34 @@ import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
+import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
+import { HistoryBackClose } from "./history-back-close"
 
-const Dialog = DialogPrimitive.Root
+const Dialog = ({ open, defaultOpen, onOpenChange, ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) => {
+  const isMobile = useIsMobile()
+  // Open state is lifted out of Radix (mirroring uncontrolled usage into local
+  // state) so HistoryBackClose can close trigger-driven dialogs too — same
+  // contract as Drawer, because a mobile dialog IS a full-screen overlay.
+  const isControlled = open !== undefined
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen ?? false)
+  const resolvedOpen = isControlled ? open : uncontrolledOpen
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next)
+      onOpenChange?.(next)
+    },
+    [isControlled, onOpenChange]
+  )
+
+  return (
+    <>
+      {isMobile && <HistoryBackClose open={resolvedOpen} onClose={() => handleOpenChange(false)} />}
+      <DialogPrimitive.Root open={resolvedOpen} onOpenChange={handleOpenChange} {...props} />
+    </>
+  )
+}
+Dialog.displayName = "Dialog"
 
 const DialogTrigger = DialogPrimitive.Trigger
 

--- a/apps/frontend/src/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/src/components/ui/dropdown-menu.tsx
@@ -57,11 +57,15 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, updatePositionStrategy = "always", ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      // Per-frame anchor tracking, for the same reason as PopoverContent: the
+      // mobile keyboard closing moves the trigger without a resize/scroll
+      // floating-ui's "optimized" strategy watches for.
+      updatePositionStrategy={updatePositionStrategy}
       className={cn(
         "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className

--- a/apps/frontend/src/components/ui/history-back-close.test.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.test.tsx
@@ -5,6 +5,8 @@ import { createMemoryRouter, Link, RouterProvider } from "react-router-dom"
 import * as mobileModule from "@/hooks/use-mobile"
 import { __resetOverlayHistoryForTests, attachOverlayHistoryRouter, OverlayHistoryLayout } from "./history-back-close"
 import { Drawer, DrawerContent, DrawerTitle } from "./drawer"
+import { Dialog, DialogContent, DialogTitle } from "./dialog"
+import { MediaGalleryProvider, useMediaGallery } from "@/contexts/media-gallery-context"
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -249,6 +251,117 @@ describe("HistoryBackClose via Drawer (mobile)", () => {
 
     // History is balanced: the next back leaves the page
     await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+  })
+})
+
+/** A dialog-based overlay (the media gallery's shape: controlled, full-screen). */
+function DialogHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <span>{open ? "dialog-open" : "dialog-closed"}</span>
+      <button onClick={() => setOpen(true)}>open-dialog</button>
+      <button onClick={() => setOpen(false)}>close-dialog</button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogTitle>Preview</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+describe("HistoryBackClose via Dialog (mobile)", () => {
+  beforeEach(() => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+  })
+
+  it("back gesture closes the dialog and stays on the page", async () => {
+    const router = makeRouter(<DialogHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router, "open-dialog")
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+
+    await waitFor(() => expect(screen.getByText("dialog-closed")).toBeInTheDocument())
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+  })
+
+  it("closing via UI pops the sentinel entry so back leaves the page", async () => {
+    const router = makeRouter(<DialogHarness />)
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    await openDrawer(router, "open-dialog")
+    fireEvent.click(screen.getByText("close-dialog"))
+
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+  })
+})
+
+/**
+ * The media gallery already deepens history itself (`?media=`) and pops that
+ * entry on close, so it now pushes TWO entries per open (its own plus the
+ * sentinel). One back press must still land on the bare stream.
+ */
+function GalleryHarness() {
+  const { mediaAttachmentId, openMedia, closeMedia } = useMediaGallery()
+  const open = mediaAttachmentId !== null
+  return (
+    <div>
+      <span>{open ? "gallery-open" : "gallery-closed"}</span>
+      <button onClick={() => openMedia("attach_1")}>open-gallery</button>
+      <Dialog open={open} onOpenChange={(next) => !next && closeMedia()}>
+        <DialogContent>
+          <DialogTitle>Media</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+describe("HistoryBackClose with the URL-driven media gallery (mobile)", () => {
+  beforeEach(() => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+  })
+
+  it("one back press closes the gallery, clears ?media= and stays on the page", async () => {
+    const router = makeRouter(
+      <MediaGalleryProvider>
+        <GalleryHarness />
+      </MediaGalleryProvider>
+    )
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    fireEvent.click(screen.getByText("open-gallery"))
+    await waitFor(() => expect(screen.getByText("gallery-open")).toBeInTheDocument())
+    // Both the ?media= entry and the sentinel have landed
+    await waitFor(() => expect(router.state.location.search).toBe("?media=attach_1"))
+    await act(async () => {})
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+
+    await waitFor(() => expect(screen.getByText("gallery-closed")).toBeInTheDocument())
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+    expect(router.state.location.search).toBe("")
+
+    // History is balanced: the next back leaves the page
     await act(async () => {
       await router.navigate(-1)
     })

--- a/apps/frontend/src/components/ui/popover.tsx
+++ b/apps/frontend/src/components/ui/popover.tsx
@@ -12,12 +12,17 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = "center", sideOffset = 4, updatePositionStrategy = "always", ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
+      // The mobile keyboard closing moves the composer without a scroll or a
+      // resize floating-ui observes: `--viewport-height` is rewritten (debounced
+      // past the window resize), so an "optimized" popover keeps the position it
+      // mounted with and floats mid-screen. Track the anchor per frame instead.
+      updatePositionStrategy={updatePositionStrategy}
       className={cn(
         "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
         className

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1109,3 +1109,12 @@ body > .rt-DialogOverlay,
 body > .rt-AlertDialogOverlay {
   z-index: 60;
 }
+
+/* Sonner renders in the app tree, so a Radix modal's `pointer-events: none` on
+   <body> reaches the toaster and makes every toast action dead while a dialog
+   or drawer is open — the "A new version is available" Reload button most
+   visibly. Toasts sit above every overlay (z-index 999999999); they stay
+   tappable there too. */
+[data-sonner-toaster] {
+  pointer-events: auto;
+}

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -449,24 +449,28 @@ export const markdownComponents: Components = {
     return null
   },
 
-  // Tables - use Shadcn UI Table. Let content set the width so long paths,
-  // URLs, and paragraphs flow naturally and the wrapper scrolls horizontally
-  // on narrow viewports instead of crushing cells into tight wrapping.
+  // Tables — Shadcn UI Table; its own wrapper is the horizontal scroller.
+  // `w-max` sizes to content, not to the message column: at column width the
+  // auto layout crushes each column to its minimum, and `break-all` on inline
+  // code makes that minimum one character. Cells cap at 70vw so a prose-heavy
+  // column can't run away instead.
   table: ({ children }) => (
-    <div className="my-2 overflow-x-auto">
-      <Table className="w-auto table-auto">{children}</Table>
+    <div className="my-2">
+      <Table className="w-max min-w-full table-auto [&_code]:break-words [&_code]:[word-break:normal]">
+        {children}
+      </Table>
     </div>
   ),
   thead: ({ children }) => <TableHeader>{children}</TableHeader>,
   tbody: ({ children }) => <TableBody>{children}</TableBody>,
   tr: ({ children }) => <TableRow>{children}</TableRow>,
   th: ({ children }) => (
-    <TableHead>
+    <TableHead className="h-auto max-w-[70vw] px-3 py-2 align-top">
       <ProcessedChildren>{children}</ProcessedChildren>
     </TableHead>
   ),
   td: ({ children }) => (
-    <TableCell>
+    <TableCell className="max-w-[70vw] px-3 py-2 align-top">
       <ProcessedChildren>{children}</ProcessedChildren>
     </TableCell>
   ),

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -453,10 +453,12 @@ export const markdownComponents: Components = {
   // `w-max` sizes to content, not to the message column: at column width the
   // auto layout crushes each column to its minimum, and `break-all` on inline
   // code makes that minimum one character. Cells cap at 70vw so a prose-heavy
-  // column can't run away instead.
+  // column can't run away instead — `anywhere` rather than `break-word` because
+  // only `anywhere` lowers min-content, so a cell holding one unbreakable token
+  // can be sized down to that cap at all.
   table: ({ children }) => (
     <div className="my-2">
-      <Table className="w-max min-w-full table-auto [&_code]:break-words [&_code]:[word-break:normal]">
+      <Table className="w-max min-w-full table-auto [&_code]:[overflow-wrap:anywhere] [&_code]:[word-break:normal]">
         {children}
       </Table>
     </div>

--- a/tests/browser/markdown-table-mobile.spec.ts
+++ b/tests/browser/markdown-table-mobile.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * A rendered markdown table at phone width — the one thing jsdom cannot answer.
+ * Table layout is intrinsic sizing plus wrapping rules, and jsdom implements
+ * neither, so "does a wide table stay readable or collapse into a column of
+ * single characters" is unverifiable everywhere except a real engine.
+ *
+ * The table this asserts on is the shape that broke: short-label columns next
+ * to inline code holding a branch name and a 40-char SHA, plus one prose cell.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+const PHONE = { width: 390, height: 800 }
+
+/** No spaces, no hyphens: nothing for the line breaker to use. */
+const UNBREAKABLE = "0123456789abcdef".repeat(6)
+
+const TABLE_MARKDOWN = [
+  "| PR | Branch | Current pushed head | Note |",
+  "| --- | --- | --- | --- |",
+  "| #1817 | `feat/invocation-source-mutations-01-canonical-state` | `923317a2548b04b2c5773ad9d2500afc405e1457` | short |",
+  `| #1823 | \`${UNBREAKABLE}\` | \`88eb613f0ea1c2c8e505e1d8cf2040d5910c7e2e\` | a prose cell long enough that letting it size to its content would drag the table far past anything a thumb wants to scroll through, several clauses over |`,
+].join("\n")
+
+async function seedTable(page: Page, workspaceId: string, streamId: string): Promise<void> {
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: { streamId, content: TABLE_MARKDOWN },
+  })
+  await expectApiOk(response, "Send table message")
+}
+
+test("a wide table scrolls instead of crushing its columns", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "md-table")
+  await createChannel(page, `table-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  await seedTable(page, workspaceId!, streamId!)
+  await page.setViewportSize(PHONE)
+  await page.reload()
+
+  const table = page.locator("table").first()
+  await expect(table).toBeVisible({ timeout: 30_000 })
+
+  // The table sizes to its content and its own wrapper scrolls — the failure
+  // this replaces had the table fit the message column exactly (no overflow)
+  // by wrapping every cell down to one character per line.
+  await expect.poll(() => table.evaluate((el) => el.getBoundingClientRect().width)).toBeGreaterThan(PHONE.width)
+  const scroller = await table.evaluateHandle((el) => el.parentElement!)
+  expect(await scroller.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true)
+
+  // Nothing spills out of its cell, including the token with no break
+  // opportunity in it, and no cell is narrower than a couple of characters.
+  const cells = await table.evaluate((el) =>
+    [...el.querySelectorAll("td, th")].map((cell) => {
+      const box = cell.getBoundingClientRect()
+      const content = [...cell.children].map((child) => child.getBoundingClientRect().right)
+      return { width: Math.round(box.width), overflow: Math.max(0, ...content) - box.right }
+    })
+  )
+  expect(Math.min(...cells.map((c) => c.width))).toBeGreaterThan(24)
+  expect(Math.max(...cells.map((c) => c.overflow))).toBeLessThanOrEqual(1)
+
+  // A table that overflows must not take the page with it.
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(
+    true
+  )
+})

--- a/tests/browser/stream-context-panel.spec.ts
+++ b/tests/browser/stream-context-panel.spec.ts
@@ -103,14 +103,12 @@ test("windows its rows and jumps to a date from a day marker", async ({ page }) 
 
   // ── Windowing: the scroller reserves the full list height, but only a slice
   // of the rows is mounted. Without virtua every row would be in the DOM.
-  const metrics = await scroller.evaluate((el) => ({
-    scrollHeight: el.scrollHeight,
-    clientHeight: el.clientHeight,
-    mountedRows: el.querySelectorAll('a[href*="example.com"]').length,
-  }))
-  expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight * 2)
-  expect(metrics.mountedRows).toBeGreaterThan(0)
-  expect(metrics.mountedRows).toBeLessThan(MESSAGE_COUNT / 2)
+  // Poll the reserved height: virtua grows it as rows are measured, so the
+  // first painted row is not the frame where the estimate has settled.
+  await expect.poll(() => scroller.evaluate((el) => el.scrollHeight / el.clientHeight)).toBeGreaterThan(2)
+  const mountedRows = await scroller.evaluate((el) => el.querySelectorAll('a[href*="example.com"]').length)
+  expect(mountedRows).toBeGreaterThan(0)
+  expect(mountedRows).toBeLessThan(MESSAGE_COUNT / 2)
 
   // ── Date jump: scroll away, then jump back via a day marker. Every seeded
   // message lands today, so "Today" is the day to return to — what is being


### PR DESCRIPTION
## Problem

Five unrelated mobile defects, all reported from a phone:

1. Composer popovers freeze at their mount position. Dismissing the keyboard without blurring the editor moves the composer via `useVisualViewport`'s debounced `--viewport-height` rewrite — a layout change floating-ui's default `"optimized"` strategy never observes (it watches ancestor scroll, window resize and `ResizeObserver`, and the window resize fires *before* the debounced var write). The drafts popover ends up floating mid-screen, hundreds of px above the composer it is anchored to.
2. Back exits the stream instead of closing an attachment preview. `Drawer` registers `HistoryBackClose`; `Dialog` did not. The timeline gallery survived only because `MediaGalleryProvider` pushes its own `?media=` entry — galleries opened from local state (`pending-attachments.tsx`, `link-preview-card.tsx`) had nothing to pop.
3. The workspace loading hairline paints over dialogs and drawers: it sits at `z-[55]` in `AppShell`, and no ancestor between it and `<body>` opens a stacking context, so it outranks the whole z-50 overlay layer.
4. Markdown tables are unreadable on a phone. `Table` was `w-auto`, so the auto layout fits the table into the message column and crushes each column toward its minimum — and `break-all` on inline code makes that minimum one character, turning a branch/SHA table into columns of single letters.
5. The "A new version of Threa is available" toast can't be tapped while settings or a drawer is open. Radix's dismissable-layer sets `pointer-events: none` on `<body>` for modal layers; Sonner renders inside the app tree, so the toast inherits it and Reload goes dead until the user closes everything else.

## Solution

One targeted fix each, four of them in the shared `ui/` primitives so the class of bug closes rather than one instance.

- `PopoverContent` / `DropdownMenuContent` default to `updatePositionStrategy="always"` (floating-ui `animationFrame: true`), overridable per call site. Per-frame anchor tracking over teaching `useComposerAnchor` to emit resize events — the anchor isn't the only thing that moves, `--viewport-height` moves the whole shell.
- `Dialog` mirrors `Drawer`: lifts open state out of Radix and mounts `HistoryBackClose` on mobile. The overlay coordinator peels one overlay per back press, so a gallery that also pushes `?media=` unwinds both entries on one press — covered by a test against the real `MediaGalleryProvider`.
- Loading hairline `z-[55]` → `z-[45]`: above the sidebar column (`z-40`), below the overlay layer.
- Tables size to content (`w-max min-w-full`) inside the Shadcn wrapper's existing scroller, cells cap at `max-w-[70vw]`, and code in a cell gets `word-break: normal` + `overflow-wrap: anywhere` (CodeRabbit's catch: only `anywhere` lowers min-content, so only `anywhere` lets a cell holding one unbreakable token be sized down to its cap). Verified in Chromium at 390px: table lays out at 770px and scrolls; a prose cell wraps at 70vw instead of running the table a mile wide.
- `[data-sonner-toaster] { pointer-events: auto }` in `index.css`. The toaster `<ol>` is `position: fixed` with zero height when empty and its toasts are absolutely positioned inside it, so this re-enables taps without introducing a dead region. A tap over a modal also dismisses that modal (Radix outside-pointerdown) — correct for Reload.

Out of scope, deliberately: `AlertDialog` keeps its no-back-close behavior (it exists to force an explicit choice), and desktop is unaffected by the `HistoryBackClose` registration (`useIsMobile` gate).

Also included: `stream-context-panel.spec.ts`'s windowing assertion sampled `scrollHeight` on the frame the first row painted, before virtua had measured enough rows to grow the reserved height. It fails ~2/3 of runs on `main` (measured: 2 of 3 with a clean tree, 1 of 3 with this branch) — now polls the ratio instead. Unrelated to this diff, fixed rather than left red (INV-22).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/ui/popover.tsx` | `updatePositionStrategy="always"` default |
| `apps/frontend/src/components/ui/dropdown-menu.tsx` | same default for menus |
| `apps/frontend/src/components/ui/dialog.tsx` | lifts open state, mounts `HistoryBackClose` on mobile |
| `apps/frontend/src/components/layout/app-shell.tsx` | loading hairline `z-[55]` → `z-[45]` |
| `apps/frontend/src/lib/markdown/components.tsx` | content-width tables, 70vw cells, code wrapping |
| `tests/browser/markdown-table-mobile.spec.ts` | **new** — table layout at 390px (scrolls, no crushed columns, no spill) |
| `apps/frontend/src/index.css` | `[data-sonner-toaster] { pointer-events: auto }` |
| `apps/frontend/src/components/ui/history-back-close.test.tsx` | 3 tests: dialog back-close, UI-close unwind, gallery double-entry |
| `tests/browser/stream-context-panel.spec.ts` | poll the reserved height instead of sampling it |

## Test plan

- [x] `bun run test` — 6501 pass, 0 fail
- [x] `bun run test:browser` — `drafts-modal` 11 pass; `attachment-stable-urls` + `message-share-cross-stream` + `user-journey` pass; `stream-context-panel --repeat-each=3` 3 pass (was 1–2 fail before the poll fix)
- [x] `bun run typecheck`, `bun run lint` — clean
- [x] `markdown-table-mobile.spec.ts` — 1 pass; verified it fails against the pre-fix `w-auto` rendering
- [x] Table layout measured in headless Chromium at 390px width (table 770px, scrolls; cells cap at 273px)
- [ ] `bun run test:e2e` — 10 pre-existing failures on this branch's base `d9e6ae20` (Pi session-control dispatch 500s, bot-runtime WS, claude-code-channel sessions). Backend-only, no path to this frontend diff; not touched here.
- [ ] Not verified on a physical phone — the five fixes are reasoned from the reported symptoms plus the code, and the browser checks above run desktop-width.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
