### PR TITLE
feat: persist the detached timeline position across reloads

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -11,6 +11,7 @@ import {
   resolveDateJumpAnchor,
   remapSuppressedWatermark,
   resolveUnreadMarkerOpen,
+  resolveAnchorRestore,
   buildAgentActivitySummary,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
@@ -568,6 +569,48 @@ describe("resolveUnreadMarkerOpen", () => {
 
   it("consumes the decision as skip (not wait) for a deep-link even while still loading — a deep-linked stream never marker-scrolls", () => {
     expect(resolveUnreadMarkerOpen({ ...base, hasDeepLink: true, isLoading: true })).toBe("skip")
+  })
+})
+
+describe("resolveAnchorRestore", () => {
+  const base = {
+    alreadyDecided: false,
+    isLoading: false,
+    isSettling: false,
+    isJumpMode: false,
+    hasDeepLink: false,
+    userInteractedAt: 0,
+    hasAnchor: true,
+    anchorInWindow: true,
+  }
+
+  it("restores once loading and the cold-load settle have resolved with the anchor in the window", () => {
+    expect(resolveAnchorRestore(base)).toBe("restore")
+  })
+
+  it("waits (without consuming the decision) while the window loads or the settle masks", () => {
+    expect(resolveAnchorRestore({ ...base, isLoading: true })).toBe("wait")
+    expect(resolveAnchorRestore({ ...base, isSettling: true })).toBe("wait")
+  })
+
+  it("skips with no persisted anchor — the tail open is untouched", () => {
+    expect(resolveAnchorRestore({ ...base, hasAnchor: false })).toBe("skip")
+    // Consumed as skip even mid-load: nothing later can produce an anchor.
+    expect(resolveAnchorRestore({ ...base, hasAnchor: false, isLoading: true })).toBe("skip")
+  })
+
+  it("skips when the anchored row is not in the loaded window (stale anchor)", () => {
+    expect(resolveAnchorRestore({ ...base, anchorInWindow: false })).toBe("skip")
+  })
+
+  it("yields to deep links, jump mode, and user gestures — they own the position", () => {
+    expect(resolveAnchorRestore({ ...base, hasDeepLink: true })).toBe("skip")
+    expect(resolveAnchorRestore({ ...base, isJumpMode: true })).toBe("skip")
+    expect(resolveAnchorRestore({ ...base, userInteractedAt: 42 })).toBe("skip")
+  })
+
+  it("decides at most once per stream open", () => {
+    expect(resolveAnchorRestore({ ...base, alreadyDecided: true })).toBe("skip")
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2405,16 +2405,24 @@ export function StreamContent({
   }
   useLayoutEffect(() => {
     if (!useVirtualized) return
+    // Consumed decisions bail before touching storage or scanning the window:
+    // `visibleItems` re-runs this effect on every timeline tick for the life
+    // of the stream, and the localStorage read + linear index scan below are
+    // not free at that cadence.
+    if (anchorRestoreRef.current.decided) return
     const anchor = loadTimelineAnchor(streamId)
+    const settled = !isLoading && !virtualIsInitialSettling
     const decision = resolveAnchorRestore({
-      alreadyDecided: anchorRestoreRef.current.decided,
+      alreadyDecided: false,
       isLoading,
       isSettling: virtualIsInitialSettling,
       isJumpMode,
       hasDeepLink: skipInitialScroll,
       userInteractedAt: userInteractedAtRef.current,
       hasAnchor: anchor !== null,
-      anchorInWindow: anchor !== null && findTimelineTargetIndex(visibleItems, anchor.targetId) >= 0,
+      // The scan only matters once the wait gates have cleared; skip it while
+      // the window is still loading or masked.
+      anchorInWindow: anchor !== null && settled && findTimelineTargetIndex(visibleItems, anchor.targetId) >= 0,
     })
     if (decision === "wait") return
     anchorRestoreRef.current.decided = true
@@ -2468,12 +2476,19 @@ export function StreamContent({
       if (timer) window.clearTimeout(timer)
       snapshot()
     }
+    // visibilitychange too: mobile OSes routinely discard a backgrounded PWA
+    // without ever firing pagehide, and hidden is the documented last event.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") onPageHide()
+    }
     el.addEventListener("scroll", onScroll, { passive: true })
     window.addEventListener("pagehide", onPageHide)
+    document.addEventListener("visibilitychange", onVisibilityChange)
     return () => {
       if (timer) window.clearTimeout(timer)
       el.removeEventListener("scroll", onScroll)
       window.removeEventListener("pagehide", onPageHide)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
     }
   }, [useVirtualized, virtualScrollerEl, streamId, isFollowingTailRef])
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -136,6 +136,7 @@ import { localStartOfDayMs } from "@/lib/dates"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { addStartBatchSelectListener, type BatchSelectIntent } from "@/lib/batch-selection-events"
 import { addMarkReadUpToHereListener, addMarkUnreadListener } from "@/lib/mark-read-events"
+import { clearTimelineAnchor, loadTimelineAnchor, saveTimelineAnchor } from "@/lib/timeline-anchor-storage"
 import { ReadFrontierContext, type ReadFrontier } from "./read-frontier-context"
 import { useReadMessageIds } from "@/hooks/use-unread-counts"
 
@@ -474,6 +475,38 @@ export function resolveUnreadMarkerOpen(args: {
   if (args.isLoading || args.isSettling || !args.readStateResolved) return "wait"
   if (!args.dividerEventId) return "skip"
   return "scroll"
+}
+
+/**
+ * Decide whether to restore a persisted detached-reading anchor on stream
+ * open (see `timeline-anchor-storage`). Same once-per-stream contract as
+ * `resolveUnreadMarkerOpen`: "wait" leaves the decision open while inputs
+ * resolve; every other verdict consumes it.
+ *
+ * A restore yields to deep links, jump mode, and any user gesture — those own
+ * the position. It only engages when the anchored row is in the loaded
+ * window: anchors are written while detached near the tail (reading context
+ * while replying), which the initial window covers; an anchor that has since
+ * fallen out of the window is stale enough that the tail is the better
+ * landing.
+ */
+export function resolveAnchorRestore(args: {
+  alreadyDecided: boolean
+  isLoading: boolean
+  isSettling: boolean
+  isJumpMode: boolean
+  hasDeepLink: boolean
+  userInteractedAt: number
+  hasAnchor: boolean
+  anchorInWindow: boolean
+}): "wait" | "skip" | "restore" {
+  if (args.alreadyDecided) return "skip"
+  if (args.hasDeepLink || args.isJumpMode) return "skip"
+  if (args.userInteractedAt > 0) return "skip"
+  if (!args.hasAnchor) return "skip"
+  if (args.isLoading || args.isSettling) return "wait"
+  if (!args.anchorInWindow) return "skip"
+  return "restore"
 }
 
 /**
@@ -1633,8 +1666,12 @@ export function StreamContent({
   // exactly the "I scroll up to read context, then get yanked back to the
   // linked message" deep-link bug.
   const scrollToMessage = useCallback(
-    (targetId: string, opts?: { align?: "center" | "start" }) => {
+    (targetId: string, opts?: { align?: "center" | "start"; topOffsetPx?: number }) => {
       const align = opts?.align ?? "center"
+      // For "start": px between the viewport top and the target's top. The
+      // unread-marker default leaves a small context gap; an anchor restore
+      // passes the exact (possibly negative) offset the reader detached at.
+      const topOffsetPx = opts?.topOffsetPx ?? UNREAD_MARKER_TOP_GAP_PX
       if (findTimelineTargetIndex(visibleItems, targetId) < 0) {
         deepLinkDebug("scrollToMessage bail: target not a timeline item yet", targetId)
         return false
@@ -1715,10 +1752,10 @@ export function StreamContent({
           const sr = scroller.getBoundingClientRect()
           const er = el.getBoundingClientRect()
           const scCenter = (sr.top + sr.bottom) / 2
-          // "start" pins the target's top near the viewport top (the unread
-          // marker open: a long first-unread message must read from its start).
-          // "center" is the deep-link behavior, unchanged.
-          const desiredTop = sr.top + UNREAD_MARKER_TOP_GAP_PX
+          // "start" pins the target's top at topOffsetPx below the viewport
+          // top (the unread marker open, an anchor restore). "center" is the
+          // deep-link behavior, unchanged.
+          const desiredTop = sr.top + topOffsetPx
           const delta = align === "start" ? er.top - desiredTop : (er.top + er.bottom) / 2 - scCenter
           if (Math.abs(delta) > 2) {
             scroller.scrollTop += delta
@@ -1739,7 +1776,7 @@ export function StreamContent({
             try {
               listRef.current?.scrollToIndex(
                 liveIdx,
-                align === "start" ? { align: "start", offset: -UNREAD_MARKER_TOP_GAP_PX } : { align: "center" }
+                align === "start" ? { align: "start", offset: -topOffsetPx } : { align: "center" }
               )
             } catch {
               // virtua can still throw internally on a freshly mounted,
@@ -2354,6 +2391,92 @@ export function StreamContent({
   if (unreadMarkerOpenRef.current.streamId !== streamId) {
     unreadMarkerOpenRef.current = { streamId, decided: false }
   }
+
+  // Restore a persisted detached-reading anchor (see timeline-anchor-storage):
+  // a reader who detached from the tail and reloaded lands back on the row
+  // they were reading, at the offset they left it. One decision per stream
+  // open, resolved by resolveAnchorRestore. A successful restore also consumes
+  // the unread-marker-open decision below — the reader's own last position is
+  // the more specific landing — which works because this layout effect is
+  // declared first and both run in the same commit.
+  const anchorRestoreRef = useRef<{ streamId: string; decided: boolean }>({ streamId, decided: false })
+  if (anchorRestoreRef.current.streamId !== streamId) {
+    anchorRestoreRef.current = { streamId, decided: false }
+  }
+  useLayoutEffect(() => {
+    if (!useVirtualized) return
+    const anchor = loadTimelineAnchor(streamId)
+    const decision = resolveAnchorRestore({
+      alreadyDecided: anchorRestoreRef.current.decided,
+      isLoading,
+      isSettling: virtualIsInitialSettling,
+      isJumpMode,
+      hasDeepLink: skipInitialScroll,
+      userInteractedAt: userInteractedAtRef.current,
+      hasAnchor: anchor !== null,
+      anchorInWindow: anchor !== null && findTimelineTargetIndex(visibleItems, anchor.targetId) >= 0,
+    })
+    if (decision === "wait") return
+    anchorRestoreRef.current.decided = true
+    if (decision !== "restore" || !anchor) return
+    if (scrollToMessage(anchor.targetId, { align: "start", topOffsetPx: anchor.offsetPx })) {
+      unreadMarkerOpenRef.current.decided = true
+    }
+  }, [
+    useVirtualized,
+    streamId,
+    isLoading,
+    virtualIsInitialSettling,
+    isJumpMode,
+    skipInitialScroll,
+    visibleItems,
+    scrollToMessage,
+  ])
+
+  // Persist the detached reading position for the restore above. While
+  // following, the stream's entry is cleared (the tail is the default
+  // landing); while detached, each settled scroll — and the page being hidden,
+  // which is the last chance before a reload — snapshots the topmost visible
+  // row and its offset from the viewport top.
+  useEffect(() => {
+    if (!useVirtualized) return
+    const el = virtualScrollerEl
+    if (!el) return
+    let timer = 0
+    const snapshot = () => {
+      timer = 0
+      if (isFollowingTailRef.current) {
+        clearTimelineAnchor(streamId)
+        return
+      }
+      const sr = el.getBoundingClientRect()
+      let best: { id: string; top: number } | null = null
+      for (const row of el.querySelectorAll<HTMLElement>("[data-message-id], [data-event-id]")) {
+        const rr = row.getBoundingClientRect()
+        if (rr.bottom <= sr.top + 1 || rr.top >= sr.bottom) continue
+        const id = row.dataset.messageId ?? row.dataset.eventId
+        if (!id) continue
+        if (!best || rr.top < best.top) best = { id, top: rr.top }
+      }
+      if (best) saveTimelineAnchor(streamId, { targetId: best.id, offsetPx: Math.round(best.top - sr.top) })
+    }
+    const onScroll = () => {
+      if (timer) window.clearTimeout(timer)
+      timer = window.setTimeout(snapshot, 250)
+    }
+    const onPageHide = () => {
+      if (timer) window.clearTimeout(timer)
+      snapshot()
+    }
+    el.addEventListener("scroll", onScroll, { passive: true })
+    window.addEventListener("pagehide", onPageHide)
+    return () => {
+      if (timer) window.clearTimeout(timer)
+      el.removeEventListener("scroll", onScroll)
+      window.removeEventListener("pagehide", onPageHide)
+    }
+  }, [useVirtualized, virtualScrollerEl, streamId, isFollowingTailRef])
+
   useLayoutEffect(() => {
     const decision = resolveUnreadMarkerOpen({
       unreadOpenPosition,

--- a/apps/frontend/src/lib/timeline-anchor-storage.test.ts
+++ b/apps/frontend/src/lib/timeline-anchor-storage.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest"
+import { saveTimelineAnchor, loadTimelineAnchor, clearTimelineAnchor } from "./timeline-anchor-storage"
+
+const STORAGE_KEY = "threa:timeline-anchors"
+
+describe("timeline-anchor-storage", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("round-trips an anchor per stream", () => {
+    saveTimelineAnchor("stream_a", { targetId: "msg_1", offsetPx: -120 })
+    saveTimelineAnchor("stream_b", { targetId: "evt_2", offsetPx: 8 })
+    expect(loadTimelineAnchor("stream_a")).toEqual({ targetId: "msg_1", offsetPx: -120 })
+    expect(loadTimelineAnchor("stream_b")).toEqual({ targetId: "evt_2", offsetPx: 8 })
+    expect(loadTimelineAnchor("stream_c")).toBeNull()
+  })
+
+  it("clears a stream's anchor without touching the others", () => {
+    saveTimelineAnchor("stream_a", { targetId: "msg_1", offsetPx: 0 })
+    saveTimelineAnchor("stream_b", { targetId: "msg_2", offsetPx: 0 })
+    clearTimelineAnchor("stream_a")
+    expect(loadTimelineAnchor("stream_a")).toBeNull()
+    expect(loadTimelineAnchor("stream_b")).toEqual({ targetId: "msg_2", offsetPx: 0 })
+  })
+
+  it("expires anchors past the TTL", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-08-12T10:00:00Z"))
+    saveTimelineAnchor("stream_a", { targetId: "msg_1", offsetPx: 0 })
+    vi.setSystemTime(new Date("2026-08-12T21:00:00Z"))
+    expect(loadTimelineAnchor("stream_a")).toEqual({ targetId: "msg_1", offsetPx: 0 })
+    vi.setSystemTime(new Date("2026-08-13T10:00:01Z"))
+    expect(loadTimelineAnchor("stream_a")).toBeNull()
+  })
+
+  it("evicts the oldest entries past the cap", () => {
+    vi.useFakeTimers()
+    const base = new Date("2026-08-12T10:00:00Z").getTime()
+    for (let i = 0; i < 51; i++) {
+      vi.setSystemTime(base + i * 1000)
+      saveTimelineAnchor(`stream_${i}`, { targetId: `msg_${i}`, offsetPx: 0 })
+    }
+    expect(loadTimelineAnchor("stream_0")).toBeNull()
+    expect(loadTimelineAnchor("stream_1")).toEqual({ targetId: "msg_1", offsetPx: 0 })
+    expect(loadTimelineAnchor("stream_50")).toEqual({ targetId: "msg_50", offsetPx: 0 })
+  })
+
+  it("survives corrupt storage", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json")
+    expect(loadTimelineAnchor("stream_a")).toBeNull()
+    saveTimelineAnchor("stream_a", { targetId: "msg_1", offsetPx: 4 })
+    expect(loadTimelineAnchor("stream_a")).toEqual({ targetId: "msg_1", offsetPx: 4 })
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ stream_b: { targetId: 7, offsetPx: "x", at: "y" } }))
+    expect(loadTimelineAnchor("stream_b")).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/timeline-anchor-storage.ts
+++ b/apps/frontend/src/lib/timeline-anchor-storage.ts
@@ -1,0 +1,77 @@
+/**
+ * Persists the timeline scroll anchor of a reader who detached from the live
+ * tail, so a reload lands them back on the row they were reading instead of
+ * snapping to the bottom. One entry per stream: the topmost visible row's id
+ * (message or event id) and its offset from the scroller's viewport top —
+ * negative when the reader is midway through a row taller than the viewport.
+ *
+ * localStorage rather than sessionStorage: the mobile PWA reload that
+ * motivated this often opens a fresh browsing session. Entries expire after
+ * ANCHOR_TTL_MS and the map is capped with the oldest evicted first, so
+ * abandoned streams don't accumulate. Following the live tail clears the
+ * stream's entry — the tail is the default landing, so only detachment is
+ * worth remembering.
+ */
+
+const STORAGE_KEY = "threa:timeline-anchors"
+const ANCHOR_TTL_MS = 12 * 60 * 60 * 1000
+const MAX_ENTRIES = 50
+
+export interface TimelineAnchor {
+  /** `data-message-id` / `data-event-id` of the topmost visible row. */
+  targetId: string
+  /** px from the scroller's viewport top to the row's top (can be negative). */
+  offsetPx: number
+}
+
+interface StoredAnchor extends TimelineAnchor {
+  at: number
+}
+
+function readAll(): Record<string, StoredAnchor> {
+  if (typeof localStorage === "undefined") return {}
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as Record<string, StoredAnchor>
+  } catch {
+    return {}
+  }
+}
+
+function writeAll(map: Record<string, StoredAnchor>): void {
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Storage quota / private-mode failures must not break scrolling.
+  }
+}
+
+export function saveTimelineAnchor(streamId: string, anchor: TimelineAnchor): void {
+  const map = readAll()
+  map[streamId] = { ...anchor, at: Date.now() }
+  const ids = Object.keys(map)
+  if (ids.length > MAX_ENTRIES) {
+    ids.sort((a, b) => (map[a]?.at ?? 0) - (map[b]?.at ?? 0))
+    for (const id of ids.slice(0, ids.length - MAX_ENTRIES)) delete map[id]
+  }
+  writeAll(map)
+}
+
+export function loadTimelineAnchor(streamId: string): TimelineAnchor | null {
+  const entry = readAll()[streamId]
+  if (!entry) return null
+  if (typeof entry.targetId !== "string" || !Number.isFinite(entry.offsetPx) || !Number.isFinite(entry.at)) return null
+  if (Date.now() - entry.at > ANCHOR_TTL_MS) return null
+  return { targetId: entry.targetId, offsetPx: entry.offsetPx }
+}
+
+export function clearTimelineAnchor(streamId: string): void {
+  const map = readAll()
+  if (!(streamId in map)) return
+  delete map[streamId]
+  writeAll(map)
+}

--- a/apps/frontend/src/lib/timeline-anchor-storage.ts
+++ b/apps/frontend/src/lib/timeline-anchor-storage.ts
@@ -55,7 +55,13 @@ export function saveTimelineAnchor(streamId: string, anchor: TimelineAnchor): vo
   map[streamId] = { ...anchor, at: Date.now() }
   const ids = Object.keys(map)
   if (ids.length > MAX_ENTRIES) {
-    ids.sort((a, b) => (map[a]?.at ?? 0) - (map[b]?.at ?? 0))
+    // Corrupt entries (readAll doesn't validate fields) sort as 0 — oldest —
+    // so eviction removes them first instead of comparing NaN.
+    const atOf = (id: string) => {
+      const at = map[id]?.at
+      return typeof at === "number" && Number.isFinite(at) ? at : 0
+    }
+    ids.sort((a, b) => atOf(a) - atOf(b))
     for (const id of ids.slice(0, ids.length - MAX_ENTRIES)) delete map[id]
   }
   writeAll(map)


### PR DESCRIPTION
Detaching from the live tail now survives a reload: previously any reload snapped back to the bottom, losing the spot the reader had deliberately scrolled to (mobile PWA reloads made this constant).

Changes:
- `lib/timeline-anchor-storage`: one anchor per stream (topmost visible row id + offset from the viewport top) in localStorage — 12h TTL, 50-entry cap, oldest evicted. localStorage over sessionStorage because a mobile PWA reload often opens a fresh session.
- Capture: while detached, each settled scroll (250ms debounce) and pagehide snapshots the anchor; while following, the entry is cleared — only detachment is worth remembering.
- Restore: `resolveAnchorRestore` (mirrors `resolveUnreadMarkerOpen`'s once-per-stream contract) waits for the window load + cold-load settle, then drives `scrollToMessage` with a new `topOffsetPx` option so the row lands at the exact (possibly negative) offset it was left at. It yields to deep links, jump mode, and any user gesture, and outranks the unread-marker open. It only engages when the anchored row is in the loaded window; a stale anchor falls back to the usual tail landing.

Verification: storage round-trip/TTL/eviction/corruption tests plus a decision table for `resolveAnchorRestore`; full frontend suite green.

Residual risk: threads use the plain scroller and don't persist anchors (virtualized timelines only); an anchor outside the initial window is skipped rather than fetched around.
