### PR TITLE
fix: detect and auto-answer Claude interstitial prompts instead of reporting blocked panes online

### DIFF
--- a/extensions/harness-daemon/src/adopt.ts
+++ b/extensions/harness-daemon/src/adopt.ts
@@ -3,7 +3,7 @@ import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
 import { existsSync, statSync } from "node:fs"
 import { hostname } from "node:os"
 import { basename, join } from "node:path"
-import { acceptClaudeBootPrompts } from "./claude-boot"
+import { acceptClaudeBootPrompts, warnIfBlocked } from "./claude-boot"
 import {
   defaultClaudeDiskDeps,
   findLiveClaudeSessions,
@@ -713,7 +713,7 @@ async function launchTakeover(params: {
   )
   console.log(`harnessd: took over Claude Code in tmux ${session}:${window} (${windowId})`)
   try {
-    await acceptClaudeBootPrompts(paneId)
+    warnIfBlocked(await acceptClaudeBootPrompts(paneId))
     return {
       tmuxSession: session,
       tmuxWindow: window,

--- a/extensions/harness-daemon/src/claude-boot.test.ts
+++ b/extensions/harness-daemon/src/claude-boot.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { acceptClaudeBootPrompts, blockedPromptSummary, classifyClaudePane } from "./claude-boot"
+
+const RESUME_PROMPT = [
+  "  This session is 2h 48m old and 274.9k tokens.",
+  "  Resuming the full session will consume a substantial portion of your usage",
+  "  limits. We recommend resuming from a summary.",
+  "❯ 1. Resume from summary (recommended)",
+  "  2. Resume full session as-is",
+  "  3. Don't ask me again",
+].join("\n")
+
+const UNKNOWN_MENU = ["Something new needs a decision", "❯ 1. Do the thing", "  2. Do the other thing"].join("\n")
+
+describe("classifyClaudePane", () => {
+  test("recognizes each interstitial family", () => {
+    expect(classifyClaudePane(RESUME_PROMPT)).toBe("resume-prompt")
+    expect(classifyClaudePane("Do you trust the files in this folder?\n❯ 1. Yes\nEnter to confirm")).toBe("safe-dialog")
+    expect(classifyClaudePane(UNKNOWN_MENU)).toBe("menu")
+    expect(classifyClaudePane("some output\n❯ \n")).toBe("idle")
+    expect(classifyClaudePane("✻ Brewing…\n❯ queued message\nesc to interrupt")).toBe("working")
+  })
+})
+
+describe("acceptClaudeBootPrompts", () => {
+  test("answers the resume-from-summary interstitial and settles idle", async () => {
+    // The 2026-08-10 incident: three revived sessions sat at this prompt while
+    // presence reported them available. Enter selects the recommended option.
+    const screens = [RESUME_PROMPT, "\n❯ \n"]
+    const keys: string[][] = []
+    let frame = 0
+    const outcome = await acceptClaudeBootPrompts("%1", {
+      capture: () => screens[Math.min(frame++, screens.length - 1)]!,
+      keys: (_pane, sent) => void keys.push(sent),
+      sleep: async () => undefined,
+    })
+    expect(keys).toEqual([["Enter"]])
+    expect(outcome).toMatchObject({ settled: true, state: "idle" })
+  })
+
+  test("reports a persistent unrecognized menu as blocked without pressing anything", async () => {
+    const keys: string[][] = []
+    const outcome = await acceptClaudeBootPrompts("%1", {
+      capture: () => UNKNOWN_MENU,
+      keys: (_pane, sent) => void keys.push(sent),
+      sleep: async () => undefined,
+    })
+    expect(keys).toEqual([])
+    expect(outcome).toMatchObject({ settled: false, state: "blocked" })
+    expect(blockedPromptSummary(outcome.lastCapture)).toBe("❯ 1. Do the thing")
+  })
+})

--- a/extensions/harness-daemon/src/claude-boot.test.ts
+++ b/extensions/harness-daemon/src/claude-boot.test.ts
@@ -33,6 +33,25 @@ describe("classifyClaudePane", () => {
     expect(classifyClaudePane("some output\n❯ \n")).toBe("idle")
     expect(classifyClaudePane("✻ Brewing…\n❯ queued message\nesc to interrupt")).toBe("working")
   })
+
+  test("transcript content never reads as a prompt (this repo's own fixtures on screen)", () => {
+    // A managed agent reading claude-boot.test.ts renders the fixture strings
+    // as tool output above the composer; the bare composer proves no modal is
+    // up, and line prefixes keep the anchored patterns from matching prose.
+    const readOutput = [
+      '  ⎿  8    "❯ 1. Resume from summary (recommended)",',
+      '  ⎿  9    "Switch model?",',
+      '  ⎿ 10    // dialogs end with an "Enter to confirm" hint',
+      "❯ ",
+    ].join("\n")
+    expect(classifyClaudePane(readOutput)).toBe("idle")
+    const busyWithDocText = [
+      '  ⎿ // update notices end with the "Enter to continue" hint',
+      "✻ Brewing…",
+      "❯ queued message",
+    ].join("\n")
+    expect(classifyClaudePane(busyWithDocText)).toBe("working")
+  })
 })
 
 describe("acceptClaudeBootPrompts", () => {

--- a/extensions/harness-daemon/src/claude-boot.test.ts
+++ b/extensions/harness-daemon/src/claude-boot.test.ts
@@ -16,6 +16,19 @@ describe("classifyClaudePane", () => {
   test("recognizes each interstitial family", () => {
     expect(classifyClaudePane(RESUME_PROMPT)).toBe("resume-prompt")
     expect(classifyClaudePane("Do you trust the files in this folder?\n❯ 1. Yes\nEnter to confirm")).toBe("safe-dialog")
+    // Captured 2026-08-10 (v2.1.226): confirm dialog behind /model in any
+    // session with history; no Enter-hint line, highlighted option is "Yes".
+    expect(
+      classifyClaudePane(
+        [
+          "Switch model?",
+          "Your next response will be slower and use more tokens",
+          "This conversation is cached for the current model. Switching to Opus 5 means the full history gets re-read on your next message.",
+          "❯ 1. Yes, switch to Opus 5",
+          "  2. No, go back",
+        ].join("\n")
+      )
+    ).toBe("safe-dialog")
     expect(classifyClaudePane(UNKNOWN_MENU)).toBe("menu")
     expect(classifyClaudePane("some output\n❯ \n")).toBe("idle")
     expect(classifyClaudePane("✻ Brewing…\n❯ queued message\nesc to interrupt")).toBe("working")

--- a/extensions/harness-daemon/src/claude-boot.ts
+++ b/extensions/harness-daemon/src/claude-boot.ts
@@ -7,6 +7,31 @@ import { capturePane, sendKeys } from "./tmux"
 // server").
 const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
 const IDLE_PROMPT_RE = /^❯\s*$/m
+// Claude Code's resume interstitial on old/large sessions ("This session is
+// 2h 48m old and 274.9k tokens…"). It has NO Enter-hint line, so the boot
+// dialog family misses it; the highlighted option is the recommended "Resume
+// from summary", so a bare Enter selects it. This left three revived sessions
+// blocked-but-reported-online on 2026-08-10.
+const RESUME_PROMPT_RE = /❯\s*\d+\.\s*Resume from summary/
+// Any other highlighted numbered option is an interstitial we don't recognize:
+// answering blind risks picking a destructive option, so it reports as blocked.
+const MENU_PROMPT_RE = /^\s*❯\s*\d+\./m
+
+export type ClaudePaneState = "idle" | "safe-dialog" | "resume-prompt" | "menu" | "working"
+
+/** Order matters: resume/dialog shapes also match the generic menu pattern. */
+export function classifyClaudePane(text: string): ClaudePaneState {
+  if (RESUME_PROMPT_RE.test(text)) return "resume-prompt"
+  if (BOOT_DIALOG_RE.test(text)) return "safe-dialog"
+  if (MENU_PROMPT_RE.test(text)) return "menu"
+  if (IDLE_PROMPT_RE.test(text)) return "idle"
+  return "working"
+}
+
+/** The first highlighted option line — the one detail a blocked report needs. */
+export function blockedPromptSummary(text: string): string {
+  return text.match(/^\s*(❯\s*\d+\..*)$/m)?.[1]?.trim() ?? "unrecognized interactive prompt"
+}
 
 export interface ClaudeBootDeps {
   capture: (paneId: string) => string
@@ -18,27 +43,59 @@ export function defaultClaudeBootDeps(): ClaudeBootDeps {
   return { capture: capturePane, keys: sendKeys, sleep: Bun.sleep }
 }
 
+export interface ClaudeBootOutcome {
+  settled: boolean
+  state: "idle" | "blocked" | "timeout"
+  lastCapture: string
+}
+
+/** Launch-path reporting for a boot that ended on an unrecognized prompt. */
+export function warnIfBlocked(outcome: ClaudeBootOutcome): ClaudeBootOutcome {
+  if (outcome.state === "blocked") {
+    console.warn(
+      `harnessd: Claude pane is blocked at an interactive prompt: ${blockedPromptSummary(outcome.lastCapture)}`
+    )
+  }
+  return outcome
+}
+
 /**
  * Walk Claude Code through its boot dialogs by pressing Enter until the
  * composer prompt is idle. Polling capture-pane beats fixed sleeps: a fast
  * boot isn't held for the full wait and a slow one isn't abandoned with a
  * dialog still open (which left the channel half-wired often enough that the
  * old two-blind-Enters approach needed constant retuning).
+ *
+ * An unrecognized menu that persists returns `blocked` early so the caller can
+ * report it — an honest `blocked` beats a silent timeout that reads as online.
  */
 export async function acceptClaudeBootPrompts(
   paneId: string,
-  deps: ClaudeBootDeps = defaultClaudeBootDeps()
-): Promise<void> {
-  const deadline = Date.now() + Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000)
+  deps: ClaudeBootDeps = defaultClaudeBootDeps(),
+  opts?: { waitMs?: number }
+): Promise<ClaudeBootOutcome> {
+  const deadline = Date.now() + (opts?.waitMs ?? Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000))
+  let menuStreak = 0
+  let text = ""
   while (Date.now() < deadline) {
-    const text = deps.capture(paneId)
-    if (BOOT_DIALOG_RE.test(text)) {
+    text = deps.capture(paneId)
+    const state = classifyClaudePane(text)
+    if (state === "resume-prompt" || state === "safe-dialog") {
+      menuStreak = 0
       deps.keys(paneId, ["Enter"])
       await deps.sleep(1000)
       continue
     }
-    if (IDLE_PROMPT_RE.test(text)) return
+    if (state === "idle") return { settled: true, state: "idle", lastCapture: text }
+    // Three consecutive sightings: a menu can flash mid-render, but one that
+    // holds for ~1.5s is really waiting on a human.
+    if (state === "menu") {
+      if (++menuStreak >= 3) return { settled: false, state: "blocked", lastCapture: text }
+    } else {
+      menuStreak = 0
+    }
     await deps.sleep(500)
   }
   console.warn("harnessd: Claude Code boot did not settle before the wait deadline; continuing")
+  return { settled: false, state: "timeout", lastCapture: text }
 }

--- a/extensions/harness-daemon/src/claude-boot.ts
+++ b/extensions/harness-daemon/src/claude-boot.ts
@@ -6,6 +6,11 @@ import { capturePane, sendKeys } from "./tmux"
 // dialog that line carries the highlighted option, e.g. "❯ 1. Use this MCP
 // server").
 const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
+// `/model <name>` in a session with history confirms behind a "Switch model?"
+// cache-invalidation dialog with no Enter-hint line. It only ever appears
+// because a model change was explicitly requested, and the highlighted option
+// is "Yes, switch" — safe to answer.
+const MODEL_SWITCH_DIALOG_RE = /Switch model\?/
 const IDLE_PROMPT_RE = /^❯\s*$/m
 // Claude Code's resume interstitial on old/large sessions ("This session is
 // 2h 48m old and 274.9k tokens…"). It has NO Enter-hint line, so the boot
@@ -23,6 +28,7 @@ export type ClaudePaneState = "idle" | "safe-dialog" | "resume-prompt" | "menu" 
 export function classifyClaudePane(text: string): ClaudePaneState {
   if (RESUME_PROMPT_RE.test(text)) return "resume-prompt"
   if (BOOT_DIALOG_RE.test(text)) return "safe-dialog"
+  if (MODEL_SWITCH_DIALOG_RE.test(text)) return "safe-dialog"
   if (MENU_PROMPT_RE.test(text)) return "menu"
   if (IDLE_PROMPT_RE.test(text)) return "idle"
   return "working"

--- a/extensions/harness-daemon/src/claude-boot.ts
+++ b/extensions/harness-daemon/src/claude-boot.ts
@@ -1,36 +1,46 @@
 import { capturePane, sendKeys } from "./tmux"
 
+// All prompt patterns are line-anchored to the dialog's own chrome (the hint
+// line or the highlighted-option line), never to prose: this repo's docs,
+// sources, and test fixtures contain the literal strings "Switch model?",
+// "Enter to confirm", and "❯ 1. Resume from summary", and managed agents work
+// on this repo — an unanchored match against tool output in the transcript
+// would type Enter into a healthy pane.
+//
 // Boot dialogs (trust prompt, development-channel warning, MCP-server approval,
-// update notices) all end with an "Enter to confirm/continue" hint; the
-// composer's input line is a bare "❯" only once boot has settled (during a
-// dialog that line carries the highlighted option, e.g. "❯ 1. Use this MCP
-// server").
-const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
+// update notices) end with an "Enter to confirm/continue" hint on its own line.
+const BOOT_DIALOG_RE = /^\s*(Press )?Enter to (confirm|continue)/m
 // `/model <name>` in a session with history confirms behind a "Switch model?"
 // cache-invalidation dialog with no Enter-hint line. It only ever appears
 // because a model change was explicitly requested, and the highlighted option
 // is "Yes, switch" — safe to answer.
-const MODEL_SWITCH_DIALOG_RE = /Switch model\?/
+const MODEL_SWITCH_DIALOG_RE = /^\s*❯\s*1\.\s*Yes, switch/m
 const IDLE_PROMPT_RE = /^❯\s*$/m
 // Claude Code's resume interstitial on old/large sessions ("This session is
 // 2h 48m old and 274.9k tokens…"). It has NO Enter-hint line, so the boot
 // dialog family misses it; the highlighted option is the recommended "Resume
 // from summary", so a bare Enter selects it. This left three revived sessions
 // blocked-but-reported-online on 2026-08-10.
-const RESUME_PROMPT_RE = /❯\s*\d+\.\s*Resume from summary/
+const RESUME_PROMPT_RE = /^\s*❯\s*\d+\.\s*Resume from summary/m
 // Any other highlighted numbered option is an interstitial we don't recognize:
 // answering blind risks picking a destructive option, so it reports as blocked.
 const MENU_PROMPT_RE = /^\s*❯\s*\d+\./m
 
 export type ClaudePaneState = "idle" | "safe-dialog" | "resume-prompt" | "menu" | "working"
 
-/** Order matters: resume/dialog shapes also match the generic menu pattern. */
+/**
+ * Order matters twice over: a modal hides the composer (verified live on the
+ * trust and switch-model dialogs), so a bare composer prompt proves no dialog
+ * is up and idle wins first — transcript text on a settled pane must never
+ * classify as a prompt. Below that, resume/dialog shapes also match the
+ * generic menu pattern.
+ */
 export function classifyClaudePane(text: string): ClaudePaneState {
+  if (IDLE_PROMPT_RE.test(text)) return "idle"
   if (RESUME_PROMPT_RE.test(text)) return "resume-prompt"
   if (BOOT_DIALOG_RE.test(text)) return "safe-dialog"
   if (MODEL_SWITCH_DIALOG_RE.test(text)) return "safe-dialog"
   if (MENU_PROMPT_RE.test(text)) return "menu"
-  if (IDLE_PROMPT_RE.test(text)) return "idle"
   return "working"
 }
 

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -9,6 +9,7 @@ import { existsSync } from "node:fs"
 import { basename, join } from "node:path"
 import { backfillIdentities, defaultBackfillDeps, summarizeBackfill, type BackfillOutcome } from "./backfill"
 import { installBootResume } from "./boot"
+import { acceptClaudeBootPrompts, blockedPromptSummary, classifyClaudePane } from "./claude-boot"
 import { liveClaudePidsIn } from "./claude-registry"
 import { defaultRepo, inferBranch, normalizeName, now } from "./cli"
 import {
@@ -58,7 +59,7 @@ import {
   type RuntimePreflightResult,
   type ScratchpadStatus,
 } from "./resume"
-import { attachedTmuxSession, ensureTmuxSession, sendKeys } from "./tmux"
+import { attachedTmuxSession, capturePane, ensureTmuxSession, sendKeys } from "./tmux"
 import type { ManagedAgent, ResumeOptions, SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
 import { defaultReapDeps, reapArchivedWorktrees } from "./reap"
 import { defaultTombstoneDeps, summarizeTombstones, tombstoneAbandonedRows, type TombstoneOutcome } from "./tombstone"
@@ -418,6 +419,7 @@ export type ReviveStatus =
   | "started"
   | "would start"
   | "already running"
+  | "blocked"
   | "failed"
   | "skipped stopped"
   | "skipped missing link"
@@ -439,6 +441,14 @@ export interface ReviveDeps {
   claudeConfig: ThreaChannelConfig
   piConfig: PiRemoteConfig
   paneStatus: (agent: ManagedAgent) => ManagedAgentPane["status"]
+  /**
+   * Probe a live Claude pane for a blocking interstitial (resume prompt,
+   * unrecognized menu) and auto-answer the known-safe ones. Returns an outcome
+   * when the pane needed attention, undefined when it is genuinely healthy —
+   * a pane sitting at "resume from summary?" is alive but cannot run a turn,
+   * which read as "already running" until 2026-08-10.
+   */
+  unblockAlivePane: (agent: ManagedAgent, dryRun: boolean) => Promise<ReviveOutcome | undefined>
   /** Live Claude pids already in this worktree, corroborated against the process table. */
   claudeProcessesIn: (worktree: string) => number[]
   pathExists: (path: string) => boolean
@@ -464,6 +474,21 @@ export function defaultReviveDeps(): ReviveDeps {
     claudeConfig: readThreaChannelConfig(),
     piConfig: readPiRemoteConfig(),
     paneStatus: (agent) => resolveManagedAgentPane(agent).status,
+    unblockAlivePane: async (agent, dryRun) => {
+      // Only a "found" pane: typing into an unverified match risks a stranger's
+      // window (same refusal the steer/kill paths make).
+      const resolved = resolveManagedAgentPane(agent)
+      if (resolved.status !== "found") return undefined
+      const state = classifyClaudePane(capturePane(resolved.pane.paneId))
+      if (state === "idle" || state === "working") return undefined
+      if (state === "menu") {
+        return { status: "blocked", detail: blockedPromptSummary(capturePane(resolved.pane.paneId)) }
+      }
+      if (dryRun) return { status: "blocked", detail: `${state} visible; a non-dry run auto-answers it` }
+      const boot = await acceptClaudeBootPrompts(resolved.pane.paneId, undefined, { waitMs: 15_000 })
+      if (boot.state === "blocked") return { status: "blocked", detail: blockedPromptSummary(boot.lastCapture) }
+      return { status: "already running", detail: `answered blocking ${state}` }
+    },
     claudeProcessesIn: liveClaudePidsIn,
     pathExists: existsSync,
     scratchpadStatus: fetchScratchpadStatus,
@@ -525,7 +550,13 @@ export async function reviveAgent(
   }
   // Ambiguity counts as alive: the next move is spawning a replacement, and a
   // duplicate agent is worse than a missed revival.
-  if (paneStatus !== "missing") return { status: "already running" }
+  if (paneStatus !== "missing") {
+    if (agent.runtime === "claude") {
+      const outcome = await deps.unblockAlivePane(agent, Boolean(options.dryRun))
+      if (outcome) return outcome
+    }
+    return { status: "already running" }
+  }
   if (agent.status === "stopped") return { status: "skipped stopped" }
   if (!agent.scratchpadUrl) return { status: "skipped missing link", detail: "no scratchpad URL recorded" }
   if (!scratchpad) return { status: "skipped missing link", detail: `invalid scratchpad URL: ${agent.scratchpadUrl}` }
@@ -946,6 +977,25 @@ export function doctor(): void {
     console.log(
       `${count === 0 ? "ok" : "drift"}\t${name}\t${count} carry an identity today's derivation cannot reproduce`
     )
+  }
+  // Live-pane interstitial scan: a Claude pane parked at an interactive prompt
+  // (resume-from-summary, unknown menu) is alive to every process check but
+  // cannot run a turn — the 2026-08-10 "online but dead" incident. `up`
+  // auto-answers the safe ones; doctor only reports.
+  for (const agent of panes ? readInventory() : []) {
+    if (agent.runtime !== "claude" || agent.status === "stopped" || agent.tombstonedAt) continue
+    let verdict: string
+    try {
+      const resolved = resolveManagedAgentPane(agent, panes)
+      if (resolved.status !== "found") continue
+      const capture = capturePane(resolved.pane.paneId)
+      const state = classifyClaudePane(capture)
+      if (state === "idle" || state === "working") continue
+      verdict = `${state}: ${blockedPromptSummary(capture)} — 'threa-harnessd up' auto-answers safe prompts`
+    } catch (error) {
+      verdict = `could not inspect pane: ${error instanceof Error ? error.message : String(error)}`
+    }
+    console.log(`blocked\tpane ${agent.name}\t${verdict}`)
   }
   const profiles = inspectProfiles()
   if (profiles.status === "invalid") {

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -479,15 +479,18 @@ export function defaultReviveDeps(): ReviveDeps {
       // window (same refusal the steer/kill paths make).
       const resolved = resolveManagedAgentPane(agent)
       if (resolved.status !== "found") return undefined
-      const state = classifyClaudePane(capturePane(resolved.pane.paneId))
+      const text = capturePane(resolved.pane.paneId)
+      const state = classifyClaudePane(text)
       if (state === "idle" || state === "working") return undefined
-      if (state === "menu") {
-        return { status: "blocked", detail: blockedPromptSummary(capturePane(resolved.pane.paneId)) }
-      }
-      if (dryRun) return { status: "blocked", detail: `${state} visible; a non-dry run auto-answers it` }
+      if (dryRun) return { status: "blocked", detail: `${state}: ${blockedPromptSummary(text)}` }
+      // The walker owns menu handling too — its 3-sighting streak filters
+      // mid-render flashes a single classification would misreport as blocked.
       const boot = await acceptClaudeBootPrompts(resolved.pane.paneId, undefined, { waitMs: 15_000 })
-      if (boot.state === "blocked") return { status: "blocked", detail: blockedPromptSummary(boot.lastCapture) }
-      return { status: "already running", detail: `answered blocking ${state}` }
+      if (boot.state === "idle") return { status: "already running", detail: `cleared blocking ${state}` }
+      // blocked or timeout: either way the pane did not reach an idle
+      // composer, and claiming "answered" here is the false-online report this
+      // path exists to kill.
+      return { status: "blocked", detail: blockedPromptSummary(boot.lastCapture) }
     },
     claudeProcessesIn: liveClaudePidsIn,
     pathExists: existsSync,

--- a/extensions/harness-daemon/src/reconnect.ts
+++ b/extensions/harness-daemon/src/reconnect.ts
@@ -2,7 +2,7 @@ import { statSync } from "node:fs"
 import { hostname } from "node:os"
 import { basename, resolve } from "node:path"
 import { readHarnessLinks, type HarnessLink } from "@threa/bot-runtime-client"
-import { acceptClaudeBootPrompts, defaultClaudeBootDeps, type ClaudeBootDeps } from "./claude-boot"
+import { acceptClaudeBootPrompts, defaultClaudeBootDeps, warnIfBlocked, type ClaudeBootDeps } from "./claude-boot"
 import {
   defaultClaudeRegistryDeps,
   resolveClaudeNativeSession,
@@ -368,7 +368,7 @@ export async function reconnectClaude(
     // this loop's 20x250ms budget, so it happens before the native-session
     // check rather than after it.
     if (!booted) {
-      await acceptClaudeBootPrompts(target.pane.paneId, boot)
+      warnIfBlocked(await acceptClaudeBootPrompts(target.pane.paneId, boot))
       booted = true
     }
     try {

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -550,6 +550,7 @@ function reviveDeps(overrides: Partial<ReviveDeps> = {}): ReviveDeps {
     claudeConfig: { workspaceId: "ws_1", apiKey: "key" },
     piConfig: { workspaceId: "ws_1", apiKey: "key" },
     paneStatus: () => "missing",
+    unblockAlivePane: async () => undefined,
     claudeProcessesIn: () => [],
     pathExists: () => true,
     scratchpadStatus: async () => "active",
@@ -754,6 +755,20 @@ test("up skips an already-running agent before touching the network", async () =
   })
   expect(await runRevive(linkedAgent(), {}, deps)).toEqual({ status: "already running" })
   expect(calls).toEqual([])
+})
+
+test("up surfaces a blocked alive pane instead of counting it as running", async () => {
+  // Alive-but-parked at an interactive prompt (resume-from-summary, unknown
+  // menu): every process check passes while no turn can run. The probe's
+  // outcome must win over the blanket "already running".
+  const deps = reviveDeps({
+    paneStatus: () => "found",
+    unblockAlivePane: async () => ({ status: "blocked", detail: "\u276f 1. Resume from summary (recommended)" }),
+  })
+  expect(await runRevive(linkedAgent(), {}, deps)).toEqual({
+    status: "blocked",
+    detail: "\u276f 1. Resume from summary (recommended)",
+  })
 })
 
 test("up refuses to launch into a worktree a live Claude already occupies", async () => {

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
 import { basename, dirname, join } from "node:path"
-import { acceptClaudeBootPrompts } from "./claude-boot"
+import { acceptClaudeBootPrompts, warnIfBlocked } from "./claude-boot"
 import { defaultClaudeDiskDeps, resumableClaudeTranscript } from "./claude-registry"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
@@ -370,7 +370,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
       Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Claude Code in tmux ${session}:${window} (${windowId})`)
 
-      if (!options.noAutoAccept) await acceptClaudeBootPrompts(paneId)
+      if (!options.noAutoAccept) warnIfBlocked(await acceptClaudeBootPrompts(paneId))
 
       const outputText = capturePane(paneId)
       return {
@@ -439,7 +439,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     )
     console.log(`harnessd: resumed Claude Code in tmux ${session}:${window} (${windowId})`)
     try {
-      await acceptClaudeBootPrompts(paneId)
+      warnIfBlocked(await acceptClaudeBootPrompts(paneId))
       // Claude's own /remote-control (claude.ai/code, the mobile app) is not
       // how a session reaches Threa — the channel MCP server is, and it is
       // already wired above. Sending it opened a MODAL dialog every revival


### PR DESCRIPTION
## Problem

`claude --resume` of a session older than ~2h / >200k tokens parks at Claude Code's interactive "resume from summary?" prompt. The channel MCP process launches anyway and heartbeats available — so harnessd (`up` said "already running"), server presence, and the sidebar all reported online while the session could not run a single turn. On 2026-08-10, three of six revived sessions sat in exactly that state; messages queued unanswered until a human pressed Enter in each pane. The boot walker missed the prompt because it only recognizes the "Enter to confirm/continue" dialog family, and its timeout was a warn-and-continue that read as success.

## Solution

Interstitials become classified states with honest outcomes, per the orchestrator's incident spec.

- `classifyClaudePane` (`claude-boot.ts`): `idle` / `safe-dialog` / `resume-prompt` / `menu` / `working`, ordered so the specific families win over the generic highlighted-option pattern. `blockedPromptSummary` extracts the option line for reports.
- The boot walker answers `resume-prompt` (Enter = the recommended summary resume, verified live on the three blocked panes) alongside the dialog family, and returns `ClaudeBootOutcome` instead of void; an unrecognized menu persisting 3 polls returns `blocked` early — never blind-answered, since an unknown option list may be destructive.
- Revive (`commands.ts`): a new `unblockAlivePane` dep probes alive Claude panes before the blanket "already running" — auto-answers safe prompts (15s budget), returns the new `blocked` status with the prompt line otherwise. Dry runs report without typing; only `"found"` pane matches are typed into (unverified matches keep the steer/kill refusal).
- `doctor` scans every live managed Claude pane and prints `blocked` rows; launch paths (`spawn`/`reconnect`/takeover) warn when a boot ends blocked.

## Test plan

- [x] harness-daemon 358 pass (4 new: classifier + walker on the live incident capture, revive blocked outcome) + tsc clean
- [x] `doctor` run live against the current 6-pane fleet (clean, post-unblock)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788978346&installation_model_id=20758&pr_number=1850&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1850&signature=d966dfffafbfaebda628e550d8b78bfdd984a40d43aa2aeae81d27abe3196d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->