### PR TITLE
feat: drag attachment pills from the tray into the composer

### DIFF
--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -178,8 +178,10 @@ export function AttachmentPill({
     <>
       <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={spin} anchored={anchored} />
       <span className={cn("truncate", labelMaxWidth)}>{label}</span>
+      {/* role=img so the count's `aria-label` names the element: a bare span has
+          no role, and an accessible name on one is not reliably exposed. */}
       {referenceCount > 1 && (
-        <span className={SECONDARY_TONE[status]} aria-label={`${referenceCount} references in this message`}>
+        <span role="img" className={SECONDARY_TONE[status]} aria-label={`${referenceCount} references in this message`}>
           {`\u00d7${referenceCount}`}
         </span>
       )}

--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -1,6 +1,6 @@
 import { useState, type ComponentType, type KeyboardEvent, type ReactNode } from "react"
 import { Link } from "react-router-dom"
-import { X } from "lucide-react"
+import { Anchor, X } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 
@@ -51,6 +51,12 @@ export interface AttachmentPillProps {
    */
   progress?: number
   labelMaxWidth?: string
+  /**
+   * How many times this attachment is referenced in the message being composed.
+   * Above zero the pill reads as drawn-from: dimmed, anchor glyph in the leading
+   * slot, and a `×N` count from two references up.
+   */
+  referenceCount?: number
   className?: string
 }
 
@@ -79,15 +85,17 @@ function PillLeading({
   icon: Icon,
   thumbnailSrc,
   spin,
+  anchored,
 }: {
   icon: ComponentType<{ className?: string }>
   thumbnailSrc?: string
   spin: boolean
+  anchored: boolean
 }) {
   const [failed, setFailed] = useState(false)
-  return (
-    <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-      {thumbnailSrc && !failed ? (
+  if (thumbnailSrc && !failed) {
+    return (
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
         <img
           src={thumbnailSrc}
           alt=""
@@ -95,9 +103,12 @@ function PillLeading({
           onError={() => setFailed(true)}
           className="h-5 w-5 rounded object-cover"
         />
-      ) : (
-        <Icon className={cn("h-3.5 w-3.5", spin && "animate-spin")} />
-      )}
+      </span>
+    )
+  }
+  return (
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+      {anchored ? <Anchor className="h-3.5 w-3.5" /> : <Icon className={cn("h-3.5 w-3.5", spin && "animate-spin")} />}
     </span>
   )
 }
@@ -146,6 +157,7 @@ export function AttachmentPill({
   activateLabel,
   progress,
   labelMaxWidth = "max-w-[160px]",
+  referenceCount = 0,
   className,
 }: AttachmentPillProps) {
   // Matches `<Button variant="outline" size="sm" className="h-8 gap-2 text-xs">`,
@@ -153,14 +165,24 @@ export function AttachmentPill({
   // keeps identical metrics moving from composer to timeline.
   // relative + overflow-hidden anchor and clip the progress fill bar.
   const baseStyles = "relative inline-flex h-8 items-center gap-2 overflow-hidden rounded-md px-3 text-xs select-none"
-  const statusStyles = STATUS_STYLES[status]
+  const statusStyles = cn(STATUS_STYLES[status], referenceCount > 0 && "opacity-60")
 
   const showProgress = typeof progress === "number" && progress >= 0 && progress < 1
+  const spin = spinning ?? status === "pending"
+  // The anchor is a resolved chip's glyph only: a failed upload keeps its error
+  // glyph and an in-flight one its spinner, both of which say more than "this is
+  // referenced". A thumbnail outranks it too — it identifies which image.
+  const anchored = referenceCount > 0 && !spin && status !== "error"
 
   const inner = (
     <>
-      <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={spinning ?? status === "pending"} />
+      <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={spin} anchored={anchored} />
       <span className={cn("truncate", labelMaxWidth)}>{label}</span>
+      {referenceCount > 1 && (
+        <span className={SECONDARY_TONE[status]} aria-label={`${referenceCount} references in this message`}>
+          {`\u00d7${referenceCount}`}
+        </span>
+      )}
       {secondary != null && <span className={SECONDARY_TONE[status]}>{secondary}</span>}
       {onRemove && (
         <button

--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -53,8 +53,8 @@ export interface AttachmentPillProps {
   labelMaxWidth?: string
   /**
    * How many times this attachment is referenced in the message being composed.
-   * Above zero the pill reads as drawn-from: dimmed, anchor glyph in the leading
-   * slot, and a `×N` count from two references up.
+   * Above zero the pill reads as drawn-from: anchor glyph in the leading slot,
+   * and a `×N` count from two references up.
    */
   referenceCount?: number
   className?: string
@@ -165,7 +165,7 @@ export function AttachmentPill({
   // keeps identical metrics moving from composer to timeline.
   // relative + overflow-hidden anchor and clip the progress fill bar.
   const baseStyles = "relative inline-flex h-8 items-center gap-2 overflow-hidden rounded-md px-3 text-xs select-none"
-  const statusStyles = cn(STATUS_STYLES[status], referenceCount > 0 && "opacity-60")
+  const statusStyles = STATUS_STYLES[status]
 
   const showProgress = typeof progress === "number" && progress >= 0 && progress < 1
   const spin = spinning ?? status === "pending"

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -12,6 +12,7 @@ import * as useMobileModule from "@/hooks/use-mobile"
 import * as contextsModule from "@/contexts"
 import * as editorModule from "@/components/editor"
 import * as micButtonModule from "./mic-button"
+import * as pendingAttachmentsModule from "@/components/timeline/pending-attachments"
 import { queueComposerCommandRequest } from "@/stores/composer-command-request-store"
 
 let isMobileMockValue = false
@@ -675,6 +676,51 @@ describe("MessageComposer", () => {
       expect(screen.getByTestId("mobile-editor-toolbar")).toHaveAttribute("data-has-special-input-controls", "yes")
       expect(screen.getByRole("button", { name: "Indent" })).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Dedent" })).toBeInTheDocument()
+    })
+
+    it("keeps the attachment tray mounted across a mobile chrome toggle, so a chip tap still activates", () => {
+      isMobileMockValue = true
+      let trayMounts = 0
+      const activate = vi.fn()
+      const MockTray = () => {
+        useEffect(() => {
+          trayMounts += 1
+        }, [])
+        return (
+          <button type="button" data-testid="tray-chip" onClick={activate}>
+            screenshot.png
+          </button>
+        )
+      }
+      spyOnExport(pendingAttachmentsModule, "PendingAttachments").mockReturnValue(
+        MockTray as unknown as typeof pendingAttachmentsModule.PendingAttachments
+      )
+      const attachments: PendingAttachment[] = [
+        { id: "att_1", filename: "screenshot.png", mimeType: "image/png", sizeBytes: 2048, status: "uploaded" },
+      ]
+
+      const onMobileChromeOpenChange = vi.fn()
+      render(
+        <MessageComposer
+          {...defaultProps}
+          pendingAttachments={attachments}
+          onMobileChromeOpenChange={onMobileChromeOpenChange}
+        />
+      )
+      expect(trayMounts).toBe(1)
+      expect(onMobileChromeOpenChange).toHaveBeenLastCalledWith(false)
+
+      // Tapping a chip focuses it, which opens the mobile chrome. The tray must
+      // keep its one React position through that: a remount tears the chip down
+      // before its click lands (and drops the tray's own preview state).
+      const chip = screen.getByTestId("tray-chip")
+      fireEvent.focus(chip)
+      fireEvent.click(chip)
+
+      expect(onMobileChromeOpenChange).toHaveBeenLastCalledWith(true)
+      expect(trayMounts).toBe(1)
+      expect(activate).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId("tray-chip")).toBe(chip)
     })
   })
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -27,6 +27,8 @@ import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
+import { countAttachmentReferences } from "@/components/editor/attachment-reference-counts"
+import { ComposerPillDndHost } from "@/components/editor/composer-pill-dnd"
 import { MicButton, type MicButtonHandle } from "./mic-button"
 import { FabDrawerCloseContext } from "./fab-drawer-close-context"
 import { StashedDraftsComposerBridgeContext, type StashedDraftsComposerBridge } from "./stashed-drafts-open-context"
@@ -699,6 +701,33 @@ export function MessageComposer({
     [onStashDraft, stashBinding, composerEmpty]
   )
 
+  // Chip state is a view of the document: how many references each attachment
+  // has, and — on delete — the references that go with it (INV-15: the cascade
+  // is a command the composer issues, never persistence reaching into a doc).
+  const attachmentReferenceCounts = useMemo(() => countAttachmentReferences(content), [content])
+  const handleRemoveAttachment = useCallback(
+    (id: string) => {
+      richEditorRef.current?.removeAttachmentReferences(id)
+      onRemoveAttachment(id)
+    },
+    [onRemoveAttachment]
+  )
+
+  const attachmentTray = (
+    <PendingAttachments
+      attachments={pendingAttachments}
+      onRemove={handleRemoveAttachment}
+      onCancelUpload={onCancelAttachmentUpload}
+      workspaceId={workspaceId}
+      referenceCounts={attachmentReferenceCounts}
+      beforePills={
+        contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
+          <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
+        ) : null
+      }
+    />
+  )
+
   const sharedEditor = (
     <RichEditor
       ref={setRichEditorHandle}
@@ -922,19 +951,7 @@ export function MessageComposer({
                 commandStreamId={commandStreamId}
                 belowToolbarContent={
                   pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
-                    <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">
-                      <PendingAttachments
-                        attachments={pendingAttachments}
-                        onRemove={onRemoveAttachment}
-                        onCancelUpload={onCancelAttachmentUpload}
-                        workspaceId={workspaceId}
-                        beforePills={
-                          contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
-                            <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
-                          ) : null
-                        }
-                      />
-                    </div>
+                    <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">{attachmentTray}</div>
                   ) : undefined
                 }
               />
@@ -1139,109 +1156,103 @@ export function MessageComposer({
           <p id={instructionsId} className="sr-only">
             {screenReaderInstructions}
           </p>
-          <PendingAttachments
-            attachments={pendingAttachments}
-            onRemove={onRemoveAttachment}
-            onCancelUpload={onCancelAttachmentUpload}
-            workspaceId={workspaceId}
-            beforePills={
-              contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
-                <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
-              ) : null
-            }
-          />
+          {/* One drag context around the tray and the editor: the tray keeps its
+            own position above the card and its chips still drag into the text.
+            Wrapping it renders no DOM node, so the layout is unchanged. */}
+          <ComposerPillDndHost>
+            {attachmentTray}
 
-          {/* Live in-app link previews for the draft. Above the card (like
+            {/* Live in-app link previews for the draft. Above the card (like
             attachments) so they read as attached to this message and stay clear
             of the keyboard on mobile. Hidden in the mobile resting state to keep
             the single-line bar minimal. */}
-          {workspaceId && (!isMobile || mobileChromeOpen) && (
-            <ComposerLinkPreviews content={content} workspaceId={workspaceId} className="mb-2" />
-          )}
+            {workspaceId && (!isMobile || mobileChromeOpen) && (
+              <ComposerLinkPreviews content={content} workspaceId={workspaceId} className="mb-2" />
+            )}
 
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={handleFileInputChange}
-            disabled={controlsDisabled}
-          />
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={handleFileInputChange}
+              disabled={controlsDisabled}
+            />
 
-          <div className="input-glow-wrapper flex-1 flex flex-col min-h-0">
-            <div
-              data-composer-card
-              className={cn(
-                "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
-                // Floating-composer shadow on the inline (non-expanded) card; the
-                // expanded fullscreen sheet stays flat.
-                !mobileExpanded && COLLAPSED_COMPOSER_SHADOW,
-                // Glass (translucent + backdrop-blur) lets the timeline show through
-                // the floating composer, but backdrop-filter re-rasterizes the blurred
-                // backdrop on every repaint — cheap on desktop, a frame-killer on
-                // mobile over a long, image-heavy timeline while typing. Opaque on
-                // mobile; keep the glass on desktop where the GPU absorbs it.
-                !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
-                // Compact padding when mobile-unfocused (single line), normal otherwise
-                isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
-                // When mobile-expanded, let the editor grow and override its internal max-height
-                mobileExpanded && "[&_.tiptap]:max-h-none"
-              )}
-              onClick={(e) => {
-                if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
-                  return
-                // On mobile unfocused, focus the (still zero-height) editor now —
-                // raising the keyboard — and expand the chrome together with the
-                // keyboard's viewport resize, so the open is a single snap.
-                if (isMobile && !mobileChromeOpen) {
-                  openMobileChromeWithKeyboard()
+            <div className="input-glow-wrapper flex-1 flex flex-col min-h-0">
+              <div
+                data-composer-card
+                className={cn(
+                  "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
+                  // Floating-composer shadow on the inline (non-expanded) card; the
+                  // expanded fullscreen sheet stays flat.
+                  !mobileExpanded && COLLAPSED_COMPOSER_SHADOW,
+                  // Glass (translucent + backdrop-blur) lets the timeline show through
+                  // the floating composer, but backdrop-filter re-rasterizes the blurred
+                  // backdrop on every repaint — cheap on desktop, a frame-killer on
+                  // mobile over a long, image-heavy timeline while typing. Opaque on
+                  // mobile; keep the glass on desktop where the GPU absorbs it.
+                  !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
+                  // Compact padding when mobile-unfocused (single line), normal otherwise
+                  isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
+                  // When mobile-expanded, let the editor grow and override its internal max-height
+                  mobileExpanded && "[&_.tiptap]:max-h-none"
+                )}
+                onClick={(e) => {
+                  if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
+                    return
+                  // On mobile unfocused, focus the (still zero-height) editor now —
+                  // raising the keyboard — and expand the chrome together with the
+                  // keyboard's viewport resize, so the open is a single snap.
+                  if (isMobile && !mobileChromeOpen) {
+                    openMobileChromeWithKeyboard()
+                    richEditorRef.current?.focus()
+                    return
+                  }
                   richEditorRef.current?.focus()
-                  return
-                }
-                richEditorRef.current?.focus()
-              }}
-            >
-              {isMobile && !mobileChromeOpen && (
-                <div
-                  className={cn(
-                    COLLAPSED_COMPOSER_ROW,
-                    "text-sm select-none pointer-events-none",
-                    mirrored && "flex-row-reverse"
-                  )}
-                >
-                  <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
-                  <div className="pointer-events-auto">{sendButton}</div>
-                </div>
-              )}
+                }}
+              >
+                {isMobile && !mobileChromeOpen && (
+                  <div
+                    className={cn(
+                      COLLAPSED_COMPOSER_ROW,
+                      "text-sm select-none pointer-events-none",
+                      mirrored && "flex-row-reverse"
+                    )}
+                  >
+                    <span className="flex-1 min-w-0 truncate text-muted-foreground">{previewText || placeholder}</span>
+                    <div className="pointer-events-auto">{sendButton}</div>
+                  </div>
+                )}
 
-              {/* Mobile-only table hint — the floating selection toolbar is
+                {/* Mobile-only table hint — the floating selection toolbar is
                suppressed on mobile (it conflicts with the OS selection popup),
                so without this banner there's no visible cue that the row /
                column / delete controls live behind the Aa button. */}
-              {isMobile && mobileChromeOpen && isInTable && !formatOpen && (
-                <button
-                  type="button"
-                  onClick={() => setFormatOpen(true)}
-                  onMouseDown={(e) => e.preventDefault()}
-                  className="flex items-center gap-2 self-start rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
-                >
-                  Editing table — tap{" "}
-                  <span className="rounded bg-background px-1 py-0.5 text-[11px] font-bold leading-none">Aa</span> to
-                  add or delete rows and columns
-                </button>
-              )}
-
-              {/* Editor — always mounted to preserve state; hidden in preview mode */}
-              <div
-                className={cn(
-                  isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
-                  mobileExpanded && "overflow-y-auto"
+                {isMobile && mobileChromeOpen && isInTable && !formatOpen && (
+                  <button
+                    type="button"
+                    onClick={() => setFormatOpen(true)}
+                    onMouseDown={(e) => e.preventDefault()}
+                    className="flex items-center gap-2 self-start rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground hover:bg-muted"
+                  >
+                    Editing table — tap{" "}
+                    <span className="rounded bg-background px-1 py-0.5 text-[11px] font-bold leading-none">Aa</span> to
+                    add or delete rows and columns
+                  </button>
                 )}
-              >
-                <div className="h-full">{sharedEditor}</div>
-              </div>
 
-              {/* Bottom action bar — visible on desktop always, on mobile when focused or dictating.
+                {/* Editor — always mounted to preserve state; hidden in preview mode */}
+                <div
+                  className={cn(
+                    isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
+                    mobileExpanded && "overflow-y-auto"
+                  )}
+                >
+                  <div className="h-full">{sharedEditor}</div>
+                </div>
+
+                {/* Bottom action bar — visible on desktop always, on mobile when focused or dictating.
                onMouseDown preventDefault keeps editor focus on mobile so the virtual keyboard
                stays open when tapping any button in this bar.
 
@@ -1254,80 +1265,81 @@ export function MessageComposer({
                DOM-subtree guard below limits the suppression to elements actually
                living under this wrapper — buttons in our own action bar — and
                leaves portaled content untouched. */}
-              {(!isMobile || mobileChromeOpen) && (
-                <div
-                  ref={actionBarWrapperRef}
-                  onMouseDown={(e) => {
-                    if (!actionBarWrapperRef.current?.contains(e.target as Node)) return
-                    e.preventDefault()
-                  }}
-                >
-                  {isMobile ? (
-                    <EditorActionBar
-                      editorHandle={richEditorRef.current}
-                      disabled={controlsDisabled}
-                      formatOpen={formatOpen}
-                      onFormatOpenChange={setFormatOpen}
-                      mobileExpanded={mobileExpanded}
-                      onMobileExpandedChange={setMobileExpanded}
-                      showAttach
-                      onAttachClick={handleAttachClick}
-                      side={actionSide}
-                      trailingContent={
-                        micButton || stashedDraftsTrigger || scheduledMessagesTrigger ? (
-                          // Mirrored too, so Send stays the outermost control
-                          // rather than sitting behind the triggers.
-                          <div className={cn("flex items-center gap-1", mirrored && "flex-row-reverse")}>
-                            {micButton}
-                            {stashedDraftsTrigger}
-                            {scheduledMessagesTrigger}
-                            {sendButton}
-                          </div>
-                        ) : (
-                          sendButton
-                        )
-                      }
-                    />
-                  ) : (
-                    <ComposerActionBar
-                      side={actionSide}
-                      disabled={controlsDisabled}
-                      formatOpen={formatOpen}
-                      onToggleFormat={() => setFormatOpen((v) => !v)}
-                      onInsertEmoji={insertEmoji}
-                      onInsertMention={insertMention}
-                      onInsertCommand={insertSlash}
-                      onAttachClick={handleAttachClick}
-                      onExpandClick={onExpandClick}
-                      micButton={micButton}
-                      stashedDraftsTrigger={stashedDraftsTrigger}
-                      scheduledMessagesTrigger={scheduledMessagesTrigger}
-                      sendButton={sendButton}
-                    />
-                  )}
-                </div>
-              )}
+                {(!isMobile || mobileChromeOpen) && (
+                  <div
+                    ref={actionBarWrapperRef}
+                    onMouseDown={(e) => {
+                      if (!actionBarWrapperRef.current?.contains(e.target as Node)) return
+                      e.preventDefault()
+                    }}
+                  >
+                    {isMobile ? (
+                      <EditorActionBar
+                        editorHandle={richEditorRef.current}
+                        disabled={controlsDisabled}
+                        formatOpen={formatOpen}
+                        onFormatOpenChange={setFormatOpen}
+                        mobileExpanded={mobileExpanded}
+                        onMobileExpandedChange={setMobileExpanded}
+                        showAttach
+                        onAttachClick={handleAttachClick}
+                        side={actionSide}
+                        trailingContent={
+                          micButton || stashedDraftsTrigger || scheduledMessagesTrigger ? (
+                            // Mirrored too, so Send stays the outermost control
+                            // rather than sitting behind the triggers.
+                            <div className={cn("flex items-center gap-1", mirrored && "flex-row-reverse")}>
+                              {micButton}
+                              {stashedDraftsTrigger}
+                              {scheduledMessagesTrigger}
+                              {sendButton}
+                            </div>
+                          ) : (
+                            sendButton
+                          )
+                        }
+                      />
+                    ) : (
+                      <ComposerActionBar
+                        side={actionSide}
+                        disabled={controlsDisabled}
+                        formatOpen={formatOpen}
+                        onToggleFormat={() => setFormatOpen((v) => !v)}
+                        onInsertEmoji={insertEmoji}
+                        onInsertMention={insertMention}
+                        onInsertCommand={insertSlash}
+                        onAttachClick={handleAttachClick}
+                        onExpandClick={onExpandClick}
+                        micButton={micButton}
+                        stashedDraftsTrigger={stashedDraftsTrigger}
+                        scheduledMessagesTrigger={scheduledMessagesTrigger}
+                        sendButton={sendButton}
+                      />
+                    )}
+                  </div>
+                )}
 
-              {/* Mobile formatting toolbar — rendered below action bar, above keyboard */}
-              {isMobile && formatOpen && (
-                <EditorToolbar
-                  editor={mobileToolbarEditor}
-                  isVisible
-                  inline
-                  inlinePosition="below"
-                  linkPopoverOpen={mobileLinkPopoverOpen}
-                  onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
-                  showSpecialInputControls
-                />
-              )}
+                {/* Mobile formatting toolbar — rendered below action bar, above keyboard */}
+                {isMobile && formatOpen && (
+                  <EditorToolbar
+                    editor={mobileToolbarEditor}
+                    isVisible
+                    inline
+                    inlinePosition="below"
+                    linkPopoverOpen={mobileLinkPopoverOpen}
+                    onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
+                    showSpecialInputControls
+                  />
+                )}
+              </div>
             </div>
-          </div>
 
-          <div className={cn("flex px-1 pt-1", mirrored ? "justify-start" : "justify-end")}>
-            <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
-              {sendHint}
-            </span>
-          </div>
+            <div className={cn("flex px-1 pt-1", mirrored ? "justify-start" : "justify-end")}>
+              <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
+                {sendHint}
+              </span>
+            </div>
+          </ComposerPillDndHost>
         </div>
       </StashedDraftsComposerBridgeContext.Provider>
     </TooltipProvider>

--- a/apps/frontend/src/components/editor/attachment-reference-counts.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-counts.ts
@@ -1,0 +1,18 @@
+import type { JSONContent } from "@threa/types"
+
+/**
+ * How many times each attachment is referenced in a draft. Derived from the
+ * document on every read — the tray is an inventory and a chip's referenced
+ * state is a view of the message, never stored alongside the attachment.
+ */
+export function countAttachmentReferences(content: JSONContent | null | undefined): Map<string, number> {
+  const counts = new Map<string, number>()
+  const visit = (node: JSONContent) => {
+    if (node.type === "attachmentReference" && typeof node.attrs?.id === "string") {
+      counts.set(node.attrs.id, (counts.get(node.attrs.id) ?? 0) + 1)
+    }
+    for (const child of node.content ?? []) visit(child)
+  }
+  if (content) visit(content)
+  return counts
+}

--- a/apps/frontend/src/components/editor/attachment-reference-extension.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.ts
@@ -36,6 +36,11 @@ declare module "@tiptap/core" {
        * Update an attachment reference by its temp ID
        */
       updateAttachmentReference: (tempId: string, updates: Partial<AttachmentReferenceAttrs>) => ReturnType
+      /**
+       * Delete every reference to one attachment. The tray is the inventory, so
+       * dropping a file from it drops the references drawn from it.
+       */
+      removeAttachmentReferences: (attachmentId: string) => ReturnType
     }
   }
 }
@@ -187,6 +192,25 @@ export const AttachmentReferenceExtension = Node.create({
             return true
           }
           return false
+        },
+
+      removeAttachmentReferences:
+        (attachmentId) =>
+        ({ tr, state, dispatch }) => {
+          const ranges: Array<{ from: number; to: number }> = []
+          state.doc.descendants((node, pos) => {
+            if (node.type.name === "attachmentReference" && node.attrs.id === attachmentId) {
+              ranges.push({ from: pos, to: pos + node.nodeSize })
+            }
+            return true
+          })
+          if (ranges.length === 0) return false
+          if (!dispatch) return true
+
+          // Back to front: an earlier deletion would shift every later range.
+          for (const range of ranges.reverse()) tr.delete(range.from, range.to)
+          dispatch(tr)
+          return true
         },
     }
   },

--- a/apps/frontend/src/components/editor/composer-pill-copy-button.test.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-copy-button.test.tsx
@@ -152,7 +152,10 @@ describe("composer pill copy control", () => {
 
     act(() => {
       editor.view.dispatch(
-        editor.state.tr.setMeta(ComposerPillDragPluginKey, { sourcePos: nodePos(editor, "mention"), dropPos: null })
+        editor.state.tr.setMeta(ComposerPillDragPluginKey, {
+          source: { kind: "doc", pos: nodePos(editor, "mention") },
+          dropPos: null,
+        })
       )
     })
     expect(copyControl()).toBeNull()

--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -107,12 +107,15 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
 
   useEffect(() => {
     if (!editor) return
-    const dom = editor.view.dom
+    if (!host.claimEditorSlot(editor)) return
+    const view = editor.view
+    const dom = view.dom
     setDraggableNode(dom)
     setDroppableNode(dom)
-    host.attach(editor.view)
+    host.attach(view)
     return () => {
-      host.detach()
+      host.detach(view)
+      host.releaseEditorSlot(editor)
       setDraggableNode(null)
       setDroppableNode(null)
     }
@@ -294,16 +297,29 @@ export function ComposerPillDndHost({ children }: { children?: ReactNode }) {
  * own an editor instance (`RichEditor`, the document editor modal) each wrap it
  * in this provider rather than relying on a context further up the tree.
  *
- * Under a `ComposerPillDndHost` it binds the editor to that host instead. The
- * branch is decided by whether a host exists, which never changes for a given
- * mount — so the children keep one React position either way.
+ * Under a `ComposerPillDndHost` whose editor slot is still free it binds the
+ * editor to that host instead. A host already driving an editor is not borrowed:
+ * a second editor rendered inside the composer's tree (the scheduled-message
+ * edit dialog, portaled but still a React descendant) opens its own context, so
+ * it neither steals the composer's view nor takes dnd-kit's ids twice. The
+ * branch is read once per mount and never flips, so the children keep one React
+ * position either way.
  */
 export function ComposerPillDndProvider({ editor, children }: { editor: Editor | null; children?: ReactNode }) {
   const ancestorHost = useComposerPillDragHost()
-  if (ancestorHost) {
+  const boundHostRef = useRef<ComposerPillDragHost | null | undefined>(undefined)
+  // Claimed during render, not in the effect: two providers can render in one
+  // commit, and the loser has to know before it picks a branch. The claim is
+  // keyed by the editor, so re-rendering or remounting this same provider
+  // re-takes its own claim rather than losing it.
+  if (boundHostRef.current === undefined) {
+    boundHostRef.current = ancestorHost?.claimEditorSlot(editor) ? ancestorHost : null
+  }
+  const boundHost = boundHostRef.current
+  if (boundHost) {
     return (
       <>
-        <ComposerPillDragBridge editor={editor} host={ancestorHost} />
+        <ComposerPillDragBridge editor={editor} host={boundHost} />
         {children}
       </>
     )

--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from "react"
 import {
   DndContext,
+  DragOverlay,
+  useDndContext,
   useDraggable,
   useDroppable,
   useSensor,
@@ -8,6 +10,7 @@ import {
   type Announcements,
   type CollisionDetection,
 } from "@dnd-kit/core"
+import { FileIcon, ImageIcon } from "lucide-react"
 import type { Transaction } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
 import type { Editor } from "@tiptap/react"
@@ -19,7 +22,10 @@ import {
   createComposerPillMoveTransaction,
   dropPositionAt,
   setComposerPillDragState,
+  type ComposerPillDragSource,
 } from "./composer-pill-drag-extension"
+import { AttachmentPill } from "@/components/composer/attachment-pill"
+import { formatFileSize } from "@/lib/file-size"
 import {
   ComposerPillDragHost,
   type ComposerPillDragLifecycle,
@@ -206,6 +212,45 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
   return null
 }
 
+/**
+ * The ghost that follows the pointer during a drag out of the tray. Only a tray
+ * source gets one: an in-document pill is already visible, dimmed in place, and
+ * a second copy of it would be new behaviour.
+ *
+ * dnd-kit anchors the overlay on the draggable node, which here is the editor
+ * itself — the tray chip is not the draggable. So the ghost is offset from the
+ * editor's corner to the pointer's start, and dnd-kit's own transform carries it
+ * from there.
+ */
+function ComposerPillDragPreview({ host }: { host: ComposerPillDragHost }) {
+  const { active } = useDndContext()
+  const source = (active?.data.current as { source?: ComposerPillDragSource | null } | undefined)?.source ?? null
+  const tray = source?.kind === "tray" ? source : null
+  const offset = useMemo(() => {
+    const rect = tray ? host.getView()?.dom.getBoundingClientRect() : null
+    if (!rect) return null
+    return { x: host.gestureStartX - rect.left, y: host.gestureStartY - rect.top }
+  }, [host, tray])
+  if (!tray || !offset) return null
+
+  const { attrs } = tray
+  return (
+    <span
+      data-testid="composer-pill-drag-preview"
+      className="inline-flex"
+      style={{ transform: `translate3d(${offset.x}px, calc(${offset.y}px - 50%), 0)` }}
+    >
+      <AttachmentPill
+        icon={attrs.mimeType.startsWith("image/") ? ImageIcon : FileIcon}
+        label={attrs.filename}
+        secondary={attrs.sizeBytes == null ? undefined : formatFileSize(attrs.sizeBytes)}
+        labelMaxWidth="max-w-[120px]"
+        className="shadow-lg"
+      />
+    </span>
+  )
+}
+
 function ComposerPillDndOwner({ editor, children }: { editor?: Editor | null; children?: ReactNode }) {
   const hostRef = useRef<ComposerPillDragHost | null>(null)
   hostRef.current ??= new ComposerPillDragHost()
@@ -224,6 +269,9 @@ function ComposerPillDndOwner({ editor, children }: { editor?: Editor | null; ch
       <ComposerPillDragHostContext.Provider value={host}>
         {editor !== undefined && <ComposerPillDragBridge editor={editor} host={host} />}
         {children}
+        <DragOverlay dropAnimation={null} style={{ pointerEvents: "none" }}>
+          <ComposerPillDragPreview host={host} />
+        </DragOverlay>
       </ComposerPillDragHostContext.Provider>
     </DndContext>
   )

--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, type ReactNode } from "react"
+import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from "react"
 import {
   DndContext,
   useDraggable,
@@ -8,14 +8,16 @@ import {
   type Announcements,
   type CollisionDetection,
 } from "@dnd-kit/core"
+import type { Transaction } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
 import type { Editor } from "@tiptap/react"
 import {
   ComposerPillDragPluginKey,
+  composerPillDragNode,
   composerPillDropPoint,
+  createComposerPillInsertTransaction,
   createComposerPillMoveTransaction,
   dropPositionAt,
-  isComposerPillNode,
   setComposerPillDragState,
 } from "./composer-pill-drag-extension"
 import {
@@ -58,9 +60,19 @@ function resolveDropPos(host: ComposerPillDragHost, x: number, y: number): numbe
   if (!view) return null
   const drag = ComposerPillDragPluginKey.getState(view.state)
   if (!drag) return null
-  const sourceNode = view.state.doc.nodeAt(drag.sourcePos)
-  if (!isComposerPillNode(sourceNode)) return null
+  const sourceNode = composerPillDragNode(view.state, drag.source)
+  if (!sourceNode) return null
   return dropPositionAt(view, x, y, sourceNode)
+}
+
+/**
+ * The editor's drag host, so surfaces rendered inside the provider (the
+ * attachment tray) can start a drag against the same sensor.
+ */
+const ComposerPillDragHostContext = createContext<ComposerPillDragHost | null>(null)
+
+export function useComposerPillDragHost(): ComposerPillDragHost | null {
+  return useContext(ComposerPillDragHostContext)
 }
 
 /**
@@ -116,17 +128,20 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
         guideRef.current?.update(view.state.doc, dropPos, x, y)
         if (dropPos !== null && dropPos !== current.dropPos) vibrate(windowFor(view), TOUCH_TARGET_HAPTIC_MS)
       }
-      setComposerPillDragState(view, { sourcePos: current.sourcePos, dropPos })
+      setComposerPillDragState(view, { source: current.source, dropPos })
     }
 
     const lifecycle: ComposerPillDragLifecycle = {
       start: (gesture) => {
         const view = host.getView()
         if (!view) return
-        const node = view.state.doc.nodeAt(gesture.sourcePos)
-        if (!isComposerPillNode(node)) return
-        const dropPos = composerPillDropPoint(view.state.doc, gesture.sourcePos, node)
-        setComposerPillDragState(view, { sourcePos: gesture.sourcePos, dropPos })
+        const node = composerPillDragNode(view.state, gesture.source)
+        if (!node) return
+        // A tray source has no position to sit at, so it starts without a drop
+        // point and takes one from the first move.
+        const dropPos =
+          gesture.source.kind === "doc" ? composerPillDropPoint(view.state.doc, gesture.source.pos, node) : null
+        setComposerPillDragState(view, { source: gesture.source, dropPos })
         if (gesture.kind !== "touch") return
         guideRef.current = new ComposerPillTouchGuide(view.dom.ownerDocument, windowFor(view))
         guideRef.current.update(view.state.doc, dropPos, gesture.startX, gesture.startY)
@@ -141,10 +156,14 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
         releaseGuide()
         if (!view) return
         const drag = ComposerPillDragPluginKey.getState(view.state)
-        const tr =
-          drag && drag.dropPos !== null
-            ? createComposerPillMoveTransaction(view.state, drag.sourcePos, drag.dropPos)
-            : null
+        let tr: Transaction | null = null
+        if (drag && drag.dropPos !== null) {
+          const node = composerPillDragNode(view.state, drag.source)
+          tr =
+            drag.source.kind === "doc"
+              ? createComposerPillMoveTransaction(view.state, drag.source.pos, drag.dropPos)
+              : node && createComposerPillInsertTransaction(view.state, node, drag.dropPos)
+        }
         if (!tr) {
           setComposerPillDragState(view, null)
           return
@@ -187,13 +206,7 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
   return null
 }
 
-/**
- * Provides in-composer pill dragging to one editor. Every editor built from
- * `createEditorExtensions()` carries the ProseMirror half, so the surfaces that
- * own an editor instance (`RichEditor`, the document editor modal) each wrap it
- * in this provider rather than relying on a context further up the tree.
- */
-export function ComposerPillDndProvider({ editor, children }: { editor: Editor | null; children?: ReactNode }) {
+function ComposerPillDndOwner({ editor, children }: { editor?: Editor | null; children?: ReactNode }) {
   const hostRef = useRef<ComposerPillDragHost | null>(null)
   hostRef.current ??= new ComposerPillDragHost()
   const host = hostRef.current
@@ -208,8 +221,44 @@ export function ComposerPillDndProvider({ editor, children }: { editor: Editor |
 
   return (
     <DndContext autoScroll sensors={sensors} collisionDetection={collisionDetection} accessibility={{ announcements }}>
-      <ComposerPillDragBridge editor={editor} host={host} />
-      {children}
+      <ComposerPillDragHostContext.Provider value={host}>
+        {editor !== undefined && <ComposerPillDragBridge editor={editor} host={host} />}
+        {children}
+      </ComposerPillDragHostContext.Provider>
     </DndContext>
   )
+}
+
+/**
+ * Owns the drag context for a surface whose editor is mounted deeper in the
+ * tree, so the drag sources that sit *outside* the editor (the composer's
+ * attachment tray) keep their own position in the DOM instead of being routed
+ * through an editor slot. The descendant `ComposerPillDndProvider` attaches the
+ * editor to this host rather than opening a second context.
+ */
+export function ComposerPillDndHost({ children }: { children?: ReactNode }) {
+  return <ComposerPillDndOwner>{children}</ComposerPillDndOwner>
+}
+
+/**
+ * Provides in-composer pill dragging to one editor. Every editor built from
+ * `createEditorExtensions()` carries the ProseMirror half, so the surfaces that
+ * own an editor instance (`RichEditor`, the document editor modal) each wrap it
+ * in this provider rather than relying on a context further up the tree.
+ *
+ * Under a `ComposerPillDndHost` it binds the editor to that host instead. The
+ * branch is decided by whether a host exists, which never changes for a given
+ * mount — so the children keep one React position either way.
+ */
+export function ComposerPillDndProvider({ editor, children }: { editor: Editor | null; children?: ReactNode }) {
+  const ancestorHost = useComposerPillDragHost()
+  if (ancestorHost) {
+    return (
+      <>
+        <ComposerPillDragBridge editor={editor} host={ancestorHost} />
+        {children}
+      </>
+    )
+  }
+  return <ComposerPillDndOwner editor={editor}>{children}</ComposerPillDndOwner>
 }

--- a/apps/frontend/src/components/editor/composer-pill-dnd.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-dnd.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from "react"
+import { createContext, useContext, useEffect, useId, useMemo, useRef, type ReactNode } from "react"
 import {
   DndContext,
   DragOverlay,
@@ -96,7 +96,15 @@ export function createComposerPillCollisionDetection(host: ComposerPillDragHost)
   }
 }
 
-function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host: ComposerPillDragHost }) {
+function ComposerPillDragBridge({
+  editor,
+  host,
+  ownerId,
+}: {
+  editor: Editor | null
+  host: ComposerPillDragHost
+  ownerId: string
+}) {
   const { setNodeRef: setDraggableNode, listeners } = useDraggable({ id: DRAGGABLE_ID, data: host.dragData })
   const { setNodeRef: setDroppableNode } = useDroppable({ id: DROPPABLE_ID })
   const guideRef = useRef<ComposerPillTouchGuide | null>(null)
@@ -107,7 +115,7 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
 
   useEffect(() => {
     if (!editor) return
-    if (!host.claimEditorSlot(editor)) return
+    if (!host.claimEditorSlot(ownerId)) return
     const view = editor.view
     const dom = view.dom
     setDraggableNode(dom)
@@ -115,11 +123,15 @@ function ComposerPillDragBridge({ editor, host }: { editor: Editor | null; host:
     host.attach(view)
     return () => {
       host.detach(view)
-      host.releaseEditorSlot(editor)
       setDraggableNode(null)
       setDroppableNode(null)
     }
-  }, [editor, host, setDraggableNode, setDroppableNode])
+  }, [editor, host, ownerId, setDraggableNode, setDroppableNode])
+
+  // The slot is held for as long as this provider is mounted, not for as long as
+  // it has an editor: rebuilding the editor must not open a window where another
+  // one can take the host.
+  useEffect(() => () => host.releaseEditorSlot(ownerId), [host, ownerId])
 
   useEffect(() => {
     const releaseGuide = () => {
@@ -258,6 +270,7 @@ function ComposerPillDndOwner({ editor, children }: { editor?: Editor | null; ch
   const hostRef = useRef<ComposerPillDragHost | null>(null)
   hostRef.current ??= new ComposerPillDragHost()
   const host = hostRef.current
+  const ownerId = useId()
 
   const sensors = useSensors(
     useSensor(
@@ -270,7 +283,7 @@ function ComposerPillDndOwner({ editor, children }: { editor?: Editor | null; ch
   return (
     <DndContext autoScroll sensors={sensors} collisionDetection={collisionDetection} accessibility={{ announcements }}>
       <ComposerPillDragHostContext.Provider value={host}>
-        {editor !== undefined && <ComposerPillDragBridge editor={editor} host={host} />}
+        {editor !== undefined && <ComposerPillDragBridge editor={editor} host={host} ownerId={ownerId} />}
         {children}
         <DragOverlay dropAnimation={null} style={{ pointerEvents: "none" }}>
           <ComposerPillDragPreview host={host} />
@@ -307,19 +320,21 @@ export function ComposerPillDndHost({ children }: { children?: ReactNode }) {
  */
 export function ComposerPillDndProvider({ editor, children }: { editor: Editor | null; children?: ReactNode }) {
   const ancestorHost = useComposerPillDragHost()
+  const ownerId = useId()
   const boundHostRef = useRef<ComposerPillDragHost | null | undefined>(undefined)
   // Claimed during render, not in the effect: two providers can render in one
   // commit, and the loser has to know before it picks a branch. The claim is
-  // keyed by the editor, so re-rendering or remounting this same provider
-  // re-takes its own claim rather than losing it.
+  // keyed by this provider, so it holds from the first render — an editor that
+  // does not exist yet must not cost the composer its own host — and re-taking
+  // it on a re-render, a StrictMode double-invoke or a remount is a no-op.
   if (boundHostRef.current === undefined) {
-    boundHostRef.current = ancestorHost?.claimEditorSlot(editor) ? ancestorHost : null
+    boundHostRef.current = ancestorHost?.claimEditorSlot(ownerId) ? ancestorHost : null
   }
   const boundHost = boundHostRef.current
   if (boundHost) {
     return (
       <>
-        <ComposerPillDragBridge editor={editor} host={boundHost} />
+        <ComposerPillDragBridge editor={editor} host={boundHost} ownerId={ownerId} />
         {children}
       </>
     )

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.test.tsx
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.test.tsx
@@ -489,7 +489,7 @@ describe("composer pill drag gestures", () => {
     vi.advanceTimersByTime(500)
     editor.view.dispatch(editor.state.tr.insertText("x ", 1))
     const mappedSourcePos = nodePos(editor, "mention")
-    expect(ComposerPillDragPluginKey.getState(editor.state)?.sourcePos).toBe(mappedSourcePos)
+    expect(ComposerPillDragPluginKey.getState(editor.state)?.source).toEqual({ kind: "doc", pos: mappedSourcePos })
 
     fireEvent.touchEnd(document, { touches: [], changedTouches: [touch(7, 10, 10)] })
     expect(editor.state.selection).toBeInstanceOf(NodeSelection)

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
@@ -233,6 +233,38 @@ function dragDecorations(state: EditorState): Decoration[] {
   return decorations
 }
 
+/**
+ * The attachment whose inline references should read as "already in the
+ * message". Asked for on demand — while its tray chip is dragged, or hovered
+ * with a mouse — rather than painted on permanently. A live drag outranks a
+ * stale hover left behind on another chip.
+ */
+export const ComposerPillHighlightPluginKey = new PluginKey<string | null>("composerPillHighlight")
+
+function highlightedAttachmentId(state: EditorState): string | null {
+  const drag = ComposerPillDragPluginKey.getState(state)
+  if (drag?.source.kind === "tray") return drag.source.attachmentId
+  return ComposerPillHighlightPluginKey.getState(state) ?? null
+}
+
+function highlightDecorations(state: EditorState): DecorationSet | null {
+  const attachmentId = highlightedAttachmentId(state)
+  if (!attachmentId) return null
+
+  const decorations: Decoration[] = []
+  state.doc.descendants((node, pos) => {
+    if (node.type.name !== "attachmentReference" || node.attrs.id !== attachmentId) return
+    decorations.push(Decoration.node(pos, pos + node.nodeSize, { class: "composer-pill-highlighted" }))
+  })
+  return decorations.length === 0 ? null : DecorationSet.create(state.doc, decorations)
+}
+
+/** The one write path for the hover half of the highlight; never enters history. */
+export function setComposerPillHighlight(view: EditorView, attachmentId: string | null) {
+  if ((ComposerPillHighlightPluginKey.getState(view.state) ?? null) === attachmentId) return
+  view.dispatch(view.state.tr.setMeta(ComposerPillHighlightPluginKey, attachmentId).setMeta("addToHistory", false))
+}
+
 function pillDecorations(state: EditorState): DecorationSet | null {
   const decorations = [...dragDecorations(state), ...selectedPillDecorations(state)]
   return decorations.length === 0 ? null : DecorationSet.create(state.doc, decorations)
@@ -340,6 +372,19 @@ export const ComposerPillDragExtension = Extension.create({
             update: reflectActive,
             destroy: () => view.dom.classList.remove("composer-pill-drag-active"),
           }
+        },
+      }),
+      new Plugin<string | null>({
+        key: ComposerPillHighlightPluginKey,
+        state: {
+          init: () => null,
+          apply: (tr, current) => {
+            const meta = tr.getMeta(ComposerPillHighlightPluginKey) as string | null | undefined
+            return meta === undefined ? current : meta
+          },
+        },
+        props: {
+          decorations: highlightDecorations,
         },
       }),
     ]

--- a/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-extension.ts
@@ -3,6 +3,7 @@ import { Fragment, Slice, type Node as ProseMirrorNode } from "@tiptap/pm/model"
 import { NodeSelection, Plugin, PluginKey, Selection, type EditorState, type Transaction } from "@tiptap/pm/state"
 import { dropPoint } from "@tiptap/pm/transform"
 import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view"
+import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
 
 export const COMPOSER_PILL_NODE_NAMES = [
   "mention",
@@ -19,9 +20,27 @@ const COMPOSER_PILL_NODE_NAME_SET = new Set<string>(COMPOSER_PILL_NODE_NAMES)
 export const MOUSE_DRAG_THRESHOLD_PX = 6
 export const COMPOSER_PILL_TOUCH_DRAG_MODE = "hold-or-selected"
 
+/**
+ * What is being dragged. A `doc` source is a pill already in the document and
+ * moves; a `tray` source is an attachment chip and always inserts a new node,
+ * so it has no position to leave behind.
+ */
+export type ComposerPillDragSource =
+  | { kind: "doc"; pos: number }
+  | { kind: "tray"; attachmentId: string; attrs: AttachmentReferenceAttrs }
+
 export interface ComposerPillDragState {
-  sourcePos: number
+  source: ComposerPillDragSource
   dropPos: number | null
+}
+
+/** The node a drag carries: the live one for a doc source, a fresh one for a tray source. */
+export function composerPillDragNode(state: EditorState, source: ComposerPillDragSource): ProseMirrorNode | null {
+  if (source.kind === "doc") {
+    const node = state.doc.nodeAt(source.pos)
+    return isComposerPillNode(node) ? node : null
+  }
+  return state.schema.nodes.attachmentReference?.create(source.attrs) ?? null
 }
 
 export const ComposerPillDragPluginKey = new PluginKey<ComposerPillDragState | null>("composerPillDrag")
@@ -129,6 +148,34 @@ export function createComposerPillMoveTransaction(
 }
 
 /**
+ * Sibling of {@link createComposerPillMoveTransaction} for a source that has no
+ * position in the document: the tray is an inventory, so a drag out of it copies
+ * the chip in and never empties it.
+ */
+export function createComposerPillInsertTransaction(
+  state: EditorState,
+  node: ProseMirrorNode,
+  requestedDropPos: number
+): Transaction | null {
+  if (!isComposerPillNode(node)) return null
+
+  const dropPos = composerPillDropPoint(state.doc, requestedDropPos, node)
+  if (dropPos === null) return null
+
+  const $insert = state.doc.resolve(dropPos)
+  if (
+    !$insert.parent.inlineContent ||
+    !$insert.parent.canReplaceWith($insert.index(), $insert.index(), node.type, node.marks)
+  ) {
+    return null
+  }
+
+  const tr = state.tr.insert(dropPos, node)
+  tr.setSelection(Selection.near(tr.doc.resolve(dropPos + node.nodeSize), 1))
+  return tr
+}
+
+/**
  * Pills are `user-select: none`, so no engine paints the selection highlight
  * over one even when it sits squarely inside the range — the surrounding text
  * highlights and the pill looks untouched. The range is real (copy carries the
@@ -149,20 +196,25 @@ function selectedPillDecorations(state: EditorState): Decoration[] {
 function dragDecorations(state: EditorState): Decoration[] {
   const drag = ComposerPillDragPluginKey.getState(state)
   if (!drag) return []
-  const source = state.doc.nodeAt(drag.sourcePos)
-  if (!isComposerPillNode(source)) return []
 
-  const decorations: Decoration[] = [
-    Decoration.node(drag.sourcePos, drag.sourcePos + source.nodeSize, {
-      class: "composer-pill-dragging",
-      "data-composer-pill-dragging": "true",
-    }),
-  ]
+  // Only a doc source has something in the document to grey out.
+  const decorations: Decoration[] = []
+  if (drag.source.kind === "doc") {
+    const sourceNode = state.doc.nodeAt(drag.source.pos)
+    if (!isComposerPillNode(sourceNode)) return []
+    decorations.push(
+      Decoration.node(drag.source.pos, drag.source.pos + sourceNode.nodeSize, {
+        class: "composer-pill-dragging",
+        "data-composer-pill-dragging": "true",
+      })
+    )
+  }
 
   if (drag.dropPos !== null) {
+    const dropPos = drag.dropPos
     decorations.push(
       Decoration.widget(
-        drag.dropPos,
+        dropPos,
         () => {
           const cursor = document.createElement("span")
           cursor.className = "composer-pill-drop-cursor"
@@ -171,7 +223,7 @@ function dragDecorations(state: EditorState): Decoration[] {
         },
         {
           key: "composer-pill-drop-cursor",
-          side: drag.dropPos <= drag.sourcePos ? -1 : 1,
+          side: drag.source.kind === "doc" && dropPos <= drag.source.pos ? -1 : 1,
           ignoreSelection: true,
         }
       )
@@ -191,10 +243,13 @@ function mappedDragState(tr: Transaction, current: ComposerPillDragState | null)
   if (meta !== undefined) return meta
   if (!current || !tr.docChanged) return current
 
-  const sourcePos = tr.mapping.map(current.sourcePos, 1)
-  const dropAssociation = current.dropPos !== null && current.dropPos <= current.sourcePos ? -1 : 1
+  const anchorPos = current.source.kind === "doc" ? current.source.pos : null
+  const dropAssociation = anchorPos !== null && current.dropPos !== null && current.dropPos <= anchorPos ? -1 : 1
   const dropPos = current.dropPos === null ? null : tr.mapping.map(current.dropPos, dropAssociation)
-  return isComposerPillNode(tr.doc.nodeAt(sourcePos)) ? { sourcePos, dropPos } : null
+  if (anchorPos === null) return { source: current.source, dropPos }
+
+  const sourcePos = tr.mapping.map(anchorPos, 1)
+  return isComposerPillNode(tr.doc.nodeAt(sourcePos)) ? { source: { kind: "doc", pos: sourcePos }, dropPos } : null
 }
 
 export function isComposerPillSelected(state: EditorState, pos: number): boolean {
@@ -256,7 +311,7 @@ export function dropPositionAt(view: EditorView, x: number, y: number, sourceNod
 export function setComposerPillDragState(view: EditorView, next: ComposerPillDragState | null) {
   const current = ComposerPillDragPluginKey.getState(view.state) ?? null
   if (current === next) return
-  if (current && next && current.sourcePos === next.sourcePos && current.dropPos === next.dropPos) return
+  if (current && next && current.source === next.source && current.dropPos === next.dropPos) return
   view.dispatch(view.state.tr.setMeta(ComposerPillDragPluginKey, next).setMeta("addToHistory", false))
 }
 

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -6,18 +6,10 @@ import {
   isComposerPillNode,
   isComposerPillSelected,
   pillFromDom,
+  type ComposerPillDragSource,
 } from "./composer-pill-drag-extension"
 
 const COMPATIBILITY_MOUSE_WINDOW_MS = 400
-
-/**
- * What is being dragged. `kind` is the discriminant a second drag source (the
- * attachment tray) hangs off without reshaping the doc case.
- */
-export interface ComposerPillDragSource {
-  kind: "doc"
-  pos: number
-}
 
 export type ComposerPillGestureKind = "mouse" | "touch"
 
@@ -30,7 +22,7 @@ export type ComposerPillGestureKind = "mouse" | "touch"
 export interface ComposerPillGesture {
   kind: ComposerPillGestureKind
   touchId: number
-  sourcePos: number
+  source: ComposerPillDragSource
   startX: number
   startY: number
 }
@@ -116,6 +108,43 @@ export class ComposerPillDragHost {
 
   get source(): ComposerPillDragSource | null {
     return this.dragData.source
+  }
+
+  /**
+   * True while the click that ends a just-activated drag is still travelling.
+   * The tray chip is also a button (it opens the lightbox), so it asks before
+   * acting on a click it may have produced by being dragged.
+   */
+  get activationClickSuppressed(): boolean {
+    return Date.now() <= this.suppressClickUntil
+  }
+
+  /**
+   * Entry point for a drag that starts outside the editor. Same activator, same
+   * sensor: only the source differs, so the tray never grows a parallel path.
+   */
+  startTrayGesture(source: Extract<ComposerPillDragSource, { kind: "tray" }>, event: MouseEvent | TouchEvent) {
+    if (!this.view?.editable) return
+    if ("touches" in event) {
+      const touch = event.touches[0]
+      if (event.touches.length !== 1 || !touch) return
+      this.dragData.source = source
+      this.gestureKind = "touch"
+      this.gestureTouchId = touch.identifier
+      this.gestureTouchEligible = false
+      this.gestureStartX = touch.clientX
+      this.gestureStartY = touch.clientY
+      this.forward("onTouchStart", event)
+      return
+    }
+    if (event.button !== 0 || Date.now() <= this.suppressMouseUntil) return
+    this.dragData.source = source
+    this.gestureKind = "mouse"
+    this.gestureTouchId = 0
+    this.gestureTouchEligible = false
+    this.gestureStartX = event.clientX
+    this.gestureStartY = event.clientY
+    this.forward("onMouseDown", event)
   }
 
   selectPill(pos: number) {

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -1,6 +1,7 @@
 import type { DraggableSyntheticListeners } from "@dnd-kit/core"
 import { NodeSelection } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
+import type { Editor } from "@tiptap/react"
 import {
   COMPOSER_PILL_TOUCH_DRAG_MODE,
   isComposerPillNode,
@@ -58,6 +59,7 @@ function touchById(list: TouchList, id: number): Touch | null {
  */
 export class ComposerPillDragHost {
   private view: EditorView | null = null
+  private editorSlotOwner: Editor | null = null
   private listeners: DraggableSyntheticListeners
   private suppressMouseUntil = 0
   private suppressClickUntil = 0
@@ -77,6 +79,24 @@ export class ComposerPillDragHost {
   cancelActiveGesture: (() => void) | null = null
   lifecycle: ComposerPillDragLifecycle | null = null
 
+  /**
+   * A host drives exactly one editor. The slot is keyed by the editor rather than
+   * by the mount that binds it, so the composer's own provider still recognises
+   * its binding when it remounts, while a *different* editor inside this host's
+   * tree (a dialog's composer) is refused and opens its own context instead of
+   * stealing the binding and tearing it down on unmount. An editor that is not
+   * built yet reserves nothing and only asks whether the slot is free.
+   */
+  claimEditorSlot(editor: Editor | null): boolean {
+    if (this.editorSlotOwner !== null && this.editorSlotOwner !== editor) return false
+    if (editor) this.editorSlotOwner = editor
+    return true
+  }
+
+  releaseEditorSlot(editor: Editor) {
+    if (this.editorSlotOwner === editor) this.editorSlotOwner = null
+  }
+
   attach(view: EditorView) {
     this.view = view
     view.dom.dataset.composerPillDragMode = COMPOSER_PILL_TOUCH_DRAG_MODE
@@ -86,11 +106,10 @@ export class ComposerPillDragHost {
     view.dom.addEventListener("dragstart", this.onNativeDragStart, true)
   }
 
-  detach() {
-    const view = this.view
+  detach(view: EditorView) {
+    if (this.view !== view) return
     this.cancelActiveGesture?.()
     this.clearAwaitedTouchCompletions()
-    if (!view) return
     view.dom.removeEventListener("mousedown", this.onMouseDown, true)
     view.dom.removeEventListener("touchstart", this.onTouchStart, true)
     view.dom.removeEventListener("click", this.onClick, true)

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -6,6 +6,7 @@ import {
   isComposerPillNode,
   isComposerPillSelected,
   pillFromDom,
+  setComposerPillHighlight,
   type ComposerPillDragSource,
 } from "./composer-pill-drag-extension"
 
@@ -154,6 +155,16 @@ export class ComposerPillDragHost {
     this.gestureStartX = event.clientX
     this.gestureStartY = event.clientY
     this.forward("onMouseDown", event)
+  }
+
+  /**
+   * Point the editor at the attachment whose references should light up. The
+   * drag half is derived from the drag state, so this carries only hover.
+   */
+  highlightAttachment(attachmentId: string | null) {
+    const view = this.view
+    if (!view) return
+    setComposerPillHighlight(view, attachmentId)
   }
 
   selectPill(pos: number) {

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -120,6 +120,15 @@ export class ComposerPillDragHost {
   }
 
   /**
+   * A fresh pointer-down means the click it produces belongs to that press, not
+   * to the drag that ended before it — otherwise the window swallows a chip tap
+   * for as long as it runs.
+   */
+  clearActivationClickSuppression() {
+    this.suppressClickUntil = 0
+  }
+
+  /**
    * Entry point for a drag that starts outside the editor. Same activator, same
    * sensor: only the source differs, so the tray never grows a parallel path.
    */
@@ -225,7 +234,7 @@ export class ComposerPillDragHost {
       event.stopImmediatePropagation()
       return
     }
-    this.suppressClickUntil = 0
+    this.clearActivationClickSuppression()
     const view = this.view
     if (!view?.editable || event.button !== 0) return
     const pill = pillFromDom(view, event.target)

--- a/apps/frontend/src/components/editor/composer-pill-drag-host.ts
+++ b/apps/frontend/src/components/editor/composer-pill-drag-host.ts
@@ -1,7 +1,6 @@
 import type { DraggableSyntheticListeners } from "@dnd-kit/core"
 import { NodeSelection } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
-import type { Editor } from "@tiptap/react"
 import {
   COMPOSER_PILL_TOUCH_DRAG_MODE,
   isComposerPillNode,
@@ -59,7 +58,7 @@ function touchById(list: TouchList, id: number): Touch | null {
  */
 export class ComposerPillDragHost {
   private view: EditorView | null = null
-  private editorSlotOwner: Editor | null = null
+  private editorSlotOwner: string | null = null
   private listeners: DraggableSyntheticListeners
   private suppressMouseUntil = 0
   private suppressClickUntil = 0
@@ -80,21 +79,22 @@ export class ComposerPillDragHost {
   lifecycle: ComposerPillDragLifecycle | null = null
 
   /**
-   * A host drives exactly one editor. The slot is keyed by the editor rather than
-   * by the mount that binds it, so the composer's own provider still recognises
-   * its binding when it remounts, while a *different* editor inside this host's
+   * A host drives exactly one editor. The slot is keyed by the provider that
+   * binds it, not by the editor, so the provider holds it from its first render
+   * — before its editor exists — and a *different* editor inside this host's
    * tree (a dialog's composer) is refused and opens its own context instead of
-   * stealing the binding and tearing it down on unmount. An editor that is not
-   * built yet reserves nothing and only asks whether the slot is free.
+   * taking a binding the composer is still building towards. The key is a
+   * `useId()`, stable across a re-render, a StrictMode double-invoke and a
+   * remount at the same position, so re-claiming is idempotent.
    */
-  claimEditorSlot(editor: Editor | null): boolean {
-    if (this.editorSlotOwner !== null && this.editorSlotOwner !== editor) return false
-    if (editor) this.editorSlotOwner = editor
+  claimEditorSlot(ownerId: string): boolean {
+    if (this.editorSlotOwner !== null && this.editorSlotOwner !== ownerId) return false
+    this.editorSlotOwner = ownerId
     return true
   }
 
-  releaseEditorSlot(editor: Editor) {
-    if (this.editorSlotOwner === editor) this.editorSlotOwner = null
+  releaseEditorSlot(ownerId: string) {
+    if (this.editorSlotOwner === ownerId) this.editorSlotOwner = null
   }
 
   attach(view: EditorView) {

--- a/apps/frontend/src/components/editor/composer-pill-sensor.ts
+++ b/apps/frontend/src/components/editor/composer-pill-sensor.ts
@@ -3,8 +3,10 @@ import { LONG_PRESS_MOVE_TOLERANCE_PX, LONG_PRESS_THRESHOLD_MS } from "@/hooks/u
 import {
   ComposerPillDragPluginKey,
   MOUSE_DRAG_THRESHOLD_PX,
+  composerPillDragNode,
   isComposerPillNode,
   isComposerPillSelected,
+  type ComposerPillDragSource,
 } from "./composer-pill-drag-extension"
 import type { ComposerPillDragHost, ComposerPillGesture, ComposerPillGestureKind } from "./composer-pill-drag-host"
 
@@ -41,7 +43,7 @@ export class ComposerPillSensor implements SensorInstance {
   private readonly win: Window
   private readonly kind: ComposerPillGestureKind
   private readonly touchId: number
-  private readonly sourcePos: number
+  private readonly source: ComposerPillDragSource
   private readonly startX: number
   private readonly startY: number
   private readonly touchDragEligible: boolean
@@ -59,14 +61,14 @@ export class ComposerPillSensor implements SensorInstance {
     this.win = this.doc.defaultView ?? window
     this.kind = this.host.gestureKind
     this.touchId = this.host.gestureTouchId
-    this.sourcePos = this.host.source?.pos ?? -1
+    this.source = this.host.source ?? { kind: "doc", pos: -1 }
     this.startX = this.host.gestureStartX
     this.startY = this.host.gestureStartY
     this.touchDragEligible = this.host.gestureTouchEligible
     this.gesture = {
       kind: this.kind,
       touchId: this.touchId,
-      sourcePos: this.sourcePos,
+      source: this.source,
       startX: this.startX,
       startY: this.startY,
     }
@@ -120,7 +122,7 @@ export class ComposerPillSensor implements SensorInstance {
   private start() {
     if (this.activated) return
     const view = this.host.getView()
-    if (!view || !isComposerPillNode(view.state.doc.nodeAt(this.sourcePos))) return
+    if (!view || !isComposerPillNode(composerPillDragNode(view.state, this.source))) return
     this.activated = true
     this.host.dragActive = true
     if (this.longPressTimer !== null) {
@@ -147,8 +149,9 @@ export class ComposerPillSensor implements SensorInstance {
 
   private finish(x: number, y: number) {
     const view = this.host.getView()
+    const docSourcePos = this.source.kind === "doc" ? this.source.pos : null
     if (!this.activated) {
-      const tappedPillPos = this.kind === "touch" && !this.holdElapsed ? this.sourcePos : null
+      const tappedPillPos = this.kind === "touch" && !this.holdElapsed ? docSourcePos : null
       this.finishGesture(this.kind === "touch")
       this.props.onEnd()
       if (tappedPillPos !== null) this.host.selectPill(tappedPillPos)
@@ -156,12 +159,12 @@ export class ComposerPillSensor implements SensorInstance {
     }
 
     if (this.kind === "touch" && !this.movedBeyondTolerance) {
-      const state = view ? ComposerPillDragPluginKey.getState(view.state) : null
-      const sourcePos = state?.sourcePos ?? this.sourcePos
+      const live = view ? ComposerPillDragPluginKey.getState(view.state)?.source : null
+      const sourcePos = live?.kind === "doc" ? live.pos : docSourcePos
       this.finishGesture(true)
       this.host.lifecycle?.cancel()
       this.props.onCancel()
-      this.host.selectPill(sourcePos)
+      if (sourcePos !== null) this.host.selectPill(sourcePos)
       return
     }
 
@@ -205,7 +208,12 @@ export class ComposerPillSensor implements SensorInstance {
     if (!this.activated) {
       if (!beyondTolerance) return
       const view = this.host.getView()
-      if (!this.touchDragEligible || !view || !isComposerPillSelected(view.state, this.sourcePos)) {
+      if (
+        !this.touchDragEligible ||
+        !view ||
+        this.source.kind !== "doc" ||
+        !isComposerPillSelected(view.state, this.source.pos)
+      ) {
         this.cancel()
         return
       }

--- a/apps/frontend/src/components/editor/editor-action-bar.test.tsx
+++ b/apps/frontend/src/components/editor/editor-action-bar.test.tsx
@@ -13,6 +13,7 @@ function renderBar(props: Partial<React.ComponentProps<typeof EditorActionBar>> 
     insertEmoji: vi.fn(),
     openSnippetEditor: vi.fn(),
     insertFiles: vi.fn(() => true),
+    removeAttachmentReferences: vi.fn(),
     insertTranscribedText: vi.fn(),
     setDictationInterim: vi.fn(),
     insertDictationChunk: vi.fn(),

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -80,6 +80,8 @@ export interface RichEditorHandle {
   openSnippetEditor(): void
   /** Upload files and insert their reference chips at the current selection. */
   insertFiles(files: File[]): boolean
+  /** Delete every inline reference to one attachment (the delete cascade). */
+  removeAttachmentReferences(attachmentId: string): void
   /** Append a committed dictation span at the caret. */
   insertTranscribedText(text: string, options?: { joinPrevious?: boolean }): void
   /** Show the live (uncommitted) dictation hypothesis as a caret ghost; empty string clears it. */
@@ -590,6 +592,12 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     (files: File[]): boolean => handleFilesInsert(files, editorRef.current),
     [handleFilesInsert]
   )
+
+  const removeAttachmentReferences = useCallback((attachmentId: string) => {
+    const editorInstance = editorRef.current
+    if (!editorInstance || editorInstance.isDestroyed) return
+    editorInstance.commands.removeAttachmentReferences(attachmentId)
+  }, [])
 
   // Save the snippet editor's contents as a text attachment, inserting the chip
   // back at the caret position the paste happened at. Reuses the same
@@ -1200,6 +1208,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       insertEmoji: handleEmojiClick,
       openSnippetEditor,
       insertFiles,
+      removeAttachmentReferences,
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,
@@ -1218,6 +1227,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       handleEmojiClick,
       openSnippetEditor,
       insertFiles,
+      removeAttachmentReferences,
       insertTranscribedText,
       setDictationInterim,
       insertDictationChunk,

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -9,6 +9,7 @@ import { RichEditor, EditorActionBar, EditorToolbar } from "@/components/editor"
 import type { RichEditorHandle } from "@/components/editor"
 import { handleMobileInlineAttachmentPicker } from "@/components/editor/mobile-inline-attachment-picker"
 import { PendingAttachments } from "@/components/timeline/pending-attachments"
+import { countAttachmentReferences } from "@/components/editor/attachment-reference-counts"
 import { DateTimeField } from "@/components/forms/date-time-field"
 import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/dates"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -324,6 +325,15 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
   const saveLabel = isPast ? "Send" : "Save"
   const title = isPast ? "Send scheduled message" : "Edit scheduled message"
 
+  const attachmentReferenceCounts = useMemo(() => countAttachmentReferences(contentJson), [contentJson])
+  const handleRemoveAttachment = useCallback(
+    (id: string) => {
+      editorRef.current?.removeAttachmentReferences(id)
+      attachmentsHook.removeAttachment(id)
+    },
+    [attachmentsHook]
+  )
+
   const editorElement = (
     <RichEditor
       ref={setRichEditorHandle}
@@ -348,8 +358,9 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
           <div className="border-b border-border/50 p-3 [&>div]:mb-0">
             <PendingAttachments
               attachments={attachmentsHook.pendingAttachments}
-              onRemove={attachmentsHook.removeAttachment}
+              onRemove={handleRemoveAttachment}
               workspaceId={workspaceId}
+              referenceCounts={attachmentReferenceCounts}
             />
           </div>
         ) : null

--- a/apps/frontend/src/components/timeline/attachment-image-index.ts
+++ b/apps/frontend/src/components/timeline/attachment-image-index.ts
@@ -1,0 +1,22 @@
+import type { PendingAttachment } from "@/hooks/use-attachments"
+
+/** Attachments that bind to the message on send: real id, upload not failed. */
+export function isMaterializableAttachment(attachment: PendingAttachment): boolean {
+  return attachment.status !== "error" && !attachment.id.startsWith("temp_")
+}
+
+/**
+ * "Image #N" is an identity, not a position, so the ordinal has one owner: the
+ * nth image among the attachments that will materialize, 1-based. A tray drag
+ * stamps it at insert and send re-derives the same number here, so a reference
+ * never appears to renumber.
+ */
+export function buildImageIndexByAttachment(attachments: readonly PendingAttachment[]): Map<PendingAttachment, number> {
+  const indexes = new Map<PendingAttachment, number>()
+  let nextIndex = 1
+  for (const attachment of attachments) {
+    if (!isMaterializableAttachment(attachment)) continue
+    if (attachment.mimeType.startsWith("image/")) indexes.set(attachment, nextIndex++)
+  }
+  return indexes
+}

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -37,6 +37,7 @@ import { STREAM_ICONS } from "@/lib/streams"
 import { useScheduleMessage } from "@/hooks"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { parseMarkdown } from "@threa/prosemirror"
+import { buildImageIndexByAttachment, isMaterializableAttachment } from "./attachment-image-index"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quote-reply-context"
 import { useConversationReply, type ConversationReplyData } from "./conversation-reply-context"
@@ -119,8 +120,7 @@ export function materializePendingAttachmentReferences(
   const uploadedQueues = new Map<string, PendingAttachment[]>()
   const materializableAttachments: PendingAttachment[] = []
   const materializableAttachmentById = new Map<string, PendingAttachment>()
-  const imageIndexByAttachment = new Map<PendingAttachment, number>()
-  let pickedImageIndex = 1
+  const imageIndexByAttachment = buildImageIndexByAttachment(pendingAttachments)
   for (const attachment of pendingAttachments) {
     // Reserved-but-still-uploading attachments materialize like uploaded ones
     // (send-while-uploading): their id is real and the message binds it while
@@ -130,12 +130,9 @@ export function materializePendingAttachmentReferences(
     // content_markdown (the serializer skips uploading nodes). Live upload
     // state rides the message's attachment summaries instead. Errors and
     // still-reserving (temp-id) files stay out of the message.
-    if (attachment.status === "error" || attachment.id.startsWith("temp_")) continue
+    if (!isMaterializableAttachment(attachment)) continue
     materializableAttachments.push(attachment)
     materializableAttachmentById.set(attachment.id, attachment)
-    if (attachment.mimeType.startsWith("image/")) {
-      imageIndexByAttachment.set(attachment, pickedImageIndex++)
-    }
     const key = attachmentMatchKey(attachment)
     const queue = uploadedQueues.get(key)
     if (queue) {

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { Editor } from "@tiptap/core"
 import type { JSONContent } from "@threa/types"
-import { ComposerPillDndProvider } from "@/components/editor/composer-pill-dnd"
+import { ComposerPillDndHost, ComposerPillDndProvider } from "@/components/editor/composer-pill-dnd"
 import { countAttachmentReferences } from "@/components/editor/attachment-reference-counts"
 import { createEditorExtensions } from "@/components/editor/editor-extensions"
 import type { PendingAttachment } from "@/hooks/use-attachments"
@@ -465,6 +465,60 @@ describe("referenced chip highlight", () => {
     const touchEditor = trayWithReferences()
     fireEvent.mouseEnter(screen.getByRole("button", { name: "Preview notes.txt" }).parentElement!)
     expect(highlighted(touchEditor)).toEqual([])
+  })
+})
+
+describe("a second editor inside the composer's drag host", () => {
+  function composerTree(first: Editor, second: Editor | null) {
+    return (
+      <ComposerPillDndHost>
+        <PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />
+        <ComposerPillDndProvider editor={first} />
+        {second && <ComposerPillDndProvider editor={second} />}
+      </ComposerPillDndHost>
+    )
+  }
+
+  function renderComposerWith(first: Editor, second: Editor | null) {
+    return render(composerTree(first, second))
+  }
+
+  it("leaves the tray drag working after the nested editor unmounts", () => {
+    const first = createEditor()
+    const second = createEditor()
+    vi.spyOn(first.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    vi.spyOn(second.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+
+    const { rerender } = renderComposerWith(first, second)
+    rerender(composerTree(first, null))
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+
+    expect(childTypes(first)).toEqual(["attachmentReference", "text"])
+  })
+
+  it("keeps the nested editor's own drag off the composer's document", () => {
+    const first = createEditor()
+    const second = createEditor([
+      { type: "text", text: "hello world" },
+      { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } },
+    ])
+    vi.spyOn(first.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    vi.spyOn(second.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderComposerWith(first, second)
+
+    const pill = second.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    fireEvent.mouseDown(pill, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 30, clientY: 10 })
+    fireEvent.mouseUp(document, { button: 0, clientX: 30, clientY: 10 })
+
+    expect(childTypes(second)).toEqual(["mention", "text"])
+    expect(childTypes(first)).toEqual(["text"])
+
+    // The tray still belongs to the composer's editor, not the newcomer's.
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    expect(childTypes(first)).toEqual(["attachmentReference", "text"])
+    expect(childTypes(second)).toEqual(["mention", "text"])
   })
 })
 

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -469,7 +469,7 @@ describe("referenced chip highlight", () => {
 })
 
 describe("a second editor inside the composer's drag host", () => {
-  function composerTree(first: Editor, second: Editor | null) {
+  function composerTree(first: Editor | null, second: Editor | null) {
     return (
       <ComposerPillDndHost>
         <PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />
@@ -495,6 +495,21 @@ describe("a second editor inside the composer's drag host", () => {
     dragChipIntoEditor(screen.getByText("screenshot.png"))
 
     expect(childTypes(first)).toEqual(["attachmentReference", "text"])
+  })
+
+  it("gives the composer the host when its editor is built after the nested one", () => {
+    const second = createEditor()
+    vi.spyOn(second.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+
+    const { rerender } = render(composerTree(null, second))
+    const first = createEditor()
+    vi.spyOn(first.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    rerender(composerTree(first, second))
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+
+    expect(childTypes(first)).toEqual(["attachmentReference", "text"])
+    expect(childTypes(second)).toEqual(["text"])
   })
 
   it("keeps the nested editor's own drag off the composer's document", () => {

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -153,6 +153,67 @@ describe("tray pill drag", () => {
   })
 })
 
+describe("drag preview", () => {
+  it("shows a preview naming the dragged attachment while a tray drag is in flight", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [attachment()])
+
+    const chip = screen.getByText("screenshot.png")
+    expect(screen.queryByTestId("composer-pill-drag-preview")).toBeNull()
+
+    fireEvent.mouseDown(chip, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 30, clientY: 10 })
+    const preview = screen.getByTestId("composer-pill-drag-preview")
+    expect(preview).toHaveTextContent("screenshot.png")
+    expect(preview).toHaveTextContent("2.0 KB")
+
+    fireEvent.mouseUp(document, { button: 0, clientX: 30, clientY: 10 })
+    expect(screen.queryByTestId("composer-pill-drag-preview")).toBeNull()
+  })
+
+  it("shows no preview for an in-document pill drag — it is dimmed in place instead", () => {
+    const editor = createEditor([
+      { type: "text", text: "hello world" },
+      { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } },
+    ])
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [attachment()])
+
+    const pill = editor.view.dom.querySelector<HTMLElement>('[data-type="mention"]')!
+    fireEvent.mouseDown(pill, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 30, clientY: 10 })
+
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).not.toBeNull()
+    expect(screen.queryByTestId("composer-pill-drag-preview")).toBeNull()
+    fireEvent.mouseUp(document, { button: 0, clientX: 30, clientY: 10 })
+  })
+})
+
+describe("chip click after a drag", () => {
+  it("still reaches the chip's activate handler", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const notes = attachment({
+      id: "att_2",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      previewUrl: "blob:preview-2",
+    })
+    renderTray(editor, [attachment(), notes])
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    const other = screen.getByRole("button", { name: "Preview notes.txt" })
+    fireEvent.mouseDown(other, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.mouseUp(other, { button: 0, clientX: 5, clientY: 5 })
+    fireEvent.click(other)
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+})
+
 describe("referenced chip leading slot", () => {
   it("keeps the error glyph on a referenced attachment that failed to upload", () => {
     const failed = attachment({
@@ -209,6 +270,30 @@ describe("referenced chip leading slot", () => {
 
     expect(container.querySelector('img[src="blob:preview-1"]')).toBeTruthy()
     expect(container.querySelector(".lucide-anchor")).toBeNull()
+  })
+
+  it("exposes the ×N count with an accessible name, and never at one reference", () => {
+    const doc = attachment({ id: "att_2", filename: "notes.txt", mimeType: "text/plain", previewUrl: undefined })
+    const once = render(
+      <PendingAttachments
+        attachments={[doc]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_2", 1]])}
+      />
+    )
+    expect(screen.queryByText("×1")).toBeNull()
+    once.unmount()
+
+    render(
+      <PendingAttachments
+        attachments={[doc]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_2", 2]])}
+      />
+    )
+    expect(screen.getByRole("img", { name: "2 references in this message" })).toHaveTextContent("×2")
   })
 
   it("shows the anchor on a referenced chip with no thumbnail of its own", () => {

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { Editor } from "@tiptap/core"
+import type { JSONContent } from "@threa/types"
+import { ComposerPillDndProvider } from "@/components/editor/composer-pill-dnd"
+import { countAttachmentReferences } from "@/components/editor/attachment-reference-counts"
+import { createEditorExtensions } from "@/components/editor/editor-extensions"
+import type { PendingAttachment } from "@/hooks/use-attachments"
+import * as useMobileModule from "@/hooks/use-mobile"
+import { extractUploadedAttachments, materializePendingAttachmentReferences } from "./message-input"
+import { PendingAttachments } from "./pending-attachments"
+
+const openEditors: Editor[] = []
+
+afterEach(() => {
+  cleanup()
+  while (openEditors.length > 0) {
+    const editor = openEditors.pop()!
+    const element = editor.view.dom.parentElement
+    editor.destroy()
+    element?.remove()
+  }
+  vi.restoreAllMocks()
+})
+
+function attachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
+  return {
+    id: "att_1",
+    filename: "screenshot.png",
+    mimeType: "image/png",
+    sizeBytes: 2048,
+    status: "uploaded",
+    previewUrl: "blob:preview-1",
+    ...overrides,
+  }
+}
+
+function createEditor(content: JSONContent[] = [{ type: "text", text: "hello world" }]) {
+  const element = document.createElement("div")
+  document.body.appendChild(element)
+  const editor = new Editor({
+    element,
+    extensions: createEditorExtensions({ placeholder: "Type a message..." }),
+    content: { type: "doc", content: [{ type: "paragraph", content }] },
+  })
+  openEditors.push(editor)
+  return editor
+}
+
+function childTypes(editor: Editor): string[] {
+  return editor.state.doc.firstChild?.content.content.map((node) => node.type.name) ?? []
+}
+
+/** Mount the tray inside the editor's drag context, the way the composer does. */
+function renderTray(editor: Editor, attachments: PendingAttachment[], onRemove = vi.fn()) {
+  return render(
+    <ComposerPillDndProvider editor={editor}>
+      <PendingAttachments attachments={attachments} onRemove={onRemove} workspaceId="ws_1" />
+    </ComposerPillDndProvider>
+  )
+}
+
+function dragChipIntoEditor(chip: HTMLElement, startX = 10) {
+  fireEvent.mouseDown(chip, { button: 0, clientX: startX, clientY: 10 })
+  fireEvent.mouseMove(document, { buttons: 1, clientX: startX + 20, clientY: 10 })
+  fireEvent.mouseUp(document, { button: 0, clientX: startX + 20, clientY: 10 })
+}
+
+describe("tray pill drag", () => {
+  it("inserts a reference per drag and leaves the chip in the tray", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [attachment()])
+
+    const chip = screen.getByText("screenshot.png")
+    dragChipIntoEditor(chip)
+    expect(childTypes(editor)).toEqual(["attachmentReference", "text"])
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    expect(childTypes(editor).filter((type) => type === "attachmentReference")).toHaveLength(2)
+    // The tray is an inventory, not a queue: the chip survives both drags.
+    expect(screen.getByText("screenshot.png")).toBeInTheDocument()
+
+    // Two nodes, one attachment on the wire.
+    expect(extractUploadedAttachments(editor.getJSON() as JSONContent)).toEqual([
+      { id: "att_1", filename: "screenshot.png", mimeType: "image/png", sizeBytes: 2048 },
+    ])
+  })
+
+  it("never deletes from the document — a tray drag is an insert, not a move", () => {
+    const editor = createEditor([
+      { type: "text", text: "hello world" },
+      { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } },
+    ])
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [attachment()])
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+
+    expect(childTypes(editor)).toEqual(["attachmentReference", "text", "mention"])
+    expect(editor.view.dom.querySelector(".composer-pill-dragging")).toBeNull()
+    expect(editor.view.dom.querySelector(".composer-pill-drop-cursor")).toBeNull()
+  })
+
+  it("counts references from the document and follows an added or removed one", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const { rerender } = render(
+      <ComposerPillDndProvider editor={editor}>
+        <PendingAttachments
+          attachments={[attachment()]}
+          onRemove={vi.fn()}
+          workspaceId="ws_1"
+          referenceCounts={countAttachmentReferences(editor.getJSON() as JSONContent)}
+        />
+      </ComposerPillDndProvider>
+    )
+    expect(screen.queryByLabelText("2 references in this message")).toBeNull()
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    const twice = countAttachmentReferences(editor.getJSON() as JSONContent)
+    expect(twice.get("att_1")).toBe(2)
+
+    const tray = (counts: ReadonlyMap<string, number>) => (
+      <ComposerPillDndProvider editor={editor}>
+        <PendingAttachments
+          attachments={[attachment()]}
+          onRemove={vi.fn()}
+          workspaceId="ws_1"
+          referenceCounts={counts}
+        />
+      </ComposerPillDndProvider>
+    )
+    rerender(tray(twice))
+    expect(screen.getByLabelText("2 references in this message")).toHaveTextContent("×2")
+
+    editor.commands.removeAttachmentReferences("att_1")
+    rerender(tray(countAttachmentReferences(editor.getJSON() as JSONContent)))
+    expect(screen.queryByLabelText("2 references in this message")).toBeNull()
+  })
+
+  it("renders one scrolling row on mobile and the wrapping tray on desktop", () => {
+    const desktop = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(desktop.container.querySelector("div")).toHaveClass("flex-wrap")
+    desktop.unmount()
+
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const mobile = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+    const row = mobile.container.querySelector("div")!
+    expect(row).toHaveClass("overflow-x-auto")
+    expect(row).not.toHaveClass("flex-wrap")
+  })
+})
+
+describe("referenced chip leading slot", () => {
+  it("keeps the error glyph on a referenced attachment that failed to upload", () => {
+    const failed = attachment({
+      status: "error",
+      error: "Upload failed",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      previewUrl: undefined,
+    })
+    const { container } = render(
+      <PendingAttachments
+        attachments={[failed]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_1", 1]])}
+      />
+    )
+
+    const leading = container.querySelector("svg")!
+    expect(leading).toHaveClass("lucide-circle-alert")
+    expect(container.querySelector(".lucide-anchor")).toBeNull()
+  })
+
+  it("keeps the spinner on a referenced attachment that is still uploading", () => {
+    const uploading = attachment({
+      status: "uploading",
+      progress: 0.4,
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      previewUrl: undefined,
+    })
+    const { container } = render(
+      <PendingAttachments
+        attachments={[uploading]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_1", 1]])}
+      />
+    )
+
+    expect(container.querySelector("svg")).toHaveClass("lucide-loader-circle")
+    expect(container.querySelector(".lucide-anchor")).toBeNull()
+  })
+
+  it("keeps the thumbnail on a referenced image chip", () => {
+    const { container } = render(
+      <PendingAttachments
+        attachments={[attachment()]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_1", 1]])}
+      />
+    )
+
+    expect(container.querySelector('img[src="blob:preview-1"]')).toBeTruthy()
+    expect(container.querySelector(".lucide-anchor")).toBeNull()
+  })
+
+  it("shows the anchor on a referenced chip with no thumbnail of its own", () => {
+    const doc = attachment({ id: "att_2", filename: "notes.txt", mimeType: "text/plain", previewUrl: undefined })
+    const { container } = render(
+      <PendingAttachments
+        attachments={[doc]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_2", 1]])}
+      />
+    )
+
+    expect(container.querySelector(".lucide-anchor")).toBeTruthy()
+  })
+})
+
+describe("tray-dragged image ordinal", () => {
+  it("stamps the ordinal send would give it, so both references read the same", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const first = attachment({ id: "att_1", filename: "first.png", previewUrl: "blob:preview-1" })
+    const second = attachment({ id: "att_2", filename: "second.png", previewUrl: "blob:preview-2" })
+    renderTray(editor, [first, second])
+
+    dragChipIntoEditor(screen.getByText("second.png"))
+
+    const inserted = (editor.getJSON() as JSONContent).content?.[0]?.content?.[0]
+    expect(inserted?.attrs?.imageIndex).toBe(2)
+
+    // The same attachment pasted as a pill and materialized at send resolves to
+    // the same ordinal — one image, one label.
+    const materialized = materializePendingAttachmentReferences(editor.getJSON() as JSONContent, [first, second])
+    expect(materialized.content?.[0]?.content?.[0]?.attrs?.imageIndex).toBe(2)
+  })
+
+  it("skips failed and still-reserving attachments when numbering, as send does", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const attachments = [
+      attachment({ id: "temp_1", filename: "reserving.png", previewUrl: "blob:preview-0" }),
+      attachment({ id: "att_1", filename: "failed.png", status: "error", previewUrl: "blob:preview-1" }),
+      attachment({ id: "att_2", filename: "sent.png", previewUrl: "blob:preview-2" }),
+    ]
+    renderTray(editor, attachments)
+
+    dragChipIntoEditor(screen.getByText("sent.png"))
+
+    expect((editor.getJSON() as JSONContent).content?.[0]?.content?.[0]?.attrs?.imageIndex).toBe(1)
+  })
+})
+
+describe("attachment delete cascade", () => {
+  it("removes every reference to the deleted attachment and leaves the others", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [attachment(), attachment({ id: "att_2", filename: "notes.txt", mimeType: "text/plain" })])
+
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    dragChipIntoEditor(screen.getByText("notes.txt"))
+    expect(countAttachmentReferences(editor.getJSON() as JSONContent)).toEqual(
+      new Map([
+        ["att_1", 2],
+        ["att_2", 1],
+      ])
+    )
+
+    expect(editor.commands.removeAttachmentReferences("att_1")).toBe(true)
+    expect(countAttachmentReferences(editor.getJSON() as JSONContent)).toEqual(new Map([["att_2", 1]]))
+    expect(editor.commands.removeAttachmentReferences("att_1")).toBe(false)
+  })
+
+  it("cascades across the temp→server id flip", () => {
+    const editor = createEditor([])
+    editor.commands.insertAttachmentReferences([
+      {
+        id: "temp_1",
+        filename: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        status: "uploading",
+        imageIndex: null,
+        error: null,
+      },
+    ])
+    editor.commands.updateAttachmentReference("temp_1", { id: "att_1", status: "uploaded" })
+    expect(countAttachmentReferences(editor.getJSON() as JSONContent).get("att_1")).toBe(1)
+
+    // The chip's id flipped with the node's, so the delete the tray issues carries
+    // the server id and still finds the reference it created under a temp one.
+    expect(editor.commands.removeAttachmentReferences("att_1")).toBe(true)
+    expect(countAttachmentReferences(editor.getJSON() as JSONContent).size).toBe(0)
+  })
+})
+
+describe("send with an unreferenced attachment", () => {
+  it("still appends it as a trailing paragraph", () => {
+    const content: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }],
+    }
+    const materialized = materializePendingAttachmentReferences(content, [attachment()])
+
+    expect(materialized.content?.[1]).toEqual({
+      type: "paragraph",
+      content: [
+        {
+          type: "attachmentReference",
+          attrs: {
+            id: "att_1",
+            filename: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 2048,
+            status: "uploaded",
+            imageIndex: 1,
+            error: null,
+          },
+        },
+      ],
+    })
+  })
+
+  it("materializes both references to one attachment without consuming it twice", () => {
+    const reference: JSONContent = {
+      type: "attachmentReference",
+      attrs: {
+        id: "att_1",
+        filename: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 2048,
+        status: "uploaded",
+        imageIndex: null,
+        error: null,
+      },
+    }
+    const content: JSONContent = { type: "doc", content: [{ type: "paragraph", content: [reference, reference] }] }
+
+    const materialized = materializePendingAttachmentReferences(content, [attachment()])
+
+    expect(materialized.content).toHaveLength(1)
+    expect(materialized.content?.[0]?.content?.map((node) => node.attrs?.imageIndex)).toEqual([1, 1])
+  })
+})

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -7,6 +7,7 @@ import { countAttachmentReferences } from "@/components/editor/attachment-refere
 import { createEditorExtensions } from "@/components/editor/editor-extensions"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import * as useMobileModule from "@/hooks/use-mobile"
+import * as inputModeModule from "@/hooks/use-input-mode"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "./message-input"
 import { PendingAttachments } from "./pending-attachments"
 
@@ -387,6 +388,83 @@ describe("attachment delete cascade", () => {
     // the server id and still finds the reference it created under a temp one.
     expect(editor.commands.removeAttachmentReferences("att_1")).toBe(true)
     expect(countAttachmentReferences(editor.getJSON() as JSONContent).size).toBe(0)
+  })
+})
+
+describe("referenced chip highlight", () => {
+  const highlighted = (editor: Editor) =>
+    [...editor.view.dom.querySelectorAll(".composer-pill-highlighted")].map((element) =>
+      element.getAttribute("data-id")
+    )
+
+  /** Two references to att_1 and one to att_2, dropped in from the tray. */
+  function trayWithReferences() {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const notes = attachment({ id: "att_2", filename: "notes.txt", mimeType: "text/plain" })
+    renderTray(editor, [attachment(), notes])
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    dragChipIntoEditor(screen.getByText("screenshot.png"))
+    dragChipIntoEditor(screen.getByText("notes.txt"))
+    return editor
+  }
+
+  it("never dims a referenced chip", () => {
+    render(
+      <PendingAttachments
+        attachments={[attachment()]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        referenceCounts={new Map([["att_1", 2]])}
+      />
+    )
+
+    const chip = screen.getByRole("button", { name: "Preview screenshot.png" })
+    expect(chip).not.toHaveClass("opacity-60")
+    // The referenced state still reads: anchor is absent only because the image
+    // thumbnail outranks it, so the count carries it here.
+    expect(screen.getByRole("img", { name: "2 references in this message" })).toHaveTextContent("×2")
+  })
+
+  it("highlights only the dragged attachment's references, and clears them on drop", () => {
+    const editor = trayWithReferences()
+    expect(highlighted(editor)).toEqual([])
+
+    const chip = screen.getByText("screenshot.png")
+    fireEvent.mouseDown(chip, { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 30, clientY: 10 })
+    expect(highlighted(editor)).toEqual(["att_1", "att_1"])
+
+    fireEvent.mouseUp(document, { button: 0, clientX: 30, clientY: 10 })
+    expect(highlighted(editor)).toEqual([])
+  })
+
+  it("clears the highlight when the drag is cancelled with Escape", () => {
+    const editor = trayWithReferences()
+
+    fireEvent.mouseDown(screen.getByText("notes.txt"), { button: 0, clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { buttons: 1, clientX: 30, clientY: 10 })
+    expect(highlighted(editor)).toEqual(["att_2"])
+
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(highlighted(editor)).toEqual([])
+  })
+
+  it("highlights on hover with a mouse and not on touch", () => {
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("mouse")
+    const editor = trayWithReferences()
+
+    const chip = screen.getByRole("button", { name: "Preview notes.txt" }).parentElement!
+    fireEvent.mouseEnter(chip)
+    expect(highlighted(editor)).toEqual(["att_2"])
+    fireEvent.mouseLeave(chip)
+    expect(highlighted(editor)).toEqual([])
+
+    cleanup()
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
+    const touchEditor = trayWithReferences()
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "Preview notes.txt" }).parentElement!)
+    expect(highlighted(touchEditor)).toEqual([])
   })
 })
 

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
 import { Loader2, FileText, Image as ImageIcon, File as FileIcon, Film, Globe, AlertCircle } from "lucide-react"
 import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer/attachment-pill"
+import { useComposerPillDragHost } from "@/components/editor/composer-pill-dnd"
+import type { ComposerPillDragHost } from "@/components/editor/composer-pill-drag-host"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
 import { buildPendingGalleryItem, uploadGalleryType, type UploadGalleryType } from "@/components/gallery/upload-preview"
@@ -10,6 +13,8 @@ import { attachmentContentUrl } from "@/api"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { retryUpload } from "@/lib/uploads/upload-manager"
 import { formatFileSize } from "@/lib/file-size"
+import { buildImageIndexByAttachment } from "./attachment-image-index"
+import { cn } from "@/lib/utils"
 
 // Leading-slot icon for a previewable type, matching the gallery's own glyphs
 // (Globe for html, FileText for docs, Film for video). Non-previewable files
@@ -29,6 +34,62 @@ function iconForType(type: UploadGalleryType | null): typeof FileIcon {
     default:
       return FileIcon
   }
+}
+
+/**
+ * Wraps a chip as a drag source for the editor's own sensor. A tray drag always
+ * inserts a reference, so the chip stays put and the same file can be dropped
+ * into the message any number of times.
+ *
+ * `touch-action` gives the browser the tray's own scroll axis and leaves the
+ * perpendicular one — the drag, towards the text — to the sensor.
+ */
+function TrayPillDraggable({
+  host,
+  attachment,
+  imageIndex,
+  row,
+  children,
+}: {
+  host: ComposerPillDragHost | null
+  attachment: PendingAttachment
+  /** "Image #N" ordinal for an image attachment, from the send-time rule. */
+  imageIndex: number | null
+  row: boolean
+  children: ReactNode
+}) {
+  const draggable = host !== null && attachment.status === "uploaded"
+  const begin = (event: MouseEvent | TouchEvent, target: EventTarget) => {
+    if (!draggable) return
+    // The × and the chip body are the same pointer target; let the button win.
+    if (target instanceof Element && target.closest("button")) return
+    host.startTrayGesture(
+      {
+        kind: "tray",
+        attachmentId: attachment.id,
+        attrs: {
+          id: attachment.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          sizeBytes: attachment.sizeBytes,
+          status: "uploaded",
+          imageIndex,
+          error: null,
+        },
+      },
+      event
+    )
+  }
+  return (
+    <span
+      className={cn("inline-flex shrink-0", draggable && "cursor-grab")}
+      style={draggable ? { touchAction: row ? "pan-x" : "pan-y" } : undefined}
+      onMouseDown={(event) => begin(event.nativeEvent, event.target)}
+      onTouchStart={(event) => begin(event.nativeEvent, event.target)}
+    >
+      {children}
+    </span>
+  )
 }
 
 const STATUS_MAP: Record<PendingAttachment["status"], AttachmentPillStatus> = {
@@ -80,6 +141,13 @@ interface ChipViewProps {
   onCancelUpload: (id: string) => void
   onOpen: (key: string) => void
   onResolveSrc: (key: string, src: string | null) => void
+  /** Inline references to this attachment in the message being composed. */
+  referenceCount: number
+  /** Single-row tray (mobile): a tighter label keeps more chips reachable. */
+  row: boolean
+  /** "Image #N" ordinal for an image attachment, from the send-time rule. */
+  imageIndex: number | null
+  dragHost: ComposerPillDragHost | null
 }
 
 function ChipView({
@@ -92,6 +160,10 @@ function ChipView({
   onCancelUpload,
   onOpen,
   onResolveSrc,
+  referenceCount,
+  row,
+  imageIndex,
+  dragHost,
 }: ChipViewProps) {
   const key = attachmentKey(attachment)
 
@@ -130,38 +202,44 @@ function ChipView({
   else if (isError) Icon = AlertCircle
 
   const canPreview = !!fullSrc && !isError
+  // A drag out of the tray ends in a click on the chip; it must not also open
+  // the lightbox or retry the upload.
+  const guard = (run: () => void) => () => {
+    if (dragHost?.activationClickSuppressed) return
+    run()
+  }
   let onActivate: (() => void) | undefined
-  if (canRetry) onActivate = () => retryUpload(attachment.id)
-  else if (canPreview) onActivate = () => onOpen(key)
+  if (canRetry) onActivate = guard(() => retryUpload(attachment.id))
+  else if (canPreview) onActivate = guard(() => onOpen(key))
 
   return (
-    <AttachmentPill
-      icon={Icon}
-      thumbnailSrc={thumbnailSrc}
-      spinning={isUploading || decrypting}
-      label={attachment.filename}
-      secondary={secondary}
-      status={status}
-      tooltip={tooltip}
-      onRemove={removeHandler}
-      removeLabel={removeLabel}
-      progress={isUploading ? attachment.progress : undefined}
-      onActivate={onActivate}
-      activateLabel={canRetry ? `Retry upload of ${attachment.filename}` : `Preview ${attachment.filename}`}
-      labelMaxWidth="max-w-[120px]"
-    />
+    <TrayPillDraggable host={dragHost} attachment={attachment} imageIndex={imageIndex} row={row}>
+      <AttachmentPill
+        icon={Icon}
+        thumbnailSrc={thumbnailSrc}
+        spinning={isUploading || decrypting}
+        label={attachment.filename}
+        secondary={secondary}
+        status={status}
+        tooltip={tooltip}
+        onRemove={removeHandler}
+        removeLabel={removeLabel}
+        progress={isUploading ? attachment.progress : undefined}
+        onActivate={onActivate}
+        activateLabel={canRetry ? `Retry upload of ${attachment.filename}` : `Preview ${attachment.filename}`}
+        labelMaxWidth={row ? "max-w-[80px]" : "max-w-[120px]"}
+        referenceCount={referenceCount}
+      />
+    </TrayPillDraggable>
   )
 }
 
 /** Chip whose preview needs no decrypt: local object URL, non-E2E image thumbnail, or icon. */
-function StaticChip(props: {
-  attachment: PendingAttachment
-  workspaceId: string | undefined
-  onRemove: (id: string) => void
-  onCancelUpload: (id: string) => void
-  onOpen: (key: string) => void
-  onResolveSrc: (key: string, src: string | null) => void
-}) {
+function StaticChip(
+  props: Omit<ChipViewProps, "galleryType" | "thumbnailSrc" | "fullSrc"> & {
+    workspaceId: string | undefined
+  }
+) {
   const type = uploadGalleryType(props.attachment)
   const src = staticSrc(props.attachment, type, props.workspaceId)
   return <ChipView {...props} galleryType={type} thumbnailSrc={src?.thumb} fullSrc={src?.full ?? null} />
@@ -171,14 +249,9 @@ function StaticChip(props: {
 function E2eChip({
   attachmentRef,
   ...props
-}: {
-  attachment: PendingAttachment
+}: Omit<ChipViewProps, "galleryType" | "thumbnailSrc" | "fullSrc" | "decrypting"> & {
   attachmentRef: AttachmentRef
   workspaceId: string
-  onRemove: (id: string) => void
-  onCancelUpload: (id: string) => void
-  onOpen: (key: string) => void
-  onResolveSrc: (key: string, src: string | null) => void
 }) {
   const type = uploadGalleryType(props.attachment)
   const decrypted = useDecryptedAttachment(props.workspaceId, attachmentRef)
@@ -214,6 +287,12 @@ interface PendingAttachmentsProps {
    * still work without it.
    */
   workspaceId?: string
+  /**
+   * References per attachment id in the message being composed, derived from the
+   * document by the composer. A referenced chip renders drawn-from, with a count
+   * from two references up.
+   */
+  referenceCounts?: ReadonlyMap<string, number>
 }
 
 /**
@@ -231,7 +310,10 @@ export function PendingAttachments({
   onCancelUpload,
   beforePills,
   workspaceId,
+  referenceCounts,
 }: PendingAttachmentsProps) {
+  const isMobile = useIsMobile()
+  const dragHost = useComposerPillDragHost()
   // Open lightbox tracked by the stable attachment key, not the id (which flips
   // temp→server on upload completion), so an open preview survives its upload.
   const [openKey, setOpenKey] = useState<string | null>(null)
@@ -248,6 +330,10 @@ export function PendingAttachments({
       return next
     })
   }, [])
+
+  // A tray-dragged image reference carries the same ordinal send would give it,
+  // so two references to one image never read as different files.
+  const imageIndexes = useMemo(() => buildImageIndexByAttachment(attachments), [attachments])
 
   const galleryItems = useMemo<GalleryItem[]>(
     () =>
@@ -270,7 +356,12 @@ export function PendingAttachments({
 
   return (
     <>
-      <div className="flex flex-wrap items-center gap-2 mb-3 max-h-[120px] overflow-y-auto">
+      <div
+        className={cn(
+          "flex items-center gap-2 mb-3",
+          isMobile ? "overflow-x-auto" : "flex-wrap max-h-[120px] overflow-y-auto"
+        )}
+      >
         {beforePills}
         {attachments.map((attachment) => {
           const key = attachmentKey(attachment)
@@ -284,6 +375,10 @@ export function PendingAttachments({
             onCancelUpload: onCancelUpload ?? onRemove,
             onOpen: setOpenKey,
             onResolveSrc,
+            referenceCount: referenceCounts?.get(attachment.id) ?? 0,
+            row: isMobile,
+            imageIndex: imageIndexes.get(attachment) ?? null,
+            dragHost,
           }
           return ref && workspaceId ? (
             <E2eChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -60,6 +60,8 @@ function TrayPillDraggable({
 }) {
   const draggable = host !== null && attachment.status === "uploaded"
   const begin = (event: MouseEvent | TouchEvent, target: EventTarget) => {
+    // Every press on a chip owns the click it produces, draggable or not.
+    host?.clearActivationClickSuppression()
     if (!draggable) return
     // The × and the chip body are the same pointer target; let the button win.
     if (target instanceof Element && target.closest("button")) return

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -4,6 +4,7 @@ import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer
 import { useComposerPillDragHost } from "@/components/editor/composer-pill-dnd"
 import type { ComposerPillDragHost } from "@/components/editor/composer-pill-drag-host"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useInputMode } from "@/hooks/use-input-mode"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
 import { buildPendingGalleryItem, uploadGalleryType, type UploadGalleryType } from "@/components/gallery/upload-preview"
@@ -58,6 +59,7 @@ function TrayPillDraggable({
   row: boolean
   children: ReactNode
 }) {
+  const inputMode = useInputMode()
   const draggable = host !== null && attachment.status === "uploaded"
   const begin = (event: MouseEvent | TouchEvent, target: EventTarget) => {
     // Every press on a chip owns the click it produces, draggable or not.
@@ -82,12 +84,22 @@ function TrayPillDraggable({
       event
     )
   }
+  // Hover is a mouse affordance: on touch the press that precedes a drag would
+  // fire it, and there is no leave to clear it.
+  const hoverHighlights = draggable && inputMode === "mouse"
+  useEffect(() => {
+    if (!hoverHighlights) return
+    return () => host?.highlightAttachment(null)
+  }, [host, hoverHighlights])
+
   return (
     <span
       className={cn("inline-flex shrink-0", draggable && "cursor-grab")}
       style={draggable ? { touchAction: row ? "pan-x" : "pan-y" } : undefined}
       onMouseDown={(event) => begin(event.nativeEvent, event.target)}
       onTouchStart={(event) => begin(event.nativeEvent, event.target)}
+      onMouseEnter={hoverHighlights ? () => host?.highlightAttachment(attachment.id) : undefined}
+      onMouseLeave={hoverHighlights ? () => host?.highlightAttachment(null) : undefined}
     >
       {children}
     </span>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -735,6 +735,15 @@ html[data-input="mouse"]
   box-shadow: inset 0 0 0 100vmax hsl(var(--primary) / 0.32);
 }
 
+/* "This one is already in your message, here." Ring + wash only, no metrics —
+   the highlight lands mid-sentence and must not reflow the line (INV-21). */
+.ProseMirror .composer-pill-highlighted {
+  border-radius: 0.375rem;
+  box-shadow:
+    inset 0 0 0 100vmax hsl(var(--primary) / 0.18),
+    0 0 0 2px hsl(var(--primary) / 0.55);
+}
+
 .ProseMirror .composer-pill-dragging {
   border-radius: 0.375rem;
   opacity: 0.42;


### PR DESCRIPTION
> Stacked on #1862 (in-composer pill drag onto dnd-kit). Review that first.

## Problem

The attachment tray above the composer has no drag affordance at all. Files land in the message wherever `materializePendingAttachmentReferences` puts them — appended as a trailing paragraph at send (`message-input.tsx:210-245`) — with no way to say "this screenshot goes *here*, next to the sentence about it".

The tray also gets unusable as it fills. Today it is `flex flex-wrap max-h-[120px] overflow-y-auto`: at twenty files that is a 120 px scrolling block on top of a composer that, with the keyboard up, has perhaps 180 px of its own.

And removing an attachment leaves any inline `attachmentReference` node orphaned in the document — `extractUploadedAttachments` still picks it up and sends it (`message-input.tsx:81-113`). Pre-existing, and the reference count added here makes it visible.

## Solution

The tray is an **inventory**; inline pills are **references** to it.

- **Drag from the tray always inserts. Never moves.** The same attachment can be referenced any number of times — you can already duplicate a pill by copying it — and moving is what you do *inside* the document. `createComposerPillInsertTransaction` is a sibling of the existing move transaction: same `canReplaceWith` guard, insert only, no delete.
- **Insert-many needed no send change**, which is worth checking rather than trusting: `materializePendingAttachmentReferences` matches nodes to attachments through a **Map** (`materializableAttachmentById.get(nodeId)`, :169), not a queue shift, so N nodes for one attachment all materialise; `extractUploadedAttachments` keys a Map by id, so the wire payload carries one attachment. Zero-reference attachments still append. Tests pin all three.
- **The chip shows its references**: an anchor glyph inside `AttachmentPill`'s existing fixed 20 px leading slot, and a `×N` count above one. Derived from the document by `countAttachmentReferences`, never stored.
- **Where a file already sits is shown on demand, not painted on.** Dragging a tray chip — or hovering one with a mouse — rings that attachment's inline references in the document (`ComposerPillHighlightPluginKey`, `.composer-pill-highlighted`). The drag half derives from the existing drag source, so it inherits every cancel path (Escape, blur, second touch, pointercancel) rather than tracking its own; a live drag outranks a stale hover. Ring and inset wash via `box-shadow` only — no metrics, so a highlight landing mid-sentence cannot reflow the line (INV-21).
- **Delete cascades, and nothing else does.** Removing an attachment removes every reference to it via a new `removeAttachmentReferences` command on the attachment-reference extension, issued by the composer through `RichEditorHandle` — a command the UI sends, not persistence logic reaching into a document (INV-15). `use-draft-composer.ts` is untouched. Deliberately *not* a validity rule: pasting a copied pill must keep working, so a paste after a delete leaves an orphan reference, and that is accepted.
- **Mobile is a single horizontally-scrolling row**; desktop keeps today's wrap. It is the only layout whose height is independent of attachment count (~40 px vs. up to 120 px), and its scroll axis is orthogonal to the drag axis — `touch-action: pan-x` in row mode hands horizontal swipes to the browser's scroller and keeps vertical movement for the sensor, so a swipe and a drag are distinguishable *before* the 500 ms hold resolves.
- **One `DndContext` wraps the tray and the editor.** `ComposerPillDndProvider` is now a pass-through when an ancestor already provides a host, so `MessageComposer` supplies one `ComposerPillDndHost` around both while the 8 standalone editors and `document-editor-modal` keep creating their own. Chunk 1's sensor, host and collision detection are reused unchanged — drop positions still resolve through `composerPillDropPoint` (INV-35/37).
- **The image ordinal rule now has one owner.** `attachment-image-index.ts` (`isMaterializableAttachment`, `buildImageIndexByAttachment`) is called by both `materializePendingAttachmentReferences` and the tray, instead of the rule existing twice (INV-33).

Chips are draggable only while `status === "uploaded"`, so no temp-id node can be inserted from the tray.

Three findings from adversarial review were fixed here, each with a regression test:

- **The mobile tray remounted on every chrome toggle.** The first cut rendered it at two React positions (a `RichEditor` slot when the mobile chrome was open, a composer-root child otherwise), because the resting mobile composer collapses its editor wrapper to `h-0`. React therefore tore down `PendingAttachments` on each transition, losing `openKey` / `srcByKey` and re-running `useDecryptedAttachment`. Tapping an image chip on a phone focuses it (`AttachmentPill` with `onActivate` renders `<div role="button" tabIndex={0}>`); the focus bubbles to the composer's `onFocusCapture`, opens the chrome, and rebuilds the tray *before the click lands* — so the preview never opened. The same mechanism closed an already-open `MediaGallery`. Fixed by lifting the context instead of relocating the tray, which also **reverses an unrequested visual change**: routing the tray through the new slot had moved the desktop tray from above the composer card to inside it. `aboveEditorContent` became unused and was deleted (INV-38).
- **The anchor glyph pre-empted the error icon, the spinner and the thumbnail.** `PillLeading` returned the anchor before consulting `spin` / `thumbnailSrc`, and the count was passed regardless of status — so an upload that reserved an id and then failed its byte transfer showed an anchor instead of `AlertCircle`, a decrypting E2E chip lost its spinner, and every referenced image chip lost its thumbnail. After a normal paste-upload nearly every chip is referenced, so this was the common case. Now gated on a resolved, non-error, non-spinning chip, with the thumbnail taking precedence.
- **Tray-dragged image references carried `imageIndex: null`.** `getDisplayText` falls through to the filename when it is falsy, so a pasted pill read "Image #1" while a second reference dragged from the tray read "screenshot.png" — and at send the ordinal was backfilled, silently relabelling it. `imageIndex` is an identity ("Image #2" is *which* image, not a position), so it must not appear to renumber.

From the whole-stack review, one blocker:

- **A nested editor stole the composer's drag host and killed it on unmount.** The scheduled-message edit dialog mounts a `RichEditor` as a React descendant of `MessageComposer`'s `ComposerPillDndHost` (portaled, but context crosses portals — this file already documents the same subtlety for synthetic events). Its bridge called `host.attach(dialogView)`, overwriting the composer's view; closing the dialog called `host.detach()`, nulling it. The composer's own bridge effect never re-runs, so drag stayed dead for the life of that composer. Repro: attach a file, open the scheduled-messages picker, edit a scheduled message, close it — tray drag and in-composer pill drag both silently stop. Fixed with a single editor slot on the host (a second editor is refused and opens its own context rather than sharing dnd-kit ids) and a view-scoped `detach` so a stale teardown cannot clear a live binding.

- **The host slot was reserved by a claim that reserved nothing** (CodeRabbit). The slot above was keyed by the editor, and a provider whose editor did not exist yet claimed with `null` — which returned `true` without taking the slot, then froze the branch on that answer. A nested editor could take the host in that window and the composer's own attach would be refused for the life of the mount. Now keyed by the provider's `useId()` (stable across a re-render, a StrictMode double-invoke and a remount at the same position, so re-claiming is idempotent — a per-render token would leak the slot on StrictMode's discarded pass), held for the provider's lifetime rather than the editor's, and `claimEditorSlot` no longer accepts `null`. No reachable behaviour change: TipTap builds the editor synchronously and neither `useEditor` call passes deps, so today no provider here ever renders without one. It is fixed because the contract was self-contradictory — a `claim` that answers `true` while reserving nothing, in an API this PR's own description invites the next editor surface to rely on — and because the slot is simpler owned by the mount that holds it than by an object that mount does not control. Fifteen lines.

From PR review, three more fixes:

- **A tray drag had no drag preview.** `DragOverlay` rendered with no children, so you picked up a chip and nothing followed the pointer — the only feedback was the in-text drop cursor. That was right for #1862 (a ghost would have been a behaviour change in a parity PR) but wrong here. It now renders an `AttachmentPill` copy for tray sources only; a doc pill drag still gets no ghost, since the pill is already dimmed in place.
- **A chip click within 400 ms of any completed drag was swallowed.** `startTrayGesture` did not clear the activation-click suppression window that the editor's `onMouseDown` clears, and the window is host-wide — so dragging a chip in and then immediately tapping another to check what it is did nothing until the second tap. A chip press now clears it; the click that actually ends a drag arrives with no intervening mousedown and stays suppressed.
- **The `×N` count's `aria-label` sat on a role-less `<span>`**, which assistive tech does not reliably expose. It now takes `role="img"`. Visible text and chip metrics unchanged.

**Deliberate deviations:**

- Cancelling an in-flight upload does not cascade; only delete does. A chip cannot be dragged before it is `uploaded`, so a cancelled upload has no tray-created reference. An inline node from the paste/pick path could still be orphaned — pre-existing, unchanged here.
- The `×N` count sits beside the label, not in the 20 px leading slot, which cannot hold it. INV-21 is honoured for the slot (contents swap, box fixed); the count's appearance does widen the chip.
- `ComposerPillDndProvider` binds to an ancestor host only if that host's single editor slot is free. This started out as an unguarded bind, justified by "none of the six `MessageComposer` call sites renders a `RichEditor`" — which checks call sites, not React descendants, and the descendant case is live: the action bar's `scheduledMessagesTrigger` slot renders `ScheduledMessagesPicker` → `ScheduledEditDialog` → its own `RichEditor`, reached through a portal that context still crosses. See the fix below.

## Files

| File | Change |
| ---- | ------ |
| `components/timeline/pending-attachments.tsx` | tray chips become draggables; mobile row vs. desktop wrap; per-layout `touch-action`; reference counts |
| `components/composer/attachment-pill.tsx` | referenced state (anchor, `×N`), gated behind resolved/non-error/non-spinning |
| `components/editor/composer-pill-drag-extension.ts` | drag source becomes a discriminated union; `createComposerPillInsertTransaction` |
| `components/editor/composer-pill-dnd.tsx` | `ComposerPillDndHost`; provider is a pass-through under an ancestor host |
| `components/editor/composer-pill-drag-host.ts` | `startTrayGesture`; source-aware payload |
| `components/editor/composer-pill-sensor.ts` | source-aware activation; tap-to-select stays doc-only |
| `components/editor/attachment-reference-extension.ts` | `removeAttachmentReferences` command |
| `components/editor/attachment-reference-counts.ts` | **new** — derive reference counts from `JSONContent` |
| `components/timeline/attachment-image-index.ts` | **new** — the one owner of the image ordinal rule |
| `components/composer/message-composer.tsx` | one `ComposerPillDndHost` around tray + editor; cascade on remove |
| `components/scheduled/scheduled-edit-dialog.tsx` | reference counts + cascade |
| `components/timeline/message-input.tsx` | uses the shared ordinal helper |
| `components/editor/rich-editor.tsx` | `removeAttachmentReferences` on the handle |
| `components/timeline/pending-attachments.tray-drag.test.tsx` | **new** — 25 tests |

## Test plan

- [x] `bun run --cwd apps/frontend test` — 6607 pass, 0 fail
- [ ] **Playwright screenshot pass at 1440 px / 390 px** — not run. This worktree's test MinIO needs port 9002, held by another worktree's stack; stopping that was not worth the disruption. Visual verification is on staging.
- [x] `pending-attachments.tray-drag.test.tsx` + `message-composer.test.tsx` + `composer-pill-drag-extension.test.tsx` against the committed tree — 88 pass
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] `bun run --cwd apps/frontend lint` — clean
- [x] Pre-commit monorepo lint + typecheck — clean
- [ ] **Touch tray drag on a real device** — no end-to-end touch test. Reasoned from chunk 1's sensor (a tray source is never node-selected, so it requires a long press) and verified by reading. jsdom has no layout, so drop resolution goes through mocked geometry.
- [ ] **Drag-preview positioning** — dnd-kit anchors the overlay on the draggable node, which here is the editor DOM rather than the chip, so the preview applies a translate from the editor's corner to the gesture's start point. jsdom has no layout, so the test proves the preview renders and names the right attachment, not that it sits under the cursor. Needs eyes on staging.
- [ ] **Mobile row at 20 attachments, on hardware** — the swipe-vs-drag disambiguation is the point of the `touch-action` split and cannot be proven in jsdom.

Covered by tests: insert-twice → two nodes, one wire attachment; zero-reference attachments still append; delete cascade across N references and across the temp→server id flip; reference count renders and updates from the document; row vs. wrap by breakpoint; tray drag never deletes from a source position; tray stays mounted across a mobile chrome toggle and a chip tap still activates; referenced+error keeps the alert glyph, referenced+uploading keeps the spinner, referenced image keeps its thumbnail; tray-dragged 2nd image gets `imageIndex: 2` and matches what send resolves; the composer keeps the host when its editor is built after a nested one.

<details>
<summary>📋 Full implementation plan</summary>

Plan of record: **https://seer.build/ws_vbyzjvdg6g/b/threa-tray-pill-dnd/** — §2 (insert semantics), §4 (density), §8 chunk 2.

3-PR stack:

1. #1862 — in-composer pill drag onto dnd-kit, no behaviour change
2. **this PR** — tray → composer drag, mobile row, delete cascade
3. `/attachment` slash command

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


