### PR TITLE
fix: skip anchor restore on PUSH navigation so stream switches auto-read

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -593,6 +593,7 @@ describe("isChromeStripCollapsed", () => {
 describe("resolveAnchorRestore", () => {
   const base = {
     alreadyDecided: false,
+    isPushNavigation: false,
     isLoading: false,
     isSettling: false,
     isJumpMode: false,
@@ -604,6 +605,12 @@ describe("resolveAnchorRestore", () => {
 
   it("restores once loading and the cold-load settle have resolved with the anchor in the window", () => {
     expect(resolveAnchorRestore(base)).toBe("restore")
+  })
+
+  it("skips on PUSH navigation — choosing a stream is a fresh open that lands at the tail and auto-reads", () => {
+    expect(resolveAnchorRestore({ ...base, isPushNavigation: true })).toBe("skip")
+    // Consumed immediately, never held through load: the nav type won't change.
+    expect(resolveAnchorRestore({ ...base, isPushNavigation: true, isLoading: true })).toBe("skip")
   })
 
   it("waits (without consuming the decision) while the window loads or the settle masks", () => {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1,6 +1,6 @@
 import { matchesDeepLinkTarget } from "@/lib/stream-links"
 import { useMemo, useEffect, useLayoutEffect, useCallback, useRef, useState } from "react"
-import { useLocation, useSearchParams } from "react-router-dom"
+import { useLocation, useNavigationType, useSearchParams } from "react-router-dom"
 import { Virtualizer, type VirtualizerHandle } from "virtua"
 import { MessageSquare, ArrowDown, ArrowUp, X, Move, Loader2, Check, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -497,7 +497,14 @@ export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerH
  * resolve; every other verdict consumes it.
  *
  * A restore yields to deep links, jump mode, and any user gesture — those own
- * the position. It only engages when the anchored row is in the loaded
+ * the position. It also yields to PUSH navigation (sidebar click, channel
+ * link): choosing a stream is a fresh open, which lands at the tail and
+ * auto-reads like it always has — restoring there parked the reader at a
+ * stale detached spot, and the read frontier (which never jumps a gap) then
+ * silently stopped auto-read for any stream once left mid-scroll. Restore is
+ * for continuations of a previous look at this stream: reload and cold
+ * relaunch (POP, or the boot path's REPLACE redirects) and history
+ * back/forward. It only engages when the anchored row is in the loaded
  * window: anchors are written while detached near the tail (reading context
  * while replying), which the initial window covers; an anchor that has since
  * fallen out of the window is stale enough that the tail is the better
@@ -505,6 +512,7 @@ export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerH
  */
 export function resolveAnchorRestore(args: {
   alreadyDecided: boolean
+  isPushNavigation: boolean
   isLoading: boolean
   isSettling: boolean
   isJumpMode: boolean
@@ -514,6 +522,7 @@ export function resolveAnchorRestore(args: {
   anchorInWindow: boolean
 }): "wait" | "skip" | "restore" {
   if (args.alreadyDecided) return "skip"
+  if (args.isPushNavigation) return "skip"
   if (args.hasDeepLink || args.isJumpMode) return "skip"
   if (args.userInteractedAt > 0) return "skip"
   if (!args.hasAnchor) return "skip"
@@ -617,6 +626,7 @@ export function StreamContent({
 }: StreamContentProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
+  const navigationType = useNavigationType()
   const socket = useSocket()
   const messageService = useMessageService()
   // Tracks the location key we've already handled for a highlight jump. Using
@@ -2458,6 +2468,10 @@ export function StreamContent({
     const settled = !isLoading && !virtualIsInitialSettling
     const decision = resolveAnchorRestore({
       alreadyDecided: false,
+      // The nav type is per-navigation, so at decision time it still describes
+      // how THIS stream was entered even though the decision can resolve a few
+      // renders after the switch (waiting out load/settle).
+      isPushNavigation: navigationType === "PUSH",
       isLoading,
       isSettling: virtualIsInitialSettling,
       isJumpMode,
@@ -2477,6 +2491,7 @@ export function StreamContent({
   }, [
     useVirtualized,
     streamId,
+    navigationType,
     isLoading,
     virtualIsInitialSettling,
     isJumpMode,

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2470,8 +2470,13 @@ export function StreamContent({
       alreadyDecided: false,
       // The nav type is per-navigation, so at decision time it still describes
       // how THIS stream was entered even though the decision can resolve a few
-      // renders after the switch (waiting out load/settle).
-      isPushNavigation: navigationType === "PUSH",
+      // renders after the switch (waiting out load/settle). One PUSH is not a
+      // stream choice: ExactRestore's second `?panel=` hop (routes/index.tsx)
+      // pushes so the Android back gesture can close the restored panel — its
+      // `panelPopsToClose` state marks the cold relaunch, which restore is for.
+      isPushNavigation:
+        navigationType === "PUSH" &&
+        (location.state as { panelPopsToClose?: boolean } | null)?.panelPopsToClose !== true,
       isLoading,
       isSettling: virtualIsInitialSettling,
       isJumpMode,
@@ -2492,6 +2497,7 @@ export function StreamContent({
     useVirtualized,
     streamId,
     navigationType,
+    location.state,
     isLoading,
     virtualIsInitialSettling,
     isJumpMode,


### PR DESCRIPTION
## Problem

The detached-anchor restore (#1868) engages on every stream open, sidebar navigation included. A stream once left mid-scroll has a persisted anchor (12h TTL), so a sidebar click opens it at that stale detached spot instead of the live tail — and since the read frontier (`advanceFrontier` in `use-last-seen-event.ts`) never jumps a gap of unseen rows, `useAutoMarkAsRead` never gets a `lastSeenEventId` and auto-read silently stops for that stream. Refresh appeared to fix it only because a cold load's window often no longer contains the anchor row (restore skips via `anchorInWindow`) so the reader lands at the tail. Reported on staging: unread badges only clear after a page refresh, never on stream switches.

## Solution

`resolveAnchorRestore` gains an `isPushNavigation` gate, checked before the wait gates so the decision is consumed immediately:

- **PUSH** (sidebar click, channel link — every stream *choice*) → skip restore; the open lands at the tail and auto-reads exactly as before #1868.
- **POP** (reload, initial page load, history back/forward) and **REPLACE** (the boot path's `ExactRestore` / `redirectStreamId` redirects in `routes/index.tsx`, i.e. PWA cold relaunch) → restore as designed. These are continuations of a previous look at the stream, which is what the anchor exists for.

`StreamContent` reads `useNavigationType()`; the type is per-navigation, so it still describes how the stream was entered even when the decision resolves several renders later (waiting out load/settle). Stale anchors on PUSH-opened streams self-clean: landing at the tail arms follow, and the capture effect clears the entry on the next scroll tick.

Back/forward deliberately keeps restoring — browser-like scroll restoration on history nav.

## Test plan

- [x] `stream-content.test.ts` — 74 pass (new PUSH decision-table cases)
- [x] full frontend suite — 6650 pass; `tsc --noEmit` clean
- [ ] real-device nav pass — needs staging deploy (label added)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789193436&installation_model_id=20758&pr_number=1872&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1872&signature=15fe1dfc79a99c59211f20a88c4736ce06edb43c3508d097d2525b9336797b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->