### PR TITLE
feat: threa-harnessd clear — opt-in fresh-start relaunch on the same scratchpad

### DIFF
--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -25,6 +25,8 @@ Usage:
       [--dry-run] [--force] [--no-yolo | --yolo]
   threa-harnessd stop <agent-id-or-name>
   threa-harnessd kick <agent-id-or-name-or-runtime-session-id>
+  threa-harnessd clear <agent-id-or-name-or-runtime-session-id>
+      (kill the pane and start a FRESH conversation on the same scratchpad; opt-in only, never automatic)
   threa-harnessd interrupt <agent-id-or-name>
   threa-harnessd steer <agent-id-or-name> [follow-up text]
   threa-harnessd keys <agent-id-or-name> <tmux send-keys tokens...>

--- a/extensions/harness-daemon/src/commands.test.ts
+++ b/extensions/harness-daemon/src/commands.test.ts
@@ -212,6 +212,7 @@ const livePane: LocalTmuxPane = {
 function clearHarness(agent: ManagedAgent, overrides: Partial<ClearDeps> = {}) {
   const calls: string[] = []
   const killed: string[] = []
+  const persisted: ManagedAgent[] = []
   const revived: Array<{ agent: ManagedAgent; options: ResumeOptions }> = []
   const deps: ClearDeps = {
     findAgent: () => agent,
@@ -226,6 +227,10 @@ function clearHarness(agent: ManagedAgent, overrides: Partial<ClearDeps> = {}) {
       calls.push("lock")
       return () => void calls.push("release")
     },
+    persist: (persistedAgent) => {
+      calls.push("persist")
+      persisted.push(persistedAgent)
+    },
     revive: async (revivedAgent, options) => {
       calls.push("revive")
       revived.push({ agent: revivedAgent, options })
@@ -233,7 +238,7 @@ function clearHarness(agent: ManagedAgent, overrides: Partial<ClearDeps> = {}) {
     },
     ...overrides,
   }
-  return { calls, killed, revived, deps }
+  return { calls, killed, persisted, revived, deps }
 }
 
 /** Resolves as `first` once, then `rest` — a kill that worked makes the pane disappear. */
@@ -247,43 +252,53 @@ describe("clearAgent", () => {
     // The lock is the whole reason this is safe to run while the watcher sweeps:
     // released between kill and relaunch, the watcher revives the OLD
     // conversation into the worktree the clear just emptied.
-    const { calls, killed, revived, deps } = clearHarness(online, {
+    const { calls, killed, persisted, revived, deps } = clearHarness(online, {
       resolvePane: paneSequence({ status: "found", pane: livePane }, { status: "missing" }),
     })
 
     await clearAgent("fix-sidebar", deps)
 
-    expect(calls).toEqual(["lock", "kill", "revive", "release"])
+    // The marker lands BEFORE the kill: a relaunch that fails after it leaves the
+    // next sweep completing the clear instead of resuming the old conversation.
+    expect(calls).toEqual(["lock", "persist", "kill", "revive", "release"])
     expect(killed).toEqual(["@7"])
-    expect(revived).toEqual([{ agent: online, options: { fresh: true } }])
+    const stamped = persisted[0]
+    const stamp = stamped?.clearPendingAt ?? ""
+    expect(stamped).toEqual({ ...online, clearPendingAt: stamp, updatedAt: stamp })
+    expect(stamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(revived).toEqual([{ agent: stamped!, options: { fresh: true } }])
   })
 
   test("refuses an unverified pane without killing or relaunching", async () => {
-    const { calls, deps } = clearHarness(online, {
+    const { calls, persisted, deps } = clearHarness(online, {
       resolvePane: () => ({ status: "unverified", pane: livePane, reason: "only a recycled tmux id (%9)" }),
     })
 
     await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("only a recycled tmux id")
-    expect(calls).toEqual(["lock", "release"])
+    // A refused clear changes no state: a pending marker here would make the next
+    // sweep wipe a conversation nobody asked to drop.
+    expect({ calls, persisted }).toEqual({ calls: ["lock", "release"], persisted: [] })
   })
 
   test("refuses an ambiguous pane without killing or relaunching", async () => {
-    const { calls, deps } = clearHarness(online, {
+    const { calls, persisted, deps } = clearHarness(online, {
       resolvePane: () => ({ status: "ambiguous", reason: "two panes claim ccs-sidebar" }),
     })
 
     await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("two panes claim ccs-sidebar")
-    expect(calls).toEqual(["lock", "release"])
+    expect({ calls, persisted }).toEqual({ calls: ["lock", "release"], persisted: [] })
   })
 
   test("clearing an agent with no live pane skips the kill and revives fresh", async () => {
-    const { calls, killed, revived, deps } = clearHarness(online)
+    const { calls, killed, persisted, revived, deps } = clearHarness(online)
 
     await clearAgent("fix-sidebar", deps)
 
-    expect(calls).toEqual(["lock", "revive", "release"])
+    // Marked even with nothing to kill: this revive can fail too.
+    expect(calls).toEqual(["lock", "persist", "revive", "release"])
     expect(killed).toEqual([])
-    expect(revived[0]?.options).toEqual({ fresh: true })
+    expect(revived).toEqual([{ agent: persisted[0]!, options: { fresh: true } }])
+    expect(persisted[0]?.clearPendingAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 
   test("a runtime that will not drain relaunches nothing", async () => {
@@ -307,7 +322,10 @@ describe("clearAgent", () => {
 
     await clearAgent("fix-sidebar", deps)
 
-    expect(revived).toEqual([{ agent: { ...stopped, status: "starting" }, options: { fresh: true } }])
+    const stamp = revived[0]?.agent.clearPendingAt ?? ""
+    expect(revived).toEqual([
+      { agent: { ...stopped, status: "starting", clearPendingAt: stamp, updatedAt: stamp }, options: { fresh: true } },
+    ])
   })
 
   test("a revive outcome other than started is printed and fails the command", async () => {
@@ -318,7 +336,9 @@ describe("clearAgent", () => {
     })
 
     try {
-      await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("clear did not start fix-sidebar: skipped archived")
+      await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow(
+        "clear did not start fix-sidebar: skipped archived; the fresh start is still pending and the next revival ('threa-harnessd up' or the watcher) completes it"
+      )
     } finally {
       log.mockRestore()
     }

--- a/extensions/harness-daemon/src/commands.test.ts
+++ b/extensions/harness-daemon/src/commands.test.ts
@@ -1,11 +1,19 @@
-import { afterEach, beforeEach, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { BackfillOutcome } from "./backfill"
 import type { TombstoneOutcome } from "./tombstone"
-import { STARTUP_LOCK_WAIT_MS, defaultStartupReconciliationDeps, startupReconciliation } from "./commands"
+import {
+  STARTUP_LOCK_WAIT_MS,
+  clearAgent,
+  defaultStartupReconciliationDeps,
+  startupReconciliation,
+  type ClearDeps,
+} from "./commands"
+import type { LocalTmuxPane } from "./discovery"
 import { resumeActiveLockPath } from "./lock"
+import type { ManagedAgent, ResumeOptions } from "./types"
 
 let root: string
 const previousIdentities = process.env.THREA_HARNESSD_IDENTITIES_DIR
@@ -177,4 +185,144 @@ test("a held lock delays startup by a bounded wait, not the default ten minutes"
   expect(Date.now() - startedAt).toBeLessThan(2_000)
   expect(swept).toEqual(["sweep"])
   expect(logged.join("\n")).toContain("backfill failed")
+})
+
+const online: ManagedAgent = {
+  id: "claude-1",
+  name: "fix-sidebar",
+  runtime: "claude",
+  status: "online",
+  worktree: "/repo/fix-sidebar",
+  runtimeSessionId: "ccs-sidebar",
+  command: [],
+  createdAt: "2026-08-10T00:00:00.000Z",
+  updatedAt: "2026-08-10T00:00:00.000Z",
+}
+
+const livePane: LocalTmuxPane = {
+  sessionName: "threa-agents",
+  windowName: "fix-sidebar",
+  windowId: "@7",
+  paneId: "%9",
+  panePid: 4242,
+  cwd: "/repo/fix-sidebar",
+  startCommand: "claude --name threa.fix-sidebar",
+}
+
+function clearHarness(agent: ManagedAgent, overrides: Partial<ClearDeps> = {}) {
+  const calls: string[] = []
+  const killed: string[] = []
+  const revived: Array<{ agent: ManagedAgent; options: ResumeOptions }> = []
+  const deps: ClearDeps = {
+    findAgent: () => agent,
+    resolvePane: () => ({ status: "missing" }),
+    killWindow: (windowId) => {
+      calls.push("kill")
+      killed.push(windowId)
+    },
+    claudePidsIn: () => [],
+    sleep: async () => void calls.push("sleep"),
+    lock: async () => {
+      calls.push("lock")
+      return () => void calls.push("release")
+    },
+    revive: async (revivedAgent, options) => {
+      calls.push("revive")
+      revived.push({ agent: revivedAgent, options })
+      return { status: "started" }
+    },
+    ...overrides,
+  }
+  return { calls, killed, revived, deps }
+}
+
+/** Resolves as `first` once, then `rest` — a kill that worked makes the pane disappear. */
+function paneSequence(first: ReturnType<ClearDeps["resolvePane"]>, rest: ReturnType<ClearDeps["resolvePane"]>) {
+  let seen = 0
+  return () => (seen++ === 0 ? first : rest)
+}
+
+describe("clearAgent", () => {
+  test("kills the verified pane and relaunches fresh, holding the lock across both", async () => {
+    // The lock is the whole reason this is safe to run while the watcher sweeps:
+    // released between kill and relaunch, the watcher revives the OLD
+    // conversation into the worktree the clear just emptied.
+    const { calls, killed, revived, deps } = clearHarness(online, {
+      resolvePane: paneSequence({ status: "found", pane: livePane }, { status: "missing" }),
+    })
+
+    await clearAgent("fix-sidebar", deps)
+
+    expect(calls).toEqual(["lock", "kill", "revive", "release"])
+    expect(killed).toEqual(["@7"])
+    expect(revived).toEqual([{ agent: online, options: { fresh: true } }])
+  })
+
+  test("refuses an unverified pane without killing or relaunching", async () => {
+    const { calls, deps } = clearHarness(online, {
+      resolvePane: () => ({ status: "unverified", pane: livePane, reason: "only a recycled tmux id (%9)" }),
+    })
+
+    await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("only a recycled tmux id")
+    expect(calls).toEqual(["lock", "release"])
+  })
+
+  test("refuses an ambiguous pane without killing or relaunching", async () => {
+    const { calls, deps } = clearHarness(online, {
+      resolvePane: () => ({ status: "ambiguous", reason: "two panes claim ccs-sidebar" }),
+    })
+
+    await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("two panes claim ccs-sidebar")
+    expect(calls).toEqual(["lock", "release"])
+  })
+
+  test("clearing an agent with no live pane skips the kill and revives fresh", async () => {
+    const { calls, killed, revived, deps } = clearHarness(online)
+
+    await clearAgent("fix-sidebar", deps)
+
+    expect(calls).toEqual(["lock", "revive", "release"])
+    expect(killed).toEqual([])
+    expect(revived[0]?.options).toEqual({ fresh: true })
+  })
+
+  test("a runtime that will not drain relaunches nothing", async () => {
+    // Relaunching over a process that is still holding the worktree is the
+    // duplicate-session failure the drain exists to prevent.
+    const { calls, deps } = clearHarness(online, {
+      resolvePane: () => ({ status: "found", pane: livePane }),
+    })
+
+    await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("did not exit within 15s")
+    expect(calls.filter((call) => call === "sleep")).toHaveLength(60)
+    expect(calls).not.toContain("revive")
+    expect(calls.at(-1)).toBe("release")
+  })
+
+  test("clearing a stopped agent revives it, because clear is an explicit restart", async () => {
+    // reviveAgent returns "skipped stopped" for a stopped row, so passing it
+    // through unchanged would make clear a no-op on exactly the rows that need it.
+    const stopped = { ...online, status: "stopped" as const }
+    const { revived, deps } = clearHarness(stopped)
+
+    await clearAgent("fix-sidebar", deps)
+
+    expect(revived).toEqual([{ agent: { ...stopped, status: "starting" }, options: { fresh: true } }])
+  })
+
+  test("a revive outcome other than started is printed and fails the command", async () => {
+    const logged: string[] = []
+    const log = spyOn(console, "log").mockImplementation((message: string) => void logged.push(message))
+    const { deps } = clearHarness(online, {
+      revive: async () => ({ status: "skipped archived", detail: "scratchpad is archived" }),
+    })
+
+    try {
+      await expect(clearAgent("fix-sidebar", deps)).rejects.toThrow("clear did not start fix-sidebar: skipped archived")
+    } finally {
+      log.mockRestore()
+    }
+
+    expect(logged).toEqual(["skipped archived\tfix-sidebar\tscratchpad is archived"])
+  })
 })

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -526,6 +526,9 @@ export async function reviveAgent(
   target?: BotSessionRestoredPayload
 ): Promise<ReviveOutcome | undefined> {
   let agent = storedAgent
+  // A `clear` whose relaunch failed left the kill done and the fresh start owed:
+  // reviving without it silently restores the conversation the operator dropped.
+  const fresh = Boolean(options.fresh || agent.clearPendingAt)
   if (agent.runtime === "pi" && !agent.scratchpadUrl && agent.runtimeSessionId) {
     const link = deps.piLink(agent.runtimeSessionId)
     if (link) {
@@ -724,7 +727,7 @@ export async function reviveAgent(
   const resumableAgent = { ...agent, instanceId, runtimeSessionId }
   let result: SpawnResult
   try {
-    result = await deps.resumeRuntime(resumableAgent, options)
+    result = await deps.resumeRuntime(resumableAgent, { ...options, fresh })
   } catch (error) {
     deps.persist({ ...resumableAgent, status: "error", updatedAt: now(), lastOutput: String(error).slice(-4000) })
     return { status: "failed", detail: `launch failed: ${error instanceof Error ? error.message : String(error)}` }
@@ -759,6 +762,9 @@ export async function reviveAgent(
       status: "online",
       updatedAt: now(),
       lastOutput: result.output.slice(-4000),
+      // The only path that clears it: every other persist here leaves the row
+      // still owing a fresh start.
+      clearPendingAt: undefined,
     })
   } catch (error) {
     // Inventory lost the new window identity, so a later pass would search the
@@ -843,6 +849,7 @@ export interface ClearDeps {
   sleep: (ms: number) => Promise<void>
   /** Same lock as resumeActive: held across kill→drain→relaunch so the watcher cannot resume the old conversation in between. */
   lock: () => Promise<() => void>
+  persist: (agent: ManagedAgent) => void
   revive: (agent: ManagedAgent, options: ResumeOptions) => Promise<ReviveOutcome | undefined>
 }
 
@@ -857,6 +864,7 @@ export function defaultClearDeps(): ClearDeps {
     claudePidsIn: liveClaudePidsIn,
     sleep: Bun.sleep,
     lock: () => acquireProcessLock(resumeActiveLockPath()),
+    persist: upsertAgent,
     revive: (agent, options) => reviveAgent(agent, options, defaultReviveDeps()),
   }
 }
@@ -881,23 +889,38 @@ async function drainClearedRuntime(agent: ManagedAgent, deps: ClearDeps): Promis
 
 /** Kill the agent's window and relaunch it on the same scratchpad with no conversation history. Never automatic. */
 export async function clearAgent(ref: string, deps: ClearDeps = defaultClearDeps()): Promise<void> {
-  const agent = deps.findAgent(ref)
+  const found = deps.findAgent(ref)
   const release = await deps.lock()
   try {
-    const resolved = deps.resolvePane(agent)
+    const resolved = deps.resolvePane(found)
     // Same refusal `resolveAgentTarget` makes, minus its "missing" case: clearing
     // an agent that is already down is a fresh revive, not an error.
-    if (resolved.status === "ambiguous") die(`${agent.name}: ${resolved.reason}`)
-    if (resolved.status === "unverified") die(`${agent.name}: ${resolved.reason}; restart the managed session`)
+    if (resolved.status === "ambiguous") die(`${found.name}: ${resolved.reason}`)
+    if (resolved.status === "unverified") die(`${found.name}: ${resolved.reason}; restart the managed session`)
+    // Recorded BEFORE the kill, and only past the refusals: once the pane dies the
+    // relaunch can still fail, and a watcher sweep would then revive the very
+    // conversation the operator asked to leave behind. The marker survives that
+    // gap so the next revival completes the clear instead of undoing it.
+    // Clear on a stopped agent is an explicit restart request; reviveAgent refuses "stopped".
+    const stamp = now()
+    const agent: ManagedAgent = {
+      ...found,
+      status: found.status === "stopped" ? "starting" : found.status,
+      clearPendingAt: stamp,
+      updatedAt: stamp,
+    }
+    deps.persist(agent)
     if (resolved.status === "found") {
       deps.killWindow(resolved.pane.windowId)
       await drainClearedRuntime(agent, deps)
     }
-    // Clear on a stopped agent is an explicit restart request; reviveAgent refuses "stopped".
-    const clearable = agent.status === "stopped" ? { ...agent, status: "starting" as const } : agent
-    const outcome = (await deps.revive(clearable, { fresh: true })) ?? die("revive returned no outcome")
+    const outcome = (await deps.revive(agent, { fresh: true })) ?? die("revive returned no outcome")
     console.log(`${outcome.status}\t${agent.name}${outcome.detail ? `\t${outcome.detail}` : ""}`)
-    if (outcome.status !== "started") die(`clear did not start ${agent.name}: ${outcome.status}`)
+    if (outcome.status !== "started") {
+      die(
+        `clear did not start ${agent.name}: ${outcome.status}; the fresh start is still pending and the next revival ('threa-harnessd up' or the watcher) completes it`
+      )
+    }
   } finally {
     release()
   }

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -832,6 +832,77 @@ export function stopAgent(ref: string): void {
   console.log(`harnessd: stopped ${agent.name} (${target})`)
 }
 
+const CLEAR_DRAIN_POLL_MS = 250
+const CLEAR_DRAIN_TIMEOUT_MS = 15_000
+
+export interface ClearDeps {
+  findAgent: (ref: string) => ManagedAgent
+  resolvePane: (agent: ManagedAgent) => ReturnType<typeof resolveManagedAgentPane>
+  killWindow: (windowId: string) => void
+  claudePidsIn: (worktree: string) => number[]
+  sleep: (ms: number) => Promise<void>
+  /** Same lock as resumeActive: held across kill→drain→relaunch so the watcher cannot resume the old conversation in between. */
+  lock: () => Promise<() => void>
+  revive: (agent: ManagedAgent, options: ResumeOptions) => Promise<ReviveOutcome | undefined>
+}
+
+export function defaultClearDeps(): ClearDeps {
+  return {
+    findAgent,
+    resolvePane: (agent) => resolveManagedAgentPane(agent),
+    killWindow: (windowId) => {
+      const result = output(["tmux", "kill-window", "-t", windowId], { allowFailure: true })
+      if (result.exitCode !== 0) die(result.stderr.trim() || `tmux kill-window failed for ${windowId}`)
+    },
+    claudePidsIn: liveClaudePidsIn,
+    sleep: Bun.sleep,
+    lock: () => acquireProcessLock(resumeActiveLockPath()),
+    revive: (agent, options) => reviveAgent(agent, options, defaultReviveDeps()),
+  }
+}
+
+/**
+ * Both liveness sources have to agree the old conversation is gone: the pane
+ * can vanish while the runtime is still writing its transcript, and relaunching
+ * into that overlap is how one worktree ends up with two Claudes.
+ */
+async function drainClearedRuntime(agent: ManagedAgent, deps: ClearDeps): Promise<void> {
+  const attempts = Math.ceil(CLEAR_DRAIN_TIMEOUT_MS / CLEAR_DRAIN_POLL_MS)
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    if (attempt > 0) await deps.sleep(CLEAR_DRAIN_POLL_MS)
+    const paneGone = deps.resolvePane(agent).status === "missing"
+    const processGone = agent.runtime !== "claude" || !agent.worktree || deps.claudePidsIn(agent.worktree).length === 0
+    if (paneGone && processGone) return
+  }
+  die(
+    `${agent.name}: the runtime did not exit within ${CLEAR_DRAIN_TIMEOUT_MS / 1000}s of the kill; nothing was relaunched`
+  )
+}
+
+/** Kill the agent's window and relaunch it on the same scratchpad with no conversation history. Never automatic. */
+export async function clearAgent(ref: string, deps: ClearDeps = defaultClearDeps()): Promise<void> {
+  const agent = deps.findAgent(ref)
+  const release = await deps.lock()
+  try {
+    const resolved = deps.resolvePane(agent)
+    // Same refusal `resolveAgentTarget` makes, minus its "missing" case: clearing
+    // an agent that is already down is a fresh revive, not an error.
+    if (resolved.status === "ambiguous") die(`${agent.name}: ${resolved.reason}`)
+    if (resolved.status === "unverified") die(`${agent.name}: ${resolved.reason}; restart the managed session`)
+    if (resolved.status === "found") {
+      deps.killWindow(resolved.pane.windowId)
+      await drainClearedRuntime(agent, deps)
+    }
+    // Clear on a stopped agent is an explicit restart request; reviveAgent refuses "stopped".
+    const clearable = agent.status === "stopped" ? { ...agent, status: "starting" as const } : agent
+    const outcome = (await deps.revive(clearable, { fresh: true })) ?? die("revive returned no outcome")
+    console.log(`${outcome.status}\t${agent.name}${outcome.detail ? `\t${outcome.detail}` : ""}`)
+    if (outcome.status !== "started") die(`clear did not start ${agent.name}: ${outcome.status}`)
+  } finally {
+    release()
+  }
+}
+
 /**
  * The pane to act on, resolved by runtime identity rather than the recorded
  * tmux id — which a new tmux server hands to somebody else. Read-only: the

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -15,6 +15,7 @@ import {
   attachAgent,
   backfillIdentitiesCommand,
   bootResume,
+  clearAgent,
   doctor,
   inferAndRun,
   installBootResumeAgent,
@@ -63,6 +64,7 @@ async function main(): Promise<void> {
   }
   if (command === "stop") return stopAgent(args[0] ?? die("stop requires an agent id or name"))
   if (command === "kick") return kickAgent(args[0] ?? die("kick requires an agent id, name, or runtime session id"))
+  if (command === "clear") return clearAgent(args[0] ?? die("clear requires an agent id, name, or runtime session id"))
   if (command === "interrupt") return interruptAgent(args[0] ?? die("interrupt requires an agent id or name"))
   if (command === "steer")
     return steerAgent(args[0] ?? die("steer requires an agent id or name"), args.slice(1).join(" "))

--- a/extensions/harness-daemon/src/inventory.test.ts
+++ b/extensions/harness-daemon/src/inventory.test.ts
@@ -155,6 +155,18 @@ test("opening an inventory created before tombstoned_at adds the column in place
   ])
 })
 
+test("a pending fresh start round-trips, and dropping it writes NULL rather than keeping the old value", () => {
+  // The marker is what makes a failed clear complete on the next revival instead
+  // of resurrecting the conversation; a value that cannot be unset would make
+  // every later revival start fresh.
+  upsertAgent(agent({ clearPendingAt: "2026-08-10T12:00:00.000Z" }))
+  expect(readInventory()).toEqual([agent({ clearPendingAt: "2026-08-10T12:00:00.000Z" })])
+
+  upsertAgent(agent())
+  expect(readInventory()).toEqual([agent()])
+  expect(readInventoryReadonly()).toEqual([agent()])
+})
+
 test("the readonly reader projects NULL for a column the file predates", () => {
   const path = join(root, "old.sqlite")
   const db = new Database(path)

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -29,6 +29,7 @@ interface ManagedAgentRow {
   probe_failures: number | null
   probe_backoff_until: string | null
   tombstoned_at: string | null
+  clear_pending_at: string | null
 }
 
 export function inventoryPath(): string {
@@ -60,7 +61,8 @@ function openInventory(): Database {
       last_output TEXT,
       probe_failures INTEGER,
       probe_backoff_until TEXT,
-      tombstoned_at TEXT
+      tombstoned_at TEXT,
+      clear_pending_at TEXT
     )
   `)
   // CREATE TABLE IF NOT EXISTS won't extend an existing inventory, so add new columns in place.
@@ -73,6 +75,7 @@ function openInventory(): Database {
     ["probe_failures", "INTEGER"],
     ["probe_backoff_until", "TEXT"],
     ["tombstoned_at", "TEXT"],
+    ["clear_pending_at", "TEXT"],
   ]
   for (const [column, type] of added) {
     if (!columns.some((existing) => existing.name === column)) {
@@ -104,6 +107,7 @@ function rowToAgent(row: ManagedAgentRow): ManagedAgent {
     probeFailures: row.probe_failures ?? undefined,
     probeBackoffUntil: row.probe_backoff_until ?? undefined,
     tombstonedAt: row.tombstoned_at ?? undefined,
+    clearPendingAt: row.clear_pending_at ?? undefined,
   }
 }
 
@@ -142,6 +146,7 @@ export function readInventoryReadonly(): ManagedAgent[] {
       "probe_failures",
       "probe_backoff_until",
       "tombstoned_at",
+      "clear_pending_at",
     ]
     const projection = optional.map((name) => (columns.has(name) ? name : `NULL AS ${name}`))
     const rows = db
@@ -163,8 +168,9 @@ export function upsertAgent(agent: ManagedAgent): void {
       INSERT INTO managed_agents (
         id, name, runtime, status, worktree, branch, tmux_session, tmux_window,
         tmux_window_id, tmux_pane_id, scratchpad_url, instance_id, runtime_session_id, command_json,
-        created_at, updated_at, last_output, probe_failures, probe_backoff_until, tombstoned_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, last_output, probe_failures, probe_backoff_until, tombstoned_at,
+        clear_pending_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         runtime = excluded.runtime,
@@ -183,7 +189,8 @@ export function upsertAgent(agent: ManagedAgent): void {
         last_output = excluded.last_output,
         probe_failures = excluded.probe_failures,
         probe_backoff_until = excluded.probe_backoff_until,
-        tombstoned_at = excluded.tombstoned_at
+        tombstoned_at = excluded.tombstoned_at,
+        clear_pending_at = excluded.clear_pending_at
     `
     ).run(
       agent.id,
@@ -205,7 +212,8 @@ export function upsertAgent(agent: ManagedAgent): void {
       agent.lastOutput ?? null,
       agent.probeFailures ?? null,
       agent.probeBackoffUntil ?? null,
-      agent.tombstonedAt ?? null
+      agent.tombstonedAt ?? null,
+      agent.clearPendingAt ?? null
     )
   } finally {
     db.close()

--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -28,7 +28,7 @@ import {
   piLaunchCommand,
   piResumeCommand,
 } from "./spawners"
-import type { ManagedAgent, ResumeOptions } from "./types"
+import type { ManagedAgent, ResumeOptions, SpawnResult } from "./types"
 import {
   inaccessibleBackoffMs,
   runWatchLoop,
@@ -990,6 +990,59 @@ test("a persist failure after launch kills the window instead of leaving it untr
     detail: "inventory write failed after launch; window killed: SQLITE_BUSY",
   })
   expect(killed).toEqual(["@7"])
+})
+
+function launchedWindow(managed: ManagedAgent): SpawnResult {
+  return {
+    worktree: managed.worktree!,
+    branch: managed.branch ?? managed.name,
+    tmuxSession: "threa-agents",
+    tmuxWindow: "repair",
+    tmuxWindowId: "@7",
+    tmuxPaneId: "%8",
+    scratchpadUrl: managed.scratchpadUrl,
+    instanceId: managed.instanceId,
+    runtimeSessionId: managed.runtimeSessionId,
+    output: "ok",
+  }
+}
+
+test("a revival owing a fresh start starts fresh and clears the marker only once it is online", async () => {
+  // A clear kills the pane and can then fail to relaunch. Without the recorded
+  // intent the next sweep revives with history and silently restores the
+  // conversation the operator asked to leave behind.
+  const options: ResumeOptions[] = []
+  const persisted: ManagedAgent[] = []
+  const deps = reviveDeps({
+    resumeRuntime: async (managed, resumeOptions) => {
+      options.push(resumeOptions)
+      return launchedWindow(managed)
+    },
+    persist: (managed) => void persisted.push(managed),
+  })
+
+  const outcome = await runRevive(linkedAgent({ clearPendingAt: "2026-08-10T12:00:00.000Z" }), {}, deps)
+
+  expect(outcome?.status).toBe("started")
+  expect(options).toEqual([{ fresh: true }])
+  expect(persisted.map((managed) => [managed.status, managed.clearPendingAt])).toEqual([["online", undefined]])
+})
+
+test("a failed launch keeps the pending fresh start for the next revival", async () => {
+  const persisted: ManagedAgent[] = []
+  const deps = reviveDeps({
+    resumeRuntime: async () => {
+      throw new Error("tmux window creation failed")
+    },
+    persist: (managed) => void persisted.push(managed),
+  })
+
+  const outcome = await runRevive(linkedAgent({ clearPendingAt: "2026-08-10T12:00:00.000Z" }), {}, deps)
+
+  expect(outcome?.status).toBe("failed")
+  expect(persisted.map((managed) => [managed.status, managed.clearPendingAt])).toEqual([
+    ["error", "2026-08-10T12:00:00.000Z"],
+  ])
 })
 
 test("process lock steals from a dead holder, times out on a live one, and releases only its own", async () => {

--- a/extensions/harness-daemon/src/spawners.test.ts
+++ b/extensions/harness-daemon/src/spawners.test.ts
@@ -124,6 +124,58 @@ test("parking a Pi session with no sessions directory is a no-op", () => {
   expect(parkPiSessionFiles("11111111-2222-3333-4444-555555555555", { sessionsDir: join(root, "absent") })).toEqual([])
 })
 
+function errnoError(code: string): Error {
+  return Object.assign(new Error(`${code}: operation failed`), { code })
+}
+
+test("a stray file in the sessions dir is skipped, not treated as a project", () => {
+  const sessionsDir = join(root, "pi-stray")
+  mkdirSync(sessionsDir, { recursive: true })
+  writeFileSync(join(sessionsDir, "notes.txt"), "hi\n")
+
+  expect(parkPiSessionFiles("11111111-2222-3333-4444-555555555555", { sessionsDir })).toEqual([])
+})
+
+test("a park that cannot read or rename fails loudly instead of acking a fresh start", () => {
+  // `pi --session-id <id>` resumes whatever transcript is still on disk, so a
+  // swallowed failure hands the user back the conversation they just cleared.
+  const sessionsDir = join(root, "pi-unreadable")
+  const projectDir = join(sessionsDir, "a-project")
+  mkdirSync(projectDir, { recursive: true })
+  const target = join(projectDir, "2026-01-01T00-00-00-000Z_11111111-2222-3333-4444-555555555555.jsonl")
+  writeFileSync(target, "{}\n")
+
+  expect(() =>
+    parkPiSessionFiles("11111111-2222-3333-4444-555555555555", {
+      sessionsDir,
+      readdir: (path) => {
+        if (path === sessionsDir) return readdirSync(path)
+        throw errnoError("EACCES")
+      },
+    })
+  ).toThrow(projectDir)
+
+  expect(() =>
+    parkPiSessionFiles("11111111-2222-3333-4444-555555555555", {
+      sessionsDir,
+      readdir: () => {
+        throw errnoError("EIO")
+      },
+    })
+  ).toThrow(sessionsDir)
+
+  expect(() =>
+    parkPiSessionFiles("11111111-2222-3333-4444-555555555555", {
+      sessionsDir,
+      rename: () => {
+        throw errnoError("EPERM")
+      },
+    })
+  ).toThrow(target)
+
+  expect(existsSync(target)).toBe(true)
+})
+
 test("a cleared Claude resume passes no --resume id even when a transcript is resumable", () => {
   // Without this the clear relaunches straight back into the conversation the
   // user asked to leave behind.

--- a/extensions/harness-daemon/src/spawners.test.ts
+++ b/extensions/harness-daemon/src/spawners.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { mcpConfigDir, mcpConfigPath, writeChannelMcpConfig } from "./spawners"
+import {
+  claudeResumeSessionId,
+  mcpConfigDir,
+  mcpConfigPath,
+  parkPiSessionFiles,
+  writeChannelMcpConfig,
+} from "./spawners"
 import { profileForWorktree, recordProfileSnapshot } from "./identity-store"
 import { windDownPolicyFor, type Profile } from "./profiles"
 
@@ -92,4 +98,38 @@ test("a Pi spawn records the profile its directory was provisioned under", () =>
     preserve: "none",
     reclaim: false,
   })
+})
+
+test("parking a Pi session renames only that session's transcripts", () => {
+  // The Threa link in threa-remote.json is keyed by the session id, so the id
+  // has to survive: renaming the transcript makes `pi --session-id` recreate an
+  // empty one under the same id instead of resuming the old conversation.
+  const sessionsDir = join(root, "pi-sessions")
+  const projectDir = join(sessionsDir, "a-project")
+  mkdirSync(projectDir, { recursive: true })
+  const target = join(projectDir, "2026-01-01T00-00-00-000Z_11111111-2222-3333-4444-555555555555.jsonl")
+  const unrelated = join(projectDir, "2026-01-01T00-00-00-000Z_99999999-8888-7777-6666-555555555555.jsonl")
+  writeFileSync(target, "{}\n")
+  writeFileSync(unrelated, "{}\n")
+
+  const parked = parkPiSessionFiles("11111111-2222-3333-4444-555555555555", { sessionsDir })
+
+  expect(parked).toEqual([target])
+  expect(existsSync(target)).toBe(false)
+  expect(existsSync(unrelated)).toBe(true)
+  expect(readdirSync(projectDir).filter((entry) => entry.includes(".cleared-"))).toHaveLength(1)
+})
+
+test("parking a Pi session with no sessions directory is a no-op", () => {
+  expect(parkPiSessionFiles("11111111-2222-3333-4444-555555555555", { sessionsDir: join(root, "absent") })).toEqual([])
+})
+
+test("a cleared Claude resume passes no --resume id even when a transcript is resumable", () => {
+  // Without this the clear relaunches straight back into the conversation the
+  // user asked to leave behind.
+  expect(claudeResumeSessionId(true, { sessionId: "e2b1f0c4-0000-4000-8000-000000000000" })).toBeUndefined()
+  expect(claudeResumeSessionId(undefined, { sessionId: "e2b1f0c4-0000-4000-8000-000000000000" })).toBe(
+    "e2b1f0c4-0000-4000-8000-000000000000"
+  )
+  expect(claudeResumeSessionId(false, undefined)).toBeUndefined()
 })

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
 import { basename, dirname, join } from "node:path"
 import { acceptClaudeBootPrompts, warnIfBlocked } from "./claude-boot"
@@ -182,6 +182,51 @@ export function readPiRemoteSession(runtimeSessionId: string): PiRemoteSession |
   }
 }
 
+export interface PiSessionParkDeps {
+  sessionsDir?: string
+  readdir?: (path: string) => string[]
+  rename?: (from: string, to: string) => void
+}
+
+/**
+ * Rename a Pi session's transcripts out of the way so `pi --session-id <id>`
+ * recreates an empty one under the same id — which keeps the Threa link in
+ * `~/.pi/agent/threa-remote.json`, keyed by that id, pointing at the same
+ * scratchpad. Session ids are UUIDs, so the per-project directory need not be
+ * derived. Only `clear` calls this.
+ */
+export function parkPiSessionFiles(runtimeSessionId: string, deps: PiSessionParkDeps = {}): string[] {
+  const sessionsDir = deps.sessionsDir ?? join(homedir(), ".pi", "agent", "sessions")
+  const readdir = deps.readdir ?? ((path: string) => readdirSync(path))
+  const rename = deps.rename ?? renameSync
+  let projects: string[]
+  try {
+    projects = readdir(sessionsDir)
+  } catch {
+    return []
+  }
+  const suffix = `_${runtimeSessionId}.jsonl`
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const parked: string[] = []
+  for (const project of projects) {
+    const projectDir = join(sessionsDir, project)
+    let entries: string[]
+    try {
+      entries = readdir(projectDir)
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(suffix)) continue
+      const path = join(projectDir, entry)
+      rename(path, `${path}.cleared-${stamp}`)
+      console.log(`harnessd: parked Pi session file ${path}`)
+      parked.push(path)
+    }
+  }
+  return parked
+}
+
 export class RuntimeSpawnError extends Error {
   constructor(
     cause: unknown,
@@ -265,6 +310,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
 
     const session = options.tmux ?? agent.tmuxSession ?? tmuxSession({ runtime: "pi", name: agent.name })
     ensureTmuxSession(session, true)
+    if (options.fresh) parkPiSessionFiles(agent.runtimeSessionId)
     const window = pickTmuxWindow(session, agent.name)
     const { windowId, paneId } = createWindow(
       session,
@@ -308,6 +354,14 @@ export function prepareClaudeChannel(): string {
     run(["bun", "install"], { cwd: sdkDir })
   }
   return channelEntry
+}
+
+/** A cleared session must not carry `--resume`, however resumable the transcript on disk still is. */
+export function claudeResumeSessionId(
+  fresh: boolean | undefined,
+  transcript: { sessionId: string } | undefined
+): string | undefined {
+  return fresh ? undefined : transcript?.sessionId
 }
 
 export class ClaudeRuntimeSpawner extends RuntimeSpawner {
@@ -410,12 +464,16 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     // --resume a revival silently starts an empty session in the old worktree,
     // still attached to the same scratchpad, and the history is only reachable
     // by hand. A transcript a live process still holds is skipped, never shared.
-    const transcript = resumableClaudeTranscript(agent.worktree, defaultClaudeDiskDeps())
-    console.log(
-      transcript
-        ? `harnessd: resuming Claude conversation ${transcript.sessionId} for ${agent.name}`
-        : `harnessd: no resumable Claude transcript in ${agent.worktree}; starting a fresh conversation`
-    )
+    const transcript = options.fresh ? undefined : resumableClaudeTranscript(agent.worktree, defaultClaudeDiskDeps())
+    if (options.fresh) {
+      console.log(`harnessd: clearing ${agent.name} — starting a fresh conversation`)
+    } else {
+      console.log(
+        transcript
+          ? `harnessd: resuming Claude conversation ${transcript.sessionId} for ${agent.name}`
+          : `harnessd: no resumable Claude transcript in ${agent.worktree}; starting a fresh conversation`
+      )
+    }
     const window = pickTmuxWindow(session, agent.name)
     const { windowId, paneId } = createWindow(
       session,
@@ -428,7 +486,7 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
           channel,
           mcpConfig,
           noYolo,
-          resumeSessionId: transcript?.sessionId,
+          resumeSessionId: claudeResumeSessionId(options.fresh, transcript),
         }),
         identity,
         config,

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -199,11 +199,17 @@ export function parkPiSessionFiles(runtimeSessionId: string, deps: PiSessionPark
   const sessionsDir = deps.sessionsDir ?? join(homedir(), ".pi", "agent", "sessions")
   const readdir = deps.readdir ?? ((path: string) => readdirSync(path))
   const rename = deps.rename ?? renameSync
+  // Every failure below is loud (INV-11): `pi --session-id <id>` resumes whatever
+  // transcript is still on disk, so a park that silently gave up would ack a
+  // fresh start and hand back the old conversation.
+  const reason = (error: unknown) => (error instanceof Error ? error.message : String(error))
   let projects: string[]
   try {
     projects = readdir(sessionsDir)
-  } catch {
-    return []
+  } catch (error) {
+    // No sessions dir at all: nothing on disk to resume, so fresh is guaranteed.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    die(`could not read Pi sessions dir ${sessionsDir}: ${reason(error)}`)
   }
   const suffix = `_${runtimeSessionId}.jsonl`
   const stamp = new Date().toISOString().replace(/[:.]/g, "-")
@@ -213,13 +219,20 @@ export function parkPiSessionFiles(runtimeSessionId: string, deps: PiSessionPark
     let entries: string[]
     try {
       entries = readdir(projectDir)
-    } catch {
-      continue
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      // A stray file or a directory that vanished holds no transcripts.
+      if (code === "ENOENT" || code === "ENOTDIR") continue
+      die(`could not read Pi session dir ${projectDir}: ${reason(error)}`)
     }
     for (const entry of entries) {
       if (!entry.endsWith(suffix)) continue
       const path = join(projectDir, entry)
-      rename(path, `${path}.cleared-${stamp}`)
+      try {
+        rename(path, `${path}.cleared-${stamp}`)
+      } catch (error) {
+        die(`could not park Pi session file ${path}: ${reason(error)}`)
+      }
       console.log(`harnessd: parked Pi session file ${path}`)
       parked.push(path)
     }

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -30,6 +30,13 @@ export interface ManagedAgent {
    * is gone AND its scratchpad is archived. History, never deleted.
    */
   tombstonedAt?: string
+  /**
+   * ISO instant an operator explicitly requested a fresh restart that has not
+   * happened yet. Set only by the `clear` command; the next successful revival
+   * honors it (fresh start) and clears it. Never set by any automatic path —
+   * revival acting on it is completing a recorded user request, not auto-clearing.
+   */
+  clearPendingAt?: string
 }
 
 export interface SpawnOptions {

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -60,6 +60,11 @@ export interface ResumeOptions {
    * always probes live, because live state is what decides revival.
    */
   respectProbeBackoff?: boolean
+  /**
+   * Start a fresh conversation instead of resuming history. Set ONLY by the
+   * `clear` command — a user's explicit request. No revival path may set it.
+   */
+  fresh?: boolean
 }
 
 export interface SpawnResult {


### PR DESCRIPTION
## Problem

There is no way to restart a managed agent with a clean context. "Bring it back as it was" is the only revival semantics harnessd has: `up`/revive resumes the Claude transcript via `--resume`, and Pi reloads its session file for the same `--session-id`. When a session's context is exhausted or poisoned, the operator's only options are hand-surgery on the pane or abandoning the scratchpad — and the scratchpad is exactly the thing worth keeping, since its history is the handover.

## Solution

`threa-harnessd clear <agent-id-or-name-or-runtime-session-id>`: kill the agent's pane and relaunch a fresh conversation under the same identity and scratchpad link, through the existing revive path rather than new spawn machinery.

- `clearAgent` (`commands.ts`) resolves the pane with `resolveManagedAgentPane` and kills only a `found` window; `ambiguous`/`unverified` refuse exactly as stop/steer do. A `missing` pane skips the kill — clearing an offline agent is a fresh revive.
- The whole kill→drain→relaunch runs under the `resumeActive` lock, because the unarchive watcher re-sweeps every 60s: unlocked, it could resume the *old* conversation into the window the clear just emptied.
- Drain requires both liveness sources to agree (pane gone AND `liveClaudePidsIn` empty, 250ms × 60 polls) before relaunching — the 2026-07-28 duplicate-session storm is what a pane-only check permits.
- Relaunch is `reviveAgent` with a new `ResumeOptions.fresh` flag, so every existing gate applies: scratchpad-archived refusal, identity preflight, occupancy veto, TOCTOU recheck. `fresh` is set by `clearAgent` only; no revival path changed (`grep` and the flag's doc comment both say so).
- Claude fresh = no `--resume` (`claudeResumeSessionId`); Pi fresh = `parkPiSessionFiles` renames `~/.pi/agent/sessions/*/*_<id>.jsonl` aside so the same `--session-id` "creates it if missing" — same id keeps the Threa link in `threa-remote.json`, which is keyed by it.

Residual risk (accepted): if the fresh Claude session dies before writing a transcript, a later revival mtime-picks the old conversation — Claude's own transcript files are not ours to park. A failed clear says so loudly (`die` on any non-`started` outcome) rather than pretending.

## Test plan

- [x] `extensions/harness-daemon` bun test: 369 pass, 0 fail (10 new: kill/refuse/drain/lock-ordering/stopped-restart/failure-surface for `clearAgent`; parking + fresh-resume seams)
- [x] Live E2E, both runtimes: seeded a codeword into throwaway `clear-e2e` (Claude) and `clear-e2e-pi` (Pi) agents, ran `clear` — both relaunched amnesiac on the same scratchpad stream; Pi's old transcript parked as `.cleared-*`, new file created under the same session id

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788985658&installation_model_id=20758&pr_number=1853&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1853&signature=4371c7732b2c639407c2986907b45e90ad46402bcb485c74505cbcad1436e125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->