### PR TITLE
fix: stop attachment uploads forking a draft row per file

### DIFF
--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -253,13 +253,21 @@ describe("StashedDraftsPicker", () => {
   describe("preview rendering", () => {
     const sealed = makeDraft("draft_e", "placeholder")
     const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
-    const preview = (status: DraftPreview["status"], text = ""): Map<string, DraftPreview> =>
-      new Map([["draft_e", { text, markdown: text, status }]])
+    const preview = (status: DraftPreview["status"], text = "", attachmentCount = 0): Map<string, DraftPreview> =>
+      new Map([["draft_e", { text, markdown: text, attachmentCount, status }]])
 
     it("renders the host-supplied decrypted body when ready", async () => {
       renderPicker({ drafts: [sealed], previewById: preview("ready", "decrypted body") })
       await open()
       expect(screen.getByText("decrypted body")).toBeInTheDocument()
+    })
+
+    it("names the files of a decrypted attachment-only draft, not 'Empty draft'", async () => {
+      // A sealed row's `attachments` is [] at rest (E2EE-4) — the count has to
+      // come from the same decrypt the body did.
+      renderPicker({ drafts: [sealed], previewById: preview("ready", "", 2) })
+      await open()
+      expect(screen.getByText("2 attachments")).toBeInTheDocument()
     })
 
     it("shows 'Decrypting…' while the body is in flight", async () => {

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -116,7 +116,9 @@ function rowPreview(draft: CachedDraft, previewById?: Map<string, DraftPreview>)
   const preview = previewById?.get(draft.id)
   if (!preview) return draftInlineText(draft.contentJson) || draftEmptyBodyLabel(draft.attachments?.length ?? 0)
   if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
-  return preview.text || draftEmptyBodyLabel(draft.attachments?.length ?? 0)
+  // The preview's count, not the row's: a sealed row holds `attachments: []` at
+  // rest, so reading it here labelled an attachment-only E2E draft "Empty draft".
+  return preview.text || draftEmptyBodyLabel(preview.attachmentCount)
 }
 
 export function StashedDraftsPicker({

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button"
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { DeleteDraftConfirmDialog } from "@/components/drafts/delete-draft-confirm-dialog"
-import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
+import { draftEmptyBodyLabel, draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useInputMode } from "@/hooks/use-input-mode"
@@ -106,14 +106,6 @@ function isPreviewSettled(draft: CachedDraft, previewById?: Map<string, DraftPre
   return previewById?.get(draft.id)?.status === "ready"
 }
 
-function attachmentOrEmptyLabel(draft: CachedDraft): string {
-  const attachmentCount = draft.attachments?.length ?? 0
-  if (attachmentCount > 0) {
-    return `${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}`
-  }
-  return "Empty draft"
-}
-
 /**
  * The row label: the host-supplied decrypted preview when present (E2E + plaintext
  * alike), otherwise derived from `contentJson` for plaintext-only callers/tests.
@@ -122,9 +114,9 @@ function attachmentOrEmptyLabel(draft: CachedDraft): string {
  */
 function rowPreview(draft: CachedDraft, previewById?: Map<string, DraftPreview>): string {
   const preview = previewById?.get(draft.id)
-  if (!preview) return draftInlineText(draft.contentJson) || attachmentOrEmptyLabel(draft)
+  if (!preview) return draftInlineText(draft.contentJson) || draftEmptyBodyLabel(draft.attachments?.length ?? 0)
   if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
-  return preview.text || attachmentOrEmptyLabel(draft)
+  return preview.text || draftEmptyBodyLabel(draft.attachments?.length ?? 0)
 }
 
 export function StashedDraftsPicker({

--- a/apps/frontend/src/components/timeline/thread-card.test.tsx
+++ b/apps/frontend/src/components/timeline/thread-card.test.tsx
@@ -82,7 +82,7 @@ describe("ThreadCard", () => {
         href="/panel/draft:stream_1:msg_1"
         workspaceId="ws_1"
         summary={undefined}
-        draft={{ preview: "half-written reply" }}
+        draft={{ preview: "half-written reply", attachmentCount: 0 }}
       />
     )
     expect(screen.getByRole("link")).toHaveAttribute("href", "/panel/draft:stream_1:msg_1")
@@ -92,18 +92,32 @@ describe("ThreadCard", () => {
     expect(screen.queryByText(/^\d+ repl(y|ies)$/)).toBeNull()
   })
 
-  it("renders the draft-only label with no snippet row when the preview is empty (sealed/attachment-only body)", () => {
+  it("renders the draft-only label with no snippet row when there is no body and no file (sealed body)", () => {
     renderCard(
       <ThreadCard
         replyCount={0}
         href="/panel/draft:stream_1:msg_1"
         workspaceId="ws_1"
         summary={undefined}
-        draft={{ preview: "" }}
+        draft={{ preview: "", attachmentCount: 0 }}
       />
     )
     expect(screen.getByText("Draft")).toBeInTheDocument()
     expect(screen.getByRole("link").querySelector("p")).toBeNull()
+  })
+
+  it("names the files of an attachment-only draft reply instead of dropping the snippet", () => {
+    renderCard(
+      <ThreadCard
+        replyCount={0}
+        href="/panel/draft:stream_1:msg_1"
+        workspaceId="ws_1"
+        summary={undefined}
+        draft={{ preview: "", attachmentCount: 2 }}
+      />
+    )
+    // Same wording as the drafts explorer and the composer stash pile.
+    expect(screen.getByText("2 attachments")).toBeInTheDocument()
   })
 
   it("appends the draft token beside the reply count and keeps the latest-reply row", () => {
@@ -113,7 +127,7 @@ describe("ThreadCard", () => {
         href="/panel/thread_1"
         workspaceId="ws_1"
         summary={baseSummary}
-        draft={{ preview: "unsent addition" }}
+        draft={{ preview: "unsent addition", attachmentCount: 0 }}
       />
     )
     expect(screen.getByText("2 replies")).toBeInTheDocument()

--- a/apps/frontend/src/components/timeline/thread-card.tsx
+++ b/apps/frontend/src/components/timeline/thread-card.tsx
@@ -6,13 +6,24 @@ import { RelativeTime } from "@/components/relative-time"
 import { useActors } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { truncateContent } from "@/components/layout/sidebar/utils"
+import { draftEmptyBodyLabel } from "@/lib/drafts/decryption"
 import { cn } from "@/lib/utils"
 
 export interface ThreadCardDraft {
   /** One-line plain text of the viewer's unsent reply. "" when there is nothing
-   *  renderable (attachment-only, or a sealed body this device can't read) —
-   *  the label still shows, the snippet row is dropped. */
+   *  renderable (attachment-only, or a sealed body this device can't read). */
   preview: string
+  /** Files on the draft. With no body text they name the row ("1 attachment"),
+   *  so an attachment-only reply reads the same here as in every other draft
+   *  list; only a row with neither drops the snippet entirely. */
+  attachmentCount: number
+}
+
+/** What the draft-only card shows under its header: the body text, else the file
+ *  count, else nothing (a sealed body this device can't read). */
+function draftSnippet(draft: ThreadCardDraft): string {
+  if (draft.preview) return draft.preview
+  return draft.attachmentCount > 0 ? draftEmptyBodyLabel(draft.attachmentCount) : ""
 }
 
 interface ThreadCardProps {
@@ -70,6 +81,7 @@ export function ThreadCard({
   if (replyCount === 0 && !draft) return null
 
   const isDraftOnly = replyCount === 0
+  const draftSnippetText = draft ? draftSnippet(draft) : ""
   const replyLabel = replyCount === 1 ? "1 reply" : `${replyCount} replies`
   const participants = summary?.participants ?? []
 
@@ -132,7 +144,7 @@ export function ThreadCard({
         <ChevronRight className="ml-auto h-3.5 w-3.5 text-muted-foreground/50 transition-transform group-hover/thread:translate-x-0.5 group-hover/thread:text-muted-foreground" />
       </div>
       {isDraftOnly
-        ? draft?.preview && <p className="truncate text-xs italic text-muted-foreground">{draft.preview}</p>
+        ? draftSnippetText && <p className="truncate text-xs italic text-muted-foreground">{draftSnippetText}</p>
         : summary && (
             <p className="truncate text-xs text-muted-foreground">
               <span className="font-medium text-foreground/80">

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -401,6 +401,43 @@ describe("useAllDrafts E2E drafts", () => {
     expect(row.isStashed).toBe(true)
   })
 
+  it("reports a decrypted attachment-only sealed draft as bodyless with its real file count", async () => {
+    // The row at rest carries neither the body nor the attachments (E2EE-4), so
+    // both come from the decrypt. An empty preview is what lets the explorer
+    // label the row by its files instead of "Encrypted draft".
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(UNLOCKED_SESSION)
+    clearDecryptCache()
+
+    await db.drafts.add({
+      id: "draft_e2e_files",
+      workspaceId,
+      scope: "stream:stream_enc",
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_sealed",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      baseVersion: 1,
+      clientUpdatedAt: 2000,
+    })
+    seedDecryption("draft_e2e_files", {
+      contentMarkdown: "",
+      contentJson: EMPTY_DOC,
+      attachmentRefs: [
+        { attachmentId: "att_1", key: "AAAA", iv: "BBBB", filename: "a.png", mimeType: "image/png", sizeBytes: 1 },
+        { attachmentId: "att_2", key: "AAAA", iv: "BBBB", filename: "b.png", mimeType: "image/png", sizeBytes: 2 },
+      ],
+    } as unknown as Parameters<typeof seedDecryption>[1])
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts.some((d) => d.id === "draft_e2e_files")).toBe(true))
+    const row = result.current.drafts.find((d) => d.id === "draft_e2e_files")!
+    expect({ preview: row.preview, attachmentCount: row.attachmentCount }).toEqual({ preview: "", attachmentCount: 2 })
+  })
+
   it("shows an 'Encrypted draft' placeholder (not a blank row) while the session is locked", async () => {
     vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
     // Default locked session from beforeEach stands.

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -141,7 +141,12 @@ function draftPreviewLabel(draft: CachedDraft, previewMap: Map<string, DraftPrev
   const preview = previewMap.get(draft.id)
   if (!preview) return "Encrypted draft"
   if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
-  return truncatePreview(preview.text) || "Encrypted draft"
+  const text = truncatePreview(preview.text)
+  if (text) return text
+  // Decrypted, and the body really is empty. With files on it the row reads as
+  // its files (the caller's fallback), exactly like a plaintext one — returning
+  // "Encrypted draft" here is what kept the attachment label off a sealed row.
+  return preview.attachmentCount > 0 ? "" : "Encrypted draft"
 }
 
 /**

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -145,6 +145,16 @@ function draftPreviewLabel(draft: CachedDraft, previewMap: Map<string, DraftPrev
 }
 
 /**
+ * How many attachments a row carries. A sealed row's `attachments` is `[]` at
+ * rest (E2EE-4), so its count comes from the decrypted preview — reading the row
+ * would report every encrypted attachment-only draft as having none.
+ */
+function draftAttachmentCount(draft: CachedDraft, previewMap: Map<string, DraftPreview>): number {
+  if (draft.ciphertext == null) return draft.attachments?.length ?? 0
+  return previewMap.get(draft.id)?.attachmentCount ?? 0
+}
+
+/**
  * The copy source for a draft row: the full markdown plus how readable it is.
  * Reads the same decrypted-preview entry the row's label does, so a sealed row
  * can never show "Decrypting…" while a copy action hands out that label (or an
@@ -510,7 +520,7 @@ export function useAllDrafts(workspaceId: string) {
           displayName,
           preview: draftPreviewLabel(loadedDraft, previewMap),
           ...draftCopySource(loadedDraft, previewMap),
-          attachmentCount: loadedDraft?.attachments?.length ?? 0,
+          attachmentCount: draftAttachmentCount(loadedDraft, previewMap),
           updatedAt: loadedDraft?.clientUpdatedAt ?? scratchpad.createdAt,
           href: `/w/${workspaceId}/s/${scratchpad.id}`,
           groupLabel: displayName,
@@ -574,7 +584,7 @@ export function useAllDrafts(workspaceId: string) {
         displayName: resolved.displayName,
         preview: draftPreviewLabel(draft, previewMap),
         ...draftCopySource(draft, previewMap),
-        attachmentCount: draft.attachments?.length ?? 0,
+        attachmentCount: draftAttachmentCount(draft, previewMap),
         updatedAt: draft.clientUpdatedAt,
         href,
         groupLabel: resolved.groupLabel,

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
@@ -71,21 +71,31 @@ describe("useDecryptedDraftPreviews", () => {
   it("returns plaintext previews straight from contentJson", () => {
     const draft = plaintextDraft("draft_p", "hello plain")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId: undefined }]))
-    expect(result.current.get("draft_p")).toEqual({ text: "hello plain", markdown: "hello plain", status: "ready" })
+    expect(result.current.get("draft_p")).toEqual({
+      text: "hello plain",
+      markdown: "hello plain",
+      attachmentCount: 0,
+      status: "ready",
+    })
   })
 
   it("returns the decrypted body for a sealed draft already in the shared cache", () => {
     const draft = sealedDraft("draft_e")
     seedDecryption("draft_e", { contentMarkdown: "secret body", contentJson: makeDoc("secret body") })
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "secret body", markdown: "secret body", status: "ready" })
+    expect(result.current.get("draft_e")).toEqual({
+      text: "secret body",
+      markdown: "secret body",
+      attachmentCount: 0,
+      status: "ready",
+    })
   })
 
   it("reports a sealed draft as locked while the session is locked (no decrypt attempted)", () => {
     vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(locked)
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "locked" })
+    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", attachmentCount: 0, status: "locked" })
   })
 
   it("reports decrypting for an unlocked sealed draft whose body hasn't landed yet", () => {
@@ -93,7 +103,7 @@ describe("useDecryptedDraftPreviews", () => {
     vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockReturnValue(new Promise(() => {}))
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "decrypting" })
+    expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", attachmentCount: 0, status: "decrypting" })
   })
 
   it("reports failed when the decrypt returns null", async () => {
@@ -105,7 +115,9 @@ describe("useDecryptedDraftPreviews", () => {
     )
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    await waitFor(() => expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", status: "failed" }))
+    await waitFor(() =>
+      expect(result.current.get("draft_e")).toEqual({ text: "", markdown: "", attachmentCount: 0, status: "failed" })
+    )
   })
 
   it("resolves each id independently across a mixed batch in one render", async () => {
@@ -127,14 +139,27 @@ describe("useDecryptedDraftPreviews", () => {
     ]
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, inputs))
 
-    await waitFor(() => expect(result.current.get("draft_fail")).toEqual({ text: "", markdown: "", status: "failed" }))
-    expect(result.current.get("draft_plain")).toEqual({ text: "plain body", markdown: "plain body", status: "ready" })
+    await waitFor(() =>
+      expect(result.current.get("draft_fail")).toEqual({ text: "", markdown: "", attachmentCount: 0, status: "failed" })
+    )
+    expect(result.current.get("draft_plain")).toEqual({
+      text: "plain body",
+      markdown: "plain body",
+      attachmentCount: 0,
+      status: "ready",
+    })
     expect(result.current.get("draft_seeded")).toEqual({
       text: "seeded body",
       markdown: "seeded body",
+      attachmentCount: 0,
       status: "ready",
     })
-    expect(result.current.get("draft_hang")).toEqual({ text: "", markdown: "", status: "decrypting" })
+    expect(result.current.get("draft_hang")).toEqual({
+      text: "",
+      markdown: "",
+      attachmentCount: 0,
+      status: "decrypting",
+    })
     expect(result.current.size).toBe(4)
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -338,6 +338,53 @@ describe("useDraftMessage", () => {
 
       expect(putSpy).not.toHaveBeenCalled()
     })
+
+    it("adds several files picked at once to ONE detached row", async () => {
+      // Uploads finishing together queue one call each, all before the first
+      // one's create resolves. Honoring their null identity forked a detached
+      // row per file (ten one-attachment drafts in a DM, all surviving the send).
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("typed"), attachments: [] })
+      const pointerId = (await db.composerLoaded.get(draftKey))?.draftId
+      const contentDraftIdRef = { current: null as string | null }
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+      await act(async () => {
+        await Promise.all([
+          result.current.addAttachment({ id: "attach_a", filename: "a.png", mimeType: "image/png", sizeBytes: 1 }),
+          result.current.addAttachment({ id: "attach_b", filename: "b.png", mimeType: "image/png", sizeBytes: 2 }),
+        ])
+      })
+
+      const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, draftKey]).toArray()
+      const detached = rows.filter((row) => row.id !== pointerId)
+      expect(detached).toHaveLength(1)
+      expect(detached[0].attachments.map((a) => a.id)).toEqual(["attach_a", "attach_b"])
+      // The pointer draft is untouched: this composer never hydrated it.
+      expect(rows.find((row) => row.id === pointerId)?.attachments).toEqual([])
+    })
+
+    it("does not mint another detached row for a file a sibling draft already holds", async () => {
+      // The per-row duplicate check looks at a row that does not exist yet, so
+      // only a scope-wide look can stop the persistence effect's re-run (it
+      // fires per upload tick) from minting a fresh copy every time.
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("typed"), attachments: [] })
+      const attachment = { id: "attach_a", filename: "a.png", mimeType: "image/png", sizeBytes: 1 }
+      const contentDraftIdRef = { current: null as string | null }
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, undefined, contentDraftIdRef))
+
+      await act(async () => {
+        await result.current.addAttachment(attachment)
+      })
+      // The composer loses its identity again (a remount, a pointer flicker) and
+      // the effect re-fires with the same uploaded file.
+      contentDraftIdRef.current = null
+      await act(async () => {
+        await result.current.addAttachment(attachment)
+      })
+
+      const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, draftKey]).toArray()
+      expect(rows).toHaveLength(2)
+    })
   })
 
   describe("removeAttachment", () => {

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -825,6 +825,41 @@ describe("useDraftMessage", () => {
         )
       })
 
+      it("does not mint a detached row for a file a sealed sibling already holds", async () => {
+        // The sealed branch of the scope-wide guard: a sibling's attachments live
+        // only in the decrypt cache (E2EE-4), so the guard has to read them there.
+        await putSealedLoaded("draft_ptr")
+        await db.drafts.put({
+          id: "draft_sib",
+          workspaceId,
+          scope: draftKey,
+          contentJson: EMPTY_DOC,
+          attachments: [],
+          ciphertext: "ct_sib",
+          envelope: { v: 2 },
+          e2eVersion: 2,
+          clientUpdatedAt: Date.now(),
+        })
+        await seedDraftCacheFromIdb(workspaceId)
+        seedDecryption("draft_sib", {
+          contentMarkdown: "",
+          contentJson: EMPTY_DOC,
+          attachmentRefs: [ref("att_z", "z.png", 7)],
+          sources: [],
+        })
+        const sealSpy = sealMock([ref("att_z", "z.png", 7)])
+        const contentDraftIdRef = { current: null as string | null }
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId, contentDraftIdRef))
+
+        await act(async () => {
+          await result.current.addAttachment({ id: "att_z", filename: "z.png", mimeType: "image/png", sizeBytes: 7 })
+        })
+
+        expect(sealSpy).not.toHaveBeenCalled()
+        expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(2)
+      })
+
       it("a content-only save preserves the draft's already-sealed attachments", async () => {
         await putSealedLoaded("draft_sealed")
         seedDecryption("draft_sealed", {

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -58,7 +58,10 @@ async function getLoadedDraftId(scope: string): Promise<string | null> {
  * Whether ANY draft filed under `scope` already carries `attachmentId` — the
  * loaded one or a detached sibling. A sealed row keeps no plaintext attachment
  * linkage at rest (E2EE-4), so its set is read from the in-memory decrypt cache,
- * the same authority the seal path re-reads.
+ * the same authority the seal path re-reads — which makes this BEST-EFFORT for
+ * E2E: a sibling evicted from that cache (or gone with a reload/lock) reads as
+ * carrying nothing, and there is no durable copy to fall back on by design. It
+ * backstops the identity rule in `addAttachment`, never replaces it.
  */
 async function scopeHasAttachment(workspaceId: string, scope: string, attachmentId: string): Promise<boolean> {
   const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -54,6 +54,19 @@ async function getLoadedDraftId(scope: string): Promise<string | null> {
   return row?.draftId ?? null
 }
 
+/**
+ * Whether ANY draft filed under `scope` already carries `attachmentId` — the
+ * loaded one or a detached sibling. A sealed row keeps no plaintext attachment
+ * linkage at rest (E2EE-4), so its set is read from the in-memory decrypt cache,
+ * the same authority the seal path re-reads.
+ */
+async function scopeHasAttachment(workspaceId: string, scope: string, attachmentId: string): Promise<boolean> {
+  const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
+  return rows.some((row) =>
+    (row.ciphertext ? cachedDraftAttachments(row.id) : (row.attachments ?? [])).some((a) => a.id === attachmentId)
+  )
+}
+
 export interface DraftFields {
   contentJson: JSONContent
   attachments: DraftAttachment[]
@@ -1057,8 +1070,15 @@ export function useDraftMessage(
     async (attachment: DraftAttachment) => {
       // The row this attachment operation belongs to, captured ONCE at CALL
       // time: the ref can move on (a repoint) across the awaits below.
-      const targetId = contentDraftId.current
+      const armedId = contentDraftId.current
       await chainWrite(async () => {
+        // A null capture is re-read HERE, after the predecessor write settled —
+        // `saveDraft`'s rule (its `expectedDraftId ?? ref` read) for the same
+        // reason. Selecting several files queues one call per upload; they all
+        // arm before the first one's create resolves, and honoring that null
+        // forked a detached row per call — ten one-attachment drafts in a DM,
+        // every one of them surviving the send.
+        const targetId = armedId ?? contentDraftId.current
         // Same assignment-time recheck `saveDraft` uses: the ref may have been
         // repointed during the awaits below, and writing the captured target back
         // would drag the composer's identity onto the superseded row.
@@ -1072,6 +1092,13 @@ export function useDraftMessage(
         let effectiveTarget = targetId
         let mintedDetachedId = false
         if (strictIdentity && targetId === null && (await getLoadedDraftId(draftKey)) !== null) {
+          // A detached row claims no pointer, so nothing ever reconciles it with
+          // its siblings — and the per-row duplicate check below looks at a row
+          // that does not exist yet, so it always passes. Only a scope-wide look
+          // can tell that this file is already persisted here; without it any
+          // repeat call (the persistence effect re-runs per upload tick) mints
+          // another copy of the same attachment.
+          if (await scopeHasAttachment(workspaceId, draftKey, attachment.id)) return
           effectiveTarget = generateLocalDraftId()
           mintedDetachedId = true
         }
@@ -1142,8 +1169,12 @@ export function useDraftMessage(
       // time: the ref can move on (a repoint) across the awaits below, and
       // reading it later would source the content from one draft and address
       // the write to another.
-      const targetId = contentDraftId.current
+      const armedId = contentDraftId.current
       await chainWrite(async () => {
+        // Null re-read in-chain, as in `addAttachment`: a removal queued behind
+        // the add that created the row must see that create's identity, or it
+        // addresses no row and silently leaves the file attached.
+        const targetId = armedId ?? contentDraftId.current
         // Assignment-time recheck, as in `addAttachment`/`saveDraft`.
         const advanceIdentity = (next: string | null) => {
           if (contentDraftId.current === targetId) contentDraftId.current = next

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -179,6 +179,17 @@ export function draftDecryptionToPreview(decryption: DraftDecryption): DraftPrev
   return { text: "", markdown: "", status: "decrypting" } // pending / none
 }
 
+/**
+ * Label for a draft row whose body renders no text. An attachment-only draft is
+ * real, unsent payload — naming its files is the only truthful thing to show, so
+ * every draft-listing surface (composer stash pile, drafts explorer) reads it
+ * from here rather than each deciding what "no text" means.
+ */
+export function draftEmptyBodyLabel(attachmentCount: number): string {
+  if (attachmentCount > 0) return `${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}`
+  return "Empty draft"
+}
+
 /** User-facing label for a non-ready preview status. */
 export function draftPreviewStatusLabel(status: Exclude<DraftPreviewStatus, "ready">): string {
   if (status === "decrypting") return "Decrypting…"

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -150,6 +150,13 @@ export interface DraftPreview {
    * state that decides its preview.
    */
   markdown: string
+  /**
+   * How many attachments the draft carries. Rides with the preview because a
+   * sealed row's `attachments` is `[]` at rest (E2EE-4) — its real set is only
+   * readable through the same decrypt this preview came from, so a list surface
+   * reading the row directly would call an attachment-only E2E draft empty.
+   */
+  attachmentCount: number
   status: DraftPreviewStatus
 }
 
@@ -171,12 +178,13 @@ export function draftDecryptionToPreview(decryption: DraftDecryption): DraftPrev
     return {
       text: draftInlineText(decryption.contentJson),
       markdown: draftMarkdown(decryption.contentJson),
+      attachmentCount: decryption.attachments.length,
       status: "ready",
     }
   }
-  if (decryption.status === "failed") return { text: "", markdown: "", status: "failed" }
-  if (decryption.status === "locked") return { text: "", markdown: "", status: "locked" }
-  return { text: "", markdown: "", status: "decrypting" } // pending / none
+  if (decryption.status === "failed") return { text: "", markdown: "", attachmentCount: 0, status: "failed" }
+  if (decryption.status === "locked") return { text: "", markdown: "", attachmentCount: 0, status: "locked" }
+  return { text: "", markdown: "", attachmentCount: 0, status: "decrypting" } // pending / none
 }
 
 /**

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -359,6 +359,21 @@ describe("put-away annotation", () => {
     expect(roamedRow?.textContent).not.toContain("Stashed")
   })
 
+  it("names the files of an attachment-only row instead of calling it empty", () => {
+    // An attachment-only draft has no body text but is real, unsent payload —
+    // exactly what the composer's stash pile already says (`draftEmptyBodyLabel`).
+    mockDrafts([
+      draft({ id: "a", displayName: "Alpha", isStashed: true, preview: "", attachmentCount: 1 }),
+      draft({ id: "b", displayName: "Bravo", isStashed: true, preview: "", attachmentCount: 3 }),
+      draft({ id: "c", displayName: "Charlie", isStashed: true, preview: "", attachmentCount: 0 }),
+    ])
+    renderPage()
+
+    expect(screen.getByText("1 attachment")).toBeInTheDocument()
+    expect(screen.getByText("3 attachments")).toBeInTheDocument()
+    expect(screen.getByText("Empty draft")).toBeInTheDocument()
+  })
+
   it("keeps the active preview when a durable marker remains on a locally loaded row", () => {
     mockDrafts([
       draft({ id: "c", displayName: "Charlie", isStashed: false, putAway: true, preview: "active-looking body" }),

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -22,6 +22,7 @@ import type { DraftActionContext } from "@/components/drafts/draft-actions"
 import { ItemList, type QuickSwitcherItem } from "@/components/quick-switcher"
 import { SidebarToggle } from "@/components/layout"
 import { cn } from "@/lib/utils"
+import { draftEmptyBodyLabel } from "@/lib/drafts/decryption"
 import { useAllDrafts, type UnifiedDraft, type DraftType } from "@/hooks"
 
 const TYPE_ICONS: Record<DraftType, React.ComponentType<{ className?: string }>> = {
@@ -178,7 +179,7 @@ export function DraftsPage() {
         description = description ? `${description}${attachmentSuffix}` : attachmentSuffix
       }
 
-      const label = draft.isStashed ? draft.preview || "Empty draft" : draft.displayName
+      const label = draft.isStashed ? draft.preview || draftEmptyBodyLabel(draft.attachmentCount) : draft.displayName
       let icon: React.ComponentType<{ className?: string }>
       if (draft.isStashed) {
         icon = Bookmark


### PR DESCRIPTION
## Problem

A DM in production holds ten live drafts created inside 2.5s on 2026-08-08, every one of them body-empty with exactly **one** attachment — and only **two distinct attachment ids** across the ten rows. They were minted locally (client base36 ids, `version = 1`, one push each), so the server's split-on-drift protocol never ran; this is client-side draft *creation*.

Two defects produce them:

1. `addAttachment` (`use-draft-message.ts`) captured `contentDraftId.current` at call time only. Picking several files queues one call per completed upload, all armed before the first one's create resolves, so each sees a null identity, takes the detached-create path (`mintedDetachedId`) and mints its own row. `upsertLoadedDraft` deliberately does not claim the pointer for a detached row, so nothing later reconciles the siblings, and resolve-on-send deletes only the pointer draft — the rest survive forever. `saveDraft` already solved this for typing (its `expectedDraftId ?? ref` read inside the write chain, and the stray-prefix-draft bug that motivated it); the attachment paths never got the same rule.
2. The detached path's duplicate check (`currentAttachments.some(...)`) reads the row it is about to mint, which does not exist — so it always passes. The persistence effect in `use-draft-composer.ts:618` re-fires per upload tick, and each pass re-minted the same file. That is the amplifier from 2 rows to 10.

Every listing surface then called them "Empty draft" (or showed nothing at all). An attachment is unsent payload — which is exactly why the empty-draft cleanup correctly left the rows alone.

## Solution

**Stop the forking.**

- `addAttachment` / `removeAttachment` keep the call-time capture (a repoint mid-flight must still address the armed row — existing tests cover it) but re-read the ref **inside** `chainWrite` when that capture is `null`. A queued call then inherits its predecessor's create instead of forking. Same shape as `saveDraft`'s `expectedDraftId ?? contentDraftId.current`.
- Before minting a detached row, `scopeHasAttachment(workspaceId, scope, attachmentId)` looks across every draft filed under the scope; already there → return. This is what makes a repeat call idempotent regardless of *why* the identity went null. Under E2E it is explicitly **best-effort**: a sealed row keeps no attachment linkage at rest (E2EE-4) and the decrypt cache is the only source, so an evicted sibling reads as empty. It backstops the identity rule, it does not replace it — stated in the code so nobody reads it as a guarantee.

**Name what the draft actually holds.** `draftEmptyBodyLabel(count)` in `lib/drafts/decryption.ts` is the single source: "1 attachment" / "3 attachments", with "Empty draft" surviving only for a body that genuinely renders nothing and no files.

- `DraftPreview` now carries `attachmentCount`. A sealed row's `attachments` is `[]` at rest, so reading the row labelled every **encrypted** attachment-only draft "Empty draft" — the count has to ride with the decrypt that produced the body. The stash pile and the explorer both read it from there.
- The in-stream thread visualizer (`ThreadCard`) dropped its snippet row entirely for an attachment-only reply draft, leaving a bare "Draft" pill. It now names the files; `ThreadCardDraft` gained the count that `ScopeDraftPreview` was already carrying.

Residual: `scopeHasAttachment` is a read-then-act over IDB, so two *separate* composer instances on one scope could still both mint in the same tick. Serializing across instances would need a cross-hook lock; the write chain covers the observed case (one composer, many uploads).

Not fixed here: the ten existing rows. Deletable from Drafts → Select → Delete; no migration, since drafts are local-first and per-user.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | Null identity re-read in-chain for both attachment paths; `scopeHasAttachment` guard on the detached-create path |
| `apps/frontend/src/lib/drafts/decryption.ts` | **new** `draftEmptyBodyLabel(attachmentCount)`; `DraftPreview.attachmentCount` |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Row attachment count comes from the preview for sealed rows |
| `apps/frontend/src/pages/drafts.tsx` | Attachment-only stashed row names its files |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | Shared label; count from the preview, not the at-rest row |
| `apps/frontend/src/components/timeline/thread-card.tsx` | Attachment-only draft reply gets a snippet instead of nothing |
| tests | `use-draft-message` (concurrent files → one row; repeat add mints nothing; sealed-sibling guard), `drafts` page, stash picker, thread card |

## Review dispositions ([review comment](https://github.com/threahq/threa/pull/1858#issuecomment-5256849755))

- **Accepted** — sealed rows labelled "Empty draft" in the stash pile (count now rides on `DraftPreview`).
- **Accepted** — `scopeHasAttachment` is unreliable for E2E: documented as best-effort by construction, plus a sealed-branch test (it fails without the guard).
- **Accepted** — thread visualizer inconsistency (adjacent surface from #1856).
- **Disputed** — "the in-chain read amplifies the hydrate effect's unconditional ref overwrite": the sequence is real, but on the pre-fix code the same interleaving produced two orphaned rows instead of one, and the second attachment now lands on the row that actually gets sent. Not a regression; residual and unchanged in kind.

## Test plan

- [x] All new tests fail on the pre-fix code (forked row per file; re-minted row for a sealed sibling's file) and pass after
- [x] `bun run --filter @threa/frontend test` — 6545 pass, 0 fail
- [x] `bun run typecheck`, `bun run lint` — clean
- [x] `bun run test` — one backend e2e (`sidebar-archived-roots`, a 5s socket timeout) flaked in the batch run; passes standalone 5/5, and this diff is frontend-only
- [ ] Not reproduced manually in the app — the trigger needs a multi-file upload racing an unhydrated composer identity; covered by the unit tests instead

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
