### PR TITLE
fix: make mobile composer resizing compact and bottom-anchored

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -865,8 +865,8 @@ describe("MessageComposer", () => {
       const handle = screen.getByTestId("composer-resize-handle")
       const root = container.firstElementChild as HTMLElement
       expect(root.style.maxHeight).toBe("")
-      // jsdom measures the shell at 0px, so the drag grows from the 140px floor:
-      // a 260px upward pull lands at max(0 + 260, 140) = 260.
+      // jsdom measures the shell at 0px, so the drag grows from the compact
+      // one-line floor: a 260px upward pull lands at 260px.
       fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
       fireEvent.pointerMove(handle, { pointerId: 1, clientY: 340 })
       expect(root.style.maxHeight).toBe("260px")
@@ -874,17 +874,15 @@ describe("MessageComposer", () => {
       expect(localStorage.getItem("threa:composer-drag-height")).toBe("260")
     })
 
-    it("clamps a downward drag to the minimum height", () => {
+    it("clamps a downward drag to the compact one-line composer", () => {
       const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
       const handle = screen.getByTestId("composer-resize-handle")
       fireEvent.pointerDown(handle, { pointerId: 1, clientY: 300 })
       fireEvent.pointerMove(handle, { pointerId: 1, clientY: 700 })
-      expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("140px")
+      expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("104px")
     })
 
     it("keeps the floor when 75% of a short viewport would dip below it", () => {
-      // Keyboard up on a short landscape viewport: the 75%-of-viewport ceiling
-      // would land under the 140px floor, inverting the clamp — the floor wins.
       const originalInnerHeight = window.innerHeight
       Object.defineProperty(window, "innerHeight", { configurable: true, value: 100 })
       try {
@@ -892,16 +890,44 @@ describe("MessageComposer", () => {
         const handle = screen.getByTestId("composer-resize-handle")
         fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
         fireEvent.pointerMove(handle, { pointerId: 1, clientY: 100 })
-        expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("140px")
+        expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("104px")
       } finally {
         Object.defineProperty(window, "innerHeight", { configurable: true, value: originalInnerHeight })
       }
+    })
+
+    it("keeps one scroll owner and anchors its visible content from the bottom while dragging", () => {
+      render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const handle = screen.getByTestId("composer-resize-handle")
+      const scroller = screen.getByTestId("composer-editor-scroll")
+      let clientHeight = 200
+      Object.defineProperties(scroller, {
+        clientHeight: { configurable: true, get: () => clientHeight },
+        scrollHeight: { configurable: true, get: () => 600 },
+      })
+      scroller.scrollTop = 360
+
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 300 })
+      clientHeight = 100
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: 500 })
+
+      expect(scroller.scrollTop).toBe(460)
+      expect(scroller).toHaveClass("overflow-y-auto")
+      expect(scroller).not.toHaveClass("max-h-[200px]")
     })
 
     it("applies the persisted drag height on mount", () => {
       localStorage.setItem("threa:composer-drag-height", "300")
       const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
       expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("300px")
+    })
+
+    it("overlays a compact handle on the card instead of reserving a full-width row", () => {
+      render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const handle = screen.getByTestId("composer-resize-handle")
+      expect(handle.parentElement).toHaveAttribute("data-composer-card")
+      expect(handle).toHaveClass("absolute", "w-16")
+      expect(handle).not.toHaveClass("-mx-3", "h-5")
     })
 
     it("shows the handle only while the mobile chrome is open", () => {

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -991,6 +991,7 @@ describe("MessageComposer", () => {
     })
 
     it("rebases to a non-transposed rotated closed viewport after the keyboard closes", () => {
+      vi.useFakeTimers()
       const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
       const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
       const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
@@ -1027,6 +1028,7 @@ describe("MessageComposer", () => {
 
         visualViewport.height = 350
         act(() => visualViewport.dispatchEvent(new Event("resize")))
+        act(() => vi.advanceTimersByTime(350))
         expect(root.style.maxHeight).toBe("")
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
@@ -1156,6 +1158,50 @@ describe("MessageComposer", () => {
         expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
         viewport.setViewport(800, 800, 0)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("")
+      } finally {
+        viewport.restore()
+      }
+    })
+
+    it("keeps the cap when a same-angle split grows while the keyboard remains open", () => {
+      vi.useFakeTimers()
+      const viewport = installOrientationViewport(390, 800, 0)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        viewport.setViewport(390, 400, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        viewport.setViewport(450, 500, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        viewport.setViewport(500, 600, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        act(() => vi.advanceTimersByTime(950))
+        expect(root.style.maxHeight).toBe("300px")
+      } finally {
+        viewport.restore()
+      }
+    })
+
+    it("recovers when a split resize and keyboard close both finish before orientation settle", () => {
+      vi.useFakeTimers()
+      const viewport = installOrientationViewport(390, 800, 0)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        viewport.setViewport(390, 400, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("200px")
+
+        viewport.setViewport(500, 300, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        viewport.setViewport(500, 600, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        act(() => vi.advanceTimersByTime(950))
         expect(root.style.maxHeight).toBe("")
       } finally {
         viewport.restore()

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -971,125 +971,24 @@ describe("MessageComposer", () => {
     it("keeps mobile mode on a touch-primary landscape viewport", () => {
       vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
       isMobileMockValue = true
-      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
-      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
-      visualViewport.height = 800
-      visualViewport.width = 800
-      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      const viewport = installOrientationViewport(800, 800, 90)
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
         const root = container.firstElementChild as HTMLElement
         expect(screen.getByTestId("composer-resize-handle")).toBeInTheDocument()
         act(() => screen.getByTestId("rich-editor").focus())
-        visualViewport.height = 400
-        act(() => visualViewport.dispatchEvent(new Event("resize")))
+
+        viewport.setViewport(800, 400, 90, 800)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+
         expect(root.style.maxHeight).toBe("200px")
       } finally {
-        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
-        else Reflect.deleteProperty(window, "visualViewport")
+        viewport.restore()
       }
     })
 
-    it("rebases to a non-transposed rotated closed viewport after the keyboard closes", () => {
+    it("settles resize-before-orientation against the rotated viewport", () => {
       vi.useFakeTimers()
-      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
-      const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
-      const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
-      const originalScreenWidth = Object.getOwnPropertyDescriptor(window.screen, "width")
-      const originalScreenHeight = Object.getOwnPropertyDescriptor(window.screen, "height")
-      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
-      visualViewport.height = 800
-      visualViewport.width = 390
-      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
-      Object.defineProperty(window, "orientation", { configurable: true, writable: true, value: 0 })
-      Object.defineProperty(window.screen, "orientation", { configurable: true, value: undefined })
-      Object.defineProperty(window.screen, "width", { configurable: true, value: 390 })
-      Object.defineProperty(window.screen, "height", { configurable: true, value: 800 })
-      try {
-        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
-        const root = container.firstElementChild as HTMLElement
-        const editor = screen.getByTestId("rich-editor")
-        act(() => editor.focus())
-
-        visualViewport.height = 400
-        act(() => visualViewport.dispatchEvent(new Event("resize")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
-
-        visualViewport.width = 800
-        visualViewport.height = 200
-        ;(window as Window & { orientation: number }).orientation = 90
-        Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 })
-        Object.defineProperty(window, "innerHeight", { configurable: true, value: 350 })
-        act(() => {
-          visualViewport.dispatchEvent(new Event("resize"))
-          window.dispatchEvent(new Event("orientationchange"))
-        })
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(104)
-
-        visualViewport.height = 350
-        act(() => visualViewport.dispatchEvent(new Event("resize")))
-        act(() => vi.advanceTimersByTime(350))
-        expect(root.style.maxHeight).toBe("")
-      } finally {
-        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
-        else Reflect.deleteProperty(window, "visualViewport")
-        if (originalOrientation) Object.defineProperty(window, "orientation", originalOrientation)
-        else Reflect.deleteProperty(window, "orientation")
-        if (originalScreenOrientation) Object.defineProperty(window.screen, "orientation", originalScreenOrientation)
-        else Reflect.deleteProperty(window.screen, "orientation")
-        if (originalScreenWidth) Object.defineProperty(window.screen, "width", originalScreenWidth)
-        if (originalScreenHeight) Object.defineProperty(window.screen, "height", originalScreenHeight)
-      }
-    })
-
-    it("does not cap a focused closed composer during rotation", () => {
-      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
-      const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
-      const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
-      const originalScreenWidth = Object.getOwnPropertyDescriptor(window.screen, "width")
-      const originalScreenHeight = Object.getOwnPropertyDescriptor(window.screen, "height")
-      const originalInnerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
-      const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
-      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
-      visualViewport.height = 800
-      visualViewport.width = 390
-      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
-      Object.defineProperty(window, "orientation", { configurable: true, writable: true, value: 0 })
-      Object.defineProperty(window.screen, "orientation", { configurable: true, value: undefined })
-      Object.defineProperty(window.screen, "width", { configurable: true, value: 390 })
-      Object.defineProperty(window.screen, "height", { configurable: true, value: 800 })
-      Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 })
-      Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 })
-      try {
-        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
-        const root = container.firstElementChild as HTMLElement
-        act(() => screen.getByTestId("rich-editor").focus())
-
-        Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 })
-        Object.defineProperty(window, "innerHeight", { configurable: true, value: 390 })
-        visualViewport.width = 800
-        visualViewport.height = 390
-        ;(window as Window & { orientation: number }).orientation = 90
-        act(() => {
-          visualViewport.dispatchEvent(new Event("resize"))
-          window.dispatchEvent(new Event("orientationchange"))
-        })
-        expect(root.style.maxHeight).toBe("")
-      } finally {
-        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
-        else Reflect.deleteProperty(window, "visualViewport")
-        if (originalOrientation) Object.defineProperty(window, "orientation", originalOrientation)
-        else Reflect.deleteProperty(window, "orientation")
-        if (originalScreenOrientation) Object.defineProperty(window.screen, "orientation", originalScreenOrientation)
-        else Reflect.deleteProperty(window.screen, "orientation")
-        if (originalScreenWidth) Object.defineProperty(window.screen, "width", originalScreenWidth)
-        if (originalScreenHeight) Object.defineProperty(window.screen, "height", originalScreenHeight)
-        if (originalInnerWidth) Object.defineProperty(window, "innerWidth", originalInnerWidth)
-        if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
-      }
-    })
-
-    it("reconciles resize-before-orientation and recovers the closed landscape viewport", () => {
       const viewport = installOrientationViewport(390, 800, 0)
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
@@ -1099,12 +998,17 @@ describe("MessageComposer", () => {
 
         viewport.setViewport(390, 400, 0)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+        expect(root.style.maxHeight).toBe("200px")
 
-        viewport.setViewport(800, 390, 0)
+        viewport.setViewport(800, 200, 0, 390)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        viewport.setViewport(800, 390, 90)
+        viewport.setViewport(800, 200, 90, 390)
         act(() => window.dispatchEvent(new Event("orientationchange")))
+        act(() => vi.advanceTimersByTime(600))
+        expect(root.style.maxHeight).toBe("104px")
+
+        viewport.setViewport(800, 390, 90)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
         expect(root.style.maxHeight).toBe("")
         expect(document.activeElement).toBe(editor)
       } finally {
@@ -1112,7 +1016,8 @@ describe("MessageComposer", () => {
       }
     })
 
-    it("reconciles orientation-before-resize and recovers the closed portrait viewport", () => {
+    it("settles orientation-before-resize without losing the keyboard cap", () => {
+      vi.useFakeTimers()
       const viewport = installOrientationViewport(800, 390, 90)
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
@@ -1120,16 +1025,16 @@ describe("MessageComposer", () => {
         const editor = screen.getByTestId("rich-editor")
         act(() => editor.focus())
 
-        viewport.setViewport(800, 200, 90)
+        viewport.setViewport(800, 200, 90, 390)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
         expect(root.style.maxHeight).toBe("104px")
 
-        viewport.setViewport(800, 400, 0)
+        viewport.setViewport(800, 200, 0, 800)
         act(() => window.dispatchEvent(new Event("orientationchange")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
-        viewport.setViewport(390, 400, 0)
+        viewport.setViewport(390, 400, 0, 800)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+        act(() => vi.advanceTimersByTime(600))
+        expect(root.style.maxHeight).toBe("200px")
 
         viewport.setViewport(390, 800, 0)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
@@ -1140,52 +1045,7 @@ describe("MessageComposer", () => {
       }
     })
 
-    it("rebases a substantial same-angle width resize without treating stable height as a keyboard", () => {
-      vi.useFakeTimers()
-      const viewport = installOrientationViewport(390, 800, 0)
-      try {
-        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
-        const root = container.firstElementChild as HTMLElement
-        act(() => screen.getByTestId("rich-editor").focus())
-
-        viewport.setViewport(800, 800, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(root.style.maxHeight).toBe("")
-        act(() => vi.advanceTimersByTime(600))
-
-        viewport.setViewport(800, 400, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
-        viewport.setViewport(800, 800, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(root.style.maxHeight).toBe("")
-      } finally {
-        viewport.restore()
-      }
-    })
-
-    it("keeps the cap when a same-angle split grows while the keyboard remains open", () => {
-      vi.useFakeTimers()
-      const viewport = installOrientationViewport(390, 800, 0)
-      try {
-        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
-        const root = container.firstElementChild as HTMLElement
-        act(() => screen.getByTestId("rich-editor").focus())
-
-        viewport.setViewport(390, 400, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        viewport.setViewport(450, 500, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        viewport.setViewport(500, 600, 0)
-        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        act(() => vi.advanceTimersByTime(950))
-        expect(root.style.maxHeight).toBe("300px")
-      } finally {
-        viewport.restore()
-      }
-    })
-
-    it("recovers when a split resize and keyboard close both finish before orientation settle", () => {
+    it("keeps the keyboard cap through a same-orientation split resize", () => {
       vi.useFakeTimers()
       const viewport = installOrientationViewport(390, 800, 0)
       try {
@@ -1199,16 +1059,18 @@ describe("MessageComposer", () => {
 
         viewport.setViewport(500, 300, 0)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        viewport.setViewport(500, 600, 0)
+        act(() => vi.advanceTimersByTime(600))
+        expect(root.style.maxHeight).toBe("150px")
+
+        viewport.setViewport(500, 624, 0)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        act(() => vi.advanceTimersByTime(950))
         expect(root.style.maxHeight).toBe("")
       } finally {
         viewport.restore()
       }
     })
 
-    it("commits a same-dimension 90-to-270 rotation at settle", () => {
+    it("commits an angle-only rotation after it settles", () => {
       vi.useFakeTimers()
       const viewport = installOrientationViewport(800, 390, 90)
       try {
@@ -1219,10 +1081,10 @@ describe("MessageComposer", () => {
         viewport.setViewport(800, 390, 270)
         act(() => window.dispatchEvent(new Event("orientationchange")))
         act(() => vi.advanceTimersByTime(600))
-
-        viewport.setViewport(800, 250, 270)
+        viewport.setViewport(800, 250, 270, 390)
         act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
-        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(125)
+
+        expect(root.style.maxHeight).toBe("125px")
       } finally {
         viewport.restore()
       }
@@ -1237,7 +1099,7 @@ describe("MessageComposer", () => {
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
         const root = container.firstElementChild as HTMLElement
-        expect(root.style.maxHeight).toBe("700px")
+        expect(root.style.maxHeight).toBe("600px")
         act(() => screen.getByTestId("rich-editor").focus())
 
         visualViewport.height = 400
@@ -1254,7 +1116,7 @@ describe("MessageComposer", () => {
 
         visualViewport.height = 800
         act(() => visualViewport.dispatchEvent(new Event("resize")))
-        expect(root.style.maxHeight).toBe("700px")
+        expect(root.style.maxHeight).toBe("600px")
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
         else Reflect.deleteProperty(window, "visualViewport")

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -989,6 +989,7 @@ describe("MessageComposer", () => {
       render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
       const handle = screen.getByTestId("composer-resize-handle")
       expect(handle.parentElement).toHaveAttribute("data-composer-card")
+      expect(handle).toHaveAttribute("data-suppress-pull-refresh")
       expect(handle).toHaveClass("absolute", "w-16")
       expect(handle).not.toHaveClass("-mx-3", "h-5")
     })

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -153,6 +153,13 @@ const MockEditorActionBar = (props: Record<string, unknown>) => (
     >
       Aa
     </button>
+    <button
+      type="button"
+      aria-label="Expand composer"
+      onClick={() => (props.onMobileExpandedChange as (v: boolean) => void)?.(true)}
+    >
+      Expand
+    </button>
     {props.trailingContent as any}
   </div>
 )
@@ -916,10 +923,66 @@ describe("MessageComposer", () => {
       expect(scroller).not.toHaveClass("max-h-[200px]")
     })
 
-    it("applies the persisted drag height on mount", () => {
-      localStorage.setItem("threa:composer-drag-height", "300")
-      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
-      expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("300px")
+    it("reclamps the persisted height when the visible viewport shrinks", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const visualViewport = new EventTarget() as EventTarget & { height: number }
+      visualViewport.height = 800
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      localStorage.setItem("threa:composer-drag-height", "700")
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        expect(root.style.maxHeight).toBe("700px")
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        visualViewport.height = 400
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+
+        expect(root.style.maxHeight).toBe("200px")
+
+        const handle = screen.getByTestId("composer-resize-handle")
+        fireEvent.pointerDown(handle, { pointerId: 1, clientY: 300 })
+        fireEvent.pointerMove(handle, { pointerId: 1, clientY: 280 })
+        fireEvent.pointerUp(handle, { pointerId: 1, clientY: 280 })
+        expect(root.style.maxHeight).toBe("200px")
+        expect(localStorage.getItem("threa:composer-drag-height")).toBe("700")
+
+        visualViewport.height = 800
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("700px")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+      }
+    })
+
+    it("reclamps expanded mode when the visible viewport shrinks", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const visualViewport = new EventTarget() as EventTarget & { height: number }
+      visualViewport.height = 800
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+        fireEvent.click(screen.getByRole("button", { name: "Expand composer" }))
+        expect(root).toHaveAttribute("data-composer-expanded", "true")
+
+        visualViewport.height = 400
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+
+        expect(root.style.minHeight).toBe("200px")
+        expect(root.style.maxHeight).toBe("200px")
+
+        visualViewport.height = 800
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.minHeight).toBe("")
+        expect(root.style.maxHeight).toBe("")
+        expect(root).toHaveClass("min-h-[75dvh]", "max-h-[75dvh]")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+      }
     })
 
     it("overlays a compact handle on the card instead of reserving a full-width row", () => {

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -9,6 +9,7 @@ import type { CachedDraft } from "@/hooks"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import type { JSONContent } from "@threa/types"
 import * as useMobileModule from "@/hooks/use-mobile"
+import * as usePointerModule from "@/hooks/use-pointer"
 import * as contextsModule from "@/contexts"
 import * as editorModule from "@/components/editor"
 import * as micButtonModule from "./mic-button"
@@ -178,6 +179,7 @@ describe("MessageComposer", () => {
     isMobileMockValue = false
     vi.useRealTimers()
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileMockValue)
+    vi.spyOn(usePointerModule, "useIsMobileOrCoarse").mockImplementation(() => isMobileMockValue)
     spyOnExport(editorModule, "RichEditor").mockReturnValue(MockRichEditor as unknown as typeof editorModule.RichEditor)
     spyOnExport(editorModule, "EditorToolbar").mockReturnValue(
       MockEditorToolbar as unknown as typeof editorModule.EditorToolbar
@@ -200,6 +202,49 @@ describe("MessageComposer", () => {
     onFileSelect: vi.fn(),
     onSubmit: vi.fn(),
     canSubmit: false,
+  }
+
+  const installOrientationViewport = (width: number, height: number, angle: number) => {
+    const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+    const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
+    const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
+    const originalScreenWidth = Object.getOwnPropertyDescriptor(window.screen, "width")
+    const originalScreenHeight = Object.getOwnPropertyDescriptor(window.screen, "height")
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
+    const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
+    const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+    Object.defineProperty(window.screen, "orientation", { configurable: true, value: undefined })
+    Object.defineProperty(window.screen, "width", { configurable: true, value: 390 })
+    Object.defineProperty(window.screen, "height", { configurable: true, value: 800 })
+    const setViewport = (nextWidth: number, nextHeight: number, nextAngle: number, layoutHeight = nextHeight) => {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: nextWidth })
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: layoutHeight })
+      Object.defineProperty(window, "orientation", { configurable: true, writable: true, value: nextAngle })
+      visualViewport.width = nextWidth
+      visualViewport.height = nextHeight
+    }
+    setViewport(width, height, angle)
+    return {
+      visualViewport,
+      setViewport,
+      restore: () => {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+        if (originalOrientation) Object.defineProperty(window, "orientation", originalOrientation)
+        else Reflect.deleteProperty(window, "orientation")
+        if (originalScreenOrientation) Object.defineProperty(window.screen, "orientation", originalScreenOrientation)
+        else Reflect.deleteProperty(window.screen, "orientation")
+        if (originalScreenWidth) Object.defineProperty(window.screen, "width", originalScreenWidth)
+        else Reflect.deleteProperty(window.screen, "width")
+        if (originalScreenHeight) Object.defineProperty(window.screen, "height", originalScreenHeight)
+        else Reflect.deleteProperty(window.screen, "height")
+        if (originalInnerWidth) Object.defineProperty(window, "innerWidth", originalInnerWidth)
+        else Reflect.deleteProperty(window, "innerWidth")
+        if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
+        else Reflect.deleteProperty(window, "innerHeight")
+      },
+    }
   }
 
   it("preserves active interim before the composer and editor refs unmount", () => {
@@ -921,6 +966,220 @@ describe("MessageComposer", () => {
       expect(scroller.scrollTop).toBe(460)
       expect(scroller).toHaveClass("overflow-y-auto")
       expect(scroller).not.toHaveClass("max-h-[200px]")
+    })
+
+    it("keeps mobile mode on a touch-primary landscape viewport", () => {
+      vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+      isMobileMockValue = true
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
+      visualViewport.height = 800
+      visualViewport.width = 800
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        expect(screen.getByTestId("composer-resize-handle")).toBeInTheDocument()
+        act(() => screen.getByTestId("rich-editor").focus())
+        visualViewport.height = 400
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("200px")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+      }
+    })
+
+    it("rebases to a non-transposed rotated closed viewport after the keyboard closes", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
+      const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
+      const originalScreenWidth = Object.getOwnPropertyDescriptor(window.screen, "width")
+      const originalScreenHeight = Object.getOwnPropertyDescriptor(window.screen, "height")
+      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
+      visualViewport.height = 800
+      visualViewport.width = 390
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      Object.defineProperty(window, "orientation", { configurable: true, writable: true, value: 0 })
+      Object.defineProperty(window.screen, "orientation", { configurable: true, value: undefined })
+      Object.defineProperty(window.screen, "width", { configurable: true, value: 390 })
+      Object.defineProperty(window.screen, "height", { configurable: true, value: 800 })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        const editor = screen.getByTestId("rich-editor")
+        act(() => editor.focus())
+
+        visualViewport.height = 400
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+
+        visualViewport.width = 800
+        visualViewport.height = 200
+        ;(window as Window & { orientation: number }).orientation = 90
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 })
+        Object.defineProperty(window, "innerHeight", { configurable: true, value: 350 })
+        act(() => {
+          visualViewport.dispatchEvent(new Event("resize"))
+          window.dispatchEvent(new Event("orientationchange"))
+        })
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(104)
+
+        visualViewport.height = 350
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+        if (originalOrientation) Object.defineProperty(window, "orientation", originalOrientation)
+        else Reflect.deleteProperty(window, "orientation")
+        if (originalScreenOrientation) Object.defineProperty(window.screen, "orientation", originalScreenOrientation)
+        else Reflect.deleteProperty(window.screen, "orientation")
+        if (originalScreenWidth) Object.defineProperty(window.screen, "width", originalScreenWidth)
+        if (originalScreenHeight) Object.defineProperty(window.screen, "height", originalScreenHeight)
+      }
+    })
+
+    it("does not cap a focused closed composer during rotation", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const originalOrientation = Object.getOwnPropertyDescriptor(window, "orientation")
+      const originalScreenOrientation = Object.getOwnPropertyDescriptor(window.screen, "orientation")
+      const originalScreenWidth = Object.getOwnPropertyDescriptor(window.screen, "width")
+      const originalScreenHeight = Object.getOwnPropertyDescriptor(window.screen, "height")
+      const originalInnerWidth = Object.getOwnPropertyDescriptor(window, "innerWidth")
+      const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
+      const visualViewport = new EventTarget() as EventTarget & { height: number; width: number }
+      visualViewport.height = 800
+      visualViewport.width = 390
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      Object.defineProperty(window, "orientation", { configurable: true, writable: true, value: 0 })
+      Object.defineProperty(window.screen, "orientation", { configurable: true, value: undefined })
+      Object.defineProperty(window.screen, "width", { configurable: true, value: 390 })
+      Object.defineProperty(window.screen, "height", { configurable: true, value: 800 })
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 })
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 })
+        Object.defineProperty(window, "innerHeight", { configurable: true, value: 390 })
+        visualViewport.width = 800
+        visualViewport.height = 390
+        ;(window as Window & { orientation: number }).orientation = 90
+        act(() => {
+          visualViewport.dispatchEvent(new Event("resize"))
+          window.dispatchEvent(new Event("orientationchange"))
+        })
+        expect(root.style.maxHeight).toBe("")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+        if (originalOrientation) Object.defineProperty(window, "orientation", originalOrientation)
+        else Reflect.deleteProperty(window, "orientation")
+        if (originalScreenOrientation) Object.defineProperty(window.screen, "orientation", originalScreenOrientation)
+        else Reflect.deleteProperty(window.screen, "orientation")
+        if (originalScreenWidth) Object.defineProperty(window.screen, "width", originalScreenWidth)
+        if (originalScreenHeight) Object.defineProperty(window.screen, "height", originalScreenHeight)
+        if (originalInnerWidth) Object.defineProperty(window, "innerWidth", originalInnerWidth)
+        if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
+      }
+    })
+
+    it("reconciles resize-before-orientation and recovers the closed landscape viewport", () => {
+      const viewport = installOrientationViewport(390, 800, 0)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        const editor = screen.getByTestId("rich-editor")
+        act(() => editor.focus())
+
+        viewport.setViewport(390, 400, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+
+        viewport.setViewport(800, 390, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        viewport.setViewport(800, 390, 90)
+        act(() => window.dispatchEvent(new Event("orientationchange")))
+        expect(root.style.maxHeight).toBe("")
+        expect(document.activeElement).toBe(editor)
+      } finally {
+        viewport.restore()
+      }
+    })
+
+    it("reconciles orientation-before-resize and recovers the closed portrait viewport", () => {
+      const viewport = installOrientationViewport(800, 390, 90)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        const editor = screen.getByTestId("rich-editor")
+        act(() => editor.focus())
+
+        viewport.setViewport(800, 200, 90)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("104px")
+
+        viewport.setViewport(800, 400, 0)
+        act(() => window.dispatchEvent(new Event("orientationchange")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+        viewport.setViewport(390, 400, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+
+        viewport.setViewport(390, 800, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("")
+        expect(document.activeElement).toBe(editor)
+      } finally {
+        viewport.restore()
+      }
+    })
+
+    it("rebases a substantial same-angle width resize without treating stable height as a keyboard", () => {
+      vi.useFakeTimers()
+      const viewport = installOrientationViewport(390, 800, 0)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        viewport.setViewport(800, 800, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("")
+        act(() => vi.advanceTimersByTime(600))
+
+        viewport.setViewport(800, 400, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(200)
+        viewport.setViewport(800, 800, 0)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(root.style.maxHeight).toBe("")
+      } finally {
+        viewport.restore()
+      }
+    })
+
+    it("commits a same-dimension 90-to-270 rotation at settle", () => {
+      vi.useFakeTimers()
+      const viewport = installOrientationViewport(800, 390, 90)
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        act(() => screen.getByTestId("rich-editor").focus())
+
+        viewport.setViewport(800, 390, 270)
+        act(() => window.dispatchEvent(new Event("orientationchange")))
+        act(() => vi.advanceTimersByTime(600))
+
+        viewport.setViewport(800, 250, 270)
+        act(() => viewport.visualViewport.dispatchEvent(new Event("resize")))
+        expect(Number.parseInt(root.style.maxHeight, 10)).toBe(125)
+      } finally {
+        viewport.restore()
+      }
     })
 
     it("reclamps the persisted height when the visible viewport shrinks", () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -297,6 +297,9 @@ export function MessageComposer({
     return subscribeComposerCommandRequest(streamId, consumeRequest)
   }, [content, onContentChange, streamId])
   const mobileRootRef = useRef<HTMLDivElement>(null)
+  const mobileEditorScrollRef = useRef<HTMLDivElement>(null)
+  const mobileEditorBottomOffsetRef = useRef(0)
+  const resizeScrollBottomRef = useRef<number | null>(null)
   const expandedShellRef = useRef<HTMLDivElement>(null)
   const actionBarWrapperRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
@@ -310,7 +313,13 @@ export function MessageComposer({
   // the 75dvh expanded preset, whose classes would otherwise outrank it.
   const [mobileDragHeight, setMobileDragHeightState] = useState<number | null>(() => loadMobileComposerDragHeight())
   const mobileDragHeightRef = useRef(mobileDragHeight)
-  const resizeDragRef = useRef<{ pointerId: number; startY: number; startHeight: number; minPx: number } | null>(null)
+  const resizeDragRef = useRef<{
+    pointerId: number
+    startY: number
+    startHeight: number
+    minPx: number
+    scrollBottomPx: number
+  } | null>(null)
   const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const root = mobileRootRef.current
     if (!root) return
@@ -321,13 +330,20 @@ export function MessageComposer({
     // The max-height caps the whole root — attachment tray and link previews
     // included — while the floor is defined against the editor card alone, so
     // the extras' height rides on top of the floor. Without this a tray plus
-    // a preview at the 140px floor crushed the editor card toward zero.
+    // a preview at the card floor crushed the editor card toward zero.
     const cardHeight = root.querySelector<HTMLElement>("[data-composer-card]")?.getBoundingClientRect().height
+    const editorScroll = mobileEditorScrollRef.current
+    const scrollBottomPx = editorScroll
+      ? Math.max(0, editorScroll.scrollHeight - editorScroll.clientHeight - editorScroll.scrollTop)
+      : 0
+    mobileEditorBottomOffsetRef.current = scrollBottomPx
+    resizeScrollBottomRef.current = scrollBottomPx
     resizeDragRef.current = {
       pointerId: e.pointerId,
       startY: e.clientY,
       startHeight: rootHeight,
       minPx: MOBILE_COMPOSER_DRAG_MIN_PX + Math.max(0, rootHeight - (cardHeight ?? rootHeight)),
+      scrollBottomPx,
     }
   }, [])
   const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -346,6 +362,10 @@ export function MessageComposer({
     if (resizeDragRef.current?.pointerId !== e.pointerId) return
     resizeDragRef.current = null
     if (mobileDragHeightRef.current !== null) persistMobileComposerDragHeight(mobileDragHeightRef.current)
+    const settledAnchor = resizeScrollBottomRef.current
+    requestAnimationFrame(() => {
+      if (resizeScrollBottomRef.current === settledAnchor) resizeScrollBottomRef.current = null
+    })
   }, [])
   // Expanded-mode FAB actions are always visible on desktop. Touch has no hover,
   // so a tap on the "+" toggles them instead.
@@ -402,6 +422,44 @@ export function MessageComposer({
   useEffect(() => {
     if (isMobile) onMobileChromeOpenChange?.(mobileChromeOpen)
   }, [isMobile, mobileChromeOpen, onMobileChromeOpenChange])
+
+  useLayoutEffect(() => {
+    const drag = resizeDragRef.current
+    const editorScroll = mobileEditorScrollRef.current
+    if (!drag || !editorScroll) return
+    editorScroll.scrollTop = Math.max(0, editorScroll.scrollHeight - editorScroll.clientHeight - drag.scrollBottomPx)
+    mobileEditorBottomOffsetRef.current = drag.scrollBottomPx
+  }, [mobileDragHeight])
+
+  useLayoutEffect(() => {
+    const editorScroll = mobileEditorScrollRef.current
+    if (!isMobile || !mobileChromeOpen || !editorScroll) return
+    let previousHeight = editorScroll.clientHeight
+    let restoring = false
+    const readBottomOffset = () =>
+      Math.max(0, editorScroll.scrollHeight - editorScroll.clientHeight - editorScroll.scrollTop)
+    mobileEditorBottomOffsetRef.current = readBottomOffset()
+    const handleScroll = () => {
+      if (!restoring && resizeScrollBottomRef.current === null) {
+        mobileEditorBottomOffsetRef.current = readBottomOffset()
+      }
+    }
+    const observer = new ResizeObserver(() => {
+      const nextHeight = editorScroll.clientHeight
+      if (nextHeight === previousHeight) return
+      const bottomOffset = resizeScrollBottomRef.current ?? mobileEditorBottomOffsetRef.current
+      restoring = true
+      editorScroll.scrollTop = Math.max(0, editorScroll.scrollHeight - nextHeight - bottomOffset)
+      previousHeight = nextHeight
+      restoring = false
+    })
+    editorScroll.addEventListener("scroll", handleScroll, { passive: true })
+    observer.observe(editorScroll)
+    return () => {
+      observer.disconnect()
+      editorScroll.removeEventListener("scroll", handleScroll)
+    }
+  }, [isMobile, mobileChromeOpen])
 
   // Defer the mobile chrome expansion until the keyboard's viewport resize
   // lands. Expanding on focus alone ran ~100ms ahead of the keyboard, so the
@@ -1303,7 +1361,7 @@ export function MessageComposer({
               <div
                 data-composer-card
                 className={cn(
-                  "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
+                  "relative rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
                   // Floating-composer shadow on the inline (non-expanded) card; the
                   // expanded fullscreen sheet stays flat.
                   !mobileExpanded && COLLAPSED_COMPOSER_SHADOW,
@@ -1315,10 +1373,9 @@ export function MessageComposer({
                   !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
                   // Compact padding when mobile-unfocused (single line), normal otherwise
                   isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
-                  // When mobile-expanded or drag-sized, let the editor grow and
-                  // override its internal max-height — the shell's cap governs.
-                  (mobileExpanded || (isMobile && mobileChromeOpen && mobileDragHeight !== null)) &&
-                    "[&_.tiptap]:max-h-none"
+                  // The outer editor viewport stays the sole scroll owner on
+                  // mobile, including before the first drag.
+                  isMobile && mobileChromeOpen && "[&_.tiptap]:max-h-none"
                 )}
                 onClick={(e) => {
                   if ((e.target as HTMLElement).closest("button,a,input,textarea,[contenteditable],[role='button']"))
@@ -1346,9 +1403,11 @@ export function MessageComposer({
                     onPointerUp={handleResizePointerEnd}
                     onPointerCancel={handleResizePointerEnd}
                     onLostPointerCapture={handleResizePointerEnd}
-                    className="-mx-3 -mt-3 flex h-5 shrink-0 touch-none cursor-ns-resize items-center justify-center"
+                    className="absolute -top-2 left-1/2 z-10 flex h-7 w-16 -translate-x-1/2 touch-none cursor-ns-resize items-center justify-center"
                   >
-                    <div className="h-1 w-9 rounded-full bg-muted-foreground/25" />
+                    <div className="rounded-full bg-card px-1.5 py-1">
+                      <div className="h-1 w-8 rounded-full bg-muted-foreground/30" />
+                    </div>
                   </div>
                 )}
                 {isMobile && !mobileChromeOpen && (
@@ -1383,9 +1442,12 @@ export function MessageComposer({
 
                 {/* Editor — always mounted to preserve state; hidden in preview mode */}
                 <div
+                  ref={mobileEditorScrollRef}
+                  data-testid="composer-editor-scroll"
                   className={cn(
                     isMobile && !mobileChromeOpen ? "h-0 overflow-hidden" : "flex-1 min-h-0",
-                    (mobileExpanded || (isMobile && mobileChromeOpen && mobileDragHeight !== null)) && "overflow-y-auto"
+                    isMobile && mobileChromeOpen && "overflow-y-auto",
+                    isMobile && mobileChromeOpen && !mobileExpanded && mobileDragHeight === null && "max-h-[200px]"
                   )}
                 >
                   <div className="h-full">{sharedEditor}</div>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -67,7 +67,6 @@ const MOBILE_COMPOSER_KEYBOARD_MAX_RATIO = 0.5
 const MOBILE_COMPOSER_DRAG_MAX_RATIO = 0.75
 const MOBILE_KEYBOARD_SETTLE_MS = 350
 const MOBILE_ORIENTATION_SETTLE_MS = 600
-const ORIENTATION_WIDTH_DELTA_PX = 100
 
 function visibleViewportHeight(): number {
   if (typeof window === "undefined") return MOBILE_COMPOSER_DEFAULT_MAX_PX * 2
@@ -346,6 +345,7 @@ export function MessageComposer({
     width: visibleViewportWidth(),
   })
   const [mobileViewportHeight, setMobileViewportHeight] = useState(visibleViewportHeight)
+  const [, refreshMobileGeometry] = useState(0)
   const [mobileKeyboardOpen, setMobileKeyboardOpen] = useState(false)
   const mobileKeyboardOpenRef = useRef(false)
   const expandedShellRef = useRef<HTMLDivElement>(null)
@@ -460,14 +460,8 @@ export function MessageComposer({
     const root = mobileRootRef.current
     const visualViewport = window.visualViewport
     let keyboardSettleId = 0
-    let orientationSettleId = 0
-    let pendingViewportWidth: number | null = null
-    let pendingViewportHeight: number | null = null
-    let pendingHeightChanged = false
-    let keyboardVisibleFloor: number | null = null
+    let geometrySettleId = 0
     const applyKeyboardState = (open: boolean) => {
-      if (open && !mobileKeyboardOpenRef.current) keyboardVisibleFloor = visibleViewportHeight()
-      if (!open) keyboardVisibleFloor = null
       mobileKeyboardOpenRef.current = open
       setMobileKeyboardOpen((current) => (current === open ? current : open))
     }
@@ -476,7 +470,6 @@ export function MessageComposer({
       keyboardSettleId = window.setTimeout(() => {
         if (isEditableFocused()) return
         const height = visibleViewportHeight()
-        keyboardVisibleFloor = null
         closedViewportHeightRef.current = closedViewportHeightEstimate()
         setMobileViewportHeight(height)
         applyKeyboardState(false)
@@ -486,144 +479,68 @@ export function MessageComposer({
       const height = visibleViewportHeight()
       const focusedInside = !!root?.contains(document.activeElement)
       setMobileViewportHeight((current) => (current === height ? current : height))
-      if (!focusedInside && mobileKeyboardOpenRef.current) {
-        keyboardVisibleFloor = null
-        settleClosedViewport()
+      if (!focusedInside) {
+        if (mobileKeyboardOpenRef.current) settleClosedViewport()
+        else applyKeyboardState(false)
         return
       }
       clearTimeout(keyboardSettleId)
       const threshold = mobileKeyboardOpenRef.current ? VIEWPORT_RECONCILE_TOLERANCE_PX : KEYBOARD_VIEWPORT_THRESHOLD_PX
-      const keyboardOpen = focusedInside && height < closedViewportHeightRef.current - threshold
-      if (!keyboardOpen) {
-        closedViewportHeightRef.current = closedViewportHeightEstimate()
-        applyKeyboardState(false)
-        return
-      }
-      keyboardVisibleFloor = Math.min(keyboardVisibleFloor ?? height, height)
-      const grewPastKeyboard = height >= keyboardVisibleFloor + KEYBOARD_VIEWPORT_THRESHOLD_PX
-      const primaryKeyboardOpen = !!visualViewport && height < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
-      if (grewPastKeyboard && !primaryKeyboardOpen) {
-        keyboardSettleId = window.setTimeout(() => {
-          const settledHeight = visibleViewportHeight()
-          const stillFocused = !!root?.contains(document.activeElement)
-          const stillHasPrimaryGap =
-            !!visualViewport && settledHeight < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
-          if (
-            stillFocused &&
-            keyboardVisibleFloor !== null &&
-            settledHeight >= keyboardVisibleFloor + KEYBOARD_VIEWPORT_THRESHOLD_PX &&
-            !stillHasPrimaryGap
-          ) {
-            closedViewportHeightRef.current = closedViewportHeightEstimate()
-            setMobileViewportHeight(settledHeight)
-            applyKeyboardState(false)
-          }
-        }, MOBILE_KEYBOARD_SETTLE_MS)
-        return
-      }
-      applyKeyboardState(true)
+      const keyboardOpen = height < closedViewportHeightRef.current - threshold
+      if (!keyboardOpen) closedViewportHeightRef.current = closedViewportHeightEstimate()
+      applyKeyboardState(keyboardOpen)
     }
-    const commitAtomicOrientation = (nextAngle: OrientationAngle, nextWidth: number) => {
-      const committed = committedOrientationRef.current
-      if (mobileKeyboardOpenRef.current && committed.width > 0 && nextWidth > 0) {
-        closedViewportHeightRef.current = Math.round(closedViewportHeightRef.current * (committed.width / nextWidth))
-        keyboardVisibleFloor = visibleViewportHeight()
-      } else if (!mobileKeyboardOpenRef.current) {
-        keyboardVisibleFloor = null
-        closedViewportHeightRef.current = Math.min(visibleViewportHeight(), window.innerHeight)
-      }
-      committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
-    }
-    const scheduleOrientationSettle = () => {
-      const width = visibleViewportWidth()
-      const height = visibleViewportHeight()
-      if (pendingViewportWidth === null || pendingViewportHeight === null) {
-        pendingViewportWidth = width
-        pendingViewportHeight = height
-      } else if (width !== pendingViewportWidth) {
-        pendingViewportWidth = width
-        pendingViewportHeight = height
-        pendingHeightChanged = false
-      } else if (height !== pendingViewportHeight) {
-        pendingHeightChanged = true
-      }
-      clearTimeout(orientationSettleId)
-      orientationSettleId = window.setTimeout(() => {
-        orientationSettleId = 0
-        const committed = committedOrientationRef.current
-        const nextAngle = orientationAngle()
-        const nextWidth = visibleViewportWidth()
-        const angleChanged = committed.angle !== nextAngle
-        const widthChanged = committed.width > 0 && nextWidth > 0 && nextWidth !== committed.width
+    const settleGeometry = () => {
+      clearTimeout(geometrySettleId)
+      geometrySettleId = window.setTimeout(() => {
+        const previous = committedOrientationRef.current
+        const width = visibleViewportWidth()
+        const height = visibleViewportHeight()
+        const focusedInside = !!root?.contains(document.activeElement)
+        const expectedClosedHeight =
+          previous.width > 0 && width > 0
+            ? Math.round(closedViewportHeightRef.current * (previous.width / width))
+            : closedViewportHeightRef.current
+        const hasPrimaryKeyboardGap = !!visualViewport && height < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
+        const keyboardOpen =
+          focusedInside && (hasPrimaryKeyboardGap || height < expectedClosedHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX)
+        const anotherEditorOwnsFocus = !focusedInside && isEditableFocused()
 
-        if (angleChanged) {
-          commitAtomicOrientation(nextAngle, nextWidth)
-          measureKeyboardState()
-        } else if (widthChanged) {
-          if (mobileKeyboardOpenRef.current) {
-            const height = visibleViewportHeight()
-            keyboardVisibleFloor = pendingHeightChanged ? Math.min(keyboardVisibleFloor ?? height, height) : height
-          } else {
-            closedViewportHeightRef.current = closedViewportHeightEstimate()
-          }
-          committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
-          measureKeyboardState()
-        }
-        pendingViewportWidth = null
-        pendingViewportHeight = null
-        pendingHeightChanged = false
+        closedViewportHeightRef.current =
+          keyboardOpen || anotherEditorOwnsFocus ? expectedClosedHeight : closedViewportHeightEstimate()
+        committedOrientationRef.current = { angle: orientationAngle(), width }
+        setMobileViewportHeight(height)
+        refreshMobileGeometry((version) => version + 1)
+        applyKeyboardState(keyboardOpen)
       }, MOBILE_ORIENTATION_SETTLE_MS)
     }
     const measure = () => {
       const committed = committedOrientationRef.current
-      const nextAngle = orientationAngle()
-      const nextWidth = visibleViewportWidth()
-      const angleChanged = committed.angle !== nextAngle
-      const widthChanged = committed.width > 0 && nextWidth > 0 && nextWidth !== committed.width
-      const substantialWidthChange = widthChanged && Math.abs(nextWidth - committed.width) >= ORIENTATION_WIDTH_DELTA_PX
-
-      if (angleChanged && substantialWidthChange) {
-        clearTimeout(orientationSettleId)
-        orientationSettleId = 0
-        pendingViewportWidth = null
-        pendingViewportHeight = null
-        pendingHeightChanged = false
-        commitAtomicOrientation(nextAngle, nextWidth)
-      } else if (angleChanged || widthChanged) {
-        // Resize and orientationchange are not atomic in every browser. Keep
-        // the committed tuple intact and preserve keyboard state until the
-        // second half arrives (or the split resize settles).
-        scheduleOrientationSettle()
-        setMobileViewportHeight((current) => {
-          const height = visibleViewportHeight()
-          return current === height ? current : height
-        })
+      const geometryChanged =
+        committed.angle !== orientationAngle() ||
+        (committed.width > 0 && visibleViewportWidth() > 0 && committed.width !== visibleViewportWidth())
+      if (geometryChanged) {
+        setMobileViewportHeight(visibleViewportHeight())
+        settleGeometry()
         return
-      } else {
-        clearTimeout(orientationSettleId)
-        orientationSettleId = 0
-        pendingViewportWidth = null
-        pendingViewportHeight = null
-        pendingHeightChanged = false
       }
+      clearTimeout(geometrySettleId)
       measureKeyboardState()
     }
-    const handleResize = () => measure()
-    const handleOrientationChange = () => measure()
     measure()
-    visualViewport?.addEventListener("resize", handleResize)
-    window.addEventListener("resize", handleResize)
-    window.addEventListener("orientationchange", handleOrientationChange)
-    document.addEventListener("focusin", handleResize)
-    document.addEventListener("focusout", handleResize)
+    visualViewport?.addEventListener("resize", measure)
+    window.addEventListener("resize", measure)
+    window.addEventListener("orientationchange", measure)
+    document.addEventListener("focusin", measure)
+    document.addEventListener("focusout", measure)
     return () => {
       clearTimeout(keyboardSettleId)
-      clearTimeout(orientationSettleId)
-      visualViewport?.removeEventListener("resize", handleResize)
-      window.removeEventListener("resize", handleResize)
-      window.removeEventListener("orientationchange", handleOrientationChange)
-      document.removeEventListener("focusin", handleResize)
-      document.removeEventListener("focusout", handleResize)
+      clearTimeout(geometrySettleId)
+      visualViewport?.removeEventListener("resize", measure)
+      window.removeEventListener("resize", measure)
+      window.removeEventListener("orientationchange", measure)
+      document.removeEventListener("focusin", measure)
+      document.removeEventListener("focusout", measure)
     }
   }, [isMobile])
 
@@ -1542,7 +1459,8 @@ export function MessageComposer({
         : { maxHeight: mobileInlineMax }
     }
     if (!mobileExpanded && mobileDragHeight !== null) {
-      return { maxHeight: Math.max(mobileDragHeight, mobileComposerFloor) }
+      const closedMax = Math.max(mobileComposerFloor, closedViewportHeightRef.current * MOBILE_COMPOSER_DRAG_MAX_RATIO)
+      return { maxHeight: Math.min(Math.max(mobileDragHeight, mobileComposerFloor), closedMax) }
     }
     return undefined
   })()

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -14,6 +14,11 @@ import {
 import { flushSync } from "react-dom"
 import { ArrowUp, X, Plus, AtSign, Slash, Paperclip } from "lucide-react"
 import { useIsMobile } from "@/hooks/use-mobile"
+import {
+  isEditableFocused,
+  KEYBOARD_VIEWPORT_THRESHOLD_PX,
+  VIEWPORT_RECONCILE_TOLERANCE_PX,
+} from "@/hooks/use-visual-viewport"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useComposerActionSide } from "@/hooks/use-composer-action-side"
 import { usePreferencesOptional } from "@/contexts"
@@ -56,6 +61,26 @@ import {
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import type { Editor } from "@tiptap/react"
 import { consumeComposerCommandRequest, subscribeComposerCommandRequest } from "@/stores/composer-command-request-store"
+
+const MOBILE_COMPOSER_DEFAULT_MAX_PX = 380
+const MOBILE_COMPOSER_KEYBOARD_MAX_RATIO = 0.5
+const MOBILE_COMPOSER_DRAG_MAX_RATIO = 0.75
+const MOBILE_KEYBOARD_SETTLE_MS = 350
+
+function visibleViewportHeight(): number {
+  if (typeof window === "undefined") return MOBILE_COMPOSER_DEFAULT_MAX_PX * 2
+  return Math.round(window.visualViewport?.height ?? window.innerHeight)
+}
+
+function closedViewportHeightEstimate(): number {
+  if (typeof window === "undefined") return MOBILE_COMPOSER_DEFAULT_MAX_PX * 2
+  return Math.max(visibleViewportHeight(), window.innerHeight)
+}
+
+function screenHeight(): number {
+  if (typeof window === "undefined") return 0
+  return window.screen.availHeight || window.screen.height
+}
 
 function prependComposerCommand(content: JSONContent, command: string): JSONContent {
   const first = content.content?.[0]
@@ -300,6 +325,11 @@ export function MessageComposer({
   const mobileEditorScrollRef = useRef<HTMLDivElement>(null)
   const mobileEditorBottomOffsetRef = useRef(0)
   const resizeScrollBottomRef = useRef<number | null>(null)
+  const closedViewportHeightRef = useRef(closedViewportHeightEstimate())
+  const screenHeightRef = useRef(screenHeight())
+  const [mobileViewportHeight, setMobileViewportHeight] = useState(visibleViewportHeight)
+  const [mobileKeyboardOpen, setMobileKeyboardOpen] = useState(false)
+  const mobileKeyboardOpenRef = useRef(false)
   const expandedShellRef = useRef<HTMLDivElement>(null)
   const actionBarWrapperRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
@@ -319,6 +349,7 @@ export function MessageComposer({
     startHeight: number
     minPx: number
     scrollBottomPx: number
+    startPreferredHeight: number
   } | null>(null)
   const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const root = mobileRootRef.current
@@ -344,16 +375,18 @@ export function MessageComposer({
       startHeight: rootHeight,
       minPx: MOBILE_COMPOSER_DRAG_MIN_PX + Math.max(0, rootHeight - (cardHeight ?? rootHeight)),
       scrollBottomPx,
+      startPreferredHeight: mobileDragHeightRef.current ?? rootHeight,
     }
   }, [])
   const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current
     if (!drag || e.pointerId !== drag.pointerId) return
-    const viewportH = window.visualViewport?.height ?? window.innerHeight
-    // The ceiling never dips below the floor (keyboard up on a short landscape
-    // viewport can put 75% of it under the minimum).
-    const maxPx = Math.max(viewportH * 0.75, drag.minPx)
-    const next = Math.round(Math.min(Math.max(drag.startHeight + (drag.startY - e.clientY), drag.minPx), maxPx))
+    const maxPx = Math.max(closedViewportHeightRef.current * MOBILE_COMPOSER_DRAG_MAX_RATIO, drag.minPx)
+    const delta = drag.startY - e.clientY
+    const growing = delta >= 0
+    const baseHeight = growing ? Math.max(drag.startHeight, drag.startPreferredHeight) : drag.startHeight
+    const preferenceCeiling = growing ? Math.max(maxPx, drag.startPreferredHeight) : maxPx
+    const next = Math.round(Math.min(Math.max(baseHeight + delta, drag.minPx), preferenceCeiling))
     setMobileExpanded(false)
     mobileDragHeightRef.current = next
     setMobileDragHeightState(next)
@@ -390,7 +423,7 @@ export function MessageComposer({
   const [mobileExtrasHeight, setMobileExtrasHeight] = useState(0)
   useLayoutEffect(() => {
     const root = mobileRootRef.current
-    if (!isMobile || mobileDragHeight === null || !root) return
+    if (!isMobile || !root) return
     const card = root.querySelector<HTMLElement>("[data-composer-card]")
     if (!card) return
     const measure = () =>
@@ -402,7 +435,73 @@ export function MessageComposer({
     observer.observe(root)
     observer.observe(card)
     return () => observer.disconnect()
-  }, [isMobile, mobileDragHeight])
+  }, [isMobile])
+
+  useLayoutEffect(() => {
+    if (!isMobile) return
+    const root = mobileRootRef.current
+    const visualViewport = window.visualViewport
+    let keyboardSettleId = 0
+    const applyKeyboardState = (open: boolean) => {
+      mobileKeyboardOpenRef.current = open
+      setMobileKeyboardOpen((current) => (current === open ? current : open))
+    }
+    const settleClosedViewport = () => {
+      clearTimeout(keyboardSettleId)
+      keyboardSettleId = window.setTimeout(() => {
+        if (isEditableFocused()) return
+        const height = visibleViewportHeight()
+        closedViewportHeightRef.current = closedViewportHeightEstimate()
+        setMobileViewportHeight(height)
+        applyKeyboardState(false)
+      }, MOBILE_KEYBOARD_SETTLE_MS)
+    }
+    const reconcileOrientationBaseline = () => {
+      const previousScreenHeight = screenHeightRef.current
+      const nextScreenHeight = screenHeight()
+      if (previousScreenHeight > 0 && nextScreenHeight > 0 && previousScreenHeight !== nextScreenHeight) {
+        closedViewportHeightRef.current = Math.round(
+          closedViewportHeightRef.current * (nextScreenHeight / previousScreenHeight)
+        )
+      }
+      screenHeightRef.current = nextScreenHeight
+    }
+    const measure = () => {
+      reconcileOrientationBaseline()
+      const height = visibleViewportHeight()
+      const focusedInside = !!root?.contains(document.activeElement)
+      setMobileViewportHeight((current) => (current === height ? current : height))
+      if (!focusedInside && mobileKeyboardOpenRef.current) {
+        settleClosedViewport()
+        return
+      }
+      clearTimeout(keyboardSettleId)
+      const threshold = mobileKeyboardOpenRef.current ? VIEWPORT_RECONCILE_TOLERANCE_PX : KEYBOARD_VIEWPORT_THRESHOLD_PX
+      const keyboardOpen = focusedInside && height < closedViewportHeightRef.current - threshold
+      if (!keyboardOpen) closedViewportHeightRef.current = closedViewportHeightEstimate()
+      applyKeyboardState(keyboardOpen)
+    }
+    const handleOrientationChange = () => {
+      reconcileOrientationBaseline()
+      if (!mobileKeyboardOpenRef.current) closedViewportHeightRef.current = closedViewportHeightEstimate()
+      measure()
+    }
+    measure()
+    visualViewport?.addEventListener("resize", measure)
+    window.addEventListener("resize", measure)
+    window.addEventListener("orientationchange", handleOrientationChange)
+    document.addEventListener("focusin", measure)
+    document.addEventListener("focusout", measure)
+    return () => {
+      clearTimeout(keyboardSettleId)
+      visualViewport?.removeEventListener("resize", measure)
+      window.removeEventListener("resize", measure)
+      window.removeEventListener("orientationchange", handleOrientationChange)
+      document.removeEventListener("focusin", measure)
+      document.removeEventListener("focusout", measure)
+    }
+  }, [isMobile])
+
   const actionSide = useComposerActionSide()
   const preferencesCtx = usePreferencesOptional()
   const mirrored = actionSide === "left"
@@ -1301,6 +1400,28 @@ export function MessageComposer({
     )
   }
 
+  const mobileComposerFloor = MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight
+  const mobileKeyboardCap = Math.max(
+    mobileComposerFloor,
+    Math.round(mobileViewportHeight * MOBILE_COMPOSER_KEYBOARD_MAX_RATIO)
+  )
+  const mobileInlineMax = Math.max(
+    mobileComposerFloor,
+    Math.min(mobileDragHeight ?? MOBILE_COMPOSER_DEFAULT_MAX_PX, mobileKeyboardCap)
+  )
+  const mobileRootStyle = (() => {
+    if (!isMobile || !mobileChromeOpen) return undefined
+    if (mobileKeyboardOpen) {
+      return mobileExpanded
+        ? { minHeight: mobileKeyboardCap, maxHeight: mobileKeyboardCap }
+        : { maxHeight: mobileInlineMax }
+    }
+    if (!mobileExpanded && mobileDragHeight !== null) {
+      return { maxHeight: Math.max(mobileDragHeight, mobileComposerFloor) }
+    }
+    return undefined
+  })()
+
   return (
     <TooltipProvider delayDuration={300}>
       <StashedDraftsComposerBridgeContext.Provider value={stashedDraftsBridge}>
@@ -1316,17 +1437,10 @@ export function MessageComposer({
             // docs/stream-timeline-perceived-performance.md). Snap instead, same
             // as the keyboard choreography.
             "flex flex-col",
-            mobileExpanded ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
+            mobileExpanded && !mobileKeyboardOpen ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
             className
           )}
-          // The drag-handle height override. A max-height (not height) so the
-          // composer stays content-driven below it; inline so it outranks the
-          // 380px default class above.
-          style={
-            isMobile && !mobileExpanded && mobileDragHeight !== null
-              ? { maxHeight: Math.max(mobileDragHeight, MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight) }
-              : undefined
-          }
+          style={mobileRootStyle}
           onFocusCapture={isMobile ? handleFocusCapture : undefined}
           onBlurCapture={isMobile ? handleBlurCapture : undefined}
           onKeyDownCapture={handleStashKeyDown}

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -461,8 +461,13 @@ export function MessageComposer({
     const visualViewport = window.visualViewport
     let keyboardSettleId = 0
     let orientationSettleId = 0
-    let rotatedKeyboardVisibleHeight: number | null = null
+    let pendingViewportWidth: number | null = null
+    let pendingViewportHeight: number | null = null
+    let pendingHeightChanged = false
+    let keyboardVisibleFloor: number | null = null
     const applyKeyboardState = (open: boolean) => {
+      if (open && !mobileKeyboardOpenRef.current) keyboardVisibleFloor = visibleViewportHeight()
+      if (!open) keyboardVisibleFloor = null
       mobileKeyboardOpenRef.current = open
       setMobileKeyboardOpen((current) => (current === open ? current : open))
     }
@@ -471,7 +476,7 @@ export function MessageComposer({
       keyboardSettleId = window.setTimeout(() => {
         if (isEditableFocused()) return
         const height = visibleViewportHeight()
-        rotatedKeyboardVisibleHeight = null
+        keyboardVisibleFloor = null
         closedViewportHeightRef.current = closedViewportHeightEstimate()
         setMobileViewportHeight(height)
         applyKeyboardState(false)
@@ -482,41 +487,66 @@ export function MessageComposer({
       const focusedInside = !!root?.contains(document.activeElement)
       setMobileViewportHeight((current) => (current === height ? current : height))
       if (!focusedInside && mobileKeyboardOpenRef.current) {
-        rotatedKeyboardVisibleHeight = null
+        keyboardVisibleFloor = null
         settleClosedViewport()
         return
       }
       clearTimeout(keyboardSettleId)
-      if (
-        focusedInside &&
-        rotatedKeyboardVisibleHeight !== null &&
-        height >= rotatedKeyboardVisibleHeight + KEYBOARD_VIEWPORT_THRESHOLD_PX
-      ) {
-        rotatedKeyboardVisibleHeight = null
+      const threshold = mobileKeyboardOpenRef.current ? VIEWPORT_RECONCILE_TOLERANCE_PX : KEYBOARD_VIEWPORT_THRESHOLD_PX
+      const keyboardOpen = focusedInside && height < closedViewportHeightRef.current - threshold
+      if (!keyboardOpen) {
         closedViewportHeightRef.current = closedViewportHeightEstimate()
         applyKeyboardState(false)
         return
       }
-      const threshold = mobileKeyboardOpenRef.current ? VIEWPORT_RECONCILE_TOLERANCE_PX : KEYBOARD_VIEWPORT_THRESHOLD_PX
-      const keyboardOpen = focusedInside && height < closedViewportHeightRef.current - threshold
-      if (!keyboardOpen) {
-        rotatedKeyboardVisibleHeight = null
-        closedViewportHeightRef.current = closedViewportHeightEstimate()
+      keyboardVisibleFloor = Math.min(keyboardVisibleFloor ?? height, height)
+      const grewPastKeyboard = height >= keyboardVisibleFloor + KEYBOARD_VIEWPORT_THRESHOLD_PX
+      const primaryKeyboardOpen = !!visualViewport && height < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
+      if (grewPastKeyboard && !primaryKeyboardOpen) {
+        keyboardSettleId = window.setTimeout(() => {
+          const settledHeight = visibleViewportHeight()
+          const stillFocused = !!root?.contains(document.activeElement)
+          const stillHasPrimaryGap =
+            !!visualViewport && settledHeight < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
+          if (
+            stillFocused &&
+            keyboardVisibleFloor !== null &&
+            settledHeight >= keyboardVisibleFloor + KEYBOARD_VIEWPORT_THRESHOLD_PX &&
+            !stillHasPrimaryGap
+          ) {
+            closedViewportHeightRef.current = closedViewportHeightEstimate()
+            setMobileViewportHeight(settledHeight)
+            applyKeyboardState(false)
+          }
+        }, MOBILE_KEYBOARD_SETTLE_MS)
+        return
       }
-      applyKeyboardState(keyboardOpen)
+      applyKeyboardState(true)
     }
     const commitAtomicOrientation = (nextAngle: OrientationAngle, nextWidth: number) => {
       const committed = committedOrientationRef.current
       if (mobileKeyboardOpenRef.current && committed.width > 0 && nextWidth > 0) {
         closedViewportHeightRef.current = Math.round(closedViewportHeightRef.current * (committed.width / nextWidth))
-        rotatedKeyboardVisibleHeight = visibleViewportHeight()
+        keyboardVisibleFloor = visibleViewportHeight()
       } else if (!mobileKeyboardOpenRef.current) {
-        rotatedKeyboardVisibleHeight = null
+        keyboardVisibleFloor = null
         closedViewportHeightRef.current = Math.min(visibleViewportHeight(), window.innerHeight)
       }
       committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
     }
     const scheduleOrientationSettle = () => {
+      const width = visibleViewportWidth()
+      const height = visibleViewportHeight()
+      if (pendingViewportWidth === null || pendingViewportHeight === null) {
+        pendingViewportWidth = width
+        pendingViewportHeight = height
+      } else if (width !== pendingViewportWidth) {
+        pendingViewportWidth = width
+        pendingViewportHeight = height
+        pendingHeightChanged = false
+      } else if (height !== pendingViewportHeight) {
+        pendingHeightChanged = true
+      }
       clearTimeout(orientationSettleId)
       orientationSettleId = window.setTimeout(() => {
         orientationSettleId = 0
@@ -525,22 +555,23 @@ export function MessageComposer({
         const nextWidth = visibleViewportWidth()
         const angleChanged = committed.angle !== nextAngle
         const widthChanged = committed.width > 0 && nextWidth > 0 && nextWidth !== committed.width
-        const substantialWidthChange =
-          widthChanged && Math.abs(nextWidth - committed.width) >= ORIENTATION_WIDTH_DELTA_PX
 
-        if (angleChanged && (substantialWidthChange || !widthChanged)) {
+        if (angleChanged) {
           commitAtomicOrientation(nextAngle, nextWidth)
           measureKeyboardState()
-        } else if (!angleChanged && widthChanged) {
-          // A same-angle width resize is a normal split resize. Do not infer a
-          // keyboard transition from height alone; Firefox can change height
-          // while a focused editor remains open.
-          if (!mobileKeyboardOpenRef.current) {
+        } else if (widthChanged) {
+          if (mobileKeyboardOpenRef.current) {
+            const height = visibleViewportHeight()
+            keyboardVisibleFloor = pendingHeightChanged ? Math.min(keyboardVisibleFloor ?? height, height) : height
+          } else {
             closedViewportHeightRef.current = closedViewportHeightEstimate()
           }
           committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
           measureKeyboardState()
         }
+        pendingViewportWidth = null
+        pendingViewportHeight = null
+        pendingHeightChanged = false
       }, MOBILE_ORIENTATION_SETTLE_MS)
     }
     const measure = () => {
@@ -554,6 +585,9 @@ export function MessageComposer({
       if (angleChanged && substantialWidthChange) {
         clearTimeout(orientationSettleId)
         orientationSettleId = 0
+        pendingViewportWidth = null
+        pendingViewportHeight = null
+        pendingHeightChanged = false
         commitAtomicOrientation(nextAngle, nextWidth)
       } else if (angleChanged || widthChanged) {
         // Resize and orientationchange are not atomic in every browser. Keep
@@ -568,6 +602,9 @@ export function MessageComposer({
       } else {
         clearTimeout(orientationSettleId)
         orientationSettleId = 0
+        pendingViewportWidth = null
+        pendingViewportHeight = null
+        pendingHeightChanged = false
       }
       measureKeyboardState()
     }

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -13,7 +13,7 @@ import {
 } from "react"
 import { flushSync } from "react-dom"
 import { ArrowUp, X, Plus, AtSign, Slash, Paperclip } from "lucide-react"
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useIsMobileOrCoarse } from "@/hooks/use-pointer"
 import {
   isEditableFocused,
   KEYBOARD_VIEWPORT_THRESHOLD_PX,
@@ -66,6 +66,8 @@ const MOBILE_COMPOSER_DEFAULT_MAX_PX = 380
 const MOBILE_COMPOSER_KEYBOARD_MAX_RATIO = 0.5
 const MOBILE_COMPOSER_DRAG_MAX_RATIO = 0.75
 const MOBILE_KEYBOARD_SETTLE_MS = 350
+const MOBILE_ORIENTATION_SETTLE_MS = 600
+const ORIENTATION_WIDTH_DELTA_PX = 100
 
 function visibleViewportHeight(): number {
   if (typeof window === "undefined") return MOBILE_COMPOSER_DEFAULT_MAX_PX * 2
@@ -77,9 +79,22 @@ function closedViewportHeightEstimate(): number {
   return Math.max(visibleViewportHeight(), window.innerHeight)
 }
 
-function screenHeight(): number {
+function visibleViewportWidth(): number {
   if (typeof window === "undefined") return 0
-  return window.screen.availHeight || window.screen.height
+  return Math.round(window.visualViewport?.width ?? window.innerWidth)
+}
+
+type OrientationAngle = number | "portrait" | "landscape" | undefined
+type CommittedOrientation = { angle: OrientationAngle; width: number }
+
+function orientationAngle(): OrientationAngle {
+  if (typeof window === "undefined") return undefined
+  const angle = window.screen?.orientation?.angle
+  if (typeof angle === "number") return angle
+  const legacyAngle = (window as Window & { orientation?: number }).orientation
+  if (typeof legacyAngle === "number") return legacyAngle
+  if (window.innerWidth <= 0 || window.innerHeight <= 0) return undefined
+  return window.innerWidth > window.innerHeight ? "landscape" : "portrait"
 }
 
 function prependComposerCommand(content: JSONContent, command: string): JSONContent {
@@ -326,7 +341,10 @@ export function MessageComposer({
   const mobileEditorBottomOffsetRef = useRef(0)
   const resizeScrollBottomRef = useRef<number | null>(null)
   const closedViewportHeightRef = useRef(closedViewportHeightEstimate())
-  const screenHeightRef = useRef(screenHeight())
+  const committedOrientationRef = useRef<CommittedOrientation>({
+    angle: orientationAngle(),
+    width: visibleViewportWidth(),
+  })
   const [mobileViewportHeight, setMobileViewportHeight] = useState(visibleViewportHeight)
   const [mobileKeyboardOpen, setMobileKeyboardOpen] = useState(false)
   const mobileKeyboardOpenRef = useRef(false)
@@ -412,7 +430,7 @@ export function MessageComposer({
   // mic button it lives in) mounted across a tap-outside blur so the session
   // isn't torn down mid-take.
   const [voiceActive, setVoiceActive] = useState(false)
-  const isMobile = useIsMobile()
+  const isMobile = useIsMobileOrCoarse()
   // Height of everything above the editor card (attachment tray, link previews)
   // — the same "extras" the drag floor reserves, measured live because a
   // persisted cap outlives the state it was chosen in: shrink the composer with
@@ -442,6 +460,8 @@ export function MessageComposer({
     const root = mobileRootRef.current
     const visualViewport = window.visualViewport
     let keyboardSettleId = 0
+    let orientationSettleId = 0
+    let rotatedKeyboardVisibleHeight: number | null = null
     const applyKeyboardState = (open: boolean) => {
       mobileKeyboardOpenRef.current = open
       setMobileKeyboardOpen((current) => (current === open ? current : open))
@@ -451,54 +471,122 @@ export function MessageComposer({
       keyboardSettleId = window.setTimeout(() => {
         if (isEditableFocused()) return
         const height = visibleViewportHeight()
+        rotatedKeyboardVisibleHeight = null
         closedViewportHeightRef.current = closedViewportHeightEstimate()
         setMobileViewportHeight(height)
         applyKeyboardState(false)
       }, MOBILE_KEYBOARD_SETTLE_MS)
     }
-    const reconcileOrientationBaseline = () => {
-      const previousScreenHeight = screenHeightRef.current
-      const nextScreenHeight = screenHeight()
-      if (previousScreenHeight > 0 && nextScreenHeight > 0 && previousScreenHeight !== nextScreenHeight) {
-        closedViewportHeightRef.current = Math.round(
-          closedViewportHeightRef.current * (nextScreenHeight / previousScreenHeight)
-        )
-      }
-      screenHeightRef.current = nextScreenHeight
-    }
-    const measure = () => {
-      reconcileOrientationBaseline()
+    const measureKeyboardState = () => {
       const height = visibleViewportHeight()
       const focusedInside = !!root?.contains(document.activeElement)
       setMobileViewportHeight((current) => (current === height ? current : height))
       if (!focusedInside && mobileKeyboardOpenRef.current) {
+        rotatedKeyboardVisibleHeight = null
         settleClosedViewport()
         return
       }
       clearTimeout(keyboardSettleId)
+      if (
+        focusedInside &&
+        rotatedKeyboardVisibleHeight !== null &&
+        height >= rotatedKeyboardVisibleHeight + KEYBOARD_VIEWPORT_THRESHOLD_PX
+      ) {
+        rotatedKeyboardVisibleHeight = null
+        closedViewportHeightRef.current = closedViewportHeightEstimate()
+        applyKeyboardState(false)
+        return
+      }
       const threshold = mobileKeyboardOpenRef.current ? VIEWPORT_RECONCILE_TOLERANCE_PX : KEYBOARD_VIEWPORT_THRESHOLD_PX
       const keyboardOpen = focusedInside && height < closedViewportHeightRef.current - threshold
-      if (!keyboardOpen) closedViewportHeightRef.current = closedViewportHeightEstimate()
+      if (!keyboardOpen) {
+        rotatedKeyboardVisibleHeight = null
+        closedViewportHeightRef.current = closedViewportHeightEstimate()
+      }
       applyKeyboardState(keyboardOpen)
     }
-    const handleOrientationChange = () => {
-      reconcileOrientationBaseline()
-      if (!mobileKeyboardOpenRef.current) closedViewportHeightRef.current = closedViewportHeightEstimate()
-      measure()
+    const commitAtomicOrientation = (nextAngle: OrientationAngle, nextWidth: number) => {
+      const committed = committedOrientationRef.current
+      if (mobileKeyboardOpenRef.current && committed.width > 0 && nextWidth > 0) {
+        closedViewportHeightRef.current = Math.round(closedViewportHeightRef.current * (committed.width / nextWidth))
+        rotatedKeyboardVisibleHeight = visibleViewportHeight()
+      } else if (!mobileKeyboardOpenRef.current) {
+        rotatedKeyboardVisibleHeight = null
+        closedViewportHeightRef.current = Math.min(visibleViewportHeight(), window.innerHeight)
+      }
+      committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
     }
+    const scheduleOrientationSettle = () => {
+      clearTimeout(orientationSettleId)
+      orientationSettleId = window.setTimeout(() => {
+        orientationSettleId = 0
+        const committed = committedOrientationRef.current
+        const nextAngle = orientationAngle()
+        const nextWidth = visibleViewportWidth()
+        const angleChanged = committed.angle !== nextAngle
+        const widthChanged = committed.width > 0 && nextWidth > 0 && nextWidth !== committed.width
+        const substantialWidthChange =
+          widthChanged && Math.abs(nextWidth - committed.width) >= ORIENTATION_WIDTH_DELTA_PX
+
+        if (angleChanged && (substantialWidthChange || !widthChanged)) {
+          commitAtomicOrientation(nextAngle, nextWidth)
+          measureKeyboardState()
+        } else if (!angleChanged && widthChanged) {
+          // A same-angle width resize is a normal split resize. Do not infer a
+          // keyboard transition from height alone; Firefox can change height
+          // while a focused editor remains open.
+          if (!mobileKeyboardOpenRef.current) {
+            closedViewportHeightRef.current = closedViewportHeightEstimate()
+          }
+          committedOrientationRef.current = { angle: nextAngle, width: nextWidth }
+          measureKeyboardState()
+        }
+      }, MOBILE_ORIENTATION_SETTLE_MS)
+    }
+    const measure = () => {
+      const committed = committedOrientationRef.current
+      const nextAngle = orientationAngle()
+      const nextWidth = visibleViewportWidth()
+      const angleChanged = committed.angle !== nextAngle
+      const widthChanged = committed.width > 0 && nextWidth > 0 && nextWidth !== committed.width
+      const substantialWidthChange = widthChanged && Math.abs(nextWidth - committed.width) >= ORIENTATION_WIDTH_DELTA_PX
+
+      if (angleChanged && substantialWidthChange) {
+        clearTimeout(orientationSettleId)
+        orientationSettleId = 0
+        commitAtomicOrientation(nextAngle, nextWidth)
+      } else if (angleChanged || widthChanged) {
+        // Resize and orientationchange are not atomic in every browser. Keep
+        // the committed tuple intact and preserve keyboard state until the
+        // second half arrives (or the split resize settles).
+        scheduleOrientationSettle()
+        setMobileViewportHeight((current) => {
+          const height = visibleViewportHeight()
+          return current === height ? current : height
+        })
+        return
+      } else {
+        clearTimeout(orientationSettleId)
+        orientationSettleId = 0
+      }
+      measureKeyboardState()
+    }
+    const handleResize = () => measure()
+    const handleOrientationChange = () => measure()
     measure()
-    visualViewport?.addEventListener("resize", measure)
-    window.addEventListener("resize", measure)
+    visualViewport?.addEventListener("resize", handleResize)
+    window.addEventListener("resize", handleResize)
     window.addEventListener("orientationchange", handleOrientationChange)
-    document.addEventListener("focusin", measure)
-    document.addEventListener("focusout", measure)
+    document.addEventListener("focusin", handleResize)
+    document.addEventListener("focusout", handleResize)
     return () => {
       clearTimeout(keyboardSettleId)
-      visualViewport?.removeEventListener("resize", measure)
-      window.removeEventListener("resize", measure)
+      clearTimeout(orientationSettleId)
+      visualViewport?.removeEventListener("resize", handleResize)
+      window.removeEventListener("resize", handleResize)
       window.removeEventListener("orientationchange", handleOrientationChange)
-      document.removeEventListener("focusin", measure)
-      document.removeEventListener("focusout", measure)
+      document.removeEventListener("focusin", handleResize)
+      document.removeEventListener("focusout", handleResize)
     }
   }, [isMobile])
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -1511,6 +1511,7 @@ export function MessageComposer({
                 {isMobile && mobileChromeOpen && (
                   <div
                     data-testid="composer-resize-handle"
+                    data-suppress-pull-refresh
                     aria-hidden
                     onPointerDown={handleResizePointerDown}
                     onPointerMove={handleResizePointerMove}

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, within } from "@testing-library/react"
 import { PendingAttachments } from "./pending-attachments"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import * as uploadManager from "@/lib/uploads/upload-manager"
-import * as useMobileModule from "@/hooks/use-mobile"
+import * as usePointerModule from "@/hooks/use-pointer"
 
 function attachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
   return {
@@ -247,7 +247,7 @@ describe("desktop rollup", () => {
 
 describe("mobile rollup and drawer", () => {
   beforeEach(() => {
-    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    vi.spyOn(usePointerModule, "useIsMobileOrCoarse").mockReturnValue(true)
   })
 
   afterEach(() => {

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { useComposerPillDragHost } from "@/components/editor/composer-pill-dnd"
 import type { ComposerPillDragHost } from "@/components/editor/composer-pill-drag-host"
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useIsMobileOrCoarse } from "@/hooks/use-pointer"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
@@ -474,7 +474,7 @@ export function PendingAttachments({
   referenceCounts,
   resting = false,
 }: PendingAttachmentsProps) {
-  const isMobile = useIsMobile()
+  const isMobile = useIsMobileOrCoarse()
   const dragHost = useComposerPillDragHost()
   // Mobile space controls: the chips can be folded away to the one-line rollup
   // (the composer already competes with the keyboard for the viewport), and the

--- a/apps/frontend/src/hooks/use-pull-to-refresh.test.tsx
+++ b/apps/frontend/src/hooks/use-pull-to-refresh.test.tsx
@@ -16,17 +16,21 @@ function Harness() {
 }
 
 describe("usePullToRefresh", () => {
-  it("ignores gestures that start inside a suppressed subtree", () => {
+  it("tracks gestures that start outside a suppressed subtree", () => {
     render(<Harness />)
     const plain = screen.getByTestId("plain")
     fireEvent.touchStart(plain, { touches: [{ clientY: 100 }] })
-    fireEvent.touchMove(plain, { touches: [{ clientY: 200 }] })
-    expect(screen.getByRole("status")).toHaveTextContent("40")
-    fireEvent.touchEnd(plain)
 
+    expect(fireEvent.touchMove(plain, { touches: [{ clientY: 200 }] })).toBe(false)
+    expect(screen.getByRole("status")).toHaveTextContent("40")
+  })
+
+  it("ignores gestures that start inside a suppressed subtree", () => {
+    render(<Harness />)
     const suppressed = screen.getByTestId("suppressed")
     fireEvent.touchStart(suppressed, { touches: [{ clientY: 100 }] })
-    fireEvent.touchMove(suppressed, { touches: [{ clientY: 400 }] })
+
+    expect(fireEvent.touchMove(suppressed, { touches: [{ clientY: 400 }] })).toBe(true)
     expect(screen.getByRole("status")).toHaveTextContent("0")
   })
 })

--- a/apps/frontend/src/hooks/use-pull-to-refresh.test.tsx
+++ b/apps/frontend/src/hooks/use-pull-to-refresh.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { usePullToRefresh } from "./use-pull-to-refresh"
+
+function Harness() {
+  const { ref, distance } = usePullToRefresh({ enabled: true })
+  return (
+    <div ref={ref}>
+      <div data-testid="plain" />
+      <div data-suppress-pull-refresh>
+        <div data-testid="suppressed" />
+      </div>
+      <output>{distance}</output>
+    </div>
+  )
+}
+
+describe("usePullToRefresh", () => {
+  it("ignores gestures that start inside a suppressed subtree", () => {
+    render(<Harness />)
+    const plain = screen.getByTestId("plain")
+    fireEvent.touchStart(plain, { touches: [{ clientY: 100 }] })
+    fireEvent.touchMove(plain, { touches: [{ clientY: 200 }] })
+    expect(screen.getByRole("status")).toHaveTextContent("40")
+    fireEvent.touchEnd(plain)
+
+    const suppressed = screen.getByTestId("suppressed")
+    fireEvent.touchStart(suppressed, { touches: [{ clientY: 100 }] })
+    fireEvent.touchMove(suppressed, { touches: [{ clientY: 400 }] })
+    expect(screen.getByRole("status")).toHaveTextContent("0")
+  })
+})

--- a/apps/frontend/src/hooks/use-pull-to-refresh.ts
+++ b/apps/frontend/src/hooks/use-pull-to-refresh.ts
@@ -47,6 +47,7 @@ export function usePullToRefresh({ enabled, onRefresh }: PullToRefreshOptions) {
     let startY = 0
     let scrollEl: HTMLElement | null = null
     let pulling = false
+    let suppressed = false
     let isRefreshing = false
     let dist = 0
     let crossedSoft = false
@@ -55,15 +56,18 @@ export function usePullToRefresh({ enabled, onRefresh }: PullToRefreshOptions) {
 
     function onTouchStart(e: TouchEvent) {
       if (isRefreshing) return
+      const target = e.target instanceof Element ? e.target : null
+      suppressed = !!target?.closest("[data-suppress-pull-refresh]")
+      if (suppressed) return
       startY = e.touches[0].clientY
-      scrollEl = findScrollParent(e.target as HTMLElement)
+      scrollEl = findScrollParent(target as HTMLElement | null)
       pulling = false
       crossedSoft = false
       crossedHard = false
     }
 
     function onTouchMove(e: TouchEvent) {
-      if (isRefreshing) return
+      if (isRefreshing || suppressed) return
       const dy = e.touches[0].clientY - startY
 
       if (dy <= 0) {
@@ -106,6 +110,10 @@ export function usePullToRefresh({ enabled, onRefresh }: PullToRefreshOptions) {
     }
 
     function onTouchEnd() {
+      if (suppressed) {
+        suppressed = false
+        return
+      }
       if (!pulling) return
       pulling = false
 

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react"
 
 /** Threshold in px — if viewport height is this much smaller than baseline, keyboard is open */
-const KEYBOARD_THRESHOLD = 100
+export const KEYBOARD_VIEWPORT_THRESHOLD_PX = 100
 
 /** How long to poll visualViewport after focus changes to catch keyboard animation (ms) */
 const POLL_DURATION = 600
@@ -43,7 +43,7 @@ const OPTIMISTIC_CLOSE_SUPPRESS_MS = 500
  * content "loading in again" after the keyboard closed. Genuine settles (URL
  * bar moved: tens of px) still apply.
  */
-const RECONCILE_TOLERANCE_PX = 8
+export const VIEWPORT_RECONCILE_TOLERANCE_PX = 8
 
 /** CSS custom property AppShell reads to size the app to the visible viewport */
 const VIEWPORT_HEIGHT_VAR = "--viewport-height"
@@ -109,7 +109,7 @@ export function useVisualViewport(enabled: boolean): boolean {
     if (isIOS()) {
       const measureOpen = () => {
         const vvHeight = vv ? vv.height : window.innerHeight
-        const open = isEditableFocused() && vvHeight < window.innerHeight - KEYBOARD_THRESHOLD
+        const open = isEditableFocused() && vvHeight < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
         setIsKeyboardOpen((prev) => (prev !== open ? open : prev))
       }
       measureOpen()
@@ -169,7 +169,8 @@ export function useVisualViewport(enabled: boolean): boolean {
       // height bounces back. Clamp to `innerHeight` in that case so layout
       // stays put until the phantom resolves.
       const editableFocused = isEditableFocused()
-      const looksLikePhantomShrink = !!vv && !editableFocused && vvHeight < window.innerHeight - KEYBOARD_THRESHOLD
+      const looksLikePhantomShrink =
+        !!vv && !editableFocused && vvHeight < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
       return looksLikePhantomShrink ? window.innerHeight : vvHeight
     }
 
@@ -188,11 +189,11 @@ export function useVisualViewport(enabled: boolean): boolean {
       const frozen = performance.now() < suppressWritesUntil
 
       // Primary: visual viewport smaller than layout viewport (Chrome, Safari)
-      let keyboardOpen = vv ? effectiveHeight < window.innerHeight - KEYBOARD_THRESHOLD : false
+      let keyboardOpen = vv ? effectiveHeight < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX : false
 
       // Fallback: viewport shrank from baseline (Firefox resizes both together)
       if (!keyboardOpen) {
-        keyboardOpen = effectiveHeight < baseHeight.current - KEYBOARD_THRESHOLD
+        keyboardOpen = effectiveHeight < baseHeight.current - KEYBOARD_VIEWPORT_THRESHOLD_PX
       }
 
       // During an optimistic close freeze the keyboard is closed as far as
@@ -319,7 +320,7 @@ export function useVisualViewport(enabled: boolean): boolean {
               // settled measurement is not worth a second resize → re-pin →
               // virtua re-measure cycle right after the optimistic snap (the
               // visible "content loads in again" double-snap on close).
-              if (Math.abs(settled - lastWrittenHeight) > RECONCILE_TOLERANCE_PX) applyHeight(settled)
+              if (Math.abs(settled - lastWrittenHeight) > VIEWPORT_RECONCILE_TOLERANCE_PX) applyHeight(settled)
             }, OPTIMISTIC_CLOSE_SUPPRESS_MS)
           }
         }, 0)
@@ -404,7 +405,7 @@ function isEditable(el: HTMLElement): boolean {
   return false
 }
 
-function isEditableFocused(): boolean {
+export function isEditableFocused(): boolean {
   const el = document.activeElement
   return el instanceof HTMLElement && isEditable(el)
 }

--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -144,6 +144,11 @@ describe("mobile composer drag height", () => {
     expect(loadMobileComposerDragHeight()).toBe(287)
   })
 
+  it("accepts the compact one-line floor", () => {
+    persistMobileComposerDragHeight(MOBILE_COMPOSER_DRAG_MIN_PX)
+    expect(loadMobileComposerDragHeight()).toBe(104)
+  })
+
   it("returns null when never dragged", () => {
     expect(loadMobileComposerDragHeight()).toBeNull()
   })

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -138,8 +138,8 @@ export function unpublishComposerHeightFromRoot(el: HTMLElement): void {
 
 const STORAGE_KEY_DRAG_HEIGHT = "threa:composer-drag-height"
 
-/** Smallest draggable mobile composer: one editor line + the action bar. */
-export const MOBILE_COMPOSER_DRAG_MIN_PX = 140
+/** Mobile card floor: border + padding + one editor line + gap + action bar. */
+export const MOBILE_COMPOSER_DRAG_MIN_PX = 104
 // Sanity ceiling for persisted values only — the live drag clamps to 75% of
 // the visual viewport, which no phone exceeds.
 const MAX_DRAG_HEIGHT_PX = 1200

--- a/tests/browser/composer-attachment-tray-mobile.spec.ts
+++ b/tests/browser/composer-attachment-tray-mobile.spec.ts
@@ -112,7 +112,7 @@ test("dragging the composer down never slices the attachment chips", async ({ pa
           .evaluate((el) => Math.round(el.getBoundingClientRect().height)),
       { timeout: 20_000 }
     )
-    .toBeGreaterThanOrEqual(140)
+    .toBeGreaterThanOrEqual(104)
 
   const send = await page
     .locator('[data-message-composer-root] button[aria-label^="Send"]')

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -9,6 +9,26 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await loginAndCreateWorkspace(page, "composer-resize")
   await createChannel(page, `resize-${Date.now().toString(36)}`)
   await page.setViewportSize(PHONE)
+  await page.addInitScript(() => {
+    let height = window.innerHeight
+    const viewport = new EventTarget()
+    Object.defineProperties(viewport, {
+      height: { get: () => height },
+      width: { get: () => window.innerWidth },
+      offsetLeft: { value: 0 },
+      offsetTop: { value: 0 },
+      pageLeft: { value: 0 },
+      pageTop: { value: 0 },
+      scale: { value: 1 },
+    })
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: viewport })
+    Object.defineProperty(window, "__setTestVisualViewportHeight", {
+      value: (next: number) => {
+        height = next
+        viewport.dispatchEvent(new Event("resize"))
+      },
+    })
+  })
   await page.reload()
 
   const card = page.locator("[data-message-composer-root] [data-composer-card]").first()
@@ -52,6 +72,15 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   expect(before.handleWidth).toBeLessThanOrEqual(64)
   expect(before.editorInset).toBeLessThanOrEqual(16)
 
+  await page.evaluate(() =>
+    (
+      window as typeof window & { __setTestVisualViewportHeight: (height: number) => void }
+    ).__setTestVisualViewportHeight(500)
+  )
+  await expect.poll(async () => (await measure()).cardHeight).toBeLessThanOrEqual(250)
+  const constrained = await measure()
+  expect(constrained.scrollBottom).toBeLessThanOrEqual(before.scrollBottom + 1)
+
   const box = (await handle.boundingBox())!
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
   await page.mouse.down()
@@ -59,8 +88,8 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await page.mouse.up()
 
   const after = await measure()
-  expect(after.cardHeight).toBeLessThan(before.cardHeight)
-  expect(after.cardTop).toBeGreaterThan(before.cardTop)
-  expect(after.cardBottom).toBeCloseTo(before.cardBottom, 0)
-  expect(after.scrollBottom).toBeLessThanOrEqual(before.scrollBottom + 1)
+  expect(after.cardHeight).toBeLessThan(constrained.cardHeight)
+  expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
+  expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
+  expect(after.scrollBottom).toBeLessThanOrEqual(constrained.scrollBottom + 1)
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -5,10 +5,15 @@ test.describe.configure({ timeout: 120_000 })
 
 const PHONE = { width: 390, height: 800 }
 
-test("mobile composer resizes from its top edge without losing the editor bottom", async ({ page }) => {
-  await loginAndCreateWorkspace(page, "composer-resize")
-  await createChannel(page, `resize-${Date.now().toString(36)}`)
-  await page.setViewportSize(PHONE)
+test("mobile composer resizes from its top edge without losing the editor bottom", async ({
+  page: setupPage,
+  browser,
+}) => {
+  await loginAndCreateWorkspace(setupPage, "composer-resize")
+  await createChannel(setupPage, `resize-${Date.now().toString(36)}`)
+  const storageState = await setupPage.context().storageState()
+  const context = await browser.newContext({ storageState, hasTouch: true, viewport: PHONE })
+  const page = await context.newPage()
   await page.addInitScript(() => {
     let height = window.innerHeight
     const viewport = new EventTarget()
@@ -29,7 +34,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
       },
     })
   })
-  await page.reload()
+  await page.goto(setupPage.url())
 
   const card = page.locator("[data-message-composer-root] [data-composer-card]").first()
   await expect(card).toBeVisible({ timeout: 30_000 })
@@ -72,6 +77,39 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   expect(before.handleWidth).toBeLessThanOrEqual(64)
   expect(before.editorInset).toBeLessThanOrEqual(16)
 
+  const cdp = await page.context().newCDPSession(page)
+  expect(await page.evaluate(() => navigator.maxTouchPoints)).toBeGreaterThan(0)
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: PHONE.width / 2, y: 24, id: 1 }],
+  })
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: PHONE.width / 2, y: 54, id: 1 }],
+  })
+  await expect(page.getByText("Pull to refresh")).toBeVisible()
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] })
+  await expect(page.getByText("Pull to refresh")).toHaveCount(0)
+  await page.waitForTimeout(350)
+  const touchBefore = await measure()
+
+  const touchBox = (await handle.boundingBox())!
+  const touchX = Math.round(touchBox.x + touchBox.width / 2)
+  const touchY = Math.round(touchBox.y + touchBox.height / 2)
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: touchX, y: touchY, id: 1 }],
+  })
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: touchX, y: touchY + 80, id: 1 }],
+  })
+  await expect(page.getByText(/Pull to refresh|Release to refresh|Release to reload/)).toHaveCount(0)
+  await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] })
+  const afterTouch = await measure()
+  expect(afterTouch.cardHeight).toBeLessThan(touchBefore.cardHeight)
+  expect(Math.abs(afterTouch.cardBottom - touchBefore.cardBottom)).toBeLessThanOrEqual(1)
+
   await page.evaluate(() =>
     (
       window as typeof window & { __setTestVisualViewportHeight: (height: number) => void }
@@ -79,7 +117,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   )
   await expect.poll(async () => (await measure()).cardHeight).toBeLessThanOrEqual(250)
   const constrained = await measure()
-  expect(constrained.scrollBottom).toBeLessThanOrEqual(before.scrollBottom + 1)
+  expect(constrained.scrollBottom).toBeLessThanOrEqual(afterTouch.scrollBottom + 1)
 
   const box = (await handle.boundingBox())!
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
@@ -92,4 +130,5 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
   expect(after.scrollBottom).toBeLessThanOrEqual(constrained.scrollBottom + 1)
+  await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -54,6 +54,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
     await editor.pressSequentially(`line ${i}`)
     await page.keyboard.press("Shift+Enter")
   }
+  const contentBeforeResize = await editor.textContent()
 
   await scroller.evaluate((el) => {
     el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 24)
@@ -78,7 +79,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
     })
 
   const before = await measure()
-  expect(before.handleWidth).toBeLessThanOrEqual(64)
+  expect(Math.abs(before.handleWidth - 64)).toBeLessThanOrEqual(1)
   expect(before.editorInset).toBeLessThanOrEqual(16)
 
   const cdp = await page.context().newCDPSession(page)
@@ -113,6 +114,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   const afterTouch = await measure()
   expect(afterTouch.cardHeight).toBeLessThan(touchBefore.cardHeight)
   expect(Math.abs(afterTouch.cardBottom - touchBefore.cardBottom)).toBeLessThanOrEqual(1)
+  expect(Math.abs(afterTouch.scrollBottom - touchBefore.scrollBottom)).toBeLessThanOrEqual(1)
 
   await page.evaluate(() =>
     (
@@ -121,7 +123,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   )
   await expect.poll(async () => (await measure()).cardHeight).toBeLessThanOrEqual(250)
   const constrained = await measure()
-  expect(constrained.scrollBottom).toBeLessThanOrEqual(afterTouch.scrollBottom + 1)
+  expect(Math.abs(constrained.scrollBottom - afterTouch.scrollBottom)).toBeLessThanOrEqual(1)
 
   const box = (await handle.boundingBox())!
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
@@ -133,6 +135,7 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   expect(after.cardHeight).toBeLessThan(constrained.cardHeight)
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
-  expect(after.scrollBottom).toBeLessThanOrEqual(constrained.scrollBottom + 1)
+  expect(Math.abs(after.scrollBottom - constrained.scrollBottom)).toBeLessThanOrEqual(1)
+  expect(await editor.textContent()).toBe(contentBeforeResize)
   await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel } from "./helpers"
+
+test.describe.configure({ timeout: 120_000 })
+
+const PHONE = { width: 390, height: 800 }
+
+test("mobile composer resizes from its top edge without losing the editor bottom", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "composer-resize")
+  await createChannel(page, `resize-${Date.now().toString(36)}`)
+  await page.setViewportSize(PHONE)
+  await page.reload()
+
+  const card = page.locator("[data-message-composer-root] [data-composer-card]").first()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+  await card.click()
+
+  const editor = page.locator("[data-message-composer-root] .tiptap").first()
+  const scroller = page.getByTestId("composer-editor-scroll")
+  const handle = page.getByTestId("composer-resize-handle")
+  await expect(handle).toBeVisible({ timeout: 10_000 })
+
+  await editor.click()
+  for (let i = 1; i <= 24; i++) {
+    await editor.pressSequentially(`line ${i}`)
+    await page.keyboard.press("Shift+Enter")
+  }
+
+  await scroller.evaluate((el) => {
+    el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 24)
+  })
+
+  const measure = () =>
+    page.evaluate(() => {
+      const cardEl = document.querySelector("[data-message-composer-root] [data-composer-card]") as HTMLElement
+      const handleEl = document.querySelector('[data-testid="composer-resize-handle"]') as HTMLElement
+      const scrollerEl = document.querySelector('[data-testid="composer-editor-scroll"]') as HTMLElement
+      const cardRect = cardEl.getBoundingClientRect()
+      const handleRect = handleEl.getBoundingClientRect()
+      const scrollerRect = scrollerEl.getBoundingClientRect()
+      return {
+        cardTop: Math.round(cardRect.top),
+        cardBottom: Math.round(cardRect.bottom),
+        cardHeight: Math.round(cardRect.height),
+        handleWidth: Math.round(handleRect.width),
+        editorInset: Math.round(scrollerRect.top - cardRect.top),
+        scrollBottom: Math.round(scrollerEl.scrollHeight - scrollerEl.clientHeight - scrollerEl.scrollTop),
+      }
+    })
+
+  const before = await measure()
+  expect(before.handleWidth).toBeLessThanOrEqual(64)
+  expect(before.editorInset).toBeLessThanOrEqual(16)
+
+  const box = (await handle.boundingBox())!
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120)
+  await page.mouse.up()
+
+  const after = await measure()
+  expect(after.cardHeight).toBeLessThan(before.cardHeight)
+  expect(after.cardTop).toBeGreaterThan(before.cardTop)
+  expect(after.cardBottom).toBeCloseTo(before.cardBottom, 0)
+  expect(after.scrollBottom).toBeLessThanOrEqual(before.scrollBottom + 1)
+})

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -45,6 +45,10 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   const handle = page.getByTestId("composer-resize-handle")
   await expect(handle).toBeVisible({ timeout: 10_000 })
 
+  await page.setViewportSize({ width: 800, height: 390 })
+  await expect(handle).toBeVisible()
+  await page.setViewportSize(PHONE)
+
   await editor.click()
   for (let i = 1; i <= 24; i++) {
     await editor.pressSequentially(`line ${i}`)


### PR DESCRIPTION
## Problem

The mobile resize handle added in [#1870](https://github.com/threahq/threa/pull/1870) occupied a full-width row whenever the composer was open. Its opaque background masked draft text, while the 140px floor prevented useful shrinking. Long drafts also changed scroll ownership on the first drag, which could move the caret or expose the wrong part of the draft.

Device testing found two more cases. A drag-sized or expanded composer retained its closed-viewport height after the keyboard reduced the visible viewport, leaving little room for the timeline. Dragging the handle downward also competed with the app-level pull-to-refresh gesture and could arm a refresh or reload.

## Solution

Keep drag-resizing with bounded inline behavior:

- Position a 64px touch target over the top border. Only its 44px center capsule is opaque, and it reserves no vertical space.
- Lower the card floor to 104px while continuing to reserve attachment and link-preview height.
- Keep one editor scroll owner and preserve its distance from the bottom through drag and viewport changes.
- Cap inline, persisted, and expanded modes at 50% of the live keyboard-visible viewport. Restore the previous size after the keyboard closes.
- Keep durable drag preferences separate from the temporary keyboard cap.
- Reconcile orientation changes before classifying keyboard state and retain the cap through focus hops and keyboard-close settling.
- Exclude touches that begin on the resize handle from pull-to-refresh for the gesture’s full lifetime.

The fullscreen overlay remains the keyboard-accessible option for dedicated long-form writing.

## Verification

187 focused frontend tests and two Chromium mobile composer specs passed. The resize spec uses a touch-enabled browser context: it first proves an ordinary downward touch arms pull-to-refresh, then verifies the same touch gesture on the resize handle only resizes the composer. Repository lint, TypeScript checks, migration checks, Dockerfile checks, and OpenAPI verification passed in the commit hook. Physical-device confirmation remains before merge.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
