### PR TITLE
fix: confirm the /model switch dialog and normalize /key args

### DIFF
--- a/extensions/bot-runtime-client/src/tmux-key.test.ts
+++ b/extensions/bot-runtime-client/src/tmux-key.test.ts
@@ -30,8 +30,14 @@ describe("allowlisted tmux keys", () => {
       expect(parseAllowedTmuxKey(name)).toBe(name as keyof typeof TMUX_KEY_TOKENS)
   })
 
-  it("rejects aliases, casing, whitespace, multiple args, unknown names, and tmux-like tokens", () => {
-    for (const value of ["esc", "Escape", " enter", "enter ", "enter down", "space", "C-c", "-t", "%2", ""]) {
+  it("accepts any casing and surrounding whitespace of an allowed name", () => {
+    for (const value of ["Enter", " enter ", "ESCAPE", "Ctrl-C"]) {
+      expect(parseAllowedTmuxKey(value)).toBe(value.trim().toLowerCase() as keyof typeof TMUX_KEY_TOKENS)
+    }
+  })
+
+  it("rejects aliases, multiple args, unknown names, and tmux-like tokens", () => {
+    for (const value of ["esc", "enter down", "space", "C-c", "-t", "%2", ""]) {
       expect(parseAllowedTmuxKey(value)).toBeUndefined()
     }
   })

--- a/extensions/bot-runtime-client/src/tmux-key.ts
+++ b/extensions/bot-runtime-client/src/tmux-key.ts
@@ -30,7 +30,8 @@ export class TmuxKeyError extends Error {
 type Spawn = (command: string, args: string[], options: { encoding: "utf8" }) => SpawnSyncReturns<string>
 
 export function parseAllowedTmuxKey(args: string): AllowedTmuxKey | undefined {
-  return Object.hasOwn(TMUX_KEY_TOKENS, args) ? (args as AllowedTmuxKey) : undefined
+  const name = args.trim().toLowerCase()
+  return Object.hasOwn(TMUX_KEY_TOKENS, name) ? (name as AllowedTmuxKey) : undefined
 }
 
 function resolveInspectedPane(output: string, target: string, expectedPid: number): string {

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -267,6 +267,7 @@ export async function runClaudeCommand(
       const alias = args.trim()
       if (!alias) return { ok: false, message: "Usage: `/model <name>` (e.g. fable, opus, sonnet, haiku, default)." }
       const result = await submitModelChange(alias)
+      if (result.unknownAlias) return { ok: false, message: `Claude Code does not recognize model \`${alias}\`.` }
       if (!result.ok) return { ok: false, message: "Could not send /model (no tmux control)." }
       return {
         ok: true,

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -30,7 +30,7 @@ import { z } from "zod"
 import { CarryOnController } from "./carry-on"
 import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
 import { formatClaudeStatusReport } from "./status"
-import { interrupt, steerText, submitLine, tmuxAvailable } from "./tmux-control"
+import { interrupt, steerText, submitLine, submitModelChange, tmuxAvailable } from "./tmux-control"
 import { TranscriptTracer } from "./transcript-trace"
 
 const RUNTIME_KIND = "claude-code-channel"
@@ -266,10 +266,14 @@ export async function runClaudeCommand(
     case "model": {
       const alias = args.trim()
       if (!alias) return { ok: false, message: "Usage: `/model <name>` (e.g. fable, opus, sonnet, haiku, default)." }
-      // `/model <name>` sets directly in current Claude Code (v2.1.199 dropped
-      // the old "Switch model?" confirm dialog), so one submit is the whole action.
-      const ok = await submitLine(`/model ${alias}`)
-      return { ok, message: ok ? `Set Claude Code model to \`${alias}\`.` : "Could not send /model (no tmux control)." }
+      const result = await submitModelChange(alias)
+      if (!result.ok) return { ok: false, message: "Could not send /model (no tmux control)." }
+      return {
+        ok: true,
+        message: result.confirmed
+          ? `Set Claude Code model to \`${alias}\` and confirmed the switch dialog.`
+          : `Set Claude Code model to \`${alias}\`.`,
+      }
     }
     case "thinking": {
       // Threa's canonical `/thinking <level>` actuated as Claude Code's `/effort`.

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -307,8 +307,31 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     )
   })
 
+  it("normalizes key-arg casing and whitespace before sending", async () => {
+    const sends: unknown[][] = []
+    const outcome = await runClaudeCommand(
+      "key",
+      "Enter",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ((...args: unknown[]) => sends.push(args)) as any,
+      { rootStreamId: "root" }
+    )
+    expect({ outcome, sends }).toEqual({
+      outcome: { ok: true, message: "Sent `enter` to the linked Claude session." },
+      sends: [["enter", process.ppid]],
+    })
+  })
+
   it("rejects malformed key args without sending", async () => {
-    for (const args of ["Enter", " enter", "enter ", "enter down", "-t", "%2", "unknown"]) {
+    for (const args of ["enter down", "-t", "%2", "unknown"]) {
       let sent = false
       expect(
         await runClaudeCommand(

--- a/extensions/claude-code-remote/src/tmux-control.test.ts
+++ b/extensions/claude-code-remote/src/tmux-control.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { captureTmuxPaneSnapshot, tmuxAvailable, type LocalCommandRunner } from "./tmux-control"
+import { captureTmuxPaneSnapshot, submitModelChange, tmuxAvailable, type LocalCommandRunner } from "./tmux-control"
 
 describe("tmuxAvailable", () => {
   const saved = {
@@ -87,5 +87,46 @@ describe("tmuxAvailable", () => {
     expect(() => captureTmuxPaneSnapshot(() => ({ exitCode: 1, stdout: "", stderr: "can't find pane: %5" }))).toThrow(
       "can't find pane: %5"
     )
+  })
+
+  // Captured 2026-08-10 (v2.1.226): /model in a session with history confirms
+  // behind this dialog; without the answering Enter the pane sat blocked while
+  // the channel reported the model as set.
+  const SWITCH_DIALOG = [
+    "Switch model?",
+    "Your next response will be slower and use more tokens",
+    "❯ 1. Yes, switch to Opus 5",
+    "  2. No, go back",
+  ].join("\n")
+
+  it("submits /model and answers the switch-confirmation dialog", async () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    const calls: string[][] = []
+    const run: LocalCommandRunner = (command) => {
+      calls.push(command)
+      return { exitCode: 0, stdout: command[1] === "capture-pane" ? SWITCH_DIALOG : "", stderr: "" }
+    }
+    expect(await submitModelChange("opus", { settleMs: 0, pollMs: 0, run })).toEqual({ ok: true, confirmed: true })
+    expect(calls).toEqual([
+      ["tmux", "send-keys", "-t", "%5", "C-u"],
+      ["tmux", "send-keys", "-t", "%5", "-l", "/model opus"],
+      ["tmux", "send-keys", "-t", "%5", "Enter"],
+      ["tmux", "capture-pane", "-p", "-t", "%5"],
+      ["tmux", "send-keys", "-t", "%5", "Enter"],
+    ])
+  })
+
+  it("presses nothing extra when the switch applies without a dialog", async () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    const calls: string[][] = []
+    const run: LocalCommandRunner = (command) => {
+      calls.push(command)
+      return { exitCode: 0, stdout: command[1] === "capture-pane" ? "❯ " : "", stderr: "" }
+    }
+    expect(await submitModelChange("sonnet", { settleMs: 0, pollMs: 0, run })).toEqual({ ok: true, confirmed: false })
+    expect(calls.filter((command) => command.includes("Enter"))).toEqual([["tmux", "send-keys", "-t", "%5", "Enter"]])
+    expect(calls.filter((command) => command[1] === "capture-pane")).toHaveLength(8)
   })
 })

--- a/extensions/claude-code-remote/src/tmux-control.test.ts
+++ b/extensions/claude-code-remote/src/tmux-control.test.ts
@@ -117,6 +117,34 @@ describe("tmuxAvailable", () => {
     ])
   })
 
+  it("reports an unknown alias instead of acking it as set", async () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    const run: LocalCommandRunner = (command) => ({
+      exitCode: 0,
+      stdout: command[1] === "capture-pane" ? "❯ /model bogus\n  ⎿  Model 'bogus' not found\n❯ " : "",
+      stderr: "",
+    })
+    expect(await submitModelChange("bogus", { settleMs: 0, pollMs: 0, run })).toEqual({
+      ok: false,
+      confirmed: false,
+      unknownAlias: true,
+    })
+  })
+
+  it("ignores dialog text quoted in the transcript (only the option line is chrome)", async () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    const transcript = ['  ⎿  4    "Switch model?",', "  ⎿  5    // cache warning copy", "❯ "].join("\n")
+    const enters: string[][] = []
+    const run: LocalCommandRunner = (command) => {
+      if (command[1] === "send-keys" && command.includes("Enter")) enters.push(command)
+      return { exitCode: 0, stdout: command[1] === "capture-pane" ? transcript : "", stderr: "" }
+    }
+    expect(await submitModelChange("opus", { settleMs: 0, pollMs: 0, run })).toEqual({ ok: true, confirmed: false })
+    expect(enters).toHaveLength(1)
+  })
+
   it("presses nothing extra when the switch applies without a dialog", async () => {
     process.env.TMUX = "/tmp/tmux-501/default,1234,0"
     process.env.TMUX_PANE = "%5"

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -113,12 +113,11 @@ export function tmuxAvailable(): boolean {
   return Boolean(process.env.TMUX && paneTarget())
 }
 
-function sendKeys(args: string[]): boolean {
+function sendKeys(args: string[], run: LocalCommandRunner = runLocalCommand): boolean {
   const target = paneTarget()
   if (!target) return false
   try {
-    const result = Bun.spawnSync(["tmux", "send-keys", "-t", target, ...args], { stdout: "pipe", stderr: "pipe" })
-    return result.exitCode === 0
+    return run(["tmux", "send-keys", "-t", target, ...args]).exitCode === 0
   } catch {
     return false
   }
@@ -140,16 +139,52 @@ export function interrupt(): boolean {
  * `-l` sends the text verbatim so `/`, spaces, and punctuation aren't parsed as
  * tmux key names. A short settle between the text and Enter lets the slash-command
  * autocomplete resolve, so `/model sonnet` submits instead of the menu eating the
- * Enter. Commands with an argument set directly in current Claude Code (v2.1.199
- * dropped the old mid-session "Switch model?" confirm dialog), so one submit is
- * the whole actuation.
+ * Enter.
  */
-export async function submitLine(text: string, opts: { settleMs?: number } = {}): Promise<boolean> {
+export async function submitLine(
+  text: string,
+  opts: { settleMs?: number; run?: LocalCommandRunner } = {}
+): Promise<boolean> {
   const settleMs = opts.settleMs ?? 150
-  if (!sendKeys(["C-u"])) return false
-  if (!sendKeys(["-l", text])) return false
+  const run = opts.run ?? runLocalCommand
+  if (!sendKeys(["C-u"], run)) return false
+  if (!sendKeys(["-l", text], run)) return false
   if (settleMs > 0) await Bun.sleep(settleMs)
-  return sendKeys(["Enter"])
+  return sendKeys(["Enter"], run)
+}
+
+// `/model <name>` sets directly only in a fresh session; any session with
+// history (i.e. every linked session in practice, v2.1.226) confirms behind a
+// "Switch model?" cache-invalidation dialog with no Enter-hint line — invisible
+// to the boot-dialog family, so it read as blocked until someone pressed Enter.
+const MODEL_SWITCH_DIALOG_RE = /Switch model\?/
+const MODEL_CONFIRM_POLLS = 8
+const MODEL_CONFIRM_POLL_MS = 250
+
+/**
+ * Submit `/model <alias>` and, when the switch-confirmation dialog appears,
+ * answer it — we initiated the switch, so the highlighted "Yes, switch" is the
+ * caller's intent. No dialog within the poll window means the switch applied
+ * directly; nothing is pressed blind.
+ */
+export async function submitModelChange(
+  alias: string,
+  opts: { settleMs?: number; pollMs?: number; run?: LocalCommandRunner } = {}
+): Promise<{ ok: boolean; confirmed: boolean }> {
+  const run = opts.run ?? runLocalCommand
+  if (!(await submitLine(`/model ${alias}`, opts))) return { ok: false, confirmed: false }
+  const target = paneTarget()
+  if (!target) return { ok: false, confirmed: false }
+  const pollMs = opts.pollMs ?? MODEL_CONFIRM_POLL_MS
+  for (let i = 0; i < MODEL_CONFIRM_POLLS; i++) {
+    if (pollMs > 0) await Bun.sleep(pollMs)
+    const captured = run(["tmux", "capture-pane", "-p", "-t", target])
+    if (captured.exitCode !== 0) break
+    if (MODEL_SWITCH_DIALOG_RE.test(captured.stdout)) {
+      return { ok: sendKeys(["Enter"], run), confirmed: true }
+    }
+  }
+  return { ok: true, confirmed: false }
 }
 
 /**

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -157,9 +157,20 @@ export async function submitLine(
 // history (i.e. every linked session in practice, v2.1.226) confirms behind a
 // "Switch model?" cache-invalidation dialog with no Enter-hint line — invisible
 // to the boot-dialog family, so it read as blocked until someone pressed Enter.
-const MODEL_SWITCH_DIALOG_RE = /Switch model\?/
+// Anchored to the dialog's highlighted-option line, not its title: this repo's
+// docs and tests contain the literal "Switch model?", and transcript text on
+// screen must never trigger the answering Enter. An unknown alias errors
+// inline ("Model 'x' not found", verified v2.1.226) — surfaced instead of
+// acked as set.
+const MODEL_SWITCH_DIALOG_RE = /^\s*❯\s*1\.\s*Yes, switch/m
 const MODEL_CONFIRM_POLLS = 8
 const MODEL_CONFIRM_POLL_MS = 250
+
+export interface ModelChangeResult {
+  ok: boolean
+  confirmed: boolean
+  unknownAlias?: boolean
+}
 
 /**
  * Submit `/model <alias>` and, when the switch-confirmation dialog appears,
@@ -170,16 +181,20 @@ const MODEL_CONFIRM_POLL_MS = 250
 export async function submitModelChange(
   alias: string,
   opts: { settleMs?: number; pollMs?: number; run?: LocalCommandRunner } = {}
-): Promise<{ ok: boolean; confirmed: boolean }> {
+): Promise<ModelChangeResult> {
   const run = opts.run ?? runLocalCommand
   if (!(await submitLine(`/model ${alias}`, opts))) return { ok: false, confirmed: false }
   const target = paneTarget()
   if (!target) return { ok: false, confirmed: false }
   const pollMs = opts.pollMs ?? MODEL_CONFIRM_POLL_MS
+  // Alias-specific so an older attempt's error line in the transcript cannot
+  // fail a later, valid switch.
+  const notFound = new RegExp(`Model '${alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}' not found`)
   for (let i = 0; i < MODEL_CONFIRM_POLLS; i++) {
     if (pollMs > 0) await Bun.sleep(pollMs)
     const captured = run(["tmux", "capture-pane", "-p", "-t", target])
     if (captured.exitCode !== 0) break
+    if (notFound.test(captured.stdout)) return { ok: false, confirmed: false, unknownAlias: true }
     if (MODEL_SWITCH_DIALOG_RE.test(captured.stdout)) {
       return { ok: sendKeys(["Enter"], run), confirmed: true }
     }

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1305,7 +1305,7 @@ describe("Pi reconnect session control", () => {
   test("rejects malformed key args without sending", async () => {
     const messages: string[] = []
     let sends = 0
-    for (const args of ["Enter", " enter", "enter ", "enter down", "-t", "%2", "unknown"]) {
+    for (const args of ["enter down", "-t", "%2", "unknown"]) {
       await __testing.runKeyCommand(invocation, args, context(true), {
         send: () => {
           sends++
@@ -1316,7 +1316,7 @@ describe("Pi reconnect session control", () => {
         },
       } as never)
     }
-    expect({ sends, messages }).toEqual({ sends: 0, messages: Array(7).fill("Usage: `/key <name>`.") })
+    expect({ sends, messages }).toEqual({ sends: 0, messages: Array(4).fill("Usage: `/key <name>`.") })
   })
 
   test("a claim from link A cannot prepare or ack after relinking to B", async () => {


### PR DESCRIPTION
## Problem

`/model <name>` from the scratchpad reads as done ("Set Claude Code model to…") while the pane actually sits at Claude Code's "Switch model?" cache-invalidation dialog. The channel comment claimed v2.1.199 dropped that dialog — true only for fresh sessions; on v2.1.226 any session with history (every linked session in practice) confirms behind it, and the dialog has no Enter-hint line so even the harnessd interstitial classifier ([#1850](https://github.com/threahq/threa/pull/1850)) can only report it blocked, not answer it. Every remote model change needed a manual `/status` + `/kick`. The natural workaround, `/key Enter`, also fails: `parseAllowedTmuxKey` is an exact-match lookup, so only lowercase `enter` parses.

Reproduced live in a scratch tmux pane: `/model sonnet` at a fresh prompt sets directly; the same submit after one turn pops `❯ 1. Yes, switch to Opus 5 / 2. No, go back`, and Enter completes the switch.

## Solution

`submitModelChange` in `tmux-control.ts`: submit `/model <alias>` via `submitLine`, then poll `capture-pane` (8 × 250ms) for `Switch model?` and answer it with Enter — we initiated the switch, so the highlighted "Yes, switch" is the caller's intent. No dialog in the window means the switch applied directly; nothing is pressed blind, so an unrecognized prompt still surfaces instead of being blind-Entered.

- `runClaudeCommand`'s `model` case uses it; the ack says when the dialog was confirmed.
- `sendKeys`/`submitLine` take an injectable `LocalCommandRunner` (the file's existing test seam) so the full key/capture sequence is pinned without tmux.
- `parseAllowedTmuxKey` trims + lowercases before the allowlist lookup — `/key Enter` and `/key ESCAPE` now work, for both the Claude channel and pi-remote; `enter down`, `C-c`, `-t` stay rejected.
- The dialog's known-safe classification on the harnessd side rides [#1850](https://github.com/threahq/threa/pull/1850) (separate commit there), so a pane already stuck at it gets unblocked by `up`/revive too.

## Files

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/tmux-control.ts` | `submitModelChange` (submit + poll + confirm); injectable runner for `sendKeys`/`submitLine` |
| `extensions/claude-code-remote/src/channel-server.ts` | `model` case routes through `submitModelChange`; stale v2.1.199 comment removed |
| `extensions/bot-runtime-client/src/tmux-key.ts` | `parseAllowedTmuxKey` normalizes case/whitespace |
| `extensions/claude-code-remote/src/tmux-control.test.ts` | dialog-confirmed and no-dialog sequences pinned with the live capture |
| `extensions/claude-code-remote/src/session-control.test.ts` | `/key Enter` normalization; malformed set narrowed |
| `extensions/bot-runtime-client/src/tmux-key.test.ts` | casing/whitespace acceptance split from rejects |
| `extensions/pi-remote/src/threa-remote.test.ts` | malformed key set narrowed to still-invalid args |

## Test plan

- [x] claude-code-remote — 131 pass; bot-runtime-client — 98 pass; pi-remote — 145 pass; tsc clean on all three
- [x] live reproduction of both dialog paths in a scratch tmux pane (v2.1.226); the fix's exact key sequence mirrors the manual one that worked
- [ ] end-to-end `/model` through a linked channel — needs a channel process restarted onto this code; will verify after merge/install

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788979390&installation_model_id=20758&pr_number=1851&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1851&signature=b147403c174f660b0bdbde6a0e259d5184b3ee6beda0e00e9d7675f0ad5b11b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->