### PR TITLE
fix: restore presence after control commands and release the poll worker latch on stop

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1654,6 +1654,81 @@ describe("claim drain serialization", () => {
     }
   })
 
+  test("a no-turn control command restores available presence instead of staying busy", async () => {
+    // The dispatch heartbeats "busy, Running /X…" on entry and every success
+    // path returned with that presence still standing — a /stop with nothing
+    // to stop left the agent advertised busy and not-accepting until some
+    // later turn happened to heartbeat (observed 2026-08-10).
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      linkedSessions: {
+        runtime: {
+          enabled: true,
+          instanceId: "pi-instance",
+          runtimeSessionId: "runtime",
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    })
+    const presence: Array<Record<string, unknown>> = []
+    let claimServed = false
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/claim")) {
+        if (claimServed) {
+          return new Response(JSON.stringify({ data: null }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        }
+        claimServed = true
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: "binv_stop",
+              activeStreamId: "stream_1",
+              sourceMessageId: "msg_stop",
+              promptMarkdown: "/stop",
+              requiredCapability: "session-control",
+              claimToken: "claim_stop",
+              claimExpiresAt: null,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      if (url.endsWith("/bot-runtime/presence") && typeof init?.body === "string") {
+        presence.push(JSON.parse(init.body) as Record<string, unknown>)
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+    const ctx = {
+      sessionManager: { getSessionId: () => "runtime", getBranch: () => [] },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: { notify: () => {}, setStatus: () => {}, theme: { fg: (_tone: string, text: string) => text } },
+    } as never
+    const pi = { sendUserMessage: () => {} } as never
+
+    try {
+      await __testing.claimIfIdle(pi, ctx)
+
+      expect(presence.at(-1)).toMatchObject({ status: "available", acceptingInvocations: true })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("runtime reset drains an in-flight claim before teardown completes", async () => {
     __testing.setConfigForTesting({
       baseUrl: "https://app.threa.io",
@@ -1996,6 +2071,122 @@ describe("reload claim continuity", () => {
       // The footer must not advertise "reloading…" forever while the dial hangs.
       expect(statuses).toContain("Threa remote: linked")
       await Promise.race([started, Promise.resolve()])
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("a Threa-triggered /reload leaves the claim loop able to claim the next message", async () => {
+    // The 2026-08-10 second wedge: a /reload arriving AS a Threa invocation
+    // (complete → handoff followUp → ctx.reload) left the reloaded session
+    // unable to claim the message that arrived mid-reload, while a pane-native
+    // reload recovered fine. This drives the full command → handoff → shutdown
+    // → start sequence and requires the next claim to happen.
+    const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void>>()
+    const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>()
+    const deliveries: Array<{ text: string; options?: unknown }> = []
+    const pi = {
+      registerCommand: (name: string, options: { handler: (args: string, ctx: any) => Promise<void> }) =>
+        commands.set(name, options),
+      on: (event: string, handler: (event: unknown, ctx: any) => Promise<void>) => handlers.set(event, handler),
+      sendUserMessage: (text: string, options?: unknown) => deliveries.push({ text, options }),
+    }
+    threaRemote(pi as never)
+
+    const runtimeSessionId = "runtime_threa_reload"
+    __testing.setConfigForTesting({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+      pollMs: 10,
+      linkedSessions: {
+        [runtimeSessionId]: {
+          enabled: true,
+          instanceId: "pi-threa-reload",
+          runtimeSessionId,
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+        },
+      },
+    })
+    const ctx = {
+      sessionManager: { getSessionId: () => runtimeSessionId, getBranch: () => [] },
+      isIdle: () => true,
+      cwd: "/tmp",
+      modelRegistry: { getAvailable: () => [] },
+      ui: {
+        setStatus: () => {},
+        notify: () => {},
+        theme: { fg: (_tone: string, text: string) => text },
+      },
+    }
+    let offer = false
+    let claimedAfterReload = 0
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/bot-invocations/claim")) {
+        if (!offer) {
+          return new Response(JSON.stringify({ data: null }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        }
+        offer = false
+        claimedAfterReload++
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: "binv_after_reload",
+              activeStreamId: "stream_1",
+              sourceMessageId: "msg_after",
+              promptMarkdown: "Hiya",
+              claimToken: "claim_after",
+              claimExpiresAt: null,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      if (url.includes("/streams/stream_1/messages?")) {
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as typeof fetch)
+
+    try {
+      await handlers.get("session_start")!({ reason: "startup" }, ctx)
+      await __testing.runReloadCommand(
+        pi as never,
+        {
+          id: "binv_reload",
+          activeStreamId: "stream_1",
+          sourceMessageId: "msg_reload",
+          promptMarkdown: "/reload",
+          claimToken: "claim_reload",
+          claimedInstanceId: "pi-threa-reload",
+          claimExpiresAt: null,
+        } as never,
+        ctx as never
+      )
+      await commands.get("threa-remote-reload")!.handler("", {
+        ...ctx,
+        reload: async () => {
+          await handlers.get("session_shutdown")!({ reason: "reload" }, ctx)
+          await handlers.get("session_start")!({ reason: "reload" }, ctx)
+        },
+      })
+
+      offer = true
+      await Bun.sleep(60)
+
+      expect(claimedAfterReload).toBe(1)
+      expect(deliveries.some((delivery) => delivery.text.includes("Hiya"))).toBe(true)
     } finally {
       fetchSpy.mockRestore()
     }

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -1915,6 +1915,11 @@ function stopPolling(): void {
   if (timer) clearTimeout(timer)
   timer = undefined
   rearmPoll = undefined
+  // Release the worker latch: a poll still awaiting something from BEFORE this
+  // stop (a reload tears polling down mid-flight) must not make every tick of
+  // the NEXT loop skip as "in flight" until that orphan settles. Its own
+  // finally guards on run id, so this reset cannot be double-cleared.
+  pollInFlightRunId = undefined
 }
 
 /**
@@ -3438,11 +3443,20 @@ async function handleSessionControlInvocation(
     }
   } catch (error) {
     await failInvocation(invocation, error)
-    lastBusyHeartbeatAt = 0
-    const busy = reconnectPending || pending !== undefined || !ctx.isIdle()
-    await heartbeat(busy ? "busy" : "available", busy ? "Busy in Pi…" : undefined, ctx).catch(() => undefined)
   } finally {
     clearInterval(renewTimer)
+    // Every success path returns straight out of the switch with the entry
+    // "Running /X…" busy presence still standing, so a no-turn command
+    // (/stop with nothing to stop, /kick, /key) left the agent advertised
+    // busy and not-accepting until some later turn happened to heartbeat.
+    // A pending reload/reconnect handoff keeps busy on purpose: the restart
+    // is imminent, and "available" would invite claims this process is about
+    // to abandon.
+    if (!reloadPending && !reconnectPending) {
+      lastBusyHeartbeatAt = 0
+      const busy = pending !== undefined || !ctx.isIdle()
+      await heartbeat(busy ? "busy" : "available", busy ? "Busy in Pi…" : undefined, ctx).catch(() => undefined)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Follow-up to [#1841](https://github.com/threahq/threa/pull/1841) — two more layers of the same split-brain, both observed live on 2026-08-10 after a **Threa-triggered** `/reload` (an invocation completing while shutdown races; #1841's verification only exercised pane-native reload):

1. `handleSessionControlInvocation` heartbeats `busy, Running /X…` on entry, and only the **catch** path restores presence. Every successful no-turn command (`/stop` with nothing to stop, `/kick`, `/key`) returns straight out of the switch, leaving the agent advertised `busy, accepting_invocations=false` until some later turn happens to heartbeat — the "ghost busy agent" in the sidebar.
2. `stopPolling` doesn't clear `pollInFlightRunId`. A poll worker orphaned mid-flight by a reload keeps the latch set, so every tick of the *next* loop skips as "in flight" until the orphan settles — claims starve on the freshly reloaded session (`Hiya` sat `pending` 6+ minutes while the pane sat idle and "linked").

## Solution

- Presence restore moved to the dispatch `finally` (available/busy by actual state), skipped while a reload/reconnect handoff is pending — those keep `busy` on purpose since the restart is imminent. The catch path's duplicate restore deleted.
- `stopPolling` resets `pollInFlightRunId`; the orphan's own `finally` guards on run id so it can't clobber the next loop's latch.
- New tests: the full Threa-triggered reload sequence (control claim → complete → handoff → shutdown → start → **next claim must happen**) and "a no-turn control command restores available presence" (fails on the old catch-only restore).

## Test plan

- [x] `extensions/pi-remote` — 129 pass (2 new)
- [ ] Live: deploying to the homelab orchestrator next; will ask Kris for one Threa-side `/reload` under observation and comment the result

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788934309&installation_model_id=20758&pr_number=1843&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1843&signature=c9519db92a26f0288cb07f6a24d396b5c178cb2574ba72d89c03b4afd709a168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->