### PR TITLE
fix: stop the sidebar counting drafts the explorer refuses to list

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -13,6 +13,7 @@ import { resetActorLookups } from "@/stores/actor-lookup"
 import { bumpAccountGeneration } from "@/db/event-writes"
 import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
+import { resetDraftContextCache } from "@/hooks/use-board-draft-context"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 import { resetComposeOverlayStoreCache } from "@/stores/compose-overlay-store"
 import { resetBoardFlashStoreCache } from "@/stores/board-flash-store"
@@ -88,6 +89,7 @@ function flushModuleStoreCaches(): void {
   resetRowConfirmations()
   resetStreamStoreCache()
   resetDraftStoreCache()
+  resetDraftContextCache()
   resetShareHandoffStoreCache()
   resetSnippetRequestStoreCache()
   resetConversationReplyOpenStoreCache()

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -116,7 +116,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const { createScratchpad } = useDraftScratchpads(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getMentionCount, getActivityCount, unreadActivityCount } = useActivityCounts(workspaceId)
-  const { draftCount, loadedDraftStreamIdSignature } = useDraftSummary(workspaceId)
+  const { draftCount, isLoading: draftsLoading, loadedDraftStreamIdSignature } = useDraftSummary(workspaceId)
   const { openCreateChannel } = useCreateChannel()
   const { user } = useAuth()
   const assignLabel = useAssignLabel(workspaceId)
@@ -393,7 +393,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
       workspaceId={workspaceId}
       quickLinks={sidebarConfig.quickLinks}
       isDraftsPage={isDraftsPage}
-      draftCount={draftCount}
+      // No badge until the archived filter can decide — a count published early
+      // is unfiltered, and it contradicts a Drafts page that is still holding.
+      draftCount={draftsLoading ? 0 : draftCount}
       isSavedPage={isSavedPage}
       savedCount={savedCount}
       isScheduledPage={isScheduledPage}

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -347,7 +347,13 @@ describe("useAllDrafts loading gate", () => {
     // workspace/board caches land, "no archived host" and "host unknown" look
     // identical, so a cold load painted every row and then retracted it.
     await seedStream({ id: "stream_arch_gate", archivedAt: "2026-01-01T00:00:00Z" })
-    await db.drafts.add(syncedDraft({ id: "draft_gate", scope: "stream:stream_arch_gate" }))
+    await seedMessageEvent("msg_gate", "stream_live_gate", 5)
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_gate", scope: "stream:stream_arch_gate" }),
+      // A thread scope too: its host resolves through a second async read, so a
+      // gate that forgot it would report ready before that read landed.
+      syncedDraft({ id: "draft_gate_thread", scope: "thread:msg_gate", clientUpdatedAt: 900 }),
+    ])
 
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
@@ -359,7 +365,12 @@ describe("useAllDrafts loading gate", () => {
     expect(result.current.summary.isLoading).toBe(result.current.all.isLoading)
 
     await act(async () => {
-      await applyWorkspaceBootstrap(workspaceId, makeReloadBootstrap([makeArchivedRoot("stream_arch_gate")], []), 1)
+      const liveHost: Stream = { ...makeArchivedRoot("stream_live_gate"), archivedAt: null }
+      await applyWorkspaceBootstrap(
+        workspaceId,
+        makeReloadBootstrap([makeArchivedRoot("stream_arch_gate")], [liveHost]),
+        1
+      )
       await seedDraftCacheFromIdb(workspaceId)
     })
 
@@ -367,9 +378,9 @@ describe("useAllDrafts loading gate", () => {
     // leave the page on "Loading..." forever.
     await waitFor(() => expect(result.current.all.isLoading).toBe(false))
     expect(result.current.summary.isLoading).toBe(false)
-    // And the row the filter hides was never exposed as a settled one.
-    expect(result.current.all.drafts).toHaveLength(0)
-    expect(result.current.summary.draftCount).toBe(0)
+    // The archived-host row is gone; the thread row on a live host stays.
+    expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_gate_thread"])
+    expect(result.current.summary.draftCount).toBe(1)
   })
 })
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -350,18 +350,26 @@ describe("useAllDrafts loading gate", () => {
     await db.drafts.add(syncedDraft({ id: "draft_gate", scope: "stream:stream_arch_gate" }))
 
     const { wrapper } = createWrapper()
-    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
 
-    expect(result.current.isLoading).toBe(true)
+    // Both surfaces read one gate, so they become authoritative together —
+    // publishing a count while the list still holds is the disagreement.
+    expect(result.current.summary.isLoading).toBe(result.current.all.isLoading)
 
     await act(async () => {
       await applyWorkspaceBootstrap(workspaceId, makeReloadBootstrap([makeArchivedRoot("stream_arch_gate")], []), 1)
       await seedDraftCacheFromIdb(workspaceId)
     })
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Settles — a gate that reads unsubscribed module state can latch true and
+    // leave the page on "Loading..." forever.
+    await waitFor(() => expect(result.current.all.isLoading).toBe(false))
+    expect(result.current.summary.isLoading).toBe(false)
     // And the row the filter hides was never exposed as a settled one.
-    expect(result.current.drafts).toHaveLength(0)
+    expect(result.current.all.drafts).toHaveLength(0)
+    expect(result.current.summary.draftCount).toBe(0)
   })
 })
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -5,7 +5,7 @@ import { createElement, type ReactNode } from "react"
 import { DEFAULT_SIDEBAR_CONFIG, type JSONContent, type Stream, type WorkspaceBootstrap } from "@threa/types"
 import { db, type CachedDraft } from "@/db"
 import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
-import { resetDraftStoreCache } from "@/stores/draft-store"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
 import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as currentUserHook from "./use-current-workspace-user-id"
@@ -303,6 +303,31 @@ describe("useAllDrafts board-composer drafts", () => {
     )
   })
 
+  it("badge hides a board draft on an archived host, in step with the list", async () => {
+    // The sidebar counted board drafts without resolving their conversation, so
+    // an archived scratchpad's reply draft showed in the badge and nowhere else —
+    // "2 drafts" over an empty explorer, with no way to reach them.
+    await seedStream({ id: "stream_arch_board", type: "scratchpad", archivedAt: "2026-01-01T00:00:00Z" })
+    await seedStream({ id: "stream_live_board", type: "scratchpad" })
+    await seedConversation("conv_arch", "stream_arch_board", "Archived pad")
+    await seedConversation("conv_live", "stream_live_board", "Live pad")
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_arch", scope: "board:reply:conv_arch" }),
+      syncedDraft({ id: "draft_live", scope: "board:reply:conv_live" }),
+    ])
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_live"])
+      expect(result.current.summary.draftCount).toBe(1)
+      expect(result.current.summary.draftCount).toBe(result.current.all.drafts.length)
+    })
+  })
+
   it("counts board drafts in the sidebar summary without flagging a stream hint", async () => {
     await db.drafts.add(syncedDraft({ id: "draft_b5", scope: "board:reply:conv_1" }))
     await db.drafts.add(syncedDraft({ id: "draft_s9", scope: "stream:stream_1" }))
@@ -313,6 +338,30 @@ describe("useAllDrafts board-composer drafts", () => {
 
     await waitFor(() => expect(result.current.draftCount).toBe(2))
     expect(result.current.loadedDraftStreamIdSignature).toBe("stream_1")
+  })
+})
+
+describe("useAllDrafts loading gate", () => {
+  it("reports isLoading until the caches the archived filter reads have landed", async () => {
+    // The filter can only HIDE once it knows each draft's host: before the
+    // workspace/board caches land, "no archived host" and "host unknown" look
+    // identical, so a cold load painted every row and then retracted it.
+    await seedStream({ id: "stream_arch_gate", archivedAt: "2026-01-01T00:00:00Z" })
+    await db.drafts.add(syncedDraft({ id: "draft_gate", scope: "stream:stream_arch_gate" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      await applyWorkspaceBootstrap(workspaceId, makeReloadBootstrap([makeArchivedRoot("stream_arch_gate")], []), 1)
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // And the row the filter hides was never exposed as a settled one.
+    expect(result.current.drafts).toHaveLength(0)
   })
 })
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SIDEBAR_CONFIG, type JSONContent, type Stream, type WorkspaceBo
 import { db, type CachedDraft } from "@/db"
 import { applyWorkspaceBootstrap } from "@/sync/workspace-sync"
 import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { resetDraftContextCache } from "./use-board-draft-context"
 import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as currentUserHook from "./use-current-workspace-user-id"
@@ -172,6 +173,9 @@ function makeReloadBootstrap(archivedStreams: Stream[], streams: Stream[] = []):
 beforeEach(async () => {
   vi.restoreAllMocks()
   resetDraftStoreCache()
+  // The board/thread reads retain their last resolved value across mounts, so a
+  // later test would otherwise read the previous one's conversations.
+  resetDraftContextCache()
   await db.drafts.clear()
   await db.composerLoaded.clear()
   await db.pendingOperations.clear()

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -328,6 +328,27 @@ describe("useAllDrafts board-composer drafts", () => {
     })
   })
 
+  it("does not re-run the board read when an unrelated draft is written", async () => {
+    // The board query keys on the board scopes only. Keyed on every scope, an
+    // unrelated draft write re-fires it, `loaded` drops, and the whole page
+    // flips to its loading state on a warm interaction.
+    await seedConversation("conv_keyed", "stream_9", "GPU budget")
+    await db.drafts.add(syncedDraft({ id: "draft_board_keyed", scope: "board:reply:conv_keyed" }))
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+    await waitFor(() => expect(result.current.drafts).toHaveLength(1))
+
+    const bulkGet = vi.spyOn(db.conversations, "bulkGet")
+    await act(async () => {
+      await db.drafts.add(syncedDraft({ id: "draft_unrelated", scope: "stream:stream_other" }))
+    })
+    await waitFor(() => expect(result.current.drafts).toHaveLength(2))
+
+    expect(bulkGet).not.toHaveBeenCalled()
+    expect(result.current.isLoading).toBe(false)
+  })
+
   it("counts board drafts in the sidebar summary without flagging a stream hint", async () => {
     await db.drafts.add(syncedDraft({ id: "draft_b5", scope: "board:reply:conv_1" }))
     await db.drafts.add(syncedDraft({ id: "draft_s9", scope: "stream:stream_1" }))

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -452,11 +452,15 @@ export function useAllDrafts(workspaceId: string) {
     return ids
   }, [composerLoaded])
 
-  // Stable signature over the set of draft scopes so the board-context queries
-  // below (gated on the board-scoped ids they reference) don't re-fire on every
-  // unrelated draft write — `useDraftsFromStore` hands back a fresh array
-  // reference each time.
-  const scopesSignature = useMemo(() => draftScopesSignature(allDrafts.map((draft) => draft.scope)), [allDrafts])
+  // The `board:*` scopes only: the board read re-fires when this changes, and
+  // keying it on every scope would re-fire it (and drop `loaded`) on an
+  // unrelated draft write — `useDraftsFromStore` hands back a fresh array each
+  // time. "" also means "no board draft", which is what lets the gate skip
+  // waiting on a read that resolves to nothing.
+  const boardScopesSignature = useMemo(
+    () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
+    [allDrafts]
+  )
 
   // Build a map of stream ID -> stream for quick lookup
   const streamMap = useMemo(() => {
@@ -480,14 +484,7 @@ export function useAllDrafts(workspaceId: string) {
     hostPostByMessageId: subtopicHostByMessageId,
     parentPostByBranchConversationId,
     loaded: boardContextLoaded,
-  } = useBoardDraftContext(workspaceId, scopesSignature)
-
-  // "" when no draft is board-scoped — the board read resolves to nothing, so
-  // waiting on it would hold the list forever for the common case.
-  const boardScopesSignature = useMemo(
-    () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
-    [allDrafts]
-  )
+  } = useBoardDraftContext(workspaceId, boardScopesSignature)
 
   // Parent-message → host-stream map for thread drafts (shared with the sidebar
   // badge so both resolve thread-draft location/archival identically).
@@ -770,8 +767,8 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     threadScopesSignature
   )
 
-  // Board scopes only — the same shared, id-keyed read the explorer makes, so
-  // both sides decide a board draft's archived host from one map.
+  // The same board-scoped read the explorer makes, so both sides decide a board
+  // draft's archived host from one map.
   const boardScopesSignature = useMemo(
     () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
     [allDrafts]

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -217,16 +217,18 @@ export function isStreamArchived(
  * conversations that resolve a board scope's host. Until then "no archived host"
  * and "host unknown" are the same value, so neither the list nor the badge may
  * present a filtered result yet. Shared so the two become authoritative at the
- * same moment (they didn't: the list held while the badge published an
- * unfiltered count).
+ * same moment — a count published while the list still holds contradicts it.
  *
  * Both inputs are live subscriptions the calling hook holds, so this flips with
  * a re-render. A gate on the seeded-cache flags would not: nothing here wakes on
  * them, so whichever render observed them false could be the last one.
  */
-function draftFilterReady(streamsLoaded: boolean, boardScopesSignature: string, boardContextLoaded: boolean): boolean {
+function draftFilterReady(
+  streamsLoaded: boolean,
+  hostReads: readonly { referenced: boolean; loaded: boolean }[]
+): boolean {
   if (!streamsLoaded) return false
-  return boardScopesSignature === "" || boardContextLoaded
+  return hostReads.every((read) => !read.referenced || read.loaded)
 }
 
 interface ResolvedDraftLocation {
@@ -301,10 +303,9 @@ function streamDraftType(stream: CachedStream | undefined): DraftType {
 /**
  * The stream a `board:*` draft hangs off — a sub-topic's own stream, else the
  * conversation's anchor stream. The archived filter's input, shared by the
- * explorer and the sidebar badge so the two can't disagree about whether a board
- * draft is hidden (they did: the badge counted board drafts on archived
- * scratchpads the explorer refused to list). `null` when the conversation isn't
- * cached — unknown host, and no row is ever hidden on missing data.
+ * explorer and the sidebar badge so the two agree on whether a board draft is
+ * hidden. `null` when the conversation isn't cached — unknown host, and no row
+ * is ever hidden on missing data.
  */
 function boardDraftHostStreamId(
   parsed: ParsedBoardDraftKey,
@@ -396,26 +397,6 @@ export function streamIdsWithLoadedDraft(drafts: UnifiedDraft[]): Set<string> {
     ids.add(draft.streamId)
   }
   return ids
-}
-
-/**
- * Map of a thread draft's parent message id → its host stream, built from cached
- * `message_created` events. Shared by the explorer ({@link useAllDrafts}), the
- * sidebar badge ({@link useDraftSummary}) and the composer pile's home-stream
- * resolution (`useStashedDrafts`) so all three resolve a
- * `thread:{parentMessageId}` draft's host stream — and therefore its archival —
- * the same way. It reads through the shared, ref-counted
- * {@link useThreadAnchorContext}: one subscription for every consumer, keyed on
- * the anchor ids the drafts actually reference, so with no thread draft it reads
- * nothing at all and with one it does keyed lookups rather than a pass over every
- * synced stream's events. A parent not yet in cache resolves to no entry (the
- * draft counts, degrading to visible rather than being hidden on missing data).
- */
-export function useDraftThreadStreamMap(
-  workspaceId: string,
-  allDrafts: CachedDraft[]
-): Map<string, { streamId: string; anchorId: string }> {
-  return useThreadAnchorContext(workspaceId, useThreadAnchorSignature(allDrafts)).streamByAnchorId
 }
 
 /** The anchor ids a set of drafts' `thread:` scopes reference — the shared
@@ -510,7 +491,11 @@ export function useAllDrafts(workspaceId: string) {
 
   // Parent-message → host-stream map for thread drafts (shared with the sidebar
   // badge so both resolve thread-draft location/archival identically).
-  const messageToStreamMap = useDraftThreadStreamMap(workspaceId, allDrafts)
+  const threadScopesSignature = useThreadAnchorSignature(allDrafts)
+  const { streamByAnchorId: messageToStreamMap, loaded: threadContextLoaded } = useThreadAnchorContext(
+    workspaceId,
+    threadScopesSignature
+  )
 
   const draftsById = useMemo(() => {
     const map = new Map<string, CachedDraft>()
@@ -693,7 +678,10 @@ export function useAllDrafts(workspaceId: string) {
 
   // Rows built before the filter can decide are provisional — rendering them
   // paints a list the next frame retracts (INV-21), which is the cold-load flash.
-  const isLoading = !draftFilterReady(streamsLoaded, boardScopesSignature, boardContextLoaded)
+  const isLoading = !draftFilterReady(streamsLoaded, [
+    { referenced: boardScopesSignature !== "", loaded: boardContextLoaded },
+    { referenced: threadScopesSignature !== "", loaded: threadContextLoaded },
+  ])
 
   return {
     drafts,
@@ -729,15 +717,14 @@ export interface DraftSummary {
  * a keystroke's debounced draft save doesn't rebuild the full {@link useAllDrafts}
  * explorer model (which it does on every change) just to read two values off it.
  * Shares {@link draftHasPayload}, {@link isStreamArchived}, and
- * {@link useDraftThreadStreamMap} with the explorer, so archived channel/DM AND
+ * the shared thread-anchor context with the explorer, so archived channel/DM AND
  * thread-reply drafts (including nested threads under an archived root) are hidden
  * from the badge and the list alike. The shared thread map reads nothing until a
  * thread draft exists, so the always-mounted sidebar stays cheap otherwise.
- * Board drafts resolve their host conversation here too — the badge counting a
- * board reply the explorer refuses to list is what left the sidebar advertising
- * drafts the user could not find (every one of them on an archived scratchpad).
- * That read is keyed on the `board:*` scopes the drafts actually reference, so a
- * user with none pays nothing.
+ * Board drafts resolve their host conversation here too, so the badge cannot
+ * advertise a draft the explorer refuses to list. That read is keyed on the
+ * `board:*` scopes the drafts actually reference, so a user with none pays
+ * nothing.
  */
 export function useDraftSummary(workspaceId: string): DraftSummary {
   const draftScratchpads = useDraftScratchpadsFromStore(workspaceId)
@@ -775,9 +762,13 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
 
   // Parent-message → host-stream map for thread drafts, so the badge hides a
   // thread reply under an archived root in step with the explorer. Gated on a
-  // thread draft existing (see `useDraftThreadStreamMap`), so the always-mounted
+  // thread draft existing (the signature is empty without one), so the always-mounted
   // sidebar reads no events until the user actually has one.
-  const messageToStreamMap = useDraftThreadStreamMap(workspaceId, allDrafts)
+  const threadScopesSignature = useThreadAnchorSignature(allDrafts)
+  const { streamByAnchorId: messageToStreamMap, loaded: threadContextLoaded } = useThreadAnchorContext(
+    workspaceId,
+    threadScopesSignature
+  )
 
   // Board scopes only — the same shared, id-keyed read the explorer makes, so
   // both sides decide a board draft's archived host from one map.
@@ -787,9 +778,11 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
   )
   const { boardPostMap, loaded: boardContextLoaded } = useBoardDraftContext(workspaceId, boardScopesSignature)
   // Same gate the list uses: a count published before the filter can decide is
-  // the badge's version of the flash, and it disagrees with a list that is still
-  // holding — the disagreement this whole change is about.
-  const isLoading = !draftFilterReady(streamsLoaded, boardScopesSignature, boardContextLoaded)
+  // unfiltered, and contradicts a list that is still holding.
+  const isLoading = !draftFilterReady(streamsLoaded, [
+    { referenced: boardScopesSignature !== "", loaded: boardContextLoaded },
+    { referenced: threadScopesSignature !== "", loaded: threadContextLoaded },
+  ])
 
   return useMemo(() => {
     let draftCount = 0

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -5,12 +5,11 @@ import { parseBoardDraftKey, type ParsedBoardDraftKey } from "@/lib/board/draft-
 import { type CompanionMode } from "@threa/types"
 import {
   deleteDraftScratchpadFromCache,
-  hasSeededDraftCache,
   useComposerLoadedFromStore,
   useDraftsFromStore,
   useDraftScratchpadsFromStore,
 } from "@/stores/draft-store"
-import { hasSeededWorkspaceCache, useWorkspaceStreams } from "@/stores/workspace-store"
+import { useWorkspaceStreams, useWorkspaceStreamsLoaded } from "@/stores/workspace-store"
 import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { isDraftId } from "./use-draft-scratchpads"
@@ -212,6 +211,24 @@ export function isStreamArchived(
   return stream.rootStreamId != null && archivedStreamIds.has(stream.rootStreamId)
 }
 
+/**
+ * Whether the reads the archived filter depends on have landed: the workspace
+ * streams that carry `archivedAt`, and — only when a board draft exists — the
+ * conversations that resolve a board scope's host. Until then "no archived host"
+ * and "host unknown" are the same value, so neither the list nor the badge may
+ * present a filtered result yet. Shared so the two become authoritative at the
+ * same moment (they didn't: the list held while the badge published an
+ * unfiltered count).
+ *
+ * Both inputs are live subscriptions the calling hook holds, so this flips with
+ * a re-render. A gate on the seeded-cache flags would not: nothing here wakes on
+ * them, so whichever render observed them false could be the last one.
+ */
+function draftFilterReady(streamsLoaded: boolean, boardScopesSignature: string, boardContextLoaded: boolean): boolean {
+  if (!streamsLoaded) return false
+  return boardScopesSignature === "" || boardContextLoaded
+}
+
 interface ResolvedDraftLocation {
   draftType: DraftType
   streamId: string | null
@@ -282,19 +299,6 @@ function streamDraftType(stream: CachedStream | undefined): DraftType {
 }
 
 /**
- * Location resolution for `board:*` draft scopes (the board's inline reply
- * composers). Every kind deep-links to the conversation panel that HOSTS the
- * draft's composer — a reply to its own conversation, a branch reply to the
- * branch's parent, a sub-topic to the conversation containing the fork message
- * — so the `?stash=` restore always lands where a consumer can auto-open the
- * form. A conversation not yet in the local cache (a roamed draft on a fresh
- * device) keeps a generic label but still links via the board route, whose
- * panel fetches the post by id, so cross-device pickup never dead-ends.
- * `supportsStashRestore` is false only where no consumer surface is known (a
- * branch whose parent isn't resolvable, a fork message in no cached
- * conversation) — those rows navigate plainly for manual pickup.
- */
-/**
  * The stream a `board:*` draft hangs off — a sub-topic's own stream, else the
  * conversation's anchor stream. The archived filter's input, shared by the
  * explorer and the sidebar badge so the two can't disagree about whether a board
@@ -310,6 +314,19 @@ function boardDraftHostStreamId(
   return boardPostMap.get(parsed.conversationId)?.conversation.streamId ?? null
 }
 
+/**
+ * Location resolution for `board:*` draft scopes (the board's inline reply
+ * composers). Every kind deep-links to the conversation panel that HOSTS the
+ * draft's composer — a reply to its own conversation, a branch reply to the
+ * branch's parent, a sub-topic to the conversation containing the fork message
+ * — so the `?stash=` restore always lands where a consumer can auto-open the
+ * form. A conversation not yet in the local cache (a roamed draft on a fresh
+ * device) keeps a generic label but still links via the board route, whose
+ * panel fetches the post by id, so cross-device pickup never dead-ends.
+ * `supportsStashRestore` is false only where no consumer surface is known (a
+ * branch whose parent isn't resolvable, a fork message in no cached
+ * conversation) — those rows navigate plainly for manual pickup.
+ */
 function resolveBoardDraftLocation(
   parsed: ParsedBoardDraftKey,
   workspaceId: string,
@@ -426,6 +443,7 @@ export function useAllDrafts(workspaceId: string) {
   const allDrafts = useDraftsFromStore(workspaceId)
   const composerLoaded = useComposerLoadedFromStore(workspaceId)
   const cachedStreams = useWorkspaceStreams(workspaceId)
+  const streamsLoaded = useWorkspaceStreamsLoaded(workspaceId)
   // Drains the offline queue so a delete enqueued below mirrors to the backend
   // promptly. Optional — outside a workspace there is no engine and the local
   // delete still stands; the op replays on the next (re)connect.
@@ -673,16 +691,9 @@ export function useAllDrafts(workspaceId: string) {
     [workspaceId, syncEngine]
   )
 
-  // The archived filter decides what NOT to show, and it reads two async caches
-  // (workspace streams, board conversations). Until both have landed, "no
-  // archived host" is indistinguishable from "host unknown", so every row
-  // qualifies — which is why a cold load painted a full list and then retracted
-  // it. Consumers render nothing until this clears rather than showing rows the
-  // very next frame removes (INV-21).
-  const isLoading =
-    !hasSeededDraftCache(workspaceId) ||
-    !hasSeededWorkspaceCache(workspaceId) ||
-    (boardScopesSignature !== "" && !boardContextLoaded)
+  // Rows built before the filter can decide are provisional — rendering them
+  // paints a list the next frame retracts (INV-21), which is the cold-load flash.
+  const isLoading = !draftFilterReady(streamsLoaded, boardScopesSignature, boardContextLoaded)
 
   return {
     drafts,
@@ -695,6 +706,12 @@ export function useAllDrafts(workspaceId: string) {
 export interface DraftSummary {
   /** Total unsent drafts for the workspace (matches the drafts-explorer row count). */
   draftCount: number
+  /**
+   * True until the archived filter's inputs have landed, exactly as in
+   * {@link useAllDrafts}. `draftCount` is unfiltered until it clears, so a
+   * consumer shows no badge rather than a number the next frame corrects.
+   */
+  isLoading: boolean
   /**
    * Comma-joined, sorted stream ids whose composer holds an unsent loaded
    * (non-stashed) draft. A string, not a Set, so a consumer can memoize on it
@@ -727,6 +744,7 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
   const allDrafts = useDraftsFromStore(workspaceId)
   const composerLoaded = useComposerLoadedFromStore(workspaceId)
   const cachedStreams = useWorkspaceStreams(workspaceId)
+  const streamsLoaded = useWorkspaceStreamsLoaded(workspaceId)
 
   const loadedByScope = useMemo(() => {
     const map = new Map<string, string | null>()
@@ -767,7 +785,11 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
     [allDrafts]
   )
-  const { boardPostMap } = useBoardDraftContext(workspaceId, boardScopesSignature)
+  const { boardPostMap, loaded: boardContextLoaded } = useBoardDraftContext(workspaceId, boardScopesSignature)
+  // Same gate the list uses: a count published before the filter can decide is
+  // the badge's version of the flash, and it disagrees with a list that is still
+  // holding — the disagreement this whole change is about.
+  const isLoading = !draftFilterReady(streamsLoaded, boardScopesSignature, boardContextLoaded)
 
   return useMemo(() => {
     let draftCount = 0
@@ -810,8 +832,9 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
       }
     }
 
-    return { draftCount, loadedDraftStreamIdSignature: [...loadedDraftStreamIds].sort().join(",") }
+    return { draftCount, isLoading, loadedDraftStreamIdSignature: [...loadedDraftStreamIds].sort().join(",") }
   }, [
+    isLoading,
     draftScratchpads,
     allDrafts,
     loadedByScope,

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -5,11 +5,12 @@ import { parseBoardDraftKey, type ParsedBoardDraftKey } from "@/lib/board/draft-
 import { type CompanionMode } from "@threa/types"
 import {
   deleteDraftScratchpadFromCache,
+  hasSeededDraftCache,
   useComposerLoadedFromStore,
   useDraftsFromStore,
   useDraftScratchpadsFromStore,
 } from "@/stores/draft-store"
-import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { hasSeededWorkspaceCache, useWorkspaceStreams } from "@/stores/workspace-store"
 import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { isDraftId } from "./use-draft-scratchpads"
@@ -293,6 +294,22 @@ function streamDraftType(stream: CachedStream | undefined): DraftType {
  * branch whose parent isn't resolvable, a fork message in no cached
  * conversation) — those rows navigate plainly for manual pickup.
  */
+/**
+ * The stream a `board:*` draft hangs off — a sub-topic's own stream, else the
+ * conversation's anchor stream. The archived filter's input, shared by the
+ * explorer and the sidebar badge so the two can't disagree about whether a board
+ * draft is hidden (they did: the badge counted board drafts on archived
+ * scratchpads the explorer refused to list). `null` when the conversation isn't
+ * cached — unknown host, and no row is ever hidden on missing data.
+ */
+function boardDraftHostStreamId(
+  parsed: ParsedBoardDraftKey,
+  boardPostMap: Map<string, CachedBoardPost>
+): string | null {
+  if (parsed.kind === "subtopic") return parsed.streamId
+  return boardPostMap.get(parsed.conversationId)?.conversation.streamId ?? null
+}
+
 function resolveBoardDraftLocation(
   parsed: ParsedBoardDraftKey,
   workspaceId: string,
@@ -323,7 +340,7 @@ function resolveBoardDraftLocation(
   }
 
   const post = boardPostMap.get(parsed.conversationId)
-  const anchorStreamId = post?.conversation.streamId ?? null
+  const anchorStreamId = boardDraftHostStreamId(parsed, boardPostMap)
   const stream = anchorStreamId ? streamMap.get(anchorStreamId) : undefined
   let target = stream ? streamLabel(stream, "sidebar") : null
   if (post) target = effectiveConversationTitle(post.conversation, streamMap.get(post.conversation.streamId))
@@ -463,7 +480,15 @@ export function useAllDrafts(workspaceId: string) {
     boardPostMap,
     hostPostByMessageId: subtopicHostByMessageId,
     parentPostByBranchConversationId,
+    loaded: boardContextLoaded,
   } = useBoardDraftContext(workspaceId, scopesSignature)
+
+  // "" when no draft is board-scoped — the board read resolves to nothing, so
+  // waiting on it would hold the list forever for the common case.
+  const boardScopesSignature = useMemo(
+    () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
+    [allDrafts]
+  )
 
   // Parent-message → host-stream map for thread drafts (shared with the sidebar
   // badge so both resolve thread-draft location/archival identically).
@@ -648,9 +673,21 @@ export function useAllDrafts(workspaceId: string) {
     [workspaceId, syncEngine]
   )
 
+  // The archived filter decides what NOT to show, and it reads two async caches
+  // (workspace streams, board conversations). Until both have landed, "no
+  // archived host" is indistinguishable from "host unknown", so every row
+  // qualifies — which is why a cold load painted a full list and then retracted
+  // it. Consumers render nothing until this clears rather than showing rows the
+  // very next frame removes (INV-21).
+  const isLoading =
+    !hasSeededDraftCache(workspaceId) ||
+    !hasSeededWorkspaceCache(workspaceId) ||
+    (boardScopesSignature !== "" && !boardContextLoaded)
+
   return {
     drafts,
     draftCount: drafts.length,
+    isLoading,
     deleteDraft,
   }
 }
@@ -679,9 +716,11 @@ export interface DraftSummary {
  * thread-reply drafts (including nested threads under an archived root) are hidden
  * from the badge and the list alike. The shared thread map reads nothing until a
  * thread draft exists, so the always-mounted sidebar stays cheap otherwise.
- * Board drafts still resolve their host stream only in the explorer (that needs
- * the conversation lookups), so the badge can over-count a board reply under an
- * archived root — rare, and the explorer still hides it.
+ * Board drafts resolve their host conversation here too — the badge counting a
+ * board reply the explorer refuses to list is what left the sidebar advertising
+ * drafts the user could not find (every one of them on an archived scratchpad).
+ * That read is keyed on the `board:*` scopes the drafts actually reference, so a
+ * user with none pays nothing.
  */
 export function useDraftSummary(workspaceId: string): DraftSummary {
   const draftScratchpads = useDraftScratchpadsFromStore(workspaceId)
@@ -722,6 +761,14 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
   // sidebar reads no events until the user actually has one.
   const messageToStreamMap = useDraftThreadStreamMap(workspaceId, allDrafts)
 
+  // Board scopes only — the same shared, id-keyed read the explorer makes, so
+  // both sides decide a board draft's archived host from one map.
+  const boardScopesSignature = useMemo(
+    () => draftScopesSignature(allDrafts.map((draft) => draft.scope).filter((scope) => parseBoardDraftKey(scope))),
+    [allDrafts]
+  )
+  const { boardPostMap } = useBoardDraftContext(workspaceId, boardScopesSignature)
+
   return useMemo(() => {
     let draftCount = 0
     const loadedDraftStreamIds = new Set<string>()
@@ -736,10 +783,14 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     for (const draft of allDrafts) {
       const parsed = parseDraftMessageKey(draft.scope)
       if (!parsed) {
-        // Board-composer drafts count toward the badge like any other (the
-        // explorer lists them), but carry no per-stream sidebar hint — the
-        // draft belongs to a conversation composer, not the stream's own.
-        if (parseBoardDraftKey(draft.scope) && draftHasPayload(draft)) draftCount++
+        // Board-composer drafts count like any other — hidden on an archived
+        // host exactly as the explorer hides them — but carry no per-stream
+        // sidebar hint: the draft belongs to a conversation composer, not the
+        // stream's own.
+        const board = parseBoardDraftKey(draft.scope)
+        if (!board || !draftHasPayload(draft)) continue
+        if (isStreamArchived(boardDraftHostStreamId(board, boardPostMap), streamMap, archivedStreamIds)) continue
+        draftCount++
         continue
       }
       // Scratchpad-scoped rows are counted above; skip them and their siblings.
@@ -747,9 +798,7 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
       if (!draftHasPayload(draft)) continue
       // Hide archived drafts: a channel/DM directly (`parsed.id` is the stream),
       // a thread reply via its parent message's host stream (nested threads
-      // caught by the root check inside `isStreamArchived`). Board drafts still
-      // aren't resolved here, so one under an archived root stays counted — the
-      // explorer still hides it.
+      // caught by the root check inside `isStreamArchived`).
       const hostStreamId = parsed.type === "thread" ? (messageToStreamMap.get(parsed.id)?.streamId ?? null) : parsed.id
       if (isStreamArchived(hostStreamId, streamMap, archivedStreamIds)) continue
       draftCount++
@@ -762,5 +811,14 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
     }
 
     return { draftCount, loadedDraftStreamIdSignature: [...loadedDraftStreamIds].sort().join(",") }
-  }, [draftScratchpads, allDrafts, loadedByScope, draftsById, streamMap, archivedStreamIds, messageToStreamMap])
+  }, [
+    draftScratchpads,
+    allDrafts,
+    loadedByScope,
+    draftsById,
+    streamMap,
+    archivedStreamIds,
+    messageToStreamMap,
+    boardPostMap,
+  ])
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.test.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { db } from "@/db"
+import { resetDraftContextCache, useBoardDraftContext } from "./use-board-draft-context"
+
+const workspaceId = "ws_1"
+
+async function seedConversation(conversationId: string, streamId: string) {
+  await db.conversations.put({
+    id: conversationId,
+    workspaceId,
+    _lastActivityMs: 1,
+    _cachedAt: 1,
+    conversation: { id: conversationId, streamId, topicSummary: null },
+  } as unknown as Parameters<typeof db.conversations.put>[0])
+}
+
+describe("useBoardDraftContext retention", () => {
+  beforeEach(async () => {
+    resetDraftContextCache()
+    await db.conversations.clear()
+    await seedConversation("conv_1", "stream_1")
+    await seedConversation("conv_2", "stream_2")
+  })
+
+  it("reports loaded on the first render after a remount", async () => {
+    const first = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(first.result.current.loaded).toBe(true))
+    first.unmount()
+
+    // Without retention this starts at the empty default, and a consumer gating
+    // its UI on `loaded` shows a loading state on every warm navigation.
+    const again = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    expect(again.result.current.loaded).toBe(true)
+    expect(again.result.current.boardPostMap.has("conv_1")).toBe(true)
+  })
+
+  it("keeps one consumer's value while another resolves a different signature", async () => {
+    // The sidebar, the explorer and every mounted composer read this at once
+    // with different signatures — retaining one entry per workspace had them
+    // evict each other, so the blip came back whenever a composer was open.
+    const explorer = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    await waitFor(() => expect(explorer.result.current.loaded).toBe(true))
+    explorer.unmount()
+
+    const composer = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_2"))
+    await waitFor(() => expect(composer.result.current.loaded).toBe(true))
+
+    const explorerAgain = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_1"))
+    expect(explorerAgain.result.current.loaded).toBe(true)
+    expect(explorerAgain.result.current.boardPostMap.has("conv_1")).toBe(true)
+  })
+
+  it("resolves to a fresh read for a signature it has not held", async () => {
+    const { result } = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_2"))
+    expect(result.current.loaded).toBe(false)
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.boardPostMap.has("conv_1")).toBe(false)
+  })
+})

--- a/apps/frontend/src/hooks/use-board-draft-context.test.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.test.ts
@@ -51,6 +51,25 @@ describe("useBoardDraftContext retention", () => {
     expect(explorerAgain.result.current.boardPostMap.has("conv_1")).toBe(true)
   })
 
+  it("does not report a signature as loaded while its read is still in flight", async () => {
+    // The live query keeps serving the previous signature's result until the new
+    // one settles, so an unstamped read would call a context resolved for the
+    // ids we just left "loaded" for the ids we are asking about now.
+    const { result, rerender } = renderHook(({ signature }) => useBoardDraftContext(workspaceId, signature), {
+      initialProps: { signature: "board:reply:conv_1" },
+    })
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+
+    rerender({ signature: "board:reply:conv_2" })
+    expect({ loaded: result.current.loaded, holdsOldConversation: result.current.boardPostMap.has("conv_1") }).toEqual({
+      loaded: false,
+      holdsOldConversation: false,
+    })
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.boardPostMap.has("conv_2")).toBe(true)
+  })
+
   it("resolves to a fresh read for a signature it has not held", async () => {
     const { result } = renderHook(() => useBoardDraftContext(workspaceId, "board:reply:conv_2"))
     expect(result.current.loaded).toBe(false)

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -11,12 +11,20 @@ export interface BoardDraftContext {
   hostPostByMessageId: Map<string, CachedBoardPost>
   /** Branch conversation id → the conversation whose message the branch forks off. */
   parentPostByBranchConversationId: Map<string, CachedBoardPost>
+  /**
+   * False until the first read resolves. A consumer that HIDES rows on what the
+   * maps say (the explorer's archived filter) must hold while this is false —
+   * an unresolved conversation is indistinguishable from one with no archived
+   * host, so acting on the empty default renders the row and then retracts it.
+   */
+  loaded: boolean
 }
 
 const EMPTY_CONTEXT: BoardDraftContext = {
   boardPostMap: new Map(),
   hostPostByMessageId: new Map(),
   parentPostByBranchConversationId: new Map(),
+  loaded: false,
 }
 
 /** Stable signature over a set of draft scopes — the gate every query below keys on. */
@@ -55,7 +63,7 @@ function scopeKeys(scopesSignature: string): ScopeKeys {
 // explorer deep-links to, since that surface hosts the draft's composer.
 async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Promise<BoardDraftContext> {
   const { conversationIdKey, branchConversationIdKey, subtopicMessageIdKey } = keys
-  if (!conversationIdKey && !subtopicMessageIdKey) return EMPTY_CONTEXT
+  if (!conversationIdKey && !subtopicMessageIdKey) return { ...EMPTY_CONTEXT, loaded: true }
 
   const convIds = conversationIdKey ? conversationIdKey.split(",") : []
   const branchIds = new Set(branchConversationIdKey ? branchConversationIdKey.split(",") : [])
@@ -105,7 +113,7 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
 
   const boardPostMap = new Map<string, CachedBoardPost>()
   for (const post of [...referenced, ...hostRows]) boardPostMap.set(post.id, post)
-  return { boardPostMap, hostPostByMessageId, parentPostByBranchConversationId }
+  return { boardPostMap, hostPostByMessageId, parentPostByBranchConversationId, loaded: true }
 }
 
 /**

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -117,23 +117,32 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
 }
 
 /**
- * The last resolved value per slot (`workspace|kind`), one entry each. A remount
- * re-runs the query from `undefined`, and falling back to the empty default
- * would report `loaded: false` again — a consumer holding its UI on that flag
- * blinks on every warm navigation, though the value it is about to re-resolve to
- * is the one already held here. The signature is checked too, so a changed set
- * of scopes falls back to the empty default rather than answering for other ids.
+ * Resolved values held across remounts, keyed by `workspace|kind|signature`. A
+ * remount re-runs the query from `undefined`, and falling back to the empty
+ * default would report `loaded: false` again — a consumer holding its UI on that
+ * flag blinks on every warm navigation, though the value it is about to
+ * re-resolve to is the one held here. The signature is part of the key, not a
+ * check against a single slot: the sidebar, the explorer and every mounted
+ * composer read this with DIFFERENT signatures at the same time, and one shared
+ * slot would have them evict each other's entry on every write. Bounded, since
+ * a signature changes with the draft set: oldest key out past the cap.
  */
-const lastResolved = new Map<string, { signature: string; value: unknown }>()
+const RETAINED_CONTEXTS = 8
+const lastResolved = new Map<string, unknown>()
 
-function rememberResolved<T>(slot: string, signature: string, value: T): T {
-  lastResolved.set(slot, { signature, value })
+function rememberResolved<T>(key: string, value: T): T {
+  lastResolved.delete(key)
+  lastResolved.set(key, value)
+  if (lastResolved.size > RETAINED_CONTEXTS) {
+    const oldest = lastResolved.keys().next()
+    if (!oldest.done) lastResolved.delete(oldest.value)
+  }
   return value
 }
 
-function recallResolved<T>(slot: string, signature: string, empty: T): T {
-  const held = lastResolved.get(slot)
-  return held?.signature === signature ? (held.value as T) : empty
+function recallResolved<T>(key: string, empty: T): T {
+  const held = lastResolved.get(key)
+  return held === undefined ? empty : (held as T)
 }
 
 /** Drop retained context values (account switch, tests). */
@@ -150,12 +159,12 @@ export function resetDraftContextCache(): void {
  */
 export function useBoardDraftContext(workspaceId: string, scopesSignature: string): BoardDraftContext {
   const keys = useMemo(() => scopeKeys(scopesSignature), [scopesSignature])
-  const slot = `${workspaceId}|board`
+  const retentionKey = `${workspaceId}|board|${scopesSignature}`
   const live = useLiveQuery(
-    async () => rememberResolved(slot, scopesSignature, await loadBoardDraftContext(workspaceId, keys)),
+    async () => rememberResolved(retentionKey, await loadBoardDraftContext(workspaceId, keys)),
     [workspaceId, keys]
   )
-  return live ?? recallResolved(slot, scopesSignature, EMPTY_CONTEXT)
+  return live ?? recallResolved(retentionKey, EMPTY_CONTEXT)
 }
 
 /**
@@ -218,11 +227,10 @@ async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string)
  * re-fire it and an anchor nobody references is never read.
  */
 export function useThreadAnchorContext(workspaceId: string, anchorIdsSignature: string): ThreadAnchorContext {
-  const slot = `${workspaceId}|thread`
+  const retentionKey = `${workspaceId}|thread|${anchorIdsSignature}`
   const live = useLiveQuery(
-    async () =>
-      rememberResolved(slot, anchorIdsSignature, await loadThreadAnchorContext(workspaceId, anchorIdsSignature)),
+    async () => rememberResolved(retentionKey, await loadThreadAnchorContext(workspaceId, anchorIdsSignature)),
     [workspaceId, anchorIdsSignature]
   )
-  return live ?? recallResolved(slot, anchorIdsSignature, EMPTY_ANCHOR_CONTEXT)
+  return live ?? recallResolved(retentionKey, EMPTY_ANCHOR_CONTEXT)
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -151,6 +151,23 @@ export function resetDraftContextCache(): void {
 }
 
 /**
+ * `useLiveQuery` keeps serving the PREVIOUS deps' result while the query for the
+ * new ones is still in flight — its internal "has a result" latch is set once and
+ * never reset. A consumer reading `loaded` off that value would take a context
+ * resolved for the ids it just left as resolved for the ids it now asks about,
+ * and decide (say) that no host is archived. The stamp is what separates
+ * "resolved for these ids" from "resolved for the ones we left".
+ */
+function stamp<T>(key: string, value: T): { key: string; value: T } {
+  return { key, value }
+}
+
+function readStamped<T>(live: { key: string; value: T } | undefined, key: string, empty: T): T {
+  if (live?.key === key) return live.value
+  return recallResolved(key, empty)
+}
+
+/**
  * The cached conversations a set of `board:*` draft scopes references, resolved
  * once for every consumer (the drafts explorer's location labels, the composer
  * pile's landing sites) so the two can't drift (INV-35). Keyed on the ids the
@@ -161,10 +178,10 @@ export function useBoardDraftContext(workspaceId: string, scopesSignature: strin
   const keys = useMemo(() => scopeKeys(scopesSignature), [scopesSignature])
   const retentionKey = `${workspaceId}|board|${scopesSignature}`
   const live = useLiveQuery(
-    async () => rememberResolved(retentionKey, await loadBoardDraftContext(workspaceId, keys)),
+    async () => stamp(retentionKey, rememberResolved(retentionKey, await loadBoardDraftContext(workspaceId, keys))),
     [workspaceId, keys]
   )
-  return live ?? recallResolved(retentionKey, EMPTY_CONTEXT)
+  return readStamped(live, retentionKey, EMPTY_CONTEXT)
 }
 
 /**
@@ -229,8 +246,12 @@ async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string)
 export function useThreadAnchorContext(workspaceId: string, anchorIdsSignature: string): ThreadAnchorContext {
   const retentionKey = `${workspaceId}|thread|${anchorIdsSignature}`
   const live = useLiveQuery(
-    async () => rememberResolved(retentionKey, await loadThreadAnchorContext(workspaceId, anchorIdsSignature)),
+    async () =>
+      stamp(
+        retentionKey,
+        rememberResolved(retentionKey, await loadThreadAnchorContext(workspaceId, anchorIdsSignature))
+      ),
     [workspaceId, anchorIdsSignature]
   )
-  return live ?? recallResolved(retentionKey, EMPTY_ANCHOR_CONTEXT)
+  return readStamped(live, retentionKey, EMPTY_ANCHOR_CONTEXT)
 }

--- a/apps/frontend/src/hooks/use-board-draft-context.ts
+++ b/apps/frontend/src/hooks/use-board-draft-context.ts
@@ -117,6 +117,31 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
 }
 
 /**
+ * The last resolved value per slot (`workspace|kind`), one entry each. A remount
+ * re-runs the query from `undefined`, and falling back to the empty default
+ * would report `loaded: false` again — a consumer holding its UI on that flag
+ * blinks on every warm navigation, though the value it is about to re-resolve to
+ * is the one already held here. The signature is checked too, so a changed set
+ * of scopes falls back to the empty default rather than answering for other ids.
+ */
+const lastResolved = new Map<string, { signature: string; value: unknown }>()
+
+function rememberResolved<T>(slot: string, signature: string, value: T): T {
+  lastResolved.set(slot, { signature, value })
+  return value
+}
+
+function recallResolved<T>(slot: string, signature: string, empty: T): T {
+  const held = lastResolved.get(slot)
+  return held?.signature === signature ? (held.value as T) : empty
+}
+
+/** Drop retained context values (account switch, tests). */
+export function resetDraftContextCache(): void {
+  lastResolved.clear()
+}
+
+/**
  * The cached conversations a set of `board:*` draft scopes references, resolved
  * once for every consumer (the drafts explorer's location labels, the composer
  * pile's landing sites) so the two can't drift (INV-35). Keyed on the ids the
@@ -125,7 +150,12 @@ async function loadBoardDraftContext(workspaceId: string, keys: ScopeKeys): Prom
  */
 export function useBoardDraftContext(workspaceId: string, scopesSignature: string): BoardDraftContext {
   const keys = useMemo(() => scopeKeys(scopesSignature), [scopesSignature])
-  return useLiveQuery(() => loadBoardDraftContext(workspaceId, keys), [workspaceId, keys], EMPTY_CONTEXT)
+  const slot = `${workspaceId}|board`
+  const live = useLiveQuery(
+    async () => rememberResolved(slot, scopesSignature, await loadBoardDraftContext(workspaceId, keys)),
+    [workspaceId, keys]
+  )
+  return live ?? recallResolved(slot, scopesSignature, EMPTY_CONTEXT)
 }
 
 /**
@@ -138,9 +168,15 @@ export interface ThreadAnchorContext {
   streamByAnchorId: Map<string, { streamId: string; anchorId: string }>
   /** Anchor id → the conversation that contains it, where one is cached. */
   conversationIdByAnchorId: Map<string, string>
+  /** False until the first read resolves — see {@link BoardDraftContext.loaded}. */
+  loaded: boolean
 }
 
-const EMPTY_ANCHOR_CONTEXT: ThreadAnchorContext = { streamByAnchorId: new Map(), conversationIdByAnchorId: new Map() }
+const EMPTY_ANCHOR_CONTEXT: ThreadAnchorContext = {
+  streamByAnchorId: new Map(),
+  conversationIdByAnchorId: new Map(),
+  loaded: false,
+}
 
 // Both reads are keyed lookups over the ids actually referenced: the sparse
 // `payload.messageId` index (v47) for message anchors, the primary key for card
@@ -148,7 +184,7 @@ const EMPTY_ANCHOR_CONTEXT: ThreadAnchorContext = { streamByAnchorId: new Map(),
 // or the whole workspace, so an always-mounted composer's subscription re-fires
 // only on writes touching an id it asked for.
 async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string): Promise<ThreadAnchorContext> {
-  if (!anchorIdKey) return EMPTY_ANCHOR_CONTEXT
+  if (!anchorIdKey) return { ...EMPTY_ANCHOR_CONTEXT, loaded: true }
   const anchorIds = anchorIdKey.split("|")
 
   const streamByAnchorId = new Map<string, { streamId: string; anchorId: string }>()
@@ -172,7 +208,7 @@ async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string)
     if (row?.workspaceId === workspaceId) conversationIdByAnchorId.set(row.messageId, row.conversationId)
   }
 
-  return { streamByAnchorId, conversationIdByAnchorId }
+  return { streamByAnchorId, conversationIdByAnchorId, loaded: true }
 }
 
 /**
@@ -182,9 +218,11 @@ async function loadThreadAnchorContext(workspaceId: string, anchorIdKey: string)
  * re-fire it and an anchor nobody references is never read.
  */
 export function useThreadAnchorContext(workspaceId: string, anchorIdsSignature: string): ThreadAnchorContext {
-  return useLiveQuery(
-    () => loadThreadAnchorContext(workspaceId, anchorIdsSignature),
-    [workspaceId, anchorIdsSignature],
-    EMPTY_ANCHOR_CONTEXT
+  const slot = `${workspaceId}|thread`
+  const live = useLiveQuery(
+    async () =>
+      rememberResolved(slot, anchorIdsSignature, await loadThreadAnchorContext(workspaceId, anchorIdsSignature)),
+    [workspaceId, anchorIdsSignature]
   )
+  return live ?? recallResolved(slot, anchorIdsSignature, EMPTY_ANCHOR_CONTEXT)
 }

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -29,10 +29,11 @@ function draft(overrides: Partial<UnifiedDraft> & { id: string; displayName: str
 
 const deleteDraft = vi.fn(async (_id: string) => {})
 
-function mockDrafts(drafts: UnifiedDraft[]) {
+function mockDrafts(drafts: UnifiedDraft[], isLoading = false) {
   vi.spyOn(hooksModule, "useAllDrafts").mockReturnValue({
     drafts,
     draftCount: drafts.length,
+    isLoading,
     deleteDraft,
   } as unknown as ReturnType<typeof hooksModule.useAllDrafts>)
 }
@@ -357,6 +358,18 @@ describe("put-away annotation", () => {
     expect(screen.getByText("Stashed")).toBeInTheDocument()
     const roamedRow = screen.getByText("roamed body").closest("a, button, li")
     expect(roamedRow?.textContent).not.toContain("Stashed")
+  })
+
+  it("paints no rows while the archived filter's caches are still landing", () => {
+    // Rows built before the filter can decide are provisional — showing them and
+    // retracting them a frame later is the cold-load flash (INV-21).
+    mockDrafts([draft({ id: "a", displayName: "Alpha" }), draft({ id: "b", displayName: "Bravo" })], true)
+    renderPage()
+
+    expect(screen.queryByText("Alpha")).toBeNull()
+    expect(screen.queryByText("Bravo")).toBeNull()
+    expect(screen.queryByText("No drafts")).toBeNull()
+    expect(screen.queryByRole("button", { name: "Select drafts" })).toBeNull()
   })
 
   it("names the files of an attachment-only row instead of calling it empty", () => {

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -46,7 +46,7 @@ function stashedRowDescription(draft: UnifiedDraft): string | null {
 export function DraftsPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const navigate = useNavigate()
-  const { drafts, deleteDraft } = useAllDrafts(workspaceId ?? "")
+  const { drafts, isLoading, deleteDraft } = useAllDrafts(workspaceId ?? "")
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [draftToDelete, setDraftToDelete] = useState<UnifiedDraft | null>(null)
   // Long-press target: one drawer for the whole list, holding the row that was
@@ -285,7 +285,7 @@ export function DraftsPage() {
                 <FileEdit className="h-5 w-5 text-muted-foreground" />
                 <h1 className="font-semibold">Drafts</h1>
               </div>
-              {drafts.length > 0 && (
+              {!isLoading && drafts.length > 0 && (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -335,6 +335,7 @@ export function DraftsPage() {
         >
           <ItemList
             items={items}
+            isLoading={isLoading}
             selectedIndex={selectedIndex}
             onSelectIndex={setSelectedIndex}
             onSelectItem={handleSelectItem}

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -388,6 +388,19 @@ export function useWorkspaceFromStore(workspaceId: string | undefined): CachedWo
   return useSingletonStoreHook(workspaceId, "workspace", cached)
 }
 
+/**
+ * Whether this workspace's stream rows have RESOLVED, as opposed to the
+ * pre-resolution cache fallback — which is indistinguishable from "no streams".
+ * A consumer that HIDES something on `archivedAt` needs that difference, and it
+ * needs to be woken when it flips: this rides the same per-table subscription
+ * the row hooks use. `hasSeededWorkspaceCache` cannot serve that purpose — it
+ * reads nine cache maps that no subscription here wakes on, so a gate built on
+ * it can latch on whichever render happens to observe it false.
+ */
+export function useWorkspaceStreamsLoaded(workspaceId: string | undefined): boolean {
+  return useWorkspaceTable(workspaceId, "streams") !== undefined
+}
+
 export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorkspaceUser[] {
   const cached = workspaceId ? (cache.users.get(workspaceId) ?? EMPTY_ROWS) : EMPTY_ROWS
   return useArrayStoreHook(workspaceId, "users", cached)


### PR DESCRIPTION
## Problem

The sidebar advertised "2 drafts" over a Drafts page that listed none — and on a cold load the page painted a full list of rows and then retracted them.

Both come from the archived filter. In production this user has 13 live drafts; 12 sit on **archived scratchpads** and one is a not-yet-created DM scratchpad scope, so the explorer correctly lists nothing. `useDraftSummary` applied that filter to stream and thread scopes but not to `board:*` ones — its own comment said so: *"Board drafts still aren't resolved here, so one under an archived root stays counted — the explorer still hides it."* The user's two board-reply drafts hang off archived scratchpads (`conv_01KZ1563…` → `stream_01KZ1529…`, `conv_01KYM1W9…` → `stream_01KYM1TE…`), so the badge counted exactly the two rows the list refused to show, with no surface to reach them from.

The flash is the same filter seen at t=0: it decides what to HIDE from two async caches (workspace streams via `useWorkspaceStreams`, board conversations via `useBoardDraftContext`). Until both land, "no archived host" and "host unknown" are indistinguishable — deliberately, so a draft is never hidden on missing data — so every row qualifies, renders, and disappears once the caches arrive.

## Solution

- `boardDraftHostStreamId(parsed, boardPostMap)` is the one rule for a board draft's host stream (sub-topic → its own stream; reply/branch → the conversation's anchor stream). `resolveBoardDraftLocation` and `useDraftSummary` both call it, so the badge and the list can't disagree again. The badge's board read is keyed on the `board:*` scopes the drafts actually reference, so a user with none pays nothing.
- `useBoardDraftContext` reports `loaded`, and `useAllDrafts` returns `isLoading` (draft cache seeded ∧ workspace cache seeded ∧ board context resolved when board scopes exist). `DraftsPage` passes it to `ItemList`'s existing loading state and holds the Select control, so provisional rows are never painted (INV-21).

Deliberately unchanged: an archived host still hides its drafts. That is the existing rule; this PR only makes the badge obey it too.

## Residual

Those 12 drafts are now consistently invisible — and unreachable: archiving a scratchpad hides its drafts with no way to view or delete them, and they stay in IDB and the `drafts` table indefinitely. Out of scope here (this PR is about the badge/list disagreement), but it wants a decision: surface them under an "Archived" group, or purge a stream's drafts when it is archived.

Thread drafts have the same t=0 window through `useThreadAnchorContext`, which has no loaded flag; `isLoading` doesn't cover them. Not the reported case, and adding a flag there is a wider change.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-all-drafts.ts` | **new** `boardDraftHostStreamId`, shared by the explorer and the badge; badge hides archived board hosts; `isLoading` |
| `apps/frontend/src/hooks/use-board-draft-context.ts` | `loaded` on the context so a hide-decision can wait for it |
| `apps/frontend/src/pages/drafts.tsx` | Holds rows and the Select control while loading |
| tests | badge/list agree on an archived board host; `isLoading` clears only once the caches land; the page paints no rows while loading |

## Test plan

- [x] Both new hook tests fail on the pre-fix code (badge counts 2 against a 1-row list; `isLoading` unavailable)
- [x] `bun run --filter @threa/frontend test` — 6548 pass, 0 fail
- [x] `bun run typecheck`, `bun run lint` — clean
- [ ] Not verified against the real workspace — needs a device with those archived-host drafts in IDB; the prod rows behind the report are confirmed read-only (12 of 13 drafts on archived scratchpads, 2 of them board-scoped)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789069785&installation_model_id=20758&pr_number=1859&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1859&signature=86169e336d67c7c78cde89746576166dec49888039d333a69d221bee4e086cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->