### PR TITLE
refactor: read commits move to a workspace-owned queue in the data layer

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2383,6 +2383,10 @@ export function StreamContent({
     const lastLoadedEventId = lastLoadedEventIdRef.current
     if (lastLoadedEventId) markAsReadRef.current(streamId, lastLoadedEventId)
     dismissUnreadDivider()
+    // An explicit go-to-bottom supersedes a landing refine loop still in its
+    // watch window — the loop only aborts on scroller gestures, and without
+    // this its next tick re-centers the marker target, reverting the jump.
+    scrollAbortRef.current?.()
     scrollToBottom({ force: true })
   }, [streamId, dismissUnreadDivider, scrollToBottom])
 
@@ -2482,6 +2486,10 @@ export function StreamContent({
     searchNavPhaseRef.current = "idle"
     searchNavVersionRef.current++
     setIsSearchNavigating(false)
+    // A landing refine loop still watching (its 1200ms window) would re-center
+    // its target on the next tick and revert this jump — a button click is not
+    // a scroller gesture, so the loop's own abort listeners never fire.
+    scrollAbortRef.current?.()
     if (isJumpMode) {
       exitJumpMode()
       // The event window is about to be replaced wholesale (jump window →

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -28,6 +28,7 @@ import {
   useEditLastMessageTrigger,
   useKeyboardShortcuts,
   useEffectiveArchived,
+  useFeatureFlag,
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
@@ -2276,6 +2277,7 @@ export function StreamContent({
   // no settle phase (`isInitialSettling` would never clear there), so exempt it.
   const settledAtBottom = !useVirtualized || !virtualIsInitialSettling
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && settledAtBottom
+  const autoReadRevamp = useFeatureFlag(workspaceId, "autoReadRevamp") === "on"
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     // The virtualized scroller late-mounts via a ref callback, AFTER
@@ -2295,6 +2297,9 @@ export function StreamContent({
     lastReadEventId: frontierLastReadEventId,
     enabled: autoMarkEnabled,
     programmaticScrollAtRef,
+    // Kill-switch (autoReadRevamp "off" reverts to strict scan-overlap
+    // contiguity); the flush half of the switch lives on the ReadCommitQueue.
+    sweepLinkEnabled: autoReadRevamp,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
   const canAutoRead = useAutoReadAttention()

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -255,6 +255,30 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
   })
 
+  it("re-fires the same mark when activity arrives with an unchanged frontier", () => {
+    // A reaction while viewing raises activityCount with no new timeline event
+    // — lastEventId stays put, so the re-fire rides on the count VALUE being an
+    // effect dep. The old code re-ran by accident (markAsRead identity churn);
+    // this pins the re-fire as deliberate (witness finding on #1882).
+    const { rerender } = renderHook((_props: { v: number }) => useAutoMarkAsRead("ws_123", "stream_123", "event_123"), {
+      initialProps: { v: 0 },
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(1)
+
+    activityCount = 1
+    rerender({ v: 1 })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_123", "event_123", { partial: false })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
+  })
+
   it("flushes a pending mark when the stream switches mid-debounce (glance triage)", () => {
     // The frontier counted the rows as seen; the debounce is network
     // coalescing, not a dwell requirement. Switching away inside the window

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
+import { renderHook as baseRenderHook, act } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
 import { useAutoMarkAsRead } from "./use-auto-mark-as-read"
+import { ReadCommitQueue, ReadCommitQueueContext } from "@/sync/read-commit-queue"
 import * as useUnreadCountsModule from "./use-unread-counts"
 import * as useActivityCountsModule from "./use-activity-counts"
 import * as useMobileModule from "./use-mobile"
@@ -9,6 +11,14 @@ import * as usePointerModule from "./use-pointer"
 const mockMarkAsRead = vi.fn()
 const mockGetUnreadCount = vi.fn()
 const mockGetActivityCount = vi.fn()
+
+// The hook reports into the workspace ReadCommitQueue; give every render a
+// real queue wired straight to the markAsRead mock so the tests exercise the
+// actual debounce/flush pipeline.
+let queue: ReadCommitQueue
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(ReadCommitQueueContext.Provider, { value: queue }, children)
+const renderHook: typeof baseRenderHook = (cb, opts) => baseRenderHook(cb, { wrapper, ...opts })
 
 let unreadCount = 1
 let activityCount = 0
@@ -47,6 +57,11 @@ describe("useAutoMarkAsRead", () => {
     mockGetUnreadCount.mockImplementation(() => unreadCount)
     mockGetActivityCount.mockImplementation(() => activityCount)
 
+    queue = new ReadCommitQueue({
+      workspaceId: "ws_123",
+      commitRef: { current: (streamId, lastEventId, opts) => mockMarkAsRead(streamId, lastEventId, opts) },
+    })
+
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileViewport)
     vi.spyOn(usePointerModule, "useCoarsePointer").mockImplementation(() => isCoarsePointer)
 
@@ -68,6 +83,7 @@ describe("useAutoMarkAsRead", () => {
 
   afterEach(() => {
     vi.runOnlyPendingTimers()
+    queue.dispose()
     vi.useRealTimers()
     vi.restoreAllMocks()
 

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -3,12 +3,12 @@ import { useUnreadCounts } from "./use-unread-counts"
 import { useActivityCounts } from "./use-activity-counts"
 import { usePageActivity } from "./use-page-activity"
 import { computeAutoReadAttention } from "@/lib/auto-read-attention"
+import { useReadCommitQueue } from "@/sync/read-commit-queue"
 import { useIsMobile } from "./use-mobile"
 import { useCoarsePointer } from "./use-pointer"
 
 interface UseAutoMarkAsReadOptions {
   enabled?: boolean
-  debounceMs?: number
   /**
    * When true, `lastEventId` is the bottom of what the viewer has seen, not the
    * tail of the loaded window — unread messages remain below the fold. The read
@@ -37,12 +37,16 @@ export function useAutoReadAttention(): boolean {
 }
 
 /**
- * Hook that automatically marks a stream as read when viewing it.
- * Debounces the mark-as-read call to avoid excessive API calls when rapidly switching streams.
+ * The view-layer half of auto-read: decide WHETHER what the frontier counted
+ * as seen should be marked (attention, elevation, dedup against the last
+ * committed mark), and report it to the workspace's `ReadCommitQueue`. The
+ * queue owns all commit mechanics — debounce, coalescing, flush on
+ * leave/pagehide — so component lifecycle can never lose a mark the viewer
+ * earned (the #1881 glance-triage bug lived exactly in that gap).
  *
- * Checks unread counts, mention counts, AND activity counts — the mark-as-read API
- * clears all of these, so this must fire when any is elevated (e.g., activity arrives
- * via the outbox handler while viewing the stream).
+ * Checks unread counts, mention counts, AND activity counts — the mark-as-read
+ * API clears all of these, so this must fire when any is elevated (e.g.,
+ * activity arrives via the outbox handler while viewing the stream).
  *
  * `lastEventId` is the furthest event the viewer has actually scrolled into
  * view (see `useLastSeenEvent`), not the last loaded event — read state never
@@ -54,109 +58,73 @@ export function useAutoMarkAsRead(
   lastEventId: string | undefined,
   options: UseAutoMarkAsReadOptions = {}
 ) {
-  const { enabled = true, debounceMs = 500, partial = false } = options
-  const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
+  const { enabled = true, partial = false } = options
+  const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
   const canAutoRead = useAutoReadAttention()
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // The mark the running debounce timer would send, so teardown can FLUSH it
-  // instead of dropping it. The debounce is network coalescing, not a dwell
-  // requirement: the frontier already said "seen", so a stream switch or
-  // unmount inside the window must still commit the mark — cancelling it was
-  // the glance-triage bug (open an unread stream, glance, move on within a
-  // second → the stream stayed unread on the server, invisibly, because the
-  // local viewing-pin had already zeroed the badge).
-  const pendingRef = useRef<{ streamId: string; lastEventId: string; partial: boolean } | null>(null)
-  const lastMarkedRef = useRef<string | null>(null)
-  // Track the partial-ness of the last mark so a partial→full transition at the
-  // SAME event (viewer scrolled partway, then on to the tail) re-fires to clear
-  // the badge optimistically instead of waiting on the server round-trip.
-  const lastMarkedPartialRef = useRef<boolean | null>(null)
+  const queue = useReadCommitQueue()
 
-  // Use refs to avoid stale closure in setTimeout callback
   const streamIdRef = useRef(streamId)
-  const lastEventIdRef = useRef(lastEventId)
-  const partialRef = useRef(partial)
   streamIdRef.current = streamId
-  lastEventIdRef.current = lastEventId
-  partialRef.current = partial
-  const markAsReadRef = useRef(markAsRead)
-  markAsReadRef.current = markAsRead
 
-  // Unmount flush: navigating off the stream page entirely (drafts, board)
-  // unmounts the consumer with the debounce still pending — commit it.
-  // Defined ABOVE the debounce effect: React runs unmount cleanups in
-  // definition order, and the debounce effect's own cleanup clears pendingRef.
+  // A fresh open of a stream forgets its committed-mark dedup, so a fully-read
+  // open still heals server-side activity once per open (D5) — the consumer
+  // (StreamContent) is not keyed by streamId, so this hook persists across
+  // switches.
   useEffect(() => {
-    return () => {
-      const pending = pendingRef.current
-      pendingRef.current = null
-      if (pending) markAsReadRef.current(pending.streamId, pending.lastEventId, { partial: pending.partial })
+    queue.resetCommitted(streamId)
+  }, [queue, streamId])
+
+  useEffect(() => {
+    if (!enabled || !lastEventId || !canAutoRead) {
+      // The gate closed with a mark still debouncing: drop it, matching the
+      // pre-queue semantics — a blur cancels rather than commits, so content
+      // glimpsed right before switching windows stays unread (never
+      // over-mark). The next attentive pass re-reports the frontier.
+      queue.cancel(streamId)
+      return
     }
-  }, [])
-
-  // The consumer (StreamContent) is not keyed by streamId, so this hook persists
-  // across stream switches. Clear the dedup refs per stream — otherwise a prior
-  // stream's marked event/partial-ness could suppress the first auto-mark in the
-  // next stream.
-  useEffect(() => {
-    lastMarkedRef.current = null
-    lastMarkedPartialRef.current = null
-  }, [streamId])
-
-  useEffect(() => {
-    if (!enabled || !lastEventId || !canAutoRead) return
 
     const unreadCount = getUnreadCount(streamId)
     const activityCount = getActivityCount(streamId)
 
-    // D5 heal: a fully-read (`!partial`) open still fires `markAsRead` once even
-    // when nothing is locally elevated. `lastEventId` is then the true tail, so
-    // the resulting `stream:read` clears server-side activity that arrived with no
+    // D5 heal: a fully-read (`!partial`) open still fires one commit even when
+    // nothing is locally elevated. `lastEventId` is then the true tail, so the
+    // resulting `stream:read` clears server-side activity that arrived with no
     // new message to scroll past (e.g. a reaction while caught up) and couples
-    // other devices. The dedup ref below gates it to once per caught-up tail. A
-    // PARTIAL (mid-window frontier) open with nothing elevated still no-ops —
+    // other devices. The committed record gates it to once per caught-up tail.
+    // A PARTIAL (mid-window frontier) open with nothing elevated still no-ops —
     // its `lastEventId` isn't the tail, so emitting `stream:read` would be wrong.
     if (unreadCount === 0 && activityCount === 0 && partial) return
 
-    // Skip if already marked this event at the same partial-ness AND no pending
-    // activities to clear. Activities can arrive via activity:created while we're
-    // viewing the stream (the outbox handler is async), so we must re-fire to
-    // clear them even if lastEventId hasn't changed; likewise a partial→full
-    // transition at the same event must re-fire to clear the badge.
-    if (lastMarkedRef.current === lastEventId && lastMarkedPartialRef.current === partial && activityCount === 0) return
-
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
+    // Skip if this exact mark was already committed AND no pending activities
+    // to clear. Activities can arrive via activity:created while we're viewing
+    // the stream (the outbox handler is async), so we must re-fire to clear
+    // them even if lastEventId hasn't changed; likewise a partial→full
+    // transition at the same event must re-fire to clear the badge. Cancelled
+    // (never-sent) marks are not in the committed record, so a blur-parked
+    // mark re-reports after refocus.
+    const committed = queue.lastCommitted(streamId)
+    if (committed && committed.lastEventId === lastEventId && committed.partial === partial && activityCount === 0) {
+      return
     }
 
-    timerRef.current = setTimeout(() => {
-      // Read current values at execution time, not capture time, so re-arms
-      // within the same stream always send the newest frontier.
-      const currentStreamId = streamIdRef.current
-      const currentLastEventId = lastEventIdRef.current
-      pendingRef.current = null
-      if (currentLastEventId) {
-        markAsRead(currentStreamId, currentLastEventId, { partial: partialRef.current })
-        lastMarkedRef.current = currentLastEventId
-        lastMarkedPartialRef.current = partialRef.current
-      }
-    }, debounceMs)
-    pendingRef.current = { streamId, lastEventId, partial }
+    queue.report(streamId, lastEventId, partial)
 
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-      }
-      const pending = pendingRef.current
-      pendingRef.current = null
-      // A stream switch mid-debounce flushes the old stream's mark (the
-      // frontier had already counted it as seen); same-stream re-arms and the
-      // attention gate dropping (blur) keep the existing cancel semantics —
-      // the next arming run re-captures the freshest frontier.
-      if (pending && pending.streamId !== streamIdRef.current) {
-        markAsRead(pending.streamId, pending.lastEventId, { partial: pending.partial })
-      }
+      // Leaving the stream flushes its pending mark — the frontier already
+      // counted the rows as seen; the debounce is network coalescing, not a
+      // dwell requirement. Same-stream re-runs fall through: the next report
+      // replaces the pending mark instead.
+      if (streamIdRef.current !== streamId) queue.flush(streamId)
     }
-  }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, canAutoRead])
+  }, [enabled, streamId, lastEventId, partial, queue, getUnreadCount, getActivityCount, canAutoRead])
+
+  // Unmounting the stream page entirely (navigating to drafts/board) is the
+  // other leave path — flush whatever stream was current.
+  useEffect(() => {
+    return () => {
+      queue.flush(streamIdRef.current)
+    }
+  }, [queue])
 }

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -63,6 +63,15 @@ export function useAutoMarkAsRead(
   const { getActivityCount } = useActivityCounts(workspaceId)
   const canAutoRead = useAutoReadAttention()
   const queue = useReadCommitQueue()
+  // Effect DEPS, not just reads: both hooks subscribe this component to the
+  // unread store, so an `activity:created` landing while the frontier is
+  // unchanged re-runs the effect through these values and re-fires the mark
+  // that clears it. The old code got that re-fire by accident — `markAsRead`'s
+  // identity churned every render, re-running the effect — so stable deps
+  // alone would silently kill the activity-arrival re-mark (witness finding
+  // on #1882).
+  const unreadCount = getUnreadCount(streamId)
+  const activityCount = getActivityCount(streamId)
 
   const streamIdRef = useRef(streamId)
   streamIdRef.current = streamId
@@ -84,9 +93,6 @@ export function useAutoMarkAsRead(
       queue.cancel(streamId)
       return
     }
-
-    const unreadCount = getUnreadCount(streamId)
-    const activityCount = getActivityCount(streamId)
 
     // D5 heal: a fully-read (`!partial`) open still fires one commit even when
     // nothing is locally elevated. `lastEventId` is then the true tail, so the
@@ -118,7 +124,7 @@ export function useAutoMarkAsRead(
       // replaces the pending mark instead.
       if (streamIdRef.current !== streamId) queue.flush(streamId)
     }
-  }, [enabled, streamId, lastEventId, partial, queue, getUnreadCount, getActivityCount, canAutoRead])
+  }, [enabled, streamId, lastEventId, partial, queue, unreadCount, activityCount, canAutoRead])
 
   // Unmounting the stream page entirely (navigating to drafts/board) is the
   // other leave path — flush whatever stream was current.

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -100,6 +100,12 @@ interface UseLastSeenEventOptions {
    * SWEEP_LINK_MS): a jump must remain a gap, not a read-through.
    */
   programmaticScrollAtRef?: React.RefObject<number>
+  /**
+   * The `autoReadRevamp` kill-switch: false disables sweep-linking entirely,
+   * reverting to strict scan-overlap contiguity (pre-#1881 semantics).
+   * Defaults true.
+   */
+  sweepLinkEnabled?: boolean
 }
 
 interface UseLastSeenEventResult {
@@ -136,6 +142,7 @@ export function useLastSeenEvent({
   lastReadEventId,
   enabled,
   programmaticScrollAtRef,
+  sweepLinkEnabled = true,
 }: UseLastSeenEventOptions): UseLastSeenEventResult {
   const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
   const [atLastRow, setAtLastRow] = useState(false)
@@ -193,6 +200,10 @@ export function useLastSeenEvent({
   // by event id, not index: a prepend shifts every index but virtua holds the
   // viewport on the same rows, and an id re-resolves to its post-shift index.
   const prevScanRef = useRef<{ topId: string; at: number } | null>(null)
+  // Ref so a live flag flip applies on the next scan without re-creating the
+  // stable recompute closure (which would re-arm listeners mid-gesture).
+  const sweepLinkEnabledRef = useRef(sweepLinkEnabled)
+  sweepLinkEnabledRef.current = sweepLinkEnabled
 
   const recompute = useCallback(() => {
     const el = scrollContainerRef.current
@@ -237,7 +248,12 @@ export function useLastSeenEvent({
     const now = performance.now()
     const prevScan = prevScanRef.current
     let effTopIdx = topIdx
-    if (prevScan && now - prevScan.at <= SWEEP_LINK_MS && (programmaticScrollAtRef?.current ?? 0) < prevScan.at) {
+    if (
+      sweepLinkEnabledRef.current &&
+      prevScan &&
+      now - prevScan.at <= SWEEP_LINK_MS &&
+      (programmaticScrollAtRef?.current ?? 0) < prevScan.at
+    ) {
       const prevTopIdx = map.get(prevScan.topId)
       if (prevTopIdx !== undefined && prevTopIdx < effTopIdx) effTopIdx = prevTopIdx
     }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -57,6 +57,7 @@ import {
   useBackgroundBootstrapSync,
 } from "@/hooks"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { usePageResume } from "@/hooks/use-page-resume"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { isServerStreamId } from "@/lib/stream-ids"
@@ -341,14 +342,20 @@ function WorkspaceSyncHandler({
   // only below once the current-workspace check has passed — so a pending mark
   // never lands in the wrong workspace on a switch.
   const { markAsRead } = useUnreadCounts(workspaceId)
+  const autoReadRevamp = useFeatureFlag(workspaceId, "autoReadRevamp") === "on"
   const readCommitQueueRef = useRef<ReadCommitQueue | null>(null)
   let readCommitQueue = readCommitQueueRef.current
   if (!readCommitQueue || readCommitQueue.workspaceId !== workspaceId || readCommitQueue.isDisposed) {
     readCommitQueue?.dispose()
-    readCommitQueue = new ReadCommitQueue({ workspaceId, commitRef: { current: markAsRead } })
+    readCommitQueue = new ReadCommitQueue({
+      workspaceId,
+      commitRef: { current: markAsRead },
+      flushOnLeaveRef: { current: autoReadRevamp },
+    })
     readCommitQueueRef.current = readCommitQueue
   }
   readCommitQueue.commitRef.current = markAsRead
+  readCommitQueue.flushOnLeaveRef.current = autoReadRevamp
   // Unlike the SyncEngine (whose destroy would break the socket-connect
   // effect under StrictMode), the queue is safe to dispose on unmount — the
   // recreate check above sees a disposed queue and builds a fresh one on the

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -63,6 +63,8 @@ import { isServerStreamId } from "@/lib/stream-ids"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext, isSyncEngineCurrent } from "@/sync/sync-engine"
+import { ReadCommitQueue, ReadCommitQueueContext } from "@/sync/read-commit-queue"
+import { useUnreadCounts } from "@/hooks/use-unread-counts"
 import { draftsApi, messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { ComposeOverlayMount } from "@/components/board/compose-overlay-mount"
@@ -333,7 +335,36 @@ function WorkspaceSyncHandler({
   // this deep link — resolve→flip in place, else bounce to the list.
   useResolveOrBounce(workspaceId, syncEngine)
 
-  return <SyncEngineContext.Provider value={syncEngine}>{children}</SyncEngineContext.Provider>
+  // The outbound read-commit pipeline, one owner per workspace (same ref-based
+  // lifecycle as the SyncEngine above). Disposing the outgoing queue flushes
+  // through ITS OWN commitRef — still the old workspace's markAsRead, updated
+  // only below once the current-workspace check has passed — so a pending mark
+  // never lands in the wrong workspace on a switch.
+  const { markAsRead } = useUnreadCounts(workspaceId)
+  const readCommitQueueRef = useRef<ReadCommitQueue | null>(null)
+  let readCommitQueue = readCommitQueueRef.current
+  if (!readCommitQueue || readCommitQueue.workspaceId !== workspaceId || readCommitQueue.isDisposed) {
+    readCommitQueue?.dispose()
+    readCommitQueue = new ReadCommitQueue({ workspaceId, commitRef: { current: markAsRead } })
+    readCommitQueueRef.current = readCommitQueue
+  }
+  readCommitQueue.commitRef.current = markAsRead
+  // Unlike the SyncEngine (whose destroy would break the socket-connect
+  // effect under StrictMode), the queue is safe to dispose on unmount — the
+  // recreate check above sees a disposed queue and builds a fresh one on the
+  // StrictMode remount. Without this, the pagehide listener held the queue
+  // alive after leaving the workspace layout.
+  useEffect(() => {
+    return () => {
+      readCommitQueueRef.current?.dispose()
+    }
+  }, [])
+
+  return (
+    <SyncEngineContext.Provider value={syncEngine}>
+      <ReadCommitQueueContext.Provider value={readCommitQueue}>{children}</ReadCommitQueueContext.Provider>
+    </SyncEngineContext.Provider>
+  )
 }
 
 function MessageQueueHandler() {

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -70,6 +70,31 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledWith("stream_b", "event_b", { partial: true })
   })
 
+  it("flush and pagehide DROP pending marks when the autoReadRevamp kill-switch is off", () => {
+    const flushOnLeaveRef = { current: false }
+    const gated = new ReadCommitQueue({
+      workspaceId: "ws_1",
+      commitRef: { current: (streamId, lastEventId, opts) => commit(streamId, lastEventId, opts) },
+      flushOnLeaveRef,
+    })
+    try {
+      gated.report("stream_a", "event_1", false)
+      gated.flush("stream_a")
+      window.dispatchEvent(new Event("pagehide"))
+      vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)
+      expect(commit).not.toHaveBeenCalled()
+      expect(gated.lastCommitted("stream_a")).toBeNull()
+
+      // The debounce fire itself is NOT gated — only leave-flushes are.
+      flushOnLeaveRef.current = false
+      gated.report("stream_a", "event_2", false)
+      vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)
+      expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_2", { partial: false })
+    } finally {
+      gated.dispose()
+    }
+  })
+
   it("resetCommitted forgets the record so a fresh open can re-commit the same mark", () => {
     queue.report("stream_a", "event_1", false)
     vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -78,11 +78,14 @@ describe("ReadCommitQueue", () => {
     expect(queue.lastCommitted("stream_a")).toBeNull()
   })
 
-  it("dispose flushes pending marks and refuses further reports", () => {
+  it("dispose flushes pending marks (a microtask later — it can run in render) and refuses further reports", async () => {
     queue.report("stream_a", "event_1", false)
     queue.dispose()
-    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_1", { partial: false })
     expect(queue.isDisposed).toBe(true)
+    // The commit is deferred out of the caller's (possibly render-phase) stack.
+    expect(commit).not.toHaveBeenCalled()
+    await Promise.resolve()
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_1", { partial: false })
 
     queue.report("stream_a", "event_2", false)
     vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { ReadCommitQueue, READ_COMMIT_DEBOUNCE_MS } from "./read-commit-queue"
+
+const commit = vi.fn()
+
+function makeQueue() {
+  return new ReadCommitQueue({
+    workspaceId: "ws_1",
+    commitRef: { current: (streamId, lastEventId, opts) => commit(streamId, lastEventId, opts) },
+  })
+}
+
+describe("ReadCommitQueue", () => {
+  let queue: ReadCommitQueue
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    commit.mockReset()
+    queue = makeQueue()
+  })
+
+  afterEach(() => {
+    queue.dispose()
+    vi.useRealTimers()
+  })
+
+  it("debounces a report and commits the newest mark (coalescing per stream)", () => {
+    queue.report("stream_a", "event_1", true)
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS - 100)
+    queue.report("stream_a", "event_2", false)
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS - 100)
+    expect(commit).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_2", { partial: false })
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_2", partial: false })
+  })
+
+  it("debounces independently per stream", () => {
+    queue.report("stream_a", "event_a", false)
+    queue.report("stream_b", "event_b", true)
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledWith("stream_a", "event_a", { partial: false })
+    expect(commit).toHaveBeenCalledWith("stream_b", "event_b", { partial: true })
+  })
+
+  it("cancel drops the pending mark without committing or recording it", () => {
+    queue.report("stream_a", "event_1", false)
+    queue.cancel("stream_a")
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)
+    expect(commit).not.toHaveBeenCalled()
+    // Not committed → a later identical report is NOT deduped away.
+    expect(queue.lastCommitted("stream_a")).toBeNull()
+  })
+
+  it("flush commits the pending mark immediately", () => {
+    queue.report("stream_a", "event_1", true)
+    queue.flush("stream_a")
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_1", { partial: true })
+    // The timer died with the flush — no double commit.
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it("pagehide flushes everything pending (leaving the page skips effect cleanup)", () => {
+    queue.report("stream_a", "event_a", false)
+    queue.report("stream_b", "event_b", true)
+    window.dispatchEvent(new Event("pagehide"))
+    expect(commit).toHaveBeenCalledWith("stream_a", "event_a", { partial: false })
+    expect(commit).toHaveBeenCalledWith("stream_b", "event_b", { partial: true })
+  })
+
+  it("resetCommitted forgets the record so a fresh open can re-commit the same mark", () => {
+    queue.report("stream_a", "event_1", false)
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)
+    expect(queue.lastCommitted("stream_a")).not.toBeNull()
+    queue.resetCommitted("stream_a")
+    expect(queue.lastCommitted("stream_a")).toBeNull()
+  })
+
+  it("dispose flushes pending marks and refuses further reports", () => {
+    queue.report("stream_a", "event_1", false)
+    queue.dispose()
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_1", { partial: false })
+    expect(queue.isDisposed).toBe(true)
+
+    queue.report("stream_a", "event_2", false)
+    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)
+    expect(commit).toHaveBeenCalledTimes(1)
+
+    // The pagehide listener is gone with the dispose.
+    window.dispatchEvent(new Event("pagehide"))
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -112,15 +112,25 @@ export class ReadCommitQueue {
     return this.disposed
   }
 
-  /** Flush everything, then stop: a disposed queue accepts no more reports.
-   *  Called on workspace switch and layout unmount — the commitRef still
-   *  points at the outgoing workspace's commit, so the flush lands where the
-   *  marks belong. The owner recreates on next render if it finds a disposed
-   *  queue in its ref (StrictMode's mount→cleanup→remount cycle). */
+  /** Detach immediately, commit what was pending a microtask later. Called on
+   *  workspace switch — which happens during the owner's RENDER (the
+   *  SyncEngine-style recreate check), where running the commit's cache writes
+   *  would be a render-phase side effect — and on layout unmount. The captured
+   *  marks still send through this queue's own commitRef, so a switch flushes
+   *  into the outgoing workspace. The owner recreates on the next render if it
+   *  finds a disposed queue in its ref (StrictMode's mount→cleanup→remount
+   *  cycle). */
   dispose(): void {
-    this.flushAll()
+    if (this.disposed) return
     this.disposed = true
     window.removeEventListener("pagehide", this.onPageHide)
+    const marks = [...this.pending.entries()]
+    this.pending.clear()
+    for (const [, mark] of marks) clearTimeout(mark.timer)
+    if (marks.length === 0) return
+    queueMicrotask(() => {
+      for (const [streamId, mark] of marks) this.send(streamId, mark)
+    })
   }
 
   private send(streamId: string, mark: ReadCommitMark): void {

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -53,13 +53,20 @@ export class ReadCommitQueue {
   // cancelled timer was.
   private readonly onPageHide = () => this.flushAll()
 
+  /** The `autoReadRevamp` kill-switch, kept fresh by the owning layout: false
+   *  makes `flush`/`flushAll`/dispose DROP pending marks instead of committing
+   *  them — the pre-#1881 leave semantics. The debounce fire is unaffected. */
+  readonly flushOnLeaveRef: { current: boolean }
+
   constructor(deps: {
     workspaceId: string
     commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
+    flushOnLeaveRef?: { current: boolean }
     debounceMs?: number
   }) {
     this.workspaceId = deps.workspaceId
     this.commitRef = deps.commitRef
+    this.flushOnLeaveRef = deps.flushOnLeaveRef ?? { current: true }
     this.debounceMs = deps.debounceMs ?? READ_COMMIT_DEBOUNCE_MS
     window.addEventListener("pagehide", this.onPageHide)
   }
@@ -85,6 +92,10 @@ export class ReadCommitQueue {
   }
 
   flush(streamId: string): void {
+    if (!this.flushOnLeaveRef.current) {
+      this.cancel(streamId)
+      return
+    }
     const mark = this.pending.get(streamId)
     if (!mark) return
     clearTimeout(mark.timer)
@@ -127,7 +138,7 @@ export class ReadCommitQueue {
     const marks = [...this.pending.entries()]
     this.pending.clear()
     for (const [, mark] of marks) clearTimeout(mark.timer)
-    if (marks.length === 0) return
+    if (marks.length === 0 || !this.flushOnLeaveRef.current) return
     queueMicrotask(() => {
       for (const [streamId, mark] of marks) this.send(streamId, mark)
     })

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -1,0 +1,138 @@
+import { createContext, useContext } from "react"
+
+export interface ReadCommitMark {
+  lastEventId: string
+  partial: boolean
+}
+
+export const READ_COMMIT_DEBOUNCE_MS = 500
+
+interface PendingMark extends ReadCommitMark {
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * The one owner of the OUTBOUND read-commit pipeline for a workspace: view
+ * components observe what was painted (the read frontier) and `report` it
+ * here; this queue owns everything that used to live in component effect
+ * lifecycle — debouncing, newest-wins coalescing per stream, flush on leave,
+ * flush-all on pagehide, and the committed-mark dedup record. Teardown
+ * semantics were read-loss semantics twice (#1881: the fling and glance-triage
+ * bugs) precisely because the commit pipeline lived inside React effects; a
+ * mark that the frontier has counted as seen must survive whatever the
+ * component tree does next.
+ *
+ * Constructed per workspace by the workspace layout (the SyncEngine pattern)
+ * and provided via `ReadCommitQueueContext`. The commit dependency is read
+ * through `commitRef` at fire time so the layout can keep it fresh across
+ * renders without reconstructing the queue — and so a queue being disposed at
+ * workspace switch still flushes through the OLD workspace's commit.
+ *
+ * Semantics preserved from the hook era:
+ * - `report` (re)arms a trailing debounce; a newer report replaces the pending
+ *   mark and resets the timer.
+ * - `cancel` drops the pending mark without committing (the attention gate
+ *   closing — blur — keeps its cancel semantics; content seen just before a
+ *   blur stays unread rather than over-marking).
+ * - `flush` commits the pending mark immediately (stream switch, unmount).
+ * - A fired or flushed mark is recorded in `lastCommitted` for the caller's
+ *   dedup; `resetCommitted` clears it on a fresh stream open so the
+ *   caught-up-open heal (D5) still fires once per open.
+ */
+export class ReadCommitQueue {
+  readonly workspaceId: string
+  readonly commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
+  private readonly debounceMs: number
+  private readonly pending = new Map<string, PendingMark>()
+  private readonly committed = new Map<string, ReadCommitMark>()
+  private disposed = false
+  // Leaving the page entirely (navigation away, tab close, mobile app kill)
+  // gives no effect cleanup a chance to run — commit whatever is pending.
+  // Best-effort: the request is a normal fetch, so an unload racing it can
+  // still drop it, but that is strictly better than the guaranteed drop a
+  // cancelled timer was.
+  private readonly onPageHide = () => this.flushAll()
+
+  constructor(deps: {
+    workspaceId: string
+    commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
+    debounceMs?: number
+  }) {
+    this.workspaceId = deps.workspaceId
+    this.commitRef = deps.commitRef
+    this.debounceMs = deps.debounceMs ?? READ_COMMIT_DEBOUNCE_MS
+    window.addEventListener("pagehide", this.onPageHide)
+  }
+
+  report(streamId: string, lastEventId: string, partial: boolean): void {
+    if (this.disposed) return
+    const existing = this.pending.get(streamId)
+    if (existing) clearTimeout(existing.timer)
+    const timer = setTimeout(() => {
+      const mark = this.pending.get(streamId)
+      if (!mark) return
+      this.pending.delete(streamId)
+      this.send(streamId, mark)
+    }, this.debounceMs)
+    this.pending.set(streamId, { lastEventId, partial, timer })
+  }
+
+  cancel(streamId: string): void {
+    const mark = this.pending.get(streamId)
+    if (!mark) return
+    clearTimeout(mark.timer)
+    this.pending.delete(streamId)
+  }
+
+  flush(streamId: string): void {
+    const mark = this.pending.get(streamId)
+    if (!mark) return
+    clearTimeout(mark.timer)
+    this.pending.delete(streamId)
+    this.send(streamId, mark)
+  }
+
+  flushAll(): void {
+    for (const streamId of [...this.pending.keys()]) this.flush(streamId)
+  }
+
+  /** The last mark actually sent for this stream — pending/cancelled marks
+   *  never appear here, so a blur-cancelled mark re-reports after refocus. */
+  lastCommitted(streamId: string): ReadCommitMark | null {
+    return this.committed.get(streamId) ?? null
+  }
+
+  /** A fresh open of the stream forgets the committed record so the once-per-
+   *  open caught-up heal can fire again. */
+  resetCommitted(streamId: string): void {
+    this.committed.delete(streamId)
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed
+  }
+
+  /** Flush everything, then stop: a disposed queue accepts no more reports.
+   *  Called on workspace switch and layout unmount — the commitRef still
+   *  points at the outgoing workspace's commit, so the flush lands where the
+   *  marks belong. The owner recreates on next render if it finds a disposed
+   *  queue in its ref (StrictMode's mount→cleanup→remount cycle). */
+  dispose(): void {
+    this.flushAll()
+    this.disposed = true
+    window.removeEventListener("pagehide", this.onPageHide)
+  }
+
+  private send(streamId: string, mark: ReadCommitMark): void {
+    this.committed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
+    this.commitRef.current(streamId, mark.lastEventId, { partial: mark.partial })
+  }
+}
+
+export const ReadCommitQueueContext = createContext<ReadCommitQueue | null>(null)
+
+export function useReadCommitQueue(): ReadCommitQueue {
+  const queue = useContext(ReadCommitQueueContext)
+  if (!queue) throw new Error("useReadCommitQueue must be used within a ReadCommitQueueContext provider")
+  return queue
+}

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,6 +54,13 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
+  // Kill-switch for the revamped auto-read semantics (#1881/#1882): "on" is
+  // the shipped behavior — sweep-linked frontier scans (a fling reads what it
+  // painted past) and flush-on-leave/pagehide for the pending mark. "off"
+  // reverts BOTH to the pre-#1881 semantics (strict scan-overlap contiguity;
+  // leaving a stream drops a still-debouncing mark) without touching the
+  // ReadCommitQueue plumbing. Delete after rollout confidence.
+  autoReadRevamp: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The


### PR DESCRIPTION
## Problem

Outbound read marks were component-owned end to end: `useAutoMarkAsRead` ran the debounce inside a React effect and fired the mutation itself, so effect teardown semantics were read-loss semantics. [#1881](https://github.com/threahq/threa/pull/1881) patched the two teardown paths it could reach (stream switch, unmount), but the shape still leaked — pagehide/tab-close mid-debounce dropped the pending mark, and any new read surface would re-wire its own commit mechanics. Kris's call: move the commit pipeline into the data layer.

## Solution

`ReadCommitQueue` (`apps/frontend/src/sync/read-commit-queue.ts`) — one owner per workspace of everything between "the frontier counted this as seen" and the network:

- `report` / `cancel` / `flush` / `flushAll`: trailing 500ms debounce with newest-wins coalescing per stream; `flush` on leave; `flushAll` on `pagehide` (new coverage — best-effort, a normal fetch, but strictly better than the guaranteed drop a cancelled timer was); `cancel` keeps blur's never-over-mark semantics.
- Committed-mark record (`lastCommitted` / `resetCommitted`) replaces the hook's dedup refs — cancelled marks never enter it, so a blur-parked mark re-reports on refocus, and `resetCommitted` per stream open keeps the once-per-open caught-up heal (D5).
- Constructed in `WorkspaceSyncHandler` beside the SyncEngine (same ref-based StrictMode-safe lifecycle; `isDisposed` recreate check makes an unmount dispose safe where the engine's is not), provided via `ReadCommitQueueContext`. `commitRef` is read at fire time, so a queue disposed at workspace switch still flushes through the outgoing workspace's `markAsRead`.
- `useAutoMarkAsRead` keeps only the view-layer decisions — attention gate, elevation checks, partial/full — and reports into the queue. Its timer/pending/flush machinery is deleted, along with the unused `debounceMs` option (INV-38).

Behavioral divergences from #1881, all deliberate (the first two surfaced by the [Overseer witness review](https://seer.build/ws_vbyzjvdg6g/r/read-commit-queue-1882) and fixed in `73c8108d`):

- The activity-arrival re-mark previously worked by accident — `markAsRead`'s per-render identity churn re-ran the effect. The stream's unread/activity count values are effect deps now, with a regression test pinning the re-fire.
- Neutral same-stream effect re-runs no longer cancel a pending mark (the old cleanup cleared the timer on every re-run); the pending mark survives until it fires, flushes, or the attention gate closes.
- Pagehide/tab-close flushes pending marks (new coverage).
- `dispose()` defers its commits by a microtask: the workspace-switch recreate calls it during render. Accepted dev-only residual: under StrictMode's simulated unmount, a disposed queue sits in context until the next render and drops reports silently — self-heals on any render, unreachable in prod.

The 7-test browser suite (both #1881 repros included) passing unchanged is the equivalence evidence.

**Kill-switch** (`d2509bd7`): the `autoReadRevamp` feature flag (workspace/user scoped, default `on`) reverts the read SEMANTICS to pre-#1881 — `off` disables sweep-linking in `useLastSeenEvent` and makes the queue's leave-flushes drop instead of commit. Live-flippable via the existing flag layers; the queue plumbing itself is not flagged (behavior-neutral delivery either way). Delete the flag after rollout confidence.

## Test plan

- [x] `read-commit-queue.test.ts` — 7 new: debounce/coalesce, per-stream isolation, cancel, flush, pagehide flush-all, committed record, dispose
- [x] `use-auto-mark-as-read.test.ts` — all 13 pass against a real queue (wrapper-provided), semantics unchanged
- [x] Browser `auto-read` suite 7/7; frontend units 6671; full monorepo lint + typecheck via pre-commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GceYF7UEshN3QRAjGQDagJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789246115&installation_model_id=20758&pr_number=1882&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1882&signature=15e0cb83d623d130a8e90c29533e4c9bd1a2766d30f6771b4e1921751bc05bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

