### PR TITLE
fix: the read frontier bridges chrome, so agent replies stop staying unread

### DIFF
--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -94,6 +94,13 @@ describe("advanceFrontier", () => {
     expect(advanceFrontier(20, 10, 15)).toBe(20)
   })
 
+  it("advances past bridged chrome when the gate says the first unread message is further down", () => {
+    // Frontier at 1, a session card at 2 that never came on screen, the unread
+    // message at 3. Raw adjacency (gate = 2) blocks; the real gate is 3.
+    expect(advanceFrontier(1, 3, 3)).toBe(1)
+    expect(advanceFrontier(1, 3, 3, 3)).toBe(3)
+  })
+
   it("treats an exactly-contiguous top (frontier + 1) as no gap", () => {
     expect(advanceFrontier(9, 10, 14)).toBe(14)
   })
@@ -199,6 +206,85 @@ describe("useLastSeenEvent re-scan triggers", () => {
     // The re-scan reaches the last row — the message that was stuck unread.
     expect(result.current.lastSeenEventId).toBe("e2")
     expect(result.current.atLastRow).toBe(true)
+  })
+
+  it("marks a message read when only an agent-session card sits between it and the pointer, off-screen", () => {
+    // Kristoffer's prod streams, exactly: pointer on his own message, an
+    // `agent_session:started` card next, then the bot's reply — which is taller
+    // than a phone viewport. Landing inside that reply (deep link or unread
+    // marker) leaves the card above the fold, so raw adjacency could never close
+    // the run and the message stayed unread while being read.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: -260, bottom: -210 }, // his message (the read pointer)
+      e1: { top: -180, bottom: -140 }, // the session card — above the fold
+      e2: { top: -40, bottom: 400 }, // the bot reply, taller than the viewport
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "agent_session:started" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+    ] as unknown as StreamEvent[]
+
+    const { result } = renderHook(() =>
+      useLastSeenEvent({
+        scrollContainerRef: { current: container },
+        events,
+        streamId: "stream_1",
+        lastReadEventId: "e0",
+        enabled: true,
+      })
+    )
+
+    expect(result.current.lastSeenEventId).toBe("e2")
+    expect(result.current.atLastRow).toBe(true)
+  })
+
+  it("still refuses to skip an unseen MESSAGE above the viewport", () => {
+    // The counterpart: same geometry, but the row between pointer and the
+    // visible message is a real message. Progressive read must still block —
+    // bridging is only ever for chrome.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: -260, bottom: -210 },
+      e1: { top: -180, bottom: -140 }, // an unread message, never on screen
+      e2: { top: -40, bottom: 400 },
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+    ] as unknown as StreamEvent[]
+
+    const { result } = renderHook(() =>
+      useLastSeenEvent({
+        scrollContainerRef: { current: container },
+        events,
+        streamId: "stream_1",
+        lastReadEventId: "e0",
+        enabled: true,
+      })
+    )
+
+    expect(result.current.lastSeenEventId).toBeUndefined()
   })
 
   it("re-arms the scan when the virtualized scroller late-mounts after enabled (scrollContainerEl)", () => {

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import type { StreamEvent } from "@threa/types"
+import { READ_BLOCKING_EVENT_TYPES, type StreamEvent } from "@threa/types"
 
 export interface VisibleRow {
   id: string
@@ -42,10 +42,34 @@ export function pickVisibleRange(rows: VisibleRow[], viewportTop: number, viewpo
  * fling — whose per-frame viewport jumps exceed the viewport height — still
  * reads as the continuous sweep it visually was.
  */
-export function advanceFrontier(frontier: number, topIdx: number, botIdx: number): number {
-  if (topIdx <= frontier + 1 && botIdx > frontier) return botIdx
+export function advanceFrontier(frontier: number, topIdx: number, botIdx: number, gateIdx = frontier + 1): number {
+  if (topIdx <= gateIdx && botIdx > frontier) return botIdx
   return frontier
 }
+
+/**
+ * The lowest index the viewport's top may sit at and still continue the read
+ * run: the first UNREAD MESSAGE after the frontier. Events that carry nothing
+ * to read — agent-session cards, command chrome, membership notices — are
+ * bridged, because a viewer who never had them on screen has not skipped any
+ * content (`READ_BLOCKING_EVENT_TYPES`).
+ *
+ * Gating on raw adjacency (`frontier + 1`) wedged real streams: every bot reply
+ * is bracketed by `agent_session:started`/`:completed`, so a session card sits
+ * between the viewer's pointer and the first unread message, and any landing
+ * that starts inside a tall message — a deep link, or the unread marker — puts
+ * that card above the fold. The run could then never close, and the message
+ * stayed unread while being read, indefinitely.
+ *
+ * Skipping a real message still blocks: its own index becomes the gate.
+ */
+export function readGateIndex(events: StreamEvent[], frontier: number): number {
+  let idx = frontier + 1
+  while (idx < events.length && !READ_BLOCKING_TYPES.has(events[idx].eventType)) idx++
+  return idx
+}
+
+const READ_BLOCKING_TYPES: ReadonlySet<string> = new Set(READ_BLOCKING_EVENT_TYPES)
 
 /**
  * Two viewport scans within this window, with no programmatic scroll write
@@ -265,7 +289,12 @@ export function useLastSeenEvent({
     if (!pinnedRef.current) {
       // External reads can only move the frontier forward.
       if (readIndexRef.current > frontierRef.current) frontierRef.current = readIndexRef.current
-      frontierRef.current = advanceFrontier(frontierRef.current, effTopIdx, botIdx)
+      frontierRef.current = advanceFrontier(
+        frontierRef.current,
+        effTopIdx,
+        botIdx,
+        readGateIndex(eventsRef.current, frontierRef.current)
+      )
     }
 
     const frontier = frontierRef.current

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -359,7 +359,12 @@ export {
 
 // Single source of truth for how each stream event renders across the timeline
 // and the board/conversation projection (anti-drift spec — see stream-rows.ts).
-export { STREAM_ROW_SPEC, BOARD_EVENT_ROW_TYPES, THREAD_ANCHORABLE_EVENT_TYPES } from "./stream-rows"
+export {
+  STREAM_ROW_SPEC,
+  BOARD_EVENT_ROW_TYPES,
+  THREAD_ANCHORABLE_EVENT_TYPES,
+  READ_BLOCKING_EVENT_TYPES,
+} from "./stream-rows"
 export type { StreamRowSpec, ConversationRef } from "./stream-rows"
 
 // Markdown → plain-text stripping for preview surfaces (shared FE/BE, INV-60)

--- a/packages/types/src/stream-rows.ts
+++ b/packages/types/src/stream-rows.ts
@@ -91,6 +91,22 @@ export interface StreamRowSpec {
    * ("Agents on the board — traces visible, never bumping", board-view-design.md).
    */
   bumps: boolean
+  /**
+   * Whether the viewer must actually have this row on screen before their read
+   * frontier may advance past it — i.e. it carries a body someone wrote and to
+   * skip it is to skip content. True only for the message bodies; agent-session
+   * cards, command chrome, membership notices and patches are all false.
+   *
+   * Progressive read (`useLastSeenEvent`) gates on this rather than on raw event
+   * adjacency. Gating on adjacency wedged real streams: every bot reply is
+   * bracketed by `agent_session:*`, so a session card routinely sits between the
+   * viewer's pointer and the first unread message, and any landing that starts
+   * inside a tall message (deep link, unread marker) leaves that card above the
+   * fold — the run could then never close and the message stayed unread while
+   * being read. Skipping chrome is not skipping content; skipping a message is,
+   * and that still blocks. Derives {@link READ_BLOCKING_EVENT_TYPES}.
+   */
+  readBlocking: boolean
 }
 
 const MESSAGE: StreamRowSpec = {
@@ -102,6 +118,7 @@ const MESSAGE: StreamRowSpec = {
   conversationRef: "self-message",
   bumps: true,
   threadable: true,
+  readBlocking: true,
 }
 
 /** A live patch onto an existing row (edit / reaction / delete / cancel). */
@@ -114,6 +131,7 @@ const PATCH: StreamRowSpec = {
   conversationRef: "none",
   bumps: false,
   threadable: false,
+  readBlocking: false,
 }
 
 /** Channel chrome: a broadcast row in the timeline, never a board/topic row. */
@@ -126,6 +144,7 @@ const CHROME_BROADCAST: StreamRowSpec = {
   conversationRef: "none",
   bumps: false,
   threadable: false,
+  readBlocking: false,
 }
 
 const AGENT_SESSION: StreamRowSpec = {
@@ -137,6 +156,7 @@ const AGENT_SESSION: StreamRowSpec = {
   conversationRef: "trigger-message",
   bumps: false,
   threadable: false,
+  readBlocking: false,
 }
 
 const COMMAND: StreamRowSpec = {
@@ -150,6 +170,7 @@ const COMMAND: StreamRowSpec = {
   conversationRef: "source-conversation",
   bumps: false,
   threadable: false,
+  readBlocking: false,
 }
 
 export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
@@ -166,6 +187,8 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     conversationRef: "none",
     bumps: false,
     threadable: false,
+    // A message body, legacy or not — skipping it is skipping something written.
+    readBlocking: true,
   },
   message_edited: PATCH,
   reaction_added: PATCH,
@@ -196,6 +219,7 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     conversationRef: "none",
     bumps: false,
     threadable: false,
+    readBlocking: false,
   },
 
   command_dispatched: COMMAND,
@@ -218,6 +242,7 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     conversationRef: "source-conversation",
     bumps: false,
     threadable: false,
+    readBlocking: false,
   },
   // Scheduled agent follow-up — payload carries `sourceConversationId`.
   "agent:follow_up_scheduled": {
@@ -229,6 +254,7 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     conversationRef: "source-conversation",
     bumps: false,
     threadable: false,
+    readBlocking: false,
   },
   // A patch that flips the matching scheduled card to "Cancelled" — not its own row.
   "agent:follow_up_cancelled": PATCH,
@@ -246,6 +272,7 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     // hand-off's result and follow-up land in one place (retires the synthetic
     // anchor-message hack).
     threadable: true,
+    readBlocking: false,
   },
   // A patch that advances the matching delegation card's status — not its own row.
   "delegation:status_changed": PATCH,
@@ -274,6 +301,7 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
     conversationRef: "none",
     bumps: false,
     threadable: true,
+    readBlocking: false,
   },
   // A patch carrying the end summary onto the matching `call_started` card — not
   // its own row (the delegation:status_changed analog).
@@ -300,3 +328,13 @@ export const BOARD_EVENT_ROW_TYPES: EventType[] = EVENT_TYPES.filter(
  * new card on is a one-line spec change, not a second parallel wiring.
  */
 export const THREAD_ANCHORABLE_EVENT_TYPES: EventType[] = EVENT_TYPES.filter((type) => STREAM_ROW_SPEC[type].threadable)
+
+/**
+ * Event types the read frontier may not advance past unseen — the message
+ * bodies. Everything else (agent-session cards, command chrome, membership
+ * notices, patches) is bridgeable: it carries nothing to read, so a viewer whose
+ * viewport starts below it has not skipped content. Derived from
+ * {@link STREAM_ROW_SPEC}'s `readBlocking` flag; `useLastSeenEvent` gates
+ * progressive read on this set.
+ */
+export const READ_BLOCKING_EVENT_TYPES: EventType[] = EVENT_TYPES.filter((type) => STREAM_ROW_SPEC[type].readBlocking)


### PR DESCRIPTION
## Problem

Messages in agent streams stay unread while you are reading them — indefinitely, until you send something. Confirmed in two prod streams, from screenshots plus the event log.

Take the smaller one (7 events total): `member_added`, Kristoffer's message, **`agent_session:started`**, the bot's reply, `agent_session:completed`, his reply, `agent_session:started`. His read pointer sat on his own message (the server advances the author's pointer on send), so the unread bot reply is **two** events later, with the agent-session card between them.

`advanceFrontier` only continued the read run when the topmost visible row was at or before `frontier + 1`. The reply is several phone-screens tall, and he opened it via a `?m=` deep link, which centers the target — so the session card was above the fold and `topIdx` was permanently past the gate. Nothing could close the run: not scrolling down (that moves further away), not sweep-linking (there was never a scan whose top reached the card). Same shape in the second stream.

This is near-systematic on mobile because *every* bot reply is bracketed by `agent_session:*`, and it got much more visible once marker and deep-link landings started positioning correctly.

## Solution

Contiguity gates on the first unread **message** after the frontier, not the first **event**. Rows that carry nothing to read — agent-session cards, command chrome, membership notices, patches — are bridged: a viewer whose viewport starts below them has not skipped any content.

- `StreamRowSpec.readBlocking` (new fact on the existing per-event-type spec, `true` only for message bodies incl. legacy `companion_response`) derives `READ_BLOCKING_EVENT_TYPES`. Adding an event type is still a compile error until it declares this, same anti-drift property the spec exists for.
- `readGateIndex(events, frontier)` walks forward to the first read-blocking event; `advanceFrontier` takes it as the gate (defaulting to `frontier + 1`, so its existing contract is unchanged).

Progressive read is intact: an actual unread message above the viewport becomes the gate and still blocks — covered by a test that is the geometric twin of the fixed one.

Not in scope: [#1884](https://github.com/threahq/threa/pull/1884) (activity viewing-pin) is **on hold** — it suppresses the sidebar row for the stream you're viewing, which would have hidden this bug rather than fixed it. Worth re-reading once this lands.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/stream-rows.ts` | `readBlocking` per type + derived `READ_BLOCKING_EVENT_TYPES` |
| `packages/types/src/index.ts` | Export the derived set |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | `readGateIndex`; `advanceFrontier` gate parameter |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | Prod-shape regression + the message-still-blocks twin |

## Test plan

- [x] `use-last-seen-event.test.ts` — 26 pass, incl. the off-screen session card (fails without the gate) and the unseen-message counterpart
- [x] Frontend units 6693; `@threa/types` 165
- [x] Browser `auto-read` 7/7 and `unread-marker-open` 2/2
- [ ] Prod confirmation — needs the deploy

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GceYF7UEshN3QRAjGQDagJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789319918&installation_model_id=20758&pr_number=1886&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1886&signature=d0b9de17f27a0d0a37fcef8939d52ee83a81dac0239a31989979cf91df0fdd7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->