### PR TITLE
fix: bound attachment download bodies and pin the stalled-body regression

### DIFF
--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -491,6 +491,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
 
     const response = await fetch(`${baseUrl}/api/v1/workspaces/${workspaceId}/bot-runtime/sessions`, {
       method: "POST",
+      signal: AbortSignal.timeout(10_000),
       headers: { "content-type": "application/json", authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
         runtimeKind: "claude-code-channel",

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -6,6 +6,10 @@ import { join } from "node:path"
 import threaRemote, { __testing } from "./threa-remote"
 
 process.env.THREA_HARNESS_LINKS_DIR = mkdtempSync(join(tmpdir(), "harness-links-test-"))
+// A harness-supervised shell exports this, and verifySupervisedRevival then
+// blocks every fake session as "points at a different scratchpad" — the suite
+// must behave the same inside a supervised pane as in CI.
+delete process.env.THREA_EXPECTED_ROOT_STREAM_ID
 
 let testStorageDirectory: string
 

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -82,6 +82,7 @@ const NO_RESPONSE_MARKER = "THREA_NO_RESPONSE"
 /** Server cap on `attachmentIds` per sealed message (`sealedAttachmentIdsSchema` caps at 16). */
 const MAX_SEALED_ATTACHMENTS_PER_MESSAGE = 16
 const FETCH_TIMEOUT_MS = 30_000
+const ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 60_000
 const MAX_FAILURE_POLL_MS = 60_000
 const BUSY_HEARTBEAT_MS = 15_000
 const CLAIM_TTL_SECONDS = 120
@@ -2309,7 +2310,9 @@ async function downloadAttachment(
   const body = await request<{ data: { url: string } }>(
     `/api/v1/workspaces/${config.workspaceId}/attachments/${attachment.id}/url`
   )
-  const response = await fetch(body.data.url)
+  // Timeout spans headers AND arrayBuffer() — a stalled download body must
+  // reject, not hang the claim turn (same pathogen as the request() bound).
+  const response = await fetch(body.data.url, { signal: AbortSignal.timeout(ATTACHMENT_DOWNLOAD_TIMEOUT_MS) })
   if (!response.ok) throw new Error(`download failed with ${response.status}`)
   const bytes = new Uint8Array(await response.arrayBuffer())
   const dir = join(cwd, ".threa-attachments", invocation.id)
@@ -2334,7 +2337,7 @@ async function downloadSealedAttachment(
   const body = await request<{ data: { url: string } }>(
     `/api/v1/workspaces/${config.workspaceId}/attachments/${ref.attachmentId}/url`
   )
-  const response = await fetch(body.data.url)
+  const response = await fetch(body.data.url, { signal: AbortSignal.timeout(ATTACHMENT_DOWNLOAD_TIMEOUT_MS) })
   if (!response.ok) throw new Error(`download failed with ${response.status}`)
   const ciphertext = new Uint8Array(await response.arrayBuffer())
   const bytes = await decryptAttachmentBytes({ ciphertext, key: ref.key, iv: ref.iv })

--- a/extensions/remote-session/src/attachments.ts
+++ b/extensions/remote-session/src/attachments.ts
@@ -106,10 +106,14 @@ export function buildReplyAttachmentSection(uploaded: AttachmentSummary[], faile
 
 // --- IO orchestration -----------------------------------------------------
 
-async function fetchAttachmentBytes(url: string): Promise<Uint8Array> {
+const DOWNLOAD_TIMEOUT_MS = 60_000
+
+export async function fetchAttachmentBytes(url: string, timeoutMs = DOWNLOAD_TIMEOUT_MS): Promise<Uint8Array> {
   // The url is a short-lived pre-signed storage URL, so it carries its own auth
-  // — a plain fetch, not the bearer-authenticated client request.
-  const response = await fetch(url)
+  // — a plain fetch, not the bearer-authenticated client request. The timeout
+  // signal spans headers AND arrayBuffer(): a stalled download body must reject,
+  // not hang the channel (same pathogen as the client request bound).
+  const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
   if (!response.ok) throw new Error(`download failed with ${response.status}`)
   return new Uint8Array(await response.arrayBuffer())
 }

--- a/extensions/remote-session/src/client.test.ts
+++ b/extensions/remote-session/src/client.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test"
+import { fetchAttachmentBytes } from "./attachments"
+import { ThreaClient } from "./client"
+import { DelegationClient } from "./delegation-client"
+
+const fetchSpy = spyOn(globalThis, "fetch")
+
+afterEach(() => fetchSpy.mockReset())
+
+/** 200 whose body never produces bytes and errors when the request aborts — a stalled server/proxy after headers. */
+function stalledResponse(init: RequestInit | undefined): Response {
+  const signal = init?.signal as AbortSignal | undefined
+  const stalled = new ReadableStream({
+    start(controller) {
+      signal?.addEventListener("abort", () => controller.error(new DOMException("aborted", "AbortError")))
+    },
+  })
+  return new Response(stalled, { status: 200, headers: { "content-type": "application/json" } })
+}
+
+// The 2026-08-10 incident: bodies that stalled after headers hung the channel's
+// request forever, the MCP server went unresponsive, and Claude Code
+// SIGINT-restarted it, failing in-flight invocations as "channel shut down".
+// Every HTTP body read must reject at the timeout instead.
+const stalledFetch = (async (_input: string | URL | Request, init?: RequestInit) =>
+  stalledResponse(init)) as unknown as typeof fetch
+
+describe("stalled response bodies reject at the fetch timeout", () => {
+  it("ThreaClient.request", async () => {
+    fetchSpy.mockImplementation(stalledFetch)
+    const client = new ThreaClient({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_1",
+      apiKey: "key",
+      fetchTimeoutMs: 25,
+    })
+    await expect(client.getMe()).rejects.toThrow()
+  })
+
+  it("DelegationClient.request", async () => {
+    fetchSpy.mockImplementation(stalledFetch)
+    const client = new DelegationClient({
+      baseUrl: "https://example.test",
+      workspaceId: "ws_1",
+      apiKey: "key",
+      fetchTimeoutMs: 25,
+    })
+    await expect(client.get("dlg_1")).rejects.toThrow()
+  })
+
+  it("fetchAttachmentBytes (pre-signed download)", async () => {
+    fetchSpy.mockImplementation(stalledFetch)
+    await expect(fetchAttachmentBytes("https://storage.example.test/blob", 25)).rejects.toThrow()
+  })
+})

--- a/extensions/remote-session/src/client.ts
+++ b/extensions/remote-session/src/client.ts
@@ -92,6 +92,7 @@ export interface ThreaClientOptions {
   baseUrl: string
   workspaceId: string
   apiKey: string
+  fetchTimeoutMs?: number
 }
 
 export class ThreaClient {
@@ -109,7 +110,7 @@ export class ThreaClient {
     // invocation as "channel shut down" (observed live 2026-08-10; same
     // pathogen as pi-remote's #1841).
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    const timeout = setTimeout(() => controller.abort(), this.opts.fetchTimeoutMs ?? FETCH_TIMEOUT_MS)
     try {
       return await this.requestWithin<T>(path, init, controller.signal)
     } finally {

--- a/extensions/remote-session/src/delegation-client.ts
+++ b/extensions/remote-session/src/delegation-client.ts
@@ -35,6 +35,7 @@ export interface DelegationClientOptions {
   baseUrl: string
   workspaceId: string
   apiKey: string
+  fetchTimeoutMs?: number
 }
 
 /**
@@ -61,7 +62,7 @@ export class DelegationClient {
     // stalled body after headers must reject at FETCH_TIMEOUT_MS, not hang the
     // channel forever.
     const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    const timeout = setTimeout(() => controller.abort(), this.opts.fetchTimeoutMs ?? FETCH_TIMEOUT_MS)
     try {
       return await this.requestWithin<T>(url, init, controller.signal)
     } finally {


### PR DESCRIPTION
## Problem

Code review of [#1847](https://github.com/threahq/threa/pull/1847) found the stalled-body pathogen still live on the attachment paths, and #1847 itself shipped unpinned by any regression test. `fetchAttachmentBytes` (`remote-session/src/attachments.ts`) fetched pre-signed download URLs with no signal at all — headers *and* body unbounded — and pi-remote's `downloadAttachment`/`downloadSealedAttachment` (`threa-remote.ts`) read `arrayBuffer()` after their timer-less fetches the same way. These run for every attachment-bearing message; the 2026-08-10 trigger messages carried screenshots, so this path executed during the incident #1847 diagnosed. Separately, the pi-remote reload-continuity suite fails on any harness-supervised machine: the pane's exported `THREA_EXPECTED_ROOT_STREAM_ID` leaks into the test process and `verifySupervisedRevival` blocks every fake session as "points at a different scratchpad" — 4 failures locally, green in CI, exactly the divergence that hides real breakage.

## Solution

Bound every remaining body read; pin the #1847 restructure with tests; make the pi-remote suite environment-independent.

- `fetchAttachmentBytes` and both pi-remote downloads ride `AbortSignal.timeout` (60s, `ATTACHMENT_DOWNLOAD_TIMEOUT_MS`) spanning headers + `arrayBuffer()`; per-attachment catch blocks already log-and-skip aborts.
- `ThreaClient`/`DelegationClient` take injectable `fetchTimeoutMs` (default 30s unchanged) — the same testability pattern as `BotRuntimeTransport` in #1841 — and new `client.test.ts` pins stalled-body rejection for both clients plus the download helper.
- `spawners.ts` pre-link fetch gets `AbortSignal.timeout(10_000)`, matching `resume.ts`.
- `threa-remote.test.ts` deletes `THREA_EXPECTED_ROOT_STREAM_ID` at module load, beside the existing `THREA_HARNESS_LINKS_DIR` isolation.

Left alone: `transport.ts#httpRequest` clears its timer at headers, but no caller reads a body — noted, not churned.

## Test plan

- [x] remote-session 177 pass (3 new) + tsc clean
- [x] pi-remote 145 pass (was 141 pass / 4 env-dependent fails)
- [x] claude-code-remote 126 pass; harness-daemon 354 pass + tsc clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788966971&installation_model_id=20758&pr_number=1848&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1848&signature=b16599e0e1c8041ec60681d4b918fabc3c573f525ed3d2773e14f897666f0e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->