### PR TITLE
feat: mobile attachment tray rework with truthful upload retry

### DIFF
--- a/apps/backend/src/middleware/rate-limit.ts
+++ b/apps/backend/src/middleware/rate-limit.ts
@@ -52,7 +52,11 @@ export function createRateLimiters(config: RateLimiterConfig): RateLimiterSet {
     upload: createRateLimit({
       name: "upload",
       windowMs: 60_000,
-      max: 20,
+      // Every file costs two requests (reserve + content), so this is a
+      // 30-file-per-minute budget — the composer tray is designed around
+      // ~20-attachment batches, and the client paces itself (3 concurrent
+      // transfers, 429-aware backoff) rather than bursting.
+      max: 60,
       key: userScopeKey,
     }),
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -797,13 +797,14 @@ export function MessageComposer({
     [onRemoveAttachment]
   )
 
-  const attachmentTray = (
+  const attachmentTray = (resting: boolean) => (
     <PendingAttachments
       attachments={pendingAttachments}
       onRemove={handleRemoveAttachment}
       onCancelUpload={onCancelAttachmentUpload}
       workspaceId={workspaceId}
       referenceCounts={attachmentReferenceCounts}
+      resting={resting}
       beforePills={
         contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
           <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
@@ -1039,7 +1040,7 @@ export function MessageComposer({
                 onRequestFileUpload={handleRequestInlineUpload}
                 belowToolbarContent={
                   pendingAttachments.length > 0 || (contextRefs && contextRefs.length > 0) ? (
-                    <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">{attachmentTray}</div>
+                    <div className="pt-1 pb-2 border-b border-border/50 [&>div]:mb-0">{attachmentTray(false)}</div>
                   ) : undefined
                 }
               />
@@ -1252,7 +1253,7 @@ export function MessageComposer({
             own position above the card and its chips still drag into the text.
             Wrapping it renders no DOM node, so the layout is unchanged. */}
           <ComposerPillDndHost>
-            {attachmentTray}
+            {attachmentTray(isMobile && !mobileChromeOpen)}
 
             {/* Live in-app link previews for the draft. Above the card (like
             attachments) so they read as attached to this message and stay clear

--- a/apps/frontend/src/components/editor/attachment-slash-command.test.tsx
+++ b/apps/frontend/src/components/editor/attachment-slash-command.test.tsx
@@ -13,6 +13,7 @@ import * as giphyModule from "@/hooks/use-giphy-enabled"
 import * as streamCommandsModule from "@/hooks/use-stream-commands"
 import * as contextsModule from "@/contexts"
 import type { PendingAttachment } from "@/hooks/use-attachments"
+import * as uploadManagerModule from "@/lib/uploads/upload-manager"
 import { attachmentReferenceAttrs, insertAttachmentReferenceAt } from "./triggers/use-attachment-picker"
 import { RichEditor, type RichEditorHandle } from "./rich-editor"
 import { countAttachmentReferences } from "./attachment-reference-counts"
@@ -269,23 +270,48 @@ describe("/attachment slash command", () => {
     expect(attachmentNodes(getContent())[0]?.attrs?.id).toBe("att_notes")
   })
 
-  it("hides the command when no tray attachment is placeable and there is no upload path", async () => {
-    const stuck: PendingAttachment[] = [
+  it("offers the command for uploading and failed tray files, hiding it only on an empty tray with no upload path", async () => {
+    const inFlight: PendingAttachment[] = [
       { id: "temp_pending", filename: "pending.txt", mimeType: "text/plain", sizeBytes: 1, status: "uploading" },
       { id: "att_broken", filename: "broken.txt", mimeType: "text/plain", sizeBytes: 2, status: "error" },
     ]
 
-    // Control: one placeable attachment and no upload path still surfaces the
-    // command — so the negative case below is about placeability, and proves
-    // the option had time to appear rather than being asserted away too early.
-    const control = mountEditor({ trayAttachments: [TRAY[0]!], noUploadPath: true })
-    typeText(control.editor, "/attach")
+    // A reference binds the id, not finished bytes — the same bar as the tray
+    // drag, so a tray of in-flight/failed files is still placeable.
+    const stuck = mountEditor({ trayAttachments: inFlight, noUploadPath: true })
+    typeText(stuck.editor, "/attach")
     expect(await screen.findByRole("option", { name: /\/attachment/ })).toBeTruthy()
     cleanup()
 
-    const { editor } = mountEditor({ trayAttachments: stuck, noUploadPath: true })
+    const { editor } = mountEditor({ trayAttachments: [], noUploadPath: true })
     typeText(editor, "/attach")
     await expect(screen.findByRole("option", { name: /\/attachment/ }, { timeout: 400 })).rejects.toThrow()
+  })
+
+  it("flips a temp-id reference to the real id (with its ordinal) when the reservation lands", async () => {
+    const reserving: PendingAttachment = {
+      id: "temp_res",
+      filename: "shot.png",
+      mimeType: "image/png",
+      sizeBytes: 50,
+      status: "uploading",
+    }
+    const { editor, getContent, setTray } = mountEditor({ trayAttachments: [reserving] })
+    await openPicker(editor)
+    fireEvent.click(await screen.findByRole("option", { name: /shot\.png/ }))
+    await waitFor(() => expect(attachmentNodes(getContent())[0]?.attrs?.id).toBe("temp_res"))
+
+    const findJob = spyOnExport(uploadManagerModule, "findUploadJob").mockReturnValue((() => ({
+      attachmentId: "att_res",
+    })) as unknown as typeof uploadManagerModule.findUploadJob)
+    setTray([{ ...reserving, id: "att_res" }])
+
+    await waitFor(() => {
+      const node = attachmentNodes(getContent())[0]
+      expect(node?.attrs?.id).toBe("att_res")
+      expect(node?.attrs?.imageIndex).toBe(1)
+    })
+    findJob.mockRestore()
   })
 
   it("resets the highlight when the typed filter changes, so typing lands on the best match", async () => {

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -5,6 +5,9 @@ import type { ResolvedPos } from "@tiptap/pm/model"
 import type { PluginKey } from "@tiptap/pm/state"
 import { useParams } from "react-router-dom"
 import { ComposerPillDndProvider } from "./composer-pill-dnd"
+import { countAttachmentReferences } from "./attachment-reference-counts"
+import { buildImageIndexByAttachment } from "@/components/timeline/attachment-image-index"
+import { findUploadJob } from "@/lib/uploads/upload-manager"
 import { createEditorExtensions } from "./editor-extensions"
 import { applyExternalEditorContent } from "./apply-external-content"
 import { ComposerPillCopyButton } from "./composer-pill-copy-button"
@@ -29,7 +32,6 @@ import {
   useCommandArgPicker,
   useAttachmentPicker,
   findPickableArg,
-  isPlaceableAttachment,
 } from "./triggers"
 import type { CommandItem } from "./triggers/types"
 import { parseMemoUrl } from "@/lib/memo-url"
@@ -357,13 +359,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // Snippet creation needs an upload handler to attach through, same as the
   // paste path; gate the `/snippet` command on it too.
   const snippetEnabled = !!onFileUpload && enableCommands
-  // `/attachment` is worth showing when there's something to place: a tray file
-  // the picker would actually offer, or an upload path to produce one. Counting
-  // raw tray length instead would open an empty picker on a tray holding only
-  // uploading or failed entries.
+  // `/attachment` is worth showing when there's something to place — any tray
+  // file (uploading and failed included; a reference binds the id, not finished
+  // bytes) — or an upload path to produce one.
   const canUploadFromPicker = !!onFileUpload && !!onRequestFileUpload
-  const hasPlaceableAttachment = (trayAttachments ?? []).some(isPlaceableAttachment)
-  const attachmentCommandEnabled = enableCommands && (canUploadFromPicker || hasPlaceableAttachment)
+  const attachmentCommandEnabled = enableCommands && (canUploadFromPicker || (trayAttachments ?? []).length > 0)
 
   // Open the snippet editor with an empty draft, anchored at the caret so the
   // chip lands where it would for a paste. Shared by the `/snippet` command and
@@ -1034,6 +1034,32 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       return () => cancelAnimationFrame(raf)
     }
   }, [editableValue, editor, externalSyncNonce])
+
+  // A reference placed (drag or picker) while its upload was still reserving
+  // carries the job's temp id. Flip it to the real id — and the image ordinal
+  // send will use — the moment the tray learns it, the same flip the paste
+  // upload path performs through its own callback. Without this the node keeps
+  // an id no send path can resolve. Ordered AFTER the external-value sync
+  // effect above: when a value change and a tray tick land in one commit, the
+  // sync must apply the incoming doc first — flipping first would hand the
+  // sync a doc that no longer matches `value`, and it would revert the flip.
+  useEffect(() => {
+    const editorInstance = editorRef.current
+    if (!editorInstance || editorInstance.isDestroyed || !trayAttachments?.length) return
+    const referenced = countAttachmentReferences(editorInstance.getJSON() as JSONContent)
+    const tempIds = [...referenced.keys()].filter((id) => id.startsWith("temp_"))
+    if (tempIds.length === 0) return
+    const imageIndexes = buildImageIndexByAttachment(trayAttachments)
+    for (const tempId of tempIds) {
+      const attachmentId = findUploadJob(tempId)?.attachmentId
+      if (!attachmentId) continue
+      const attachment = trayAttachments.find((a) => a.id === attachmentId)
+      editorInstance.commands.updateAttachmentReference(tempId, {
+        id: attachmentId,
+        imageIndex: attachment ? (imageIndexes.get(attachment) ?? null) : null,
+      })
+    }
+  }, [trayAttachments])
 
   // Re-parse content when mentionables load or currentUser becomes known (for correct mention type colors)
   useEffect(() => {

--- a/apps/frontend/src/components/editor/triggers/attachment-picker-options.ts
+++ b/apps/frontend/src/components/editor/triggers/attachment-picker-options.ts
@@ -20,21 +20,14 @@ export function attachmentPickerOptionKey(option: AttachmentPickerOption): strin
 }
 
 /**
- * Can this attachment be referenced yet? Settled bytes and a real id — the same
- * bar the tray drag sets, so the picker never offers what a drag would refuse,
- * and `/attachment` never opens on an empty list.
- */
-export function isPlaceableAttachment(attachment: PendingAttachment): boolean {
-  return attachment.status === "uploaded" && !attachment.id.startsWith("temp_")
-}
-
-/**
- * Tray rows for the picker: only attachments that can actually be referenced,
- * each carrying the ordinal a tray drag would stamp.
+ * Tray rows for the picker: every tray attachment, each carrying the ordinal a
+ * tray drag would stamp. Uploading and failed files are offered too — same bar
+ * as the drag: a reference binds the id, not finished bytes, and a still-
+ * reserving temp id is flipped by the editor when the reservation lands.
  */
 export function buildAttachmentPickerOptions(attachments: readonly PendingAttachment[]): AttachmentPickerOption[] {
   const imageIndexes = buildImageIndexByAttachment(attachments)
-  return attachments.filter(isPlaceableAttachment).map((attachment) => ({
+  return attachments.map((attachment) => ({
     kind: "attachment" as const,
     attachment,
     imageIndex: imageIndexes.get(attachment) ?? null,

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import { PendingAttachments } from "./pending-attachments"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import * as uploadManager from "@/lib/uploads/upload-manager"
+import * as useMobileModule from "@/hooks/use-mobile"
 
 function attachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
   return {
@@ -198,5 +199,106 @@ describe("PendingAttachments", () => {
     const bar = screen.getByRole("progressbar", { name: "Uploading screenshot.png" })
     expect(bar).toHaveAttribute("aria-valuenow", "42")
     expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument()
+  })
+})
+
+describe("mobile rollup and drawer", () => {
+  beforeEach(() => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const files = [
+    attachment({ id: "attach_ok", filename: "ok.png", previewUrl: "blob:ok" }),
+    attachment({ id: "attach_up", filename: "up.png", status: "uploading", progress: 0.4, previewUrl: "blob:up" }),
+    attachment({
+      id: "attach_net",
+      filename: "net.txt",
+      mimeType: "text/plain",
+      status: "error",
+      error: "Network error during upload",
+      canRetry: true,
+      previewUrl: undefined,
+    }),
+    attachment({
+      id: "attach_dead",
+      filename: "dead.txt",
+      mimeType: "text/plain",
+      status: "error",
+      error: "size mismatch",
+      canRetry: false,
+      previewUrl: undefined,
+    }),
+  ]
+
+  it("summarizes the tray in one line and bulk-retries only the retryable failures", () => {
+    const retrySpy = vi.spyOn(uploadManager, "retryUpload").mockResolvedValue(undefined)
+    render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+
+    const summary = screen.getByRole("button", { name: "Show all attachments" })
+    expect(summary).toHaveTextContent(/4 files/)
+    expect(summary).toHaveTextContent(/1 uploading/)
+    expect(summary).toHaveTextContent(/2 failed/)
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry all" }))
+    expect(retrySpy.mock.calls.map((call) => call[0])).toEqual(["attach_net"])
+  })
+
+  it("shows only the rollup line while the composer rests, with the drawer still reachable", () => {
+    render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" resting />)
+
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Hide attachment chips" })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all attachments" }))
+    expect(within(screen.getByRole("dialog")).getByText("ok.png")).toBeInTheDocument()
+  })
+
+  it("folds the chips away behind the rollup line and restores them", () => {
+    render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(screen.getByText("ok.png")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide attachment chips" }))
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Show all attachments" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Show attachment chips" }))
+    expect(screen.getByText("ok.png")).toBeInTheDocument()
+  })
+
+  it("opens the drawer with full filenames, live status, and per-row recovery", () => {
+    const retrySpy = vi.spyOn(uploadManager, "retryUpload").mockResolvedValue(undefined)
+    const onRemove = vi.fn()
+    render(<PendingAttachments attachments={files} onRemove={onRemove} workspaceId="ws_1" />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all attachments" }))
+    const dialog = screen.getByRole("dialog")
+    expect(within(dialog).getByText("Uploading — 40%")).toBeInTheDocument()
+    expect(within(dialog).getByText("Network error during upload")).toBeInTheDocument()
+    expect(within(dialog).getByText("size mismatch")).toBeInTheDocument()
+
+    // A terminal failure gets remove-only recovery; the network-class one retries.
+    expect(within(dialog).queryByRole("button", { name: "Retry upload of dead.txt" })).not.toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole("button", { name: "Retry upload of net.txt" }))
+    expect(retrySpy).toHaveBeenCalledWith("attach_net")
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove failed" }))
+    expect(onRemove.mock.calls.map((call) => call[0])).toEqual(["attach_net", "attach_dead"])
+  })
+
+  it("cancels an in-flight upload from its drawer row instead of removing it", () => {
+    const onRemove = vi.fn()
+    const onCancelUpload = vi.fn()
+    render(
+      <PendingAttachments attachments={files} onRemove={onRemove} onCancelUpload={onCancelUpload} workspaceId="ws_1" />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all attachments" }))
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel upload of up.png" }))
+    expect(onCancelUpload).toHaveBeenCalledWith("attach_up")
+    expect(onRemove).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -202,6 +202,49 @@ describe("PendingAttachments", () => {
   })
 })
 
+const files = [
+  attachment({ id: "attach_ok", filename: "ok.png", previewUrl: "blob:ok" }),
+  attachment({ id: "attach_up", filename: "up.png", status: "uploading", progress: 0.4, previewUrl: "blob:up" }),
+  attachment({
+    id: "attach_net",
+    filename: "net.txt",
+    mimeType: "text/plain",
+    status: "error",
+    error: "Network error during upload",
+    canRetry: true,
+    previewUrl: undefined,
+  }),
+  attachment({
+    id: "attach_dead",
+    filename: "dead.txt",
+    mimeType: "text/plain",
+    status: "error",
+    error: "size mismatch",
+    canRetry: false,
+    previewUrl: undefined,
+  }),
+]
+
+describe("desktop rollup", () => {
+  it("shows the same summary, bulk retry, and fold — without the drawer tap", () => {
+    const retrySpy = vi.spyOn(uploadManager, "retryUpload").mockResolvedValue(undefined)
+    render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+
+    expect(screen.getByText(/4 files/)).toBeInTheDocument()
+    expect(screen.getByText(/2 failed/)).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Show all attachments" })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry 1" }))
+    expect(retrySpy.mock.calls.map((call) => call[0])).toEqual(["attach_net"])
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide attachment chips" }))
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Show attachment chips" }))
+    expect(screen.getByText("ok.png")).toBeInTheDocument()
+    retrySpy.mockRestore()
+  })
+})
+
 describe("mobile rollup and drawer", () => {
   beforeEach(() => {
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
@@ -210,29 +253,6 @@ describe("mobile rollup and drawer", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
-
-  const files = [
-    attachment({ id: "attach_ok", filename: "ok.png", previewUrl: "blob:ok" }),
-    attachment({ id: "attach_up", filename: "up.png", status: "uploading", progress: 0.4, previewUrl: "blob:up" }),
-    attachment({
-      id: "attach_net",
-      filename: "net.txt",
-      mimeType: "text/plain",
-      status: "error",
-      error: "Network error during upload",
-      canRetry: true,
-      previewUrl: undefined,
-    }),
-    attachment({
-      id: "attach_dead",
-      filename: "dead.txt",
-      mimeType: "text/plain",
-      status: "error",
-      error: "size mismatch",
-      canRetry: false,
-      previewUrl: undefined,
-    }),
-  ]
 
   it("summarizes the tray in one line and bulk-retries only the retryable failures", () => {
     const retrySpy = vi.spyOn(uploadManager, "retryUpload").mockResolvedValue(undefined)

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -243,7 +243,9 @@ describe("mobile rollup and drawer", () => {
     expect(summary).toHaveTextContent(/1 uploading/)
     expect(summary).toHaveTextContent(/2 failed/)
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry all" }))
+    // The button carries the retryable count, not "all" — the failed tally
+    // includes terminal failures a retry can never fix.
+    fireEvent.click(screen.getByRole("button", { name: "Retry 1" }))
     expect(retrySpy.mock.calls.map((call) => call[0])).toEqual(["attach_net"])
   })
 
@@ -255,6 +257,20 @@ describe("mobile rollup and drawer", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Show all attachments" }))
     expect(within(screen.getByRole("dialog")).getByText("ok.png")).toBeInTheDocument()
+  })
+
+  it("resting folds context-ref pills too, matching the link-preview rule", () => {
+    render(
+      <PendingAttachments
+        attachments={[]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+        resting
+        beforePills={<span>context-ref-pill</span>}
+      />
+    )
+
+    expect(screen.queryByText("context-ref-pill")).not.toBeInTheDocument()
   })
 
   it("folds the chips away behind the rollup line and restores them", () => {

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -88,6 +88,31 @@ describe("tray pill drag", () => {
     ])
   })
 
+  it("drags uploading and failed chips too — a reference binds the id, not finished bytes", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    renderTray(editor, [
+      attachment({ id: "att_up", filename: "up.png", status: "uploading", progress: 0.4, previewUrl: "blob:up" }),
+      attachment({
+        id: "att_dead",
+        filename: "dead.txt",
+        mimeType: "text/plain",
+        status: "error",
+        error: "Network error during upload",
+        previewUrl: undefined,
+      }),
+    ])
+
+    dragChipIntoEditor(screen.getByText("up.png"))
+    dragChipIntoEditor(screen.getByText("dead.txt"))
+
+    const ids = (editor.getJSON() as JSONContent).content?.[0]?.content
+      ?.filter((node) => node.type === "attachmentReference")
+      .map((node) => node.attrs?.id)
+    // Both drops land at the mocked pos 1, so the later drop sits first.
+    expect(ids).toEqual(["att_dead", "att_up"])
+  })
+
   it("never deletes from the document — a tray drag is an insert, not a move", () => {
     const editor = createEditor([
       { type: "text", text: "hello world" },

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -141,16 +141,20 @@ describe("tray pill drag", () => {
     expect(screen.queryByLabelText("2 references in this message")).toBeNull()
   })
 
-  it("renders one scrolling row on mobile and the wrapping tray on desktop", () => {
+  it("wraps the tray on both breakpoints, with the tighter height cap and the rollup line on mobile", () => {
     const desktop = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
-    expect(desktop.container.querySelector("div")).toHaveClass("flex-wrap")
+    expect(desktop.container.querySelector("div")).toHaveClass("flex-wrap", "max-h-[120px]")
+    expect(screen.queryByRole("button", { name: "Show all attachments" })).toBeNull()
     desktop.unmount()
 
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
     const mobile = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
-    const row = mobile.container.querySelector("div")!
-    expect(row).toHaveClass("overflow-x-auto")
-    expect(row).not.toHaveClass("flex-wrap")
+    // A single horizontal row hid everything past the fold and fought the
+    // page's own scroll axis — the tray wraps and scrolls vertically now.
+    expect(mobile.container.querySelector(".overflow-x-auto")).toBeNull()
+    const tray = screen.getByText("screenshot.png").closest(".flex-wrap")
+    expect(tray).toHaveClass("max-h-[96px]", "overflow-y-auto")
+    expect(screen.getByRole("button", { name: "Show all attachments" })).toHaveTextContent("1 file")
   })
 })
 

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -166,9 +166,12 @@ describe("tray pill drag", () => {
     expect(screen.queryByLabelText("2 references in this message")).toBeNull()
   })
 
-  it("wraps the tray on both breakpoints, with the tighter height cap and the rollup line on mobile", () => {
+  it("wraps the tray on both breakpoints, with the tighter height cap and the drawer tap on mobile", () => {
     const desktop = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
-    expect(desktop.container.querySelector("div")).toHaveClass("flex-wrap", "max-h-[120px]")
+    expect(desktop.container.querySelector(".flex-wrap")).toHaveClass("max-h-[120px]")
+    // Desktop gets the same rollup summary, but as plain text — the wrapped
+    // tray is its own full list, so there is no drawer behind a tap.
+    expect(screen.getByText(/1 file/)).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Show all attachments" })).toBeNull()
     desktop.unmount()
 
@@ -262,8 +265,7 @@ describe("referenced chip leading slot", () => {
       />
     )
 
-    const leading = container.querySelector("svg")!
-    expect(leading).toHaveClass("lucide-circle-alert")
+    expect(container.querySelector(".lucide-circle-alert")).toBeTruthy()
     expect(container.querySelector(".lucide-anchor")).toBeNull()
   })
 
@@ -284,7 +286,7 @@ describe("referenced chip leading slot", () => {
       />
     )
 
-    expect(container.querySelector("svg")).toHaveClass("lucide-loader-circle")
+    expect(container.querySelector(".lucide-loader-circle")).toBeTruthy()
     expect(container.querySelector(".lucide-anchor")).toBeNull()
   })
 

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -459,9 +459,11 @@ interface PendingAttachmentsProps {
  * in-memory E2E decrypt). Non-previewable files keep a plain type-icon chip.
  * Renders nothing when both lists are empty.
  *
- * On mobile a one-line rollup sits above the chips — count, failure tally,
- * bulk retry — and opens {@link AttachmentListDrawer} for the full list; the
- * chips wrap to a capped couple of rows and can be folded away entirely.
+ * A one-line rollup sits above the chips on every breakpoint — count, failure
+ * tally, bulk retry, fold chevron. On mobile the chips wrap to a capped couple
+ * of rows and the rollup opens {@link AttachmentListDrawer} for the full list;
+ * desktop's taller wrapped tray is its own full list, so the summary there is
+ * plain text.
  */
 export function PendingAttachments({
   attachments,
@@ -543,11 +545,24 @@ export function PendingAttachments({
   // Resting folds everything (context-ref pills included — same rule as the
   // composer's link previews); the manual fold only exists while the rollup
   // renders, so it scopes to having attachments.
-  const foldChips = isMobile && (resting || (collapsed && attachments.length > 0))
+  const foldChips = (isMobile && resting) || (collapsed && attachments.length > 0)
+
+  const rollupSummary = (
+    <>
+      <span className="truncate">
+        {attachments.length} {attachments.length === 1 ? "file" : "files"}
+        {uploadingCount > 0 && ` · ${uploadingCount} uploading`}
+      </span>
+      {failedCount > 0 && <span className="font-medium text-destructive">· {failedCount} failed</span>}
+    </>
+  )
 
   return (
     <>
-      {isMobile && attachments.length > 0 && (
+      {attachments.length > 0 && (
+        // The rollup renders on every breakpoint — the counts, bulk retry and
+        // fold ARE the overview; only the drawer behind the mobile tap is a
+        // phone affordance (desktop's wrapped tray is its own full list).
         // preventDefault keeps editor focus (and the keyboard) through taps on
         // this line's buttons — same guard as the composer's action bar. Safe
         // as a blanket here: every child is our own button, nothing portaled.
@@ -555,19 +570,19 @@ export function PendingAttachments({
           className="mb-1.5 flex h-6 items-center gap-3 text-xs text-muted-foreground"
           onMouseDown={(event) => event.preventDefault()}
         >
-          <button
-            type="button"
-            className="flex min-w-0 items-center gap-1"
-            onClick={() => setDrawerOpen(true)}
-            aria-label="Show all attachments"
-          >
-            <span className="truncate">
-              {attachments.length} {attachments.length === 1 ? "file" : "files"}
-              {uploadingCount > 0 && ` · ${uploadingCount} uploading`}
-            </span>
-            {failedCount > 0 && <span className="font-medium text-destructive">· {failedCount} failed</span>}
-            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-          </button>
+          {isMobile ? (
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-1"
+              onClick={() => setDrawerOpen(true)}
+              aria-label="Show all attachments"
+            >
+              {rollupSummary}
+              <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+            </button>
+          ) : (
+            <span className="flex min-w-0 items-center gap-1">{rollupSummary}</span>
+          )}
           {retryableIds.length > 0 && (
             <button
               type="button"

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -305,12 +305,14 @@ function E2eChip({
 function AttachmentListDrawer({
   open,
   onOpenChange,
+  onAnimationEnd,
   attachments,
   onRemove,
   onCancelUpload,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
+  onAnimationEnd: (open: boolean) => void
   attachments: PendingAttachment[]
   onRemove: (id: string) => void
   onCancelUpload: (id: string) => void
@@ -318,7 +320,7 @@ function AttachmentListDrawer({
   const failed = attachments.filter((a) => a.status === "error")
   const retryable = failed.filter((a) => a.canRetry === true)
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
+    <Drawer open={open} onOpenChange={onOpenChange} onAnimationEnd={onAnimationEnd}>
       <DrawerContent className="max-h-[85dvh]">
         <DrawerTitle className="px-4 pt-1 text-sm font-medium">Attachments</DrawerTitle>
         <p className="px-4 pb-2 text-xs text-muted-foreground">
@@ -396,7 +398,7 @@ function AttachmentListDrawer({
                   for (const a of retryable) void retryUpload(a.id)
                 }}
               >
-                Retry all
+                Retry {retryable.length}
               </Button>
             )}
           </div>
@@ -471,6 +473,21 @@ export function PendingAttachments({
   // with its chips showing.
   const [collapsed, setCollapsed] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  // True from close until vaul's exit animation lands, so removing the last
+  // attachment from the open sheet slides it out instead of snapping the whole
+  // subtree out of the DOM.
+  const [drawerExiting, setDrawerExiting] = useState(false)
+  const handleDrawerOpenChange = useCallback((open: boolean) => {
+    setDrawerOpen(open)
+    if (!open) setDrawerExiting(true)
+  }, [])
+  const handleDrawerAnimationEnd = useCallback((open: boolean) => {
+    if (!open) setDrawerExiting(false)
+  }, [])
+  const attachmentCount = attachments.length
+  useEffect(() => {
+    if (attachmentCount === 0 && drawerOpen) handleDrawerOpenChange(false)
+  }, [attachmentCount, drawerOpen, handleDrawerOpenChange])
   // Open lightbox tracked by the stable attachment key, not the id (which flips
   // temp→server on upload completion), so an open preview survives its upload.
   const [openKey, setOpenKey] = useState<string | null>(null)
@@ -507,7 +524,8 @@ export function PendingAttachments({
     [attachments, srcByKey]
   )
 
-  if (attachments.length === 0 && !beforePills) return null
+  // The drawer must survive its exit animation even when the list empties.
+  if (attachments.length === 0 && !beforePills && !drawerOpen && !drawerExiting) return null
 
   const galleryIndex = openKey ? galleryItems.findIndex((g) => g.attachmentId === pendingGalleryId(openKey)) : -1
 
@@ -515,12 +533,21 @@ export function PendingAttachments({
   const uploadingCount = attachments.filter((a) => a.status === "uploading").length
   const retryableIds = attachments.filter((a) => a.status === "error" && a.canRetry === true).map((a) => a.id)
   const CollapseChevron = collapsed ? ChevronDown : ChevronUp
-  const foldChips = isMobile && attachments.length > 0 && (resting || collapsed)
+  // Resting folds everything (context-ref pills included — same rule as the
+  // composer's link previews); the manual fold only exists while the rollup
+  // renders, so it scopes to having attachments.
+  const foldChips = isMobile && (resting || (collapsed && attachments.length > 0))
 
   return (
     <>
       {isMobile && attachments.length > 0 && (
-        <div className="mb-1.5 flex h-6 items-center gap-3 text-xs text-muted-foreground">
+        // preventDefault keeps editor focus (and the keyboard) through taps on
+        // this line's buttons — same guard as the composer's action bar. Safe
+        // as a blanket here: every child is our own button, nothing portaled.
+        <div
+          className="mb-1.5 flex h-6 items-center gap-3 text-xs text-muted-foreground"
+          onMouseDown={(event) => event.preventDefault()}
+        >
           <button
             type="button"
             className="flex min-w-0 items-center gap-1"
@@ -542,7 +569,7 @@ export function PendingAttachments({
                 for (const id of retryableIds) void retryUpload(id)
               }}
             >
-              Retry all
+              Retry {retryableIds.length}
             </button>
           )}
           {!resting && (
@@ -557,7 +584,7 @@ export function PendingAttachments({
           )}
         </div>
       )}
-      {!foldChips && (
+      {!foldChips && (attachments.length > 0 || beforePills) && (
         <div
           className={cn(
             "flex flex-wrap items-center mb-3 overflow-y-auto",
@@ -593,10 +620,11 @@ export function PendingAttachments({
           })}
         </div>
       )}
-      {isMobile && attachments.length > 0 && (
+      {isMobile && (attachments.length > 0 || drawerOpen || drawerExiting) && (
         <AttachmentListDrawer
           open={drawerOpen}
-          onOpenChange={setDrawerOpen}
+          onOpenChange={handleDrawerOpenChange}
+          onAnimationEnd={handleDrawerAnimationEnd}
           attachments={attachments}
           onRemove={onRemove}
           onCancelUpload={onCancelUpload ?? onRemove}

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,6 +1,20 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
-import { Loader2, FileText, Image as ImageIcon, File as FileIcon, Film, Globe, AlertCircle } from "lucide-react"
+import {
+  Loader2,
+  FileText,
+  Image as ImageIcon,
+  File as FileIcon,
+  Film,
+  Globe,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  X,
+} from "lucide-react"
 import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer/attachment-pill"
+import { Button } from "@/components/ui/button"
+import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { useComposerPillDragHost } from "@/components/editor/composer-pill-dnd"
 import type { ComposerPillDragHost } from "@/components/editor/composer-pill-drag-host"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -42,21 +56,20 @@ function iconForType(type: UploadGalleryType | null): typeof FileIcon {
  * inserts a reference, so the chip stays put and the same file can be dropped
  * into the message any number of times.
  *
- * `touch-action` gives the browser the tray's own scroll axis and leaves the
- * perpendicular one — the drag, towards the text — to the sensor.
+ * `touch-action: pan-y` gives the browser the tray's own scroll axis (the tray
+ * wraps and scrolls vertically on every breakpoint); the drag itself activates
+ * on a long press, which involves no movement, so it needs no axis of its own.
  */
 function TrayPillDraggable({
   host,
   attachment,
   imageIndex,
-  row,
   children,
 }: {
   host: ComposerPillDragHost | null
   attachment: PendingAttachment
   /** "Image #N" ordinal for an image attachment, from the send-time rule. */
   imageIndex: number | null
-  row: boolean
   children: ReactNode
 }) {
   const inputMode = useInputMode()
@@ -95,7 +108,7 @@ function TrayPillDraggable({
   return (
     <span
       className={cn("inline-flex shrink-0", draggable && "cursor-grab")}
-      style={draggable ? { touchAction: row ? "pan-x" : "pan-y" } : undefined}
+      style={draggable ? { touchAction: "pan-y" } : undefined}
       onMouseDown={(event) => begin(event.nativeEvent, event.target)}
       onTouchStart={(event) => begin(event.nativeEvent, event.target)}
       onMouseEnter={hoverHighlights ? () => host?.highlightAttachment(attachment.id) : undefined}
@@ -157,8 +170,8 @@ interface ChipViewProps {
   onResolveSrc: (key: string, src: string | null) => void
   /** Inline references to this attachment in the message being composed. */
   referenceCount: number
-  /** Single-row tray (mobile): a tighter label keeps more chips reachable. */
-  row: boolean
+  /** Mobile tray: a tighter label fits more chips per wrapped row. */
+  compact: boolean
   /** "Image #N" ordinal for an image attachment, from the send-time rule. */
   imageIndex: number | null
   dragHost: ComposerPillDragHost | null
@@ -175,7 +188,7 @@ function ChipView({
   onOpen,
   onResolveSrc,
   referenceCount,
-  row,
+  compact,
   imageIndex,
   dragHost,
 }: ChipViewProps) {
@@ -198,7 +211,9 @@ function ChipView({
   // A retryable failure's bytes are still held locally — same in-place retry
   // the timeline chip offers, instead of forcing remove-and-repick.
   const canRetry = isError && attachment.canRetry === true
-  let secondary = formatFileSize(attachment.sizeBytes)
+  // Compact chips drop the size so two fit per wrapped mobile row; the error
+  // state keeps its word — it's the tap affordance, not decoration.
+  let secondary: string | undefined = compact ? undefined : formatFileSize(attachment.sizeBytes)
   if (isError) secondary = canRetry ? "Retry" : "Failed"
 
   const isGenericError =
@@ -227,7 +242,7 @@ function ChipView({
   else if (canPreview) onActivate = guard(() => onOpen(key))
 
   return (
-    <TrayPillDraggable host={dragHost} attachment={attachment} imageIndex={imageIndex} row={row}>
+    <TrayPillDraggable host={dragHost} attachment={attachment} imageIndex={imageIndex}>
       <AttachmentPill
         icon={Icon}
         thumbnailSrc={thumbnailSrc}
@@ -241,7 +256,7 @@ function ChipView({
         progress={isUploading ? attachment.progress : undefined}
         onActivate={onActivate}
         activateLabel={canRetry ? `Retry upload of ${attachment.filename}` : `Preview ${attachment.filename}`}
-        labelMaxWidth={row ? "max-w-[80px]" : "max-w-[120px]"}
+        labelMaxWidth={compact ? "max-w-[72px]" : "max-w-[120px]"}
         referenceCount={referenceCount}
       />
     </TrayPillDraggable>
@@ -281,6 +296,116 @@ function E2eChip({
   )
 }
 
+/**
+ * Bottom-sheet overview of the whole tray (mobile): full filenames, live
+ * status, per-row retry/remove, and bulk recovery — the chips themselves show
+ * a couple of wrapped rows at most, so this is where "what exactly is attached
+ * and what failed" gets answered at twenty attachments.
+ */
+function AttachmentListDrawer({
+  open,
+  onOpenChange,
+  attachments,
+  onRemove,
+  onCancelUpload,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  attachments: PendingAttachment[]
+  onRemove: (id: string) => void
+  onCancelUpload: (id: string) => void
+}) {
+  const failed = attachments.filter((a) => a.status === "error")
+  const retryable = failed.filter((a) => a.canRetry === true)
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[85dvh]">
+        <DrawerTitle className="px-4 pt-1 text-sm font-medium">Attachments</DrawerTitle>
+        <p className="px-4 pb-2 text-xs text-muted-foreground">
+          {attachments.length} {attachments.length === 1 ? "file" : "files"}
+          {failed.length > 0 && <span className="font-medium text-destructive"> · {failed.length} failed</span>}
+        </p>
+        <ul className="min-h-0 flex-1 overflow-y-auto px-2">
+          {attachments.map((attachment) => {
+            const isUploading = attachment.status === "uploading"
+            const isError = attachment.status === "error"
+            let Icon = iconForType(uploadGalleryType(attachment))
+            if (isUploading) Icon = Loader2
+            else if (isError) Icon = AlertCircle
+            let statusText: ReactNode = formatFileSize(attachment.sizeBytes)
+            if (isUploading) statusText = `Uploading — ${Math.round((attachment.progress ?? 0) * 100)}%`
+            else if (isError) statusText = attachment.error || "Upload failed"
+            return (
+              <li
+                key={attachmentKey(attachment)}
+                className="flex items-center gap-3 border-b border-border/50 px-2 py-2.5 last:border-b-0"
+              >
+                <span
+                  className={cn(
+                    "flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground",
+                    isError && "bg-destructive/10 text-destructive"
+                  )}
+                >
+                  <Icon className={cn("h-4 w-4", isUploading && "animate-spin")} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm">{attachment.filename}</span>
+                  <span className={cn("block truncate text-xs text-muted-foreground", isError && "text-destructive")}>
+                    {statusText}
+                  </span>
+                </span>
+                {isError && attachment.canRetry === true && (
+                  <button
+                    type="button"
+                    className="px-2 py-1.5 text-xs font-medium text-primary"
+                    onClick={() => void retryUpload(attachment.id)}
+                    aria-label={`Retry upload of ${attachment.filename}`}
+                  >
+                    Retry
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="rounded-full p-1.5 text-muted-foreground active:bg-muted"
+                  onClick={() => (isUploading ? onCancelUpload(attachment.id) : onRemove(attachment.id))}
+                  aria-label={isUploading ? `Cancel upload of ${attachment.filename}` : `Remove ${attachment.filename}`}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+        {failed.length > 0 && (
+          <div className="flex gap-2 px-4 pt-2 pb-[max(12px,env(safe-area-inset-bottom))]">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              onClick={() => {
+                for (const a of failed) onRemove(a.id)
+              }}
+            >
+              Remove failed
+            </Button>
+            {retryable.length > 0 && (
+              <Button
+                size="sm"
+                className="flex-1"
+                onClick={() => {
+                  for (const a of retryable) void retryUpload(a.id)
+                }}
+              >
+                Retry all
+              </Button>
+            )}
+          </div>
+        )}
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
 interface PendingAttachmentsProps {
   attachments: PendingAttachment[]
   onRemove: (id: string) => void
@@ -307,6 +432,13 @@ interface PendingAttachmentsProps {
    * from two references up.
    */
   referenceCounts?: ReadonlyMap<string, number>
+  /**
+   * The mobile composer is in its resting (single-line bar) state: fold the
+   * chips down to the rollup line so a parked draft doesn't occupy the reading
+   * strip. The drawer stays reachable through the rollup; the chips return
+   * when the composer opens. No effect on desktop.
+   */
+  resting?: boolean
 }
 
 /**
@@ -317,6 +449,10 @@ interface PendingAttachmentsProps {
  * the leading slot (from local bytes, the non-E2E server thumbnail, or an
  * in-memory E2E decrypt). Non-previewable files keep a plain type-icon chip.
  * Renders nothing when both lists are empty.
+ *
+ * On mobile a one-line rollup sits above the chips — count, failure tally,
+ * bulk retry — and opens {@link AttachmentListDrawer} for the full list; the
+ * chips wrap to a capped couple of rows and can be folded away entirely.
  */
 export function PendingAttachments({
   attachments,
@@ -325,9 +461,16 @@ export function PendingAttachments({
   beforePills,
   workspaceId,
   referenceCounts,
+  resting = false,
 }: PendingAttachmentsProps) {
   const isMobile = useIsMobile()
   const dragHost = useComposerPillDragHost()
+  // Mobile space controls: the chips can be folded away to the one-line rollup
+  // (the composer already competes with the keyboard for the viewport), and the
+  // drawer holds the full list. Both are per-mount — a fresh composer starts
+  // with its chips showing.
+  const [collapsed, setCollapsed] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
   // Open lightbox tracked by the stable attachment key, not the id (which flips
   // temp→server on upload completion), so an open preview survives its upload.
   const [openKey, setOpenKey] = useState<string | null>(null)
@@ -368,39 +511,97 @@ export function PendingAttachments({
 
   const galleryIndex = openKey ? galleryItems.findIndex((g) => g.attachmentId === pendingGalleryId(openKey)) : -1
 
+  const failedCount = attachments.filter((a) => a.status === "error").length
+  const uploadingCount = attachments.filter((a) => a.status === "uploading").length
+  const retryableIds = attachments.filter((a) => a.status === "error" && a.canRetry === true).map((a) => a.id)
+  const CollapseChevron = collapsed ? ChevronDown : ChevronUp
+  const foldChips = isMobile && attachments.length > 0 && (resting || collapsed)
+
   return (
     <>
-      <div
-        className={cn(
-          "flex items-center gap-2 mb-3",
-          isMobile ? "overflow-x-auto" : "flex-wrap max-h-[120px] overflow-y-auto"
-        )}
-      >
-        {beforePills}
-        {attachments.map((attachment) => {
-          const key = attachmentKey(attachment)
-          const ref =
-            workspaceId && !attachment.previewUrl && uploadGalleryType(attachment) != null
-              ? getAttachmentRef(attachment.id)
-              : undefined
-          const shared = {
-            attachment,
-            onRemove,
-            onCancelUpload: onCancelUpload ?? onRemove,
-            onOpen: setOpenKey,
-            onResolveSrc,
-            referenceCount: referenceCounts?.get(attachment.id) ?? 0,
-            row: isMobile,
-            imageIndex: imageIndexes.get(attachment) ?? null,
-            dragHost,
-          }
-          return ref && workspaceId ? (
-            <E2eChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />
-          ) : (
-            <StaticChip key={key} workspaceId={workspaceId} {...shared} />
-          )
-        })}
-      </div>
+      {isMobile && attachments.length > 0 && (
+        <div className="mb-1.5 flex h-6 items-center gap-3 text-xs text-muted-foreground">
+          <button
+            type="button"
+            className="flex min-w-0 items-center gap-1"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="Show all attachments"
+          >
+            <span className="truncate">
+              {attachments.length} {attachments.length === 1 ? "file" : "files"}
+              {uploadingCount > 0 && ` · ${uploadingCount} uploading`}
+            </span>
+            {failedCount > 0 && <span className="font-medium text-destructive">· {failedCount} failed</span>}
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+          </button>
+          {retryableIds.length > 0 && (
+            <button
+              type="button"
+              className="shrink-0 font-medium text-primary"
+              onClick={() => {
+                for (const id of retryableIds) void retryUpload(id)
+              }}
+            >
+              Retry all
+            </button>
+          )}
+          {!resting && (
+            <button
+              type="button"
+              className="-m-1 ml-auto shrink-0 p-1"
+              onClick={() => setCollapsed((value) => !value)}
+              aria-label={collapsed ? "Show attachment chips" : "Hide attachment chips"}
+            >
+              <CollapseChevron className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+      {!foldChips && (
+        <div
+          className={cn(
+            "flex flex-wrap items-center mb-3 overflow-y-auto",
+            // Two chip rows plus a sliver of the third, so "there's more" is
+            // visible without stealing the strip the composer already fights
+            // the keyboard for. The full list lives in the drawer.
+            isMobile ? "max-h-[96px] gap-1.5" : "max-h-[120px] gap-2"
+          )}
+        >
+          {beforePills}
+          {attachments.map((attachment) => {
+            const key = attachmentKey(attachment)
+            const ref =
+              workspaceId && !attachment.previewUrl && uploadGalleryType(attachment) != null
+                ? getAttachmentRef(attachment.id)
+                : undefined
+            const shared = {
+              attachment,
+              onRemove,
+              onCancelUpload: onCancelUpload ?? onRemove,
+              onOpen: setOpenKey,
+              onResolveSrc,
+              referenceCount: referenceCounts?.get(attachment.id) ?? 0,
+              compact: isMobile,
+              imageIndex: imageIndexes.get(attachment) ?? null,
+              dragHost,
+            }
+            return ref && workspaceId ? (
+              <E2eChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />
+            ) : (
+              <StaticChip key={key} workspaceId={workspaceId} {...shared} />
+            )
+          })}
+        </div>
+      )}
+      {isMobile && attachments.length > 0 && (
+        <AttachmentListDrawer
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+          attachments={attachments}
+          onRemove={onRemove}
+          onCancelUpload={onCancelUpload ?? onRemove}
+        />
+      )}
 
       {workspaceId && galleryItems.length > 0 && (
         <MediaGallery

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -54,7 +54,10 @@ function iconForType(type: UploadGalleryType | null): typeof FileIcon {
 /**
  * Wraps a chip as a drag source for the editor's own sensor. A tray drag always
  * inserts a reference, so the chip stays put and the same file can be dropped
- * into the message any number of times.
+ * into the message any number of times. EVERY chip drags — uploading and failed
+ * included: a reference is a binding to the id, not to finished bytes (the same
+ * send-while-uploading model the message itself uses), and a chip whose gestures
+ * die with its upload state hands the flick to the page instead of the tray.
  *
  * `touch-action: pan-y` gives the browser the tray's own scroll axis (the tray
  * wraps and scrolls vertically on every breakpoint); the drag itself activates
@@ -73,7 +76,7 @@ function TrayPillDraggable({
   children: ReactNode
 }) {
   const inputMode = useInputMode()
-  const draggable = host !== null && attachment.status === "uploaded"
+  const draggable = host !== null
   const begin = (event: MouseEvent | TouchEvent, target: EventTarget) => {
     // Every press on a chip owns the click it produces, draggable or not.
     host?.clearActivationClickSuppression()
@@ -84,6 +87,10 @@ function TrayPillDraggable({
       {
         kind: "tray",
         attachmentId: attachment.id,
+        // Marker semantics: the doc pill is a reference, not a transfer gauge —
+        // live status stays on the chip row. A reference dragged in while the
+        // reservation is still in flight carries the temp id; the editor flips
+        // it to the real id when the tray learns it.
         attrs: {
           id: attachment.id,
           filename: attachment.filename,
@@ -108,7 +115,7 @@ function TrayPillDraggable({
   return (
     <span
       className={cn("inline-flex shrink-0", draggable && "cursor-grab")}
-      style={draggable ? { touchAction: "pan-y" } : undefined}
+      style={{ touchAction: "pan-y" }}
       onMouseDown={(event) => begin(event.nativeEvent, event.target)}
       onTouchStart={(event) => begin(event.nativeEvent, event.target)}
       onMouseEnter={hoverHighlights ? () => host?.highlightAttachment(attachment.id) : undefined}

--- a/apps/frontend/src/hooks/use-attachments.test.ts
+++ b/apps/frontend/src/hooks/use-attachments.test.ts
@@ -324,6 +324,38 @@ describe("useAttachments", () => {
       expect(result.current.pendingAttachments[0]).toMatchObject({ id: "attach_123", status: "uploading" })
     })
 
+    it("merges with in-flight uploads instead of evicting them (mid-batch draft write-back)", async () => {
+      mockReserve()
+      vi.spyOn(xhrTransport, "xhrUpload").mockImplementation(() => new Promise(() => {}))
+
+      const { result } = renderHook(() => useAttachments(workspaceId))
+      act(() => {
+        result.current.handleFileSelect(
+          createChangeEvent([
+            createFile("image1.png", "image/png"),
+            createFile("image2.png", "image/png"),
+            createFile("doc.pdf", "application/pdf"),
+          ])
+        )
+      })
+      await waitFor(() => expect(result.current.pendingAttachments.some((a) => a.id === "attach_1")).toBe(true))
+
+      // The draft persists ids as reservations land, and its write-back re-read
+      // restores while the rest of the batch is still reserving/streaming — the
+      // composer must keep holding every picked file, not just the persisted one.
+      act(() => {
+        result.current.restore([{ id: "attach_1", filename: "image1.png", mimeType: "image/png", sizeBytes: 12 }])
+      })
+
+      expect(result.current.pendingAttachments).toHaveLength(3)
+      expect(result.current.pendingAttachments.map((a) => a.filename).sort()).toEqual([
+        "doc.pdf",
+        "image1.png",
+        "image2.png",
+      ])
+      expect(result.current.imageCount).toBe(2)
+    })
+
     it("falls back to inert uploaded facts for ids with no live job (reload case)", () => {
       const { result } = renderHook(() => useAttachments(workspaceId))
       act(() => {

--- a/apps/frontend/src/hooks/use-attachments.test.ts
+++ b/apps/frontend/src/hooks/use-attachments.test.ts
@@ -153,6 +153,24 @@ describe("useAttachments", () => {
       expect(result.current.uploadedIds).toEqual([])
     })
 
+    it("offers no retry on a terminal rejection — the same bytes fail the same way every time", async () => {
+      mockReserve()
+      vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 422, body: { error: "size mismatch" } })
+      vi.spyOn(attachmentsApi, "reportUploadFailure").mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useAttachments(workspaceId))
+      act(() => {
+        result.current.handleFileSelect(createChangeEvent([createFile("test.txt", "text/plain")]))
+      })
+
+      await waitFor(() => expect(result.current.pendingAttachments[0]?.status).toBe("error"))
+      expect(result.current.pendingAttachments[0]).toMatchObject({
+        id: "attach_123",
+        error: "size mismatch",
+        canRetry: false,
+      })
+    })
+
     it("removing a failed upload deletes its leaked reservation", async () => {
       mockReserve()
       vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 422, body: { error: "nope" } })

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -47,8 +47,10 @@ export interface PendingAttachment {
   previewUrl?: string
   /**
    * A failed upload whose bytes can be re-streamed against its reservation
-   * (`retryUpload`). False for reservation failures — nothing durable exists
-   * to retry against, so remove-and-repick is the only recovery.
+   * (`retryUpload`) with a chance of succeeding. False for reservation
+   * failures (nothing durable to retry against) and for terminal rejections
+   * (4xx, swept reservation — the same bytes fail the same way every time);
+   * remove-and-repick is the only recovery for those.
    */
   canRetry?: boolean
 }
@@ -127,7 +129,9 @@ function jobToPending(job: UploadJob): PendingAttachment {
     error: job.error,
     progress: job.status === "uploaded" ? undefined : job.progress,
     previewUrl: job.previewUrl,
-    canRetry: job.status === "error" && !!job.attachmentId,
+    // A terminal rejection (4xx, swept reservation) fails identically on every
+    // retry — only network-class failures earn the affordance.
+    canRetry: job.status === "error" && !!job.attachmentId && job.retryable !== false,
   }
 }
 

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -305,11 +305,29 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
         const job = claimUpload(a.id)
         return job ? { kind: "job" as const, jobId: job.jobId } : { kind: "restored" as const, ...a }
       })
-      entriesRef.current = restored
-      setEntries(restored)
-      const restoredImageCount = attachments.filter((a) => a.mimeType.startsWith("image/")).length
-      setImageCount(restoredImageCount)
-      imageCountRef.current = restoredImageCount
+      // MERGE with what this composer already holds, never replace: the draft
+      // persists ids as their reservations arrive, and its own write-back
+      // re-read can restore mid-batch — evicting the jobs still waiting for
+      // their ids silently dropped every not-yet-reserved file of a multi-pick.
+      // Scope changes clear the entries before restoring, so kept entries are
+      // always this scope's own in-flight work.
+      const restoredIds = new Set(attachments.map((a) => a.id))
+      const restoredJobIds = new Set(restored.flatMap((e) => (e.kind === "job" ? [e.jobId] : [])))
+      const kept = entriesRef.current.filter((entry) => {
+        if (entry.kind === "restored") return !restoredIds.has(entry.id)
+        if (restoredJobIds.has(entry.jobId)) return false
+        const jobAttachmentId = findUploadJob(entry.jobId)?.attachmentId
+        return jobAttachmentId === null || jobAttachmentId === undefined || !restoredIds.has(jobAttachmentId)
+      })
+      const next = [...restored, ...kept]
+      entriesRef.current = next
+      setEntries(next)
+      const mergedImageCount = next.filter((entry) => {
+        const mimeType = entry.kind === "restored" ? entry.mimeType : findUploadJob(entry.jobId)?.mimeType
+        return mimeType?.startsWith("image/") === true
+      }).length
+      setImageCount(mergedImageCount)
+      imageCountRef.current = mergedImageCount
     },
     []
   )

--- a/apps/frontend/src/lib/uploads/upload-manager.test.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.test.ts
@@ -305,6 +305,45 @@ describe("upload-manager", () => {
     for (const job of jobs) await waitForJobStatus(job.jobId, "uploaded")
   })
 
+  it("a release unwinding across a reset cannot grant a post-reset batch a fourth stream", async () => {
+    let nextId = 0
+    vi.spyOn(attachmentsApi, "reserve").mockImplementation(async (_ws, input) => ({
+      attachment: { id: `attach_g${++nextId}`, filename: input.filename } as never,
+      upload: { method: "POST" as const, url: "/x", field: "file" as const },
+    }))
+    const settlers: Array<() => void> = []
+    const xhr = vi.spyOn(xhrTransport, "xhrUpload").mockImplementation(
+      // Deliberately ignores the abort signal: the old transfer's finally must
+      // still be pending when the post-reset batch fills the gate.
+      () =>
+        new Promise((resolve) => {
+          settlers.push(() => resolve({ status: 201, body: {} }))
+        })
+    )
+
+    const stale = startUpload(WS, makeFile())
+    await waitForReservation(stale.jobId)
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(1))
+
+    resetUploadManager()
+    await db.uploadJobs.clear()
+
+    const jobs = Array.from({ length: 4 }, () => startUpload(WS, makeFile()))
+    for (const job of jobs) await waitForReservation(job.jobId)
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(4)) // 1 stale + 3 new; 4th queued
+
+    // The pre-reset transfer settles now — its release belongs to the old
+    // generation and must not open the fourth slot.
+    settlers.shift()!()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(xhr).toHaveBeenCalledTimes(4)
+
+    // A genuine release from the new generation still advances the queue.
+    settlers.shift()!()
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(5))
+    while (settlers.length > 0) settlers.shift()!()
+  })
+
   it("a duplicate-completion loser (404 but settled server-side) resolves as success", async () => {
     mockReserve("attach_dup")
     // Another tab/device won the duplicate completion: this tab's POST 404s
@@ -399,15 +438,10 @@ describe("upload-manager", () => {
     await resumeWorkspaceUploads(WS)
 
     await vi.waitFor(() => {
-      const urls = xhr.mock.calls.map((call) => call[0].url)
-      expect(urls).toHaveLength(3)
-      expect(urls).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining("/attachments/attach_resume/content"),
-          expect.stringContaining("/attachments/attach_heal/content"),
-          expect.stringContaining("/attachments/attach_legacy/content"),
-        ])
-      )
+      // One exact set: proves the three restartable rows streamed AND that
+      // attach_dead did not (INV-23/24).
+      const requested = xhr.mock.calls.map((call) => call[0].url.split("/attachments/")[1]).sort()
+      expect(requested).toEqual(["attach_heal/content", "attach_legacy/content", "attach_resume/content"])
     })
     const dead = getUploadJobByAttachmentId("attach_dead")
     expect(dead).toMatchObject({ status: "error", error: "size mismatch", retryable: false })

--- a/apps/frontend/src/lib/uploads/upload-manager.test.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { attachmentsApi } from "@/api"
+import { ApiError } from "@/api/client"
 import { db } from "@/db"
 import { getAttachmentRef, clearAttachmentRefCache } from "@/lib/crypto/attachment-crypto"
 import * as xhrTransport from "./xhr-upload"
@@ -219,6 +220,89 @@ describe("upload-manager", () => {
     await vi.advanceTimersByTimeAsync(2_000)
     await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(2))
     await vi.waitFor(() => expect(findUploadJob(job.jobId)?.status).toBe("uploaded"))
+  })
+
+  it("waits out a 429 on the byte stream and succeeds — pacing, not failure", async () => {
+    vi.useFakeTimers()
+    mockReserve("attach_paced")
+    const xhr = vi
+      .spyOn(xhrTransport, "xhrUpload")
+      .mockResolvedValueOnce({ status: 429, body: { error: "Rate limit exceeded" } })
+      .mockResolvedValueOnce({ status: 429, body: { error: "Rate limit exceeded" } })
+      .mockResolvedValueOnce({ status: 201, body: {} })
+
+    const job = startUpload(WS, makeFile())
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(1))
+
+    // The rate-limit schedule (5s, then 15s) — deliberately longer than the
+    // whole network backoff, which a 429 must not consume.
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(2))
+    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.waitFor(() => expect(findUploadJob(job.jobId)?.status).toBe("uploaded"))
+  })
+
+  it("429 exhaustion goes terminal but keeps the retry affordance — the bytes are fine", async () => {
+    vi.useFakeTimers()
+    mockReserve("attach_limited")
+    vi.spyOn(attachmentsApi, "reportUploadFailure").mockResolvedValue(undefined)
+    vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 429, body: { error: "Rate limit exceeded" } })
+
+    const job = startUpload(WS, makeFile())
+    await vi.waitFor(() => expect(findUploadJob(job.jobId)?.status).toBe("uploading"))
+    await vi.advanceTimersByTimeAsync(200_000) // exhaust 5/15/30/60/60
+    await vi.waitFor(() => expect(findUploadJob(job.jobId)?.status).toBe("error"))
+
+    expect(findUploadJob(job.jobId)).toMatchObject({ error: "Rate limit exceeded", retryable: true })
+  })
+
+  it("a rate-limited reservation waits in place instead of stranding the file without an id", async () => {
+    vi.useFakeTimers()
+    const reserve = vi
+      .spyOn(attachmentsApi, "reserve")
+      .mockRejectedValueOnce(new ApiError(429, "rate_limited", "Rate limit exceeded"))
+      .mockImplementation(async (_ws, input) => ({
+        attachment: { id: "attach_waited", filename: input.filename } as never,
+        upload: { method: "POST" as const, url: "/x", field: "file" as const },
+      }))
+    vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 201, body: {} })
+
+    const job = startUpload(WS, makeFile())
+    await vi.waitFor(() => expect(reserve).toHaveBeenCalledTimes(1))
+    expect(findUploadJob(job.jobId)?.status).toBe("reserving")
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => expect(findUploadJob(job.jobId)?.attachmentId).toBe("attach_waited"))
+    await vi.waitFor(() => expect(findUploadJob(job.jobId)?.status).toBe("uploaded"))
+  })
+
+  it("caps concurrent byte streams at three; the rest queue and start as slots free", async () => {
+    let nextId = 0
+    vi.spyOn(attachmentsApi, "reserve").mockImplementation(async (_ws, input) => ({
+      attachment: { id: `attach_q${++nextId}`, filename: input.filename } as never,
+      upload: { method: "POST" as const, url: "/x", field: "file" as const },
+    }))
+    const settlers: Array<() => void> = []
+    const xhr = vi.spyOn(xhrTransport, "xhrUpload").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settlers.push(() => resolve({ status: 201, body: {} }))
+        })
+    )
+
+    const jobs = Array.from({ length: 5 }, () => startUpload(WS, makeFile()))
+    for (const job of jobs) await waitForReservation(job.jobId)
+
+    // All five are reserved (send can bind every id), but only three stream.
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(3))
+    expect(settlers).toHaveLength(3)
+
+    settlers.shift()!()
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(4))
+    settlers.shift()!()
+    await vi.waitFor(() => expect(xhr).toHaveBeenCalledTimes(5))
+    while (settlers.length > 0) settlers.shift()!()
+    for (const job of jobs) await waitForJobStatus(job.jobId, "uploaded")
   })
 
   it("a duplicate-completion loser (404 but settled server-side) resolves as success", async () => {

--- a/apps/frontend/src/lib/uploads/upload-manager.test.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.test.ts
@@ -285,44 +285,48 @@ describe("upload-manager", () => {
     expect(xhr).toHaveBeenCalledTimes(2)
   })
 
-  it("resumes persisted jobs after a reload: pending rows restart, failed rows surface as failed", async () => {
+  it("resumes persisted jobs after a reload: pending and retryably-failed rows restart, terminal ones stay dead", async () => {
     const xhr = vi.spyOn(xhrTransport, "xhrUpload").mockResolvedValue({ status: 201, body: {} })
+    const row = (
+      attachmentId: string,
+      filename: string,
+      extra: { status: "pending" | "failed"; error?: string; retryable?: boolean }
+    ) => ({
+      attachmentId,
+      workspaceId: WS,
+      filename,
+      mimeType: "text/plain",
+      sizeBytes: 4,
+      e2e: false,
+      blob: new Blob(["data"], { type: "text/plain" }),
+      createdAt: Date.now(),
+      ...extra,
+    })
     await db.uploadJobs.bulkPut([
-      {
-        attachmentId: "attach_resume",
-        workspaceId: WS,
-        filename: "resume.txt",
-        mimeType: "text/plain",
-        sizeBytes: 11,
-        e2e: false,
-        blob: new Blob(["hello world"], { type: "text/plain" }),
-        status: "pending",
-        createdAt: Date.now(),
-      },
-      {
-        attachmentId: "attach_dead",
-        workspaceId: WS,
-        filename: "dead.txt",
-        mimeType: "text/plain",
-        sizeBytes: 4,
-        e2e: false,
-        blob: new Blob(["dead"], { type: "text/plain" }),
-        status: "failed",
-        error: "Network error during upload",
-        createdAt: Date.now(),
-      },
+      row("attach_resume", "resume.txt", { status: "pending" }),
+      // Network-class failure from a previous session (an app kill mid-stream):
+      // reopening IS the back-online moment, so it restarts like a pending row.
+      // A legacy row without the flag gets the same benefit of the doubt.
+      row("attach_heal", "heal.txt", { status: "failed", error: "Network error during upload", retryable: true }),
+      row("attach_legacy", "legacy.txt", { status: "failed", error: "Network error during upload" }),
+      row("attach_dead", "dead.txt", { status: "failed", error: "size mismatch", retryable: false }),
     ])
 
     await resumeWorkspaceUploads(WS)
 
     await vi.waitFor(() => {
-      expect(xhr).toHaveBeenCalledTimes(1)
-      expect(xhr).toHaveBeenCalledWith(
-        expect.objectContaining({ url: expect.stringContaining("/attachments/attach_resume/content") })
+      const urls = xhr.mock.calls.map((call) => call[0].url)
+      expect(urls).toHaveLength(3)
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("/attachments/attach_resume/content"),
+          expect.stringContaining("/attachments/attach_heal/content"),
+          expect.stringContaining("/attachments/attach_legacy/content"),
+        ])
       )
     })
     const dead = getUploadJobByAttachmentId("attach_dead")
-    expect(dead).toMatchObject({ status: "error", error: "Network error during upload" })
+    expect(dead).toMatchObject({ status: "error", error: "size mismatch", retryable: false })
     await vi.waitFor(async () => expect(await db.uploadJobs.get("attach_resume")).toBeUndefined())
   })
 

--- a/apps/frontend/src/lib/uploads/upload-manager.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.ts
@@ -26,7 +26,7 @@
  */
 
 import { attachmentsApi } from "@/api"
-import { API_BASE } from "@/api/client"
+import { API_BASE, ApiError } from "@/api/client"
 import { db, type CachedUploadJob } from "@/db"
 import { encryptAttachmentBytes, rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { uploadGalleryType } from "@/components/gallery/upload-preview"
@@ -38,8 +38,55 @@ import { XhrNetworkError } from "./xhr-upload"
 const E2E_CIPHERTEXT_FILENAME = "encrypted"
 const E2E_CIPHERTEXT_MIME = "application/octet-stream"
 
-/** Backoff for transient (network / 5xx / 429) failures before going terminal. */
+/** Backoff for transient (network / 5xx) failures before going terminal. */
 const RETRY_DELAYS_MS = [2_000, 5_000, 15_000]
+
+/**
+ * Backoff for 429s, on the reservation and the byte stream alike. The server's
+ * upload window is per-minute and each file costs two requests (reserve +
+ * content), so a big batch legitimately overruns it — waiting out the window
+ * is normal pacing, not a failure, and it gets a schedule long enough to
+ * actually reach the next window instead of burning the network budget in 22s.
+ */
+const RATE_LIMIT_RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 60_000]
+
+/**
+ * At most this many byte streams in flight; the rest queue FIFO. Reservations
+ * stay unqueued — one cheap request each, and the id must land immediately for
+ * send-while-uploading. The cap keeps a batch from opening every transfer at
+ * once (the `Promise.all` burst that ate the whole rate window in one second).
+ */
+const MAX_CONCURRENT_TRANSFERS = 3
+let activeTransfers = 0
+const transferQueue: Array<() => void> = []
+
+function acquireTransferSlot(signal: AbortSignal): Promise<void> {
+  if (activeTransfers < MAX_CONCURRENT_TRANSFERS) {
+    activeTransfers++
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    const grant = () => {
+      signal.removeEventListener("abort", onAbort)
+      activeTransfers++
+      resolve()
+    }
+    const onAbort = () => {
+      const index = transferQueue.indexOf(grant)
+      if (index !== -1) transferQueue.splice(index, 1)
+      reject(new DOMException("Aborted", "AbortError"))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+    transferQueue.push(grant)
+  })
+}
+
+function releaseTransferSlot(): void {
+  // Floored at zero: resetUploadManager zeroes the gate while aborted
+  // transfers may still be unwinding toward their own release.
+  activeTransfers = Math.max(0, activeTransfers - 1)
+  transferQueue.shift()?.()
+}
 
 export type UploadJobStatus = "reserving" | "uploading" | "uploaded" | "error"
 
@@ -330,16 +377,26 @@ async function runReserveAndUpload(jobId: string, file: File, signal: AbortSigna
     }
     if (signal.aborted) return
 
-    const reservation = await attachmentsApi.reserve(
-      job.workspaceId,
-      {
-        filename: job.e2e ? E2E_CIPHERTEXT_FILENAME : job.filename,
-        mimeType: job.e2e ? E2E_CIPHERTEXT_MIME : job.mimeType,
-        sizeBytes: uploadBlob.size,
-        ...(job.e2e && { e2e: true }),
-      },
-      { signal }
-    )
+    const reserveInput = {
+      filename: job.e2e ? E2E_CIPHERTEXT_FILENAME : job.filename,
+      mimeType: job.e2e ? E2E_CIPHERTEXT_MIME : job.mimeType,
+      sizeBytes: uploadBlob.size,
+      ...(job.e2e && { e2e: true }),
+    }
+    // A rate-limited reservation waits out the window in place (the job stays
+    // `reserving`); failing it terminally would strand the file with no id and
+    // therefore no retry affordance at all.
+    let reservation: Awaited<ReturnType<typeof attachmentsApi.reserve>>
+    for (let attempt = 0; ; attempt++) {
+      try {
+        reservation = await attachmentsApi.reserve(job.workspaceId, reserveInput, { signal })
+        break
+      } catch (err) {
+        const rateLimited = ApiError.isApiError(err) && err.status === 429
+        if (!rateLimited || attempt >= RATE_LIMIT_RETRY_DELAYS_MS.length) throw err
+        await sleep(RATE_LIMIT_RETRY_DELAYS_MS[attempt], signal)
+      }
+    }
     const attachmentId = reservation.attachment?.id
     if (!attachmentId) throw new Error("Invalid response: missing attachment data")
 
@@ -407,7 +464,17 @@ async function uploadBytes(jobId: string, signal: AbortSignal): Promise<void> {
   const job = state.jobs.get(jobId)
   if (!job?.attachmentId) return
   const { workspaceId, attachmentId } = job
-  await withUploadLock(attachmentId, () => uploadBytesLocked(jobId, workspaceId, attachmentId, signal))
+  try {
+    await acquireTransferSlot(signal)
+  } catch (err) {
+    if (isAbortError(err)) return
+    throw err
+  }
+  try {
+    await withUploadLock(attachmentId, () => uploadBytesLocked(jobId, workspaceId, attachmentId, signal))
+  } finally {
+    releaseTransferSlot()
+  }
 }
 
 /** Settle the job locally as successfully uploaded. */
@@ -435,7 +502,13 @@ async function uploadBytesLocked(
   // Network-class failures (connection drops, 5xx, 429 exhaustion) leave the
   // bytes retryable; a 4xx rejection or non-network throw is terminal.
   let terminalRetryable = true
-  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+  // Separate budgets: a 429 is the server pacing us, not the link failing, so
+  // waiting out the rate window must not consume the (much shorter) network
+  // retry schedule.
+  let networkAttempt = 0
+  let rateLimitAttempt = 0
+  while (true) {
+    let retryDelay: number | null = null
     try {
       await waitForOnline(signal)
       const response = await xhrTransport.xhrUpload({
@@ -458,7 +531,14 @@ async function uploadBytesLocked(
       }
 
       const body = response.body as { error?: string; code?: string } | null
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+      if (response.status === 429) {
+        if (rateLimitAttempt >= RATE_LIMIT_RETRY_DELAYS_MS.length) {
+          terminalError = body?.error ?? "Rate limit exceeded"
+          break
+        }
+        retryDelay = RATE_LIMIT_RETRY_DELAYS_MS[rateLimitAttempt]
+        rateLimitAttempt += 1
+      } else if (response.status >= 400 && response.status < 500) {
         terminalRetryable = false
         // A duplicate completion race (another tab/device already settled this
         // upload) surfaces as 404/409 here — that's a success, not a failure.
@@ -478,8 +558,9 @@ async function uploadBytesLocked(
         }
         terminalError = body?.error ?? `Upload rejected (${response.status})`
         break
+      } else {
+        terminalError = body?.error ?? `Upload failed (${response.status})`
       }
-      terminalError = body?.error ?? `Upload failed (${response.status})`
     } catch (err) {
       if (isAbortError(err) || signal.aborted) return
       if (!(err instanceof XhrNetworkError)) {
@@ -490,12 +571,15 @@ async function uploadBytesLocked(
       terminalError = "Network error during upload"
     }
 
-    if (attempt < RETRY_DELAYS_MS.length) {
-      try {
-        await sleep(RETRY_DELAYS_MS[attempt], signal)
-      } catch {
-        return // aborted while waiting
-      }
+    if (retryDelay === null) {
+      if (networkAttempt >= RETRY_DELAYS_MS.length) break
+      retryDelay = RETRY_DELAYS_MS[networkAttempt]
+      networkAttempt += 1
+    }
+    try {
+      await sleep(retryDelay, signal)
+    } catch {
+      return // aborted while waiting
     }
   }
 
@@ -653,6 +737,10 @@ export function resetUploadManager(): void {
   resumeEpoch++
   for (const controller of controllers.values()) controller.abort()
   controllers.clear()
+  // Nothing holds a transfer slot after a teardown; queued acquires were
+  // rejected by their aborted signals above.
+  transferQueue.length = 0
+  activeTransfers = 0
   for (const job of state.jobs.values()) revokePreviewUrl(job.previewUrl)
   state.jobs.clear()
   blobs.clear()

--- a/apps/frontend/src/lib/uploads/upload-manager.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.ts
@@ -59,17 +59,24 @@ const RATE_LIMIT_RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 60_000]
 const MAX_CONCURRENT_TRANSFERS = 3
 let activeTransfers = 0
 const transferQueue: Array<() => void> = []
+/**
+ * Bumped by resetUploadManager. A slot release carries the generation it was
+ * acquired under; a release from before a reset is ignored — the reset already
+ * zeroed the gate, and letting the stale decrement through would grant a
+ * fourth stream to a batch started after the reset.
+ */
+let transferGateGeneration = 0
 
-function acquireTransferSlot(signal: AbortSignal): Promise<void> {
+function acquireTransferSlot(signal: AbortSignal): Promise<number> {
   if (activeTransfers < MAX_CONCURRENT_TRANSFERS) {
     activeTransfers++
-    return Promise.resolve()
+    return Promise.resolve(transferGateGeneration)
   }
   return new Promise((resolve, reject) => {
     const grant = () => {
       signal.removeEventListener("abort", onAbort)
       activeTransfers++
-      resolve()
+      resolve(transferGateGeneration)
     }
     const onAbort = () => {
       const index = transferQueue.indexOf(grant)
@@ -81,9 +88,8 @@ function acquireTransferSlot(signal: AbortSignal): Promise<void> {
   })
 }
 
-function releaseTransferSlot(): void {
-  // Floored at zero: resetUploadManager zeroes the gate while aborted
-  // transfers may still be unwinding toward their own release.
+function releaseTransferSlot(generation: number): void {
+  if (generation !== transferGateGeneration) return
   activeTransfers = Math.max(0, activeTransfers - 1)
   transferQueue.shift()?.()
 }
@@ -464,8 +470,9 @@ async function uploadBytes(jobId: string, signal: AbortSignal): Promise<void> {
   const job = state.jobs.get(jobId)
   if (!job?.attachmentId) return
   const { workspaceId, attachmentId } = job
+  let slotGeneration: number
   try {
-    await acquireTransferSlot(signal)
+    slotGeneration = await acquireTransferSlot(signal)
   } catch (err) {
     if (isAbortError(err)) return
     throw err
@@ -473,7 +480,7 @@ async function uploadBytes(jobId: string, signal: AbortSignal): Promise<void> {
   try {
     await withUploadLock(attachmentId, () => uploadBytesLocked(jobId, workspaceId, attachmentId, signal))
   } finally {
-    releaseTransferSlot()
+    releaseTransferSlot(slotGeneration)
   }
 }
 
@@ -738,7 +745,9 @@ export function resetUploadManager(): void {
   for (const controller of controllers.values()) controller.abort()
   controllers.clear()
   // Nothing holds a transfer slot after a teardown; queued acquires were
-  // rejected by their aborted signals above.
+  // rejected by their aborted signals above, and the generation bump makes
+  // any still-unwinding transfer's eventual release a no-op.
+  transferGateGeneration++
   transferQueue.length = 0
   activeTransfers = 0
   for (const job of state.jobs.values()) revokePreviewUrl(job.previewUrl)

--- a/apps/frontend/src/lib/uploads/upload-manager.ts
+++ b/apps/frontend/src/lib/uploads/upload-manager.ts
@@ -583,8 +583,8 @@ let resumeEpoch = 0
 
 /**
  * Resume this workspace's persisted upload jobs after a reload/app reopen:
- * pending rows restart their transfer immediately, failed rows surface as
- * failed (the timeline chip offers retry). Idempotent per workspace per
+ * pending and retryably-failed rows restart their transfer immediately;
+ * terminally-failed rows surface as failed. Idempotent per workspace per
  * session; jobs already live in memory are skipped.
  */
 export async function resumeWorkspaceUploads(workspaceId: string): Promise<void> {
@@ -612,7 +612,12 @@ export async function resumeWorkspaceUploads(workspaceId: string): Promise<void>
     const jobId = newJobId()
     jobIdByAttachmentId.set(row.attachmentId, jobId)
     blobs.set(jobId, row.blob)
-    const failed = row.status === "failed"
+    // A retryable failure (network-class) restarts alongside the pending rows:
+    // reopening the app IS the connectivity-restored moment for a transfer that
+    // died with the page, and the `online` auto-heal never fires for it — the
+    // browser wasn't open to see the transition. Only terminal rejections
+    // surface as dead.
+    const failed = row.status === "failed" && row.retryable === false
     state.jobs.set(jobId, {
       jobId,
       workspaceId,
@@ -623,8 +628,8 @@ export async function resumeWorkspaceUploads(workspaceId: string): Promise<void>
       e2e: row.e2e,
       status: failed ? "error" : "uploading",
       progress: 0,
-      error: row.error,
-      retryable: failed ? (row.retryable ?? true) : undefined,
+      error: failed ? row.error : undefined,
+      retryable: failed ? false : undefined,
       // E2E rows hold ciphertext — nothing previewable locally.
       previewUrl: row.e2e ? undefined : createPreviewUrl(row.blob, row),
       // Resumed jobs start unheld; a draft restore may claim them.


### PR DESCRIPTION
## Why

Field report from a phone (video): a draft holding ~20 attachments showed every tray chip red with "Retry", and the single horizontal chip row was nearly unusable — no overview, and vertical flicks fought the page scroll. Diagnosis: the uploads had died with a backgrounded page; on reopen, resume left retryable failures dead (the `online` auto-heal event never fires for a transfer that died with the page), the chip offered "Retry" even for reservations the server sweep had already reaped, and the row layout hid 17 of 20 chips.

## Changes

- **Truthful retry.** `canRetry` now requires the job's `retryable` flag — terminal rejections and swept reservations show "Failed" with remove-only recovery instead of a retry that 404s forever.
- **Self-healing resume.** `resumeWorkspaceUploads` restarts retryably-failed rows exactly like interrupted ones; only terminal failures surface dead. Reopening the app is the back-online moment.
- **Mobile tray redesign.** The horizontal scroll row is gone: chips wrap (two per row, size text dropped) capped at ~2.5 rows with vertical scroll, under a rollup line — "12 files · 2 uploading · 2 failed", bulk **Retry {n}** (the true retryable count), and a fold chevron. Tapping the rollup opens a bottom-sheet drawer: full filenames, live per-row status, per-row retry/remove, bulk "Retry {n}" / "Remove failed".
- **Space-aware resting state.** While the mobile composer sits in its single-line bar, the tray folds to the rollup line (same rule as composer link previews), so a parked draft no longer occupies the reading strip.
- Touch mechanics: tray chips now use `touch-action: pan-y` everywhere — vertical flicks scroll, long-press still drags into the composer (activation is hold-based, so it needs no axis).

## Verification

Full frontend suite green (6630 tests, 7 net new: rollup counts/bulk retry scoping, fold/resting states, drawer actions, resume auto-retry, terminal-rejection `canRetry`); typecheck + lint clean; Playwright visual pass at 390×844 (resting / open / folded / drawer) and 1440×900 (desktop tray unchanged) — screenshots below.

## Residual risk

Real-device touch behavior (long-press drag vs. vertical scroll on the wrapped tray) still needs hardware confirmation.

| Resting | Open | Folded | Drawer |
|---|---|---|---|
| ![resting](https://seer.build/ws_vbyzjvdg6g/i/img_4kt6ev0zbd/tray-mobile-resting.webp) | ![open](https://seer.build/ws_vbyzjvdg6g/i/img_kd2x7g102q/tray-mobile-tray.webp) | ![folded](https://seer.build/ws_vbyzjvdg6g/i/img_t075cm5n2t/tray-mobile-tray-collapsed.webp) | ![drawer](https://seer.build/ws_vbyzjvdg6g/i/img_11k3436d5w/tray-mobile-drawer.webp) |

Desktop — same rollup (counts, bulk retry, fold), plain-text summary since the taller wrapped tray is its own full list (no drawer):

![desktop](https://seer.build/ws_vbyzjvdg6g/i/img_8zjydgxdwf/tray-desktop-rollup.webp)

`399c5314` addresses the in-branch code review: resting folds context-ref pills too, the drawer survives its exit animation when the list empties, bulk retry carries the true retryable count, and the rollup line keeps editor focus like the action bar.

`a27ec29b` widens dragging to the whole tray: uploading, failed, and still-reserving chips all drag into the composer (a reference binds the id, not finished bytes — the send-while-uploading model), the `/attachment` picker offers the same set, and every chip owns `touch-action: pan-y` so a flick on any chip scrolls the tray instead of the page. A temp-id reference from a drag during the reservation window flips to the real id (with its image ordinal) when the reservation lands — ordered after the external-value sync effect, which would otherwise revert the flip when a value change and an upload tick share a commit. Suite: 6658 pass / 0 fail.

`d1f91646` brings the rollup line to desktop — same counts, bulk retry, and fold as mobile; only the drawer stays a phone affordance. Suite: 6659 pass / 0 fail.

`19c57be0` fixes multi-file batches bursting into the upload rate limit (20 req/min/user shared by reserve + content = a 10-file budget, and the client opened every transfer at once): byte streams gate at 3 concurrent, 429s wait out the window on a dedicated 5s–60s schedule on both the reservation and content paths (a rate-limited reservation retries in place instead of stranding the file with no id and no retry affordance), 429 exhaustion stays retryable, and the server window rises to 60/min to fit the 20-file design target. Suites: frontend 6663 / backend-unit 4054, 0 fail.

`b82900ac` fixes multi-pick attachments vanishing from the tray: the draft persists ids as reservations land, and its write-back re-read fired the late-hydrate `restore()` mid-batch — replacing the composer's held entries with the one id the draft knew, orphaning the rest (user-visible as 5 chips collapsing to 1). `restore()` now merges: restored ids first, then every entry the composer holds that the draft doesn't know yet; scope changes still clear the tray first, so nothing crosses streams. Regression test pins the mid-batch write-back scenario. Verification note: local full-suite runs on this change flaked one unrelated test per run (different file each time — draft-pointer timing, then a sidebar test; each passes in isolation and the failing draft file mocks `useAttachments` wholesale, so the changed code is unreachable there) — CI is the authoritative gate.
