### PR TITLE
fix: the composer height cap comes off the editor, not the attachment tray

### DIFF
--- a/apps/frontend/src/components/composer/composer-link-previews.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.tsx
@@ -64,7 +64,7 @@ export function ComposerLinkPreviews({ content, workspaceId, className }: Compos
   const dismiss = (url: string) => setDismissed((prev) => new Set(prev).add(url))
 
   return (
-    <div className={cn("flex flex-wrap gap-2 max-h-[120px] overflow-y-auto", className)}>
+    <div className={cn("flex shrink-0 flex-wrap gap-2 max-h-[120px] overflow-y-auto", className)}>
       {visible.map((link) => (
         <ComposerLinkChip key={link.url} link={link} workspaceId={workspaceId} onDismiss={dismiss} />
       ))}

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -360,6 +360,29 @@ export function MessageComposer({
   // isn't torn down mid-take.
   const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobile()
+  // Height of everything above the editor card (attachment tray, link previews)
+  // — the same "extras" the drag floor reserves, measured live because a
+  // persisted cap outlives the state it was chosen in: shrink the composer with
+  // nothing attached, attach a file later, and the cap no longer fits the tray
+  // plus a usable card. The extras hold their height (shrinking clips their own
+  // chips), so without this the card takes the whole deficit and its action bar
+  // spills below the viewport.
+  const [mobileExtrasHeight, setMobileExtrasHeight] = useState(0)
+  useLayoutEffect(() => {
+    const root = mobileRootRef.current
+    if (!isMobile || mobileDragHeight === null || !root) return
+    const card = root.querySelector<HTMLElement>("[data-composer-card]")
+    if (!card) return
+    const measure = () =>
+      setMobileExtrasHeight(
+        Math.max(0, Math.round(root.getBoundingClientRect().height - card.getBoundingClientRect().height))
+      )
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(root)
+    observer.observe(card)
+    return () => observer.disconnect()
+  }, [isMobile, mobileDragHeight])
   const actionSide = useComposerActionSide()
   const preferencesCtx = usePreferencesOptional()
   const mirrored = actionSide === "left"
@@ -1241,7 +1264,11 @@ export function MessageComposer({
           // The drag-handle height override. A max-height (not height) so the
           // composer stays content-driven below it; inline so it outranks the
           // 380px default class above.
-          style={isMobile && !mobileExpanded && mobileDragHeight !== null ? { maxHeight: mobileDragHeight } : undefined}
+          style={
+            isMobile && !mobileExpanded && mobileDragHeight !== null
+              ? { maxHeight: Math.max(mobileDragHeight, MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight) }
+              : undefined
+          }
           onFocusCapture={isMobile ? handleFocusCapture : undefined}
           onBlurCapture={isMobile ? handleBlurCapture : undefined}
           onKeyDownCapture={handleStashKeyDown}

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -567,7 +567,7 @@ export function PendingAttachments({
         // this line's buttons — same guard as the composer's action bar. Safe
         // as a blanket here: every child is our own button, nothing portaled.
         <div
-          className="mb-1.5 flex h-6 items-center gap-3 text-xs text-muted-foreground"
+          className="mb-1.5 flex h-6 shrink-0 items-center gap-3 text-xs text-muted-foreground"
           onMouseDown={(event) => event.preventDefault()}
         >
           {isMobile ? (
@@ -608,8 +608,13 @@ export function PendingAttachments({
       )}
       {!foldChips && (attachments.length > 0 || beforePills) && (
         <div
+          data-testid="attachment-chip-row"
           className={cn(
-            "flex flex-wrap items-center mb-3 overflow-y-auto",
+            // shrink-0: the tray is a flex child of the composer shell, whose
+            // height is capped (drag handle / 380px). Shrinkable, it absorbed
+            // the whole deficit — chips sliced off at the bottom — while the
+            // editor card kept its size. The cap belongs to the card.
+            "flex shrink-0 flex-wrap items-center mb-3 overflow-y-auto",
             // Two chip rows plus a sliver of the third, so "there's more" is
             // visible without stealing the strip the composer already fights
             // the keyboard for. The full list lives in the drawer.

--- a/tests/browser/composer-attachment-tray-mobile.spec.ts
+++ b/tests/browser/composer-attachment-tray-mobile.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * The mobile attachment tray sits above the composer card, inside the shell
+ * whose height the drag handle caps. Shrinkable, the tray absorbed the whole
+ * cap deficit — the chip row collapsed under its chips and sliced them off at
+ * the bottom, resizing again on every card-height change. Only a real engine
+ * answers this: the deficit comes from flex distribution over measured boxes.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+const PHONE = { width: 390, height: 800 }
+
+const DRAFT =
+  "Can you make sure the loading indicator in the topbar had the correct z index? In this video you can see it flashing by on top of the sidebar which is wrong, it should be below the sidebar. "
+
+test("dragging the composer down never slices the attachment chips", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "tray-size")
+  await createChannel(page, `tray-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  for (let i = 1; i <= 12; i++) {
+    await expectApiOk(
+      await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+        data: { streamId, content: `seed ${i}` },
+      }),
+      `seed ${i}`
+    )
+  }
+
+  await page.setViewportSize(PHONE)
+  await page.reload()
+
+  const card = page.locator("[data-message-composer-root] [data-composer-card]").first()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  await card.click()
+  const editor = page.locator("[data-message-composer-root] .tiptap").first()
+  await expect(page.getByTestId("composer-resize-handle")).toBeVisible({ timeout: 10_000 })
+
+  await page.locator('[data-message-composer-root] input[type="file"][multiple]').setInputFiles({
+    name: "VID_20260813_174107.mp4",
+    mimeType: "video/mp4",
+    buffer: Buffer.alloc(2048, 7),
+  })
+  await expect(page.getByTestId("attachment-chip-row")).toBeVisible({ timeout: 20_000 })
+
+  await editor.click()
+  await editor.pressSequentially(DRAFT.repeat(3), { delay: 1 })
+
+  const measure = () =>
+    page.evaluate(() => {
+      const row = document.querySelector('[data-testid="attachment-chip-row"]') as HTMLElement
+      const chip = row.firstElementChild as HTMLElement
+      return {
+        rowBottom: Math.round(row.getBoundingClientRect().bottom),
+        rowHeight: Math.round(row.getBoundingClientRect().height),
+        chipBottom: Math.round(chip.getBoundingClientRect().bottom),
+        chipHeight: Math.round(chip.getBoundingClientRect().height),
+      }
+    })
+
+  const resting = await measure()
+  expect(resting.rowHeight).toBe(resting.chipHeight)
+
+  // Drag the composer's top edge down, past the point where the card hits its
+  // own floor: every step must leave the one chip row at its natural height.
+  const handle = page.getByTestId("composer-resize-handle")
+  const box = (await handle.boundingBox())!
+  const x = box.x + box.width / 2
+  const y = box.y + box.height / 2
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  for (const dy of [40, 80, 120, 160, 200]) {
+    await page.mouse.move(x, y + dy)
+    expect(await measure(), `chips intact at drag +${dy}`).toMatchObject({
+      rowHeight: resting.chipHeight,
+      chipHeight: resting.chipHeight,
+    })
+  }
+  await page.mouse.up()
+
+  const dragged = await measure()
+  expect(dragged.chipBottom, "chip ends inside its row").toBeLessThanOrEqual(dragged.rowBottom)
+  expect(dragged.rowHeight).toBe(resting.chipHeight)
+})

--- a/tests/browser/composer-attachment-tray-mobile.spec.ts
+++ b/tests/browser/composer-attachment-tray-mobile.spec.ts
@@ -88,4 +88,34 @@ test("dragging the composer down never slices the attachment chips", async ({ pa
   const dragged = await measure()
   expect(dragged.chipBottom, "chip ends inside its row").toBeLessThanOrEqual(dragged.rowBottom)
   expect(dragged.rowHeight).toBe(resting.chipHeight)
+
+  // A cap chosen while nothing was attached outlives that state. With the tray
+  // holding its height, the card would take the whole deficit — down to 38px,
+  // its action bar spilling below the viewport. The cap floors at
+  // MOBILE_COMPOSER_DRAG_MIN_PX + the tray's measured height instead.
+  await page.evaluate(() => localStorage.setItem("threa:composer-drag-height", "180"))
+  await page.reload()
+  await card.click()
+  await expect(page.getByTestId("composer-resize-handle")).toBeVisible({ timeout: 10_000 })
+  await page.locator('[data-message-composer-root] input[type="file"][multiple]').setInputFiles(
+    [1, 2, 3, 4, 5, 6].map((n) => ({
+      name: `another-really-long-attachment-name-${n}.mp4`,
+      mimeType: "video/mp4",
+      buffer: Buffer.alloc(1024, n),
+    }))
+  )
+  await expect
+    .poll(
+      () =>
+        page
+          .locator("[data-message-composer-root] [data-composer-card]")
+          .evaluate((el) => Math.round(el.getBoundingClientRect().height)),
+      { timeout: 20_000 }
+    )
+    .toBeGreaterThanOrEqual(140)
+
+  const send = await page
+    .locator('[data-message-composer-root] button[aria-label^="Send"]')
+    .evaluate((el) => ({ bottom: el.getBoundingClientRect().bottom, viewport: window.innerHeight }))
+  expect(send.bottom, "send button stays inside the viewport").toBeLessThanOrEqual(send.viewport)
 })


### PR DESCRIPTION
## Problem

On mobile the attachment tray above the composer got squeezed and its chips sliced off at the bottom, resizing again on every composer height change. The tray (`PendingAttachments` rollup + chip row) and the link-preview strip are flex children of the composer shell in `message-composer.tsx`, whose height the drag handle caps (`maxHeight: mobileDragHeight`, else `max-h-[380px]`). Both strips were shrinkable, so the cap deficit came out of them: measured at a 390×800 viewport, dragging the composer down took the chip row from 32px to 17px while the 32px chip stayed 32px — clipped by the row's own `overflow-y-auto`.

## Solution

`shrink-0` on the three strips above the card, so the cap comes off the editor card instead:

- `pending-attachments.tsx` — rollup row and chip row keep their natural height; the chip row's `max-h-[96px]` still bounds it at ~2.5 wrapped rows.
- `composer-link-previews.tsx` — same defect, same strip, one class.
- At full drag-down the card now lands on exactly 140px and the tray on 32px (measured), instead of 163px/17px.

Second commit, from the review: the persisted cap needed a floor. `mobileDragHeight` is restored from localStorage on every mount, but the reservation for the strips (`MOBILE_COMPOSER_DRAG_MIN_PX + extras`) only existed inside `handleResizePointerDown`. Shrink the composer with nothing attached, attach files later, and the stale cap no longer fit the tray plus a usable card — with the tray no longer giving way, the card collapsed to **38px** and its action bar spilled below the viewport (send button at `bottom: 813` on an 800px viewport). The inline cap now floors at `max(dragHeight, MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight)`, with extras measured live by a `ResizeObserver` on the root and the card — the same quantity the drag clamp reserves at pointer-down. Same scenario after: cap self-heals 180 → 282, card exactly 140, chip row 96, send inside the viewport.

Residual, acknowledged not fixed: the classed `max-h-[380px]` has no such floor, so on desktop a full chip row (162px with margins) plus a full link-preview strip (128px) would leave the card ~90px. Not reached in measurement (1280×720, 8 attachments, long draft → chip row 112, card 207, send visible); it needs many attachments and several link previews at once.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/pending-attachments.tsx` | `shrink-0` on rollup + chip row; `data-testid="attachment-chip-row"` |
| `apps/frontend/src/components/composer/composer-link-previews.tsx` | `shrink-0` on the preview strip |
| `apps/frontend/src/components/composer/message-composer.tsx` | live extras measurement; inline cap floors at `MOBILE_COMPOSER_DRAG_MIN_PX + extras` |
| `tests/browser/composer-attachment-tray-mobile.spec.ts` | **new** — phone viewport: drag the composer down through the card's floor (chip row stays at chip height at every step), then a stale 180px cap + 7 files (card ≥ 140px, send button inside the viewport) |

## Test plan

- [x] `bunx playwright test tests/browser/composer-attachment-tray-mobile.spec.ts` — 1 pass; the drag half fails on the pre-fix code (`chips intact at drag +40`, row 27 vs chip 32), the stale-cap half fails on the first commit alone (card 38px)
- [x] `vitest run` over `components/composer`, `pending-attachments*`, `composer-height-storage` — 181 pass
- [x] `bun run --cwd apps/frontend typecheck`, `lint` — clean
- [x] `/code-review` (sonnet ×4) — one issue found and fixed in-branch, one acknowledged residual (see the review comment)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
