### PR TITLE
fix: auto-read misses — sweep-linked read frontier + flush-on-leave debounce

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1550,6 +1550,13 @@ export function StreamContent({
   // reveals the tail before a positional landing can take the mask over.
   const landingPendingRef = useRef(true)
 
+  // Stamped on every programmatic scroll write (landing positioning, refine
+  // loop, detached-hold re-pins, jump-to-latest, plus the scroll hook's own
+  // pins). The read-frontier sweep in useLastSeenEvent refuses to link scans
+  // across a stamp, so programmatic jumps stay read gaps while user flings
+  // sweep — see SWEEP_LINK_MS.
+  const programmaticScrollAtRef = useRef(0)
+
   const {
     listRef,
     scrollerRef: virtualScrollerRef,
@@ -1575,6 +1582,7 @@ export function StreamContent({
     isJumpMode,
     userInteractedAtRef,
     landingPendingRef,
+    programmaticScrollAtRef,
   })
 
   // Scroll container element, owned by useTimelineScroll. Attached to the
@@ -1878,6 +1886,7 @@ export function StreamContent({
           const desiredTop = sr.top + topOffsetPx
           const delta = align === "start" ? er.top - desiredTop : (er.top + er.bottom) / 2 - scCenter
           if (Math.abs(delta) > 2) {
+            programmaticScrollAtRef.current = performance.now()
             scroller.scrollTop += delta
             stableTicks = 0
           } else {
@@ -1903,6 +1912,7 @@ export function StreamContent({
           // and MAX_MS still bounds the loop if it never does.
           if (liveIdx >= 0) {
             try {
+              programmaticScrollAtRef.current = performance.now()
               listRef.current?.scrollToIndex(
                 liveIdx,
                 align === "start" ? { align: "start", offset: -topOffsetPx } : { align: "center" }
@@ -2284,6 +2294,7 @@ export function StreamContent({
     streamId,
     lastReadEventId: frontierLastReadEventId,
     enabled: autoMarkEnabled,
+    programmaticScrollAtRef,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
   const canAutoRead = useAutoReadAttention()
@@ -2495,12 +2506,14 @@ export function StreamContent({
       const idx = findEventItemIndex(visibleItems, dividerEventId)
       if (idx < 0) return
       try {
+        programmaticScrollAtRef.current = performance.now()
         listRef.current?.scrollToIndex(idx, { align: "start", offset: -UNREAD_MARKER_TOP_GAP_PX })
       } catch {
         // A not-yet-measured virtua list can throw; the row is already rendered
         // by the time this button is clickable, so this is best-effort.
       }
     } else {
+      programmaticScrollAtRef.current = performance.now()
       scrollContainerRef.current
         ?.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(dividerEventId)}"]`)
         ?.scrollIntoView({ block: "start" })
@@ -2536,6 +2549,10 @@ export function StreamContent({
     const row = el.querySelector<HTMLElement>(`[data-message-id="${escaped}"], [data-event-id="${escaped}"]`)
     if (!row) return
     const delta = row.getBoundingClientRect().top - (el.getBoundingClientRect().top + hold.offsetPx)
+    // Position-preserving by definition (re-pins the same row at the same
+    // offset), so it does not stamp the programmatic-scroll ref — breaking a
+    // user fling's sweep chain over a layout compensation was exactly the
+    // false positive the stamp must avoid.
     if (Math.abs(delta) > 1) el.scrollTop += delta
   }, [virtualScrollerEl, isFollowingTailRef, userInteractedAtRef])
   useLayoutEffect(() => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -239,6 +239,61 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
   })
 
+  it("flushes a pending mark when the stream switches mid-debounce (glance triage)", () => {
+    // The frontier counted the rows as seen; the debounce is network
+    // coalescing, not a dwell requirement. Switching away inside the window
+    // must commit the old stream's mark — dropping it left glanced streams
+    // unread on the server while the local viewing-pin showed them read.
+    const { rerender } = renderHook(({ streamId, lastEventId }) => useAutoMarkAsRead("ws_123", streamId, lastEventId), {
+      initialProps: { streamId: "stream_a", lastEventId: "event_a" },
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+
+    rerender({ streamId: "stream_b", lastEventId: "event_b" })
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_a", "event_a", { partial: false })
+
+    // The new stream's own mark still debounces normally.
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_b", "event_b", { partial: false })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
+  })
+
+  it("flushes a pending mark on unmount (navigating off the stream page)", () => {
+    const { unmount } = renderHook(() => useAutoMarkAsRead("ws_123", "stream_a", "event_a"))
+
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+
+    unmount()
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_a", "event_a", { partial: false })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(1)
+  })
+
+  it("does NOT flush when attention drops mid-debounce (blur still cancels)", () => {
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_a", "event_a"))
+
+    act(() => {
+      vi.advanceTimersByTime(250)
+      visibilityState = "hidden"
+      hasFocus = false
+      document.dispatchEvent(new Event("visibilitychange"))
+      window.dispatchEvent(new Event("blur"))
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
   it("clears the dedup on stream switch so the next stream's first mark always fires", () => {
     // The consumer isn't keyed by streamId, so the hook persists across switches.
     // The dedup refs must reset per stream — otherwise a prior stream's marked

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -59,6 +59,14 @@ export function useAutoMarkAsRead(
   const { getActivityCount } = useActivityCounts(workspaceId)
   const canAutoRead = useAutoReadAttention()
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The mark the running debounce timer would send, so teardown can FLUSH it
+  // instead of dropping it. The debounce is network coalescing, not a dwell
+  // requirement: the frontier already said "seen", so a stream switch or
+  // unmount inside the window must still commit the mark — cancelling it was
+  // the glance-triage bug (open an unread stream, glance, move on within a
+  // second → the stream stayed unread on the server, invisibly, because the
+  // local viewing-pin had already zeroed the badge).
+  const pendingRef = useRef<{ streamId: string; lastEventId: string; partial: boolean } | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
   // Track the partial-ness of the last mark so a partial→full transition at the
   // SAME event (viewer scrolled partway, then on to the tail) re-fires to clear
@@ -72,6 +80,20 @@ export function useAutoMarkAsRead(
   streamIdRef.current = streamId
   lastEventIdRef.current = lastEventId
   partialRef.current = partial
+  const markAsReadRef = useRef(markAsRead)
+  markAsReadRef.current = markAsRead
+
+  // Unmount flush: navigating off the stream page entirely (drafts, board)
+  // unmounts the consumer with the debounce still pending — commit it.
+  // Defined ABOVE the debounce effect: React runs unmount cleanups in
+  // definition order, and the debounce effect's own cleanup clears pendingRef.
+  useEffect(() => {
+    return () => {
+      const pending = pendingRef.current
+      pendingRef.current = null
+      if (pending) markAsReadRef.current(pending.streamId, pending.lastEventId, { partial: pending.partial })
+    }
+  }, [])
 
   // The consumer (StreamContent) is not keyed by streamId, so this hook persists
   // across stream switches. Clear the dedup refs per stream — otherwise a prior
@@ -109,20 +131,31 @@ export function useAutoMarkAsRead(
     }
 
     timerRef.current = setTimeout(() => {
-      // Read current values at execution time, not capture time, so a stream
-      // switch during the debounce window marks the stream actually in view.
+      // Read current values at execution time, not capture time, so re-arms
+      // within the same stream always send the newest frontier.
       const currentStreamId = streamIdRef.current
       const currentLastEventId = lastEventIdRef.current
+      pendingRef.current = null
       if (currentLastEventId) {
         markAsRead(currentStreamId, currentLastEventId, { partial: partialRef.current })
         lastMarkedRef.current = currentLastEventId
         lastMarkedPartialRef.current = partialRef.current
       }
     }, debounceMs)
+    pendingRef.current = { streamId, lastEventId, partial }
 
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current)
+      }
+      const pending = pendingRef.current
+      pendingRef.current = null
+      // A stream switch mid-debounce flushes the old stream's mark (the
+      // frontier had already counted it as seen); same-stream re-arms and the
+      // attention gate dropping (blur) keep the existing cancel semantics —
+      // the next arming run re-captures the freshest frontier.
+      if (pending && pending.streamId !== streamIdRef.current) {
+        markAsRead(pending.streamId, pending.lastEventId, { partial: pending.partial })
       }
     }
   }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, canAutoRead])

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -36,13 +36,30 @@ export function pickVisibleRange(rows: VisibleRow[], viewportTop: number, viewpo
  * the bottom of the viewport when the viewport's top is at or above the first
  * unread row (`frontier + 1`) — i.e. there is no gap of unseen rows between the
  * read frontier and what's on screen. Landing at the live bottom leaves such a
- * gap, so the frontier (and the read pointer) stays put; flinging past a block
- * of rows without them entering the viewport likewise stops the advance.
+ * gap, so the frontier (and the read pointer) stays put. `topIdx` is the
+ * sweep-effective top: recompute substitutes the previous scan's top when two
+ * scans link into one continuous user scroll (see SWEEP_LINK_MS), so a fast
+ * fling — whose per-frame viewport jumps exceed the viewport height — still
+ * reads as the continuous sweep it visually was.
  */
 export function advanceFrontier(frontier: number, topIdx: number, botIdx: number): number {
   if (topIdx <= frontier + 1 && botIdx > frontier) return botIdx
   return frontier
 }
+
+/**
+ * Two viewport scans within this window, with no programmatic scroll write
+ * between them, belong to one continuous user scroll: everything between the
+ * first scan's top and the second scan's bottom was painted on the way through,
+ * so the pair advances the frontier as one swept range. Without this, a fast
+ * fling (or a busy main thread dropping rAF scans — mobile with heavy rows)
+ * moves the viewport more than its own height between scans, the contiguity
+ * check fails once, and the whole read-through silently marks nothing.
+ * Programmatic scrolls (jump-to-latest, deep links, landing positioning) stamp
+ * `programmaticScrollAtRef` on every write, which breaks the link — a jump
+ * stays a gap the viewer never read.
+ */
+export const SWEEP_LINK_MS = 1500
 
 interface UseLastSeenEventOptions {
   /** The owned scroll container (virtualized timeline or plain thread scroller). */
@@ -77,6 +94,12 @@ interface UseLastSeenEventOptions {
   lastReadEventId: string | null | undefined
   /** Off while loading/jumping/draft — no scroller to read, nothing to track. */
   enabled: boolean
+  /**
+   * Timestamp (performance.now()) of the owner's last programmatic scroll
+   * write. Scans on either side of a stamp never sweep-link (see
+   * SWEEP_LINK_MS): a jump must remain a gap, not a read-through.
+   */
+  programmaticScrollAtRef?: React.RefObject<number>
 }
 
 interface UseLastSeenEventResult {
@@ -112,6 +135,7 @@ export function useLastSeenEvent({
   streamId,
   lastReadEventId,
   enabled,
+  programmaticScrollAtRef,
 }: UseLastSeenEventOptions): UseLastSeenEventResult {
   const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
   const [atLastRow, setAtLastRow] = useState(false)
@@ -165,6 +189,11 @@ export function useLastSeenEvent({
   const prevLastReadIdRef = useRef(lastReadEventId)
   const prevStreamIdRef = useRef(streamId)
 
+  // The previous scan's viewport top, for sweep-linking (SWEEP_LINK_MS). Keyed
+  // by event id, not index: a prepend shifts every index but virtua holds the
+  // viewport on the same rows, and an id re-resolves to its post-shift index.
+  const prevScanRef = useRef<{ topId: string; at: number } | null>(null)
+
   const recompute = useCallback(() => {
     const el = scrollContainerRef.current
     if (!el) return
@@ -199,13 +228,28 @@ export function useLastSeenEvent({
     if (topIdx === undefined || botIdx === undefined) return
     const lastRenderedIdx = map.get(rows[rows.length - 1].id) ?? botIdx
 
+    // Sweep-link with the previous scan: within SWEEP_LINK_MS and with no
+    // programmatic scroll write since that scan, the movement between the two
+    // viewports is one continuous user scroll — everything from the previous
+    // scan's top downward was painted on the way through, so contiguity is
+    // judged from there. A programmatic stamp (jump, landing, refine loop)
+    // newer than the previous scan breaks the link so a jump stays a gap.
+    const now = performance.now()
+    const prevScan = prevScanRef.current
+    let effTopIdx = topIdx
+    if (prevScan && now - prevScan.at <= SWEEP_LINK_MS && (programmaticScrollAtRef?.current ?? 0) < prevScan.at) {
+      const prevTopIdx = map.get(prevScan.topId)
+      if (prevTopIdx !== undefined && prevTopIdx < effTopIdx) effTopIdx = prevTopIdx
+    }
+    prevScanRef.current = { topId: range.topId, at: now }
+
     // While pinned (the pointer was just moved back by mark-as-unread and the
     // now-unread row is still on screen) hold the frontier so advanceFrontier
     // doesn't immediately re-read it; a user scroll lifts the pin.
     if (!pinnedRef.current) {
       // External reads can only move the frontier forward.
       if (readIndexRef.current > frontierRef.current) frontierRef.current = readIndexRef.current
-      frontierRef.current = advanceFrontier(frontierRef.current, topIdx, botIdx)
+      frontierRef.current = advanceFrontier(frontierRef.current, effTopIdx, botIdx)
     }
 
     const frontier = frontierRef.current
@@ -230,7 +274,7 @@ export function useLastSeenEvent({
     } else {
       setLastSeenEventId((prev) => (prev === undefined ? prev : undefined))
     }
-  }, [scrollContainerRef])
+  }, [scrollContainerRef, programmaticScrollAtRef])
 
   // Reset on stream switch — the new stream's frontier seeds from its own read
   // pointer, never inheriting the previous stream's position.
@@ -238,6 +282,7 @@ export function useLastSeenEvent({
     frontierRef.current = readIndexRef.current
     prevReadSeqRef.current = readSeqRef.current
     pinnedRef.current = false
+    prevScanRef.current = null
     setLastSeenEventId(undefined)
     setAtLastRow(false)
     setUnreadAboveViewport(false)
@@ -253,6 +298,9 @@ export function useLastSeenEvent({
   useEffect(() => {
     if (!enabled) return
     const el = scrollContainerEl ?? scrollContainerRef.current
+    // A re-arm (enabled flip, scroller mount, jump-mode exit) starts a fresh
+    // sweep baseline — scans across a disabled window must never link.
+    prevScanRef.current = null
     let raf = 0
     const schedule = () => {
       if (raf) return

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -95,6 +95,14 @@ interface UseTimelineScrollOptions {
    * is the secondary signal for touch/wheel that hasn't yet moved scrollTop.
    */
   userInteractedAtRef?: React.MutableRefObject<number>
+  /**
+   * Stamped (performance.now()) on every programmatic scroll write this hook
+   * makes — the tail pin, scrollToBottom, and the smooth-to-bottom animation's
+   * per-event frames. The read-frontier sweep (`useLastSeenEvent`) refuses to
+   * link scans across a stamp, so a programmatic jump stays a read gap while a
+   * user fling sweeps.
+   */
+  programmaticScrollAtRef?: React.MutableRefObject<number>
 }
 
 interface UseTimelineScrollReturn {
@@ -189,6 +197,7 @@ export function useTimelineScroll({
   isJumpMode = false,
   userInteractedAtRef,
   landingPendingRef,
+  programmaticScrollAtRef,
 }: UseTimelineScrollOptions): UseTimelineScrollReturn {
   const listRef = useRef<VirtualizerHandle>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -343,6 +352,11 @@ export function useTimelineScroll({
   // handleScroll sees no user movement and follow stays armed. That is what lets
   // the ResizeObserver, the keyboard backstop, and the cold-load settle all pin
   // freely without a programmatic time-window to tell them apart.
+  // Deliberately NOT stamped for the read-frontier sweep: the pin either
+  // holds an already-at-bottom position or reveals new content at the bottom
+  // edge of a watched tail — it never skips rows past the viewport, so it must
+  // not break a user fling's sweep chain (jump-to-latest stamps in
+  // scrollToBottom instead, where the actual jump decision lives).
   const pinToBottom = useCallback(() => {
     const el = scrollerRef.current
     if (!el) return
@@ -351,6 +365,13 @@ export function useTimelineScroll({
     prevScrollHeightRef.current = el.scrollHeight
   }, [])
 
+  // A smooth scrollToBottom animates over many frames the browser owns, so a
+  // single stamp at kickoff would expire mid-flight and the frontier sweep
+  // would link the animation's later frames as a user scroll. handleScroll
+  // re-stamps every frame while this is set; cleared on arrival, on a user
+  // gesture, or by the time cap (a smooth-to-bottom never runs longer).
+  const smoothToBottomStartedAtRef = useRef(0)
+
   const scrollToBottom = useCallback(
     (options?: { force?: boolean; behavior?: ScrollBehavior }) => {
       if (!options?.force && !isFollowingTailRef.current) return
@@ -358,15 +379,17 @@ export function useTimelineScroll({
       setIsScrolledFarFromBottom(false)
       const el = scrollerRef.current
       if (!el) return
+      if (programmaticScrollAtRef) programmaticScrollAtRef.current = performance.now()
       if (options?.behavior === "smooth") {
         // Animated: let the browser drive scrollTop over several frames.
         // handleScroll re-arms at the bottom and tracks prevScrollTop as it goes.
+        smoothToBottomStartedAtRef.current = performance.now()
         el.scrollTo({ top: el.scrollHeight, behavior: "smooth" })
       } else {
         pinToBottom()
       }
     },
-    [pinToBottom]
+    [pinToBottom, programmaticScrollAtRef]
   )
 
   const disableAutoScroll = useCallback(() => {
@@ -551,6 +574,18 @@ export function useTimelineScroll({
     // Secondary signal for a touch/wheel gesture that hasn't moved scrollTop yet.
     const now = performance.now()
     const userGestured = now - (userInteractedAtRef?.current ?? 0) < USER_SCROLL_GRACE_MS
+    // Keep the programmatic stamp fresh through a smooth-to-bottom animation:
+    // its frames are browser-driven scroll events indistinguishable from a
+    // fling, and the frontier sweep must not read the jumped range as read.
+    if (smoothToBottomStartedAtRef.current) {
+      const arrived = distanceFromBottom <= AT_BOTTOM_PX
+      if (userGestured || arrived || now - smoothToBottomStartedAtRef.current > 2000) {
+        smoothToBottomStartedAtRef.current = 0
+        if (arrived && programmaticScrollAtRef) programmaticScrollAtRef.current = now
+      } else if (programmaticScrollAtRef) {
+        programmaticScrollAtRef.current = now
+      }
+    }
     if (heightStable && userGestured) {
       if (el.scrollTop > prevTop + 1) lastGestureScrollDirRef.current = "down"
       else if (el.scrollTop < prevTop - 1) lastGestureScrollDirRef.current = "up"
@@ -597,7 +632,7 @@ export function useTimelineScroll({
     // While following we're effectively at the tail (the observer re-pins), so
     // never surface jump-to-latest; only when the user has actually scrolled up.
     setIsScrolledFarFromBottom(!isFollowingTailRef.current && distanceFromBottom > JUMP_TO_LATEST_PX)
-  }, [isJumpMode, userInteractedAtRef])
+  }, [isJumpMode, userInteractedAtRef, programmaticScrollAtRef])
 
   // Initial scroll-to-bottom once the first window is populated. Runs in a
   // layout effect (pre-paint) against the owned scroller so there is no visible

--- a/tests/browser/auto-read.spec.ts
+++ b/tests/browser/auto-read.spec.ts
@@ -396,6 +396,39 @@ test.describe("Timeline auto-read", () => {
     await otherContext.close()
   })
 
+  test("a quick triage visit — open, glance, leave — still marks what was on screen", async ({ page, browser }) => {
+    // The everyday miss: switch into a stream whose unreads are fully on
+    // screen, glance, move on within a second. The mark is debounced 500ms and
+    // used to be CANCELLED (not flushed) when the effect tore down on the
+    // navigation — the frontier said "seen", the network call never went out,
+    // and the stream stayed unread on the server.
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 3)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-unread msg-003` })
+    ).toBeVisible({ timeout: 20000 })
+    // The glance: reveal happened (mask gone), the read-frontier scan has had
+    // a beat to run — but we leave before the 500ms debounce fires.
+    await expect(page.getByTestId("settle-mask")).toHaveCount(0, { timeout: 10000 })
+    await page.waitForTimeout(250)
+    await page.getByRole("link", { name: "Drafts" }).click()
+    await expect(page).toHaveURL(new RegExp(`/w/${workspaceId}/drafts`))
+
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "leaving mid-debounce must flush the pending mark, not drop it",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+
   test("a small unread run that fits the viewport marks read with no gesture at all", async ({ page, browser }) => {
     const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 3)
     await page.setViewportSize({ width: 1024, height: 500 })

--- a/tests/browser/auto-read.spec.ts
+++ b/tests/browser/auto-read.spec.ts
@@ -1,0 +1,422 @@
+import { test, expect, type Page, type Browser } from "@playwright/test"
+import { loginAndCreateWorkspace, loginInNewContext, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * Auto-mark-as-read fires for real: opening an unread stream and reading it
+ * (scrolling to the tail, or just having it all on screen) advances the
+ * SERVER read state — unreadCounts for the stream reaches 0 without any
+ * manual mark. Reported intermittent ("auto read doesn't always fire") after
+ * the atomic-landing stack (#1875/#1876) changed when the settle mask clears,
+ * which is the arming gate for the read-frontier scan (settledAtBottom in
+ * StreamContent).
+ *
+ * Ground truth is the workspace bootstrap's unreadCounts (server-derived from
+ * stream_read_state), not the sidebar badge — the badge has known optimistic
+ * races that would mask a server-side miss.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+function extractIds(page: Page): { workspaceId: string; streamId: string } {
+  const url = page.url()
+  const workspaceMatch = url.match(/\/w\/([^/]+)/)
+  const streamMatch = url.match(/\/s\/([^/?]+)/)
+  if (!workspaceMatch || !streamMatch) throw new Error(`Could not extract IDs from URL: ${url}`)
+  return { workspaceId: workspaceMatch[1], streamId: streamMatch[1] }
+}
+
+async function seedFrom(page: Page, workspaceId: string, streamId: string, count: number, prefix: string, startAt = 1) {
+  for (let i = startAt; i < startAt + count; i += 5) {
+    const end = Math.min(i + 4, startAt + count - 1)
+    await Promise.all(
+      Array.from({ length: end - i + 1 }, (_, k) =>
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix} msg-${String(i + k).padStart(3, "0")}` },
+          })
+          .then((r) => expectApiOk(r, `Send message ${i + k}`))
+      )
+    )
+  }
+}
+
+async function serverUnreadCount(page: Page, workspaceId: string, streamId: string): Promise<number> {
+  const res = await page.request.get(`/api/workspaces/${workspaceId}/bootstrap`)
+  await expectApiOk(res, "Workspace bootstrap")
+  const body = (await res.json()) as { data?: { unreadCounts?: Record<string, number> } }
+  const counts = body.data?.unreadCounts
+  if (!counts) throw new Error(`Bootstrap response missing unreadCounts; keys: ${Object.keys(body).join(",")}`)
+  return counts[streamId] ?? 0
+}
+
+async function distanceFromBottom(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const el = document.querySelector("[data-suppress-pull-refresh]")
+    if (!(el instanceof HTMLElement)) return null
+    return el.scrollHeight - el.scrollTop - el.clientHeight
+  })
+}
+
+/** Owner reads 10 messages, leaves, a second user posts `unreadCount` more. */
+async function setUpUnreadChannel(browser: Browser, ownerPage: Page, unreadCount: number) {
+  const owner = await loginAndCreateWorkspace(ownerPage, "auto-read")
+  const testId = owner.testId
+  const prefix = `[${testId}]`
+
+  await createChannel(ownerPage, `autoread-${testId}`)
+  const { workspaceId, streamId } = extractIds(ownerPage)
+
+  await expectApiOk(
+    await ownerPage.request.patch(`/api/workspaces/${workspaceId}/preferences`, {
+      data: { unreadOpenPosition: "marker" },
+    }),
+    "Set marker preference"
+  )
+
+  await seedFrom(ownerPage, workspaceId, streamId, 10, prefix)
+  await expect(
+    ownerPage
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix} msg-010` })
+  ).toBeVisible({ timeout: 20000 })
+
+  // Navigate away so the unreads arrive while not viewing.
+  await ownerPage.goto(`/w/${workspaceId}/drafts`)
+  await expect(ownerPage).toHaveURL(new RegExp(`/w/${workspaceId}/drafts`))
+
+  const other = await loginInNewContext(browser, `autoread-b-${testId}@example.com`, `AutoRead B ${testId}`)
+  await expectApiOk(
+    await other.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+      data: { role: "member", name: `AutoRead B ${testId}` },
+    }),
+    "Second user joins workspace"
+  )
+  await expectApiOk(
+    await other.page.request.post(`/api/workspaces/${workspaceId}/streams/${streamId}/join`, { data: {} }),
+    "Second user joins the channel"
+  )
+  await expect
+    .poll(
+      async () =>
+        (
+          await other.page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix}-unread msg-001` },
+          })
+        ).status(),
+      { timeout: 10000, message: "second user's first post should be accepted after joining" }
+    )
+    .toBe(201)
+  if (unreadCount > 1) await seedFrom(other.page, workspaceId, streamId, unreadCount - 1, `${prefix}-unread`, 2)
+
+  // The unread run is real server-side before the owner opens the stream.
+  await expect
+    .poll(() => serverUnreadCount(ownerPage, workspaceId, streamId), {
+      timeout: 10000,
+      message: "server should report the seeded unreads",
+    })
+    .toBeGreaterThanOrEqual(unreadCount)
+
+  return { testId, prefix, workspaceId, streamId, otherContext: other.context }
+}
+
+test.describe("Timeline auto-read", () => {
+  test("scrolling through the unreads to the tail marks the stream read on the server", async ({ page, browser }) => {
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 25)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    const firstUnread = page
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix}-unread msg-001` })
+      .first()
+    await expect(firstUnread).toBeVisible({ timeout: 20000 })
+
+    // Read down through the unreads to the tail with real wheel gestures.
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const box = await scroller.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 24)
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.wheel(0, 300)
+          await page.waitForTimeout(120)
+          return await distanceFromBottom(page)
+        },
+        { timeout: 20000, message: "should reach the tail by scrolling" }
+      )
+      .toBeLessThan(60)
+
+    // Idle past the auto-mark debounce (500ms) + round trip, then the server
+    // must agree the stream is fully read.
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "auto-read should clear the server unread count after reading to the tail",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+
+  test("a message arriving while viewing at the tail re-marks the stream read", async ({ page, browser }) => {
+    // The prod signature: watermark written at t, a new message lands at t+4s
+    // while the viewer is still on the stream — and no re-mark ever fires,
+    // leaving the stream unread-by-one.
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 25)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    const firstUnread = page
+      .getByRole("main")
+      .locator(".message-item")
+      .filter({ hasText: `${prefix}-unread msg-001` })
+      .first()
+    await expect(firstUnread).toBeVisible({ timeout: 20000 })
+
+    // Read down to the tail and let the full mark land server-side.
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const box = await scroller.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 24)
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.wheel(0, 300)
+          await page.waitForTimeout(120)
+          return await distanceFromBottom(page)
+        },
+        { timeout: 20000, message: "should reach the tail by scrolling" }
+      )
+      .toBeLessThan(60)
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "initial read-through should clear the unread count",
+      })
+      .toBe(0)
+
+    // A few seconds later — viewer still parked at the tail, no gestures — the
+    // other user posts. The new message appends into the followed tail; the
+    // read frontier must advance through it and re-mark without any input.
+    await page.waitForTimeout(3000)
+    const late = await otherContext.pages()[0]!.request.post(`/api/workspaces/${workspaceId}/messages`, {
+      data: { streamId, content: `${prefix}-late arrival msg-999` },
+    })
+    await expectApiOk(late, "Late arrival message")
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-late arrival msg-999` })
+    ).toBeVisible({ timeout: 15000 })
+
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "arrival while viewing at the tail should re-mark the stream read",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+
+  test("blur → arrival → refocus → another arrival: every step re-marks once attentive", async ({ page, browser }) => {
+    // The prod trace for the reported miss: watermark wrote seconds after a
+    // refocus (the parked mark firing), then a message arrived 4s later while
+    // still viewing — and no re-mark ever happened. Drive the same focus
+    // choreography deterministically.
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 25)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-unread msg-001` })
+    ).toBeVisible({ timeout: 20000 })
+
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const box = await scroller.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 24)
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.wheel(0, 300)
+          await page.waitForTimeout(120)
+          return await distanceFromBottom(page)
+        },
+        { timeout: 20000, message: "should reach the tail by scrolling" }
+      )
+      .toBeLessThan(60)
+    await expect.poll(() => serverUnreadCount(page, workspaceId, streamId), { timeout: 15000 }).toBe(0)
+
+    // Blur the window (attention formula reads document.hasFocus()).
+    await page.evaluate(() => {
+      Object.defineProperty(document, "hasFocus", { configurable: true, value: () => false })
+      window.dispatchEvent(new Event("blur"))
+    })
+
+    // A message arrives while blurred — the frontier advances but the mark must
+    // park (auto-read requires attention). Server unread stays elevated.
+    const other = otherContext.pages()[0]!
+    await expectApiOk(
+      await other.request.post(`/api/workspaces/${workspaceId}/messages`, {
+        data: { streamId, content: `${prefix}-late blurred-arrival msg-901` },
+      }),
+      "Arrival while blurred"
+    )
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-late blurred-arrival msg-901` })
+    ).toBeVisible({ timeout: 15000 })
+    await page.waitForTimeout(2000)
+    expect(await serverUnreadCount(page, workspaceId, streamId), "blurred viewer must not auto-read").toBeGreaterThan(0)
+
+    // Refocus — the parked mark fires.
+    await page.evaluate(() => {
+      Object.defineProperty(document, "hasFocus", { configurable: true, value: () => true })
+      window.dispatchEvent(new Event("focus"))
+    })
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "refocus should release the parked mark",
+      })
+      .toBe(0)
+
+    // Seconds later, while still focused, another message arrives — this is the
+    // step that silently missed in prod.
+    await page.waitForTimeout(3000)
+    await expectApiOk(
+      await other.request.post(`/api/workspaces/${workspaceId}/messages`, {
+        data: { streamId, content: `${prefix}-late focused-arrival msg-902` },
+      }),
+      "Arrival after refocus"
+    )
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-late focused-arrival msg-902` })
+    ).toBeVisible({ timeout: 15000 })
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "arrival after the refocus mark should re-mark the stream read",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+
+  test("a fast fling through the unreads to the tail still marks the stream read", async ({ page, browser }) => {
+    // The contiguity rule advances the frontier only while consecutive scans
+    // overlap. A fast fling (or a busy main thread dropping rAF scans on
+    // mobile) moves the viewport more than its own height between scans — the
+    // advance silently stops and nothing ever marks, even though every row was
+    // painted on the way down. Large wheel deltas reproduce that scan gap
+    // deterministically.
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 25)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-unread msg-001` })
+    ).toBeVisible({ timeout: 20000 })
+
+    const scroller = page.locator("[data-suppress-pull-refresh]")
+    const box = await scroller.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 24)
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.wheel(0, 2000)
+          return await distanceFromBottom(page)
+        },
+        { timeout: 20000, message: "should reach the tail by flinging" }
+      )
+      .toBeLessThan(60)
+
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "a fast fling to the tail should still mark the stream read",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+
+  test("jump-to-latest skips the unread block — it stays unread (a jump is a gap, not a sweep)", async ({
+    page,
+    browser,
+  }) => {
+    // The counterpart to the fling test: the sweep only links USER scrolling.
+    // A programmatic jump from the marker to the tail must not read the block
+    // it skipped — the whole point of progressive read.
+    // 40 unreads: at the marker landing the tail sits well past the
+    // jump-button threshold (600px from the bottom), so the button shows with
+    // no scrolling at all — nothing gets read before the jump.
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 40)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-unread msg-001` })
+    ).toBeVisible({ timeout: 20000 })
+
+    await expect(page.getByRole("button", { name: "Jump to latest" })).toBeVisible({ timeout: 10000 })
+    await page.getByRole("button", { name: "Jump to latest" }).click()
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 10000, message: "jump should land at the tail" })
+      .toBeLessThan(60)
+
+    // Idle well past the auto-mark debounce; the skipped block must remain
+    // unread on the server.
+    await page.waitForTimeout(3000)
+    expect(
+      await serverUnreadCount(page, workspaceId, streamId),
+      "the block skipped by the jump must stay unread"
+    ).toBeGreaterThan(0)
+
+    await otherContext.close()
+  })
+
+  test("a small unread run that fits the viewport marks read with no gesture at all", async ({ page, browser }) => {
+    const { prefix, workspaceId, streamId, otherContext } = await setUpUnreadChannel(browser, page, 3)
+    await page.setViewportSize({ width: 1024, height: 500 })
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix}-unread msg-003` })
+    ).toBeVisible({ timeout: 20000 })
+
+    // No scroll, no click — viewing alone must auto-read (the initial frontier
+    // scan on settle-complete + ResizeObserver re-scans own this).
+    await expect
+      .poll(() => serverUnreadCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "auto-read should fire with no user gesture when the unreads are all on screen",
+      })
+      .toBe(0)
+
+    await otherContext.close()
+  })
+})


### PR DESCRIPTION
## Problem

"Auto read doesn't always fire." Two independent causes, both reproduced with server-truth Playwright tests before fixing:

1. **Fling loss.** `useLastSeenEvent` advances the read frontier only when consecutive viewport scans overlap (`advanceFrontier` contiguity), and scans run once per rAF. A fast fling — or a busy main thread dropping frames, i.e. mobile with heavy rows — moves the viewport more than its own height between scans; contiguity fails once and every later scan fails too, so a whole read-through marks nothing.
2. **Glance-triage loss.** The 500ms auto-mark debounce was cancelled, not flushed, when its effect tore down. Switching into a stream whose unreads are fully on screen and moving on within ~a second dropped the pending mark — the frontier said "seen", the network call never went out.

Both are invisible locally (the `stream:activity` viewing-pin zeroes the badge optimistically) and heal server-side on the viewer's next send (author-pointer advance), so prod `stream_read_state` shows no long-term stuck rows and the bug reads as random.

## Solution

- **Sweep-link the scans**: two scans within `SWEEP_LINK_MS` (1.5s) with no programmatic scroll write between them are one continuous user scroll — contiguity is judged from the previous scan's top. Keyed by row id so virtua prepend shifts re-resolve; baseline resets on stream switch and scan re-arm.
- **Stamp the jumps**: `programmaticScrollAtRef` (owned by `StreamContent`) is stamped by the `scrollToMessage` refine loop, `scrollToFirstUnread`, and `scrollToBottom` (the smooth branch re-stamps per scroll event in `handleScroll`, 2s cap). A stamp newer than the previous scan breaks the link — jump-to-latest / deep links / landings stay read gaps. Position-preserving writes (`pinToBottom` tail pins, `applyDetachedHold` re-pins) deliberately do NOT stamp — a mid-fling layout compensation must not sever the chain (the first iteration over-stamped and re-broke the fling).
- **Flush, don't drop**: the debounce is network coalescing, not a dwell requirement. A stream switch mid-debounce flushes the old stream's mark in the effect cleanup; unmount (navigating to drafts/board) flushes via a mount-once cleanup defined above the debounce effect (React runs unmount cleanups in definition order). Blur keeps the existing cancel semantics.

Accepted edge: a browser-native jump we can't stamp (End key, scrollbar teleport) within 1.5s of scrolling sweeps the skipped rows as read. Conversation-panel auto-read is a separate read model, unchanged.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | Sweep-link in `recompute`, `SWEEP_LINK_MS`, `programmaticScrollAtRef` opt |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | Stamp in `scrollToBottom`; smooth-flight re-stamp in `handleScroll` |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | Pending-mark flush on stream switch + unmount |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Ref + stamps at refine-loop / marker / non-virtualized jump sites |
| `apps/frontend/src/hooks/use-auto-mark-as-read.test.ts` | Flush semantics: switch, unmount, blur-still-cancels |
| `tests/browser/auto-read.spec.ts` | **new** — 7-test server-truth auto-read suite |

## Test plan

- [x] `tests/browser/auto-read.spec.ts` — 7/7 (slow read-through, arrival-at-tail re-mark, blur→refocus choreography, fling-to-tail and glance-triage repros — both fail on main, pass here — jump-to-latest-preserves-gap, no-gesture short stream); asserts server `unreadCounts`, not the badge
- [x] Landing regression specs — `timeline-anchor-restore`, `unread-marker-open`, `stream-switch-stability` 6/6
- [x] Frontend units 6664 pass (13 in the auto-mark suite); full monorepo lint + typecheck via pre-commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GceYF7UEshN3QRAjGQDagJ
