### PR TITLE
fix: mobile loading hairline paints under the sidebar drawer

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -283,16 +283,6 @@ export function AppShell({ sidebar, children }: AppShellProps) {
       {/* Pull-to-refresh container — pulling anywhere (sidebar or main content)
            translates the entire area uniformly */}
       <div ref={pullRef} className="relative flex flex-1 flex-col overflow-hidden">
-        {/* Workspace-wide loading indicator — hairline along the bottom of the
-             sidebar/page header row (h-12). Spans the full viewport so it links
-             the two headers visually now that the top bar is gone. Above the
-             sidebar column (z-40), below the z-50 overlay layer: no ancestor
-             here opens a stacking context, so anything higher paints the
-             hairline over dialogs, drawers and menus portalled to the body. */}
-        <div className="pointer-events-none absolute left-0 right-0 top-12 z-[45]">
-          <TopbarLoadingIndicator visible={showLoadingIndicator} />
-        </div>
-
         <div
           className="absolute inset-x-0 top-0 z-10 flex items-center justify-center gap-2 pointer-events-none"
           style={{ height: `${pullDistance}px` }}
@@ -324,6 +314,17 @@ export function AppShell({ sidebar, children }: AppShellProps) {
               transition: pulling ? "none" : "height 0.3s ease-out",
             }}
           />
+
+          {/* Workspace-wide loading indicator — hairline along the bottom of the
+               sidebar/page header row (h-12). Lives inside the pull-translated
+               area (a transform, so its own stacking context) to be orderable
+               against the sidebar column (z-40) and mobile overlay layer
+               (backdrop z-30): on desktop it spans both headers above the
+               sidebar column, on mobile the sidebar is a drawer over the page,
+               so the hairline belongs under it and its backdrop. */}
+          <div className={cn("pointer-events-none absolute left-0 right-0 top-12", isMobile ? "z-[25]" : "z-[45]")}>
+            <TopbarLoadingIndicator visible={showLoadingIndicator} />
+          </div>
 
           {/* Mobile backdrop - always in DOM so swipe gestures can control opacity imperatively */}
           {isMobile && (


### PR DESCRIPTION
## Problem

The workspace loading hairline (`TopbarLoadingIndicator` in `app-shell.tsx`) rendered as a sibling of the pull-to-refresh container at `z-[45]`. That container is `transform`ed, so it owns a stacking context — any positive z on the outside sibling paints the hairline over the entire app area, including the mobile sidebar drawer (`aside`, `z-40`) and its backdrop (`z-30`). On mobile the line flashes across the open drawer during a refresh.

## Solution

Move the indicator inside the pull-translated container so it is orderable against the drawer layer, and pick z by form factor:

- Mobile `z-[25]` — under the backdrop (`z-30`) and drawer (`z-40`); on mobile the sidebar is an overlay over the page, so the page's loading line belongs behind it.
- Desktop keeps `z-[45]` — the sidebar is an opaque inline column there, and the hairline is meant to span both headers, so it stays above `z-40` and below the `z-[60]` top fade.

Side effect of the move: the hairline now translates with the pull instead of staying pinned while the headers slide down. Pull is gated on `touchCapable`, so desktop geometry is unchanged.

Alternative considered: `z-[35]` (above backdrop, under drawer) — the line would still burn bright across the dimmed right-hand sliver while the drawer is open.

## Test plan

- [x] `bun run typecheck` + `bun run lint` (pre-commit hooks, full monorepo) — pass
- [ ] Not verified in a running app — no dev stack up in this session; change is CSS stacking order only, from the video's mobile repro.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789228187&installation_model_id=20758&pr_number=1878&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1878&signature=eb79533c51592634c8e464d2482c4827e10efe57b0d25e3e672fb1df6d18aad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->