### PR TITLE
feat: stack unread above read in the activity feed

### DIFF
--- a/apps/frontend/src/components/activity/activity-content.tsx
+++ b/apps/frontend/src/components/activity/activity-content.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react"
 import { cn } from "@/lib/utils"
 import { RelativeTime } from "@/components/relative-time"
 import { stripMarkdownToInline } from "@/lib/markdown"
@@ -28,8 +29,6 @@ const DEFAULT_DISPLAY: ActivityDisplay = ACTIVITY_DISPLAY.message
 interface ActivityPreviewProps {
   contentPreview: string
   toEmoji?: (shortcode: string) => string | null
-  /** Reaction glyph rendered ahead of the text (e.g. 👍). */
-  emoji?: string | null
   /** Unread rows render the content at full strength; read rows are dimmed. */
   isUnread?: boolean
 }
@@ -39,17 +38,23 @@ interface ActivityPreviewProps {
  * notification, so it carries the visual weight (body size, foreground colour)
  * while the actor/verb/stream line above it stays a muted caption. Strips
  * markdown, collapses newlines, optionally resolves emoji shortcodes, and
- * clamps to two lines.
+ * clamps to three lines.
  */
-export function ActivityPreview({ contentPreview, toEmoji, emoji, isUnread }: ActivityPreviewProps) {
+export function ActivityPreview({ contentPreview, toEmoji, isUnread }: ActivityPreviewProps) {
   const previewText = stripMarkdownToInline(contentPreview, toEmoji)
-  if (!previewText && !emoji) return null
+  if (!previewText) return null
   return (
     <p className={cn("mt-1 text-sm leading-snug line-clamp-3", isUnread ? "text-foreground" : "text-foreground/80")}>
-      {emoji && <span className="mr-1 align-middle">{emoji}</span>}
       {previewText}
     </p>
   )
+}
+
+/** Solid while unread, a hollow ring once read this visit, invisible otherwise. */
+function dotStyle(urgencyColor: string, isUnread: boolean, wasReadThisVisit: boolean): CSSProperties | undefined {
+  if (isUnread) return { backgroundColor: urgencyColor }
+  if (wasReadThisVisit) return { boxShadow: `inset 0 0 0 1px ${urgencyColor}`, opacity: 0.5 }
+  return undefined
 }
 
 interface ActivityContentProps {
@@ -57,11 +62,11 @@ interface ActivityContentProps {
   streamName: string
   activityType: string
   contentPreview: string
-  /** Emoji character for reaction activities; null for other types. */
-  emoji?: string | null
   /** Resolver for :shortcode: emoji inside the content preview. */
   toEmoji?: (shortcode: string) => string | null
   createdAt: string
+  /** The row's `URGENCY_COLORS` entry — what the unread dot is painted with. */
+  urgencyColor: string
   isUnread: boolean
   /** Held in the Unread section but already read — see `ActivityItem`. */
   wasReadThisVisit?: boolean
@@ -73,9 +78,9 @@ export function ActivityContent({
   streamName,
   activityType,
   contentPreview,
-  emoji,
   toEmoji,
   createdAt,
+  urgencyColor,
   isUnread,
   wasReadThisVisit = false,
   isSelf,
@@ -86,7 +91,6 @@ export function ActivityContent({
   let verb = display.kind === "actor-prefixed" && isSelf ? display.selfVerb : display.verb
   if (!hasStream && activityType === "saved_reminder") verb = STANDALONE_REMINDER_VERB
   const showActor = display.kind === "actor-prefixed" && !isSelf
-  const reactionEmoji = activityType === "reaction" ? emoji : null
 
   return (
     <div className="min-w-0 flex-1">
@@ -100,36 +104,27 @@ export function ActivityContent({
           {showActor && " "}
           {verb}
           {hasStream && " "}
-          {hasStream && (
-            <span className={cn("font-medium", isUnread ? "text-primary" : "text-foreground")}>{streamName}</span>
-          )}
+          {hasStream && <span className="font-medium text-foreground">{streamName}</span>}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <RelativeTime
-            date={createdAt}
-            terse
-            className={cn("text-xs tabular-nums", isUnread ? "text-foreground/70" : "text-muted-foreground/70")}
-          />
-          {/* Unread marker, right-aligned with the time. Space is reserved when
-              read (transparent) so toggling read/unread never shifts the row
+          <RelativeTime date={createdAt} terse className="text-xs tabular-nums text-muted-foreground/70" />
+          {/* Unread marker, right-aligned with the time, painted the same
+              urgency colour as the row's strip. Space is reserved when read
+              (transparent) so toggling read/unread never shifts the row
               (INV-21). A row read during this visit keeps a hollow ring — it
               stays in the Unread section, so it must still read as part of that
               batch. Self rows are always read, so they get no marker. */}
           {!isSelf && (
             <span
               aria-hidden
-              className={cn(
-                "h-2 w-2 rounded-full",
-                isUnread && "bg-primary",
-                !isUnread && wasReadThisVisit && "ring-1 ring-inset ring-primary/50",
-                !isUnread && !wasReadThisVisit && "bg-transparent"
-              )}
+              className="h-2 w-2 rounded-full"
+              style={dotStyle(urgencyColor, isUnread, wasReadThisVisit)}
             />
           )}
         </div>
       </div>
 
-      <ActivityPreview contentPreview={contentPreview} toEmoji={toEmoji} emoji={reactionEmoji} isUnread={isUnread} />
+      <ActivityPreview contentPreview={contentPreview} toEmoji={toEmoji} isUnread={isUnread} />
     </div>
   )
 }

--- a/apps/frontend/src/components/activity/activity-content.tsx
+++ b/apps/frontend/src/components/activity/activity-content.tsx
@@ -45,7 +45,7 @@ export function ActivityPreview({ contentPreview, toEmoji, emoji, isUnread }: Ac
   const previewText = stripMarkdownToInline(contentPreview, toEmoji)
   if (!previewText && !emoji) return null
   return (
-    <p className={cn("mt-1 text-sm leading-snug line-clamp-2", isUnread ? "text-foreground" : "text-foreground/80")}>
+    <p className={cn("mt-1 text-sm leading-snug line-clamp-3", isUnread ? "text-foreground" : "text-foreground/80")}>
       {emoji && <span className="mr-1 align-middle">{emoji}</span>}
       {previewText}
     </p>
@@ -63,6 +63,8 @@ interface ActivityContentProps {
   toEmoji?: (shortcode: string) => string | null
   createdAt: string
   isUnread: boolean
+  /** Held in the Unread section but already read — see `ActivityItem`. */
+  wasReadThisVisit?: boolean
   isSelf: boolean
 }
 
@@ -75,6 +77,7 @@ export function ActivityContent({
   toEmoji,
   createdAt,
   isUnread,
+  wasReadThisVisit = false,
   isSelf,
 }: ActivityContentProps) {
   const display = ACTIVITY_DISPLAY[activityType] ?? DEFAULT_DISPLAY
@@ -97,15 +100,31 @@ export function ActivityContent({
           {showActor && " "}
           {verb}
           {hasStream && " "}
-          {hasStream && <span className="font-medium text-foreground">{streamName}</span>}
+          {hasStream && (
+            <span className={cn("font-medium", isUnread ? "text-primary" : "text-foreground")}>{streamName}</span>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <RelativeTime date={createdAt} terse className="text-xs tabular-nums text-muted-foreground/70" />
+          <RelativeTime
+            date={createdAt}
+            terse
+            className={cn("text-xs tabular-nums", isUnread ? "text-foreground/70" : "text-muted-foreground/70")}
+          />
           {/* Unread marker, right-aligned with the time. Space is reserved when
               read (transparent) so toggling read/unread never shifts the row
-              (INV-21). Self rows are always read, so they get no marker. */}
+              (INV-21). A row read during this visit keeps a hollow ring — it
+              stays in the Unread section, so it must still read as part of that
+              batch. Self rows are always read, so they get no marker. */}
           {!isSelf && (
-            <span aria-hidden className={cn("h-1.5 w-1.5 rounded-full", isUnread ? "bg-blue-500" : "bg-transparent")} />
+            <span
+              aria-hidden
+              className={cn(
+                "h-2 w-2 rounded-full",
+                isUnread && "bg-primary",
+                !isUnread && wasReadThisVisit && "ring-1 ring-inset ring-primary/50",
+                !isUnread && !wasReadThisVisit && "bg-transparent"
+              )}
+            />
           )}
         </div>
       </div>

--- a/apps/frontend/src/components/activity/activity-content.tsx
+++ b/apps/frontend/src/components/activity/activity-content.tsx
@@ -115,11 +115,18 @@ export function ActivityContent({
               stays in the Unread section, so it must still read as part of that
               batch. Self rows are always read, so they get no marker. */}
           {!isSelf && (
-            <span
-              aria-hidden
-              className="h-2 w-2 rounded-full"
-              style={dotStyle(urgencyColor, isUnread, wasReadThisVisit)}
-            />
+            <>
+              {/* The dot and the row's strip are both colour, so the state they
+                  carry has to be said out loud too — a read row keeps its slot
+                  in the Unread section, which is otherwise indistinguishable
+                  from a still-unread one without sight. */}
+              {(isUnread || wasReadThisVisit) && <span className="sr-only">{isUnread ? "Unread" : "Read"}</span>}
+              <span
+                aria-hidden
+                className="h-2 w-2 rounded-full"
+                style={dotStyle(urgencyColor, isUnread, wasReadThisVisit)}
+              />
+            </>
           )}
         </div>
       </div>

--- a/apps/frontend/src/components/activity/activity-item.tsx
+++ b/apps/frontend/src/components/activity/activity-item.tsx
@@ -148,11 +148,9 @@ function renderTypeGlyph(activityType: string, reactionEmoji: string | null) {
     "absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full ring-2 ring-background"
   if (activityType === "reaction") {
     if (!reactionEmoji) return null
-    return (
-      <span aria-hidden className={cn(badge, "bg-background text-[10px] leading-none")}>
-        {reactionEmoji}
-      </span>
-    )
+    // Not `aria-hidden`: which emoji it was is the row's payload, and the verb
+    // line ("reacted to a message in …") can't carry it.
+    return <span className={cn(badge, "bg-background text-[10px] leading-none")}>{reactionEmoji}</span>
   }
   if (activityType === "mention") {
     return (

--- a/apps/frontend/src/components/activity/activity-item.tsx
+++ b/apps/frontend/src/components/activity/activity-item.tsx
@@ -1,8 +1,10 @@
 import { Link } from "react-router-dom"
-import { AtSign, Bell, PhoneMissed, SmilePlus, UserPlus, type LucideIcon } from "lucide-react"
+import { AtSign, Bell } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { buildConversationPanelPath } from "@/lib/stream-links"
+import { resolveEmojiShortcodes } from "@/lib/markdown"
 import { isActivityUnread } from "@/hooks/use-activity-sections"
+import { URGENCY_COLORS } from "@/components/layout/sidebar/config"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { PersonaAvatar } from "@/components/persona-avatar"
 import { ActivityContent } from "./activity-content"
@@ -19,16 +21,16 @@ export interface ActivityItemAvatar {
 }
 
 /**
- * Corner badge naming what kind of activity a row is, so the type is readable
- * without parsing the verb. `message` and `saved_reminder` are omitted on
- * purpose: messages are the bulk of the feed (a badge on every row is noise)
- * and reminders already render a Bell in place of the avatar.
+ * Which strand of the sidebar's urgency vocabulary (`URGENCY_COLORS`) a row
+ * belongs to. Same four meanings the stream list uses — red is a mention, gold
+ * is a persona, green is a bot, blue is everything else — so gold keeps meaning
+ * "an agent did this" here instead of "unread".
  */
-const ACTIVITY_GLYPH: Record<string, { icon: LucideIcon; className: string }> = {
-  mention: { icon: AtSign, className: "bg-primary text-primary-foreground" },
-  reaction: { icon: SmilePlus, className: "bg-amber-500 text-white" },
-  member_added: { icon: UserPlus, className: "bg-emerald-500 text-white" },
-  missed_call: { icon: PhoneMissed, className: "bg-rose-500 text-white" },
+export function activityUrgency(activity: Activity): keyof typeof URGENCY_COLORS {
+  if (activity.activityType === "mention") return "mentions"
+  if (activity.actorType === "persona") return "ai"
+  if (activity.actorType === "bot") return "bot"
+  return "activity"
 }
 
 interface ActivityItemProps {
@@ -69,6 +71,11 @@ export function ActivityItem({
   const isSystem = actorType === "system"
   const isReminder = activity.activityType === "saved_reminder"
   const href = resolveActivityHref(workspaceId, activity)
+  const urgency = activityUrgency(activity)
+  // The reaction's own glyph, resolved: the wire carries either a raw character
+  // or a `:shortcode:` (both shapes are emitted — see the activity service).
+  const reactionEmoji =
+    activity.activityType === "reaction" && activity.emoji ? resolveEmojiShortcodes(activity.emoji, toEmoji) : null
 
   return (
     <Link
@@ -77,32 +84,41 @@ export function ActivityItem({
         if (isUnread) onMarkAsRead(activity.id)
       }}
       className={cn(
-        // The left rail is always 2px wide (transparent when there's nothing to
-        // say) so reading a row can never shift it sideways (INV-21).
-        "group flex items-start gap-3 rounded-lg border-l-2 px-3 py-2.5 transition-colors sm:px-4 sm:py-3",
-        isUnread && "border-primary bg-primary/[0.07] hover:bg-primary/[0.12]",
-        !isUnread && wasReadThisVisit && "border-primary/25",
-        !isUnread && !wasReadThisVisit && "border-transparent",
+        "group flex items-stretch rounded-lg transition-colors",
+        isUnread && "bg-muted/40 hover:bg-muted/70",
         !isUnread && !isSelf && "hover:bg-muted/50",
         isSelf && "opacity-75 hover:bg-muted/40 hover:opacity-100"
       )}
     >
-      <div className="relative shrink-0">
-        {renderAvatar({ isReminder, isPersona, isSystem, isBot, actorAvatar, actorName })}
-        {renderTypeGlyph(activity.activityType)}
-      </div>
-      <ActivityContent
-        actorName={actorName}
-        streamName={streamName}
-        activityType={activity.activityType}
-        contentPreview={contentPreview}
-        emoji={activity.emoji}
-        toEmoji={toEmoji}
-        createdAt={activity.createdAt}
-        isUnread={isUnread}
-        wasReadThisVisit={wasReadThisVisit}
-        isSelf={isSelf}
+      {/* Urgency strip, the sidebar's signal for the same thing (`UrgencyStrip`
+          in `sidebar/stream-item.tsx`). The slot is always 4px wide and only the
+          colour changes, so reading a row can't shift it (INV-21). */}
+      <span
+        aria-hidden
+        className="w-1 shrink-0 rounded-l-lg transition-colors"
+        style={{
+          backgroundColor: isUnread || wasReadThisVisit ? URGENCY_COLORS[urgency] : URGENCY_COLORS.quiet,
+          opacity: !isUnread && wasReadThisVisit ? 0.3 : 1,
+        }}
       />
+      <div className="flex min-w-0 flex-1 items-start gap-3 px-3 py-2.5 sm:px-4 sm:py-3">
+        <div className="relative shrink-0">
+          {renderAvatar({ isReminder, isPersona, isSystem, isBot, actorAvatar, actorName })}
+          {renderTypeGlyph(activity.activityType, reactionEmoji)}
+        </div>
+        <ActivityContent
+          actorName={actorName}
+          streamName={streamName}
+          activityType={activity.activityType}
+          contentPreview={contentPreview}
+          toEmoji={toEmoji}
+          createdAt={activity.createdAt}
+          urgencyColor={URGENCY_COLORS[urgency]}
+          isUnread={isUnread}
+          wasReadThisVisit={wasReadThisVisit}
+          isSelf={isSelf}
+        />
+      </div>
     </Link>
   )
 }
@@ -122,21 +138,30 @@ function resolveActivityHref(workspaceId: string, activity: Activity): string {
   return `/w/${workspaceId}/saved`
 }
 
-function renderTypeGlyph(activityType: string) {
-  const glyph = ACTIVITY_GLYPH[activityType]
-  if (!glyph) return null
-  const Icon = glyph.icon
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full ring-2 ring-background",
-        glyph.className
-      )}
-    >
-      <Icon className="h-2 w-2" strokeWidth={3} />
-    </span>
-  )
+/**
+ * Corner badge on the avatar. A reaction shows the emoji it actually was — the
+ * one thing the caption can't say — and a mention shows an @. Every other type
+ * is already unambiguous in the verb line, so it gets nothing.
+ */
+function renderTypeGlyph(activityType: string, reactionEmoji: string | null) {
+  const badge =
+    "absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full ring-2 ring-background"
+  if (activityType === "reaction") {
+    if (!reactionEmoji) return null
+    return (
+      <span aria-hidden className={cn(badge, "bg-background text-[10px] leading-none")}>
+        {reactionEmoji}
+      </span>
+    )
+  }
+  if (activityType === "mention") {
+    return (
+      <span aria-hidden className={cn(badge, "text-white")} style={{ backgroundColor: URGENCY_COLORS.mentions }}>
+        <AtSign className="h-2.5 w-2.5" strokeWidth={3} />
+      </span>
+    )
+  }
+  return null
 }
 
 function renderAvatar(params: {

--- a/apps/frontend/src/components/activity/activity-item.tsx
+++ b/apps/frontend/src/components/activity/activity-item.tsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom"
-import { Bell } from "lucide-react"
+import { AtSign, Bell, PhoneMissed, SmilePlus, UserPlus, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { buildConversationPanelPath } from "@/lib/stream-links"
+import { isActivityUnread } from "@/hooks/use-activity-sections"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { PersonaAvatar } from "@/components/persona-avatar"
 import { ActivityContent } from "./activity-content"
@@ -17,6 +18,19 @@ export interface ActivityItemAvatar {
   avatarUrl?: string
 }
 
+/**
+ * Corner badge naming what kind of activity a row is, so the type is readable
+ * without parsing the verb. `message` and `saved_reminder` are omitted on
+ * purpose: messages are the bulk of the feed (a badge on every row is noise)
+ * and reminders already render a Bell in place of the avatar.
+ */
+const ACTIVITY_GLYPH: Record<string, { icon: LucideIcon; className: string }> = {
+  mention: { icon: AtSign, className: "bg-primary text-primary-foreground" },
+  reaction: { icon: SmilePlus, className: "bg-amber-500 text-white" },
+  member_added: { icon: UserPlus, className: "bg-emerald-500 text-white" },
+  missed_call: { icon: PhoneMissed, className: "bg-rose-500 text-white" },
+}
+
 interface ActivityItemProps {
   activity: Activity
   actorName: string
@@ -25,6 +39,12 @@ interface ActivityItemProps {
   workspaceId: string
   toEmoji?: (shortcode: string) => string | null
   onMarkAsRead: (activityId: string) => void
+  /**
+   * Row is held in the Unread section but has since been read — this visit's
+   * "you just opened this". Keeps a faded rail and a hollow dot so the row
+   * still reads as part of the unread batch without competing with what's left.
+   */
+  wasReadThisVisit?: boolean
 }
 
 export function ActivityItem({
@@ -35,12 +55,13 @@ export function ActivityItem({
   workspaceId,
   toEmoji,
   onMarkAsRead,
+  wasReadThisVisit = false,
 }: ActivityItemProps) {
   // Self rows are inserted already read by the backend, so the unread dot is
   // never shown for them regardless of the `readAt` value. Give them a muted
   // background so they're visually distinct from things others did.
   const isSelf = activity.isSelf
-  const isUnread = !isSelf && !activity.readAt
+  const isUnread = isActivityUnread(activity)
   const contentPreview = (activity.context.contentPreview as string) ?? ""
   const actorType = activity.actorType
   const isPersona = actorType === "persona"
@@ -56,13 +77,20 @@ export function ActivityItem({
         if (isUnread) onMarkAsRead(activity.id)
       }}
       className={cn(
-        "group flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors sm:px-4 sm:py-3",
-        isUnread && "bg-primary/5 hover:bg-primary/10",
+        // The left rail is always 2px wide (transparent when there's nothing to
+        // say) so reading a row can never shift it sideways (INV-21).
+        "group flex items-start gap-3 rounded-lg border-l-2 px-3 py-2.5 transition-colors sm:px-4 sm:py-3",
+        isUnread && "border-primary bg-primary/[0.07] hover:bg-primary/[0.12]",
+        !isUnread && wasReadThisVisit && "border-primary/25",
+        !isUnread && !wasReadThisVisit && "border-transparent",
         !isUnread && !isSelf && "hover:bg-muted/50",
         isSelf && "opacity-75 hover:bg-muted/40 hover:opacity-100"
       )}
     >
-      {renderAvatar({ isReminder, isPersona, isSystem, isBot, actorAvatar, actorName })}
+      <div className="relative shrink-0">
+        {renderAvatar({ isReminder, isPersona, isSystem, isBot, actorAvatar, actorName })}
+        {renderTypeGlyph(activity.activityType)}
+      </div>
       <ActivityContent
         actorName={actorName}
         streamName={streamName}
@@ -72,6 +100,7 @@ export function ActivityItem({
         toEmoji={toEmoji}
         createdAt={activity.createdAt}
         isUnread={isUnread}
+        wasReadThisVisit={wasReadThisVisit}
         isSelf={isSelf}
       />
     </Link>
@@ -91,6 +120,23 @@ function resolveActivityHref(workspaceId: string, activity: Activity): string {
   }
   if (activity.streamId) return `/w/${workspaceId}/s/${activity.streamId}?m=${activity.messageId}`
   return `/w/${workspaceId}/saved`
+}
+
+function renderTypeGlyph(activityType: string) {
+  const glyph = ACTIVITY_GLYPH[activityType]
+  if (!glyph) return null
+  const Icon = glyph.icon
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "absolute -bottom-0.5 -right-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full ring-2 ring-background",
+        glyph.className
+      )}
+    >
+      <Icon className="h-2 w-2" strokeWidth={3} />
+    </span>
+  )
 }
 
 function renderAvatar(params: {

--- a/apps/frontend/src/components/activity/activity-section.tsx
+++ b/apps/frontend/src/components/activity/activity-section.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react"
+
+interface ActivitySectionProps {
+  label: string
+  /** Rendered as a pill beside the label; omitted when zero. */
+  count?: number
+  children: ReactNode
+}
+
+export function ActivitySection({ label, count, children }: ActivitySectionProps) {
+  return (
+    <section aria-label={label} className="mb-4 last:mb-0">
+      {/* Transparent 2px border mirrors the rows' unread rail so the label
+          lines up with their text instead of sitting 2px to its left. */}
+      <div className="sticky top-0 z-10 flex items-center gap-2 border-l-2 border-transparent bg-background/90 px-3 py-1.5 backdrop-blur-sm sm:px-4">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</span>
+        {count !== undefined && count > 0 && (
+          <span className="rounded-full bg-primary/15 px-1.5 py-px text-[10px] font-semibold tabular-nums text-primary">
+            {count}
+          </span>
+        )}
+        <span className="h-px flex-1 bg-border" />
+      </div>
+      <div className="flex flex-col gap-0.5">{children}</div>
+    </section>
+  )
+}

--- a/apps/frontend/src/components/activity/activity-section.tsx
+++ b/apps/frontend/src/components/activity/activity-section.tsx
@@ -10,12 +10,12 @@ interface ActivitySectionProps {
 export function ActivitySection({ label, count, children }: ActivitySectionProps) {
   return (
     <section aria-label={label} className="mb-4 last:mb-0">
-      {/* Transparent 2px border mirrors the rows' unread rail so the label
-          lines up with their text instead of sitting 2px to its left. */}
-      <div className="sticky top-0 z-10 flex items-center gap-2 border-l-2 border-transparent bg-background/90 px-3 py-1.5 backdrop-blur-sm sm:px-4">
+      {/* Left padding clears the rows' 4px urgency strip so the label lines up
+          with their text rather than with the strip. */}
+      <div className="sticky top-0 z-10 flex items-center gap-2 bg-background/90 py-1.5 pl-4 pr-3 backdrop-blur-sm sm:pl-5 sm:pr-4">
         <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{label}</span>
         {count !== undefined && count > 0 && (
-          <span className="rounded-full bg-primary/15 px-1.5 py-px text-[10px] font-semibold tabular-nums text-primary">
+          <span className="rounded-full bg-muted px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-foreground">
             {count}
           </span>
         )}

--- a/apps/frontend/src/hooks/use-activity-sections.test.ts
+++ b/apps/frontend/src/hooks/use-activity-sections.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { partitionActivitySections, resetActivitySectionLatch } from "./use-activity-sections"
+import type { Activity } from "@threa/types"
+
+const WS = "ws_1"
+
+function activity(id: string, overrides: Partial<Activity> = {}): Activity {
+  return {
+    id,
+    workspaceId: WS,
+    userId: "usr_me",
+    activityType: "message",
+    streamId: "stream_1",
+    messageId: `msg_${id}`,
+    actorId: "usr_other",
+    actorType: "user",
+    context: {},
+    readAt: null,
+    createdAt: "2026-08-11T10:00:00.000Z",
+    isSelf: false,
+    emoji: null,
+    ...overrides,
+  }
+}
+
+const read = (id: string) => activity(id, { readAt: "2026-08-11T09:00:00.000Z" })
+
+describe("partitionActivitySections", () => {
+  beforeEach(() => resetActivitySectionLatch())
+
+  it("splits the feed into unread and already-read rows", () => {
+    const rows = [activity("a"), read("b"), activity("c")]
+
+    expect(partitionActivitySections(WS, rows)).toEqual({
+      unread: [rows[0], rows[2]],
+      read: [rows[1]],
+      stillUnreadCount: 2,
+    })
+  })
+
+  it("keeps a row in the unread section after it is read, and stops counting it", () => {
+    partitionActivitySections(WS, [activity("a"), activity("b")])
+
+    const rows = [read("a"), activity("b")]
+    expect(partitionActivitySections(WS, rows)).toEqual({
+      unread: [rows[0], rows[1]],
+      read: [],
+      stillUnreadCount: 1,
+    })
+  })
+
+  it("prepends newly arrived unread rows above the latched ones", () => {
+    partitionActivitySections(WS, [activity("a"), read("z")])
+
+    const rows = [activity("new"), read("a"), read("z")]
+    const sections = partitionActivitySections(WS, rows)
+
+    expect(sections.unread.map((row) => row.id)).toEqual(["new", "a"])
+    expect(sections.read.map((row) => row.id)).toEqual(["z"])
+  })
+
+  it("never latches self rows, which are inserted already read", () => {
+    const rows = [activity("mine", { isSelf: true, actorId: "usr_me" })]
+
+    expect(partitionActivitySections(WS, rows)).toEqual({ unread: [], read: rows, stillUnreadCount: 0 })
+  })
+
+  it("latches per workspace", () => {
+    partitionActivitySections(WS, [activity("a")])
+
+    expect(partitionActivitySections("ws_2", [read("a")]).unread).toEqual([])
+  })
+})

--- a/apps/frontend/src/hooks/use-activity-sections.ts
+++ b/apps/frontend/src/hooks/use-activity-sections.ts
@@ -1,0 +1,68 @@
+import { useMemo } from "react"
+import type { Activity } from "@threa/types"
+
+/**
+ * Unread from the viewer's perspective. Self rows are inserted already-read by
+ * the backend and never count, whatever `readAt` holds.
+ */
+export function isActivityUnread(activity: Activity): boolean {
+  return !activity.isSelf && !activity.readAt
+}
+
+/**
+ * Ids latched into the Unread section, per workspace. Module-scoped on purpose:
+ * the section a row sits in must survive leaving the Activity page and coming
+ * back (the whole point is that opening a row doesn't make it disappear), and
+ * must reset on a hard refresh. A component ref would reset on every unmount; a
+ * persisted store would never reset.
+ */
+const latchByWorkspace = new Map<string, Set<string>>()
+
+/** Drop every latched membership. Tests only — a refresh is the real reset. */
+export function resetActivitySectionLatch(): void {
+  latchByWorkspace.clear()
+}
+
+export interface ActivitySections {
+  /** Rows latched into the Unread section, feed order (createdAt desc). */
+  unread: Activity[]
+  /** Everything else, feed order. */
+  read: Activity[]
+  /** Rows in {@link unread} that are still genuinely unread. */
+  stillUnreadCount: number
+}
+
+/**
+ * Split the feed into the two stacked sections. A row enters Unread the first
+ * time it is seen unread and stays there for the rest of the visit — reading it
+ * restyles the row in place instead of moving it under the reader's eye. New
+ * arrivals prepend for free: the feed is already `createdAt` desc, so
+ * partitioning it preserves the frozen relative order of everything already
+ * latched.
+ */
+export function partitionActivitySections(workspaceId: string, activities: readonly Activity[]): ActivitySections {
+  let latch = latchByWorkspace.get(workspaceId)
+  if (!latch) {
+    latch = new Set()
+    latchByWorkspace.set(workspaceId, latch)
+  }
+
+  const unread: Activity[] = []
+  const read: Activity[] = []
+  let stillUnreadCount = 0
+
+  for (const activity of activities) {
+    if (isActivityUnread(activity)) {
+      latch.add(activity.id)
+      stillUnreadCount++
+    }
+    if (latch.has(activity.id)) unread.push(activity)
+    else read.push(activity)
+  }
+
+  return { unread, read, stillUnreadCount }
+}
+
+export function useActivitySections(workspaceId: string, activities: Activity[] | undefined): ActivitySections {
+  return useMemo(() => partitionActivitySections(workspaceId, activities ?? []), [workspaceId, activities])
+}

--- a/apps/frontend/src/lib/markdown/index.ts
+++ b/apps/frontend/src/lib/markdown/index.ts
@@ -1,2 +1,2 @@
 export { MarkdownContent } from "@/components/ui/markdown-content"
-export { stripMarkdown, stripMarkdownToInline, truncateInline } from "./strip"
+export { stripMarkdown, stripMarkdownToInline, truncateInline, resolveEmojiShortcodes } from "./strip"

--- a/apps/frontend/src/pages/activity.test.tsx
+++ b/apps/frontend/src/pages/activity.test.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, within } from "@/test"
+import * as hooksModule from "@/hooks"
+import * as emojiModule from "@/hooks/use-workspace-emoji"
+import * as countsModule from "@/hooks/use-activity-counts"
+import * as workspaceStore from "@/stores/workspace-store"
+import { resetActivitySectionLatch } from "@/hooks/use-activity-sections"
+import { SidebarProvider, PreferencesProvider } from "@/contexts"
+import { ActivityPage } from "./activity"
+import type { Activity } from "@threa/types"
+
+const WS = "ws_1"
+
+function activity(id: string, overrides: Partial<Activity> = {}): Activity {
+  return {
+    id,
+    workspaceId: WS,
+    userId: "usr_me",
+    activityType: "message",
+    streamId: "stream_1",
+    messageId: `msg_${id}`,
+    actorId: "usr_other",
+    actorType: "user",
+    context: { contentPreview: `preview ${id}`, streamName: "general" },
+    readAt: null,
+    createdAt: "2026-08-11T10:00:00.000Z",
+    isSelf: false,
+    emoji: null,
+    ...overrides,
+  }
+}
+
+const READ_AT = "2026-08-11T09:00:00.000Z"
+
+function mockFeed(activities: Activity[]) {
+  vi.spyOn(hooksModule, "useActivityFeed").mockReturnValue({
+    data: activities,
+    isLoading: false,
+  } as unknown as ReturnType<typeof hooksModule.useActivityFeed>)
+}
+
+function page(client: QueryClient): ReactElement {
+  return (
+    <QueryClientProvider client={client}>
+      <PreferencesProvider workspaceId={WS}>
+        <SidebarProvider>
+          <MemoryRouter initialEntries={[`/w/${WS}/activity`]}>
+            <Routes>
+              <Route path="/w/:workspaceId/activity/:filter?" element={<ActivityPage />} />
+            </Routes>
+          </MemoryRouter>
+        </SidebarProvider>
+      </PreferencesProvider>
+    </QueryClientProvider>
+  )
+}
+
+/** Row text inside a named section, in DOM order. Scoped by the section's
+ *  accessible name so the same-named filter tab can't be mistaken for it. */
+function sectionRows(label: string): string[] {
+  return within(screen.getByRole("region", { name: label }))
+    .getAllByRole("link")
+    .map((link) => link.textContent ?? "")
+}
+
+describe("ActivityPage sections", () => {
+  beforeEach(() => {
+    resetActivitySectionLatch()
+    vi.spyOn(hooksModule, "useMarkActivityRead").mockReturnValue({ mutate: vi.fn() } as unknown as ReturnType<
+      typeof hooksModule.useMarkActivityRead
+    >)
+    vi.spyOn(hooksModule, "useMarkAllActivityRead").mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof hooksModule.useMarkAllActivityRead>)
+    vi.spyOn(hooksModule, "useActors").mockReturnValue({
+      getActorName: (id: string) => `actor ${id}`,
+      getActorAvatar: () => ({ fallback: "A" }),
+    } as unknown as ReturnType<typeof hooksModule.useActors>)
+    vi.spyOn(emojiModule, "useWorkspaceEmoji").mockReturnValue({ toEmoji: () => null } as unknown as ReturnType<
+      typeof emojiModule.useWorkspaceEmoji
+    >)
+    vi.spyOn(countsModule, "useActivityCounts").mockReturnValue({ unreadActivityCount: 0 } as unknown as ReturnType<
+      typeof countsModule.useActivityCounts
+    >)
+    vi.spyOn(workspaceStore, "useWorkspaceStreams").mockReturnValue([])
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("stacks unread above read, counting what is still unread", () => {
+    mockFeed([activity("a"), activity("b", { readAt: READ_AT }), activity("c")])
+    render(page(new QueryClient()))
+
+    expect(sectionRows("Unread").join("|")).toContain("preview a")
+    expect(sectionRows("Unread").join("|")).toContain("preview c")
+    expect(sectionRows("Earlier").join("|")).toContain("preview b")
+    expect(within(screen.getByRole("region", { name: "Unread" })).getByText("2")).toBeInTheDocument()
+  })
+
+  it("keeps a row in the unread section after it is read, in its original slot", () => {
+    const client = new QueryClient()
+    mockFeed([activity("a"), activity("b")])
+    const { rerender } = render(page(client))
+    expect(sectionRows("Unread")).toHaveLength(2)
+
+    mockFeed([activity("a", { readAt: "2026-08-11T10:30:00.000Z" }), activity("b")])
+    rerender(page(client))
+
+    const rows = sectionRows("Unread")
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toContain("preview a")
+    expect(screen.queryByRole("region", { name: "Earlier" })).not.toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Unread" })).getByText("1")).toBeInTheDocument()
+  })
+
+  it("renders one flat list when nothing is unread", () => {
+    mockFeed([activity("a", { readAt: READ_AT })])
+    render(page(new QueryClient()))
+
+    expect(screen.queryByRole("region", { name: "Unread" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("region", { name: "Earlier" })).not.toBeInTheDocument()
+    expect(screen.getByText("preview a")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/pages/activity.test.tsx
+++ b/apps/frontend/src/pages/activity.test.tsx
@@ -124,6 +124,23 @@ describe("ActivityPage sections", () => {
     const row = within(screen.getByRole("region", { name: "Unread" })).getByRole("link")
     expect(row.textContent).toContain("❤️")
     expect(row.textContent).not.toContain(":heart:")
+    // Which emoji it was is the row's payload — it must reach assistive tech,
+    // not sit behind aria-hidden like the decorative strip and dot do.
+    expect(screen.getByText("❤️").closest("[aria-hidden]")).toBeNull()
+  })
+
+  it("says unread vs read out loud, since the strip and dot are colour only", () => {
+    mockFeed([activity("a"), activity("b")])
+    const client = new QueryClient()
+    const { rerender } = render(page(client))
+    expect(sectionRows("Unread")[0]).toContain("Unread")
+
+    mockFeed([activity("a", { readAt: "2026-08-11T10:30:00.000Z" }), activity("b")])
+    rerender(page(client))
+
+    const rows = sectionRows("Unread")
+    expect(rows[0]).toContain("Read")
+    expect(rows[1]).toContain("Unread")
   })
 
   it("renders one flat list when nothing is unread", () => {

--- a/apps/frontend/src/pages/activity.test.tsx
+++ b/apps/frontend/src/pages/activity.test.tsx
@@ -80,9 +80,9 @@ describe("ActivityPage sections", () => {
       getActorName: (id: string) => `actor ${id}`,
       getActorAvatar: () => ({ fallback: "A" }),
     } as unknown as ReturnType<typeof hooksModule.useActors>)
-    vi.spyOn(emojiModule, "useWorkspaceEmoji").mockReturnValue({ toEmoji: () => null } as unknown as ReturnType<
-      typeof emojiModule.useWorkspaceEmoji
-    >)
+    vi.spyOn(emojiModule, "useWorkspaceEmoji").mockReturnValue({
+      toEmoji: (shortcode: string) => (shortcode === "heart" ? "❤️" : null),
+    } as unknown as ReturnType<typeof emojiModule.useWorkspaceEmoji>)
     vi.spyOn(countsModule, "useActivityCounts").mockReturnValue({ unreadActivityCount: 0 } as unknown as ReturnType<
       typeof countsModule.useActivityCounts
     >)
@@ -115,6 +115,15 @@ describe("ActivityPage sections", () => {
     expect(rows[0]).toContain("preview a")
     expect(screen.queryByRole("region", { name: "Earlier" })).not.toBeInTheDocument()
     expect(within(screen.getByRole("region", { name: "Unread" })).getByText("1")).toBeInTheDocument()
+  })
+
+  it("shows a reaction's own emoji, resolving the shortcode the wire may carry", () => {
+    mockFeed([activity("r", { activityType: "reaction", emoji: ":heart:" })])
+    render(page(new QueryClient()))
+
+    const row = within(screen.getByRole("region", { name: "Unread" })).getByRole("link")
+    expect(row.textContent).toContain("❤️")
+    expect(row.textContent).not.toContain(":heart:")
   })
 
   it("renders one flat list when nothing is unread", () => {

--- a/apps/frontend/src/pages/activity.tsx
+++ b/apps/frontend/src/pages/activity.tsx
@@ -10,8 +10,10 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { useActivityCounts } from "@/hooks/use-activity-counts"
 import { getStreamName, streamFallbackLabel } from "@/lib/streams"
+import { useActivitySections, isActivityUnread } from "@/hooks/use-activity-sections"
 import { ActivityItem } from "@/components/activity/activity-item"
 import { ActivityEmpty } from "@/components/activity/activity-empty"
+import { ActivitySection } from "@/components/activity/activity-section"
 import { ActivitySkeleton } from "@/components/activity/activity-skeleton"
 import { PageHeaderTabs } from "@/components/layout"
 import { commitCounterMutation } from "@/sync/catch-up-batch"
@@ -67,6 +69,12 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
   const streamById = useMemo(() => {
     return new Map(idbStreams.map((s) => [s.id, s]))
   }, [idbStreams])
+
+  // Stacked Unread / Earlier sections, on the "all" tab only: "unread" is
+  // server-filtered (a locked section there would fight the query, which drops
+  // a row the moment it's read) and "me" is all-self, so never unread.
+  const sections = useActivitySections(workspaceId, activities)
+  const showSections = filter === "all" && sections.unread.length > 0
 
   // Fix A4 backstop (docs/sparse-read-overlay-design.md): when the unread feed
   // resolves, reconcile the held activity set to exactly the rows the server
@@ -128,27 +136,41 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
     return streamFallbackLabel("thread", "activity")
   }
 
+  function renderRow(activity: Activity, inUnreadSection: boolean) {
+    return (
+      <ActivityItem
+        key={activity.id}
+        activity={activity}
+        actorName={getActorName(activity.actorId, activity.actorType as AuthorType)}
+        actorAvatar={getActorAvatar(activity.actorId, activity.actorType as AuthorType)}
+        streamName={resolveActivityStreamName(activity)}
+        workspaceId={workspaceId}
+        toEmoji={toEmoji}
+        onMarkAsRead={(id) => markRead.mutate(id)}
+        wasReadThisVisit={inUnreadSection && !isActivityUnread(activity)}
+      />
+    )
+  }
+
   let content = <ActivitySkeleton />
   if (!isLoading) {
     if (!activities?.length) {
       content = <ActivityEmpty isFiltered={filter !== "all"} />
-    } else {
+    } else if (showSections) {
       content = (
-        <div className="flex flex-col gap-0.5">
-          {activities.map((activity) => (
-            <ActivityItem
-              key={activity.id}
-              activity={activity}
-              actorName={getActorName(activity.actorId, activity.actorType as AuthorType)}
-              actorAvatar={getActorAvatar(activity.actorId, activity.actorType as AuthorType)}
-              streamName={resolveActivityStreamName(activity)}
-              workspaceId={workspaceId}
-              toEmoji={toEmoji}
-              onMarkAsRead={(id) => markRead.mutate(id)}
-            />
-          ))}
-        </div>
+        <>
+          <ActivitySection label="Unread" count={sections.stillUnreadCount}>
+            {sections.unread.map((activity) => renderRow(activity, true))}
+          </ActivitySection>
+          {sections.read.length > 0 && (
+            <ActivitySection label="Earlier">
+              {sections.read.map((activity) => renderRow(activity, false))}
+            </ActivitySection>
+          )}
+        </>
       )
+    } else {
+      content = <div className="flex flex-col gap-0.5">{activities.map((activity) => renderRow(activity, false))}</div>
     }
   }
 
@@ -182,7 +204,7 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
       />
 
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
-        <main className="py-2">{content}</main>
+        <main className="mx-auto w-full min-w-0 max-w-[800px] px-1 py-2 sm:px-4">{content}</main>
       </ScrollArea>
     </div>
   )


### PR DESCRIPTION
## Problem

The activity feed is one flat `createdAt DESC` list (`ActivityPageInner` in `apps/frontend/src/pages/activity.tsx`), so unread rows are buried among read ones with a 1.5px `bg-blue-500` dot as their only marker. Opening a row sets `readAt`, which restyles it in place but leaves it interleaved, so there is no way to see "what did I still not read" without switching to the Unread tab and losing the surrounding context. The list also spans the full page width, unlike the stream and board, which both cap at 800px. Reaction rows rendered `activity.emoji` raw, so a wire value of `:heart:` reached the DOM as the literal shortcode.

## Solution

Split the **All** tab into stacked `Unread` / `Earlier` sections whose membership is latched for the visit, so reading a row never moves it, and mark rows with the sidebar's existing urgency vocabulary rather than a new one.

- `partitionActivitySections` (`hooks/use-activity-sections.ts`) walks the feed once: a row that is unread (`!isSelf && !readAt`) is added to a per-workspace `Set` of latched ids and stays in `Unread` for the rest of the visit, restyled rather than relocated. `stillUnreadCount` counts only rows that are *genuinely* still unread, so the header pill ticks down in place.
- **Latch at module scope, keyed by workspace, over a component ref** — a ref resets on unmount, so navigating into a stream and back would reshuffle the sections under the reader. Module scope resets on a hard refresh, which is the boundary the feature is specified against.
- **No frozen order array** (unlike `useStableBoardView`'s `CommittedView.order`) — the server returns `ORDER BY created_at DESC` (`apps/backend/src/features/activity/repository.ts:244`) and new rows are the newest, so partitioning a desc list already prepends arrivals and preserves the frozen relative order of everything latched. The board needs the snapshot because its order is activity-desc and mutable; this feed's is not.
- **Scoped to the `all` tab.** `me` is `mineOnly` (self rows, inserted already-read — never unread) and `unread` is `unreadOnly`, server-filtered: a latched section there would fight a query that drops each row on its next refetch.
- **Marking reuses `URGENCY_COLORS`** (`components/layout/sidebar/config.ts`) over a per-feed palette. `activityUrgency()` maps each row to the same four meanings the stream list uses — red mention, gold persona, green bot, blue other — painted onto a 4px strip that mirrors `UrgencyStrip` in `sidebar/stream-item.tsx`, plus the trailing dot. A first pass used `--primary` gold for *all* unread rows; every row then read as agent activity, because gold already means "a persona did this" everywhere else in the app. The strip now also says *which kind* of unread it is.
- **Neutral `bg-muted/40` for the unread surface**, following the rule already written at `sidebar/stream-item.tsx:638` — "the tinted background means exactly one thing: you are here" — so unread can't be confused with active. Slot width never changes (`URGENCY_COLORS.quiet` is transparent), so reading a row can't shift it (INV-21).
- **Reactions render the emoji itself** as the avatar's corner badge, through `resolveEmojiShortcodes` — the activity service emits both raw characters (`✅`) and shortcodes (`:eyes:`), and only the raw form used to render. Mention rows keep a red `@` badge; the other types get none, since their verb line already names them.
- Preview `line-clamp-2` → `line-clamp-3`; width capped at `max-w-[800px]`, the same value as `event-list.tsx:1256` and `board.tsx:951`.

Left alone deliberately: the **Unread tab is now largely redundant** with Unread pinned to the top of All, but removing a route is a separate call. The feed still fetches one 50-row page with no pagination, so past 50 unread rows `Earlier` renders empty — pre-existing, not introduced here.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-activity-sections.ts` | **new** — `isActivityUnread`, `partitionActivitySections`, `useActivitySections`, per-workspace latch |
| `apps/frontend/src/components/activity/activity-section.tsx` | **new** — sticky, `aria-label`led section header with count pill |
| `apps/frontend/src/pages/activity.tsx` | Sectioned rendering on `all`; 800px column; `renderRow` helper |
| `apps/frontend/src/components/activity/activity-item.tsx` | `activityUrgency`, urgency strip, emoji/mention corner badge, `wasReadThisVisit` |
| `apps/frontend/src/components/activity/activity-content.tsx` | Urgency-coloured dot + hollow variant, 3-line preview, emoji dropped from the preview text |
| `apps/frontend/src/lib/markdown/index.ts` | Re-export `resolveEmojiShortcodes` (already exported by `./strip`) |
| `apps/frontend/src/hooks/use-activity-sections.test.ts` | **new** — latch semantics, per-workspace isolation, self rows |
| `apps/frontend/src/pages/activity.test.tsx` | **new** — mounts the real page (INV-39): stacking, count, read-in-place, shortcode reaction, flat fallback |

## Test plan

- [x] `apps/frontend` vitest — 561 files / 6528 tests pass
- [x] `bun run lint` (all workspaces) + monorepo typecheck — clean, via pre-commit
- [x] Rendered in the app on staging; the gold-for-everything and raw-`:heart:` problems above were both found that way and fixed in the second commit
- [x] Static two-theme render of the shipped classes: https://seer.build/ws_vbyzjvdg6g/b/activity-sections-4aa914/
- [ ] Colour-blind check of the four-colour strip not done — it inherits whatever the sidebar's vocabulary already is, and position (Unread section) carries the read/unread signal independently

Residual risk: the latch `Set` only grows within a page session (one entry per row ever seen unread, dropped on refresh). Bounded by activity volume, never persisted.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
