### PR TITLE
feat: /clear session-control command for Claude and Pi scratchpads

### DIFF
--- a/apps/backend/src/features/commands/catalog.test.ts
+++ b/apps/backend/src/features/commands/catalog.test.ts
@@ -12,5 +12,12 @@ describe("session-control command catalog", () => {
       scope: "stream",
       args: [{ name: "--force", required: false, description: "Reconnect despite local runtime activity" }],
     })
+    expect(commands.find((command) => command.name === "clear")).toEqual({
+      name: "clear",
+      description: "Restart the linked session with a fresh conversation on this scratchpad",
+      kind: "bot-runtime",
+      scope: "stream",
+      args: [{ name: "--force", required: false, description: "Clear despite local runtime activity" }],
+    })
   })
 })

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -20,6 +20,7 @@ export const SESSION_CONTROL_COMMAND_NAMES = [
   "run",
   "carry-on",
   "reconnect",
+  "clear",
   "key",
 ] as const
 export type SessionControlCommandName = (typeof SESSION_CONTROL_COMMAND_NAMES)[number]
@@ -142,6 +143,13 @@ export function listSessionControlCommandInfos(): CommandInfo[] {
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "--force", required: false, description: "Reconnect despite local runtime activity" }],
+    },
+    {
+      name: "clear",
+      description: "Restart the linked session with a fresh conversation on this scratchpad",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+      args: [{ name: "--force", required: false, description: "Clear despite local runtime activity" }],
     },
     {
       name: "key",

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -38,7 +38,8 @@ export function resolveRuntimeInvocationRouting(
     commandName === "stop" ||
     commandName === "kick" ||
     commandName === "carry-on" ||
-    ((commandName === "reconnect" || commandName === "key") && runtimeKind === BotRuntimeKinds.PI_LOCAL)
+    ((commandName === "reconnect" || commandName === "clear" || commandName === "key") &&
+      runtimeKind === BotRuntimeKinds.PI_LOCAL)
   ) {
     // Pi advertises `active-scratchpad` while busy. The Claude Code channel
     // instead advertises only `session-control` while busy, so its interrupts

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -4,7 +4,7 @@ import { resolveRuntimeInvocationRouting } from "./handlers"
 
 describe("resolveRuntimeInvocationRouting", () => {
   it("routes interrupt commands to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "key"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "clear", "key"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
@@ -13,7 +13,7 @@ describe("resolveRuntimeInvocationRouting", () => {
   })
 
   it("routes interrupt commands to session-control for the Claude Code channel (so a busy channel still claims control)", () => {
-    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "key"]) {
+    for (const name of ["steer", "stop", "kick", "carry-on", "reconnect", "clear", "key"]) {
       expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.CLAUDE_CODE_CHANNEL)).toEqual({
         trigger: BotInvocationTriggers.SESSION_CONTROL,
         requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,

--- a/extensions/bot-runtime-client/src/harness-reconnect.test.ts
+++ b/extensions/bot-runtime-client/src/harness-reconnect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, mock } from "bun:test"
-import { harnessReconnectAvailable, prepareHarnessReconnect } from "./harness-reconnect"
+import { harnessReconnectAvailable, prepareHarnessClear, prepareHarnessReconnect } from "./harness-reconnect"
 
 const filesystem = (events: unknown[]) => ({
   mkdir: (path: string, options: unknown) => events.push(["mkdir", path, options]),
@@ -109,6 +109,90 @@ describe("prepareHarnessReconnect", () => {
     )
     expect(() =>
       prepareHarnessReconnect("runtime", "root", { entrypoint: "/missing", exists: () => false, spawn: spawn as never })
+    ).toThrow("entrypoint not found")
+    expect(spawn).not.toHaveBeenCalled()
+  })
+})
+
+describe("prepareHarnessClear", () => {
+  it("starts detached with the bare clear routing and private append-log stdio", () => {
+    const events: unknown[] = []
+    const unref = mock(() => events.push(["unref"]))
+    const spawn = mock((...args: unknown[]) => {
+      events.push(["spawn", ...args])
+      return { on: () => undefined, unref }
+    })
+    const start = prepareHarnessClear("runtime_exact", {
+      entrypoint: "/repo/harnessd.ts",
+      bunExecutable: "/bun",
+      logPath: "/private/harnessd/clear.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: spawn as never,
+    })
+
+    expect(events).toEqual([])
+    start()
+    expect(events).toEqual([
+      ["mkdir", "/private/harnessd", { recursive: true, mode: 0o700 }],
+      ["chmod", "/private/harnessd", 0o700],
+      ["open", "/private/harnessd/clear.log", "a", 0o600],
+      ["chmod", "/private/harnessd/clear.log", 0o600],
+      ["spawn", "/bun", ["/repo/harnessd.ts", "clear", "runtime_exact"], { detached: true, stdio: ["ignore", 41, 41] }],
+      ["unref"],
+      ["close", 41],
+    ])
+    expect(() => start()).toThrow("already started")
+  })
+
+  it("logs a sanitized asynchronous spawn error without crashing after acknowledgement", async () => {
+    const events: unknown[] = []
+    let emitError: ((error: Error & { code?: unknown }) => void) | undefined
+    const start = prepareHarnessClear("runtime_secret", {
+      entrypoint: "/secret/harnessd.ts",
+      bunExecutable: "/secret/bun",
+      logPath: "/logs/clear.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: (() => ({
+        on: (_event: "error", listener: typeof emitError) => {
+          emitError = listener
+        },
+        unref: () => undefined,
+      })) as never,
+    })
+
+    start()
+    queueMicrotask(() => emitError?.(Object.assign(new Error("/secret/bun runtime_secret"), { code: "ENOENT" })))
+    await Promise.resolve()
+
+    expect(events.slice(-2)).toEqual([
+      ["close", 41],
+      ["appendFile", "/logs/clear.log", "Harness clear launch failed (ENOENT)\n", { mode: 0o600 }],
+    ])
+    expect(JSON.stringify(events)).not.toContain("runtime_secret")
+  })
+
+  it("closes the parent log fd when spawn fails", () => {
+    const events: unknown[] = []
+    const start = prepareHarnessClear("runtime", {
+      entrypoint: "/harnessd.ts",
+      logPath: "/logs/clear.log",
+      exists: () => true,
+      fs: filesystem(events),
+      spawn: (() => {
+        throw new Error("spawn failed")
+      }) as never,
+    })
+    expect(() => start()).toThrow("spawn failed")
+    expect(events.at(-1)).toEqual(["close", 41])
+  })
+
+  it("preparation validates only identity and entrypoint", () => {
+    const spawn = mock(() => ({ on: () => undefined, unref: () => undefined }))
+    expect(() => prepareHarnessClear(" ", { exists: () => true, spawn: spawn as never })).toThrow("Runtime session")
+    expect(() =>
+      prepareHarnessClear("runtime", { entrypoint: "/missing", exists: () => false, spawn: spawn as never })
     ).toThrow("entrypoint not found")
     expect(spawn).not.toHaveBeenCalled()
   })

--- a/extensions/bot-runtime-client/src/harness-reconnect.ts
+++ b/extensions/bot-runtime-client/src/harness-reconnect.ts
@@ -30,30 +30,31 @@ export interface PrepareHarnessReconnectOptions {
   fs?: HarnessReconnectFs
 }
 
+export type PrepareHarnessClearOptions = Omit<PrepareHarnessReconnectOptions, "force">
+
 export function harnessReconnectAvailable(
   options: Pick<PrepareHarnessReconnectOptions, "entrypoint" | "exists"> = {}
 ): boolean {
   return (options.exists ?? existsSync)(options.entrypoint ?? harnessDaemonEntrypoint())
 }
 
-export function prepareHarnessReconnect(
-  runtimeSessionId: string,
-  rootStreamId: string,
-  options: PrepareHarnessReconnectOptions = {}
-): () => void {
-  if (!runtimeSessionId.trim()) throw new Error("Runtime session id is missing.")
-  if (!rootStreamId.trim()) throw new Error("Root stream id is missing.")
+function requireHarnessEntrypoint(options: PrepareHarnessClearOptions): string {
   const entrypoint = options.entrypoint ?? harnessDaemonEntrypoint()
   if (!harnessReconnectAvailable(options)) throw new Error(`Harness daemon entrypoint not found: ${entrypoint}`)
+  return entrypoint
+}
 
+function prepareDetachedHarnessCommand(
+  command: "reconnect" | "clear",
+  args: string[],
+  options: PrepareHarnessClearOptions
+): () => void {
   let started = false
   return () => {
-    if (started) throw new Error("Harness reconnect was already started.")
+    if (started) throw new Error(`Harness ${command} was already started.`)
     started = true
-    const args = [entrypoint, "reconnect", runtimeSessionId, "--root-stream-id", rootStreamId]
-    if (options.force) args.push("--force")
     const bunExecutable = (options.bunExecutable ?? process.env.THREA_HARNESSD_BUN_BIN?.trim()) || "bun"
-    const logPath = options.logPath ?? join(homedir(), ".threa", "harnessd", "reconnect.log")
+    const logPath = options.logPath ?? join(homedir(), ".threa", "harnessd", `${command}.log`)
     const fs = options.fs ?? {
       mkdir: mkdirSync,
       open: openSync,
@@ -75,7 +76,7 @@ export function prepareHarnessReconnect(
       child.on("error", (error) => {
         const code = typeof error.code === "string" && /^E[A-Z0-9_]{1,31}$/.test(error.code) ? ` (${error.code})` : ""
         try {
-          fs.appendFile(logPath, `Harness reconnect launch failed${code}\n`, { mode: 0o600 })
+          fs.appendFile(logPath, `Harness ${command} launch failed${code}\n`, { mode: 0o600 })
         } catch {}
       })
       child.unref()
@@ -83,4 +84,23 @@ export function prepareHarnessReconnect(
       fs.close(logFd)
     }
   }
+}
+
+export function prepareHarnessReconnect(
+  runtimeSessionId: string,
+  rootStreamId: string,
+  options: PrepareHarnessReconnectOptions = {}
+): () => void {
+  if (!runtimeSessionId.trim()) throw new Error("Runtime session id is missing.")
+  if (!rootStreamId.trim()) throw new Error("Root stream id is missing.")
+  const entrypoint = requireHarnessEntrypoint(options)
+  const args = [entrypoint, "reconnect", runtimeSessionId, "--root-stream-id", rootStreamId]
+  if (options.force) args.push("--force")
+  return prepareDetachedHarnessCommand("reconnect", args, options)
+}
+
+export function prepareHarnessClear(runtimeSessionId: string, options: PrepareHarnessClearOptions = {}): () => void {
+  if (!runtimeSessionId.trim()) throw new Error("Runtime session id is missing.")
+  const entrypoint = requireHarnessEntrypoint(options)
+  return prepareDetachedHarnessCommand("clear", [entrypoint, "clear", runtimeSessionId], options)
 }

--- a/extensions/bot-runtime-client/src/index.ts
+++ b/extensions/bot-runtime-client/src/index.ts
@@ -28,7 +28,9 @@ export {
 export { harnessDaemonEntrypoint, runHarnessKick, type HarnessKickResult } from "./harness-kick"
 export {
   harnessReconnectAvailable,
+  prepareHarnessClear,
   prepareHarnessReconnect,
+  type PrepareHarnessClearOptions,
   type PrepareHarnessReconnectOptions,
 } from "./harness-reconnect"
 export {

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -195,6 +195,41 @@ export async function runClaudeCommand(
   afterAck?: () => void | Promise<void>
   onHandoffReset?: () => void
 }> {
+  const harnessHandoffResult = (spec: {
+    commandLabel: string
+    ackMessage: string
+    root: string
+    target: ReconnectTarget | undefined
+    force: boolean
+    start: () => void
+  }) => ({
+    ok: true,
+    message: spec.ackMessage,
+    afterAck: async () => {
+      if (!spec.force && reconnectBusy?.()) {
+        throw new Error(
+          `Claude became busy after ${spec.commandLabel} acknowledgement; retry when idle or use \`/${spec.commandLabel} --force\`.`
+        )
+      }
+      await stopDelegationsForReconnect?.(spec.force)
+      const current = reconnectTarget?.()
+      if (
+        reconnectReady?.() === false ||
+        (current &&
+          (current.stopped ||
+            current.linkState !== "linked" ||
+            current.rootStreamId !== spec.root ||
+            current.linkGeneration !== spec.target?.linkGeneration))
+      ) {
+        throw new Error(
+          `Remote session changed while delegation intake was quiescing; ${spec.commandLabel} was not started.`
+        )
+      }
+      spec.start()
+    },
+    onHandoffReset: restartDelegationsAfterReset,
+  })
+
   switch (name) {
     case "key": {
       const key = parseAllowedTmuxKey(args)
@@ -219,31 +254,14 @@ export async function runClaudeCommand(
       if (!runtimeSessionId || !root) throw new Error("Harness reconnect is unavailable for this session.")
       const force = args === "--force"
       const startReconnect = prepareHarnessReconnect(runtimeSessionId, root, { force })
-      return {
-        ok: true,
-        message: "Reconnect request accepted; attempting to resume the linked Claude session.",
-        afterAck: async () => {
-          if (!force && reconnectBusy?.()) {
-            throw new Error(
-              "Claude became busy after reconnect acknowledgement; retry when idle or use `/reconnect --force`."
-            )
-          }
-          await stopDelegationsForReconnect?.(force)
-          const current = reconnectTarget?.()
-          if (
-            reconnectReady?.() === false ||
-            (current &&
-              (current.stopped ||
-                current.linkState !== "linked" ||
-                current.rootStreamId !== root ||
-                current.linkGeneration !== target?.linkGeneration))
-          ) {
-            throw new Error("Remote session changed while delegation intake was quiescing; reconnect was not started.")
-          }
-          startReconnect()
-        },
-        onHandoffReset: restartDelegationsAfterReset,
-      }
+      return harnessHandoffResult({
+        commandLabel: "reconnect",
+        ackMessage: "Reconnect request accepted; attempting to resume the linked Claude session.",
+        root,
+        target,
+        force,
+        start: startReconnect,
+      })
     }
     case "clear": {
       if (args !== "" && args !== "--force") {
@@ -257,29 +275,14 @@ export async function runClaudeCommand(
       if (!runtimeSessionId || !root) throw new Error("Harness clear is unavailable for this session.")
       const force = args === "--force"
       const start = prepareHarnessClear(runtimeSessionId)
-      return {
-        ok: true,
-        message: "Clear accepted — killing this session and starting a fresh conversation on the same scratchpad.",
-        afterAck: async () => {
-          if (!force && reconnectBusy?.()) {
-            throw new Error("Claude became busy after clear acknowledgement; retry when idle or use `/clear --force`.")
-          }
-          await stopDelegationsForReconnect?.(force)
-          const current = reconnectTarget?.()
-          if (
-            reconnectReady?.() === false ||
-            (current &&
-              (current.stopped ||
-                current.linkState !== "linked" ||
-                current.rootStreamId !== root ||
-                current.linkGeneration !== target?.linkGeneration))
-          ) {
-            throw new Error("Remote session changed while delegation intake was quiescing; clear was not started.")
-          }
-          start()
-        },
-        onHandoffReset: restartDelegationsAfterReset,
-      }
+      return harnessHandoffResult({
+        commandLabel: "clear",
+        ackMessage: "Clear accepted — killing this session and starting a fresh conversation on the same scratchpad.",
+        root,
+        target,
+        force,
+        start,
+      })
     }
     case "carry-on": {
       if (!carryOn) return { ok: false, message: "Quota carry-on is unavailable for this session." }

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
 import {
   harnessReconnectAvailable,
+  prepareHarnessClear,
   prepareHarnessReconnect,
   runHarnessKick,
   killOwnWindow,
@@ -44,7 +45,8 @@ export const CHANNEL_SOURCE = "threa-channel"
 // case); Threa's canonical `thinking` maps to Claude Code's `/effort`;
 // `carry-on` queues text for the quota carry-on resume (see carry-on.ts);
 // `kick` asks harnessd to press Enter in this session's pane; `status` reads
-// connection/activity state and captures the visible pane without sending keys.
+// connection/activity state and captures the visible pane without sending keys;
+// `clear` asks harnessd to restart this session with a fresh conversation.
 const SESSION_CONTROL_COMMANDS = [
   "stop",
   "steer",
@@ -57,6 +59,7 @@ const SESSION_CONTROL_COMMANDS = [
   "reload",
   "carry-on",
   "reconnect",
+  "clear",
   "key",
 ] as const
 // Model options for the composer's arg picker: built-in /model aliases plus
@@ -242,6 +245,42 @@ export async function runClaudeCommand(
         onHandoffReset: restartDelegationsAfterReset,
       }
     }
+    case "clear": {
+      if (args !== "" && args !== "--force") {
+        return { ok: false, message: "Usage: `/clear [--force]`." }
+      }
+      if (args !== "--force" && reconnectBusy?.()) {
+        return { ok: false, message: "Claude is busy; retry when idle or use `/clear --force`." }
+      }
+      const target = reconnectTarget?.()
+      const root = target?.rootStreamId ?? rootStreamId?.()
+      if (!runtimeSessionId || !root) throw new Error("Harness clear is unavailable for this session.")
+      const force = args === "--force"
+      const start = prepareHarnessClear(runtimeSessionId)
+      return {
+        ok: true,
+        message: "Clear accepted — killing this session and starting a fresh conversation on the same scratchpad.",
+        afterAck: async () => {
+          if (!force && reconnectBusy?.()) {
+            throw new Error("Claude became busy after clear acknowledgement; retry when idle or use `/clear --force`.")
+          }
+          await stopDelegationsForReconnect?.(force)
+          const current = reconnectTarget?.()
+          if (
+            reconnectReady?.() === false ||
+            (current &&
+              (current.stopped ||
+                current.linkState !== "linked" ||
+                current.rootStreamId !== root ||
+                current.linkGeneration !== target?.linkGeneration))
+          ) {
+            throw new Error("Remote session changed while delegation intake was quiescing; clear was not started.")
+          }
+          start()
+        },
+        onHandoffReset: restartDelegationsAfterReset,
+      }
+    }
     case "carry-on": {
       if (!carryOn) return { ok: false, message: "Quota carry-on is unavailable for this session." }
       return carryOn.enqueue(args)
@@ -333,7 +372,8 @@ export function createClaudeSessionControl(
     get commands() {
       return runtimeSessionId
         ? SESSION_CONTROL_COMMANDS.filter((command) => {
-            if (command === "reconnect") return Boolean(rootStreamId?.() && harnessReconnectAvailable())
+            if (command === "reconnect" || command === "clear")
+              return Boolean(rootStreamId?.() && harnessReconnectAvailable())
             // `kick` runs through the same harnessd entrypoint as `reconnect`,
             // so an uninstalled daemon makes it unrunnable too. tmux is already
             // covered by the tmuxAvailable() gate above.
@@ -342,7 +382,7 @@ export function createClaudeSessionControl(
             return true
           })
         : SESSION_CONTROL_COMMANDS.filter(
-            (command) => command !== "kick" && command !== "reconnect" && command !== "key"
+            (command) => command !== "kick" && command !== "reconnect" && command !== "clear" && command !== "key"
           )
     },
     modelSuggestions: MODEL_SUGGESTIONS,

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -67,6 +67,18 @@ describe("createClaudeSessionControl", () => {
     })
   })
 
+  it("advertises clear only with exact runtime, root, and harness entrypoint", () => {
+    withTmuxEnv({ TMUX: "/tmp/tmux-1/default,1,0", TMUX_PANE: "%1" }, () => {
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).toContain("clear")
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => undefined)!.commands).not.toContain(
+        "clear"
+      )
+      expect(createClaudeSessionControl()!.commands).not.toContain("clear")
+      process.env.THREA_HARNESSD_ENTRYPOINT = "/definitely/missing/harnessd.ts"
+      expect(createClaudeSessionControl(undefined, "runtime", undefined, () => "root")!.commands).not.toContain("clear")
+    })
+  })
+
   it("advertises kick only when the harness entrypoint exists", () => {
     // kick shells out to the same harnessd entrypoint reconnect uses, so an
     // uninstalled daemon makes it a dead button rather than a working command.
@@ -235,6 +247,134 @@ describe("runClaudeCommand validation (paths that never touch tmux)", () => {
     await expect(outcome.afterAck?.()).rejects.toBe(releaseError)
     outcome.onHandoffReset?.()
     expect(resets).toBe(1)
+  })
+
+  it("accepts only empty or exact --force clear args", async () => {
+    for (const args of ["--FORCE", "force", "--force=true", "--force --force", "extra"]) {
+      expect(await runClaudeCommand("clear", args, undefined, "runtime", undefined, () => "root")).toEqual({
+        ok: false,
+        message: "Usage: `/clear [--force]`.",
+      })
+    }
+    for (const args of ["", "--force"]) {
+      const outcome = await runClaudeCommand("clear", args, undefined, "runtime", undefined, () => "root")
+      expect(outcome.ok).toBe(true)
+      expect(outcome.message).toBe(
+        "Clear accepted — killing this session and starting a fresh conversation on the same scratchpad."
+      )
+      expect(typeof outcome.afterAck).toBe("function")
+    }
+  })
+
+  it("refuses non-force clear during in-flight or quota-held work", async () => {
+    const busy = await runClaudeCommand(
+      "clear",
+      "",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      () => true
+    )
+    expect(busy).toEqual({ ok: false, message: "Claude is busy; retry when idle or use `/clear --force`." })
+    expect(
+      (
+        await runClaudeCommand(
+          "clear",
+          "--force",
+          undefined,
+          "runtime",
+          undefined,
+          () => "root",
+          () => true
+        )
+      ).ok
+    ).toBe(true)
+  })
+
+  it("refuses non-force clear when work begins after the outcome but before afterAck", async () => {
+    let busy = false
+    const outcome = await runClaudeCommand(
+      "clear",
+      "",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      () => busy
+    )
+
+    expect(outcome.ok).toBe(true)
+    busy = true
+    await expect(outcome.afterAck?.()).rejects.toThrow(
+      "Claude became busy after clear acknowledgement; retry when idle or use `/clear --force`."
+    )
+  })
+
+  for (const lifecycle of ["shutdown", "archive→same-root restore"] as const) {
+    it(`does not launch clear when ${lifecycle} wins during deferred delegation quiesce`, async () => {
+      let releaseQuiesce!: () => void
+      const quiesce = new Promise<void>((resolve) => (releaseQuiesce = resolve))
+      let target: {
+        stopped: boolean
+        linkGeneration: number
+        linkState: "unlinked" | "linked" | "detached"
+        rootStreamId: string | undefined
+      } = { stopped: false, linkGeneration: 1, linkState: "linked", rootStreamId: "root" }
+      const outcome = await runClaudeCommand(
+        "clear",
+        "--force",
+        undefined,
+        "runtime",
+        undefined,
+        () => "root",
+        undefined,
+        () => quiesce,
+        undefined,
+        () => target
+      )
+
+      const postAck = outcome.afterAck?.()
+      target =
+        lifecycle === "shutdown"
+          ? { stopped: true, linkGeneration: 1, linkState: "unlinked", rootStreamId: undefined }
+          : { stopped: false, linkGeneration: 3, linkState: "linked", rootStreamId: "root" }
+      releaseQuiesce()
+
+      await expect(postAck).rejects.toThrow(
+        "Remote session changed while delegation intake was quiescing; clear was not started."
+      )
+    })
+  }
+
+  it("does not launch clear when delegation quiesce fails and exposes intake restoration", async () => {
+    const releaseError = new Error("delegation release failed: 500")
+    let resets = 0
+    const outcome = await runClaudeCommand(
+      "clear",
+      "--force",
+      undefined,
+      "runtime",
+      undefined,
+      () => "root",
+      undefined,
+      async () => {
+        throw releaseError
+      },
+      () => {
+        resets += 1
+      }
+    )
+
+    await expect(outcome.afterAck?.()).rejects.toBe(releaseError)
+    outcome.onHandoffReset?.()
+    expect(resets).toBe(1)
+  })
+
+  it("fails loudly when /clear has no harness-managed runtime identity", async () => {
+    expect(runClaudeCommand("clear", "", undefined, undefined, undefined, () => "root")).rejects.toThrow(
+      "Harness clear is unavailable for this session."
+    )
   })
 
   it("sends one exact allowed key using Claude's parent PID", async () => {

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1536,6 +1536,234 @@ describe("Pi reconnect session control", () => {
   })
 })
 
+describe("Pi clear session control", () => {
+  const invocation = {
+    id: "binv_clear",
+    claimToken: "claim",
+    claimedInstanceId: "pi-instance",
+    rootStreamId: "stream-root-exact",
+  } as never
+  const context = (idle: boolean) =>
+    ({
+      sessionManager: { getSessionId: () => "runtime-exact" },
+      modelRegistry: { getAvailable: () => [] },
+      isIdle: () => idle,
+    }) as never
+  const linkedConfig = (link: Record<string, unknown>) => ({
+    baseUrl: "https://app.threa.io",
+    workspaceId: "ws_123",
+    apiKey: "threa_bk_test",
+    linkedSessions: { "runtime-exact": link },
+  })
+  const validLink = {
+    enabled: true,
+    instanceId: "pi-instance",
+    runtimeSessionId: "runtime-exact",
+    rootStreamId: "stream-root-exact",
+    activeStreamId: "stream-root-exact",
+    streamUrlPath: "/streams/stream-root-exact",
+  }
+
+  beforeEach(() => {
+    process.env.TMUX_PANE = "%9"
+    __testing.setConfigForTesting(linkedConfig(validLink) as never)
+  })
+
+  afterEach(() => {
+    delete process.env.TMUX_PANE
+    __testing.clearPendingForTesting()
+    __testing.setConfigForTesting(undefined)
+  })
+
+  test("routes by runtime session alone, starts only after the ack, and stays nonaccepting", async () => {
+    for (const force of [false, true]) {
+      const prepared: unknown[][] = []
+      const order: string[] = []
+      await __testing.runClearCommand(invocation, force ? "--force" : "", context(true), {
+        available: () => true,
+        prepare: (...args: unknown[]) => {
+          prepared.push(args)
+          return () => order.push("start")
+        },
+        complete: async () => {
+          order.push("complete")
+          return true
+        },
+        heartbeat: async () => undefined,
+      } as never)
+      expect({ prepared, order, guarded: __testing.reconnectPending() }).toEqual({
+        prepared: [["runtime-exact"]],
+        order: ["complete", "start"],
+        guarded: true,
+      })
+      expect(await __testing.claimNextInvocation(context(true))).toBeNull()
+      __testing.clearPendingForTesting()
+    }
+  })
+
+  test("advertises clear only for the exact current harness link", () => {
+    const ctx = context(true)
+    const advertised = (available: boolean) =>
+      (__testing.buildRuntimeCapabilities(ctx, () => available).sessionControlCommands as string[]).includes("clear")
+
+    expect(advertised(true)).toBe(true)
+    expect(advertised(false)).toBe(false)
+
+    __testing.setConfigForTesting(linkedConfig({ ...validLink, runtimeSessionId: "runtime-other" }) as never)
+    expect(advertised(true)).toBe(false)
+
+    __testing.setConfigForTesting(linkedConfig(validLink) as never)
+    delete process.env.TMUX_PANE
+    expect(advertised(true)).toBe(false)
+  })
+
+  test("a claim from link A cannot prepare or ack after relinking to B", async () => {
+    let prepared = 0
+    let acknowledged = 0
+    for (const staleInvocation of [
+      { ...invocation, rootStreamId: "stream-root-a" },
+      { ...invocation, claimedInstanceId: "pi-instance-a" },
+    ]) {
+      await expect(
+        __testing.runClearCommand(staleInvocation as never, "", context(true), {
+          available: () => true,
+          prepare: () => {
+            prepared++
+            return () => undefined
+          },
+          complete: async () => {
+            acknowledged++
+            return true
+          },
+        } as never)
+      ).rejects.toThrow("Harness clear is unavailable")
+    }
+    expect({ prepared, acknowledged }).toEqual({ prepared: 0, acknowledged: 0 })
+  })
+
+  test("accepts only empty args or exact --force", async () => {
+    const messages: string[] = []
+    let prepared = 0
+    for (const args of ["--force ", " --force", "--force=yes", "extra"]) {
+      await __testing.runClearCommand(invocation, args, context(true), {
+        available: () => true,
+        prepare: () => {
+          prepared++
+          return () => undefined
+        },
+        complete: async (_invocation: unknown, message: string) => {
+          messages.push(message)
+          return true
+        },
+      } as never)
+    }
+    expect({ messages, prepared }).toEqual({
+      messages: Array(4).fill("Usage: `/clear [--force]`."),
+      prepared: 0,
+    })
+  })
+
+  test("preparation failure and failed ack never start clear", async () => {
+    expect(
+      __testing.runClearCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => {
+          throw new Error("preflight failed")
+        },
+        complete: async () => true,
+      } as never)
+    ).rejects.toThrow("preflight failed")
+
+    let started = false
+    await __testing.runClearCommand(invocation, "", context(true), {
+      available: () => true,
+      prepare: () => () => {
+        started = true
+      },
+      complete: async () => false,
+      heartbeat: async () => undefined,
+    } as never)
+    expect(started).toBe(false)
+    expect(__testing.reconnectPending()).toBe(false)
+  })
+
+  test("revalidates pinned link facts after ack and restores actual presence", async () => {
+    for (const mutate of [
+      (link: Record<string, unknown>) => (link.enabled = false),
+      (link: Record<string, unknown>) => (link.rootStreamId = "stream-other"),
+      (link: Record<string, unknown>) => (link.runtimeSessionId = "runtime-other"),
+      (link: Record<string, unknown>) => (link.instanceId = "pi-other"),
+    ]) {
+      const link = { ...validLink }
+      __testing.setConfigForTesting(linkedConfig(link) as never)
+      let started = false
+      const presence: string[] = []
+      await __testing.runClearCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => () => {
+          started = true
+        },
+        complete: async () => {
+          mutate(link)
+          return true
+        },
+        heartbeat: async (status: string) => {
+          presence.push(status)
+        },
+      } as never)
+      expect({ started, presence: presence.at(-1) }).toEqual({
+        started: false,
+        presence: link.enabled ? "available" : "offline",
+      })
+      __testing.clearPendingForTesting()
+    }
+  })
+
+  test("synchronous start failure restores the handoff state", async () => {
+    await expect(
+      __testing.runClearCommand(invocation, "", context(true), {
+        available: () => true,
+        prepare: () => () => {
+          throw new Error("start failed")
+        },
+        complete: async () => true,
+        heartbeat: async () => undefined,
+      } as never)
+    ).rejects.toThrow("start failed")
+    expect(__testing.reconnectPending()).toBe(false)
+  })
+
+  test("force bypasses only local busy state and never an owned Threa invocation", async () => {
+    const messages: string[] = []
+    let prepared = 0
+    const deps = {
+      available: () => true,
+      prepare: () => {
+        prepared++
+        return () => {}
+      },
+      complete: async (_invocation: unknown, message: string) => {
+        messages.push(message)
+        return true
+      },
+      heartbeat: async () => undefined,
+    } as never
+    await __testing.runClearCommand(invocation, "", context(false), deps)
+    await __testing.runClearCommand(invocation, "--force", context(false), deps)
+    __testing.clearPendingForTesting()
+    __testing.beginPendingInvocation({ id: "binv_owned", claimToken: "owned" } as never)
+    await __testing.runClearCommand(invocation, "--force", context(false), deps)
+    expect({ messages, prepared }).toEqual({
+      messages: [
+        "Pi is busy; retry when idle or use `/clear --force`.",
+        "Clear accepted; killing this session and starting a fresh conversation on the same scratchpad.",
+        "A Threa invocation is still running; use `/stop` before clearing.",
+      ],
+      prepared: 1,
+    })
+  })
+})
+
 describe("claim drain serialization", () => {
   afterEach(() => {
     __testing.clearPendingForTesting()

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -3248,28 +3248,47 @@ interface ReconnectCommandDeps {
   heartbeat?: typeof heartbeat
 }
 
-async function runReconnectCommand(
+interface ClearCommandDeps {
+  available: () => boolean
+  prepare: typeof prepareHarnessClear
+  complete: typeof completeInvocationWithMarkdown
+  heartbeat?: typeof heartbeat
+}
+
+interface HarnessHandoffSpec {
+  usage: string
+  pendingMessage: string
+  busyMessage: string
+  unavailableMessage: string
+  ackMessage: string
+  heartbeatText: string
+  prepare: (facts: { runtimeSessionId: string; rootStreamId: string; force: boolean }) => () => void
+}
+
+interface HarnessHandoffDeps {
+  available: () => boolean
+  complete: typeof completeInvocationWithMarkdown
+  heartbeat?: typeof heartbeat
+}
+
+async function runHarnessHandoffCommand(
   invocation: ClaimedInvocation,
   args: string,
   ctx: ExtensionContext,
-  deps: ReconnectCommandDeps = {
-    available: harnessReconnectAvailable,
-    prepare: prepareHarnessReconnect,
-    complete: completeInvocationWithMarkdown,
-    heartbeat,
-  }
+  deps: HarnessHandoffDeps,
+  spec: HarnessHandoffSpec
 ): Promise<void> {
   const sendHeartbeat = deps.heartbeat ?? heartbeat
   if (args !== "" && args !== "--force") {
-    await deps.complete(invocation, "Usage: `/reconnect [--force]`.", ctx)
+    await deps.complete(invocation, spec.usage, ctx)
     return
   }
   if (pending) {
-    await deps.complete(invocation, "A Threa invocation is still running; use `/stop` before reconnecting.", ctx)
+    await deps.complete(invocation, spec.pendingMessage, ctx)
     return
   }
   if (args !== "--force" && !ctx.isIdle()) {
-    await deps.complete(invocation, "Pi is busy; retry when idle or use `/reconnect --force`.", ctx)
+    await deps.complete(invocation, spec.busyMessage, ctx)
     return
   }
   const link = currentReconnectLink(ctx, deps.available)
@@ -3286,22 +3305,24 @@ async function runReconnectCommand(
     invocationFacts.claimedInstanceId !== instanceId ||
     sessionTearingDown
   ) {
-    throw new Error("Harness reconnect is unavailable for this session.")
+    throw new Error(spec.unavailableMessage)
   }
   const linkFacts = {
     instanceId: link.instanceId,
     runtimeSessionId: link.runtimeSessionId,
     rootStreamId: link.rootStreamId,
   }
-  const start = deps.prepare(runtimeSessionId, linkFacts.rootStreamId, { force: args === "--force" })
+  const start = spec.prepare({
+    runtimeSessionId,
+    rootStreamId: linkFacts.rootStreamId,
+    force: args === "--force",
+  })
+  // The latch means "harness restart imminent — stay busy, accept no claims",
+  // which is exactly what both handoffs are about to cause.
   reconnectPending = true
-  await sendHeartbeat("busy", "Reconnect handoff…", ctx).catch(() => undefined)
+  await sendHeartbeat("busy", spec.heartbeatText, ctx).catch(() => undefined)
   try {
-    const acknowledged = await deps.complete(
-      invocation,
-      "Reconnect request accepted; attempting to resume the linked Pi session.",
-      ctx
-    )
+    const acknowledged = await deps.complete(invocation, spec.ackMessage, ctx)
     const currentLink = currentReconnectLink(ctx, deps.available)
     const lifecycleChanged =
       sessionTearingDown ||
@@ -3335,11 +3356,26 @@ async function runReconnectCommand(
   }
 }
 
-interface ClearCommandDeps {
-  available: () => boolean
-  prepare: typeof prepareHarnessClear
-  complete: typeof completeInvocationWithMarkdown
-  heartbeat?: typeof heartbeat
+async function runReconnectCommand(
+  invocation: ClaimedInvocation,
+  args: string,
+  ctx: ExtensionContext,
+  deps: ReconnectCommandDeps = {
+    available: harnessReconnectAvailable,
+    prepare: prepareHarnessReconnect,
+    complete: completeInvocationWithMarkdown,
+    heartbeat,
+  }
+): Promise<void> {
+  await runHarnessHandoffCommand(invocation, args, ctx, deps, {
+    usage: "Usage: `/reconnect [--force]`.",
+    pendingMessage: "A Threa invocation is still running; use `/stop` before reconnecting.",
+    busyMessage: "Pi is busy; retry when idle or use `/reconnect --force`.",
+    unavailableMessage: "Harness reconnect is unavailable for this session.",
+    ackMessage: "Reconnect request accepted; attempting to resume the linked Pi session.",
+    heartbeatText: "Reconnect handoff…",
+    prepare: ({ runtimeSessionId, rootStreamId, force }) => deps.prepare(runtimeSessionId, rootStreamId, { force }),
+  })
 }
 
 async function runClearCommand(
@@ -3353,82 +3389,15 @@ async function runClearCommand(
     heartbeat,
   }
 ): Promise<void> {
-  const sendHeartbeat = deps.heartbeat ?? heartbeat
-  if (args !== "" && args !== "--force") {
-    await deps.complete(invocation, "Usage: `/clear [--force]`.", ctx)
-    return
-  }
-  if (pending) {
-    await deps.complete(invocation, "A Threa invocation is still running; use `/stop` before clearing.", ctx)
-    return
-  }
-  if (args !== "--force" && !ctx.isIdle()) {
-    await deps.complete(invocation, "Pi is busy; retry when idle or use `/clear --force`.", ctx)
-    return
-  }
-  const link = currentReconnectLink(ctx, deps.available)
-  const lifecycleGeneration = sessionLifecycleGeneration
-  const runtimeSessionId = getRuntimeSessionId(ctx)
-  const instanceId = getSessionInstanceId(ctx)
-  const invocationFacts = {
-    rootStreamId: invocation.rootStreamId,
-    claimedInstanceId: invocation.claimedInstanceId,
-  }
-  if (
-    !link ||
-    invocationFacts.rootStreamId !== link.rootStreamId ||
-    invocationFacts.claimedInstanceId !== instanceId ||
-    sessionTearingDown
-  ) {
-    throw new Error("Harness clear is unavailable for this session.")
-  }
-  const linkFacts = {
-    instanceId: link.instanceId,
-    runtimeSessionId: link.runtimeSessionId,
-    rootStreamId: link.rootStreamId,
-  }
-  const start = deps.prepare(runtimeSessionId)
-  // The latch means "harness restart imminent — stay busy, accept no claims",
-  // which is exactly a clear's state too.
-  reconnectPending = true
-  await sendHeartbeat("busy", "Clear handoff…", ctx).catch(() => undefined)
-  try {
-    const acknowledged = await deps.complete(
-      invocation,
-      "Clear accepted; killing this session and starting a fresh conversation on the same scratchpad.",
-      ctx
-    )
-    const currentLink = currentReconnectLink(ctx, deps.available)
-    const lifecycleChanged =
-      sessionTearingDown ||
-      sessionLifecycleGeneration !== lifecycleGeneration ||
-      !currentLink ||
-      currentLink.instanceId !== linkFacts.instanceId ||
-      currentLink.runtimeSessionId !== linkFacts.runtimeSessionId ||
-      currentLink.rootStreamId !== linkFacts.rootStreamId ||
-      getRuntimeSessionId(ctx) !== runtimeSessionId ||
-      getSessionInstanceId(ctx) !== instanceId ||
-      invocation.rootStreamId !== invocationFacts.rootStreamId ||
-      invocation.claimedInstanceId !== invocationFacts.claimedInstanceId
-    if (!acknowledged || lifecycleChanged) {
-      reconnectPending = false
-      const enabled = isEnabled(ctx)
-      await sendHeartbeat(
-        enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline",
-        undefined,
-        ctx
-      ).catch(() => undefined)
-      return
-    }
-    start()
-  } catch (error) {
-    reconnectPending = false
-    const enabled = isEnabled(ctx)
-    await sendHeartbeat(enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline", undefined, ctx).catch(
-      () => undefined
-    )
-    throw error
-  }
+  await runHarnessHandoffCommand(invocation, args, ctx, deps, {
+    usage: "Usage: `/clear [--force]`.",
+    pendingMessage: "A Threa invocation is still running; use `/stop` before clearing.",
+    busyMessage: "Pi is busy; retry when idle or use `/clear --force`.",
+    unavailableMessage: "Harness clear is unavailable for this session.",
+    ackMessage: "Clear accepted; killing this session and starting a fresh conversation on the same scratchpad.",
+    heartbeatText: "Clear handoff…",
+    prepare: ({ runtimeSessionId }) => deps.prepare(runtimeSessionId),
+  })
 }
 
 async function runStopCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -27,6 +27,7 @@ import {
   harnessReconnectAvailable,
   parseSealedAckContext,
   parseSealedTurnContext,
+  prepareHarnessClear,
   prepareHarnessReconnect,
   runHarnessKick,
   parseAllowedTmuxKey,
@@ -126,6 +127,7 @@ const SESSION_CONTROL_COMMANDS = [
   "kick",
   "carry-on",
   "reconnect",
+  "clear",
   "key",
 ] as const
 type PiSessionControlCommandName = (typeof SESSION_CONTROL_COMMANDS)[number]
@@ -812,11 +814,11 @@ function buildRuntimeCapabilities(
     supportsMentionInvocations: true,
     supportsSessionControlCommands: true,
     sessionControlCommands: SESSION_CONTROL_COMMANDS.filter((command) => {
-      // `kick` and `reconnect` both act through the harnessd entrypoint, which
-      // finds this session by its tmux pane and presses Enter into it. Neither
-      // can run without a pane and an installed daemon — everything else here
-      // actuates in-process through the extension API and needs no tmux at all.
-      if (command === "kick" || command === "reconnect") {
+      // `kick`, `reconnect`, and `clear` all act through the harnessd
+      // entrypoint, which finds this session by its tmux pane. None can run
+      // without a pane and an installed daemon — everything else here actuates
+      // in-process through the extension API and needs no tmux at all.
+      if (command === "kick" || command === "reconnect" || command === "clear") {
         return Boolean(ctx && currentReconnectLink(ctx, reconnectAvailable))
       }
       if (command === "key") return Boolean(ctx && currentSessionControlLink(ctx))
@@ -3333,6 +3335,102 @@ async function runReconnectCommand(
   }
 }
 
+interface ClearCommandDeps {
+  available: () => boolean
+  prepare: typeof prepareHarnessClear
+  complete: typeof completeInvocationWithMarkdown
+  heartbeat?: typeof heartbeat
+}
+
+async function runClearCommand(
+  invocation: ClaimedInvocation,
+  args: string,
+  ctx: ExtensionContext,
+  deps: ClearCommandDeps = {
+    available: harnessReconnectAvailable,
+    prepare: prepareHarnessClear,
+    complete: completeInvocationWithMarkdown,
+    heartbeat,
+  }
+): Promise<void> {
+  const sendHeartbeat = deps.heartbeat ?? heartbeat
+  if (args !== "" && args !== "--force") {
+    await deps.complete(invocation, "Usage: `/clear [--force]`.", ctx)
+    return
+  }
+  if (pending) {
+    await deps.complete(invocation, "A Threa invocation is still running; use `/stop` before clearing.", ctx)
+    return
+  }
+  if (args !== "--force" && !ctx.isIdle()) {
+    await deps.complete(invocation, "Pi is busy; retry when idle or use `/clear --force`.", ctx)
+    return
+  }
+  const link = currentReconnectLink(ctx, deps.available)
+  const lifecycleGeneration = sessionLifecycleGeneration
+  const runtimeSessionId = getRuntimeSessionId(ctx)
+  const instanceId = getSessionInstanceId(ctx)
+  const invocationFacts = {
+    rootStreamId: invocation.rootStreamId,
+    claimedInstanceId: invocation.claimedInstanceId,
+  }
+  if (
+    !link ||
+    invocationFacts.rootStreamId !== link.rootStreamId ||
+    invocationFacts.claimedInstanceId !== instanceId ||
+    sessionTearingDown
+  ) {
+    throw new Error("Harness clear is unavailable for this session.")
+  }
+  const linkFacts = {
+    instanceId: link.instanceId,
+    runtimeSessionId: link.runtimeSessionId,
+    rootStreamId: link.rootStreamId,
+  }
+  const start = deps.prepare(runtimeSessionId)
+  // The latch means "harness restart imminent — stay busy, accept no claims",
+  // which is exactly a clear's state too.
+  reconnectPending = true
+  await sendHeartbeat("busy", "Clear handoff…", ctx).catch(() => undefined)
+  try {
+    const acknowledged = await deps.complete(
+      invocation,
+      "Clear accepted; killing this session and starting a fresh conversation on the same scratchpad.",
+      ctx
+    )
+    const currentLink = currentReconnectLink(ctx, deps.available)
+    const lifecycleChanged =
+      sessionTearingDown ||
+      sessionLifecycleGeneration !== lifecycleGeneration ||
+      !currentLink ||
+      currentLink.instanceId !== linkFacts.instanceId ||
+      currentLink.runtimeSessionId !== linkFacts.runtimeSessionId ||
+      currentLink.rootStreamId !== linkFacts.rootStreamId ||
+      getRuntimeSessionId(ctx) !== runtimeSessionId ||
+      getSessionInstanceId(ctx) !== instanceId ||
+      invocation.rootStreamId !== invocationFacts.rootStreamId ||
+      invocation.claimedInstanceId !== invocationFacts.claimedInstanceId
+    if (!acknowledged || lifecycleChanged) {
+      reconnectPending = false
+      const enabled = isEnabled(ctx)
+      await sendHeartbeat(
+        enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline",
+        undefined,
+        ctx
+      ).catch(() => undefined)
+      return
+    }
+    start()
+  } catch (error) {
+    reconnectPending = false
+    const enabled = isEnabled(ctx)
+    await sendHeartbeat(enabled ? (ctx.isIdle() && !pending ? "available" : "busy") : "offline", undefined, ctx).catch(
+      () => undefined
+    )
+    throw error
+  }
+}
+
 async function runStopCommand(invocation: ClaimedInvocation, ctx: ExtensionContext): Promise<void> {
   const hadPendingRemoteInvocation = pending !== undefined
   const wasBusy = !ctx.isIdle()
@@ -3463,6 +3561,9 @@ async function handleSessionControlInvocation(
         return
       case "reconnect":
         await runReconnectCommand(invocation, command.args, ctx)
+        return
+      case "clear":
+        await runClearCommand(invocation, command.args, ctx)
         return
       case "key":
         await runKeyCommand(invocation, command.args, ctx)
@@ -4378,6 +4479,7 @@ export const __testing = {
   claimNextInvocation,
   claimIfIdle,
   runReconnectCommand,
+  runClearCommand,
   runReloadCommand,
   scheduleRecoveredCompletion,
   runKeyCommand,


### PR DESCRIPTION
## Problem

[#1853](https://github.com/threahq/threa/pull/1853) added `threa-harnessd clear`, but the place a fresh start is actually wanted is the scratchpad — the operator watching a session drown in stale context types there, not in a terminal next to harnessd. There is no `/clear` session-control command, and the backend's canonical `SESSION_CONTROL_COMMAND_NAMES` allowlist means a runtime cannot just advertise one into existence.

## Solution

`/clear [--force]` in both runtimes, riding `/reconnect`'s ack-then-detached-spawn pattern — the channel process lives inside the pane harnessd is about to kill, so the invocation completes first and a detached `threa-harnessd clear <runtime-session-id>` does the killing.

- Backend: `clear` added to the canonical list and `listSessionControlCommandInfos()` (`--force` arg documented). For `pi-local` it routes to `active-scratchpad` like `reconnect` does — a busy Pi drops the `session-control` capability from its claims, which would make `/clear --force` unclaimable exactly when it's wanted. The Claude channel keeps `session-control` routing (it advertises it while busy).
- `bot-runtime-client`: the detached-spawn body of `prepareHarnessReconnect` is extracted into a shared helper; new `prepareHarnessClear(runtimeSessionId)` spawns `clear` with its own `~/.threa/harnessd/clear.log`. Reconnect's exported signature and tests are untouched.
- Claude channel (`channel-server.ts`): `case "clear"` mirrors `case "reconnect"` — busy refusal without `--force`, same delegation-quiescing and remote-session-changed rechecks in `afterAck`, advertised only with a linked root stream and an installed harnessd.
- Pi (`threa-remote.ts`): `runClearCommand` mirrors `runReconnectCommand`, reusing the `reconnectPending` latch (both mean "harness restart imminent — stay busy, accept no claims").

Existing channels surface `/clear` after their next restart (capabilities are sent at hello). `docs/claude-channel-session-control.md` untouched: its command lists are an explicit v1 snapshot already omitting `reconnect`/`key`.

## Test plan

- [x] bot-runtime-client 102, claude-code-remote 139, pi-remote 153, harness-daemon 369, backend `features/commands` 23 — all pass, 0 fail (new: clear spawn/one-shot/entrypoint cases; Claude advertise/usage/busy/afterAck-ordering; Pi routing/busy/lifecycle-recheck mirrors)
- [ ] `/clear` typed in a real scratchpad — needs a restarted channel to advertise the command; verified indirectly by the harnessd-side E2E in [#1853](https://github.com/threahq/threa/pull/1853) plus the ack-ordering tests here

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788985676&installation_model_id=20758&pr_number=1854&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1854&signature=b031d43b11af995724a608505b3b37924ae0fd324a3c14a5e28dc3a3d8094355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->