### PR TITLE
fix: reject session-control trace steps with a terminal code and stop sending them

### DIFF
--- a/apps/backend/src/features/public-api/runtime-write-ops.ts
+++ b/apps/backend/src/features/public-api/runtime-write-ops.ts
@@ -1,7 +1,7 @@
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
 import { HttpError } from "@threa/backend-common"
-import { BotRuntimeKinds } from "@threa/types"
+import { BotInvocationTriggers, BotRuntimeKinds } from "@threa/types"
 import {
   assertManifestAllows,
   type BotRuntimeInstance,
@@ -174,6 +174,16 @@ export function createBotRuntimeWriteOps(deps: BotRuntimeWriteOpsDeps): BotRunti
       claimToken: params.claimToken,
     })
     if (!claim) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
+    // Session-control claims create no agent_sessions row (the claim handler
+    // skips the insert), so appendStep below could only throw "row not found" —
+    // an error-level stack per step, acked to the runtime as INTERNAL_ERROR.
+    // Reject with a terminal code the runtime can treat as definitive instead.
+    if (claim.trigger === BotInvocationTriggers.SESSION_CONTROL) {
+      throw new HttpError("Session-control invocations record no trace steps", {
+        status: 409,
+        code: "SESSION_CONTROL_TRACE_UNSUPPORTED",
+      })
+    }
     const accessible = await botChannelService.isStreamAccessibleForBot(
       params.workspaceId,
       params.botId,

--- a/apps/backend/tests/integration/bot-invocation-steps-session-control.test.ts
+++ b/apps/backend/tests/integration/bot-invocation-steps-session-control.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import type { Server } from "socket.io"
+import { HttpError } from "@threa/backend-common"
+import { setupTestDatabase } from "./setup"
+import { createBotRuntimeWriteOps } from "../../src/features/public-api"
+import { BotInvocationRepository } from "../../src/features/bot-runtimes"
+import type { BotRuntimeService } from "../../src/features/bot-runtimes"
+import type { BotChannelService } from "../../src/features/api-keys"
+import { AgentSessionRepository } from "../../src/features/agents"
+import { streamId, workspaceId, userId } from "../../src/lib/id"
+
+/**
+ * `recordSteps` against a session-control claim, on the real schema. The claim
+ * handler skips the `agent_sessions` insert for session-control invocations, so
+ * a step write can only die inside `appendStep` ("row not found" → a logged
+ * 500, acked INTERNAL_ERROR — the 2026-08-10 log spam). The op must reject
+ * up front with a terminal code instead.
+ */
+describe("recordSteps on a session-control claim", () => {
+  let pool: Pool
+  const ws = workspaceId()
+  const botId = `bot_${Math.random().toString(36).slice(2, 10)}`
+  const instanceId = "steps-guard-test"
+  const stream = streamId()
+  const author = userId()
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM bot_invocations WHERE workspace_id = $1", [ws])
+    await pool.query("DELETE FROM agent_sessions WHERE stream_id = $1", [stream])
+    await pool.end()
+  })
+
+  function ops() {
+    // Only `findActiveClaim` runs before the guard under test; the rest of the
+    // dependency surface is unreachable in these cases (the happy path's
+    // presence touch swallows its own errors by contract).
+    return createBotRuntimeWriteOps({
+      pool,
+      io: { to: () => ({ emit: () => {} }) } as unknown as Server,
+      botRuntimeService: {
+        findActiveClaim: (params: Parameters<typeof BotInvocationRepository.findActiveClaim>[1]) =>
+          BotInvocationRepository.findActiveClaim(pool, params),
+        findPresenceByInstance: async () => null,
+      } as unknown as BotRuntimeService,
+      botChannelService: {
+        isStreamAccessibleForBot: async () => true,
+      } as unknown as BotChannelService,
+    })
+  }
+
+  async function seedClaim(id: string, trigger: string, claimToken: string): Promise<void> {
+    await BotInvocationRepository.insertIdempotent(pool, {
+      id,
+      workspaceId: ws,
+      rootStreamId: stream,
+      activeStreamId: stream,
+      sourceMessageId: `msg_${id}`,
+      responseStreamId: stream,
+      actorType: "bot",
+      actorId: botId,
+      trigger,
+      requiredCapability: "session-control",
+      promptMarkdown: "/stop",
+      authorUserId: author,
+      mentionedActorSlugs: [],
+      targetInstanceId: null,
+      targetRuntimeSessionId: null,
+      metadata: {},
+    })
+    await pool.query(
+      `UPDATE bot_invocations
+       SET status = 'claimed', claimed_by_instance_id = $2, claim_token = $3, claim_expires_at = NOW() + interval '60 seconds'
+       WHERE id = $1`,
+      [id, instanceId, claimToken]
+    )
+  }
+
+  test("rejects with SESSION_CONTROL_TRACE_UNSUPPORTED before touching agent_sessions", async () => {
+    await seedClaim("binv_sc_guard", "session-control", "tok_sc_guard")
+    const error = await ops()
+      .recordSteps({
+        workspaceId: ws,
+        botId,
+        invocationId: "binv_sc_guard",
+        instanceId,
+        claimToken: "tok_sc_guard",
+        steps: [{ stepType: "context_received", content: "Running /stop" }],
+      })
+      .then(
+        () => null,
+        (err: unknown) => err
+      )
+    expect(error).toBeInstanceOf(HttpError)
+    expect((error as HttpError).code).toBe("SESSION_CONTROL_TRACE_UNSUPPORTED")
+    expect((error as HttpError).status).toBe(409)
+  })
+
+  test("a regular claim with its agent session still records", async () => {
+    await seedClaim("binv_sc_regular", "active-scratchpad", "tok_sc_regular")
+    await AgentSessionRepository.insertRunningOrSkip(pool, {
+      id: "binv_sc_regular",
+      streamId: stream,
+      personaId: botId,
+      triggerMessageId: "msg_binv_sc_regular",
+      initialSequence: 0n,
+    })
+    const result = await ops().recordSteps({
+      workspaceId: ws,
+      botId,
+      invocationId: "binv_sc_regular",
+      instanceId,
+      claimToken: "tok_sc_regular",
+      steps: [{ stepType: "thinking", content: "working" }],
+    })
+    expect(result.steps).toHaveLength(1)
+    const persisted = await pool.query("SELECT step_type, content FROM agent_session_steps WHERE session_id = $1", [
+      "binv_sc_regular",
+    ])
+    expect(persisted.rows).toEqual([{ step_type: "thinking", content: "working" }])
+  })
+})

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1723,6 +1723,7 @@ describe("claim drain serialization", () => {
               activeStreamId: "stream_1",
               sourceMessageId: "msg_stop",
               promptMarkdown: "/stop",
+              trigger: "session-control",
               requiredCapability: "session-control",
               claimToken: "claim_stop",
               claimExpiresAt: null,
@@ -1752,6 +1753,10 @@ describe("claim drain serialization", () => {
       await __testing.claimIfIdle(pi, ctx)
 
       expect(presence.at(-1)).toMatchObject({ status: "available", acceptingInvocations: true })
+      // Session-control claims have no agent session server-side; a step write
+      // can only bounce (SESSION_CONTROL_TRACE_UNSUPPORTED), so none may leave.
+      const stepWrites = fetchSpy.mock.calls.map((call) => String(call[0])).filter((url) => url.includes("/steps"))
+      expect(stepWrites).toEqual([])
     } finally {
       fetchSpy.mockRestore()
     }

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -952,6 +952,11 @@ async function recordInvocationTraceStep(
   statusText?: string
 ): Promise<void> {
   if (!config) return
+  // Session-control claims have no agent session server-side, so the server
+  // can never persist their steps — it rejects each one (an INTERNAL_ERROR ack
+  // before SESSION_CONTROL_TRACE_UNSUPPORTED existed). Presence heartbeats
+  // carry the "Running /x…" status instead.
+  if (invocation.trigger === "session-control") return
   const trimmed = truncateForTrace(
     content,
     invocation.sealing ? SEALED_TRACE_CONTENT_MAX_CHARS : TRACE_CONTENT_MAX_CHARS


### PR DESCRIPTION
## Problem

The `ws steps rejected (INTERNAL_ERROR)` the pi orchestrator logged during the 2026-08-10 debugging is a design gap, not a transient: session-control invocations never get an `agent_sessions` row (the claim handler in `public-api/handlers.ts` skips the insert for `isSessionControl`), but `handleSessionControlInvocation` in pi-remote records a `context_received` trace step for every control command. Each one dies inside `AgentSessionRepository.appendStep` ("agent_sessions row not found") — an error-level stack in the backend log (27 today, all `/reload` and `/stop`) and a generic INTERNAL_ERROR ack the runtime can't interpret.

## Solution

Both sides stop pretending the write can work.

- `recordSteps` (`public-api/runtime-write-ops.ts`) rejects a session-control claim up front: 409 `SESSION_CONTROL_TRACE_UNSUPPORTED` — an `HttpError` the socket ack path treats as terminal and the server never error-logs. Guard sits right after `findActiveClaim`, so it also wins over the E2E-plaintext rejection for control claims on sealed streams.
- pi-remote's `recordInvocationTraceStep` returns early for `trigger === "session-control"` — no step frames leave the client at all; the "Running /x…" status already travels via presence heartbeats. The `/stop` control test now pins that no `/steps` request is sent.
- No sealed-path guard: control claims get no callback binding, so `authorizeSealedCallback` already fails them cleanly.

New integration test (`bot-invocation-steps-session-control.test.ts`, INV-68) seeds a claimed session-control invocation against the real schema and asserts the structured rejection; a companion case proves a regular claim with its session row still records through the projector. Note for local runs: a stale `threa_test` (missing `bot_invocations`' unique constraint) fails these — drop the DB and let setup remigrate.

## Test plan

- [x] new integration test 2 pass (fresh `threa_test`); pi-remote 145 pass
- [x] backend lint + typecheck via pre-commit hook

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788967793&installation_model_id=20758&pr_number=1849&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1849&signature=59adc1cb2d149e870064ba83571caad7ce06ce819ebf778b5f75264237845286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->