### PR TITLE
fix: viewing pins activity rows too, so the stream you're reading stops lighting up

### DIFF
--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -3822,6 +3822,86 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     cleanup()
   })
 
+  it("does not hold an activity for the stream being viewed attentively (no lit-row flash)", async () => {
+    // The counter is already pinned while viewing, so holding the activity row
+    // lit the sidebar row — via activityCount — for the whole auto-read round
+    // trip, on a stream the user was looking at, and without it ever entering
+    // the Unread section. Same gate as the counter pin.
+    const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true)
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient, "stream_1")
+
+    const before = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    emit("activity:created", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activity: {
+        id: "act_viewed",
+        activityType: "message",
+        streamId: "stream_1",
+        messageId: "msg_viewed",
+        actorId: "member_2",
+        actorType: "user",
+        context: {},
+        createdAt: new Date().toISOString(),
+        isSelf: false,
+        emoji: null,
+      },
+    })
+
+    const after = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(after?.activityCounts.stream_1).toBe(before?.activityCounts.stream_1)
+    expect(after?.unreadActivityCount).toBe(before?.unreadActivityCount)
+
+    cleanup()
+    focusSpy.mockRestore()
+  })
+
+  it("holds an activity for the viewed stream when unfocused, and for other streams always", async () => {
+    // The mirror of the counter pin's guard: suppressing while unattentive
+    // would zero a count no auto-read confirm is coming for.
+    const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false)
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    const { emit, cleanup } = register(queryClient, "stream_1")
+
+    const base = {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      activity: {
+        id: "act_unfocused",
+        activityType: "message",
+        streamId: "stream_1",
+        messageId: "msg_unfocused",
+        actorId: "member_2",
+        actorType: "user",
+        context: {},
+        createdAt: new Date().toISOString(),
+        isSelf: false,
+        emoji: null,
+      },
+    }
+    const before = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    emit("activity:created", base)
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.activityCounts.stream_1).toBe(
+      (before?.activityCounts.stream_1 ?? 0) + 1
+    )
+
+    // A different stream is held even while focused on stream_1.
+    focusSpy.mockReturnValue(true)
+    emit("activity:created", {
+      ...base,
+      activity: { ...base.activity, id: "act_other", messageId: "msg_other", streamId: "stream_2" },
+    })
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.activityCounts.stream_2).toBe(
+      (before?.activityCounts.stream_2 ?? 0) + 1
+    )
+
+    cleanup()
+    focusSpy.mockRestore()
+  })
+
   it("upserts activity:created rows by id (idempotent) and derives counts from the held set", async () => {
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1842,6 +1842,21 @@ export function registerWorkspaceSocketHandlers(
     if (payload.workspaceId !== workspaceId) return
 
     const a = payload.activity
+    // Viewing pins activity exactly as it pins the message counter above: a row
+    // for the stream the viewer is attentively looking at is about to be cleared
+    // by the auto-read confirm, so holding it lights the sidebar row and the
+    // activity badge for the whole debounce + round trip — on a stream the user
+    // is staring at. That flash reads as a bug precisely because the counter IS
+    // pinned: the row lit up while never entering the Unread section. Gated on
+    // the SAME `isAutoReadAttentiveNow()` signal for the same reason documented
+    // there — suppressing while unattentive would zero a count no confirm is
+    // coming for. A row suppressed but never read server-side (the viewer is
+    // parked above the fold, so the frontier never advances past it) comes back
+    // on the next bootstrap, which is the counter pin's recovery too.
+    if (a.streamId && refs.getCurrentStreamId() === a.streamId && isAutoReadAttentiveNow()) {
+      invalidateActivityFeed(true)
+      return
+    }
     // The held set is the source of truth (D3/D4): upsert the row by its stable
     // id so a replayed event (sync-log catch-up, INV-53) updates in place rather
     // than duplicating; the derived counts follow. Self rows are skipped inside


### PR DESCRIPTION
## Problem

A message arriving in the stream you are actively reading lights that stream's sidebar row — blue, and *not* in the Unread section — until the auto-read round trip clears it (500ms debounce + POST + echo). Reported from prod; the server state was already correct, so this is purely a client-side flash.

The cause is an asymmetry. The message counter has been pinned while attentively viewing since [#1479](https://github.com/threahq/threa/pull/1479) — `stream:activity` applies `isViewing: isViewingStream && isAutoReadAttentiveNow()`, which is why the stream never enters the Unread section. But `handleActivityCreated` holds its row unconditionally, and `calculateUrgency` lights a row on `unreadCount > 0 || activityCount > 0`. So the row lights via the unpinned half while the pinned half keeps it out of the section — the exact "lit but unsectioned" state that reads as a bug.

The colour is the same race: `activity:created` arrives on the always-joined per-user room, often ahead of the `stream:activity` that commits `lastMessagePreview`, so `calculateUrgency` still sees the *previous* message's author and falls through to the human/unknown colour ("activity", blue) rather than the bot/persona one.

## Solution

Pin activity the way the counter is already pinned: in `handleActivityCreated`, skip holding a row whose `streamId` is the stream currently being viewed while `isAutoReadAttentiveNow()` — the auto-read confirm that clears it server-side is already on its way. The activity feed is still invalidated, so a mounted feed page refetches as before.

Gated on the *same* signal as the counter pin, for the reason documented there: suppressing while unattentive would zero a count no confirm is coming for. A row suppressed but never actually read server-side (the viewer is parked above the fold, so the frontier never advances past it) returns on the next bootstrap — the counter pin's recovery path too.

Not addressed here: the preview/activity ordering that picks the colour. Once the row no longer lights while viewing, the mis-coloured window is only reachable for streams you are *not* looking at, where the preview commit and the paint land together.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/workspace-sync.ts` | Viewing+attentive gate in `handleActivityCreated` |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Suppressed-while-viewing, held-while-unfocused, held-for-other-streams |

## Test plan

- [x] `workspace-sync.test.ts` — 127 pass, including the three new cases mirroring the counter pin's own tests
- [x] Frontend units 6692 pass; `auto-read` browser suite 7/7 (the read/activity coupling is what this touches)
- [ ] Prod confirmation of the flash being gone — needs the deploy

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GceYF7UEshN3QRAjGQDagJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789317055&installation_model_id=20758&pr_number=1884&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1884&signature=da5e8a181f5c57a351963419cd10371f68286aa8c0c37f2ea241a9aea0d2edc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->