### PR TITLE
fix: never resolve a Pi row through the Claude identity stack

### DIFF
--- a/extensions/harness-daemon/src/discovery.ts
+++ b/extensions/harness-daemon/src/discovery.ts
@@ -671,7 +671,11 @@ export function defaultAgentIdentityResolver(
   attested: AttestedRuntime[] = attestedRuntimes(readHarnessLinks(), canonicalOrRaw)
 ): AgentIdentityResolver {
   return (agent) => {
-    if (!agent.worktree) return agent.runtimeSessionId
+    // The rungs below answer "what CLAUDE identity does this directory have" —
+    // a Pi row resolved through them inherits a coexisting Claude's minted id,
+    // collides with the real Claude row in `latestAgentsByIdentity`, and drops
+    // out of every revival sweep silently. A Pi's recorded id IS its identity.
+    if (agent.runtime !== "claude" || !agent.worktree) return agent.runtimeSessionId
     const resolved = runtimeIdentityFor({ cwd: agent.worktree, agent, identities, attested, canonical: canonicalOrRaw })
     return resolved.source === "derived" ? agent.runtimeSessionId : resolved.runtimeSessionId
   }

--- a/extensions/harness-daemon/src/inventory.test.ts
+++ b/extensions/harness-daemon/src/inventory.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { AgentIdentityResolver } from "./discovery"
+import { defaultAgentIdentityResolver, type AgentIdentityResolver } from "./discovery"
 import { findAgentOrUndefined, readInventory, readInventoryReadonly, upsertAgent } from "./inventory"
 import { latestAgentsByIdentity } from "./resume"
 import type { ManagedAgent } from "./types"
@@ -209,4 +209,33 @@ test("a targeted restore considers a tombstoned row; an untargeted sweep does no
 
   expect(latestAgentsByIdentity([dead], resolverFor({}))).toEqual([])
   expect(latestAgentsByIdentity([dead], resolverFor({}), true)).toEqual([dead])
+})
+
+test("a Pi row is never resolved through the Claude identity stack", () => {
+  // The live regression (2026-08-10): a Pi and a Claude sharing one cwd, with
+  // a Claude record minted for it — the Pi row resolved to the CLAUDE minted
+  // id, collided with the real Claude row in latestAgentsByIdentity, and
+  // silently dropped out of every `up` sweep.
+  const resolver = defaultAgentIdentityResolver(
+    [
+      {
+        runtimeSessionId: "ccs-claude",
+        instanceId: "cc-claude",
+        worktree: "/home/user",
+        runtimeKind: "claude-code-channel",
+        mintedAt: "2026-08-10T00:00:00.000Z",
+        source: "mint",
+      },
+    ],
+    []
+  )
+  const pi = agent({ id: "pi-1", runtime: "pi", worktree: "/home/user", runtimeSessionId: "pi-uuid" })
+  const claude = agent({ id: "claude-1", worktree: "/home/user", runtimeSessionId: "ccs-claude" })
+
+  expect(resolver(pi)).toBe("pi-uuid")
+  expect(
+    latestAgentsByIdentity([pi, claude], resolver)
+      .map((row) => row.id)
+      .sort()
+  ).toEqual(["claude-1", "pi-1"])
 })


### PR DESCRIPTION
## Problem

Regression from [#1838](https://github.com/threahq/threa/pull/1838), observed live: the Pi orchestrator died and `threa-harnessd up` silently skipped its row — no `resolve` line, no skip status. `defaultAgentIdentityResolver` runs `runtimeIdentityFor` (the Claude resolver) for **any** row with a worktree. Pre-#1838, a shared cwd's two records made the minted rung ambiguous and the Pi row fell through to `derived` → kept its own id. Post-#1838 the minted rung is Claude-scoped, resolves cleanly, and hands the **Pi row the coexisting Claude's minted id** — it then collides with the real Claude row in `latestAgentsByIdentity` (`identity:ccs-…@/home/…` key) and the newer row wins, dropping the Pi from every revival sweep with nothing reported.

## Solution

A non-Claude row's recorded `runtimeSessionId` **is** its identity — return it without consulting the Claude rungs. Test pins the live scenario: Pi + Claude rows sharing a cwd with a Claude record minted for it; the resolver keeps `pi-uuid` and `latestAgentsByIdentity` keeps both rows.

## Test plan

- [x] `extensions/harness-daemon` — 354 pass (1 new), `tsc --noEmit` clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788937523&installation_model_id=20758&pr_number=1845&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1845&signature=9b4735b4b65d031e8d9a5271984661ce7417769758fc1c7ee8c9e07c52b66678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->