### PR TITLE
feat: hide floating timeline chrome when the strip above the composer is short

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -12,6 +12,7 @@ import {
   remapSuppressedWatermark,
   resolveUnreadMarkerOpen,
   resolveAnchorRestore,
+  isChromeStripCollapsed,
   buildAgentActivitySummary,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
@@ -569,6 +570,23 @@ describe("resolveUnreadMarkerOpen", () => {
 
   it("consumes the decision as skip (not wait) for a deep-link even while still loading — a deep-linked stream never marker-scrolls", () => {
     expect(resolveUnreadMarkerOpen({ ...base, hasDeepLink: true, isLoading: true })).toBe("skip")
+  })
+})
+
+describe("isChromeStripCollapsed", () => {
+  it("collapses when the strip above the composer drops under the minimum", () => {
+    // Mobile keyboard open + tall draft: 360px scroller minus a 230px composer
+    // leaves ~2 rows — pills would cover most of it.
+    expect(isChromeStripCollapsed(360, 230)).toBe(true)
+    // One-line composer with the keyboard open keeps the chrome.
+    expect(isChromeStripCollapsed(400, 90)).toBe(false)
+    // Desktop never collapses.
+    expect(isChromeStripCollapsed(900, 144)).toBe(false)
+  })
+
+  it("uses the strip (scroller minus composer), not the raw scroller height", () => {
+    expect(isChromeStripCollapsed(800, 700)).toBe(true)
+    expect(isChromeStripCollapsed(800, 0)).toBe(false)
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -478,19 +478,6 @@ export function resolveUnreadMarkerOpen(args: {
 }
 
 /**
- * Decide whether to restore a persisted detached-reading anchor on stream
- * open (see `timeline-anchor-storage`). Same once-per-stream contract as
- * `resolveUnreadMarkerOpen`: "wait" leaves the decision open while inputs
- * resolve; every other verdict consumes it.
- *
- * A restore yields to deep links, jump mode, and any user gesture — those own
- * the position. It only engages when the anchored row is in the loaded
- * window: anchors are written while detached near the tail (reading context
- * while replying), which the initial window covers; an anchor that has since
- * fallen out of the window is stale enough that the tail is the better
- * landing.
- */
-/**
  * The floating chrome (date pill, jump-to-latest, unread banner) hides when
  * the visible strip between the scroller top and the floating composer drops
  * under this height. With the keyboard up and a tall reply drafted the strip
@@ -503,6 +490,19 @@ export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerH
   return scrollerClientHeightPx - composerHeightPx < CHROME_MIN_STRIP_PX
 }
 
+/**
+ * Decide whether to restore a persisted detached-reading anchor on stream
+ * open (see `timeline-anchor-storage`). Same once-per-stream contract as
+ * `resolveUnreadMarkerOpen`: "wait" leaves the decision open while inputs
+ * resolve; every other verdict consumes it.
+ *
+ * A restore yields to deep links, jump mode, and any user gesture — those own
+ * the position. It only engages when the anchored row is in the loaded
+ * window: anchors are written while detached near the tail (reading context
+ * while replying), which the initial window covers; an anchor that has since
+ * fallen out of the window is stale enough that the tail is the better
+ * landing.
+ */
 export function resolveAnchorRestore(args: {
   alreadyDecided: boolean
   isLoading: boolean
@@ -2822,9 +2822,11 @@ export function StreamContent({
                             isFetchingNewer ? "opacity-100" : "opacity-0"
                           )}
                           style={{
-                            // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
+                            // Sit above the Jump to latest button (when visible) which itself sits
+                            // above the floating composer. chromeCollapsed unmounts that button, so
+                            // the clearance drops with it.
                             bottom:
-                              isJumpMode || isScrolledFarFromBottom
+                              (isJumpMode || isScrolledFarFromBottom) && !chromeCollapsed
                                 ? "calc(var(--composer-height, 0px) + 3.5rem)"
                                 : "calc(var(--composer-height, 0px) + 0.5rem)",
                           }}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -490,6 +490,19 @@ export function resolveUnreadMarkerOpen(args: {
  * fallen out of the window is stale enough that the tail is the better
  * landing.
  */
+/**
+ * The floating chrome (date pill, jump-to-latest, unread banner) hides when
+ * the visible strip between the scroller top and the floating composer drops
+ * under this height. With the keyboard up and a tall reply drafted the strip
+ * is barely two message rows, and center-anchored pills covered most of what
+ * remained. Chrome returns as soon as the strip regrows.
+ */
+export const CHROME_MIN_STRIP_PX = 160
+
+export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerHeightPx: number): boolean {
+  return scrollerClientHeightPx - composerHeightPx < CHROME_MIN_STRIP_PX
+}
+
 export function resolveAnchorRestore(args: {
   alreadyDecided: boolean
   isLoading: boolean
@@ -1600,8 +1613,39 @@ export function StreamContent({
   // carry `data-message-id`/`.message-content`, so an unscoped detector would
   // fire a second "Quote" button and route the quote to the wrong composer.
   const quoteScopeRef = useRef<HTMLDivElement>(null)
+  // Space-aware chrome: hide the floating pills (date header, jump-to-latest,
+  // unread banner) while the strip above the composer is too short for them to
+  // overlay without covering what little content remains — the mobile keyboard
+  // plus a tall draft leaves ~2 rows visible. Recomputed on scroller resizes
+  // (keyboard open/close) and on composer height changes (via
+  // handleComposerHeightChange below, since the floating composer doesn't
+  // resize the scroller).
+  const [chromeCollapsed, setChromeCollapsed] = useState(false)
+  const recomputeChromeCollapsedRef = useRef<() => void>(() => {})
+  useEffect(() => {
+    const el = useVirtualized ? virtualScrollerEl : plainScrollRef.current
+    if (!el) return
+    const recompute = () => {
+      const raw = Number.parseFloat(getComputedStyle(el).getPropertyValue("--composer-height"))
+      setChromeCollapsed(isChromeStripCollapsed(el.clientHeight, Number.isFinite(raw) ? raw : 0))
+    }
+    recomputeChromeCollapsedRef.current = recompute
+    recompute()
+    const ro = new ResizeObserver(recompute)
+    ro.observe(el)
+    return () => {
+      recomputeChromeCollapsedRef.current = () => {}
+      ro.disconnect()
+    }
+    // isLoading: the plain (thread) scroller mounts behind the loading
+    // skeleton, and only a state dep re-runs this effect once it exists.
+  }, [useVirtualized, virtualScrollerEl, plainScrollRef, isLoading, streamId])
+
   const handleComposerHeightChange = useCallback(
     (_px: number, opts: { initial: boolean }) => {
+      // Composer growth doesn't resize the scroller (the composer floats), so
+      // the space-aware chrome re-checks here rather than via ResizeObserver.
+      recomputeChromeCollapsedRef.current()
       if (skipInitialScroll || isJumpMode) return
       const rePin = () => {
         const draftScroller = draftScrollRef.current
@@ -2757,6 +2801,7 @@ export function StreamContent({
                           batchPointerHandlers={batchPointerHandlers}
                           conversationOverlay={activeConversationOverlay}
                           onJumpToDate={handleJumpToDate}
+                          chromeCollapsed={chromeCollapsed}
                         />
                         {/* Overlay loading indicators — absolutely positioned so they
                     don't cause layout shift when prepending older messages. */}
@@ -2840,8 +2885,9 @@ export function StreamContent({
                     )}
                   </div>
                   {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
-              Positioned above the floating composer pill. */}
-                  {(isJumpMode || isScrolledFarFromBottom) && (
+              Positioned above the floating composer pill. Hidden while the
+              strip above the composer is too short to overlay (chromeCollapsed). */}
+                  {(isJumpMode || isScrolledFarFromBottom) && !chromeCollapsed && (
                     <div
                       className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
                       style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
@@ -2862,7 +2908,7 @@ export function StreamContent({
               Hidden while search is open: jumping the timeline would yank it out
               from under the active search-result navigation, and the Escape
               mark-read shortcut is gated on `!isSearchOpen` too. */}
-                  {unreadBannerVisible && (
+                  {unreadBannerVisible && !chromeCollapsed && (
                     <div
                       // Sits clearly below the floating date pill (top-2, ~30px tall)
                       // so the top-center affordances never overlap.
@@ -3024,6 +3070,7 @@ function TimelineMessageList({
   batchPointerHandlers,
   conversationOverlay,
   onJumpToDate,
+  chromeCollapsed,
 }: {
   visibleItems: TimelineItem[]
   cancelledFollowUpIds: Set<string>
@@ -3086,6 +3133,8 @@ function TimelineMessageList({
   conversationOverlay?: ConversationOverlayContext
   /** Jump to the first message on or after a date (floating date header). */
   onJumpToDate: (date: Date) => void
+  /** True while the strip above the composer is too short for floating chrome. */
+  chromeCollapsed: boolean
 }) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
@@ -3466,7 +3515,7 @@ function TimelineMessageList({
       </div>
       <StreamDateHeader
         dayStartMs={topDayMs}
-        visible={datePillVisible}
+        visible={datePillVisible && !chromeCollapsed}
         onJumpToDate={onJumpToDate}
         scrollerRef={scrollerRef}
       />


### PR DESCRIPTION
With the keyboard up and a tall reply drafted, the visible strip above the mobile composer is barely two message rows — and the date pill, jump-to-latest button, and unread banner covered most of it (user screenshot: both pills dead-center of the remaining content).

Changes: `isChromeStripCollapsed` hides the floating chrome while `scroller clientHeight − composer height < 160px`. Recomputed from a ResizeObserver on the scroller (keyboard open/close) and from `handleComposerHeightChange` (composer growth floats over the scroller without resizing it). Gates the date pill's existing `visible` prop, the jump-to-latest button, and the unread banner; chrome returns as soon as the strip regrows. Overlay-only visibility change, so no layout shift (INV-21).

Verification: unit tests for the predicate at mobile-keyboard/desktop geometries; full frontend suite green.

Residual risk: the transient "Loading older/newer messages" pills intentionally still show — they are the only fetch feedback. 160px is a heuristic (~2 message rows); easy to tune.

Review follow-up (Opus): fixed the fetch-newer pill keeping jump-button clearance while the button is collapsed, and a doc block that had landed between `resolveAnchorRestore`'s JSDoc and its declaration. Known trade-off: collapsing the chrome also hides the only touch exits from jump mode / the unread banner while the keyboard is up; dismissing the keyboard restores them.
