### PR TITLE
refactor: move in-composer pill drag onto dnd-kit

### DIFF
--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, type ReactNode } from "react"
 import {
   DndContext,
-  DragOverlay,
   useDraggable,
   useDroppable,
   useSensor,
@@ -211,7 +210,6 @@ export function ComposerPillDndProvider({ editor, children }: { editor: Editor |
     <DndContext autoScroll sensors={sensors} collisionDetection={collisionDetection} accessibility={{ announcements }}>
       <ComposerPillDragBridge editor={editor} host={host} />
       {children}
-      <DragOverlay dropAnimation={null} style={{ pointerEvents: "none" }} />
     </DndContext>
   )
 }

--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useRef, type ReactNode } from "react"
+import {
+  DndContext,
+  DragOverlay,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type Announcements,
+  type CollisionDetection,
+} from "@dnd-kit/core"
+import type { EditorView } from "@tiptap/pm/view"
+import type { Editor } from "@tiptap/react"
+import {
+  ComposerPillDragPluginKey,
+  composerPillDropPoint,
+  createComposerPillMoveTransaction,
+  dropPositionAt,
+  isComposerPillNode,
+  setComposerPillDragState,
+} from "./composer-pill-drag-extension"
+import {
+  ComposerPillDragHost,
+  type ComposerPillDragLifecycle,
+  type ComposerPillGesture,
+} from "./composer-pill-drag-host"
+import { ComposerPillSensor } from "./composer-pill-sensor"
+import { ComposerPillTouchGuide } from "./composer-pill-touch-guide"
+
+const DRAGGABLE_ID = "composer-pill"
+const DROPPABLE_ID = "composer-pill-editor"
+const TOUCH_ACTIVATION_HAPTIC_MS = 10
+const TOUCH_TARGET_HAPTIC_MS = 10
+const TOUCH_DROP_HAPTIC_PATTERN_MS = [10, 20, 10]
+
+// Announcements only. dnd-kit's `screenReaderInstructions` are reached through
+// the `aria-describedby` in `useDraggable().attributes`, and those attributes
+// belong on a draggable element — here that would be the contenteditable itself,
+// which must not take `role="button"`. Announcements go through the live region
+// and need no attributes.
+const announcements: Announcements = {
+  onDragStart: () => "Picked up the pill. Move to choose where it lands.",
+  onDragOver: () => undefined,
+  onDragEnd: () => "Dropped the pill.",
+  onDragCancel: () => "Cancelled. The pill stayed where it was.",
+}
+
+function vibrate(win: Window, pattern: number | number[]) {
+  try {
+    win.navigator.vibrate?.(pattern)
+  } catch {
+    // Vibration is optional feedback.
+  }
+}
+
+/** The editor's answer to "where would this land": a ProseMirror position. */
+function resolveDropPos(host: ComposerPillDragHost, x: number, y: number): number | null {
+  const view = host.getView()
+  if (!view) return null
+  const drag = ComposerPillDragPluginKey.getState(view.state)
+  if (!drag) return null
+  const sourceNode = view.state.doc.nodeAt(drag.sourcePos)
+  if (!isComposerPillNode(sourceNode)) return null
+  return dropPositionAt(view, x, y, sourceNode)
+}
+
+/**
+ * Pointer coordinates, not rectangles, decide where a pill lands: the drop
+ * target is a ProseMirror position, so the editor resolves it and reports it as
+ * the single collision's payload. No position (pointer outside the editor, or a
+ * slot the pill can't occupy) means no collision at all.
+ */
+export function createComposerPillCollisionDetection(host: ComposerPillDragHost): CollisionDetection {
+  return ({ pointerCoordinates }) => {
+    if (!host.engaged || !pointerCoordinates) return []
+    const dropPos = resolveDropPos(host, pointerCoordinates.x, pointerCoordinates.y)
+    if (dropPos === null) return []
+    return [{ id: DROPPABLE_ID, data: { dropPos } }]
+  }
+}
+
+function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host: ComposerPillDragHost }) {
+  const { setNodeRef: setDraggableNode, listeners } = useDraggable({ id: DRAGGABLE_ID, data: host.dragData })
+  const { setNodeRef: setDroppableNode } = useDroppable({ id: DROPPABLE_ID })
+  const guideRef = useRef<ComposerPillTouchGuide | null>(null)
+
+  useEffect(() => {
+    host.setListeners(listeners)
+  }, [host, listeners])
+
+  useEffect(() => {
+    if (!editor) return
+    const dom = editor.view.dom
+    setDraggableNode(dom)
+    setDroppableNode(dom)
+    host.attach(editor.view)
+    return () => {
+      host.detach()
+      setDraggableNode(null)
+      setDroppableNode(null)
+    }
+  }, [editor, host, setDraggableNode, setDroppableNode])
+
+  useEffect(() => {
+    const releaseGuide = () => {
+      guideRef.current?.destroy()
+      guideRef.current = null
+    }
+    const windowFor = (view: EditorView) => view.dom.ownerDocument.defaultView ?? window
+
+    const applyDropAt = (gesture: ComposerPillGesture, x: number, y: number) => {
+      const view = host.getView()
+      const current = view ? ComposerPillDragPluginKey.getState(view.state) : null
+      if (!view || !current) return
+      const dropPos = resolveDropPos(host, x, y)
+      if (gesture.kind === "touch") {
+        guideRef.current?.update(view.state.doc, dropPos, x, y)
+        if (dropPos !== null && dropPos !== current.dropPos) vibrate(windowFor(view), TOUCH_TARGET_HAPTIC_MS)
+      }
+      setComposerPillDragState(view, { sourcePos: current.sourcePos, dropPos })
+    }
+
+    const lifecycle: ComposerPillDragLifecycle = {
+      start: (gesture) => {
+        const view = host.getView()
+        if (!view) return
+        const node = view.state.doc.nodeAt(gesture.sourcePos)
+        if (!isComposerPillNode(node)) return
+        const dropPos = composerPillDropPoint(view.state.doc, gesture.sourcePos, node)
+        setComposerPillDragState(view, { sourcePos: gesture.sourcePos, dropPos })
+        if (gesture.kind !== "touch") return
+        guideRef.current = new ComposerPillTouchGuide(view.dom.ownerDocument, windowFor(view))
+        guideRef.current.update(view.state.doc, dropPos, gesture.startX, gesture.startY)
+        vibrate(windowFor(view), TOUCH_ACTIVATION_HAPTIC_MS)
+      },
+      move: applyDropAt,
+      // The release coordinates, not the last rate-limited move, decide where the
+      // pill lands: a fast flick can lift between two dispatched moves.
+      end: (gesture, x, y) => {
+        applyDropAt(gesture, x, y)
+        const view = host.getView()
+        releaseGuide()
+        if (!view) return
+        const drag = ComposerPillDragPluginKey.getState(view.state)
+        const tr =
+          drag && drag.dropPos !== null
+            ? createComposerPillMoveTransaction(view.state, drag.sourcePos, drag.dropPos)
+            : null
+        if (!tr) {
+          setComposerPillDragState(view, null)
+          return
+        }
+        view.dispatch(tr.setMeta(ComposerPillDragPluginKey, null).setMeta("uiEvent", "drop"))
+        if (gesture.kind === "touch") vibrate(windowFor(view), TOUCH_DROP_HAPTIC_PATTERN_MS)
+      },
+      cancel: () => {
+        const view = host.getView()
+        releaseGuide()
+        if (view) setComposerPillDragState(view, null)
+      },
+    }
+
+    host.lifecycle = lifecycle
+    return () => {
+      releaseGuide()
+      if (host.lifecycle === lifecycle) host.lifecycle = null
+    }
+  }, [host])
+
+  // The pill can be mapped away (deleted, or replaced by an external content
+  // sync) mid-drag; the plugin drops its state, and the gesture has to follow.
+  useEffect(() => {
+    if (!editor) return
+    const onUpdate = () => {
+      const drag = ComposerPillDragPluginKey.getState(editor.view.state)
+      if (!drag) {
+        if (host.dragActive) host.cancelActiveGesture?.()
+        return
+      }
+      guideRef.current?.refresh(editor.view.state.doc, drag.dropPos)
+    }
+    editor.on("update", onUpdate)
+    return () => {
+      editor.off("update", onUpdate)
+    }
+  }, [editor, host])
+
+  return null
+}
+
+/**
+ * Provides in-composer pill dragging to one editor. Every editor built from
+ * `createEditorExtensions()` carries the ProseMirror half, so the surfaces that
+ * own an editor instance (`RichEditor`, the document editor modal) each wrap it
+ * in this provider rather than relying on a context further up the tree.
+ */
+export function ComposerPillDndProvider({ editor, children }: { editor: Editor | null; children?: ReactNode }) {
+  const hostRef = useRef<ComposerPillDragHost | null>(null)
+  hostRef.current ??= new ComposerPillDragHost()
+  const host = hostRef.current
+
+  const sensors = useSensors(
+    useSensor(
+      ComposerPillSensor,
+      useMemo(() => ({ host }), [host])
+    )
+  )
+  const collisionDetection = useMemo(() => createComposerPillCollisionDetection(host), [host])
+
+  return (
+    <DndContext autoScroll sensors={sensors} collisionDetection={collisionDetection} accessibility={{ announcements }}>
+      <ComposerPillDragBridge editor={editor} host={host} />
+      {children}
+      <DragOverlay dropAnimation={null} style={{ pointerEvents: "none" }} />
+    </DndContext>
+  )
+}

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.test.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.test.tsx
@@ -1,15 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { fireEvent } from "@testing-library/react"
+import { cleanup, fireEvent, render } from "@testing-library/react"
 import { Editor } from "@tiptap/core"
 import { NodeSelection } from "@tiptap/pm/state"
 import type { JSONContent } from "@threa/types"
 import { serializeClipboardSlice } from "./clipboard-copy"
+import { ComposerPillDndProvider } from "./composer-pill-dnd"
 import { createEditorExtensions } from "./editor-extensions"
 import {
   COMPOSER_PILL_NODE_NAMES,
   ComposerPillDragPluginKey,
   composerPillDropPoint,
   createComposerPillMoveTransaction,
+  dropPositionAt,
   isComposerPillNode,
 } from "./composer-pill-drag-extension"
 
@@ -17,7 +19,16 @@ const openEditors: Editor[] = []
 let originalVibrateDescriptor: PropertyDescriptor | undefined
 let vibrateMocked = false
 
+/**
+ * The gesture layer lives in React now, so an editor only drags once its
+ * dnd-kit provider is mounted around it.
+ */
+function mountPillDnd(editor: Editor) {
+  render(<ComposerPillDndProvider editor={editor} />)
+}
+
 afterEach(() => {
+  cleanup()
   while (openEditors.length > 0) {
     const editor = openEditors.pop()!
     const element = editor.view.dom.parentElement
@@ -52,6 +63,7 @@ function createPillEditor(content: JSONContent[] = [pill("mention"), pill("chann
     content: { type: "doc", content: [{ type: "paragraph", content }] },
   })
   openEditors.push(editor)
+  mountPillDnd(editor)
   return editor
 }
 
@@ -223,6 +235,62 @@ describe("composer pill drag gestures", () => {
     expect(editor.state.selection).not.toBeInstanceOf(NodeSelection)
     expect(editor.state.selection.empty).toBe(true)
     expect(editor.view.dom.querySelector(".composer-pill-drop-cursor")).toBeNull()
+  })
+
+  it("drops the pill where the pointer was released, not where the last move landed", () => {
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    const midPos = nodePos(editor, "slashCommand")
+    const endPos = midPos + 1
+    vi.spyOn(editor.view, "posAtCoords").mockImplementation(({ left }) => ({
+      pos: left >= 30 ? endPos : midPos,
+      inside: -1,
+    }))
+
+    fireEvent.mouseDown(source, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 18, clientY: 10 })
+    expect(ComposerPillDragPluginKey.getState(editor.state)?.dropPos).toBe(midPos)
+
+    fireEvent.mouseUp(source, { button: 0, clientX: 40, clientY: 10 })
+    expect(childTypes(editor)).toEqual(["channelLink", "slashCommand", "mention"])
+  })
+
+  it("suppresses the ending touch's compatibility mouse even after a stray mouse press", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.touchStart(source, { touches: [touch(7, 10, 10)] })
+    vi.advanceTimersByTime(500)
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+
+    vi.advanceTimersByTime(401)
+    const strayMouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    })
+    source.dispatchEvent(strayMouseDown)
+    expect(strayMouseDown.defaultPrevented).toBe(false)
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+
+    vi.advanceTimersByTime(401)
+    fireEvent.touchEnd(document, { touches: [], changedTouches: [touch(7, 10, 10)] })
+    const compatibilityMouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    })
+    editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!.dispatchEvent(compatibilityMouseDown)
+
+    expect(compatibilityMouseDown.defaultPrevented).toBe(true)
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
   })
 
   it("allows another mouse press after a drag while suppressing its trailing click", () => {
@@ -596,5 +664,109 @@ describe("composer pill drag gestures", () => {
     expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
     expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
     expect(document.querySelector(".composer-pill-touch-guide")).toBeNull()
+  })
+})
+
+describe("composer pill drop points", () => {
+  it("snaps a raw pointer position to the nearest token boundary", () => {
+    const editor = createPillEditor([pill("mention"), { type: "text", text: "hello world" }])
+    const source = editor.state.doc.nodeAt(nodePos(editor, "mention"))!
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 5, inside: -1 })
+
+    expect(dropPositionAt(editor.view, 40, 10, source)).toBe(7)
+  })
+
+  it("splits a hovered pill at its midpoint instead of asking for a text position", () => {
+    const editor = createPillEditor()
+    const source = editor.state.doc.nodeAt(nodePos(editor, "mention"))!
+    const hovered = editor.view.dom.querySelector<HTMLElement>('[data-type="channelLink"]')!
+    const hoveredPos = nodePos(editor, "channelLink")
+    vi.spyOn(hovered, "getBoundingClientRect").mockReturnValue({ left: 100, width: 20 } as DOMRect)
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(hovered)
+    const posAtCoords = vi.spyOn(editor.view, "posAtCoords")
+
+    expect(dropPositionAt(editor.view, 104, 10, source)).toBe(hoveredPos)
+    expect(dropPositionAt(editor.view, 116, 10, source)).toBe(hoveredPos + 1)
+    expect(posAtCoords).not.toHaveBeenCalled()
+  })
+
+  it("offers no drop position for a pointer outside the editor", () => {
+    const editor = createPillEditor()
+    const source = editor.state.doc.nodeAt(nodePos(editor, "mention"))!
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(document.body)
+
+    expect(dropPositionAt(editor.view, 900, 900, source)).toBeNull()
+  })
+})
+
+describe("composer pill drag sensor", () => {
+  function isDragging(editor: Editor): boolean {
+    return editor.view.dom.querySelector(".composer-pill-dragging") !== null
+  }
+
+  it("holds a mouse press until it travels the activation threshold", () => {
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.mouseDown(source, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 15, clientY: 10 })
+    expect(isDragging(editor)).toBe(false)
+
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 16, clientY: 10 })
+    expect(isDragging(editor)).toBe(true)
+  })
+
+  it("activates an unselected pill only on the long-press threshold", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.touchStart(source, { touches: [touch(1, 10, 10)] })
+    vi.advanceTimersByTime(499)
+    expect(isDragging(editor)).toBe(false)
+
+    vi.advanceTimersByTime(1)
+    expect(isDragging(editor)).toBe(true)
+  })
+
+  it("activates a selected pill on movement and leaves an unselected one alone", () => {
+    const selected = createPillEditor()
+    const selectedSource = selected.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    tapPill(selectedSource)
+    fireEvent.touchStart(selectedSource, { touches: [touch(1, 10, 10)] })
+    fireEvent.touchMove(document, { touches: [touch(1, 21, 10)] })
+    expect(isDragging(selected)).toBe(true)
+
+    const unselected = createPillEditor()
+    const unselectedSource = unselected.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    fireEvent.touchStart(unselectedSource, { touches: [touch(2, 10, 10)] })
+    fireEvent.touchMove(document, { touches: [touch(2, 21, 10)] })
+    expect(isDragging(unselected)).toBe(false)
+  })
+
+  it("cancels an in-flight drag on Escape, on window blur, and on a second finger", () => {
+    vi.useFakeTimers()
+    const editor = createPillEditor()
+    const source = () => editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+
+    fireEvent.mouseDown(source(), { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 18, clientY: 10 })
+    expect(isDragging(editor)).toBe(true)
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(isDragging(editor)).toBe(false)
+
+    fireEvent.mouseDown(source(), { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 18, clientY: 10 })
+    expect(isDragging(editor)).toBe(true)
+    fireEvent.blur(window)
+    expect(isDragging(editor)).toBe(false)
+
+    fireEvent.mouseUp(document, { button: 0, clientX: 18, clientY: 10 })
+    fireEvent.touchStart(source(), { touches: [touch(9, 10, 10)] })
+    vi.advanceTimersByTime(500)
+    expect(isDragging(editor)).toBe(true)
+    fireEvent.touchStart(document.body, { touches: [touch(9, 10, 10), touch(10, 50, 50)] })
+    expect(isDragging(editor)).toBe(false)
+    expect(childTypes(editor)).toEqual(["mention", "channelLink", "slashCommand"])
   })
 })

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
@@ -3,8 +3,6 @@ import { Fragment, Slice, type Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { NodeSelection, Plugin, PluginKey, Selection, type EditorState, type Transaction } from "@tiptap/pm/state"
 import { dropPoint } from "@tiptap/pm/transform"
 import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view"
-import { LONG_PRESS_MOVE_TOLERANCE_PX, LONG_PRESS_THRESHOLD_MS } from "@/hooks/use-long-press"
-import { ComposerPillTouchGuide } from "./composer-pill-touch-guide"
 
 export const COMPOSER_PILL_NODE_NAMES = [
   "mention",
@@ -17,28 +15,13 @@ export const COMPOSER_PILL_NODE_NAMES = [
 ] as const
 
 const COMPOSER_PILL_NODE_NAME_SET = new Set<string>(COMPOSER_PILL_NODE_NAMES)
-const MOUSE_DRAG_THRESHOLD_PX = 6
-const COMPATIBILITY_MOUSE_WINDOW_MS = 400
-const TOUCH_ACTIVATION_HAPTIC_MS = 10
-const TOUCH_TARGET_HAPTIC_MS = 10
-const TOUCH_DROP_HAPTIC_PATTERN_MS = [10, 20, 10]
-const TOUCH_DRAG_MODE = "hold-or-selected"
 
-interface ComposerPillDragState {
+export const MOUSE_DRAG_THRESHOLD_PX = 6
+export const COMPOSER_PILL_TOUCH_DRAG_MODE = "hold-or-selected"
+
+export interface ComposerPillDragState {
   sourcePos: number
   dropPos: number | null
-}
-
-interface PendingDrag {
-  kind: "mouse" | "touch"
-  id: number
-  sourcePos: number
-  startX: number
-  startY: number
-  holdElapsed: boolean
-  touchDragEligible: boolean
-  movedBeyondTolerance: boolean
-  active: boolean
 }
 
 export const ComposerPillDragPluginKey = new PluginKey<ComposerPillDragState | null>("composerPillDrag")
@@ -214,7 +197,7 @@ function mappedDragState(tr: Transaction, current: ComposerPillDragState | null)
   return isComposerPillNode(tr.doc.nodeAt(sourcePos)) ? { sourcePos, dropPos } : null
 }
 
-function isComposerPillSelected(state: EditorState, pos: number): boolean {
+export function isComposerPillSelected(state: EditorState, pos: number): boolean {
   const { selection } = state
   return selection instanceof NodeSelection && selection.from === pos && isComposerPillNode(selection.node)
 }
@@ -234,7 +217,7 @@ function eventElement(target: EventTarget | null): Element | null {
   return target instanceof Node ? target.parentElement : null
 }
 
-function pillFromDom(view: EditorView, target: EventTarget | null): { element: Element; pos: number } | null {
+export function pillFromDom(view: EditorView, target: EventTarget | null): { element: Element; pos: number } | null {
   let element = eventElement(target)
   while (element && element !== view.dom) {
     if (element.hasAttribute("data-type")) {
@@ -250,12 +233,8 @@ function pillFromDom(view: EditorView, target: EventTarget | null): { element: E
   return null
 }
 
-function dropPositionAt(view: EditorView, x: number, y: number): number | null {
-  const sourceState = ComposerPillDragPluginKey.getState(view.state)
-  if (!sourceState) return null
-  const sourceNode = view.state.doc.nodeAt(sourceState.sourcePos)
-  if (!isComposerPillNode(sourceNode)) return null
-
+/** Resolve viewport coordinates to the pill drop position the plugin should paint. */
+export function dropPositionAt(view: EditorView, x: number, y: number, sourceNode: ProseMirrorNode): number | null {
   const hit = view.dom.ownerDocument.elementFromPoint(x, y)
   if (hit && hit !== view.dom && !view.dom.contains(hit)) return null
 
@@ -273,413 +252,12 @@ function dropPositionAt(view: EditorView, x: number, y: number): number | null {
   return rawPos === null ? null : composerPillDropPoint(view.state.doc, rawPos, sourceNode)
 }
 
-function distanceFromStart(drag: PendingDrag, x: number, y: number): number {
-  return Math.hypot(x - drag.startX, y - drag.startY)
-}
-
-function movedBeyondLongPressTolerance(drag: PendingDrag, x: number, y: number): boolean {
-  return (
-    Math.abs(x - drag.startX) > LONG_PRESS_MOVE_TOLERANCE_PX || Math.abs(y - drag.startY) > LONG_PRESS_MOVE_TOLERANCE_PX
-  )
-}
-
-function touchById(list: TouchList, id: number): Touch | null {
-  for (let index = 0; index < list.length; index++) {
-    const touch = list[index]
-    if (touch?.identifier === id) return touch
-  }
-  return null
-}
-
-function vibrate(win: Window, pattern: number | number[]) {
-  try {
-    win.navigator.vibrate?.(pattern)
-  } catch {
-    // Vibration is optional feedback.
-  }
-}
-
-class ComposerPillDragController {
-  private view: EditorView
-  private readonly doc: Document
-  private readonly win: Window
-  private pending: PendingDrag | null = null
-  private longPressTimer: number | null = null
-  private suppressMouseUntil = 0
-  private suppressClickUntil = 0
-  private readonly awaitingTouchCompletions = new Set<number>()
-  private touchGuide: ComposerPillTouchGuide | null = null
-
-  constructor(view: EditorView) {
-    this.view = view
-    this.doc = view.dom.ownerDocument
-    view.dom.dataset.composerPillDragMode = TOUCH_DRAG_MODE
-    this.win = this.doc.defaultView ?? window
-    view.dom.addEventListener("mousedown", this.onMouseDown, true)
-    view.dom.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true })
-    view.dom.addEventListener("click", this.onClick, true)
-    view.dom.addEventListener("contextmenu", this.onContextMenu, true)
-    view.dom.addEventListener("dragstart", this.onNativeDragStart, true)
-  }
-
-  update(view: EditorView, previousState?: EditorState) {
-    this.view = view
-    const dragState = ComposerPillDragPluginKey.getState(view.state)
-    const active = dragState !== null && dragState !== undefined
-    view.dom.classList.toggle("composer-pill-drag-active", active)
-    if (this.pending?.active && !active) {
-      this.clearPending()
-      return
-    }
-    if (previousState?.doc !== view.state.doc && this.pending?.kind === "touch" && this.pending.active && dragState) {
-      this.touchGuide?.refresh(view.state.doc, dragState.dropPos)
-    }
-  }
-
-  destroy() {
-    this.view.dom.removeEventListener("mousedown", this.onMouseDown, true)
-    this.view.dom.removeEventListener("touchstart", this.onTouchStart, true)
-    this.view.dom.removeEventListener("click", this.onClick, true)
-    this.view.dom.removeEventListener("contextmenu", this.onContextMenu, true)
-    this.view.dom.removeEventListener("dragstart", this.onNativeDragStart, true)
-    this.clearPending(true)
-    this.clearAwaitedTouchCompletions()
-    this.view.dom.classList.remove("composer-pill-drag-active")
-    delete this.view.dom.dataset.composerPillDragMode
-  }
-
-  private begin(drag: PendingDrag) {
-    this.cancel()
-    this.pending = drag
-    this.doc.addEventListener("keydown", this.onKeyDown, true)
-    this.win.addEventListener("blur", this.onWindowBlur)
-
-    if (drag.kind === "mouse") {
-      this.doc.addEventListener("mousemove", this.onMouseMove, true)
-      this.doc.addEventListener("mouseup", this.onMouseUp, true)
-      return
-    }
-
-    this.doc.addEventListener("touchstart", this.onAdditionalTouchStart, true)
-    this.doc.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false })
-    this.doc.addEventListener("touchend", this.onTouchEnd, true)
-    this.doc.addEventListener("touchcancel", this.onTouchCancel, true)
-    this.doc.addEventListener("selectstart", this.onSelectStart, true)
-    this.longPressTimer = this.win.setTimeout(() => {
-      const pending = this.pending
-      if (!pending || pending.kind !== "touch") return
-      pending.holdElapsed = true
-      this.suppressMouseUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
-      this.activate()
-    }, LONG_PRESS_THRESHOLD_MS)
-  }
-
-  private activate() {
-    const drag = this.pending
-    if (!drag || drag.active || !isComposerPillNode(this.view.state.doc.nodeAt(drag.sourcePos))) return
-    drag.active = true
-    if (drag.kind === "touch" && this.longPressTimer !== null) {
-      this.win.clearTimeout(this.longPressTimer)
-      this.longPressTimer = null
-    }
-    this.win.getSelection()?.removeAllRanges()
-    const dropPos = composerPillDropPoint(
-      this.view.state.doc,
-      drag.sourcePos,
-      this.view.state.doc.nodeAt(drag.sourcePos)!
-    )
-    this.setDragState({ sourcePos: drag.sourcePos, dropPos })
-    if (drag.kind === "touch") {
-      this.updateTouchGuide(drag.startX, drag.startY, dropPos)
-      vibrate(this.win, TOUCH_ACTIVATION_HAPTIC_MS)
-    }
-  }
-
-  private updateDrop(x: number, y: number) {
-    const drag = this.pending
-    if (!drag?.active) return
-    const current = ComposerPillDragPluginKey.getState(this.view.state)
-    if (!current) {
-      this.clearPending()
-      return
-    }
-    const dropPos = dropPositionAt(this.view, x, y)
-    if (drag.kind === "touch") {
-      this.updateTouchGuide(x, y, dropPos)
-      if (dropPos !== null && dropPos !== current.dropPos) vibrate(this.win, TOUCH_TARGET_HAPTIC_MS)
-    }
-    this.setDragState({ ...current, dropPos })
-  }
-
-  private finish(x: number, y: number) {
-    const drag = this.pending
-    if (!drag?.active) {
-      const touchedPill = drag?.kind === "touch"
-      const tappedPillPos = touchedPill && !drag.holdElapsed ? drag.sourcePos : null
-      this.cancel(touchedPill)
-      if (tappedPillPos !== null) this.selectPill(tappedPillPos)
-      return
-    }
-    if (drag.kind === "touch" && !drag.movedBeyondTolerance) {
-      const sourcePos = ComposerPillDragPluginKey.getState(this.view.state)?.sourcePos ?? drag.sourcePos
-      this.clearPending(true)
-      this.clearDragState()
-      this.selectPill(sourcePos)
-      return
-    }
-
-    this.updateDrop(x, y)
-    const current = ComposerPillDragPluginKey.getState(this.view.state)
-    const tr =
-      current?.dropPos === null || current?.dropPos === undefined
-        ? null
-        : createComposerPillMoveTransaction(this.view.state, current.sourcePos, current.dropPos)
-
-    const touchDrop = drag.kind === "touch"
-    this.clearPending(touchDrop)
-    if (tr) {
-      this.view.dispatch(tr.setMeta(ComposerPillDragPluginKey, null).setMeta("uiEvent", "drop"))
-      if (touchDrop) vibrate(this.win, TOUCH_DROP_HAPTIC_PATTERN_MS)
-    } else {
-      this.clearDragState()
-    }
-  }
-
-  private cancel = (touchFinished = false) => {
-    const wasActive = this.pending?.active === true
-    this.clearPending(touchFinished)
-    if (wasActive) this.clearDragState()
-  }
-
-  private clearPending(touchFinished = false) {
-    const touchId = this.pending?.kind === "touch" ? this.pending.id : null
-    if (touchId !== null) this.suppressMouseUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
-    if (this.pending?.active) this.suppressClickUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
-    if (this.longPressTimer !== null) {
-      this.win.clearTimeout(this.longPressTimer)
-      this.longPressTimer = null
-    }
-    this.doc.removeEventListener("mousemove", this.onMouseMove, true)
-    this.doc.removeEventListener("mouseup", this.onMouseUp, true)
-    this.doc.removeEventListener("touchstart", this.onAdditionalTouchStart, true)
-    this.doc.removeEventListener("touchmove", this.onTouchMove, true)
-    this.doc.removeEventListener("touchend", this.onTouchEnd, true)
-    this.doc.removeEventListener("touchcancel", this.onTouchCancel, true)
-    this.doc.removeEventListener("selectstart", this.onSelectStart, true)
-    this.doc.removeEventListener("keydown", this.onKeyDown, true)
-    this.win.removeEventListener("blur", this.onWindowBlur)
-    this.removeTouchGuide()
-    this.pending = null
-    if (touchId !== null) {
-      if (touchFinished) this.stopAwaitingTouchCompletion(touchId)
-      else this.awaitTouchCompletion(touchId)
-    }
-  }
-
-  private awaitTouchCompletion(id: number) {
-    if (this.awaitingTouchCompletions.has(id)) return
-    if (this.awaitingTouchCompletions.size === 0) {
-      this.doc.addEventListener("touchend", this.onAwaitedTouchCompletion, true)
-      this.doc.addEventListener("touchcancel", this.onAwaitedTouchCompletion, true)
-    }
-    this.awaitingTouchCompletions.add(id)
-  }
-
-  private stopAwaitingTouchCompletion(id: number) {
-    this.awaitingTouchCompletions.delete(id)
-    if (this.awaitingTouchCompletions.size === 0) this.removeAwaitedTouchCompletionListeners()
-  }
-
-  private clearAwaitedTouchCompletions() {
-    this.awaitingTouchCompletions.clear()
-    this.removeAwaitedTouchCompletionListeners()
-  }
-
-  private removeAwaitedTouchCompletionListeners() {
-    this.doc.removeEventListener("touchend", this.onAwaitedTouchCompletion, true)
-    this.doc.removeEventListener("touchcancel", this.onAwaitedTouchCompletion, true)
-  }
-
-  private onAwaitedTouchCompletion = (event: TouchEvent) => {
-    let completed = false
-    for (const id of this.awaitingTouchCompletions) {
-      if (!touchById(event.changedTouches, id) && touchById(event.touches, id)) continue
-      this.awaitingTouchCompletions.delete(id)
-      completed = true
-    }
-    if (completed) this.suppressMouseUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
-    if (this.awaitingTouchCompletions.size === 0) this.removeAwaitedTouchCompletionListeners()
-  }
-
-  private updateTouchGuide(x: number, y: number, dropPos: number | null) {
-    if (this.pending?.kind !== "touch" || !this.pending.active) return
-    this.touchGuide ??= new ComposerPillTouchGuide(this.doc, this.win)
-    this.touchGuide.update(this.view.state.doc, dropPos, x, y)
-  }
-
-  private removeTouchGuide() {
-    this.touchGuide?.destroy()
-    this.touchGuide = null
-  }
-
-  private setDragState(next: ComposerPillDragState) {
-    const current = ComposerPillDragPluginKey.getState(this.view.state)
-    if (current?.sourcePos === next.sourcePos && current.dropPos === next.dropPos) return
-    this.view.dispatch(this.view.state.tr.setMeta(ComposerPillDragPluginKey, next).setMeta("addToHistory", false))
-  }
-
-  private clearDragState() {
-    const dragState = ComposerPillDragPluginKey.getState(this.view.state)
-    if (dragState === null || dragState === undefined) return
-    this.view.dispatch(this.view.state.tr.setMeta(ComposerPillDragPluginKey, null).setMeta("addToHistory", false))
-  }
-
-  private selectPill(pos: number) {
-    const node = this.view.state.doc.nodeAt(pos)
-    if (!isComposerPillNode(node) || !NodeSelection.isSelectable(node)) return
-    this.view.focus()
-    this.view.dispatch(
-      this.view.state.tr.setSelection(NodeSelection.create(this.view.state.doc, pos)).setMeta("pointer", true)
-    )
-  }
-
-  private onMouseDown = (event: MouseEvent) => {
-    if (Date.now() <= this.suppressMouseUntil) {
-      event.preventDefault()
-      event.stopImmediatePropagation()
-      return
-    }
-    this.suppressClickUntil = 0
-    if (!this.view.editable || event.button !== 0) return
-    const pill = pillFromDom(this.view, event.target)
-    if (!pill) return
-    this.begin({
-      kind: "mouse",
-      id: 0,
-      sourcePos: pill.pos,
-      startX: event.clientX,
-      startY: event.clientY,
-      holdElapsed: false,
-      touchDragEligible: false,
-      movedBeyondTolerance: false,
-      active: false,
-    })
-  }
-
-  private onMouseMove = (event: MouseEvent) => {
-    const drag = this.pending
-    if (!drag || drag.kind !== "mouse") return
-    if (!drag.active && distanceFromStart(drag, event.clientX, event.clientY) < MOUSE_DRAG_THRESHOLD_PX) return
-    if (!drag.active) this.activate()
-    if (!this.pending?.active) return
-    event.preventDefault()
-    event.stopPropagation()
-    this.updateDrop(event.clientX, event.clientY)
-  }
-
-  private onMouseUp = (event: MouseEvent) => {
-    const drag = this.pending
-    if (!drag || drag.kind !== "mouse") return
-    if (drag.active) event.preventDefault()
-    this.finish(event.clientX, event.clientY)
-  }
-
-  private onTouchStart = (event: TouchEvent) => {
-    if (!this.view.editable || event.touches.length !== 1) {
-      this.cancel()
-      return
-    }
-    const pill = pillFromDom(this.view, event.target)
-    const touch = event.touches[0]
-    if (!pill || !touch) return
-    this.begin({
-      kind: "touch",
-      id: touch.identifier,
-      sourcePos: pill.pos,
-      startX: touch.clientX,
-      startY: touch.clientY,
-      holdElapsed: false,
-      touchDragEligible: isComposerPillSelected(this.view.state, pill.pos),
-      movedBeyondTolerance: false,
-      active: false,
-    })
-  }
-
-  private onAdditionalTouchStart = (event: TouchEvent) => {
-    if (this.pending?.kind === "touch" && event.touches.length > 1) this.cancel()
-  }
-
-  private onTouchMove = (event: TouchEvent) => {
-    const drag = this.pending
-    if (!drag || drag.kind !== "touch") return
-    if (event.touches.length > 1) {
-      this.cancel()
-      return
-    }
-    const touch = touchById(event.touches, drag.id)
-    if (!touch) return
-    const movedBeyondTolerance = movedBeyondLongPressTolerance(drag, touch.clientX, touch.clientY)
-    if (movedBeyondTolerance) drag.movedBeyondTolerance = true
-    if (!drag.active) {
-      if (!movedBeyondTolerance) return
-      if (!drag.touchDragEligible || !isComposerPillSelected(this.view.state, drag.sourcePos)) {
-        this.cancel()
-        return
-      }
-      this.activate()
-    }
-    if (!this.pending?.active) return
-    if (event.cancelable) event.preventDefault()
-    event.stopPropagation()
-    if (drag.movedBeyondTolerance) this.updateDrop(touch.clientX, touch.clientY)
-  }
-
-  private onTouchEnd = (event: TouchEvent) => {
-    const drag = this.pending
-    if (!drag || drag.kind !== "touch") return
-    const touch = touchById(event.changedTouches, drag.id)
-    if (!touch) return
-    if (drag.active && event.cancelable) event.preventDefault()
-    this.finish(touch.clientX, touch.clientY)
-  }
-
-  private onTouchCancel = () => this.cancel(true)
-
-  private onSelectStart = (event: Event) => {
-    if (this.pending?.kind !== "touch") return
-    event.preventDefault()
-  }
-
-  private onKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape") return
-    event.preventDefault()
-    this.cancel()
-  }
-
-  private onWindowBlur = () => this.cancel()
-
-  private onClick = (event: MouseEvent) => {
-    const now = Date.now()
-    if (now > this.suppressMouseUntil && now > this.suppressClickUntil) return
-    this.suppressMouseUntil = 0
-    this.suppressClickUntil = 0
-    event.preventDefault()
-    event.stopImmediatePropagation()
-  }
-
-  private onContextMenu = (event: MouseEvent) => {
-    const pending = this.pending
-    if (!pending || pending.kind !== "touch") return
-    event.preventDefault()
-    if (pending.active) return
-    pending.holdElapsed = true
-    this.suppressMouseUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
-    this.activate()
-  }
-
-  private onNativeDragStart = (event: DragEvent) => {
-    if (pillFromDom(this.view, event.target)) event.preventDefault()
-  }
+/** The one write path into the plugin's drag state; drags never enter history. */
+export function setComposerPillDragState(view: EditorView, next: ComposerPillDragState | null) {
+  const current = ComposerPillDragPluginKey.getState(view.state) ?? null
+  if (current === next) return
+  if (current && next && current.sourcePos === next.sourcePos && current.dropPos === next.dropPos) return
+  view.dispatch(view.state.tr.setMeta(ComposerPillDragPluginKey, next).setMeta("addToHistory", false))
 }
 
 export const ComposerPillDragExtension = Extension.create({
@@ -697,10 +275,15 @@ export const ComposerPillDragExtension = Extension.create({
           decorations: pillDecorations,
         },
         view(view) {
-          const controller = new ComposerPillDragController(view)
+          const reflectActive = (target: EditorView) => {
+            target.dom.classList.toggle(
+              "composer-pill-drag-active",
+              ComposerPillDragPluginKey.getState(target.state) != null
+            )
+          }
           return {
-            update: (updatedView, previousState) => controller.update(updatedView, previousState),
-            destroy: () => controller.destroy(),
+            update: reflectActive,
+            destroy: () => view.dom.classList.remove("composer-pill-drag-active"),
           }
         },
       }),

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -1,0 +1,244 @@
+import type { DraggableSyntheticListeners } from "@dnd-kit/core"
+import { NodeSelection } from "@tiptap/pm/state"
+import type { EditorView } from "@tiptap/pm/view"
+import {
+  COMPOSER_PILL_TOUCH_DRAG_MODE,
+  isComposerPillNode,
+  isComposerPillSelected,
+  pillFromDom,
+} from "./composer-pill-drag-extension"
+
+const COMPATIBILITY_MOUSE_WINDOW_MS = 400
+
+/**
+ * What is being dragged. `kind` is the discriminant a second drag source (the
+ * attachment tray) hangs off without reshaping the doc case.
+ */
+export interface ComposerPillDragSource {
+  kind: "doc"
+  pos: number
+}
+
+export type ComposerPillGestureKind = "mouse" | "touch"
+
+/**
+ * One gesture's immutable identity, snapshotted by the sensor at pointer-down.
+ * The host's own fields are overwritten by the next pointer-down on any pill —
+ * which can land before the previous gesture ends — so anything acting on behalf
+ * of the gesture that is ending reads this, never the host.
+ */
+export interface ComposerPillGesture {
+  kind: ComposerPillGestureKind
+  touchId: number
+  sourcePos: number
+  startX: number
+  startY: number
+}
+
+/**
+ * The editor-side effects of a drag. Driven straight from the sensor rather than
+ * from dnd-kit's React callbacks: a gesture can start and be cancelled inside a
+ * single tick (a hold that the OS immediately steals), and the callbacks only
+ * fire once dnd-kit's `active` state has rendered — teardown would be skipped
+ * and the drag decoration would stick.
+ */
+export interface ComposerPillDragLifecycle {
+  start(gesture: ComposerPillGesture): void
+  move(gesture: ComposerPillGesture, x: number, y: number): void
+  end(gesture: ComposerPillGesture, x: number, y: number): void
+  cancel(): void
+}
+
+function touchById(list: TouchList, id: number): Touch | null {
+  for (let index = 0; index < list.length; index++) {
+    const touch = list[index]
+    if (touch?.identifier === id) return touch
+  }
+  return null
+}
+
+/**
+ * Editor-side half of the pill drag: it owns the `view.dom` listeners, hands the
+ * gesture to dnd-kit's activator, and keeps the compatibility-event suppression
+ * windows that outlive any single drag (a touch's synthesised mouse events land
+ * after the sensor is gone).
+ */
+export class ComposerPillDragHost {
+  private view: EditorView | null = null
+  private listeners: DraggableSyntheticListeners
+  private suppressMouseUntil = 0
+  private suppressClickUntil = 0
+  private readonly awaitingTouchCompletions = new Set<number>()
+
+  /** Mutable payload read through the draggable's `data` ref at activation. */
+  readonly dragData: { source: ComposerPillDragSource | null } = { source: null }
+  gestureKind: ComposerPillGestureKind = "mouse"
+  gestureTouchId = 0
+  gestureTouchEligible = false
+  gestureStartX = 0
+  gestureStartY = 0
+  /** True once the gesture has produced a pointer move the drop point may follow. */
+  engaged = false
+  /** True between the sensor's activation and its teardown. */
+  dragActive = false
+  cancelActiveGesture: (() => void) | null = null
+  lifecycle: ComposerPillDragLifecycle | null = null
+
+  attach(view: EditorView) {
+    this.view = view
+    view.dom.dataset.composerPillDragMode = COMPOSER_PILL_TOUCH_DRAG_MODE
+    view.dom.addEventListener("mousedown", this.onMouseDown, true)
+    view.dom.addEventListener("touchstart", this.onTouchStart, { capture: true, passive: true })
+    view.dom.addEventListener("click", this.onClick, true)
+    view.dom.addEventListener("dragstart", this.onNativeDragStart, true)
+  }
+
+  detach() {
+    const view = this.view
+    this.cancelActiveGesture?.()
+    this.clearAwaitedTouchCompletions()
+    if (!view) return
+    view.dom.removeEventListener("mousedown", this.onMouseDown, true)
+    view.dom.removeEventListener("touchstart", this.onTouchStart, true)
+    view.dom.removeEventListener("click", this.onClick, true)
+    view.dom.removeEventListener("dragstart", this.onNativeDragStart, true)
+    delete view.dom.dataset.composerPillDragMode
+    this.view = null
+  }
+
+  setListeners(listeners: DraggableSyntheticListeners) {
+    this.listeners = listeners
+  }
+
+  getView(): EditorView | null {
+    return this.view
+  }
+
+  get source(): ComposerPillDragSource | null {
+    return this.dragData.source
+  }
+
+  selectPill(pos: number) {
+    const view = this.view
+    if (!view) return
+    const node = view.state.doc.nodeAt(pos)
+    if (!isComposerPillNode(node) || !NodeSelection.isSelectable(node)) return
+    view.focus()
+    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)).setMeta("pointer", true))
+  }
+
+  suppressCompatibilityMouse() {
+    this.suppressMouseUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
+  }
+
+  gestureEnded(gesture: ComposerPillGesture, options: { activated: boolean; touchFinished: boolean }) {
+    const touchId = gesture.kind === "touch" ? gesture.touchId : null
+    if (touchId !== null) this.suppressCompatibilityMouse()
+    if (options.activated) this.suppressClickUntil = Date.now() + COMPATIBILITY_MOUSE_WINDOW_MS
+    this.engaged = false
+    this.dragActive = false
+    this.cancelActiveGesture = null
+    if (touchId === null) return
+    if (options.touchFinished) this.stopAwaitingTouchCompletion(touchId)
+    else this.awaitTouchCompletion(touchId)
+  }
+
+  private ownerDocument(): Document | null {
+    return this.view?.dom.ownerDocument ?? null
+  }
+
+  private awaitTouchCompletion(id: number) {
+    const doc = this.ownerDocument()
+    if (!doc || this.awaitingTouchCompletions.has(id)) return
+    if (this.awaitingTouchCompletions.size === 0) {
+      doc.addEventListener("touchend", this.onAwaitedTouchCompletion, true)
+      doc.addEventListener("touchcancel", this.onAwaitedTouchCompletion, true)
+    }
+    this.awaitingTouchCompletions.add(id)
+  }
+
+  private stopAwaitingTouchCompletion(id: number) {
+    this.awaitingTouchCompletions.delete(id)
+    if (this.awaitingTouchCompletions.size === 0) this.removeAwaitedTouchCompletionListeners()
+  }
+
+  private clearAwaitedTouchCompletions() {
+    this.awaitingTouchCompletions.clear()
+    this.removeAwaitedTouchCompletionListeners()
+  }
+
+  private removeAwaitedTouchCompletionListeners() {
+    const doc = this.ownerDocument()
+    if (!doc) return
+    doc.removeEventListener("touchend", this.onAwaitedTouchCompletion, true)
+    doc.removeEventListener("touchcancel", this.onAwaitedTouchCompletion, true)
+  }
+
+  private onAwaitedTouchCompletion = (event: TouchEvent) => {
+    let completed = false
+    for (const id of this.awaitingTouchCompletions) {
+      if (!touchById(event.changedTouches, id) && touchById(event.touches, id)) continue
+      this.awaitingTouchCompletions.delete(id)
+      completed = true
+    }
+    if (completed) this.suppressCompatibilityMouse()
+    if (this.awaitingTouchCompletions.size === 0) this.removeAwaitedTouchCompletionListeners()
+  }
+
+  private forward(eventName: "onMouseDown" | "onTouchStart", event: Event) {
+    const listener = this.listeners?.[eventName]
+    listener?.({ nativeEvent: event } as unknown as React.SyntheticEvent)
+  }
+
+  private onMouseDown = (event: MouseEvent) => {
+    if (Date.now() <= this.suppressMouseUntil) {
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      return
+    }
+    this.suppressClickUntil = 0
+    const view = this.view
+    if (!view?.editable || event.button !== 0) return
+    const pill = pillFromDom(view, event.target)
+    if (!pill) return
+    this.dragData.source = { kind: "doc", pos: pill.pos }
+    this.gestureKind = "mouse"
+    this.gestureTouchId = 0
+    this.gestureTouchEligible = false
+    this.gestureStartX = event.clientX
+    this.gestureStartY = event.clientY
+    this.forward("onMouseDown", event)
+  }
+
+  private onTouchStart = (event: TouchEvent) => {
+    const view = this.view
+    if (!view?.editable || event.touches.length !== 1) {
+      this.cancelActiveGesture?.()
+      return
+    }
+    const pill = pillFromDom(view, event.target)
+    const touch = event.touches[0]
+    if (!pill || !touch) return
+    this.dragData.source = { kind: "doc", pos: pill.pos }
+    this.gestureKind = "touch"
+    this.gestureTouchId = touch.identifier
+    this.gestureTouchEligible = isComposerPillSelected(view.state, pill.pos)
+    this.gestureStartX = touch.clientX
+    this.gestureStartY = touch.clientY
+    this.forward("onTouchStart", event)
+  }
+
+  private onClick = (event: MouseEvent) => {
+    const now = Date.now()
+    if (now > this.suppressMouseUntil && now > this.suppressClickUntil) return
+    this.suppressMouseUntil = 0
+    this.suppressClickUntil = 0
+    event.preventDefault()
+    event.stopImmediatePropagation()
+  }
+
+  private onNativeDragStart = (event: DragEvent) => {
+    const view = this.view
+    if (view && pillFromDom(view, event.target)) event.preventDefault()
+  }
+}

--- a/apps/frontend/src/components/editor/composer-pill-sensor.ts
+++ b/apps/frontend/src/components/editor/composer-pill-sensor.ts
@@ -1,0 +1,253 @@
+import type { Activators, SensorInstance, SensorProps } from "@dnd-kit/core"
+import { LONG_PRESS_MOVE_TOLERANCE_PX, LONG_PRESS_THRESHOLD_MS } from "@/hooks/use-long-press"
+import {
+  ComposerPillDragPluginKey,
+  MOUSE_DRAG_THRESHOLD_PX,
+  isComposerPillNode,
+  isComposerPillSelected,
+} from "./composer-pill-drag-extension"
+import type { ComposerPillDragHost, ComposerPillGesture, ComposerPillGestureKind } from "./composer-pill-drag-host"
+
+export interface ComposerPillSensorOptions {
+  host: ComposerPillDragHost
+}
+
+function touchById(list: TouchList, id: number): Touch | null {
+  for (let index = 0; index < list.length; index++) {
+    const touch = list[index]
+    if (touch?.identifier === id) return touch
+  }
+  return null
+}
+
+/**
+ * Pointer rules dnd-kit's stock sensors can't express: a mouse activates on
+ * {@link MOUSE_DRAG_THRESHOLD_PX} of movement, while a touch activates on a
+ * {@link LONG_PRESS_THRESHOLD_MS} hold *or* — when the pill is already
+ * node-selected — as soon as it moves past {@link LONG_PRESS_MOVE_TOLERANCE_PX}.
+ * A touch that neither holds nor qualifies stays a tap or a scroll.
+ */
+export class ComposerPillSensor implements SensorInstance {
+  autoScrollEnabled = true
+
+  static activators: Activators<ComposerPillSensorOptions> = [
+    { eventName: "onMouseDown", handler: () => true },
+    { eventName: "onTouchStart", handler: () => true },
+  ]
+
+  private readonly props: SensorProps<ComposerPillSensorOptions>
+  private readonly host: ComposerPillDragHost
+  private readonly doc: Document
+  private readonly win: Window
+  private readonly kind: ComposerPillGestureKind
+  private readonly touchId: number
+  private readonly sourcePos: number
+  private readonly startX: number
+  private readonly startY: number
+  private readonly touchDragEligible: boolean
+  private readonly gesture: ComposerPillGesture
+  private activated = false
+  private holdElapsed = false
+  private movedBeyondTolerance = false
+  private longPressTimer: number | null = null
+
+  constructor(props: SensorProps<ComposerPillSensorOptions>) {
+    this.props = props
+    this.host = props.options.host
+    const view = this.host.getView()
+    this.doc = view?.dom.ownerDocument ?? document
+    this.win = this.doc.defaultView ?? window
+    this.kind = this.host.gestureKind
+    this.touchId = this.host.gestureTouchId
+    this.sourcePos = this.host.source?.pos ?? -1
+    this.startX = this.host.gestureStartX
+    this.startY = this.host.gestureStartY
+    this.touchDragEligible = this.host.gestureTouchEligible
+    this.gesture = {
+      kind: this.kind,
+      touchId: this.touchId,
+      sourcePos: this.sourcePos,
+      startX: this.startX,
+      startY: this.startY,
+    }
+    this.host.engaged = false
+    this.host.cancelActiveGesture = this.cancel
+
+    this.doc.addEventListener("keydown", this.onKeyDown, true)
+    this.win.addEventListener("blur", this.onWindowBlur)
+
+    if (this.kind === "mouse") {
+      this.doc.addEventListener("mousemove", this.onMouseMove, true)
+      this.doc.addEventListener("mouseup", this.onMouseUp, true)
+      return
+    }
+
+    this.doc.addEventListener("touchstart", this.onAdditionalTouchStart, true)
+    this.doc.addEventListener("touchmove", this.onTouchMove, { capture: true, passive: false })
+    this.doc.addEventListener("touchend", this.onTouchEnd, true)
+    this.doc.addEventListener("touchcancel", this.onTouchCancel, true)
+    this.doc.addEventListener("selectstart", this.onSelectStart, true)
+    this.doc.addEventListener("contextmenu", this.onContextMenu, true)
+    this.longPressTimer = this.win.setTimeout(() => {
+      this.holdElapsed = true
+      this.host.suppressCompatibilityMouse()
+      this.start()
+    }, LONG_PRESS_THRESHOLD_MS)
+  }
+
+  private detach() {
+    if (this.longPressTimer !== null) {
+      this.win.clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
+    this.doc.removeEventListener("keydown", this.onKeyDown, true)
+    this.win.removeEventListener("blur", this.onWindowBlur)
+    this.doc.removeEventListener("mousemove", this.onMouseMove, true)
+    this.doc.removeEventListener("mouseup", this.onMouseUp, true)
+    this.doc.removeEventListener("touchstart", this.onAdditionalTouchStart, true)
+    this.doc.removeEventListener("touchmove", this.onTouchMove, true)
+    this.doc.removeEventListener("touchend", this.onTouchEnd, true)
+    this.doc.removeEventListener("touchcancel", this.onTouchCancel, true)
+    this.doc.removeEventListener("selectstart", this.onSelectStart, true)
+    this.doc.removeEventListener("contextmenu", this.onContextMenu, true)
+  }
+
+  private finishGesture(touchFinished: boolean) {
+    this.detach()
+    this.host.gestureEnded(this.gesture, { activated: this.activated, touchFinished })
+  }
+
+  private start() {
+    if (this.activated) return
+    const view = this.host.getView()
+    if (!view || !isComposerPillNode(view.state.doc.nodeAt(this.sourcePos))) return
+    this.activated = true
+    this.host.dragActive = true
+    if (this.longPressTimer !== null) {
+      this.win.clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
+    this.win.getSelection()?.removeAllRanges()
+    this.host.lifecycle?.start(this.gesture)
+    this.props.onStart({ x: this.startX, y: this.startY })
+  }
+
+  private move(x: number, y: number) {
+    this.host.engaged = true
+    this.host.lifecycle?.move(this.gesture, x, y)
+    this.props.onMove({ x, y })
+  }
+
+  private cancel = () => {
+    const wasActivated = this.activated
+    this.finishGesture(false)
+    if (wasActivated) this.host.lifecycle?.cancel()
+    this.props.onCancel()
+  }
+
+  private finish(x: number, y: number) {
+    const view = this.host.getView()
+    if (!this.activated) {
+      const tappedPillPos = this.kind === "touch" && !this.holdElapsed ? this.sourcePos : null
+      this.finishGesture(this.kind === "touch")
+      this.props.onEnd()
+      if (tappedPillPos !== null) this.host.selectPill(tappedPillPos)
+      return
+    }
+
+    if (this.kind === "touch" && !this.movedBeyondTolerance) {
+      const state = view ? ComposerPillDragPluginKey.getState(view.state) : null
+      const sourcePos = state?.sourcePos ?? this.sourcePos
+      this.finishGesture(true)
+      this.host.lifecycle?.cancel()
+      this.props.onCancel()
+      this.host.selectPill(sourcePos)
+      return
+    }
+
+    this.finishGesture(this.kind === "touch")
+    this.host.lifecycle?.end(this.gesture, x, y)
+    this.props.onEnd()
+  }
+
+  private onMouseMove = (event: MouseEvent) => {
+    if (!this.activated) {
+      if (Math.hypot(event.clientX - this.startX, event.clientY - this.startY) < MOUSE_DRAG_THRESHOLD_PX) return
+      this.start()
+      if (!this.activated) return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    this.move(event.clientX, event.clientY)
+  }
+
+  private onMouseUp = (event: MouseEvent) => {
+    if (this.activated) event.preventDefault()
+    this.finish(event.clientX, event.clientY)
+  }
+
+  private onAdditionalTouchStart = (event: TouchEvent) => {
+    if (event.touches.length > 1) this.cancel()
+  }
+
+  private onTouchMove = (event: TouchEvent) => {
+    if (event.touches.length > 1) {
+      this.cancel()
+      return
+    }
+    const touch = touchById(event.touches, this.touchId)
+    if (!touch) return
+    const beyondTolerance =
+      Math.abs(touch.clientX - this.startX) > LONG_PRESS_MOVE_TOLERANCE_PX ||
+      Math.abs(touch.clientY - this.startY) > LONG_PRESS_MOVE_TOLERANCE_PX
+    if (beyondTolerance) this.movedBeyondTolerance = true
+
+    if (!this.activated) {
+      if (!beyondTolerance) return
+      const view = this.host.getView()
+      if (!this.touchDragEligible || !view || !isComposerPillSelected(view.state, this.sourcePos)) {
+        this.cancel()
+        return
+      }
+      this.start()
+      if (!this.activated) return
+    }
+    if (event.cancelable) event.preventDefault()
+    event.stopPropagation()
+    if (this.movedBeyondTolerance) this.move(touch.clientX, touch.clientY)
+  }
+
+  private onTouchEnd = (event: TouchEvent) => {
+    const touch = touchById(event.changedTouches, this.touchId)
+    if (!touch) return
+    if (this.activated && event.cancelable) event.preventDefault()
+    this.finish(touch.clientX, touch.clientY)
+  }
+
+  private onTouchCancel = () => {
+    const wasActivated = this.activated
+    this.finishGesture(true)
+    if (wasActivated) this.host.lifecycle?.cancel()
+    this.props.onCancel()
+  }
+
+  private onSelectStart = (event: Event) => {
+    event.preventDefault()
+  }
+
+  private onContextMenu = (event: MouseEvent) => {
+    event.preventDefault()
+    if (this.activated) return
+    this.holdElapsed = true
+    this.host.suppressCompatibilityMouse()
+    this.start()
+  }
+
+  private onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return
+    event.preventDefault()
+    this.cancel()
+  }
+
+  private onWindowBlur = () => this.cancel()
+}

--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
+import { ComposerPillDndProvider } from "./composer-pill-dnd"
 import { createEditorExtensions } from "./editor-extensions"
 import { EditorBehaviors, handleLinkToolbarAction, isSuggestionActive } from "./editor-behaviors"
 import {
@@ -406,10 +407,12 @@ export function DocumentEditorModal({
           className="flex-1 overflow-hidden cursor-text"
           onClick={() => editor?.commands.focus("end")}
         >
-          <EditorContent editor={editor} className="h-full" />
-          {renderMentionList()}
-          {renderChannelList()}
-          {renderEmojiGrid()}
+          <ComposerPillDndProvider editor={editor}>
+            <EditorContent editor={editor} className="h-full" />
+            {renderMentionList()}
+            {renderChannelList()}
+            {renderEmojiGrid()}
+          </ComposerPillDndProvider>
         </div>
 
         <ResponsiveDialogFooter className="px-4 py-3 border-t flex-row items-center">

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -4,6 +4,7 @@ import { GapCursor } from "@tiptap/pm/gapcursor"
 import type { ResolvedPos } from "@tiptap/pm/model"
 import type { PluginKey } from "@tiptap/pm/state"
 import { useParams } from "react-router-dom"
+import { ComposerPillDndProvider } from "./composer-pill-dnd"
 import { createEditorExtensions } from "./editor-extensions"
 import { applyExternalEditorContent } from "./apply-external-content"
 import { ComposerPillCopyButton } from "./composer-pill-copy-button"
@@ -1231,46 +1232,48 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
   return (
     <div ref={containerRef} className={cn("relative flex-1", disabled && "cursor-not-allowed opacity-50", className)}>
-      <EditorToolbar
-        editor={editor}
-        isVisible={staticToolbarOpen || toolbarVisible}
-        inline={staticToolbarOpen}
-        linkPopoverOpen={linkPopoverOpen}
-        onLinkPopoverOpenChange={setLinkPopoverOpen}
-        onDropdownOpenChange={setDropdownOpen}
-        trailingContent={staticToolbarOpen ? toolbarTrailingContent : undefined}
-      />
-      {belowToolbarContent}
-      <EditorContent editor={editor} />
-      <ComposerPillCopyButton editor={editor} />
-      {enableMentions ? renderMentionList() : null}
-      {enableChannels ? renderChannelList() : null}
-      {enableCommands ? renderCommandList() : null}
-      {enableCommands ? renderArgPicker() : null}
-      {enableEmoji ? renderEmojiGrid() : null}
-      {enableMemoEmbed ? renderMemoList() : null}
-      {giphyEnabled && workspaceId ? (
-        <GiphyPickerDialog
-          open={giphyOpen}
-          onOpenChange={setGiphyOpen}
-          workspaceId={workspaceId}
-          onSelect={handleGifSelect}
+      <ComposerPillDndProvider editor={editor}>
+        <EditorToolbar
+          editor={editor}
+          isVisible={staticToolbarOpen || toolbarVisible}
+          inline={staticToolbarOpen}
+          linkPopoverOpen={linkPopoverOpen}
+          onLinkPopoverOpenChange={setLinkPopoverOpen}
+          onDropdownOpenChange={setDropdownOpen}
+          trailingContent={staticToolbarOpen ? toolbarTrailingContent : undefined}
         />
-      ) : null}
-      {onFileUpload ? (
-        <SnippetEditorDialog
-          open={snippetDraft !== null}
-          onOpenChange={(open) => {
-            if (!open) {
-              setSnippetDraft(null)
-              snippetInsertPosRef.current = null
-            }
-          }}
-          initialText={snippetDraft?.text ?? ""}
-          defaultFilename={snippetDraft?.filename ?? SNIPPET_FALLBACK_FILENAME}
-          onSave={handleSnippetSave}
-        />
-      ) : null}
+        {belowToolbarContent}
+        <EditorContent editor={editor} />
+        <ComposerPillCopyButton editor={editor} />
+        {enableMentions ? renderMentionList() : null}
+        {enableChannels ? renderChannelList() : null}
+        {enableCommands ? renderCommandList() : null}
+        {enableCommands ? renderArgPicker() : null}
+        {enableEmoji ? renderEmojiGrid() : null}
+        {enableMemoEmbed ? renderMemoList() : null}
+        {giphyEnabled && workspaceId ? (
+          <GiphyPickerDialog
+            open={giphyOpen}
+            onOpenChange={setGiphyOpen}
+            workspaceId={workspaceId}
+            onSelect={handleGifSelect}
+          />
+        ) : null}
+        {onFileUpload ? (
+          <SnippetEditorDialog
+            open={snippetDraft !== null}
+            onOpenChange={(open) => {
+              if (!open) {
+                setSnippetDraft(null)
+                snippetInsertPosRef.current = null
+              }
+            }}
+            initialText={snippetDraft?.text ?? ""}
+            defaultFilename={snippetDraft?.filename ?? SNIPPET_FALLBACK_FILENAME}
+            onSave={handleSnippetSave}
+          />
+        ) : null}
+      </ComposerPillDndProvider>
     </div>
   )
 })


### PR DESCRIPTION
## Problem

In-composer pill drag is a hand-rolled pointer/touch engine: `ComposerPillDragController` in `composer-pill-drag-extension.ts` was ~380 of the file's 709 lines, re-implementing long-press timers, movement thresholds, compatibility-mouse suppression windows, awaited touch completions, and per-gesture cancellation — all bound directly to `view.dom` in capture phase, with native HTML5 drag explicitly `preventDefault`ed. It has no autoscroll and no keyboard or screen-reader path.

It also has exactly one drag source: an integer `sourcePos`. The next PR in this stack needs a second source — an attachment chip in the tray, which has no document position — and teaching the controller about that means growing the hand-rolled engine rather than replacing it.

`@dnd-kit/core` is already a dependency (6.3.1), used by the sidebar for stream filing and section reordering.

## Solution

Move the gesture layer onto dnd-kit; leave ProseMirror owning what a drop position *means*. No user-visible behaviour changes.

- **`DndContext` lives in `RichEditor`, not `MessageComposer`.** `ComposerPillDragExtension` is registered unconditionally in `createEditorExtensions()` (`editor-extensions.ts:136`), so every editor built from that factory has pill drag — and only 2 of the 9 `<RichEditor>` mounts are inside `MessageComposer`. A context there would have silently stripped drag from 8 editors. `RichEditor` and `document-editor-modal` (which builds its own TipTap instance) both wrap in the shared `ComposerPillDndProvider`, which takes the editor as a prop rather than sniffing the tree.
- **One imperatively-activated draggable, not one per pill.** `mention`, `channelLink` and `slashCommand` have no React node view — all three come from `create-trigger-extension.ts`, which emits plain DOM. Giving them `useDraggable` would mean `ReactNodeViewRenderer` on the trigger factory, i.e. a React root per mention in every document. Instead a single draggable is bound to `view.dom` and the source pill is resolved by the existing `pillFromDom`. The seven node types are untouched.
- **Pointer coordinates resolve the drop, not rectangles.** A custom collision detector reads `pointerCoordinates` (present on the 6.3.1 `CollisionDetection` arg) and routes through `composerPillDropPoint` → `nearestInlineTokenBoundary`, returning the position as the single collision's payload. No position — pointer outside the editor, a slot the pill can't occupy — means no collision.
- **Custom sensor over `TouchSensor`.** Today's touch rule is *hold 500 ms **or** move on an already node-selected pill* (`TOUCH_DRAG_MODE = "hold-or-selected"`). dnd-kit expresses a delay constraint or a distance constraint, not that disjunction conditioned on editor state, so `ComposerPillSensor` implements it directly against `LONG_PRESS_THRESHOLD_MS` / `LONG_PRESS_MOVE_TOLERANCE_PX` (INV-33 — the constants keep their one home in `use-long-press.ts`).
- **`composer-pill-drag-host.ts`** keeps the non-React half that dnd-kit has no opinion about: `view.dom` listeners, the compatibility-mouse and trailing-click suppression windows, awaited touch completions, `selectPill`, and the mutable drag payload whose `kind` discriminant chunk 2's `{ kind: "tray", attachmentId }` hangs off.
- **The plugin keeps** its state shape, `pillDecorations` / `dragDecorations` / `selectedPillDecorations`, `composerPillDropPoint`, `createComposerPillMoveTransaction`, `isComposerPillNode`, `pillFromDom`, and native `dragstart` suppression. `dropPositionAt` now takes the source node as a parameter instead of reading plugin state, so a tray source can reuse it unchanged.

Two findings from adversarial review were fixed here, each with a regression test confirmed to fail against reverted source:

- **The drop landed at the last pointer-*move* position, not the release position.** The deleted controller called `updateDrop(x, y)` with the mouseup/touchend coordinates before building the transaction. Move events are rate-limited to ~vsync, so any release between two dispatched moves — fast drag, trackpad flick-and-click, a finger sliding on lift-off — dropped the pill a token slot or more behind where the user let go; touch diverges more often still, since `touchend.changedTouches` routinely differs from the last `touchmove`. `finish(x, y)` now re-resolves at the release coordinates through the same `applyDropAt` closure `move` is, then builds the transaction.
- **Compatibility-mouse suppression read host-mutable fields at teardown.** `gestureEnded()` derived `touchId` from fields every pointer-down overwrites. On a hybrid device — touchstart on a pill, 500 ms hold, wait past the 400 ms window, press the mouse — the host had already flipped to `mouse`/`0`, so the finger lifting skipped both `suppressCompatibilityMouse()` and `awaitTouchCompletion()`, letting the synthesised `mousedown` clear the node selection the touch release just made. The sensor now passes its own constructor snapshot (`ComposerPillGesture`) into teardown, haptics, and the touch guide.

**Deliberate deviations, so nobody "fixes" them:**

- `autoScroll` is enabled on the `DndContext`. There is none today, so this is a small behaviour *addition* in a parity PR: dragging near a scrollable ancestor's edge now scrolls it.
- `DragOverlay` renders with no children — no visible ghost, matching today. The mount point exists for the next PR.
- `accessibility` supplies `announcements` only. dnd-kit's `screenReaderInstructions` are reached through the `aria-describedby` in `useDraggable().attributes`, and those attributes belong on a draggable element — here that would be the contenteditable, which must not take `role="button"`. Announcements go through the live region and need no attributes.
- The editor-side ProseMirror writes run through a lifecycle the sensor calls synchronously rather than through `useDndMonitor`. dnd-kit's `onDragEnd`/`onDragCancel` only fire once `active` has rendered, so a gesture started and cancelled inside one tick (a hold immediately stolen by the OS, `touchcancel`) skipped teardown and left the `composer-pill-dragging` decoration stuck — three existing assertions caught it. dnd-kit still computes `over` from the same resolver; only the document mutation is synchronous.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/composer-pill-dnd.tsx` | **new** — `ComposerPillDndProvider`, collision detector, drag lifecycle, touch guide + haptics |
| `apps/frontend/src/components/editor/composer-pill-drag-host.ts` | **new** — `view.dom` listeners, suppression windows, awaited touch completions, drag payload |
| `apps/frontend/src/components/editor/composer-pill-sensor.ts` | **new** — mouse 6 px / touch hold-or-selected activation, cancellation |
| `apps/frontend/src/components/editor/composer-pill-drag-extension.ts` | `ComposerPillDragController` **deleted** (−468 lines net); exports the drop-point and state-write seams |
| `apps/frontend/src/components/editor/composer-pill-drag-extension.test.{ts → tsx}` | renamed for JSX; every existing assertion intact, +6 tests |
| `apps/frontend/src/components/editor/rich-editor.tsx` | wraps its body in `ComposerPillDndProvider` |
| `apps/frontend/src/components/editor/document-editor-modal.tsx` | wraps its editor in the same provider |

## Test plan

- [x] `bun run --cwd apps/frontend test` — 6551/6558 pass. The 7 failures are timeout-shaped flakes in `e2e-session-store`, `conversation-panel`, `message-event` and `billing-timezone-section`, caused by concurrent local test runs; all 4 files pass in isolation (125 tests) and none touch the editor.
- [x] `composer-pill-drag-extension.test.tsx` — 35 pass (33 existing assertions unchanged + 6 new)
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] `bun run --cwd apps/frontend lint` — clean
- [x] Pre-commit monorepo lint + typecheck — clean
- [ ] **Real-device touch pass** — not run locally. jsdom has no layout, so drop resolution under test goes through mocked `elementFromPoint` / `posAtCoords` / `getBoundingClientRect`; the pointer→position path is verified logically, not geometrically. Haptics, touch-guide placement and the new autoscroll are unverified locally. This is why the PR carries `staging`.
- [ ] **`document-editor-modal` drag** — no mounted-modal test; it needs router/query/preferences context. Wired through the same provider as `RichEditor`, so proven by construction rather than by test.

New tests: drop-point resolution from raw coordinates (token-boundary snap, hovered-pill midpoint split with `posAtCoords` asserted unused, pointer outside the editor → null); sensor activation (5 px no / 6 px yes, 499 ms no / 500 ms yes, selected-pill move activates, unselected does not); Escape / window blur / second touch each cancel with the document unchanged; drop at release position vs. last move; compatibility-mouse suppression surviving an interleaved mouse press.

- [ ] **Playwright screenshot pass at 1440 px / 390 px** — not run. This worktree's test MinIO needs port 9002, held by another worktree's stack; stopping that was not worth the disruption. Visual verification is on staging.

<details>
<summary>📋 Full implementation plan</summary>

Plan of record: **https://seer.build/ws_vbyzjvdg6g/b/threa-tray-pill-dnd/** — §3 (the migration) and §8 chunk 1 (deliverables, tests, exclusions).

This is the bottom of a 3-PR stack:

1. **this PR** — in-composer pill drag onto dnd-kit, no behaviour change
2. tray → composer drag: insert semantics, mobile horizontal row, delete cascade
3. `/attachment` slash command

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

