### PR TITLE
fix: bound the Claude channel HTTP body reads inside the abort window

### DIFF
--- a/extensions/remote-session/src/client.ts
+++ b/extensions/remote-session/src/client.ts
@@ -102,25 +102,34 @@ export class ThreaClient {
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    // One abort window over headers AND body. Clearing the timer once headers
+    // arrived left every `response.text()`/`response.json()` below unbounded —
+    // a stalled body hung the channel's request forever, the MCP server went
+    // unresponsive, and Claude Code SIGINT-restarted it, failing the in-flight
+    // invocation as "channel shut down" (observed live 2026-08-10; same
+    // pathogen as pi-remote's #1841).
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-    // A FormData body must keep its multipart boundary header, which fetch sets
-    // only when Content-Type is left unset — so never force JSON on uploads.
-    const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData
-    let response: Response
     try {
-      response = await fetch(`${this.base}${path}`, {
-        ...init,
-        signal: controller.signal,
-        headers: {
-          Authorization: `Bearer ${this.opts.apiKey}`,
-          ...(isFormData ? {} : { "Content-Type": "application/json" }),
-          ...init?.headers,
-        },
-      })
+      return await this.requestWithin<T>(path, init, controller.signal)
     } finally {
       clearTimeout(timeout)
     }
+  }
+
+  private async requestWithin<T>(path: string, init: RequestInit | undefined, signal: AbortSignal): Promise<T> {
+    // A FormData body must keep its multipart boundary header, which fetch sets
+    // only when Content-Type is left unset — so never force JSON on uploads.
+    const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData
+    const response = await fetch(`${this.base}${path}`, {
+      ...init,
+      signal,
+      headers: {
+        Authorization: `Bearer ${this.opts.apiKey}`,
+        ...(isFormData ? {} : { "Content-Type": "application/json" }),
+        ...init?.headers,
+      },
+    })
     if (!response.ok) {
       // Read the structured `code` so callers can branch on the specific error
       // (e.g. an E2E-plaintext rejection vs a capability/validation 400) instead

--- a/extensions/remote-session/src/delegation-client.ts
+++ b/extensions/remote-session/src/delegation-client.ts
@@ -57,24 +57,34 @@ export class DelegationClient {
   }
 
   private async request<T>(url: string, init?: RequestInit & { claimToken?: string }): Promise<T> {
-    const { claimToken, ...request } = init ?? {}
+    // One abort window over headers AND body, matching ThreaClient.request: a
+    // stalled body after headers must reject at FETCH_TIMEOUT_MS, not hang the
+    // channel forever.
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-    let response: Response
     try {
-      response = await fetch(url, {
-        ...request,
-        signal: controller.signal,
-        headers: {
-          Authorization: `Bearer ${this.opts.apiKey}`,
-          "Content-Type": "application/json",
-          ...(claimToken ? { [CALLBACK_TOKEN_HEADER]: claimToken } : {}),
-          ...request.headers,
-        },
-      })
+      return await this.requestWithin<T>(url, init, controller.signal)
     } finally {
       clearTimeout(timeout)
     }
+  }
+
+  private async requestWithin<T>(
+    url: string,
+    init: (RequestInit & { claimToken?: string }) | undefined,
+    signal: AbortSignal
+  ): Promise<T> {
+    const { claimToken, ...request } = init ?? {}
+    const response = await fetch(url, {
+      ...request,
+      signal,
+      headers: {
+        Authorization: `Bearer ${this.opts.apiKey}`,
+        "Content-Type": "application/json",
+        ...(claimToken ? { [CALLBACK_TOKEN_HEADER]: claimToken } : {}),
+        ...request.headers,
+      },
+    })
     if (!response.ok) {
       let code: string | undefined
       if (response.headers.get("content-type")?.includes("application/json")) {


### PR DESCRIPTION
## Problem

Two live Claude channel sessions (`threa.agent-rediness`, `seer.agent-rediness`) degraded 2026-08-10 14:00–14:47Z: invocations failed with "Claude Code channel shut down" (14:00, 14:03, 14:44), completions flushed in bursts on channel reconnect (one took 23 minutes), and the MCP logs show Claude Code SIGINT→SIGTERM-restarting the channel process. Root cause is the same pathogen [#1841](https://github.com/threahq/threa/pull/1841) fixed in pi-remote: `ThreaClient.request` (`remote-session/src/client.ts`) and `DelegationClient.request` clear their abort timer in a `finally` around `fetch` alone — every `response.text()`/`response.json()` after it is unbounded. A response whose body stalls after headers hangs the channel's request forever; the stdio MCP server stops answering, Claude Code restarts it, and the in-flight invocation is failed by the shutdown path (`session.ts` `shutdownErrorMessage`).

## Solution

One `AbortController` window over fetch + body read in both clients (`request` delegates to `requestWithin` inside the timer's `try/finally`), mirroring #1841's transport restructure. No behavior change beyond a stalled body now rejecting at `FETCH_TIMEOUT_MS`. The stalled-body semantics are pinned by the transport test added in #1841 ("bounds a hint response whose body stalls after headers"); these two helpers now share that exact shape.

## Test plan

- [x] `extensions/remote-session` — 174 pass, `tsc` clean · `extensions/claude-code-remote` — 126 pass
- [ ] Live: after merge + `~/dev/threa` pull, channels pick the fix on their next (already frequent) restart

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965823&installation_model_id=20758&pr_number=1847&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1847&signature=5c205712d47c7f83c664e285912089730586365e2cc73b7a0fc50fd89c05caa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->