### PR TITLE
test: await the composer focus in the conversation-reply arm test

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -666,7 +666,9 @@ describe("MessageInput", () => {
 
       const strip = screen.getByTestId("conversation-reply-strip")
       expect(strip).toHaveTextContent("Replying in Pizza plans")
-      expect(mockComposerFocus).toHaveBeenCalledTimes(1)
+      // Focus lands a tick after arm() resolves; asserting synchronously flaked
+      // under CI load (0 calls observed on 2026-08-10).
+      await waitFor(() => expect(mockComposerFocus).toHaveBeenCalledTimes(1))
     })
 
     it("files the send into the armed conversation and clears the strip on success", async () => {


### PR DESCRIPTION
## Problem

`MessageInput › reply in conversation › arms the composer … and focuses the editor` flaked on [#1841](https://github.com/threahq/threa/pull/1841)'s Frontend Tests (4/4): `mockComposerFocus` observed 0 calls. Focus is dispatched a tick after `arm()` resolves, so the synchronous `toHaveBeenCalledTimes(1)` races under CI load; passes 4/4 locally.

## Solution

Wrap the focus assertion in `waitFor` (same pattern as the strip-clear assertion below it). No production code touched.

## Test plan

- [x] `apps/frontend` message-input.test.tsx — 34 pass, 4 consecutive runs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788933412&installation_model_id=20758&pr_number=1842&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1842&signature=4c0f4ca9fcf3717ed29280422d26f24d2faef9e845e5471e2d43e4ebecab7856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->