### PR TITLE
fix: unread-marker open takes the settle over — no tail flash on unread streams

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -519,7 +519,7 @@ describe("resolveUnreadMarkerOpen", () => {
     unreadOpenPosition: "marker" as const,
     alreadyDecided: false,
     isLoading: false,
-    isSettling: false,
+    hasItems: true,
     readStateResolved: true,
     isJumpMode: false,
     hasDeepLink: false,
@@ -527,13 +527,15 @@ describe("resolveUnreadMarkerOpen", () => {
     dividerEventId: "event_5" as string | undefined,
   }
 
-  it("scrolls to the marker once loading, settle, and read state have all resolved", () => {
+  it("scrolls to the marker once the window is loaded with rows and the read state has resolved — it does NOT wait out the cold-load settle (it takes the settle over behind the mask)", () => {
     expect(resolveUnreadMarkerOpen(base)).toBe("scroll")
   })
 
-  it("waits (without consuming the decision) while the window is loading, the cold-load settle is masking, or the read position is unresolved", () => {
+  it("waits (without consuming the decision) while the window is loading or unpopulated, or the read position is unresolved", () => {
     expect(resolveUnreadMarkerOpen({ ...base, isLoading: true })).toBe("wait")
-    expect(resolveUnreadMarkerOpen({ ...base, isSettling: true })).toBe("wait")
+    // Cold-boot grace window: loading reads done while the window is still
+    // empty — consuming here is the restore's #1873 bug, same class.
+    expect(resolveUnreadMarkerOpen({ ...base, hasItems: false })).toBe("wait")
     expect(resolveUnreadMarkerOpen({ ...base, readStateResolved: false })).toBe("wait")
   })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -451,9 +451,14 @@ export function resolveDateJumpAnchor(args: {
  * unread-open-position preference (Discord-style: land on the first unread).
  *
  * Returns:
- *  - "wait"   — inputs still resolving (window loading, cold-load settle
- *               masking, read position or the preference itself unhydrated);
- *               do NOT consume the once-per-stream decision yet.
+ *  - "wait"   — inputs still resolving (window loading or unpopulated, read
+ *               position or the preference itself unhydrated); do NOT consume
+ *               the once-per-stream decision yet. Deliberately does NOT wait
+ *               out the cold-load settle: the marker scroll takes the settle
+ *               over (hold the mask, position, reveal at the divider) exactly
+ *               like the anchor restore — waiting for settle-end revealed the
+ *               TAIL first and jumped to the divider a beat later on every
+ *               open of an unread stream.
  *  - "skip"   — decision consumed, open at the bottom as usual ("latest" mode,
  *               nothing unread, a deep-link/jump owns the scroll, or the user
  *               already scrolled).
@@ -468,7 +473,9 @@ export function resolveUnreadMarkerOpen(args: {
   unreadOpenPosition: UnreadOpenPosition | null
   alreadyDecided: boolean
   isLoading: boolean
-  isSettling: boolean
+  /** The event window has rows — `isLoading` alone misses the cold-boot grace
+   *  window where loading reads done while IDB is still resolving. */
+  hasItems: boolean
   readStateResolved: boolean
   isJumpMode: boolean
   hasDeepLink: boolean
@@ -480,7 +487,7 @@ export function resolveUnreadMarkerOpen(args: {
   if (args.userInteractedAt > 0) return "skip"
   if (args.unreadOpenPosition === null) return "wait"
   if (args.unreadOpenPosition !== "marker") return "skip"
-  if (args.isLoading || args.isSettling || !args.readStateResolved) return "wait"
+  if (args.isLoading || !args.hasItems || !args.readStateResolved) return "wait"
   if (!args.dividerEventId) return "skip"
   return "scroll"
 }
@@ -1705,7 +1712,14 @@ export function StreamContent({
         }
         // Main timeline: force on initial correction (cold-load anchor fix),
         // but respect the follow flag for runtime composer growth so a user
-        // scrolled up to read history isn't yanked back to the tail.
+        // scrolled up to read history isn't yanked back to the tail. The
+        // initial force also yields to a positioned reader: a scrollToMessage
+        // refine loop in flight (anchor restore, unread-marker open, deep
+        // link) or an already-landed detached position owns the viewport — a
+        // late-mounting composer must not stomp it back to the tail.
+        if (opts.initial && (scrollAbortRef.current || (!isFollowingTailRef.current && detachedHoldRef.current))) {
+          return
+        }
         if (useVirtualized) {
           virtualScrollToBottomRef.current({ force: opts.initial })
         } else {
@@ -2662,6 +2676,13 @@ export function StreamContent({
         detachedHoldRef.current = null
         return
       }
+      // A scrollToMessage refine loop mid-flight means the current position is
+      // transient, not a reading position. The debounce normally covers this
+      // (each tick resets it), but pagehide/visibilitychange snapshot
+      // SYNCHRONOUSLY — backgrounding the app mid-jump would persist an
+      // arbitrary in-between scroll as the saved anchor. Keep the previous
+      // anchor instead.
+      if (scrollAbortRef.current) return
       const best = snapshotTopVisibleRow(el)
       if (best) {
         saveTimelineAnchor(streamId, { targetId: best.id, offsetPx: best.offsetPx })
@@ -2736,7 +2757,7 @@ export function StreamContent({
       unreadOpenPosition,
       alreadyDecided: unreadMarkerOpenRef.current.decided,
       isLoading,
-      isSettling: useVirtualized && virtualIsInitialSettling,
+      hasItems: visibleItems.length > 0,
       readStateResolved: frontierSequence !== undefined,
       isJumpMode,
       // The per-stream deep-link latch, not the transient ?m= param — a stream
@@ -2755,7 +2776,33 @@ export function StreamContent({
     // unread message taller than the viewport reads from its start. Falls back
     // to the one-shot path only for the plain thread scroller, where all rows
     // are real DOM already.
-    if (!useVirtualized || !dividerEventId || !scrollToMessage(dividerEventId, { align: "start" })) {
+    if (useVirtualized && dividerEventId) {
+      // Take over the cold-load settle exactly like the anchor restore:
+      // position on the divider behind the mask and reveal once it has held,
+      // so the first painted frame is at the marker — not a tail flash
+      // followed by a visible jump up (the "flicker on every unread stream"
+      // report; the old restore used to eat this decision on most opens,
+      // which is why the jump only became prominent once PUSH switches
+      // stopped restoring).
+      holdSettleForRestore()
+      const decidedFor = unreadMarkerOpenRef.current
+      const revealIfCurrent = () => {
+        if (unreadMarkerOpenRef.current !== decidedFor) return
+        revealSettle()
+        // Timed-out-without-landing fallback: the guard still targets the
+        // divider — pull once more after the loop releases the scroller.
+        requestAnimationFrame(applyDetachedHold)
+      }
+      detachedHoldRef.current = {
+        id: dividerEventId,
+        offsetPx: UNREAD_MARKER_TOP_GAP_PX,
+        takenAt: performance.now(),
+      }
+      if (!scrollToMessage(dividerEventId, { align: "start", onFirstSettle: revealIfCurrent })) {
+        revealIfCurrent()
+        scrollToFirstUnread()
+      }
+    } else if (!dividerEventId || !scrollToMessage(dividerEventId, { align: "start" })) {
       scrollToFirstUnread()
     }
   }, [
@@ -2763,13 +2810,16 @@ export function StreamContent({
     streamId,
     isLoading,
     useVirtualized,
-    virtualIsInitialSettling,
+    visibleItems,
     frontierSequence,
     isJumpMode,
     skipInitialScroll,
     dividerEventId,
     scrollToMessage,
     scrollToFirstUnread,
+    holdSettleForRestore,
+    revealSettle,
+    applyDetachedHold,
   ])
 
   const editLastMessageCtxWithScroll = useMemo(

--- a/tests/browser/unread-marker-open.spec.ts
+++ b/tests/browser/unread-marker-open.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect, type Page, type Browser } from "@playwright/test"
+import { loginAndCreateWorkspace, loginInNewContext, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * Open-at-unread-marker (unreadOpenPosition: "marker"): a stream with unreads
+ * opens WITH the first painted frame already at the unread divider — never a
+ * tail flash followed by a visible jump up to the divider. Same settle-
+ * takeover contract as the anchor restore; this was the "flicker on every
+ * unread stream" report once PUSH switches stopped consuming the marker
+ * decision via the restore.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+function extractIds(page: Page): { workspaceId: string; streamId: string } {
+  const url = page.url()
+  const workspaceMatch = url.match(/\/w\/([^/]+)/)
+  const streamMatch = url.match(/\/s\/([^/?]+)/)
+  if (!workspaceMatch || !streamMatch) throw new Error(`Could not extract IDs from URL: ${url}`)
+  return { workspaceId: workspaceMatch[1], streamId: streamMatch[1] }
+}
+
+async function seedFrom(page: Page, workspaceId: string, streamId: string, count: number, prefix: string, startAt = 1) {
+  for (let i = startAt; i < startAt + count; i += 5) {
+    const end = Math.min(i + 4, startAt + count - 1)
+    await Promise.all(
+      Array.from({ length: end - i + 1 }, (_, k) =>
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix} msg-${String(i + k).padStart(3, "0")}` },
+          })
+          .then((r) => expectApiOk(r, `Send message ${i + k}`))
+      )
+    )
+  }
+}
+
+async function setUpUnreadChannel(browser: Browser, ownerPage: Page) {
+  const owner = await loginAndCreateWorkspace(ownerPage, "marker-open")
+  const testId = owner.testId
+  const prefix = `[${testId}]`
+
+  await createChannel(ownerPage, `marker-${testId}`)
+  const { workspaceId, streamId } = extractIds(ownerPage)
+
+  // The viewer opens at the unread marker.
+  await expectApiOk(
+    await ownerPage.request.patch(`/api/workspaces/${workspaceId}/preferences`, {
+      data: { unreadOpenPosition: "marker" },
+    }),
+    "Set marker preference"
+  )
+
+  // Owner seeds some history they have READ (they are viewing the channel).
+  await seedFrom(ownerPage, workspaceId, streamId, 10, prefix)
+  await expect(
+    ownerPage
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix} msg-010` })
+  ).toBeVisible({ timeout: 20000 })
+
+  // Navigate away so the unreads below arrive while not viewing.
+  await ownerPage.goto(`/w/${workspaceId}/drafts`)
+  await expect(ownerPage).toHaveURL(new RegExp(`/w/${workspaceId}/drafts`))
+
+  // A second user joins and posts the unread run.
+  const other = await loginInNewContext(browser, `marker-b-${testId}@example.com`, `Marker B ${testId}`)
+  await expectApiOk(
+    await other.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+      data: { role: "member", name: `Marker B ${testId}` },
+    }),
+    "Second user joins workspace"
+  )
+  await expectApiOk(
+    await other.page.request.post(`/api/workspaces/${workspaceId}/streams/${streamId}/join`, { data: {} }),
+    "Second user joins the channel"
+  )
+  // The join's write authority can lag the join response by a beat under
+  // parallel load — poll the first unread post until it lands, then seed.
+  await expect
+    .poll(
+      async () =>
+        (
+          await other.page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix}-unread msg-001` },
+          })
+        ).status(),
+      { timeout: 10000, message: "second user's first post should be accepted after joining" }
+    )
+    .toBe(201)
+  await seedFrom(other.page, workspaceId, streamId, 24, `${prefix}-unread`, 2)
+
+  return { testId, prefix, workspaceId, streamId, otherContext: other.context }
+}
+
+test.describe("Unread marker open", () => {
+  test("sidebar switch into an unread stream paints at the divider — no tail flash, and it holds", async ({
+    page,
+    browser,
+  }) => {
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    // The switch under test: from /drafts into the unread channel.
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+
+    // The unread divider ("New" marker) must end up near the viewport top,
+    // with the first unread message visible right below it — and hold there.
+    const divider = page.getByText("New", { exact: true }).first()
+    const firstUnread = page
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix}-unread msg-001` })
+      .first()
+    await expect(firstUnread).toBeVisible({ timeout: 20000 })
+
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const scrollerBox = await scroller.boundingBox()
+    expect(scrollerBox).not.toBeNull()
+
+    await expect
+      .poll(
+        async () => {
+          const box = await firstUnread.boundingBox()
+          return box ? Math.round(box.y - scrollerBox!.y) : -9999
+        },
+        { timeout: 10000, message: "first unread should sit near the viewport top" }
+      )
+      .toBeLessThan(200)
+
+    // The tail must NOT be on screen (we are parked at the divider, 25
+    // messages above the newest).
+    const lastMsg = page
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix}-unread msg-025` })
+      .first()
+    const lastBox = await lastMsg.boundingBox()
+    if (lastBox) {
+      expect(lastBox.y, "newest message should be below the viewport").toBeGreaterThan(
+        scrollerBox!.y + scrollerBox!.height - 10
+      )
+    }
+
+    // And it holds: the divider position is stable over the next second (the
+    // detached viewport guard owns it; late reflows must not slide the view).
+    const posA = await firstUnread.boundingBox()
+    await page.waitForTimeout(1000)
+    const posB = await firstUnread.boundingBox()
+    expect(posA).not.toBeNull()
+    expect(posB).not.toBeNull()
+    expect(Math.abs(posB!.y - posA!.y)).toBeLessThanOrEqual(3)
+
+    await expect(divider).toBeVisible()
+    await otherContext.close()
+  })
+})


### PR DESCRIPTION
## Problem

The prod "jump/flicker galore" recording, frame-diffed: streams land at the tail, then visibly jump ~170px up toward the unread divider. The reporter's `unreadOpenPosition` is `"marker"` (verified read-only in prod) — and the marker-open scroll has the exact flaw the anchor restore was cured of in #1873/#1874: it waits out the cold-load settle, but the settle **reveals at the tail**, and the divider scroll lands frames later through virtua's async `scrollToIndex`. The jump went mostly unseen while the pre-#1872 restore consumed the marker decision on every revisit; PUSH switches stopping restoring un-hid it on every sidebar switch into an unread stream.

## Solution

- The marker scroll mirrors the restore's settle takeover: decides once the window has rows (`hasItems` gate — same cold-boot grace-window trap as #1873), holds the settle mask, positions on the divider behind it, seeds the detached viewport guard with the divider target, and reveals once the divider holds (rAF fallback pull if the refine loop times out unlanded). Threads/plain scroller keep the old direct path.
- Two findings from the parallel cumulative audit (pre-stack `f5f3ffde` → `504dcec0`, three adversarial lenses) land here too:
  - `pagehide`/`visibilitychange` snapshot during an in-flight `scrollToMessage` refine loop persisted a transient mid-jump position as the saved reading anchor; the synchronous snapshot now yields while a loop is active.
  - The composer's `initial: true` height correction force-pinned to the tail blind to a positioned reader; it now yields to an active refine loop or a landed detached position.
- Audit otherwise: 12/12 behavior contracts PASS (tail landing/auto-read, live-append pin, detach, re-arm, jump-to-latest, deep link, marker, prepend hold, reload restore, threads, drafts/jump-mode, mobile keyboard/drag). Known residual, deliberately not fixed here: a transient bootstrap-fallback window during the IDB race can consume the restore decision as "stale anchor" and land at the tail — bounded (pre-#1868 behavior), rare, needs a window-authority signal from use-events to fix cleanly.

## Test plan

- [x] new `unread-marker-open.spec.ts` — second user seeds 25 unreads; the switch paints with the first unread near the viewport top, tail off-screen, holds ±3px for 1s (3× repeats; one infra socket-hang-up on parallel seeding passed in isolation)
- [x] full frontend units 6653 pass; anchor-restore + switch-stability + marker matrix green
- [ ] real-device pass — staging label added

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789219000&installation_model_id=20758&pr_number=1875&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1875&signature=11adb862bfc93ba35c8a9b7f61682fcbdd324ec6772c21460440c8b221242009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->