### PR TITLE
fix: keep composer stable across draft promotion

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -1242,5 +1242,19 @@ describe("MessageInput", () => {
 
       expect(screen.getByText("Failed to create stream. Please try again.")).toBeInTheDocument()
     })
+
+    it("does not restore an aborted stale send into the next stream", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("Keep this in the old stream")
+      const aborted = new Error("Draft promotion wait aborted")
+      aborted.name = "AbortError"
+      mockSendMessage.mockRejectedValue(aborted)
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(mockSetContent.mock.calls).toEqual([[EMPTY_DOC]])
+      expect(screen.queryByText("Failed to create stream. Please try again.")).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -20,6 +20,7 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { relocateLoadedDraft, stashLoadedDraft } from "@/hooks/use-draft-message"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useComposeTrace } from "@/lib/compose-trace"
+import { getDraftPromotionSource } from "@/lib/draft-promotions"
 import { usePreferences } from "@/contexts"
 import { useConnectionState } from "@/components/layout/connection-status"
 import {
@@ -384,16 +385,17 @@ function MessageInputComponent({
     ? boardPostLastActiveStreamId(conversationReplyPost)
     : null
 
-  // The draft scope this composer edits — the target when armed, the stream's own
-  // otherwise. `scopeId` MUST follow it: the composer's rehydrate keys on
-  // `scopeId` (`use-draft-composer.ts`), so a mismatched pair renders one draft
-  // while every save targets another.
+  // The persistence key follows the route, while editor identity spans the one
+  // draft→real promotion handoff so in-flight keystrokes are not rehydrated away.
   const draftKey = effectiveTarget ?? hostScope
+  const promotedFromDraftId = getDraftPromotionSource(streamId)
+  const composerScopeId =
+    effectiveTarget ?? getDraftMessageKey({ type: "stream", streamId: promotedFromDraftId ?? streamId })
   const syncEngine = useOptionalSyncEngine()
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
-    scopeId: draftKey,
+    scopeId: composerScopeId,
     e2eStreamId: e2eRootStreamId,
   })
   const quoteReplyCtx = useQuoteReply()
@@ -861,11 +863,15 @@ function MessageInputComponent({
         if (result.navigateTo) {
           navigate(result.navigateTo, { replace: result.replace ?? false })
         }
-      } catch {
-        // This only happens for draft promotion failure (stream creation failed)
-        // Real stream message failures are handled in the timeline with retry
-        composer.setContent(contentJson)
-        setError("Failed to create stream. Please try again.")
+      } catch (error) {
+        // Route changes abort a stale promotion wait. The old scope still owns
+        // its durable draft; restoring here would inject it into the next stream.
+        if (!(error instanceof Error && error.name === "AbortError")) {
+          // This only happens for draft promotion failure (stream creation failed)
+          // Real stream message failures are handled in the timeline with retry
+          composer.setContent(contentJson)
+          setError("Failed to create stream. Please try again.")
+        }
       } finally {
         composer.setIsSending(false)
       }

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -199,6 +199,20 @@ describe("useDraftComposer", () => {
   })
 
   describe("scope change", () => {
+    it("keeps live content when the persistence key changes within one logical scope", () => {
+      mockDraftLoadedId = null
+      const { result, rerender } = renderHook(
+        ({ currentKey }) => useDraftComposer({ workspaceId, draftKey: currentKey, scopeId: "promotion:draft_1" }),
+        { initialProps: { currentKey: "stream:draft_1" } }
+      )
+
+      act(() => result.current.handleContentChange(makeDoc("follow-up typed during promotion")))
+      rerender({ currentKey: "stream:stream_1" })
+
+      expect(result.current.content).toEqual(makeDoc("follow-up typed during promotion"))
+      expect(mockClearAttachments).not.toHaveBeenCalled()
+    })
+
     it("keeps live content and attachments when the same draft identity changes filing scope", () => {
       const sourceKey = "board:reply:conv_1"
       const targetKey = "stream:stream_1"

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -16,6 +16,7 @@ import * as e2eSession from "@/stores/e2e-session-store"
 import * as streamKeyCache from "@/lib/crypto/stream-key-cache"
 import * as messageEnvelope from "@/lib/crypto/message-envelope"
 import { clearStreamNameCache, getCachedStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
+import { emitDraftPromoted } from "@/lib/draft-promotions"
 
 function createWrapper(
   queryClient: QueryClient,
@@ -290,6 +291,90 @@ describe("useStreamOrDraft real stream send", () => {
     expect(queuedEvent?.payload).toMatchObject({
       conversationId: "conv_1",
       declaredConversationId: "conv_1",
+    })
+  })
+})
+
+describe("useStreamOrDraft scratchpad draft send", () => {
+  beforeEach(async () => {
+    await clearAllCachedData()
+    await db.pendingMessages.clear()
+    await db.events.clear()
+    await db.draftScratchpads.clear()
+  })
+
+  it("routes a follow-up queued during materialization into the promoted stream", async () => {
+    await db.workspaceUsers.put({
+      id: "member_promotion",
+      workspaceId: "ws_promotion",
+      workosUserId: "workos_1",
+      email: "kris@example.com",
+      role: "owner",
+      slug: "kris",
+      name: "Kris",
+      joinedAt: "2026-08-14T06:00:00Z",
+      _cachedAt: Date.now(),
+    } as never)
+    await db.draftScratchpads.put({
+      id: "draft_promotion",
+      workspaceId: "ws_promotion",
+      displayName: null,
+      companionMode: "on",
+      createdAt: Date.now(),
+    })
+
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useStreamOrDraft("ws_promotion", "draft_promotion"), {
+      wrapper: createWrapper(queryClient),
+    })
+    await waitFor(() => {
+      expect(result.current.stream?.id).toBe("draft_promotion")
+      expect(result.current.currentUserId).toBe("member_promotion")
+    })
+
+    await act(async () => {
+      await result.current.sendMessage({
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "first" }] }],
+        },
+      })
+    })
+
+    let followUp!: Promise<{ navigateTo?: string; replace?: boolean }>
+    act(() => {
+      followUp = result.current.sendMessage({
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "follow-up" }] }],
+        },
+      })
+    })
+    await waitFor(async () => {
+      expect(
+        (await db.pendingMessages.toArray()).filter((message) => message.draftId === "draft_promotion")
+      ).toHaveLength(1)
+    })
+
+    emitDraftPromoted({
+      draftId: "draft_promotion",
+      realStreamId: "stream_promoted",
+      workspaceId: "ws_promotion",
+    })
+    await act(async () => {
+      await followUp
+    })
+
+    const messages = await db.pendingMessages.toArray()
+    const routingByContent = Object.fromEntries(
+      messages.map(({ content, streamId, streamCreation }) => [content, { streamId, streamCreation }])
+    )
+    expect(routingByContent).toEqual({
+      first: {
+        streamId: "draft_promotion",
+        streamCreation: expect.objectContaining({ type: "scratchpad" }),
+      },
+      "follow-up": { streamId: "stream_promoted", streamCreation: undefined },
     })
   })
 })

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -19,7 +19,7 @@ import { getDraftMessageKey, purgeScopeDrafts, upsertLoadedDraft } from "./use-d
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import { resolveDmDisplayName } from "@/lib/streams"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import { onDraftPromoted } from "@/lib/draft-promotions"
+import { getPromotedStreamId, onDraftPromoted, waitForDraftPromotion } from "@/lib/draft-promotions"
 import type {
   Stream,
   StreamMember,
@@ -183,7 +183,10 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
   const navigate = useNavigate()
   const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
   const { getScratchpad, updateScratchpad, deleteScratchpad } = useDraftScratchpads(workspaceId)
+  const promotionWaitController = useMemo(() => new AbortController(), [workspaceId, streamId])
   const draft = enabled ? getScratchpad(streamId) : undefined
+
+  useEffect(() => () => promotionWaitController.abort(), [promotionWaitController])
 
   const stream: VirtualStream | undefined = draft
     ? {
@@ -227,26 +230,50 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
         throw new Error("Cannot send message: user identity not resolved yet")
       }
 
-      const draftData = await db.draftScratchpads.get(streamId)
-      const companionMode = draftData?.companionMode ?? "on"
+      // The optimistic first message renders before promotion replaces the route.
+      // A follow-up can therefore enter this stale draft callback; join the first
+      // promotion instead of materializing a second scratchpad.
+      const knownPromotedStreamId = getPromotedStreamId(streamId)
+      const promotionPending = knownPromotedStreamId
+        ? null
+        : await db.pendingMessages
+            .filter(
+              (message) =>
+                message.draftId === streamId &&
+                (message.streamCreation !== undefined || message.promotedStreamId !== undefined)
+            )
+            .first()
+      const promotedStreamId =
+        knownPromotedStreamId ??
+        promotionPending?.promotedStreamId ??
+        (promotionPending
+          ? await waitForDraftPromotion(workspaceId, streamId, { signal: promotionWaitController.signal })
+          : null)
 
-      await queueDraftMessage(input, {
-        workspaceId,
-        streamId,
-        streamCreation: {
-          type: StreamTypes.SCRATCHPAD,
-          displayName: draftData?.displayName ?? undefined,
-          companionMode,
-          companionPersonaId: draftData?.companionPersonaId,
-          allowedToolCategories: draftData?.allowedToolCategories,
-        },
-        draftId: streamId,
-      })
+      if (promotedStreamId) {
+        await queueDraftMessage(input, { workspaceId, streamId: promotedStreamId })
+      } else {
+        const draftData = await db.draftScratchpads.get(streamId)
+        const companionMode = draftData?.companionMode ?? "on"
+
+        await queueDraftMessage(input, {
+          workspaceId,
+          streamId,
+          streamCreation: {
+            type: StreamTypes.SCRATCHPAD,
+            displayName: draftData?.displayName ?? undefined,
+            companionMode,
+            companionPersonaId: draftData?.companionPersonaId,
+            allowedToolCategories: draftData?.allowedToolCategories,
+          },
+          draftId: streamId,
+        })
+      }
 
       // Navigation is handled by the promotion listener above
       return {}
     },
-    [streamId, workspaceId, currentUserId, queueDraftMessage]
+    [streamId, workspaceId, currentUserId, queueDraftMessage, promotionWaitController]
   )
 
   return {

--- a/apps/frontend/src/lib/draft-promotions.test.ts
+++ b/apps/frontend/src/lib/draft-promotions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import {
+  emitDraftPromoted,
+  getDraftPromotionSource,
+  getPromotedStreamId,
+  waitForDraftPromotion,
+} from "./draft-promotions"
+
+describe("draft promotions", () => {
+  it("retains both sides of a promotion for stale send callbacks and composer continuity", () => {
+    emitDraftPromoted({ draftId: "draft_lookup", realStreamId: "stream_lookup", workspaceId: "ws_1" })
+
+    expect(getPromotedStreamId("draft_lookup")).toBe("stream_lookup")
+    expect(getDraftPromotionSource("stream_lookup")).toBe("draft_lookup")
+  })
+
+  it("resolves a waiter registered while materialization is in flight", async () => {
+    const promoted = waitForDraftPromotion("ws_1", "draft_wait")
+
+    emitDraftPromoted({ draftId: "draft_wait", realStreamId: "stream_wait", workspaceId: "ws_1" })
+
+    await expect(promoted).resolves.toBe("stream_wait")
+  })
+
+  it("rejects and removes a waiter when its composer unmounts", async () => {
+    const controller = new AbortController()
+    const promoted = waitForDraftPromotion("ws_1", "draft_abort", { signal: controller.signal })
+
+    controller.abort()
+
+    await expect(promoted).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  it("bounds a wait when materialization keeps failing", async () => {
+    const promoted = waitForDraftPromotion("ws_1", "draft_timeout", { timeoutMs: 1 })
+
+    await expect(promoted).rejects.toThrow("Timed out waiting for draft promotion")
+  })
+})

--- a/apps/frontend/src/lib/draft-promotions.ts
+++ b/apps/frontend/src/lib/draft-promotions.ts
@@ -22,6 +22,8 @@ export interface DraftPromotion {
 type Listener = (promotion: DraftPromotion) => void
 
 const listeners = new Set<Listener>()
+const promotionsByDraftId = new Map<string, DraftPromotion>()
+const promotionsByRealStreamId = new Map<string, DraftPromotion>()
 
 export function onDraftPromoted(listener: Listener): () => void {
   listeners.add(listener)
@@ -30,7 +32,53 @@ export function onDraftPromoted(listener: Listener): () => void {
   }
 }
 
+export function getPromotedStreamId(draftId: string): string | null {
+  return promotionsByDraftId.get(draftId)?.realStreamId ?? null
+}
+
+export function getDraftPromotionSource(realStreamId: string): string | null {
+  return promotionsByRealStreamId.get(realStreamId)?.draftId ?? null
+}
+
+export function waitForDraftPromotion(
+  workspaceId: string,
+  draftId: string,
+  options: { signal?: AbortSignal; timeoutMs?: number } = {}
+): Promise<string> {
+  const existing = promotionsByDraftId.get(draftId)
+  if (existing?.workspaceId === workspaceId) return Promise.resolve(existing.realStreamId)
+
+  return new Promise((resolve, reject) => {
+    let unsubscribe = () => {}
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error("Timed out waiting for draft promotion"))
+    }, options.timeoutMs ?? 30_000)
+    const abort = () => {
+      cleanup()
+      const error = new Error("Draft promotion wait aborted")
+      error.name = "AbortError"
+      reject(error)
+    }
+    const cleanup = () => {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener("abort", abort)
+      unsubscribe()
+    }
+
+    unsubscribe = onDraftPromoted((promotion) => {
+      if (promotion.workspaceId !== workspaceId || promotion.draftId !== draftId) return
+      cleanup()
+      resolve(promotion.realStreamId)
+    })
+    if (options.signal?.aborted) abort()
+    else options.signal?.addEventListener("abort", abort, { once: true })
+  })
+}
+
 export function emitDraftPromoted(promotion: DraftPromotion): void {
+  promotionsByDraftId.set(promotion.draftId, promotion)
+  promotionsByRealStreamId.set(promotion.realStreamId, promotion)
   for (const listener of listeners) {
     listener(promotion)
   }


### PR DESCRIPTION
## Problem

The first message in a draft scratchpad renders optimistically before `promoteDraft` replaces the `draft_*` route with its real `stream_*` route. A follow-up typed in that window could be reset by composer rehydration or enter the stale draft send callback, which created a second scratchpad and posted the message outside the visible timeline. The attachment-tray changes in [#1866](https://github.com/threahq/threa/pull/1866) widened this existing timing window enough to make `dynamic-naming.spec.ts` fail consistently.

## Solution

- Record both sides of each promotion in `draft-promotions.ts`. `MessageInput` uses the source draft as the logical composer scope during the route handoff, preserving editor content while persistence moves to the real stream scope.
- Make stale draft sends reuse a known promotion or wait for the first pending promotion instead of issuing another stream creation.
- Bound promotion waits to 30 seconds and abort them when the draft hook changes scope or unmounts. Failed materialization restores the submitted content through the existing error path instead of leaving a listener and disabled composer.

## Verification

- `dynamic-naming.spec.ts --workers=1 --repeat-each=3`: 3 passed after the final fix
- Frontend targeted tests: 104 passed
- Frontend lint and typecheck passed
- Pre-commit repository lint, typecheck, migration, Dockerfile, Astro, and OpenAPI checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789283013&installation_model_id=20758&pr_number=1883&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1883&signature=06e618e8375a43e3ccfe7e7d1de5cb481df6b267add4cb6360394f0a90dfa7c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->