### PR TITLE
mobile scroll/gesture wins

### DIFF
--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -341,6 +341,34 @@ describe("useTimelineScroll — scroll position", () => {
     expect(harness.current.isFollowingTailRef.current).toBe(false)
   })
 
+  it("disarms follow on an upward touch drag inside the at-bottom band even while content heights are shifting", () => {
+    // The mobile "won't let me correct it" bug: while typing, every keystroke
+    // grows the composer footer spacer, so scroll frames are height-UNSTABLE
+    // and the scrollTop-delta scroll-up detection (`scrolledUp`) never fires.
+    // Inside the at-bottom band that meant the upward drag was read as "still
+    // at the bottom" and follow re-armed — the next re-pin won over the
+    // user's finger. The gesture's own direction (touch finger delta) must
+    // disarm follow regardless of height stability.
+    const userInteractedAtRef = { current: 0 }
+    const harness = renderScrollHook(opts({ itemCount: 50, getFirstKey: () => "e10", userInteractedAtRef }))
+    let height = 5000
+    const el = makeScrollerDiv({ scrollHeight: 5000, clientHeight: 800, scrollTop: 4200 })
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height })
+    act(() => harness.current.registerScroller(el))
+    act(() => harness.current.handleScroll())
+    expect(harness.current.isFollowingTailRef.current).toBe(true)
+    // Finger lands and drags DOWN (content down = viewport scrolls up) — the
+    // touch listeners stamp the gesture and record its direction.
+    el.dispatchEvent(Object.assign(new Event("touchstart"), { touches: [{ clientY: 300 }] }))
+    el.dispatchEvent(Object.assign(new Event("touchmove"), { touches: [{ clientY: 380 }] }))
+    // The composer grew in the same beat: scrollTop drops a little while
+    // scrollHeight rises, landing still inside the 32px at-bottom band.
+    height = 5010
+    el.scrollTop = 4190
+    act(() => harness.current.handleScroll())
+    expect(harness.current.isFollowingTailRef.current).toBe(false)
+  })
+
   it("does not detach from sub-threshold jitter inside the band without a gesture", () => {
     // The same small scrollTop move with NO gesture (reflow jitter, momentum
     // settle) must keep follow armed — only a deliberate gesture detaches.
@@ -412,6 +440,50 @@ describe("useTimelineScroll — observer attaches when the scroller mounts late"
       expect(el.scrollTop).toBe(1000)
       act(() => observers[0].cb([], observers[0] as unknown as ResizeObserver))
       expect(el.scrollTop).toBe(5000)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("leaves a detached reader's scrollTop alone when the viewport resizes (keyboard open/close)", () => {
+    // The scroller resizes at its BOTTOM edge (keyboard, composer chrome), so
+    // an untouched scrollTop keeps what the user positioned at the top of the
+    // viewport in place. The old delta-shift anchored the bottom edge instead,
+    // pushing the message a replier had parked at the top out of the viewport
+    // on every composer open.
+    const observers: MockResizeObserver[] = []
+    class MockResizeObserver {
+      targets: Element[] = []
+      constructor(public cb: ResizeObserverCallback) {
+        observers.push(this)
+      }
+      observe(t: Element) {
+        this.targets.push(t)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    try {
+      const harness = renderScrollHook(opts({ itemCount: 50, getFirstKey: () => "e10" }))
+      const content = document.createElement("div")
+      harness.current.contentRef.current = content
+      const el = makeScrollerDiv({ scrollHeight: 5000, clientHeight: 800, scrollTop: 2000 })
+      act(() => harness.current.registerScroller(el))
+      act(() => harness.current.disableAutoScroll())
+      // Keyboard opens: the scroller shrinks 800 → 500 and the observer fires
+      // with a viewport entry.
+      Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 500 })
+      act(() =>
+        observers[0].cb([{ target: el } as unknown as ResizeObserverEntry], observers[0] as unknown as ResizeObserver)
+      )
+      expect(el.scrollTop).toBe(2000)
+      // And closes again: still hands-off.
+      Object.defineProperty(el, "clientHeight", { configurable: true, get: () => 800 })
+      act(() =>
+        observers[0].cb([{ target: el } as unknown as ResizeObserverEntry], observers[0] as unknown as ResizeObserver)
+      )
+      expect(el.scrollTop).toBe(2000)
     } finally {
       vi.unstubAllGlobals()
     }
@@ -612,6 +684,68 @@ describe("useTimelineScroll — dead-band dock (downward release short of the bo
       gestureScrollTo(harness, el, userInteractedAtRef, 4140)
       expect(harness.current.isFollowingTailRef.current).toBe(false)
       // Scroll events go quiet — the settle window elapses.
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(5000)
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not dock an upward touch drag whose scrollTop deltas are masked by reflow (stale 'down' direction)", () => {
+    // The video'd mobile yank: an upward touch drag through height-unstable
+    // frames (virtua measuring, composer growing) never recorded via the
+    // scrollTop-delta path, so the direction ref kept a stale "down" from an
+    // earlier gesture — and 200ms after the finger lifted, the dock "completed"
+    // a downward gesture the user never made, force-scrolling to the bottom
+    // and re-arming follow. Direction read off the touch events themselves
+    // must keep the release parked.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      // An earlier downward wheel recorded "down".
+      el.dispatchEvent(Object.assign(new Event("wheel"), { deltaY: 120 }))
+      // New touch gesture: finger drags the content down (viewport scrolls up)
+      // while every frame is height-unstable.
+      let height = 5000
+      Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height })
+      el.dispatchEvent(Object.assign(new Event("touchstart"), { touches: [{ clientY: 200 }] }))
+      el.dispatchEvent(Object.assign(new Event("touchmove"), { touches: [{ clientY: 320 }] }))
+      height = 5060
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      el.dispatchEvent(Object.assign(new Event("touchend"), { touches: [] }))
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(4140)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("caps the dock band when the composer dwarfs the viewport (mobile keyboard open)", () => {
+    // On mobile the composer can be a third of the viewport, so treating the
+    // full composer height as "undershot the bottom" docked deliberate
+    // reading positions. The band is capped at a quarter of the viewport:
+    // releases beyond it stay put, releases inside it still dock.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      // Keyboard-open mobile: composer 380px over an 800px scroller → the
+      // uncapped band would be 380+32; the cap brings it to 200+32.
+      el.style.setProperty("--composer-height", "380px")
+      gestureScrollTo(harness, el, userInteractedAtRef, 3600)
+      // Downward release 300px short of max: inside the uncapped band, outside
+      // the capped one — a chosen position, stays.
+      gestureScrollTo(harness, el, userInteractedAtRef, 3900)
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(3900)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+      // Downward release 100px short: inside the capped band → docks.
+      gestureScrollTo(harness, el, userInteractedAtRef, 4100)
       act(() => vi.advanceTimersByTime(200))
       expect(el.scrollTop).toBe(5000)
       expect(harness.current.isFollowingTailRef.current).toBe(true)

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -713,12 +713,44 @@ describe("useTimelineScroll — dead-band dock (downward release short of the bo
       Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height })
       el.dispatchEvent(Object.assign(new Event("touchstart"), { touches: [{ clientY: 200 }] }))
       el.dispatchEvent(Object.assign(new Event("touchmove"), { touches: [{ clientY: 320 }] }))
-      height = 5060
+      // Release INSIDE the dock band (5010 - 4140 - 800 = 70 ≤ 70 + 32), so
+      // only the corrected direction — not the band check — prevents the dock.
+      height = 5010
       gestureScrollTo(harness, el, userInteractedAtRef, 4140)
       el.dispatchEvent(Object.assign(new Event("touchend"), { touches: [] }))
       act(() => vi.advanceTimersByTime(200))
       expect(el.scrollTop).toBe(4140)
       expect(harness.current.isFollowingTailRef.current).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not let a finger-lift reversal flip a downward drag's direction (still docks)", () => {
+    // The last touchmove before lift-off commonly reverses 2–3px as the finger
+    // peels off the glass. Recording it verbatim flipped a long downward drag
+    // to "up" at the last instant, so the dock the drag was heading into never
+    // fired. Direction recording has hysteresis: sub-threshold moves don't flip.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      let height = 5000
+      Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height })
+      // Finger sweeps up the glass (viewport scrolls DOWN, toward the tail)…
+      el.dispatchEvent(Object.assign(new Event("touchstart"), { touches: [{ clientY: 500 }] }))
+      el.dispatchEvent(Object.assign(new Event("touchmove"), { touches: [{ clientY: 380 }] }))
+      // …then reverses 3px on lift-off. Sub-threshold: direction stays "down".
+      el.dispatchEvent(Object.assign(new Event("touchmove"), { touches: [{ clientY: 383 }] }))
+      // Height-unstable release inside the band, so the scroll-based recording
+      // cannot correct a flipped direction — only the hysteresis protects it.
+      height = 5010
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      el.dispatchEvent(Object.assign(new Event("touchend"), { touches: [] }))
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(5010)
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
     } finally {
       vi.unstubAllGlobals()
       vi.useRealTimers()

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -30,6 +30,19 @@ function readComposerHeight(el: HTMLElement): number {
   return Number.isFinite(px) ? px : 0
 }
 
+/**
+ * The dead-band dock's trigger band. The composer hides exactly
+ * `--composer-height` px of scroll range, but on mobile (keyboard open) the
+ * composer can dwarf the visible strip — treating ALL of it as "undershot the
+ * bottom" docked deliberate reading positions. A downward release more than a
+ * quarter of the viewport above the tail is a chosen position, not an
+ * undershoot; desktop composers are far under the cap, so nothing changes
+ * there.
+ */
+function dockBandPx(el: HTMLElement): number {
+  return Math.min(readComposerHeight(el), el.clientHeight / 4)
+}
+
 interface UseTimelineScrollOptions {
   /** Total item count of the virtualized list. */
   itemCount: number
@@ -200,15 +213,26 @@ export function useTimelineScroll({
   const initialSettleCleanupRef = useRef<((reveal?: boolean) => void) | null>(null)
 
   // Direction of the last GESTURE-DRIVEN scroll movement (null until one
-  // happens). Only gesture-fresh, height-stable deltas record here: momentum
-  // events after a flick carry no fresh gesture stamp but only ever continue
-  // the drag's direction, so the drag-phase value stays correct through them —
-  // while programmatic positioning (divider/deep-link scrolls, our pins, the
-  // observer's viewport shifts) and browser clamps never register. The
-  // dead-band dock below consults this so it only ever completes a gesture
-  // that was heading TOWARD the bottom; an upward nudge (peeking at context
-  // while typing) is a position the user chose, and docking it would undo
-  // what they just revealed at the top of the viewport.
+  // happens). Two writers, both immune to programmatic positioning (divider/
+  // deep-link scrolls, our pins, browser clamps):
+  //  - The input events themselves (wheel deltaY sign, touch finger delta, in
+  //    the gesture-stamp effect below). Unambiguous regardless of content
+  //    reflow — on mobile the content height is rarely stable mid-drag (virtua
+  //    measuring rows, the composer growing per keystroke), so scrollTop-delta
+  //    recording alone skipped those frames and a stale "down" made the
+  //    dead-band dock complete an upward gesture the user never made. A fresh
+  //    touchstart clears it: a tap must not inherit the previous gesture's
+  //    direction.
+  //  - Gesture-fresh, height-stable scrollTop deltas in handleScroll — the
+  //    only signal a desktop scrollbar drag emits.
+  // Momentum events after a flick carry no fresh gesture stamp but only ever
+  // continue the drag's direction, so the drag-phase value stays correct
+  // through them. The dead-band dock consults this so it only ever completes a
+  // gesture that was heading TOWARD the bottom; an upward nudge (peeking at
+  // context while typing) is a position the user chose, and docking it would
+  // undo what they just revealed at the top of the viewport. handleScroll also
+  // reads it to disarm follow on an upward drag whose scrollTop movement is
+  // masked by reflow.
   const lastGestureScrollDirRef = useRef<"up" | "down" | null>(null)
 
   // Reset all scroll state synchronously when the stream changes, before the
@@ -416,6 +440,13 @@ export function useTimelineScroll({
       if (el.scrollTop > prevTop + 1) lastGestureScrollDirRef.current = "down"
       else if (el.scrollTop < prevTop - 1) lastGestureScrollDirRef.current = "up"
     }
+    // The gesture's own direction (wheel deltaY / touch finger delta, recorded
+    // by the gesture-stamp effect) says the user is heading up while we sit
+    // above the true bottom. This is the signal that stays reliable on mobile:
+    // mid-drag the content height is rarely stable (virtua measuring rows, the
+    // composer growing per keystroke), so `scrolledUp` misses the movement and
+    // the re-pin used to win over the user's finger.
+    const gestureIntentUp = lastGestureScrollDirRef.current === "up" && userGestured && distanceFromBottom > 1
     // The composer footer spacer is dead space at the very bottom. During the
     // initial cold-load settle we keep the generous composer-height band so a
     // slightly-undershoot landing doesn't disarm follow before convergence; once
@@ -433,7 +464,7 @@ export function useTimelineScroll({
     // no scroller gesture, so they never count as a user scroll-up and follow
     // stays armed through a keyboard open. Content growth never lowers scrollTop,
     // and our own pins sync prevTop, so neither reads as scrolledUp.
-    const userScrolledUp = scrolledUp && userGestured
+    const userScrolledUp = (scrolledUp && userGestured) || gestureIntentUp
     if (atBottom && !userScrolledUp) {
       // Reaching the tail re-arms follow — except in jump mode, where the user
       // is anchored on a deep-linked message and a transient atBottom from
@@ -486,8 +517,12 @@ export function useTimelineScroll({
   //    composer expands/collapses. While following → pin.
   //  - viewport (scrollerRef): shrinks/grows as the mobile keyboard opens/closes
   //    (AppShell is sized to --viewport-height; see useVisualViewport). While
-  //    following → pin; while reading → shift scrollTop by the height delta so
-  //    the row under the user's eyes stays put as the visible area changes.
+  //    following → pin; while reading → hands-off. The scroller resizes at its
+  //    BOTTOM edge, so an untouched scrollTop keeps whatever the user
+  //    positioned at the top of the viewport exactly where it is; shifting by
+  //    the height delta instead anchored the bottom edge, which pushed the
+  //    message a replier had parked at the top up out of the viewport on every
+  //    composer/keyboard open.
   //
   // Every geometry change a user could care about routes through here, so there
   // is no separate media-load listener, composer-resize handler, or per-frame
@@ -498,7 +533,6 @@ export function useTimelineScroll({
     const content = contentRef.current
     if (!scroller || !content) return
 
-    let prevClientHeight = scroller.clientHeight
     let pendingRecheck = 0
     const clearPendingRecheck = () => {
       if (pendingRecheck) {
@@ -521,7 +555,6 @@ export function useTimelineScroll({
         const elapsedSinceGesture = performance.now() - (userInteractedAtRef?.current ?? 0)
         const userScrolling = elapsedSinceGesture < USER_SCROLL_GRACE_MS
         if (!hasViewportEntry && userScrolling) {
-          prevClientHeight = el.clientHeight
           // The resize itself is real — a message, session card, or the composer
           // genuinely changed size — we're only holding off because a scroller
           // gesture landed a moment ago. If that's the only resize this content
@@ -540,20 +573,18 @@ export function useTimelineScroll({
         }
         clearPendingRecheck()
         pinToBottom()
-        prevClientHeight = el.clientHeight
         return
       }
-      // Only a viewport (scroller) resize should move a read position; content
-      // entries leave clientHeight unchanged, so their delta is 0 (no-op).
-      if (!hasViewportEntry) return
-      const clientHeight = el.clientHeight
-      const delta = prevClientHeight - clientHeight
-      prevClientHeight = clientHeight
-      if (delta !== 0) {
-        el.scrollTop += delta
-        prevScrollTopRef.current = el.scrollTop
-        prevScrollHeightRef.current = el.scrollHeight
-      }
+      // Detached (reading): hands-off, for BOTH entry kinds. Content resizes
+      // leave clientHeight unchanged anyway; a viewport resize (keyboard or
+      // composer chrome opening/closing) shrinks or grows the scroller at its
+      // BOTTOM edge, so an untouched scrollTop keeps whatever the user
+      // positioned at the top of the viewport exactly where it is. Shifting
+      // scrollTop by the height delta instead anchored the bottom edge — the
+      // message a replier had parked at the top was pushed out of the viewport
+      // on every composer open. When the viewport grows past the content end
+      // the browser clamps scrollTop on its own; handleScroll never reads that
+      // clamp as a user scroll (it lands exactly at the new bottom).
     })
 
     observer.observe(scroller)
@@ -584,10 +615,20 @@ export function useTimelineScroll({
     }
   }, [resetKey, pinToBottom, scrollerEl])
 
-  // Genuine-input stamp on the owned scroller. wheel/touch/pointer/keydown are
-  // real user gestures; `scroll` is deliberately NOT listened to (our own
-  // programmatic pins fire it). handleScroll and the observer above read this
-  // stamp to tell a deliberate scroll-up from content growth.
+  // Genuine-input stamp + gesture direction on the owned scroller.
+  // wheel/touch/pointer/keydown are real user gestures; `scroll` is
+  // deliberately NOT listened to (our own programmatic pins fire it).
+  // handleScroll and the observer above read the stamp to tell a deliberate
+  // scroll-up from content growth.
+  //
+  // Direction comes from the input events themselves — wheel deltaY sign,
+  // touch finger delta — because they stay unambiguous when content reflow
+  // makes scrollTop deltas unreadable (see lastGestureScrollDirRef). A finger
+  // moving DOWN drags the content down, which scrolls the viewport UP. A fresh
+  // touchstart clears the direction so a tap never inherits the previous
+  // gesture's; `touches` is read defensively because a browser tap may deliver
+  // no touch points by the time the handler runs (and unit tests dispatch bare
+  // Events).
   //
   // Gated on the mounted scroller element for the same reason as the observer:
   // the scroller renders behind the loading skeleton, so an effect reading
@@ -603,15 +644,35 @@ export function useTimelineScroll({
     const mark = () => {
       userInteractedAtRef.current = performance.now()
     }
-    el.addEventListener("wheel", mark, { passive: true })
-    el.addEventListener("touchstart", mark, { passive: true })
-    el.addEventListener("touchmove", mark, { passive: true })
+    let lastTouchY: number | null = null
+    const onWheel = (e: WheelEvent) => {
+      mark()
+      if (e.deltaY > 0) lastGestureScrollDirRef.current = "down"
+      else if (e.deltaY < 0) lastGestureScrollDirRef.current = "up"
+    }
+    const onTouchStart = (e: TouchEvent) => {
+      mark()
+      lastTouchY = e.touches?.[0]?.clientY ?? null
+      lastGestureScrollDirRef.current = null
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      mark()
+      const y = e.touches?.[0]?.clientY
+      if (y === undefined) return
+      if (lastTouchY !== null && Math.abs(y - lastTouchY) > 1) {
+        lastGestureScrollDirRef.current = y > lastTouchY ? "up" : "down"
+      }
+      lastTouchY = y
+    }
+    el.addEventListener("wheel", onWheel, { passive: true })
+    el.addEventListener("touchstart", onTouchStart, { passive: true })
+    el.addEventListener("touchmove", onTouchMove, { passive: true })
     el.addEventListener("pointerdown", mark, { passive: true })
     el.addEventListener("keydown", mark)
     return () => {
-      el.removeEventListener("wheel", mark)
-      el.removeEventListener("touchstart", mark)
-      el.removeEventListener("touchmove", mark)
+      el.removeEventListener("wheel", onWheel)
+      el.removeEventListener("touchstart", onTouchStart)
+      el.removeEventListener("touchmove", onTouchMove)
       el.removeEventListener("pointerdown", mark)
       el.removeEventListener("keydown", mark)
     }
@@ -655,7 +716,7 @@ export function useTimelineScroll({
       if (lastGestureScrollDirRef.current !== "down") return
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
       if (distanceFromBottom <= 1) return
-      if (distanceFromBottom > readComposerHeight(el) + AT_BOTTOM_PX) return
+      if (distanceFromBottom > dockBandPx(el) + AT_BOTTOM_PX) return
       scrollToBottom({ force: true, behavior: "smooth" })
     }
     const schedule = () => {

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -16,6 +16,15 @@ const DEAD_BAND_DOCK_SETTLE_MS = 200
 /** Consecutive frames of unchanged scrollHeight that mark the cold-load settle
  *  as converged, so the content can be revealed without a visible bounce. */
 const SETTLE_STABLE_FRAMES = 3
+/** Finger travel (px) from the last recorded anchor before a touchmove records
+ *  a gesture direction. The final touchmove before lift-off commonly reverses
+ *  2–3px as the finger peels off the glass; recording that flipped a long
+ *  downward drag to "up", suppressing the dead-band dock and detaching follow.
+ *  Sub-threshold moves keep the anchor, so a slow consistent drag accumulates
+ *  past it while jitter oscillates around it and never flips. */
+const TOUCH_DIRECTION_HYSTERESIS_PX = 8
+/** Cap on the dead-band dock's trigger band, as a fraction of the viewport. */
+const DOCK_BAND_MAX_VIEWPORT_FRACTION = 0.25
 
 /**
  * Height (px) of the floating composer, published as `--composer-height` on the
@@ -40,7 +49,7 @@ function readComposerHeight(el: HTMLElement): number {
  * there.
  */
 function dockBandPx(el: HTMLElement): number {
-  return Math.min(readComposerHeight(el), el.clientHeight / 4)
+  return Math.min(readComposerHeight(el), el.clientHeight * DOCK_BAND_MAX_VIEWPORT_FRACTION)
 }
 
 interface UseTimelineScrollOptions {
@@ -659,10 +668,17 @@ export function useTimelineScroll({
       mark()
       const y = e.touches?.[0]?.clientY
       if (y === undefined) return
-      if (lastTouchY !== null && Math.abs(y - lastTouchY) > 1) {
-        lastGestureScrollDirRef.current = y > lastTouchY ? "up" : "down"
+      if (lastTouchY === null) {
+        lastTouchY = y
+        return
       }
-      lastTouchY = y
+      // Hysteresis: only a move past the threshold records a direction and
+      // advances the anchor, so the tiny reversal of a finger peeling off the
+      // glass can't flip a long drag's direction at the last instant.
+      if (Math.abs(y - lastTouchY) > TOUCH_DIRECTION_HYSTERESIS_PX) {
+        lastGestureScrollDirRef.current = y > lastTouchY ? "up" : "down"
+        lastTouchY = y
+      }
     }
     el.addEventListener("wheel", onWheel, { passive: true })
     el.addEventListener("touchstart", onTouchStart, { passive: true })


### PR DESCRIPTION
On mobile, scrolling up while replying got yanked back to the live tail (user-reported, with video). Two mechanisms: gesture direction was recorded only from height-stable scrollTop deltas, which mobile reflow (virtua row measurement, composer growing per keystroke) constantly masked — so the dead-band dock could fire on a stale "down" and "complete" an upward gesture the user never made; and the dock's trigger band (composer height + 32px) swallowed most of the visible strip once the keyboard-open composer dwarfed the viewport.

Changes:
- Gesture direction now reads off the input events themselves (wheel deltaY sign, touch finger delta); a fresh touchstart clears it so a tap can't inherit a stale direction. `handleScroll` disarms follow on an up-intent gesture even when reflow masks the scrollTop delta.
- Dock band capped at `min(composerHeight, clientHeight / 4)` — desktop composers sit far under the cap, so nothing changes there.
- A viewport resize while detached no longer shifts scrollTop: the scroller resizes at its bottom edge, so hands-off keeps the row the reader parked at the top exactly where it was. The old delta-shift anchored the bottom edge and pushed that row out of the viewport on every composer/keyboard open.

Verification: four new regression tests in `use-timeline-scroll.test.tsx` (34 pass); the stale-direction dock and unstable-band detach tests fail against the old implementation. Full frontend suite, typecheck, and lint green.

Residual risk: detached desktop window-resize anchoring changes from bottom-stable to top-stable — standard reading behavior, but a visible change if anyone relied on the old one.

Review follow-up (Opus): touch-direction recording now has an 8px hysteresis anchor so the 2–3px reversal of a finger peeling off the glass can't flip a long drag's direction at lift-off; the dock band's viewport fraction is a named constant. One deliberate semantic note: a reader detached within a keyboard-height of the tail who closes the keyboard gets clamped to the new bottom and re-arms follow — visually nothing moves (top rows hold), it's just no longer "detached".
