### PR TITLE
fix: reveal the cold-load settle at the restored anchor, not the tail

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -595,7 +595,6 @@ describe("resolveAnchorRestore", () => {
     alreadyDecided: false,
     isPushNavigation: false,
     isLoading: false,
-    isSettling: false,
     isJumpMode: false,
     hasDeepLink: false,
     userInteractedAt: 0,
@@ -603,7 +602,7 @@ describe("resolveAnchorRestore", () => {
     anchorInWindow: true,
   }
 
-  it("restores once loading and the cold-load settle have resolved with the anchor in the window", () => {
+  it("restores as soon as the window is loaded with the anchor in it — it does NOT wait out the cold-load settle, so it can take the settle over behind the mask", () => {
     expect(resolveAnchorRestore(base)).toBe("restore")
   })
 
@@ -613,9 +612,8 @@ describe("resolveAnchorRestore", () => {
     expect(resolveAnchorRestore({ ...base, isPushNavigation: true, isLoading: true })).toBe("skip")
   })
 
-  it("waits (without consuming the decision) while the window loads or the settle masks", () => {
+  it("waits (without consuming the decision) while the window loads", () => {
     expect(resolveAnchorRestore({ ...base, isLoading: true })).toBe("wait")
-    expect(resolveAnchorRestore({ ...base, isSettling: true })).toBe("wait")
   })
 
   it("skips with no persisted anchor — the tail open is untouched", () => {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -240,6 +240,14 @@ export const DEEP_LINK_HOLD_MAX_MS = 600
 const UNREAD_MARKER_TOP_GAP_PX = 56
 
 /**
+ * Consecutive 60ms refine ticks the scrollToMessage target must hold its
+ * aligned position before `onFirstSettle` fires — long enough that virtua's
+ * measurement reflow has genuinely converged, short enough (~180ms) that the
+ * anchor restore's skeleton hold is imperceptible on top of the load itself.
+ */
+const SCROLL_SETTLE_STABLE_TICKS = 3
+
+/**
  * Whether the timeline should keep showing the skeleton while a deep-link
  * (?m=) target is fetched into the window. Holds only while there is real
  * cached content that would otherwise paint at the wrong anchor, and never
@@ -509,12 +517,18 @@ export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerH
  * while replying), which the initial window covers; an anchor that has since
  * fallen out of the window is stale enough that the tail is the better
  * landing.
+ *
+ * Deliberately does NOT wait for the cold-load settle: the restore engages the
+ * moment the window is loaded, while the settle mask is still up, and takes
+ * the settle over (holdSettleForRestore → scroll → revealSettle). Waiting for
+ * the settle to finish meant the mask dropped at the TAIL and the restore's
+ * scroll landed a frame later — a visible tail-flash-then-jump on every
+ * reload of a stream with a saved position.
  */
 export function resolveAnchorRestore(args: {
   alreadyDecided: boolean
   isPushNavigation: boolean
   isLoading: boolean
-  isSettling: boolean
   isJumpMode: boolean
   hasDeepLink: boolean
   userInteractedAt: number
@@ -526,7 +540,7 @@ export function resolveAnchorRestore(args: {
   if (args.hasDeepLink || args.isJumpMode) return "skip"
   if (args.userInteractedAt > 0) return "skip"
   if (!args.hasAnchor) return "skip"
-  if (args.isLoading || args.isSettling) return "wait"
+  if (args.isLoading) return "wait"
   if (!args.anchorInWindow) return "skip"
   return "restore"
 }
@@ -1551,6 +1565,8 @@ export function StreamContent({
     isFollowingTailRef,
     handleScroll: handleVirtualScroll,
     resetShiftBaseline,
+    holdSettleForRestore,
+    revealSettle,
   } = useTimelineScroll({
     itemCount: useVirtualized ? visibleItems.length : 0,
     getFirstKey: () => (useVirtualized && visibleItems.length > 0 ? getTimelineItemKey(visibleItems[0]) : null),
@@ -1720,8 +1736,27 @@ export function StreamContent({
   // exactly the "I scroll up to read context, then get yanked back to the
   // linked message" deep-link bug.
   const scrollToMessage = useCallback(
-    (targetId: string, opts?: { align?: "center" | "start"; topOffsetPx?: number }) => {
+    (
+      targetId: string,
+      opts?: {
+        align?: "center" | "start"
+        topOffsetPx?: number
+        /** Fires exactly once, the first time the target has held its aligned
+         *  position for a few ticks — or the loop ends without ever landing
+         *  (user abort, timeout, superseded). The anchor restore holds the
+         *  cold-load skeleton up until this, so the first revealed frame is
+         *  already at the restored position instead of a tail flash. */
+        onFirstSettle?: () => void
+      }
+    ) => {
       const align = opts?.align ?? "center"
+      let settleNotified = false
+      let stableTicks = 0
+      const notifySettled = () => {
+        if (settleNotified) return
+        settleNotified = true
+        opts?.onFirstSettle?.()
+      }
       // For "start": px between the viewport top and the target's top. The
       // unread-marker default leaves a small context gap; an anchor restore
       // passes the exact (possibly negative) offset the reader detached at.
@@ -1761,6 +1796,7 @@ export function StreamContent({
       let aborted = false
       const abort = () => {
         aborted = true
+        notifySettled()
         if (scrollRetryTimerRef.current !== null) {
           window.clearTimeout(scrollRetryTimerRef.current)
           scrollRetryTimerRef.current = null
@@ -1813,8 +1849,14 @@ export function StreamContent({
           const delta = align === "start" ? er.top - desiredTop : (er.top + er.bottom) / 2 - scCenter
           if (Math.abs(delta) > 2) {
             scroller.scrollTop += delta
+            stableTicks = 0
+          } else if (++stableTicks >= SCROLL_SETTLE_STABLE_TICKS) {
+            // Landed and holding — the loop keeps watching for late reflows
+            // (link previews), but the position is presentable now.
+            notifySettled()
           }
         } else {
+          stableTicks = 0
           // Target is virtualized out — ask Virtuoso to render it (0-based
           // index). Re-resolve against the live timeline every tick: the
           // window can shift under this loop, and a stale/out-of-range index
@@ -2465,12 +2507,11 @@ export function StreamContent({
     // not free at that cadence.
     if (anchorRestoreRef.current.decided) return
     const anchor = loadTimelineAnchor(streamId)
-    const settled = !isLoading && !virtualIsInitialSettling
     const decision = resolveAnchorRestore({
       alreadyDecided: false,
       // The nav type is per-navigation, so at decision time it still describes
       // how THIS stream was entered even though the decision can resolve a few
-      // renders after the switch (waiting out load/settle). One PUSH is not a
+      // renders after the switch (waiting out the load). One PUSH is not a
       // stream choice: ExactRestore's second `?panel=` hop (routes/index.tsx)
       // pushes so the Android back gesture can close the restored panel — its
       // `panelPopsToClose` state marks the cold relaunch, which restore is for.
@@ -2478,20 +2519,39 @@ export function StreamContent({
         navigationType === "PUSH" &&
         (location.state as { panelPopsToClose?: boolean } | null)?.panelPopsToClose !== true,
       isLoading,
-      isSettling: virtualIsInitialSettling,
       isJumpMode,
       hasDeepLink: skipInitialScroll,
       userInteractedAt: userInteractedAtRef.current,
       hasAnchor: anchor !== null,
-      // The scan only matters once the wait gates have cleared; skip it while
-      // the window is still loading or masked.
-      anchorInWindow: anchor !== null && settled && findTimelineTargetIndex(visibleItems, anchor.targetId) >= 0,
+      // The scan only matters once the wait gate has cleared; skip it while
+      // the window is still loading.
+      anchorInWindow: anchor !== null && !isLoading && findTimelineTargetIndex(visibleItems, anchor.targetId) >= 0,
     })
     if (decision === "wait") return
     anchorRestoreRef.current.decided = true
     if (decision !== "restore" || !anchor) return
-    if (scrollToMessage(anchor.targetId, { align: "start", topOffsetPx: anchor.offsetPx })) {
+    // Take over the cold-load settle: cancel its pin-to-bottom loop but keep
+    // the skeleton mask up, position on the anchor behind it, and reveal once
+    // the anchor has held its spot — so the first painted frame is already at
+    // the restored position instead of a tail flash followed by a jump.
+    // Reveal is guarded by decision identity: if the user switches streams
+    // before this restore's refine loop ends, its late notification must not
+    // strip the NEXT stream's settle mask mid-measurement.
+    holdSettleForRestore()
+    const decidedFor = anchorRestoreRef.current
+    const revealIfCurrent = () => {
+      if (anchorRestoreRef.current === decidedFor) revealSettle()
+    }
+    if (
+      scrollToMessage(anchor.targetId, {
+        align: "start",
+        topOffsetPx: anchor.offsetPx,
+        onFirstSettle: revealIfCurrent,
+      })
+    ) {
       unreadMarkerOpenRef.current.decided = true
+    } else {
+      revealIfCurrent()
     }
   }, [
     useVirtualized,
@@ -2499,11 +2559,12 @@ export function StreamContent({
     navigationType,
     location.state,
     isLoading,
-    virtualIsInitialSettling,
     isJumpMode,
     skipInitialScroll,
     visibleItems,
     scrollToMessage,
+    holdSettleForRestore,
+    revealSettle,
   ])
 
   // Persist the detached reading position for the restore above. While

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -924,4 +924,45 @@ describe("useTimelineScroll — cold-load settle across a stream switch", () => 
       caf.mockRestore()
     }
   })
+
+  it("holdSettleForRestore stops the settle without revealing; revealSettle then drops the mask", () => {
+    // The anchor-restore handoff: the restore engages while the settle mask is
+    // still up, cancels the pin-to-bottom loop (which would fight the anchor
+    // scroll), keeps the mask, and reveals itself once positioned. A settle
+    // that kept ticking after the handoff would reveal at the TAIL — the
+    // tail-flash-then-jump bounce this exists to remove.
+    const rafCallbacks: FrameRequestCallback[] = []
+    const raf = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    const caf = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+    const runFrame = () => act(() => rafCallbacks.shift()?.(performance.now()))
+    try {
+      const harness = renderScrollHook(opts({ itemCount: 0, getFirstKey: () => null, resetKey: "stream_a" }))
+      const content = document.createElement("div")
+      harness.current.contentRef.current = content
+      const el = makeScrollerDiv({ scrollHeight: 1000, clientHeight: 800 })
+      act(() => harness.current.registerScroller(el))
+
+      harness.rerender(opts({ itemCount: 10, getFirstKey: () => "a1", resetKey: "stream_a" }))
+      expect(harness.current.isInitialSettling).toBe(true)
+
+      act(() => harness.current.holdSettleForRestore())
+
+      // Height is stable, so an un-cancelled settle would converge and reveal
+      // within SETTLE_STABLE_FRAMES ticks. The handed-off loop must not.
+      runFrame()
+      runFrame()
+      runFrame()
+      runFrame()
+      expect(harness.current.isInitialSettling).toBe(true)
+
+      act(() => harness.current.revealSettle())
+      expect(harness.current.isInitialSettling).toBe(false)
+    } finally {
+      raf.mockRestore()
+      caf.mockRestore()
+    }
+  })
 })

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -124,6 +124,18 @@ interface UseTimelineScrollReturn {
    * mis-detected as a prepend.
    */
   resetShiftBaseline: () => void
+  /**
+   * Hand the cold-load settle over to an anchor restore: cancel the in-flight
+   * settle-to-bottom loop WITHOUT dropping the skeleton mask, so the caller can
+   * position the viewport off-screen and reveal at the restored spot via
+   * `revealSettle`. Without this the settle reveals at the tail first and the
+   * restore's scroll lands a frame later — a visible tail-flash-then-jump on
+   * every reload of a stream with a saved reading position. No-op when no
+   * settle is in flight.
+   */
+  holdSettleForRestore: () => void
+  /** Drop the cold-load settle mask. Idempotent; pairs with holdSettleForRestore. */
+  revealSettle: () => void
 }
 
 /**
@@ -334,6 +346,14 @@ export function useTimelineScroll({
   const resetShiftBaseline = useCallback(() => {
     prevFirstKeyRef.current = null
     prevCountRef.current = 0
+  }, [])
+
+  const holdSettleForRestore = useCallback(() => {
+    initialSettleCleanupRef.current?.(false)
+  }, [])
+
+  const revealSettle = useCallback(() => {
+    setIsInitialSettling(false)
   }, [])
 
   // Hidden cold-load settle: pin to the bottom every frame while virtua measures
@@ -796,5 +816,7 @@ export function useTimelineScroll({
     disableAutoScroll,
     handleScroll,
     resetShiftBaseline,
+    holdSettleForRestore,
+    revealSettle,
   }
 }


### PR DESCRIPTION
## Problem

The landing-at-last-location restore (#1868) bounces on reload: the timeline paints at the tail for 1–2 frames, then visibly jumps up to the saved anchor. Frame-by-frame of the report's recording shows the sequence — skeleton → tail paint → jump — on every reload, regardless of content age, so it isn't the legacy-embed dimension issue.

Cause: `resolveAnchorRestore` waited out the cold-load settle, but `settleToBottom` reveals the skeleton mask **at the tail** — that reveal is the first painted frame. The restore then runs in the reveal commit, and when the anchor row isn't in the DOM yet its scroll goes through virtua's async `scrollToIndex`, landing a frame or two after the paint.

## Solution

The restore takes the settle over instead of waiting behind it:

- `resolveAnchorRestore` drops the `isSettling` wait gate — it decides as soon as the window is loaded, while the mask is still up.
- New `holdSettleForRestore()` / `revealSettle()` on `useTimelineScroll`: cancel the settle's pin-to-bottom loop **without** revealing (the pin would fight the anchor scroll), leaving the mask up for the restore to drop.
- `scrollToMessage` gains `onFirstSettle` — fires exactly once when the target has held its aligned position for 3 refine ticks (~180ms), or when the loop ends without landing (user abort, timeout, superseded), so the mask can never stick. Reveal is guarded by decision identity so a fast stream switch can't have a late notification strip the next stream's mask mid-measurement.

First painted frame is now already at the restored position. PUSH navigation (skip → tail + auto-read, #1872) and deep links are untouched; a `scrollToMessage` bail on the restore path reveals immediately.

## Test plan

- [x] `stream-content.test.ts` + `use-timeline-scroll.test.tsx` — 110 pass (decision table updated; new hold/reveal handoff test)
- [x] full frontend suite green; `tsc --noEmit` clean
- [ ] real-device reload pass — needs staging deploy (label added)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199285&installation_model_id=20758&pr_number=1873&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1873&signature=1c1bb8dcabc7b46a25ee75fce14c8ef70c8b10f5bf112b6990f2a3105b1ddeb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->