### PR TITLE
test: make the session-control steps integration test rerun-safe

### DIFF
--- a/apps/backend/tests/integration/bot-invocation-steps-session-control.test.ts
+++ b/apps/backend/tests/integration/bot-invocation-steps-session-control.test.ts
@@ -31,6 +31,10 @@ describe("recordSteps on a session-control claim", () => {
 
   afterAll(async () => {
     await pool.query("DELETE FROM bot_invocations WHERE workspace_id = $1", [ws])
+    await pool.query(
+      "DELETE FROM agent_session_steps WHERE session_id IN (SELECT id FROM agent_sessions WHERE stream_id = $1)",
+      [stream]
+    )
     await pool.query("DELETE FROM agent_sessions WHERE stream_id = $1", [stream])
     await pool.end()
   })


### PR DESCRIPTION
## Problem

Review of [#1849](https://github.com/threahq/threa/pull/1849) (merged) found its integration test is not rerun-safe against a persistent local `threa_test`: `bot-invocation-steps-session-control.test.ts` seeds a step row under the fixed id `binv_sc_regular` but its `afterAll` never deletes from `agent_session_steps` — no FK cascade exists (INV-1), so the row leaks and a second single-file run fails on the persisted-rows assertion. Full-suite runs were masked only because `agent-session.test.ts` happens to truncate that table first.

## Solution

Delete `agent_session_steps` for the test's stream in `afterAll`, before the `agent_sessions` delete, matching the sibling suites' cleanup.

## Test plan

- [x] ran the file three times in a row against a persistent local DB: run 1 failed on the previously-leaked row (proving the leak), runs 2–3 pass clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788981056&installation_model_id=20758&pr_number=1852&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1852&signature=75103953a9916bf77eedd28ff6c25ec2392d33e4b4c2f47f7cdadf059a39f973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->