### PR TITLE
fix: keep the Pi remote poll loop alive through stalled HTTP bodies and hung dials

### DIFF
--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -472,6 +472,45 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
       ioSpy.mockRestore()
     }
   })
+
+  it("bounds a hint response whose body stalls after headers, and stays re-dialable", async () => {
+    // Clearing the abort timer once headers arrived left `res.json()` unbounded:
+    // one stalled body hung connect() forever with `connecting` latched true, so
+    // no later call could ever dial — presence froze while the pane said linked.
+    let calls = 0
+    global.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      calls++
+      if (calls === 1) {
+        const signal = init?.signal as AbortSignal | undefined
+        const stalled = new ReadableStream({
+          start(controller) {
+            signal?.addEventListener("abort", () => controller.error(new DOMException("aborted", "AbortError")))
+          },
+        })
+        return new Response(stalled, { status: 200, headers: { "content-type": "application/json" } })
+      }
+      return new Response(JSON.stringify({ wsUrl: "https://ws.example.test" }), { status: 200 })
+    }) as unknown as typeof fetch
+    const fake = makeFakeSocket()
+    const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      const transport = new BotRuntimeTransport({
+        baseUrl: "https://app.example.test",
+        workspaceId: "ws_1",
+        apiKey: "threa_bk_test",
+        hello: HELLO,
+        fetchTimeoutMs: 25,
+      })
+
+      await transport.connect()
+      expect(ioSpy).toHaveBeenCalledTimes(0)
+
+      await transport.connect()
+      expect(ioSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
 })
 
 describe("the routed writes never reject (best-effort contract)", () => {

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -408,10 +408,24 @@ export class BotRuntimeTransport {
 
   /** The wsUrl hint is served by the edge workspace-router at `/api/workspaces/:id/config` (NOT /api/v1). */
   async resolveWsHint(): Promise<WsHint | undefined> {
-    const res = await this.httpRequest(`/api/workspaces/${this.workspaceId}/config`, { method: "GET" })
-    if (!res.ok) return undefined
-    const body = (await res.json()) as { wsUrl?: string }
-    return parseWsHint({ url: body.wsUrl })
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.fetchTimeoutMs)
+    try {
+      // Headers AND body under one abort window. `httpRequest` clears its timer
+      // once headers arrive, so a response whose body then stalls left
+      // `res.json()` awaiting forever — with `connecting` latched true, no later
+      // call could ever redial, and the runtime sat "linked" but unreachable.
+      const res = await fetch(`${this.base}/api/workspaces/${this.workspaceId}/config`, {
+        method: "GET",
+        signal: controller.signal,
+        headers: { Authorization: `Bearer ${this.apiKey}`, "Content-Type": "application/json" },
+      })
+      if (!res.ok) return undefined
+      const body = (await res.json()) as { wsUrl?: string }
+      return parseWsHint({ url: body.wsUrl })
+    } finally {
+      clearTimeout(timeout)
+    }
   }
 
   private async httpRecordStepsFallback(

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1964,13 +1964,14 @@ describe("reload claim continuity", () => {
         },
       },
     })
+    const statuses: Array<string | undefined> = []
     const ctx = {
       sessionManager: { getSessionId: () => runtimeSessionId, getBranch: () => [] },
       isIdle: () => true,
       cwd: "/tmp",
       modelRegistry: { getAvailable: () => [] },
       ui: {
-        setStatus: () => {},
+        setStatus: (_key: string, text?: string) => void statuses.push(text),
         notify: () => {},
         theme: { fg: (_tone: string, text: string) => text },
       },
@@ -1992,6 +1993,8 @@ describe("reload claim continuity", () => {
       await Bun.sleep(30)
 
       expect(requests.some((url) => url.endsWith("/bot-invocations/claim"))).toBe(true)
+      // The footer must not advertise "reloading…" forever while the dial hangs.
+      expect(statuses).toContain("Threa remote: linked")
       await Promise.race([started, Promise.resolve()])
     } finally {
       fetchSpy.mockRestore()

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1935,6 +1935,69 @@ describe("reload claim continuity", () => {
     }
   })
 
+  test("polling starts even while the ws-hint dial hangs", async () => {
+    // The 2026-08-10 wedge: session_start awaited connect() BEFORE startPolling,
+    // so a ws-hint fetch that never settled froze the runtime at one startup
+    // heartbeat — no polls, no claims, pane still "linked". The backstop must
+    // start before the dial it backs up.
+    const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
+    const pi = {
+      registerCommand: () => {},
+      on: (event: string, handler: (event: unknown, ctx: any) => Promise<void>) => handlers.set(event, handler),
+      sendUserMessage: () => {},
+    }
+    threaRemote(pi as never)
+
+    const runtimeSessionId = "runtime_hung_dial"
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      pollMs: 10,
+      linkedSessions: {
+        [runtimeSessionId]: {
+          enabled: true,
+          instanceId: "pi-hung-dial",
+          runtimeSessionId,
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => runtimeSessionId, getBranch: () => [] },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        setStatus: () => {},
+        notify: () => {},
+        theme: { fg: (_tone: string, text: string) => text },
+      },
+    }
+    const requests: string[] = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      const url = String(input)
+      requests.push(url)
+      if (url.includes("/api/workspaces/ws_123/config")) return new Promise<Response>(() => {})
+      const data = url.endsWith("/bot-invocations/claim") ? null : {}
+      return new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+
+    try {
+      const started = handlers.get("session_start")!({ reason: "reload" }, ctx)
+      await Bun.sleep(30)
+
+      expect(requests.some((url) => url.endsWith("/bot-invocations/claim"))).toBe(true)
+      await Promise.race([started, Promise.resolve()])
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("restores, renews, and completes the in-flight claim after the extension cache is cleared", async () => {
     const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
     const pi = {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -4521,6 +4521,11 @@ export default function (pi: ExtensionAPI): void {
     // 2026-08-10 — session_start hung inside connect() and the runtime froze at
     // one startup heartbeat, footer still "linked".
     startPolling(pi, ctx)
+    // The shutdown hook wrote "reloading…", and nothing else rewrites the
+    // footer until the next invocation runs — so without this a healthy,
+    // polling runtime advertises a reload that finished long ago. "linked"
+    // means the session link, not the socket, so it goes before the dial.
+    setRemoteStatus(ctx, pending ? `Threa remote: running ${pending.id}` : "Threa remote: linked")
     await ensureTransport(pi, ctx)?.connect()
     if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")
   })

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -684,16 +684,6 @@ function summarizeError(error: unknown): string {
   return [message, causeCode ? `(${causeCode})` : ""].filter(Boolean).join(" ").replace(/\s+/g, " ").slice(0, 180)
 }
 
-async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-  try {
-    return await fetch(url, { ...init, signal: controller.signal })
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
 class ThreaApiError extends Error {
   constructor(
     readonly status: number,
@@ -706,14 +696,31 @@ class ThreaApiError extends Error {
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!config) throw new Error("Threa remote config not loaded")
   const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData
-  const response = await fetchWithTimeout(`${config.baseUrl.replace(/\/$/, "")}${path}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${config.apiKey}`,
-      ...(!isFormData && { "Content-Type": "application/json" }),
-      ...init?.headers,
-    },
-  })
+  // One abort window over headers AND body. Clearing the timer once headers
+  // arrived left the `response.json()` below unbounded — a response whose body
+  // then stalls hangs its caller forever, and a hung await inside the poll loop
+  // parks the loop with no timer armed: presence freezes while the pane still
+  // says "linked". That is the recurring split-brain, so the window closes only
+  // after the body is consumed.
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(`${config.baseUrl.replace(/\/$/, "")}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        ...(!isFormData && { "Content-Type": "application/json" }),
+        ...init?.headers,
+      },
+    })
+    return await readRequestBody<T>(response)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function readRequestBody<T>(response: Response): Promise<T> {
   if (!response.ok) {
     // Surface the server's JSON error (Zod `fieldErrors`, `code`, ...) when the
     // API itself rejects the request, so a 400 is debuggable instead of a bare
@@ -2232,8 +2239,10 @@ async function enableRemote(pi: ExtensionAPI, ctx: ExtensionContext): Promise<vo
   }
   lastBusyHeartbeatAt = 0
   await heartbeat("available", undefined, ctx)
-  await ensureTransport(pi, ctx)?.connect()
+  // Backstop before dial, matching session_start: a stalled connect() must not
+  // keep the poll loop from ever starting.
   startPolling(pi, ctx)
+  await ensureTransport(pi, ctx)?.connect()
   ctx.ui.notify("Threa remote enabled for this Pi session", "info")
 }
 
@@ -3829,21 +3838,32 @@ function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
   if (!isEnabled(ctx)) return
   stopPolling()
   const runId = ++pollingRunId
+  const arm = (delayMs: number) => {
+    if (runId !== pollingRunId) return
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => void poll(), delayMs)
+  }
   const poll = async () => {
     if (runId !== pollingRunId) return
-    if (pollInFlightRunId !== undefined) {
-      timer = setTimeout(() => void poll(), basePollMs())
-      return
-    }
+    // Re-armed BEFORE any await: scheduling must not depend on the poll body
+    // settling. When it does, one stalled response parks the loop with no timer
+    // armed — presence frozen, claims dead, pane still "linked" (2026-08-10).
+    // A completed poll's finally overrides this tick with its computed delay.
+    arm(basePollMs())
+    if (pollInFlightRunId !== undefined) return
     pollInFlightRunId = runId
     let delayMs = basePollMs()
     try {
       // Self-heal the /bot socket: if the hint resolve failed on enable /
       // session_start (transient blip), retry it here. connect() is guarded, so
       // while Socket.IO is mid-reconnect (socket present, not yet connected)
-      // this is a no-op rather than a second dial.
+      // this is a no-op rather than a second dial. Deliberately NOT awaited:
+      // the claim below is the backstop, and a dial that stalls must not hold
+      // this worker (an in-flight worker skips every later tick).
       if (isEnabled(ctx) && !transport?.socketConnected) {
-        await ensureTransport(pi, ctx)?.connect()
+        void ensureTransport(pi, ctx)
+          ?.connect()
+          .catch((error) => emitPollDebug(ctx, `poll socket self-heal failed: ${summarizeError(error)}`))
       }
       await probeArchiveState(ctx)
       const contactedServer = await claimIfIdle(pi, ctx)
@@ -3854,14 +3874,10 @@ function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
       delayMs = failurePollMs()
     } finally {
       if (pollInFlightRunId === runId) pollInFlightRunId = undefined
-      if (runId === pollingRunId) timer = setTimeout(() => void poll(), delayMs)
+      arm(delayMs)
     }
   }
-  rearmPoll = (delayMs: number) => {
-    if (runId !== pollingRunId) return
-    if (timer) clearTimeout(timer)
-    timer = setTimeout(() => void poll(), delayMs)
-  }
+  rearmPoll = arm
   void poll()
 }
 
@@ -4463,8 +4479,9 @@ export default function (pi: ExtensionAPI): void {
         setRemoteStatus(ctx, "Threa remote: revival blocked")
         return
       }
-      await ensureTransport(pi, ctx)?.connect()
+      // Backstop before dial, matching session_start.
       startPolling(pi, ctx)
+      await ensureTransport(pi, ctx)?.connect()
     },
   })
 
@@ -4498,8 +4515,13 @@ export default function (pi: ExtensionAPI): void {
     await heartbeat(pending ? "busy" : "available", pending ? "Working on Threa invocation…" : undefined, ctx).catch(
       (error) => emitPollDebug(ctx, `session startup heartbeat failed; continuing: ${summarizeError(error)}`)
     )
-    await ensureTransport(pi, ctx)?.connect()
+    // Polling FIRST: it is the backstop, and its first tick self-heals the
+    // socket, so a dial that stalls or throws must not be able to take it down
+    // with it. Sequencing the dial ahead of the loop did exactly that on
+    // 2026-08-10 — session_start hung inside connect() and the runtime froze at
+    // one startup heartbeat, footer still "linked".
     startPolling(pi, ctx)
+    await ensureTransport(pi, ctx)?.connect()
     if (event.reason === "reload") ctx.ui.notify("Threa remote reconnected after reload.", "info")
   })
 


### PR DESCRIPTION
## Problem

The Pi orchestrator repeatedly ends split-brained: server shows the instance `busy`/silent with invocations stuck `pending`, while the local pane says "Threa remote: linked". Reproduced 2026-08-10 on current code (post-#1535/#1790): after `/reload`, exactly one startup heartbeat, then presence frozen, zero polls, no socket. Root cause is two stacked defects. (1) `fetchWithTimeout`/`httpRequest` clear their abort timer once **headers** arrive; `response.json()` after that is unbounded, so a response whose body stalls hangs its caller forever — in `BotRuntimeTransport.resolveWsHint` that latches `connecting=true` so no later dial can ever run. (2) The poll loop armed its next timer only in the poll body's `finally`, and `session_start`/enable awaited `connect()` **before** `startPolling()` — one hung await parks the backstop with no timer, taking down the exact recovery #1790 added.

## Solution

- `transport.ts` `resolveWsHint`: fetch + body read under one `AbortController` window (`fetchTimeoutMs`), so a stalled body rejects instead of hanging and `connecting` unlatches in `finally`.
- `threa-remote.ts` `request()`: same single-window restructure (body reads moved into `readRequestBody`, timer cleared only after the body is consumed); `fetchWithTimeout` deleted (sole caller).
- `startPolling`: next tick armed **before** any await; a completed poll's `finally` overrides with the computed backoff delay (`arm` clears the prior timer, so one chain, unchanged cadence semantics). The socket self-heal inside the poll is no longer awaited — `connect()` is guarded, and the claim below is the backstop.
- `startPolling(...)` now precedes `await connect()` at all three call sites (session_start, enable, link).

Tests: transport — stalled-body hint response settles within `fetchTimeoutMs` and the transport stays re-dialable; pi-remote — "polling starts even while the ws-hint dial hangs" (fails on the old ordering/loop, the existing suite only covered a *rejecting* heartbeat, not a *hanging* dial).

## Test plan

- [x] `extensions/pi-remote`: 127 pass · `extensions/bot-runtime-client`: 97 pass · `extensions/claude-code-remote` (shares the transport): 126 pass
- [x] Pre-commit monorepo lint/typecheck
- [ ] Live verification pending: install to `~/.pi/agent/extensions/threa-remote`, respawn the orchestrator, reload-survival + heartbeat watch (doing now; will comment)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788932406&installation_model_id=20758&pr_number=1841&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1841&signature=a3a37f9a8b7aef0f166e545e2ddb426c89071f4e62eaafe4328e6f37b853e496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->