### PR TITLE
feat: drag-resize the mobile composer from its top edge

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -882,6 +882,22 @@ describe("MessageComposer", () => {
       expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("140px")
     })
 
+    it("keeps the floor when 75% of a short viewport would dip below it", () => {
+      // Keyboard up on a short landscape viewport: the 75%-of-viewport ceiling
+      // would land under the 140px floor, inverting the clamp — the floor wins.
+      const originalInnerHeight = window.innerHeight
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: 100 })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const handle = screen.getByTestId("composer-resize-handle")
+        fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
+        fireEvent.pointerMove(handle, { pointerId: 1, clientY: 100 })
+        expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("140px")
+      } finally {
+        Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight })
+      }
+    })
+
     it("applies the persisted drag height on mount", () => {
       localStorage.setItem("threa:composer-drag-height", "300")
       const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -841,4 +841,56 @@ describe("MessageComposer", () => {
       expect(screen.queryByText("stashed body")).not.toBeInTheDocument()
     })
   })
+
+  describe("mobile drag-resize", () => {
+    beforeEach(() => {
+      isMobileMockValue = true
+      localStorage.clear()
+      // The open chrome mounts the real MicButton, whose dictation session
+      // drives editor methods the mock editor doesn't implement.
+      const MockMicButton = forwardRef(function MockMicButton(
+        _props: unknown,
+        ref: ForwardedRef<{ abort: () => void; prepareSendAsIs: () => void }>
+      ) {
+        useImperativeHandle(ref, () => ({ abort: vi.fn(), prepareSendAsIs: vi.fn() }))
+        return null
+      })
+      spyOnExport(micButtonModule, "MicButton").mockReturnValue(
+        MockMicButton as unknown as typeof micButtonModule.MicButton
+      )
+    })
+
+    it("drags the open composer's max-height and persists it on release", () => {
+      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const handle = screen.getByTestId("composer-resize-handle")
+      const root = container.firstElementChild as HTMLElement
+      expect(root.style.maxHeight).toBe("")
+      // jsdom measures the shell at 0px, so the drag grows from the 140px floor:
+      // a 260px upward pull lands at max(0 + 260, 140) = 260.
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: 340 })
+      expect(root.style.maxHeight).toBe("260px")
+      fireEvent.pointerUp(handle, { pointerId: 1, clientY: 340 })
+      expect(localStorage.getItem("threa:composer-drag-height")).toBe("260")
+    })
+
+    it("clamps a downward drag to the minimum height", () => {
+      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const handle = screen.getByTestId("composer-resize-handle")
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 300 })
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: 700 })
+      expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("140px")
+    })
+
+    it("applies the persisted drag height on mount", () => {
+      localStorage.setItem("threa:composer-drag-height", "300")
+      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("300px")
+    })
+
+    it("shows the handle only while the mobile chrome is open", () => {
+      render(<MessageComposer {...defaultProps} workspaceId="ws_1" />)
+      expect(screen.queryByTestId("composer-resize-handle")).not.toBeInTheDocument()
+    })
+  })
 })

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -40,6 +40,11 @@ import type { DraftContextRef } from "@/lib/context-bag/types"
 import { cn } from "@/lib/utils"
 import { COLLAPSED_COMPOSER_ROW, COLLAPSED_COMPOSER_SHADOW } from "@/components/composer/collapsed-composer-bar"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
+import {
+  loadMobileComposerDragHeight,
+  persistMobileComposerDragHeight,
+  MOBILE_COMPOSER_DRAG_MIN_PX,
+} from "@/lib/composer-height-storage"
 import { collapsedComposerPreview } from "@/lib/drafts/collapsed-composer-preview"
 import type { PendingAttachment, UploadResult } from "@/hooks/use-attachments"
 import {
@@ -298,6 +303,42 @@ export function MessageComposer({
   const [formatOpen, setFormatOpen] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
+  // User-chosen composer height from the drag handle (mobile, chrome open).
+  // Applied as a max-height so the composer stays content-driven below it:
+  // dragging down shrinks an overgrown draft to free the timeline, dragging
+  // up raises the growth cap. Persisted per device on release; a drag exits
+  // the 75dvh expanded preset, whose classes would otherwise outrank it.
+  const [mobileDragHeight, setMobileDragHeightState] = useState<number | null>(() => loadMobileComposerDragHeight())
+  const mobileDragHeightRef = useRef(mobileDragHeight)
+  const resizeDragRef = useRef<{ pointerId: number; startY: number; startHeight: number } | null>(null)
+  const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const root = mobileRootRef.current
+    if (!root) return
+    // Keep focus in the editor (and the keyboard up) through the drag.
+    e.preventDefault()
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    resizeDragRef.current = {
+      pointerId: e.pointerId,
+      startY: e.clientY,
+      startHeight: root.getBoundingClientRect().height,
+    }
+  }, [])
+  const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = resizeDragRef.current
+    if (!drag || e.pointerId !== drag.pointerId) return
+    const viewportH = window.visualViewport?.height ?? window.innerHeight
+    const next = Math.round(
+      Math.min(Math.max(drag.startHeight + (drag.startY - e.clientY), MOBILE_COMPOSER_DRAG_MIN_PX), viewportH * 0.75)
+    )
+    setMobileExpanded(false)
+    mobileDragHeightRef.current = next
+    setMobileDragHeightState(next)
+  }, [])
+  const handleResizePointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (resizeDragRef.current?.pointerId !== e.pointerId) return
+    resizeDragRef.current = null
+    if (mobileDragHeightRef.current !== null) persistMobileComposerDragHeight(mobileDragHeightRef.current)
+  }, [])
   // Expanded-mode FAB actions are always visible on desktop. Touch has no hover,
   // so a tap on the "+" toggles them instead.
   const [fabActionsOpen, setFabActionsOpen] = useState(false)
@@ -1188,6 +1229,10 @@ export function MessageComposer({
             mobileExpanded ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
             className
           )}
+          // The drag-handle height override. A max-height (not height) so the
+          // composer stays content-driven below it; inline so it outranks the
+          // 380px default class above.
+          style={isMobile && !mobileExpanded && mobileDragHeight !== null ? { maxHeight: mobileDragHeight } : undefined}
           onFocusCapture={isMobile ? handleFocusCapture : undefined}
           onBlurCapture={isMobile ? handleBlurCapture : undefined}
           onKeyDownCapture={handleStashKeyDown}
@@ -1234,8 +1279,9 @@ export function MessageComposer({
                   !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
                   // Compact padding when mobile-unfocused (single line), normal otherwise
                   isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
-                  // When mobile-expanded, let the editor grow and override its internal max-height
-                  mobileExpanded && "[&_.tiptap]:max-h-none"
+                  // When mobile-expanded or drag-sized, let the editor grow and
+                  // override its internal max-height — the shell's cap governs.
+                  (mobileExpanded || (isMobile && mobileDragHeight !== null)) && "[&_.tiptap]:max-h-none"
                 )}
                 onClick={(e) => {
                   if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
@@ -1251,6 +1297,22 @@ export function MessageComposer({
                   richEditorRef.current?.focus()
                 }}
               >
+                {/* Drag handle: resize the open composer by its top edge. A
+                    pointer control only (no keyboard path) — the expand toggle
+                    in the action bar remains the accessible size control. */}
+                {isMobile && mobileChromeOpen && (
+                  <div
+                    data-testid="composer-resize-handle"
+                    aria-hidden
+                    onPointerDown={handleResizePointerDown}
+                    onPointerMove={handleResizePointerMove}
+                    onPointerUp={handleResizePointerEnd}
+                    onPointerCancel={handleResizePointerEnd}
+                    className="-mx-3 -mt-3 flex h-5 shrink-0 touch-none cursor-ns-resize items-center justify-center"
+                  >
+                    <div className="h-1 w-9 rounded-full bg-muted-foreground/25" />
+                  </div>
+                )}
                 {isMobile && !mobileChromeOpen && (
                   <div
                     className={cn(
@@ -1285,7 +1347,7 @@ export function MessageComposer({
                 <div
                   className={cn(
                     isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
-                    mobileExpanded && "overflow-y-auto"
+                    (mobileExpanded || (isMobile && mobileDragHeight !== null)) && "overflow-y-auto"
                   )}
                 >
                   <div className="h-full">{sharedEditor}</div>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -310,26 +310,34 @@ export function MessageComposer({
   // the 75dvh expanded preset, whose classes would otherwise outrank it.
   const [mobileDragHeight, setMobileDragHeightState] = useState<number | null>(() => loadMobileComposerDragHeight())
   const mobileDragHeightRef = useRef(mobileDragHeight)
-  const resizeDragRef = useRef<{ pointerId: number; startY: number; startHeight: number } | null>(null)
+  const resizeDragRef = useRef<{ pointerId: number; startY: number; startHeight: number; minPx: number } | null>(null)
   const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const root = mobileRootRef.current
     if (!root) return
     // Keep focus in the editor (and the keyboard up) through the drag.
     e.preventDefault()
     e.currentTarget.setPointerCapture?.(e.pointerId)
+    const rootHeight = root.getBoundingClientRect().height
+    // The max-height caps the whole root — attachment tray and link previews
+    // included — while the floor is defined against the editor card alone, so
+    // the extras' height rides on top of the floor. Without this a tray plus
+    // a preview at the 140px floor crushed the editor card toward zero.
+    const cardHeight = root.querySelector<HTMLElement>("[data-composer-card]")?.getBoundingClientRect().height
     resizeDragRef.current = {
       pointerId: e.pointerId,
       startY: e.clientY,
-      startHeight: root.getBoundingClientRect().height,
+      startHeight: rootHeight,
+      minPx: MOBILE_COMPOSER_DRAG_MIN_PX + Math.max(0, rootHeight - (cardHeight ?? rootHeight)),
     }
   }, [])
   const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current
     if (!drag || e.pointerId !== drag.pointerId) return
     const viewportH = window.visualViewport?.height ?? window.innerHeight
-    const next = Math.round(
-      Math.min(Math.max(drag.startHeight + (drag.startY - e.clientY), MOBILE_COMPOSER_DRAG_MIN_PX), viewportH * 0.75)
-    )
+    // The ceiling never dips below the floor (keyboard up on a short landscape
+    // viewport can put 75% of it under the minimum).
+    const maxPx = Math.max(viewportH * 0.75, drag.minPx)
+    const next = Math.round(Math.min(Math.max(drag.startHeight + (drag.startY - e.clientY), drag.minPx), maxPx))
     setMobileExpanded(false)
     mobileDragHeightRef.current = next
     setMobileDragHeightState(next)
@@ -1281,7 +1289,8 @@ export function MessageComposer({
                   isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
                   // When mobile-expanded or drag-sized, let the editor grow and
                   // override its internal max-height — the shell's cap governs.
-                  (mobileExpanded || (isMobile && mobileDragHeight !== null)) && "[&_.tiptap]:max-h-none"
+                  (mobileExpanded || (isMobile && mobileChromeOpen && mobileDragHeight !== null)) &&
+                    "[&_.tiptap]:max-h-none"
                 )}
                 onClick={(e) => {
                   if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
@@ -1308,6 +1317,7 @@ export function MessageComposer({
                     onPointerMove={handleResizePointerMove}
                     onPointerUp={handleResizePointerEnd}
                     onPointerCancel={handleResizePointerEnd}
+                    onLostPointerCapture={handleResizePointerEnd}
                     className="-mx-3 -mt-3 flex h-5 shrink-0 touch-none cursor-ns-resize items-center justify-center"
                   >
                     <div className="h-1 w-9 rounded-full bg-muted-foreground/25" />
@@ -1347,7 +1357,7 @@ export function MessageComposer({
                 <div
                   className={cn(
                     isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
-                    (mobileExpanded || (isMobile && mobileDragHeight !== null)) && "overflow-y-auto"
+                    (mobileExpanded || (isMobile && mobileChromeOpen && mobileDragHeight !== null)) && "overflow-y-auto"
                   )}
                 >
                   <div className="h-full">{sharedEditor}</div>

--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile"
-import { applyPersistedComposerHeight, persistComposerHeight } from "./composer-height-storage"
+import {
+  applyPersistedComposerHeight,
+  persistComposerHeight,
+  loadMobileComposerDragHeight,
+  persistMobileComposerDragHeight,
+  MOBILE_COMPOSER_DRAG_MIN_PX,
+} from "./composer-height-storage"
 
 const DESKTOP_KEY = "threa:composer-height:desktop"
 const MOBILE_KEY = "threa:composer-height:mobile"
@@ -122,5 +128,34 @@ describe("persistComposerHeight", () => {
     persistComposerHeight(12)
     persistComposerHeight(999)
     expect(localStorage.getItem(DESKTOP_KEY)).toBeNull()
+  })
+})
+
+describe("mobile composer drag height", () => {
+  const DRAG_KEY = "threa:composer-drag-height"
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("round-trips the dragged height", () => {
+    persistMobileComposerDragHeight(287.4)
+    expect(localStorage.getItem(DRAG_KEY)).toBe("287")
+    expect(loadMobileComposerDragHeight()).toBe(287)
+  })
+
+  it("returns null when never dragged", () => {
+    expect(loadMobileComposerDragHeight()).toBeNull()
+  })
+
+  it("drops values outside the sanity window on both write and read", () => {
+    persistMobileComposerDragHeight(MOBILE_COMPOSER_DRAG_MIN_PX - 1)
+    expect(localStorage.getItem(DRAG_KEY)).toBeNull()
+    persistMobileComposerDragHeight(5000)
+    expect(localStorage.getItem(DRAG_KEY)).toBeNull()
+    localStorage.setItem(DRAG_KEY, "12")
+    expect(loadMobileComposerDragHeight()).toBeNull()
+    localStorage.setItem(DRAG_KEY, "junk")
+    expect(loadMobileComposerDragHeight()).toBeNull()
   })
 })

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -134,6 +134,46 @@ export function unpublishComposerHeightFromRoot(el: HTMLElement): void {
   document.documentElement.style.setProperty(CSS_VAR, `${survivor}px`)
 }
 
+// --- Mobile drag-resize preference -----------------------------------------
+
+const STORAGE_KEY_DRAG_HEIGHT = "threa:composer-drag-height"
+
+/** Smallest draggable mobile composer: one editor line + the action bar. */
+export const MOBILE_COMPOSER_DRAG_MIN_PX = 140
+// Sanity ceiling for persisted values only — the live drag clamps to 75% of
+// the visual viewport, which no phone exceeds.
+const MAX_DRAG_HEIGHT_PX = 1200
+
+/**
+ * The user-chosen mobile composer height from the drag handle (a max-height:
+ * the composer stays content-driven below it). Persisted per device so the
+ * preference survives reloads; null when the user has never dragged.
+ */
+export function loadMobileComposerDragHeight(): number | null {
+  if (typeof localStorage === "undefined") return null
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_DRAG_HEIGHT)
+    if (!raw) return null
+    const parsed = Number.parseInt(raw, 10)
+    if (!Number.isFinite(parsed)) return null
+    if (parsed < MOBILE_COMPOSER_DRAG_MIN_PX || parsed > MAX_DRAG_HEIGHT_PX) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function persistMobileComposerDragHeight(heightPx: number): void {
+  if (typeof localStorage === "undefined") return
+  const rounded = Math.round(heightPx)
+  if (rounded < MOBILE_COMPOSER_DRAG_MIN_PX || rounded > MAX_DRAG_HEIGHT_PX) return
+  try {
+    localStorage.setItem(STORAGE_KEY_DRAG_HEIGHT, String(rounded))
+  } catch {
+    // Storage quota / private-mode failures shouldn't crash the render path.
+  }
+}
+
 /**
  * Persists a freshly-measured composer height for the next page load, keyed by
  * the current viewport so mobile and desktop never seed each other's fallback.


### PR DESCRIPTION
A long mobile reply grows the composer until the timeline is unreadable, and the only control was the all-or-nothing 75dvh expand toggle. The user asked to resize it directly.

Changes: the open mobile composer gets a grab bar above the editor. Dragging sets a max-height override — the composer stays content-driven below it — so an overgrown draft can be shrunk to see the timeline, or the 380px default growth cap raised. Clamped between 140px (one editor line + action bar) and 75% of the visual viewport; persisted per device (`threa:composer-drag-height`, bounds-checked on read and write) and reapplied on mount. A drag exits the 75dvh expanded preset, whose classes would otherwise outrank the inline override; the preset itself is unchanged. When a drag height is set, the editor's internal tiptap max-height is released and the editor wrapper scrolls, same as expanded mode.

Verification: component tests drive pointer events on the handle and assert the max-height override, the 140px clamp, persistence on release, mount-time reapplication, and that the handle only renders while the chrome is open; storage bounds tests; full frontend suite green.

Residual risk: the handle is pointer-only (no keyboard path) — the action-bar expand toggle remains the accessible size control. Per-frame resizes during a drag re-fire the composer height publish, the same cost profile as the existing keyboard choreography.
