### PR TITLE
feat: show unsent thread reply drafts in the in-stream thread visualizer

### DIFF
--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -413,7 +413,6 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     try {
       // Clear input optimistically inside try so we can restore on failure
       composer.setContent(EMPTY_DOC)
-      composer.resolveDraft()
       composer.clearAttachments()
 
       // Seal the reply under the encrypted root when the parent is E2E — the
@@ -444,6 +443,12 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
           e2e,
         }
       )
+
+      // AFTER the queue write, never before: the anchor's thread slot indicates
+      // this draft, and `queueDraftMessage` is what bumps the anchor's
+      // replyCount — resolving first leaves a frame with neither, collapsing the
+      // slot and replaying its grow-in on the way back.
+      composer.resolveDraft()
     } catch {
       // Restore content so the user can retry
       composer.setContent(contentJson)

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -447,8 +447,15 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
       // AFTER the queue write, never before: the anchor's thread slot indicates
       // this draft, and `queueDraftMessage` is what bumps the anchor's
       // replyCount — resolving first leaves a frame with neither, collapsing the
-      // slot and replaying its grow-in on the way back.
-      composer.resolveDraft()
+      // slot and replaying its grow-in on the way back. Failure is handled
+      // apart from the queue's: the reply IS queued at this point, so the
+      // composer must stay cleared and no retry prompt is warranted — the only
+      // symptom is a stale draft row.
+      try {
+        await composer.resolveDraft()
+      } catch (err) {
+        console.error("Failed to resolve draft after queueing thread reply", err)
+      }
     } catch {
       // Restore content so the user can retry
       composer.setContent(contentJson)

--- a/apps/frontend/src/components/timeline/call-card.tsx
+++ b/apps/frontend/src/components/timeline/call-card.tsx
@@ -3,7 +3,7 @@ import { Link2, LogIn, MessageSquareReply, Phone, PhoneForwarded, Video } from "
 import { toast } from "sonner"
 import type { CallEndedEventPayload, CallStartedEventPayload, StreamEvent, ThreadSummary } from "@threa/types"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { useActors } from "@/hooks"
+import { useActors, useThreadDraft } from "@/hooks"
 import { useActiveCall } from "@/stores/active-calls-store"
 import { useCallLaunch } from "@/components/call/call-launch-context"
 import { useCallPhase, useCallStreamId } from "@/components/call/call-store-hooks"
@@ -120,7 +120,12 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
   const inCallStreamId = useCallStreamId()
   // Shared thread affordance keyed on the card's event id: `replyUrl` opens the
   // real thread when one exists, else the draft panel to start the call chat.
-  const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
+  const { threadHref, replyUrl, effectiveThreadId } = useThreadAnchor(streamId, event.id, {
+    threadId: payload?.threadId,
+  })
+  // The viewer's unsent reply on this card's thread — shown on the slot before
+  // the thread stream exists too (keyed on the anchor until promotion).
+  const threadDraft = useThreadDraft(workspaceId, event.id, effectiveThreadId)
   // Known before the click, so the affordance says what will actually happen
   // instead of a Join that 409s and then asks.
   const onAnotherDevice = useCallOnAnotherDevice(workspaceId, payload?.callId)
@@ -275,6 +280,8 @@ export function CallCard({ event, workspaceId, streamId, endedPatch, isThreadPar
           threadHref={threadHref}
           summary={payload.threadSummary}
           workspaceId={workspaceId}
+          draft={threadDraft}
+          draftHref={replyUrl}
         />
       )}
       <TimelineCardQuickActions actions={actions} />

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -25,7 +25,7 @@ import {
 } from "@threa/types"
 import { delegationsApi } from "@/api"
 import { usePanel } from "@/contexts"
-import { useActors } from "@/hooks"
+import { useActors, useThreadDraft } from "@/hooks"
 import { agentOutcomeKeys } from "@/hooks/use-agent-outcomes"
 import { delegationKeys } from "@/hooks/use-stream-delegations"
 import {
@@ -140,7 +140,12 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
   // Shared thread affordance, keyed on the card's canonical id (its event id) —
   // the anchor delegation completion threads on. `replyUrl` points at the real
   // thread when one exists, else the draft panel for starting one.
-  const { threadHref, replyUrl } = useThreadAnchor(streamId, event.id, { threadId: payload?.threadId })
+  const { threadHref, replyUrl, effectiveThreadId } = useThreadAnchor(streamId, event.id, {
+    threadId: payload?.threadId,
+  })
+  // The viewer's unsent reply on this card's thread — shown on the slot before
+  // the thread stream exists too (keyed on the anchor until promotion).
+  const threadDraft = useThreadDraft(workspaceId, event.id, effectiveThreadId)
   const [optimisticallyCancelled, setOptimisticallyCancelled] = useState(false)
   const [optimisticallyDone, setOptimisticallyDone] = useState(false)
   const [optimisticallyRequeued, setOptimisticallyRequeued] = useState(false)
@@ -442,6 +447,8 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch, isT
           threadHref={threadHref}
           summary={payload.threadSummary}
           workspaceId={workspaceId}
+          draft={threadDraft}
+          draftHref={replyUrl}
         />
       )}
       <TimelineCardQuickActions actions={actions} />

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -36,6 +36,7 @@ import {
   reactionShortcodes,
   focusAtEnd,
   findVisibleZoneEditor,
+  useThreadDraft,
   type MessageAgentActivity,
 } from "@/hooks"
 import { Quote, MessageSquareReply, Check, Layers } from "lucide-react"
@@ -997,10 +998,14 @@ function SentMessageEvent({
   // Shared thread affordance wiring, keyed on this message's canonical id.
   // `activity.threadStreamId` lets us link to the real thread immediately when
   // an agent response is in flight, before the slower stream:created event.
-  const { threadHref, replyUrl } = useThreadAnchor(streamId, payload.messageId, {
+  const { threadHref, replyUrl, effectiveThreadId } = useThreadAnchor(streamId, payload.messageId, {
     threadId,
     activityThreadStreamId: activity?.threadStreamId,
   })
+  // The viewer's unsent reply in this thread — indicated on the slot whether or
+  // not the thread stream exists yet (the draft is keyed on the anchor until
+  // promotion re-scopes it onto the thread).
+  const threadDraft = useThreadDraft(workspaceId, payload.messageId, effectiveThreadId)
 
   // Thread card shown below the message body when a thread exists with replies.
   // Users without a thread start one via the hover toolbar or context menu —
@@ -1017,6 +1022,8 @@ function SentMessageEvent({
       threadHref={threadHref}
       summary={payload.threadSummary}
       workspaceId={workspaceId}
+      draft={threadDraft}
+      draftHref={replyUrl}
     />
   ) : null
 

--- a/apps/frontend/src/components/timeline/thread-card.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-card.test.tsx
@@ -74,4 +74,52 @@ describe("ThreadCard", () => {
     const preview = screen.getByText(/latest/i)
     expect(preview.textContent).not.toContain("**")
   })
+
+  it("renders the draft-only card at replyCount 0, linking to the draft reply panel", () => {
+    renderCard(
+      <ThreadCard
+        replyCount={0}
+        href="/panel/draft:stream_1:msg_1"
+        workspaceId="ws_1"
+        summary={undefined}
+        draft={{ preview: "half-written reply" }}
+      />
+    )
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/panel/draft:stream_1:msg_1")
+    expect(screen.getByText("Draft")).toBeInTheDocument()
+    expect(screen.getByText("half-written reply")).toBeInTheDocument()
+    // No reply count to show — the thread stream does not exist yet.
+    expect(screen.queryByText(/^\d+ repl(y|ies)$/)).toBeNull()
+  })
+
+  it("renders the draft-only label with no snippet row when the preview is empty (sealed/attachment-only body)", () => {
+    const { container } = renderCard(
+      <ThreadCard
+        replyCount={0}
+        href="/panel/draft:stream_1:msg_1"
+        workspaceId="ws_1"
+        summary={undefined}
+        draft={{ preview: "" }}
+      />
+    )
+    expect(screen.getByText("Draft")).toBeInTheDocument()
+    expect(container.querySelectorAll("p").length).toBe(0)
+  })
+
+  it("appends the draft token beside the reply count and keeps the latest-reply row", () => {
+    renderCard(
+      <ThreadCard
+        replyCount={2}
+        href="/panel/thread_1"
+        workspaceId="ws_1"
+        summary={baseSummary}
+        draft={{ preview: "unsent addition" }}
+      />
+    )
+    expect(screen.getByText("2 replies")).toBeInTheDocument()
+    expect(screen.getByLabelText("Unsent draft")).toHaveTextContent("Draft")
+    // Row 2 still belongs to the latest reply — the draft never replaces it.
+    expect(screen.getByText(/latest/i).textContent).toContain("latest")
+    expect(screen.queryByText("unsent addition")).toBeNull()
+  })
 })

--- a/apps/frontend/src/components/timeline/thread-card.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-card.test.tsx
@@ -93,7 +93,7 @@ describe("ThreadCard", () => {
   })
 
   it("renders the draft-only label with no snippet row when the preview is empty (sealed/attachment-only body)", () => {
-    const { container } = renderCard(
+    renderCard(
       <ThreadCard
         replyCount={0}
         href="/panel/draft:stream_1:msg_1"
@@ -103,7 +103,7 @@ describe("ThreadCard", () => {
       />
     )
     expect(screen.getByText("Draft")).toBeInTheDocument()
-    expect(container.querySelectorAll("p").length).toBe(0)
+    expect(screen.getByRole("link").querySelector("p")).toBeNull()
   })
 
   it("appends the draft token beside the reply count and keeps the latest-reply row", () => {

--- a/apps/frontend/src/components/timeline/thread-card.tsx
+++ b/apps/frontend/src/components/timeline/thread-card.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import { ChevronRight } from "lucide-react"
+import { ChevronRight, Pencil } from "lucide-react"
 import type { ThreadSummary } from "@threa/types"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
@@ -8,11 +8,25 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { truncateContent } from "@/components/layout/sidebar/utils"
 import { cn } from "@/lib/utils"
 
+export interface ThreadCardDraft {
+  /** One-line plain text of the viewer's unsent reply. "" when there is nothing
+   *  renderable (attachment-only, or a sealed body this device can't read) —
+   *  the label still shows, the snippet row is dropped. */
+  preview: string
+}
+
 interface ThreadCardProps {
   replyCount: number
   href: string
   workspaceId: string
   summary?: ThreadSummary
+  /**
+   * The viewer's unsent reply draft in this thread. With replies it appends a
+   * muted "Draft" token after the timestamp; at `replyCount === 0` it is the
+   * whole card (the thread stream does not exist yet, so there is nothing else
+   * to show) and `href` points at the draft reply panel.
+   */
+  draft?: ThreadCardDraft | null
   /**
    * Render a pulsing gold dot next to the reply count when a session is
    * actively producing content in this thread. Lets the card stay mounted
@@ -37,13 +51,15 @@ interface ThreadCardProps {
  *
  * Preview text routes through `truncateContent()` (→ `stripMarkdownToInline`)
  * so raw markdown from `contentMarkdown` never ships as literal syntax to
- * users (INV-60).
+ * users (INV-60). The draft snippet needs no stripping — it is projected from
+ * the composer's `contentJson`, never markdown.
  */
 export function ThreadCard({
   replyCount,
   href,
   workspaceId,
   summary,
+  draft,
   isActive,
   ownsLeftLine = true,
   className,
@@ -51,8 +67,9 @@ export function ThreadCard({
   const { getActorName } = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
 
-  if (replyCount === 0) return null
+  if (replyCount === 0 && !draft) return null
 
+  const isDraftOnly = replyCount === 0
   const replyLabel = replyCount === 1 ? "1 reply" : `${replyCount} replies`
   const participants = summary?.participants ?? []
 
@@ -71,7 +88,13 @@ export function ThreadCard({
       )}
     >
       <div className="flex items-center gap-2 text-xs">
-        {participants.length > 0 && (
+        {isDraftOnly && (
+          <span className="flex items-center gap-1.5">
+            <Pencil aria-hidden className="h-3.5 w-3.5 text-primary" />
+            <span className="font-medium text-primary group-hover/thread:underline">Draft</span>
+          </span>
+        )}
+        {!isDraftOnly && participants.length > 0 && (
           <div className="flex gap-0.5">
             {participants.map((participant) => (
               <ActorAvatar
@@ -84,7 +107,7 @@ export function ThreadCard({
             ))}
           </div>
         )}
-        <span className="font-medium text-primary group-hover/thread:underline">{replyLabel}</span>
+        {!isDraftOnly && <span className="font-medium text-primary group-hover/thread:underline">{replyLabel}</span>}
         {isActive && (
           <span className="relative flex h-1.5 w-1.5" aria-label="Session active">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60 opacity-75" />
@@ -97,17 +120,28 @@ export function ThreadCard({
             <RelativeTime date={summary.lastReplyAt} terse className="text-muted-foreground" />
           </>
         )}
+        {draft && !isDraftOnly && (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="flex items-center gap-1 italic text-muted-foreground" aria-label="Unsent draft">
+              <Pencil aria-hidden className="h-3 w-3" />
+              Draft
+            </span>
+          </>
+        )}
         <ChevronRight className="ml-auto h-3.5 w-3.5 text-muted-foreground/50 transition-transform group-hover/thread:translate-x-0.5 group-hover/thread:text-muted-foreground" />
       </div>
-      {summary && (
-        <p className="truncate text-xs text-muted-foreground">
-          <span className="font-medium text-foreground/80">
-            {getActorName(summary.latestReply.actorId, summary.latestReply.actorType)}
-          </span>
-          <span className="text-muted-foreground/60">: </span>
-          {truncateContent(summary.latestReply.contentMarkdown, 120, toEmoji)}
-        </p>
-      )}
+      {isDraftOnly
+        ? draft?.preview && <p className="truncate text-xs italic text-muted-foreground">{draft.preview}</p>
+        : summary && (
+            <p className="truncate text-xs text-muted-foreground">
+              <span className="font-medium text-foreground/80">
+                {getActorName(summary.latestReply.actorId, summary.latestReply.actorType)}
+              </span>
+              <span className="text-muted-foreground/60">: </span>
+              {truncateContent(summary.latestReply.contentMarkdown, 120, toEmoji)}
+            </p>
+          )}
     </Link>
   )
 }

--- a/apps/frontend/src/components/timeline/thread-slot.draft-send.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-slot.draft-send.test.tsx
@@ -1,0 +1,138 @@
+import { beforeEach, describe, it, expect, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { MemoryRouter } from "react-router-dom"
+import type { JSONContent, ThreadSummary } from "@threa/types"
+// eslint-disable-next-line no-restricted-imports -- test seeds/inspects IDB directly to drive the real draft registry
+import { db } from "@/db"
+import { resolveLoadedDraft, upsertLoadedDraft } from "@/hooks/use-draft-message"
+import { resetDraftStoreCache } from "@/stores/draft-store"
+import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
+import { useThreadDraft, __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
+import * as hooksModule from "@/hooks"
+import * as workspaceEmojiModule from "@/hooks/use-workspace-emoji"
+import * as relativeTimeModule from "@/components/relative-time"
+import { ThreadSlot } from "./thread-slot"
+
+const workspaceId = "ws_1"
+const anchorId = "msg_anchor"
+const scope = `thread:${anchorId}`
+const threadId = "stream_thread"
+
+const doc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+const summary: ThreadSummary = {
+  lastReplyAt: "2026-04-19T12:00:00.000Z",
+  participants: [{ id: "user_alice", type: "user" }],
+  latestReply: {
+    messageId: "msg_sent",
+    actorId: "user_alice",
+    actorType: "user",
+    contentMarkdown: "typed but unsent",
+  },
+}
+
+beforeEach(async () => {
+  vi.restoreAllMocks()
+  vi.spyOn(hooksModule, "useActors").mockReturnValue({
+    getActorName: (id: string) => `Name-${id.slice(-4)}`,
+    getActorAvatar: (id: string) => ({ fallback: id.slice(0, 2).toUpperCase(), avatarUrl: null }),
+  } as unknown as ReturnType<typeof hooksModule.useActors>)
+  vi.spyOn(workspaceEmojiModule, "useWorkspaceEmoji").mockReturnValue({
+    toEmoji: () => null,
+  } as unknown as ReturnType<typeof workspaceEmojiModule.useWorkspaceEmoji>)
+  vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((({ date }: { date: string }) => (
+    <time dateTime={date}>{date}</time>
+  )) as unknown as typeof relativeTimeModule.RelativeTime)
+  __clearBoardDraftsRegistry()
+  resetDraftResolutionGuard()
+  resetDraftStoreCache()
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
+  await db.pendingOperations.clear()
+})
+
+/**
+ * The in-stream slot wired to the real drafts registry, with the two halves of a
+ * draft send driven separately: "reply landed" is what `queueDraftMessage` does
+ * (optimistic replyCount + threadId on the anchor), "resolve" is the real
+ * `resolveLoadedDraft` the composer calls. Order between them is the thing under
+ * test.
+ */
+function SendHarness() {
+  const [replyLanded, setReplyLanded] = useState(false)
+  const draft = useThreadDraft(workspaceId, anchorId, replyLanded ? threadId : undefined)
+  return (
+    <>
+      <button onClick={() => setReplyLanded(true)}>reply landed</button>
+      <button onClick={() => void resolveLoadedDraft(workspaceId, scope)}>resolve draft</button>
+      <div data-testid="slot-host">
+        <ThreadSlot
+          activity={undefined}
+          replyCount={replyLanded ? 1 : 0}
+          threadHref={replyLanded ? "/panel/thread_1" : null}
+          summary={replyLanded ? summary : undefined}
+          workspaceId={workspaceId}
+          draft={draft}
+          draftHref="/panel/draft:stream_1:msg_1"
+        />
+      </div>
+    </>
+  )
+}
+
+describe("thread draft send transition", () => {
+  it("keeps the slot element and skips the grow-in when the reply lands before the draft resolves", async () => {
+    const user = userEvent.setup()
+    await upsertLoadedDraft(workspaceId, scope, { contentJson: doc("typed but unsent"), attachments: [] })
+
+    render(
+      <MemoryRouter>
+        <SendHarness />
+      </MemoryRouter>
+    )
+    const host = screen.getByTestId("slot-host")
+    await waitFor(() => expect(screen.getByText("typed but unsent")).toBeInTheDocument())
+    // Past the slot's 300ms hydration grace, so a genuine visible flip WOULD
+    // animate — otherwise the animation assertion below proves nothing.
+    await new Promise((resolve) => setTimeout(resolve, 350))
+    const slotBeforeSend = host.firstChild
+    expect(slotBeforeSend).not.toBeNull()
+
+    await user.click(screen.getByText("reply landed"))
+    await user.click(screen.getByText("resolve draft"))
+
+    await waitFor(() => expect(screen.queryByText("Draft")).toBeNull())
+    expect(screen.getByText("1 reply")).toBeInTheDocument()
+    expect(host.firstChild).toBe(slotBeforeSend)
+    expect(host.querySelector(".animate-thread-grow")).toBeNull()
+    expect(await db.drafts.get({ scope })).toBeUndefined()
+  })
+
+  it("loses the slot element (and replays the grow-in) when the draft resolves before the reply lands", async () => {
+    const user = userEvent.setup()
+    await upsertLoadedDraft(workspaceId, scope, { contentJson: doc("typed but unsent"), attachments: [] })
+
+    render(
+      <MemoryRouter>
+        <SendHarness />
+      </MemoryRouter>
+    )
+    const host = screen.getByTestId("slot-host")
+    await waitFor(() => expect(screen.getByText("typed but unsent")).toBeInTheDocument())
+    await new Promise((resolve) => setTimeout(resolve, 350))
+    const slotBeforeSend = host.firstChild
+
+    await user.click(screen.getByText("resolve draft"))
+    await waitFor(() => expect(host.firstChild).toBeNull())
+    await user.click(screen.getByText("reply landed"))
+
+    expect(screen.getByText("1 reply")).toBeInTheDocument()
+    expect(host.firstChild).not.toBe(slotBeforeSend)
+    expect(host.querySelector(".animate-thread-grow")).not.toBeNull()
+  })
+})

--- a/apps/frontend/src/components/timeline/thread-slot.draft-send.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-slot.draft-send.test.tsx
@@ -6,7 +6,9 @@ import { MemoryRouter } from "react-router-dom"
 import type { JSONContent, ThreadSummary } from "@threa/types"
 // eslint-disable-next-line no-restricted-imports -- test seeds/inspects IDB directly to drive the real draft registry
 import { db } from "@/db"
-import { resolveLoadedDraft, upsertLoadedDraft } from "@/hooks/use-draft-message"
+import { renderHook } from "@testing-library/react"
+import { resolveLoadedDraft, rescopeScopeDrafts, upsertLoadedDraft } from "@/hooks/use-draft-message"
+import { useBoardDraftsReady } from "@/hooks/use-scope-draft-preview"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 import { useThreadDraft, __clearBoardDraftsRegistry } from "@/hooks/use-scope-draft-preview"
@@ -134,5 +136,28 @@ describe("thread draft send transition", () => {
     expect(screen.getByText("1 reply")).toBeInTheDocument()
     expect(host.firstChild).not.toBe(slotBeforeSend)
     expect(host.querySelector(".animate-thread-grow")).not.toBeNull()
+  })
+
+  it("resolves the sent draft by identity when the promotion rescope wins the race", async () => {
+    await upsertLoadedDraft(workspaceId, scope, { contentJson: doc("typed but unsent"), attachments: [] })
+    const draftId = (await db.composerLoaded.get(scope))?.draftId
+    expect(draftId).toBeTruthy()
+
+    // Promotion wins the race: promoteDraft's rescope moves the row AND its
+    // loaded pointer onto the real thread's scope before the send's resolve
+    // reads them. A pointer-only resolve at the old scope would then no-op,
+    // leaving the sent draft alive — rendered as a false "Draft" chip.
+    await rescopeScopeDrafts(workspaceId, scope, `stream:${threadId}`)
+    expect((await db.drafts.get(draftId!))?.scope).toBe(`stream:${threadId}`)
+
+    await resolveLoadedDraft(workspaceId, scope, draftId)
+
+    expect(await db.drafts.get(draftId!)).toBeUndefined()
+    expect(await db.composerLoaded.get(`stream:${threadId}`)).toBeUndefined()
+
+    const ready = renderHook(() => useBoardDraftsReady(workspaceId))
+    const { result } = renderHook(() => useThreadDraft(workspaceId, anchorId, threadId))
+    await waitFor(() => expect(ready.result.current).toBe(true))
+    expect(result.current).toBeNull()
   })
 })

--- a/apps/frontend/src/components/timeline/thread-slot.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-slot.test.tsx
@@ -106,6 +106,74 @@ describe("ThreadSlot", () => {
     expect(lines.length).toBe(1)
   })
 
+  it("is visible for a draft with no thread yet, rendering the draft card at the draft panel url", () => {
+    renderSlot(
+      <ThreadSlot
+        activity={undefined}
+        replyCount={0}
+        threadHref={null}
+        summary={undefined}
+        workspaceId="ws_1"
+        draft={{ draftId: "draft_1", preview: "typed but unsent", attachmentCount: 0, isCheckedOut: true }}
+        draftHref="/panel/draft:stream_1:msg_1"
+      />
+    )
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/panel/draft:stream_1:msg_1")
+    expect(screen.getByText("Draft")).toBeInTheDocument()
+    expect(screen.getByText("typed but unsent")).toBeInTheDocument()
+  })
+
+  it("stays null for a draft with nowhere to point (no thread and no draft url)", () => {
+    const { container } = renderSlot(
+      <ThreadSlot
+        activity={undefined}
+        replyCount={0}
+        threadHref={null}
+        summary={undefined}
+        workspaceId="ws_1"
+        draft={{ draftId: "draft_1", preview: "typed but unsent", attachmentCount: 0, isCheckedOut: true }}
+        draftHref={null}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("keeps the same slot element (and no replayed grow-in) when the draft card becomes the reply card", () => {
+    const { container, rerender } = renderSlot(
+      <ThreadSlot
+        activity={undefined}
+        replyCount={0}
+        threadHref={null}
+        summary={undefined}
+        workspaceId="ws_1"
+        draft={{ draftId: "draft_1", preview: "typed but unsent", attachmentCount: 0, isCheckedOut: true }}
+        draftHref="/panel/draft:stream_1:msg_1"
+      />
+    )
+    const slotBeforeSend = container.firstChild
+    expect(slotBeforeSend).not.toBeNull()
+
+    // The send: the optimistic reply lands and the draft row is gone. Both sides
+    // of the swap live in the same grid cell, so the slot is never unmounted.
+    rerender(
+      <MemoryRouter>
+        <ThreadSlot
+          activity={undefined}
+          replyCount={1}
+          threadHref="/panel/thread_1"
+          summary={summary}
+          workspaceId="ws_1"
+          draft={null}
+          draftHref="/panel/draft:stream_1:msg_1"
+        />
+      </MemoryRouter>
+    )
+    expect(container.firstChild).toBe(slotBeforeSend)
+    expect(screen.getByText("1 reply")).toBeInTheDocument()
+    expect(screen.queryByText("Draft")).toBeNull()
+    expect(container.querySelector(".animate-thread-grow")).toBeNull()
+  })
+
   it("applies the grow-in animation only on the first visible→true transition", () => {
     // On initial mount with visible=true (replies already exist when we first
     // see the component, e.g. a Virtuoso scroll-in), the useEffect's wasRef

--- a/apps/frontend/src/components/timeline/thread-slot.tsx
+++ b/apps/frontend/src/components/timeline/thread-slot.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import type { ThreadSummary } from "@threa/types"
-import { getStepLabel, type MessageAgentActivity } from "@/hooks"
+import { getStepLabel, type MessageAgentActivity, type ScopeDraftPreview } from "@/hooks"
 import { useTrace } from "@/contexts"
 import { cn } from "@/lib/utils"
 import { ThreadCard } from "./thread-card"
@@ -12,6 +12,11 @@ interface ThreadSlotProps {
   threadHref: string | null
   summary?: ThreadSummary
   workspaceId: string
+  /** The viewer's unsent reply draft for this anchor (`useThreadDraft`). */
+  draft?: ScopeDraftPreview | null
+  /** Panel url for the not-yet-created thread (`useThreadAnchor().replyUrl`) —
+   *  where a draft-only card points until a real thread exists. */
+  draftHref?: string | null
 }
 
 /**
@@ -28,14 +33,31 @@ interface ThreadSlotProps {
  *      `grid-template-rows` transition — the line is absolute-positioned to
  *      the slot container, so it follows the container's growing height
  *
- * When nothing is thread-related (no activity, no replies), the slot returns
- * null. Otherwise the line is always present; the body swaps between a
+ * When nothing is thread-related (no activity, no replies, no draft), the slot
+ * returns null. Otherwise the line is always present; the body swaps between a
  * "thinking" line (italic text + persona) and the full ThreadCard body.
+ *
+ * A viewer's unsent draft reply keeps the slot visible before the thread stream
+ * exists, and the card it renders occupies the SAME grid cell as the reply card
+ * — so sending the draft is a content swap inside a mounted slot: the gold line
+ * persists and `visible` never flips, which is what stops the grow-in animation
+ * from replaying on the send.
  */
-export function ThreadSlot({ activity, replyCount, threadHref, summary, workspaceId }: ThreadSlotProps) {
+export function ThreadSlot({
+  activity,
+  replyCount,
+  threadHref,
+  summary,
+  workspaceId,
+  draft,
+  draftHref,
+}: ThreadSlotProps) {
   const hasActivity = !!activity
   const hasThread = replyCount > 0 && !!threadHref
-  const visible = hasActivity || hasThread
+  const cardHref = threadHref ?? draftHref ?? null
+  const hasDraft = !!draft && !!cardHref
+  const showCard = hasThread || hasDraft
+  const visible = hasActivity || showCard
 
   // Only play the grow-in animation for genuine post-mount transitions —
   // e.g. Ariadne starts thinking mid-session, or a reply lands while the
@@ -101,17 +123,18 @@ export function ThreadSlot({ activity, replyCount, threadHref, summary, workspac
       <div
         className="grid transition-[grid-template-rows] duration-[450ms] ease-out"
         style={{
-          gridTemplateRows: hasThread ? "0fr 1fr" : "1fr 0fr",
+          gridTemplateRows: showCard ? "0fr 1fr" : "1fr 0fr",
         }}
       >
-        <div className="overflow-hidden">{activity && !hasThread ? <ThinkingRow activity={activity} /> : null}</div>
+        <div className="overflow-hidden">{activity && !showCard ? <ThinkingRow activity={activity} /> : null}</div>
         <div className="overflow-hidden">
-          {hasThread && threadHref ? (
+          {showCard && cardHref ? (
             <ThreadCard
-              replyCount={replyCount}
-              href={threadHref}
+              replyCount={hasThread ? replyCount : 0}
+              href={cardHref}
               workspaceId={workspaceId}
               summary={summary}
+              draft={draft}
               isActive={hasActivity}
               ownsLeftLine={false}
             />

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -76,6 +76,7 @@ export {
 
 export {
   useScopeDraftPreview,
+  useThreadDraft,
   useBoardSubtopicDraftIndex,
   useBoardDraftPayloadScopes,
   useBoardScopeDraftIndex,

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -369,17 +369,38 @@ async function removeLoadedDraftLocally(
    * destroy whatever the pointer now holds (and mirror the delete everywhere).
    * The pointer-addressed callers ("whatever is loaded") pass nothing.
    */
-  expectedDraftId?: string | null
+  expectedDraftId?: string | null,
+  /**
+   * The row the caller holds, used when the scope's pointer is GONE — a
+   * promotion rescope (`rescopeScopeDrafts`) racing a resolve-on-send moves the
+   * row and its pointer to the real stream's scope before this reads them, and
+   * a pointer-only teardown then no-ops, leaving the just-sent draft alive
+   * under the new scope (rendered as a false "Draft" chip by the thread card,
+   * and rehydrated into the thread's composer). With the fallback the teardown
+   * follows the row by identity: the delete and mirror proceed, and every
+   * pointer in the workspace naming the row is cleared wherever the rescope
+   * parked it.
+   */
+  fallbackDraftId?: string | null
 ): Promise<void> {
   let removedId: string | null = null
+  const clearedScopes: string[] = []
   await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
-    const loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
+    let loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
     if (expectedDraftId && loadedId !== expectedDraftId) return
+    if (!loadedId && fallbackDraftId && (await db.drafts.get(fallbackDraftId))) loadedId = fallbackDraftId
     let version: number | undefined
     if (loadedId) {
       const row = await db.drafts.get(loadedId)
       version = row?.baseVersion
       await db.drafts.delete(loadedId)
+      const holders = await db.composerLoaded.where("workspaceId").equals(workspaceId).toArray()
+      for (const holder of holders) {
+        if (holder.draftId === loadedId && holder.scope !== scope) {
+          await db.composerLoaded.delete(holder.scope)
+          clearedScopes.push(holder.scope)
+        }
+      }
     }
     await db.composerLoaded.delete(scope)
     if (loadedId) await mirror(loadedId, version)
@@ -387,6 +408,10 @@ async function removeLoadedDraftLocally(
   })
   if (removedId) deleteDraftFromCache(workspaceId, removedId)
   setComposerLoadedInCache(workspaceId, scope, null)
+  for (const clearedScope of clearedScopes) {
+    clearStagedDraft(workspaceId, clearedScope)
+    setComposerLoadedInCache(workspaceId, clearedScope, null)
+  }
 }
 
 /**
@@ -472,7 +497,13 @@ async function removeDraftRowById(
  * CAS clear-on-send so a copy that drifted on another device survives as a stash
  * entry instead of being collaterally deleted (plan §resolve-on-send).
  */
-export async function resolveLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+export async function resolveLoadedDraft(
+  workspaceId: string,
+  scope: string,
+  /** The row whose content was sent — lets the teardown follow it if a
+   *  promotion rescope moved it (and its pointer) off `scope` mid-send. */
+  sentDraftId?: string | null
+): Promise<void> {
   // Drop the staging buffer first (synchronous) so the just-sent content can't be
   // recovered by a reload, nor re-staged by a debounced flush racing the teardown
   // — the same resurrection class the resolution guard below closes.
@@ -484,14 +515,20 @@ export async function resolveLoadedDraft(workspaceId: string, scope: string): Pr
   // that would route a racing save into the create path — so the save sees the
   // advanced seq and drops its create.
   recordScopeResolved(scope)
-  await removeLoadedDraftLocally(workspaceId, scope, async (loadedId, baseVersion) => {
-    // Remember this draft's (id, version) so an inbound echo of our own push, or a
-    // reconnect bootstrap that re-seeds the still-present server row before the
-    // resolve op drains, is dropped rather than resurrected as a stash entry. A
-    // strictly newer version from another device is NOT suppressed (no-loss).
-    markDraftResolved(loadedId, baseVersion ?? 0)
-    await syncDraftResolution(workspaceId, loadedId, baseVersion)
-  })
+  await removeLoadedDraftLocally(
+    workspaceId,
+    scope,
+    async (loadedId, baseVersion) => {
+      // Remember this draft's (id, version) so an inbound echo of our own push, or a
+      // reconnect bootstrap that re-seeds the still-present server row before the
+      // resolve op drains, is dropped rather than resurrected as a stash entry. A
+      // strictly newer version from another device is NOT suppressed (no-loss).
+      markDraftResolved(loadedId, baseVersion ?? 0)
+      await syncDraftResolution(workspaceId, loadedId, baseVersion)
+    },
+    undefined,
+    sentDraftId
+  )
 }
 
 /**
@@ -672,8 +709,10 @@ export async function restoreStashedDraftToComposer(
  * real stream and keep roaming instead of being discarded. The loaded pointer
  * follows its draft (via `migrateLocalDraftScope`). No-op when the scope is empty.
  *
- * The just-sent loaded draft is already resolved by the send path before promotion
- * runs, so in practice this carries the surviving stash entries.
+ * In practice this carries the surviving stash entries: the send path resolves
+ * the loaded draft concurrently, and its teardown is identity-addressed
+ * (`resolveLoadedDraft`'s `sentDraftId`), so a rescope that wins the race and
+ * moves the sent row here is still found and resolved under the new scope.
  */
 export async function rescopeScopeDrafts(workspaceId: string, fromScope: string, toScope: string): Promise<void> {
   const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, fromScope]).toArray()
@@ -1222,7 +1261,7 @@ export function useDraftMessage(
       debounceRef.current = null
     }
 
-    await resolveLoadedDraft(workspaceId, draftKey)
+    await resolveLoadedDraft(workspaceId, draftKey, contentDraftId.current)
     contentDraftId.current = null
     syncEngine?.kickOperationQueue()
   }, [draftKey, workspaceId, syncEngine, contentDraftId])

--- a/apps/frontend/src/hooks/use-queue-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { StreamTypes, type JSONContent } from "@threa/types"
+import { createDraftPanelId } from "@/contexts/panel-context"
 import * as dbModule from "@/db"
 import * as contextsModule from "@/contexts"
 import * as authModule from "@/auth"
@@ -160,6 +161,52 @@ describe("useQueueDraftMessage", () => {
       envelope: undefined,
       e2eVersion: undefined,
     })
+  })
+
+  it("bumps the anchor with an optimistic thread summary so the card keeps its preview row", async () => {
+    const replySpy = vi.spyOn(streamSyncModule, "optimisticReplyCountUpdate")
+
+    const { result } = setup()
+    let clientId = ""
+    await act(async () => {
+      const queued = await result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        { workspaceId: WORKSPACE_ID, streamId: PANEL_ID, streamCreation: threadCreation, draftId: PANEL_ID }
+      )
+      clientId = queued.clientId
+    })
+
+    expect(replySpy).toHaveBeenCalledWith(
+      threadCreation.parentStreamId,
+      threadCreation.parentMessageId,
+      createDraftPanelId(threadCreation.parentStreamId, threadCreation.parentMessageId),
+      {
+        lastReplyAt: expect.any(String),
+        participants: [{ id: USER_ID, type: "user" }],
+        latestReply: { messageId: clientId, actorId: USER_ID, actorType: "user", contentMarkdown: "hi" },
+      }
+    )
+  })
+
+  it("leaves the optimistic summary's preview text empty for a sealed reply", async () => {
+    mockUnlockedSession()
+    const replySpy = vi.spyOn(streamSyncModule, "optimisticReplyCountUpdate")
+
+    const { result } = setup()
+    await act(async () => {
+      await result.current.queueDraftMessage(
+        { contentJson: CONTENT },
+        {
+          workspaceId: WORKSPACE_ID,
+          streamId: PANEL_ID,
+          streamCreation: threadCreation,
+          draftId: PANEL_ID,
+          e2e: { rootStreamId: ROOT_STREAM_ID, hasActors: false },
+        }
+      )
+    })
+
+    expect(replySpy.mock.calls[0][3]?.latestReply.contentMarkdown).toBe("")
   })
 
   it("refuses to queue an encrypted draft when the session is locked", async () => {

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -264,7 +264,19 @@ export function useQueueDraftMessage(workspaceId: string) {
       const anchorId = params.streamCreation?.parentAnchorId ?? params.streamCreation?.parentMessageId
       if (params.streamCreation?.type === StreamTypes.THREAD && params.streamCreation.parentStreamId && anchorId) {
         const draftPanelId = createDraftPanelId(params.streamCreation.parentStreamId, anchorId)
-        await optimisticReplyCountUpdate(params.streamCreation.parentStreamId, anchorId, draftPanelId).catch(() => {})
+        await optimisticReplyCountUpdate(params.streamCreation.parentStreamId, anchorId, draftPanelId, {
+          lastReplyAt: now,
+          participants: [{ id: currentUserId, type: "user" }],
+          latestReply: {
+            messageId: clientId,
+            actorId: currentUserId,
+            actorType: "user",
+            // A sealed reply's server summary carries the empty placeholder
+            // markdown (the card has no decrypt path), so anything else here
+            // would render and then blank out on heal.
+            contentMarkdown: e2eFields ? "" : contentMarkdown,
+          },
+        }).catch(() => {})
       }
 
       notifyQueue()

--- a/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.test.ts
@@ -4,6 +4,7 @@ import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
 import {
   useScopeDraftPreview,
+  useThreadDraft,
   useBoardDraftPayloadScopes,
   useBoardScopeDraftIndex,
   useBoardSubtopicDraftIndex,
@@ -88,6 +89,112 @@ describe("useScopeDraftPreview", () => {
 
   it("throws on a non-board scope — the shared snapshot only covers board:* rows", () => {
     expect(() => renderHook(() => useScopeDraftPreview(workspaceId, "stream:stream_1"))).toThrow(/board draft scopes/)
+  })
+})
+
+describe("useThreadDraft", () => {
+  const anchorId = "msg_anchor"
+  const threadScope = `thread:${anchorId}`
+
+  it("advertises the anchor-keyed draft before the thread stream exists", async () => {
+    await seed("draft_thread", threadScope, "reply in progress", 1000)
+    await db.composerLoaded.put({ scope: threadScope, workspaceId, draftId: "draft_thread" })
+
+    const { result } = renderHook(() => useThreadDraft(workspaceId, anchorId))
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        draftId: "draft_thread",
+        preview: "reply in progress",
+        attachmentCount: 0,
+        isCheckedOut: true,
+      })
+    )
+  })
+
+  it("never reads null across the promotion rescope, then serves the row from the stream key", async () => {
+    await seed("draft_thread", threadScope, "reply in progress", 1000)
+    const threadId = "stream_thread"
+
+    const seen: (ReturnType<typeof useThreadDraft> | null)[] = []
+    const { result } = renderHook(() => {
+      const draft = useThreadDraft(workspaceId, anchorId, threadId)
+      seen.push(draft)
+      return draft
+    })
+    await waitFor(() => expect(result.current?.draftId).toBe("draft_thread"))
+
+    // The promotion rescope, exactly as `rescopeScopeDrafts` does it: one
+    // transaction, so no emission can observe the row under neither key.
+    seen.length = 0
+    await db.transaction("rw", db.drafts, async () => {
+      const row = await db.drafts.get("draft_thread")
+      await db.drafts.put({ ...row!, scope: `stream:${threadId}`, clientUpdatedAt: 2000 })
+    })
+    await waitFor(async () => expect((await db.drafts.get("draft_thread"))?.scope).toBe(`stream:${threadId}`))
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0))
+    expect(seen.filter((entry) => entry === null)).toEqual([])
+    expect(result.current?.draftId).toBe("draft_thread")
+
+    // Proof the read now comes through the stream key: without the thread id
+    // there is no anchor-keyed row left to find.
+    const anchorOnly = renderHook(() => useThreadDraft(workspaceId, anchorId))
+    expect(anchorOnly.result.current).toBeNull()
+  })
+
+  it("prefers the promoted stream scope over a stale anchor-keyed sibling", async () => {
+    const threadId = "stream_thread"
+    await seed("draft_stale_anchor", threadScope, "composed before promotion", 3000)
+    await seed("draft_promoted", `stream:${threadId}`, "the live reply", 1000)
+
+    const { result } = renderHook(() => useThreadDraft(workspaceId, anchorId, threadId))
+    await waitFor(() => expect(result.current).toMatchObject({ draftId: "draft_promoted", preview: "the live reply" }))
+  })
+
+  it("hides a stashed thread draft, and shows it again once it is checked out", async () => {
+    await db.drafts.add({
+      id: "draft_stashed",
+      workspaceId,
+      scope: threadScope,
+      contentJson: doc("put away"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+      stashedAt: 1500,
+    })
+    // Control on the same snapshot: a live thread draft on another anchor still
+    // advertises, so the null below is the stash flag's doing.
+    await seed("draft_live", "thread:msg_other", "live", 1000)
+
+    const { result } = renderHook(() => useThreadDraft(workspaceId, anchorId))
+    const control = renderHook(() => useThreadDraft(workspaceId, "msg_other"))
+    await waitFor(() => expect(control.result.current?.draftId).toBe("draft_live"))
+    expect(result.current).toBeNull()
+
+    await db.composerLoaded.put({ scope: threadScope, workspaceId, draftId: "draft_stashed" })
+    await waitFor(() => expect(result.current).toMatchObject({ draftId: "draft_stashed", isCheckedOut: true }))
+  })
+
+  it("stays null for a row with no payload, and drops the indicator when the draft is deleted", async () => {
+    await seed("draft_empty", threadScope, "", 1000)
+    await db.composerLoaded.put({ scope: threadScope, workspaceId, draftId: "draft_empty" })
+
+    const { result } = renderHook(() => useThreadDraft(workspaceId, anchorId))
+    const ready = renderHook(() => useBoardDraftsReady(workspaceId))
+    await waitFor(() => expect(ready.result.current).toBe(true))
+    expect(result.current).toBeNull()
+
+    await db.drafts.put({
+      id: "draft_empty",
+      workspaceId,
+      scope: threadScope,
+      contentJson: doc("now it has a body"),
+      attachments: [],
+      clientUpdatedAt: 2000,
+    })
+    await waitFor(() => expect(result.current?.preview).toBe("now it has a body"))
+
+    // `draft:deleted` (or a resolve-on-send) removes the row — indicator gone.
+    await db.drafts.delete("draft_empty")
+    await waitFor(() => expect(result.current).toBeNull())
   })
 })
 

--- a/apps/frontend/src/hooks/use-scope-draft-preview.ts
+++ b/apps/frontend/src/hooks/use-scope-draft-preview.ts
@@ -59,6 +59,9 @@ function bestRow(rows: CachedDraft[], loadedDraftId: string | null): CachedDraft
   return advertisable.reduce((a, b) => (b.clientUpdatedAt > a.clientUpdatedAt ? b : a))
 }
 
+const THREAD_DRAFT_SCOPE_PREFIX = "thread:"
+const STREAM_DRAFT_SCOPE_PREFIX = "stream:"
+
 interface BoardDraftsSnapshot {
   previewByScope: Map<string, ScopeDraftPreview>
   subtopicByMessageId: Map<string, SubtopicDraftEntry>
@@ -73,6 +76,13 @@ interface BoardDraftsSnapshot {
    * unreachable from the very view named after drafts.
    */
   payloadScopes: Set<string>
+  /** `thread:{anchorId}` drafts keyed by anchor — the reply a timeline item
+   *  carries before its thread stream exists. */
+  threadDraftByAnchorId: Map<string, ScopeDraftPreview>
+  /** `stream:{streamId}` drafts keyed by stream — where a thread reply's scope
+   *  lands after promotion (and, harmlessly, every channel/scratchpad draft;
+   *  lookups are by thread stream id). */
+  threadDraftByStreamId: Map<string, ScopeDraftPreview>
 }
 
 const EMPTY_SNAPSHOT: BoardDraftsSnapshot = {
@@ -80,6 +90,8 @@ const EMPTY_SNAPSHOT: BoardDraftsSnapshot = {
   subtopicByMessageId: new Map(),
   checkedOutScopes: new Set(),
   payloadScopes: new Set(),
+  threadDraftByAnchorId: new Map(),
+  threadDraftByStreamId: new Map(),
 }
 
 interface BoardDraftsEntry {
@@ -103,11 +115,21 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
   const subtopicByMessageId = new Map<string, SubtopicDraftEntry>()
   const checkedOutScopes = new Set<string>()
   const payloadScopes = new Set<string>()
+  const threadDraftByAnchorId = new Map<string, ScopeDraftPreview>()
+  const threadDraftByStreamId = new Map<string, ScopeDraftPreview>()
   for (const [scope, scopeRows] of byScope) {
     const loadedDraftId = loadedByScope.get(scope) ?? null
+    const best = bestRow(scopeRows, loadedDraftId)
+    if (!scope.startsWith(BOARD_DRAFT_SCOPE_PREFIX)) {
+      if (best && scope.startsWith(THREAD_DRAFT_SCOPE_PREFIX)) {
+        threadDraftByAnchorId.set(scope.slice(THREAD_DRAFT_SCOPE_PREFIX.length), toPreview(best, loadedDraftId))
+      } else if (best && scope.startsWith(STREAM_DRAFT_SCOPE_PREFIX)) {
+        threadDraftByStreamId.set(scope.slice(STREAM_DRAFT_SCOPE_PREFIX.length), toPreview(best, loadedDraftId))
+      }
+      continue
+    }
     if (loadedDraftId !== null && scopeRows.some((row) => row.id === loadedDraftId)) checkedOutScopes.add(scope)
     if (scopeRows.some(hasPayload)) payloadScopes.add(scope)
-    const best = bestRow(scopeRows, loadedDraftId)
     if (best) previewByScope.set(scope, toPreview(best, loadedDraftId))
     const parsed = parseBoardDraftKey(scope)
     if (parsed?.kind === "subtopic") {
@@ -130,12 +152,23 @@ function buildSnapshot(rows: CachedDraft[], loadedByScope: Map<string, string | 
       }
     }
   }
-  return { previewByScope, subtopicByMessageId, checkedOutScopes, payloadScopes }
+  return {
+    previewByScope,
+    subtopicByMessageId,
+    checkedOutScopes,
+    payloadScopes,
+    threadDraftByAnchorId,
+    threadDraftByStreamId,
+  }
 }
 
-// INV-9 exception: one shared board-drafts liveQuery per workspace, ref-counted
+// INV-9 exception: one shared drafts liveQuery per workspace, ref-counted
 // across every resting affordance that advertises a draft (card reply buttons,
-// branch-tail pills, sub-topic indicators). Per-affordance queries can never
+// branch-tail pills, sub-topic indicators, in-stream thread cards). Drafts per
+// user are few, so the query covers the whole workspace rather than one range
+// per scope family — a thread draft is looked up under two keys at once
+// (`thread:{anchor}` and `stream:{threadId}`), which only one snapshot can
+// answer without a gap at promotion. Per-affordance queries can never
 // have data at first paint — Dexie's first emission is always post-mount — so
 // the pills popped in a frame after the board revealed, shifting layout. The
 // registry resolves ONCE per workspace, the board's reveal gate waits on it
@@ -161,10 +194,7 @@ function subscribeBoardDrafts(workspaceId: string, listener: () => void): () => 
       // than bulkGet on the scopes with rows, so a pointer-only change (a stash
       // detaching the loaded pointer) re-fires the query too.
       const [rows, pointers] = await Promise.all([
-        db.drafts
-          .where("[workspaceId+scope]")
-          .between([workspaceId, BOARD_DRAFT_SCOPE_PREFIX], [workspaceId, BOARD_DRAFT_SCOPE_PREFIX + "\uffff"])
-          .toArray(),
+        db.drafts.where("workspaceId").equals(workspaceId).toArray(),
         db.composerLoaded.where("workspaceId").equals(workspaceId).toArray(),
       ])
       return { rows, pointers }
@@ -203,8 +233,9 @@ function useBoardDraftsSubscription(workspaceId: string) {
  * so an affordance mounting after the board's reveal has its pill in its very
  * first frame. Null when the scope holds nothing worth showing.
  *
- * Board scopes only (`board:*`) — the registry's query is bounded to that
- * prefix, so any other scope would silently read null (INV-11: fail loudly).
+ * Board scopes only (`board:*`) — `previewByScope` is built from that prefix
+ * alone, so any other scope would silently read null (INV-11: fail loudly).
+ * A thread reply draft reads through {@link useThreadDraft} instead.
  */
 export function useScopeDraftPreview(workspaceId: string, scope: string): ScopeDraftPreview | null {
   if (!scope.startsWith(BOARD_DRAFT_SCOPE_PREFIX)) {
@@ -215,6 +246,34 @@ export function useScopeDraftPreview(workspaceId: string, scope: string): ScopeD
     () => boardDraftsRegistry.get(workspaceId)?.snapshot.previewByScope.get(scope) ?? null,
     [workspaceId, scope]
   )
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/**
+ * The viewer's unsent reply draft for a timeline anchor — what the in-stream
+ * thread card indicates. A thread reply draft lives under `thread:{anchorId}`
+ * until the thread stream exists and under `stream:{threadId}` after promotion
+ * re-scopes it; both keys are read off the SAME snapshot, so the atomic rescope
+ * can never show a frame where neither holds the row. The stream key wins — it
+ * is the post-promotion truth, and a stale anchor-keyed sibling (a stash
+ * composed before promotion) must not outrank it.
+ *
+ * Advertise semantics are the board's ({@link useScopeDraftPreview}): payload
+ * rows only, stashed rows hidden unless checked out into this device's composer.
+ * Null when there is nothing to indicate.
+ */
+export function useThreadDraft(
+  workspaceId: string,
+  anchorId: string,
+  threadId?: string | null
+): ScopeDraftPreview | null {
+  const subscribe = useBoardDraftsSubscription(workspaceId)
+  const getSnapshot = useCallback(() => {
+    const snapshot = boardDraftsRegistry.get(workspaceId)?.snapshot
+    if (!snapshot) return null
+    const byStream = threadId ? snapshot.threadDraftByStreamId.get(threadId) : undefined
+    return byStream ?? snapshot.threadDraftByAnchorId.get(anchorId) ?? null
+  }, [workspaceId, anchorId, threadId])
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -7,6 +7,7 @@ import {
   detectSequenceGap,
   getLatestPersistedSequence,
   getPersistedTail,
+  optimisticReplyCountUpdate,
   preserveBakedInAppData,
   registerStreamSocketHandlers,
   toCachedStreamBootstrap,
@@ -31,6 +32,7 @@ import type {
   StreamBootstrap,
   StreamEvent,
   StreamMember,
+  ThreadSummary,
   WorkspaceBootstrap,
 } from "@threa/types"
 
@@ -1530,6 +1532,117 @@ describe("updateMessageEvent — indexed payload.messageId lookup", () => {
       { messageId: "msg_heal", threadId: "thread_healed" },
       { memoId: "memo_1", threadId: "thread_card" },
     ])
+  })
+})
+
+describe("optimisticReplyCountUpdate", () => {
+  const streamId = "stream_optimistic"
+
+  function seedAnchor(id: string, payload: Record<string, unknown>) {
+    return db.events.put({
+      ...makeEvent({ id, streamId, sequence: "1", payload }),
+      workspaceId: "ws_1",
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    } as CachedEvent)
+  }
+
+  const summary: ThreadSummary = {
+    lastReplyAt: "2026-08-11T10:00:00.000Z",
+    participants: [{ id: "user_me", type: "user" }],
+    latestReply: { messageId: "msg_mine", actorId: "user_me", actorType: "user", contentMarkdown: "my reply" },
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("writes the summary alongside the count so the card keeps its preview row", async () => {
+    await seedAnchor("evt_first", { messageId: "msg_anchor", replyCount: 0 })
+
+    await optimisticReplyCountUpdate(streamId, "msg_anchor", "draft_panel", summary)
+
+    const row = await db.events.get("evt_first")
+    expect(row?.payload).toEqual({
+      messageId: "msg_anchor",
+      threadId: "draft_panel",
+      replyCount: 1,
+      threadSummary: summary,
+    })
+  })
+
+  it("appends the sender to an existing summary's participants and replaces latestReply", async () => {
+    const existing: ThreadSummary = {
+      lastReplyAt: "2026-08-11T09:00:00.000Z",
+      participants: [{ id: "user_other", type: "user" }],
+      latestReply: {
+        messageId: "msg_theirs",
+        actorId: "user_other",
+        actorType: "user",
+        contentMarkdown: "their reply",
+      },
+    }
+    await seedAnchor("evt_merge", { messageId: "msg_anchor", replyCount: 1, threadSummary: existing })
+
+    await optimisticReplyCountUpdate(streamId, "msg_anchor", "draft_panel", summary)
+
+    const row = await db.events.get("evt_merge")
+    expect(row?.payload).toEqual({
+      messageId: "msg_anchor",
+      threadId: "draft_panel",
+      replyCount: 2,
+      threadSummary: {
+        lastReplyAt: summary.lastReplyAt,
+        participants: [{ id: "user_other", type: "user" }, ...summary.participants],
+        latestReply: summary.latestReply,
+      },
+    })
+  })
+
+  it("keeps an already-present sender once, and never grows participants past the server's cap of 3", async () => {
+    const alreadyIn: ThreadSummary["participants"] = [
+      { id: "user_a", type: "user" },
+      { id: "user_me", type: "user" },
+    ]
+    const full: ThreadSummary["participants"] = [
+      { id: "user_a", type: "user" },
+      { id: "persona_b", type: "persona" },
+      { id: "bot_c", type: "bot" },
+    ]
+    const latestReply = { messageId: "msg_a", actorId: "user_a", actorType: "user" as const, contentMarkdown: "a" }
+    await seedAnchor("evt_dedupe", {
+      messageId: "msg_dedupe",
+      replyCount: 4,
+      threadSummary: { lastReplyAt: "2026-08-11T09:00:00.000Z", participants: alreadyIn, latestReply },
+    })
+    await seedAnchor("evt_capped", {
+      messageId: "msg_capped",
+      replyCount: 9,
+      threadSummary: { lastReplyAt: "2026-08-11T09:00:00.000Z", participants: full, latestReply },
+    })
+
+    await optimisticReplyCountUpdate(streamId, "msg_dedupe", "draft_panel", summary)
+    await optimisticReplyCountUpdate(streamId, "msg_capped", "draft_panel", summary)
+
+    const rows = await db.events.bulkGet(["evt_dedupe", "evt_capped"])
+    expect(rows.map((row) => (row?.payload as { threadSummary: ThreadSummary }).threadSummary.participants)).toEqual([
+      alreadyIn,
+      full,
+    ])
+  })
+
+  it("leaves the payload's summary untouched when no summary is passed", async () => {
+    await seedAnchor("evt_nosummary", { messageId: "msg_anchor", replyCount: 2, contentMarkdown: "parent" })
+
+    await optimisticReplyCountUpdate(streamId, "msg_anchor", "draft_panel")
+
+    const row = await db.events.get("evt_nosummary")
+    expect(row?.payload).toEqual({
+      messageId: "msg_anchor",
+      contentMarkdown: "parent",
+      threadId: "draft_panel",
+      replyCount: 3,
+    })
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -983,6 +983,21 @@ export async function updateEventByAnchor(
     })
 }
 
+/** Server caps thread participants at 3, ordered by first reply. */
+const THREAD_SUMMARY_PARTICIPANT_LIMIT = 3
+
+function mergeThreadSummary(existing: ThreadSummary | undefined, next: ThreadSummary): ThreadSummary {
+  if (!existing) return next
+  const actor = next.latestReply
+  const participants = existing.participants.some((p) => p.id === actor.actorId)
+    ? existing.participants
+    : [...existing.participants, { id: actor.actorId, type: actor.actorType }].slice(
+        0,
+        THREAD_SUMMARY_PARTICIPANT_LIMIT
+      )
+  return { lastReplyAt: next.lastReplyAt, participants, latestReply: actor }
+}
+
 /**
  * Optimistically update an anchor item's replyCount and threadId in IDB.
  *
@@ -991,16 +1006,24 @@ export async function updateEventByAnchor(
  * thread:updated may miss this event because the panel navigated away
  * from the parent stream (handlers were cleaned up on unmount). Keyed by the
  * anchor's canonical id so event-anchored (card) threads bump too.
+ *
+ * `summary` exists because count-only is a visible height snap: the thread card
+ * renders a preview row only when it has a `threadSummary`, so a send collapses
+ * the card to a single summary-less row until `thread:updated` heals it ~400ms
+ * later and the row grows back. Passing the sender's own reply as the summary
+ * makes the heal a visually identical no-op.
  */
 export async function optimisticReplyCountUpdate(
   parentStreamId: string,
   anchorId: string,
-  threadId: string
+  threadId: string,
+  summary?: ThreadSummary
 ): Promise<void> {
   await updateEventByAnchor(parentStreamId, anchorId, (p) => ({
     ...p,
     threadId,
     replyCount: ((p.replyCount as number) ?? 0) + 1,
+    ...(summary ? { threadSummary: mergeThreadSummary(p.threadSummary as ThreadSummary | undefined, summary) } : {}),
   }))
 }
 


### PR DESCRIPTION
## Problem

An unsent thread reply draft is invisible in-stream. `ThreadSlot`/`ThreadCard` render nothing at `replyCount === 0`, so a reply composed but not sent (thread creation is lazy — the stream exists only after the first sent reply) leaves no trace under the parent message, and a thread with replies gives no hint that you left one half-written. Drafts already sync per-user into Dexie; nothing read them on this surface. Slack-style expectation, mockup approved by Kris: https://seer.build/ws_vbyzjvdg6g/b/thread-drafts-in-stream-561d12/

## Solution

Frontend-only: the in-stream thread card reads the viewer's draft off the existing drafts registry, in both thread lifecycles and across the transition.

- **One snapshot, two keys.** The per-workspace ref-counted liveQuery in `use-scope-draft-preview.ts` widens from the `board:*` range to all workspace drafts and derives `threadDraftByAnchorId` (`thread:{anchorId}`, pre-creation) and `threadDraftByStreamId` (`stream:{id}`, post-promotion). New `useThreadDraft(workspaceId, anchorId, threadId?)` reads stream-key first, anchor-key second from the same snapshot — the promotion rescope (`rescopeScopeDrafts`, one Dexie transaction) can never emit a frame where neither key holds the row. Widening the existing registry over a second per-prefix registry: two registries can't answer both keys from one emission, which is exactly the promotion gap.
- **Advertise semantics reused verbatim** (`bestRow`/`hasPayload`/`toPreview`): payload rows only, stashed hidden unless checked out. Board maps stay gated on the `board:` prefix — board hooks behaviorally unchanged.
- **`ThreadCard`**: guard becomes `replyCount === 0 && !draft`. Draft-only variant renders pencil + gold "Draft" + italic one-line preview (snippet dropped when empty — sealed/attachment-only bodies), href = draft reply panel. With replies, a muted italic `· ✏ Draft` token lands after the timestamp; the latest-reply row is untouched.
- **`ThreadSlot`**: `visible` now includes the draft; the draft card occupies the same grid cell as the reply card, so a send is a content swap inside a mounted slot — gold line persists, `animate-thread-grow` can't replay.
- **Optimistic thread summary** (`ef0ff367`, after testing on staging): `optimisticReplyCountUpdate` previously wrote only `replyCount`+`threadId`, so a sent draft collapsed the card to a summary-less single row until the server's `thread:updated` healed it ~400ms later — a visible 2→1→2-row height snap (diagnosed frame-by-frame from a staging recording). The draft send now passes the sender's own reply as an optimistic `ThreadSummary` (merged into any existing summary, participants capped at 3 like the server; empty preview for sealed sends since the card has no decrypt path), so the card swaps draft→final layout in one step and the heal is visually a no-op.
- **Send-order fix** (`stream-panel.tsx`): `composer.resolveDraft()` moved after `await queueDraftMessage(...)`. Before, the draft row died before `optimisticReplyCountUpdate` wrote the reply — one frame with neither collapses the slot and replays the grow-in. `resolveLoadedDraft` is order-independent (CAS by draft id/scope seq, no read of the queue); a queue failure now also leaves the draft alive alongside the restored composer body.

Deliberate scope: someone else's drafts never show (drafts are private; viewer-local indicator). One indicator per thread regardless of stash siblings (newest advertised, like the board). Accepted tradeoffs: any draft write now re-fires the shared registry (board surfaces re-render on non-board draft saves; bounded by the 500ms save debounce and small per-user draft counts), and with agent activity + a draft + no thread the draft card takes the slot over the `ThinkingRow` (the pulsing activity dot still shows via `isActive`).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-scope-draft-preview.ts` | Registry widened to all workspace drafts; thread lookup maps; `useThreadDraft` |
| `apps/frontend/src/components/timeline/thread-card.tsx` | `draft` prop: draft-only variant + draft token |
| `apps/frontend/src/components/timeline/thread-slot.tsx` | `draft`/`draftHref` props; draft keeps slot visible in the card's grid cell |
| `apps/frontend/src/components/timeline/message-event.tsx`, `call-card.tsx`, `delegation-event.tsx` | Wire `useThreadDraft` + `draftHref={replyUrl}` into the slot |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Resolve draft after the queue write, awaited in its own try/catch (resolve failure ≠ send failure) |
| `apps/frontend/src/sync/stream-sync.ts`, `stream-sync.test.ts` | `optimisticReplyCountUpdate` accepts an optional `ThreadSummary`; merge helper + tests |
| `apps/frontend/src/hooks/use-queue-draft-message.ts`, `.test.ts` | Draft send passes the optimistic summary (empty preview when sealed) |
| `apps/frontend/src/components/timeline/thread-slot.draft-send.test.tsx` | **new** — real Dexie + real resolve; wrong-order control proves the no-flicker assertion bites |
| `apps/frontend/src/components/timeline/thread-card.test.tsx`, `thread-slot.test.tsx`, `apps/frontend/src/hooks/use-scope-draft-preview.test.ts` | Draft variants, slot identity across send, promotion-rescope no-null-frame, stash/empty/delete semantics |

## Test plan

- [x] Full frontend suite — 6538 pass, 0 fail (run twice per commit: implementer + independent re-run at review)
- [x] `tsc --noEmit` + `eslint src/` clean; full monorepo pre-commit gate (all-apps lint + typecheck + api-docs check) passed on commit
- [x] Promotion seamlessness asserted (recorded every hook emission across the rescope; zero nulls) and send-transition slot identity asserted with a wrong-order control test
- [ ] Full `StreamPanel` send-flow integration test — no existing harness mounts `StreamPanel` (needs panel/socket/pending-message contexts + live tiptap); `thread-slot.draft-send.test.tsx` drives the real draft write/resolve + real registry + real slot instead, with the queue's contribution (`replyCount`/`threadHref`) as props, matching how they reach the slot in production

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Show the viewer's unsent thread reply draft in the in-stream thread visualizer (`ThreadSlot`/`ThreadCard`) — before the thread stream exists, after it exists, seamlessly across the draft→thread promotion, and disappearing on send/empty/delete from any device. Frontend-only.

## What Was Built

### Drafts registry: thread lookup maps (`apps/frontend/src/hooks/use-scope-draft-preview.ts`)

The per-workspace ref-counted Dexie liveQuery (previously bounded to `board:*` scopes) now reads all workspace drafts plus composer pointers. `buildSnapshot` gates the four board structures on the `board:` prefix (board semantics unchanged) and additionally derives:

- `threadDraftByAnchorId` — from `thread:{anchorId}` scopes (reply drafts before the thread stream exists)
- `threadDraftByStreamId` — from `stream:{id}` scopes (where promotion re-scopes a thread draft; also harmlessly holds channel/scratchpad drafts, never looked up)

`useThreadDraft(workspaceId, anchorId, threadId?)` reads stream-key first, anchor-key second, off the same snapshot via `useSyncExternalStore`. Advertise semantics reuse `bestRow`/`hasPayload`/`toPreview` verbatim: payload rows only, stashed rows hidden unless checked out into this device's composer.

### `ThreadCard` (`apps/frontend/src/components/timeline/thread-card.tsx`)

New `draft?: ThreadCardDraft | null` prop. Null-guard is `replyCount === 0 && !draft`. Draft-only variant (replyCount 0): pencil + gold "Draft" label + italic truncated preview row (dropped when preview is empty — sealed/attachment-only bodies); `href` is the draft reply panel. With replies: muted italic `· ✏ Draft` token (`aria-label="Unsent draft"`) appended after the timestamp; latest-reply row untouched.

### `ThreadSlot` (`apps/frontend/src/components/timeline/thread-slot.tsx`)

New `draft`/`draftHref` props. `cardHref = threadHref ?? draftHref`; `visible` includes the draft state. The draft-only card renders in the same grid cell as the reply card, so a send is a content swap inside a mounted slot — the gold left-line persists and the `animate-thread-grow` ref-gating never sees `visible` flip.

### Call sites

`message-event.tsx`, `call-card.tsx`, `delegation-event.tsx`: take `effectiveThreadId` from the existing `useThreadAnchor`, call `useThreadDraft`, pass `draft` + `draftHref={replyUrl}`. Thread-parent suppression unchanged.

### Send-ordering fix (`apps/frontend/src/components/thread/stream-panel.tsx`)

`composer.resolveDraft()` moved from before to after `await queueDraftMessage(...)` in the draft-thread submit handler. `queueDraftMessage` ends with `optimisticReplyCountUpdate` (anchor gets `threadId` + `replyCount 1`), so the reply is durable before the draft row disappears — no frame with neither, which previously collapsed the slot and replayed its grow-in. `resolveLoadedDraft` is order-independent: CAS by draft id / scope seq, no dependency on the queue. Bonus: a queue failure now leaves the draft row alive alongside the restored composer body.

## Design Decisions

### Widen the existing registry, not a second one
**Chose:** one workspace-wide liveQuery serving board + thread surfaces.
**Why:** a thread draft must be looked up under two keys at once (`thread:{anchor}` and `stream:{threadId}`); only one snapshot can answer both without a gap at the promotion rescope. Two registries emit independently.
**Cost accepted:** any draft write re-fires the shared query (board surfaces re-render on non-board saves; bounded by the 500ms save debounce and small per-user draft counts).

### Advertise semantics = the board's
Stashed drafts hidden (advertising one would un-do the stash / open an empty composer on tap), empty drafts hidden, checked-out wins over the stash flag. One indicator per thread regardless of stash siblings (newest advertised) — no "N drafts" plural.

### Reorder over sticky-ref
For the send flicker, reordering the real cause (resolve after queue) beat masking it with a one-frame sticky draft ref in the slot. A control test asserts the wrong order does flicker, proving the assertion mechanism.

### Styling
Gold "Draft" label when it is the row's primary affordance (draft-only); muted italic token when secondary to "N replies". Per the approved mockup; defaults chosen after Kris approved without overriding the open questions.

## What's NOT Included

- No backend changes — drafts are private per-user; the indicator is viewer-local by construction.
- No changes to the drafts explorer, sidebar pencil (`DraftIndicator`), or board indicators.
- No full `StreamPanel` send-flow integration test — no existing harness mounts `StreamPanel` (panel/socket/pending-message contexts + live tiptap). `thread-slot.draft-send.test.tsx` covers the real draft write + real `resolveLoadedDraft` + real registry + real slot, with the queue's contribution (`replyCount`/`threadHref`) driven as props (matching how they reach the slot in production), plus the wrong-order control.
- Known ceded edge: agent activity + draft + no thread shows the draft card instead of the `ThinkingRow` (activity still signaled via the card's pulsing `isActive` dot).

## Status

- [x] Registry widening + `useThreadDraft`
- [x] `ThreadCard`/`ThreadSlot` draft states
- [x] Three call sites wired
- [x] Send reorder
- [x] Tests: 6538 frontend tests pass; typecheck + lint clean
- [x] Staging-recording follow-up: optimistic thread summary so the draft→thread conversion holds its two-row height (`ef0ff367`)

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_012aj7WuDHYg9LxRha2KHp1C

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789029407&installation_model_id=20758&pr_number=1856&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1856&signature=127b48f00f880bd9712492369e78a07675254e5ba4fa5d462801fce845e5ba3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

