### PR TITLE
fix: keep capped sidebar streams reachable

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -120,6 +120,36 @@ describe("resolveSections — Smart preset", () => {
     expect(recent?.items.map((i) => i.id)).toEqual(["u1", "u2", "r1", "r2", "r3"])
   })
 
+  it("moves reads capped out of Recent into Everything Else", () => {
+    const processedStreams = Array.from({ length: 6 }, (_, i) =>
+      makeItem({ id: `r${i + 1}`, section: "recent", activity: 100 - i })
+    )
+
+    expect(shape({ processedStreams })).toEqual([
+      { id: "important", items: [] },
+      { id: "recent", items: ["r1", "r2", "r3", "r4", "r5"] },
+      { id: "other", items: ["r6"] },
+    ])
+  })
+
+  it("keeps Everything Else as the remainder when it is ordered above Recent", () => {
+    const processedStreams = Array.from({ length: 6 }, (_, i) =>
+      makeItem({ id: `r${i + 1}`, section: "recent", activity: 100 - i })
+    )
+    const otherFirst = {
+      ...SMART_SIDEBAR_CONFIG,
+      sections: [
+        { id: "other", spec: { kind: "smart" as const, bucket: "other" as const } },
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+      ],
+    }
+
+    expect(shape({ processedStreams }, otherFirst)).toEqual([
+      { id: "other", items: ["r6"] },
+      { id: "recent", items: ["r1", "r2", "r3", "r4", "r5"] },
+    ])
+  })
+
   it("Recent shows all unreads when there are 5 or more", () => {
     const processedStreams = Array.from({ length: 7 }, (_, i) =>
       makeItem({ id: `u${i}`, section: "recent", activity: 100 - i })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -99,14 +99,19 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
   // so the label lens claims them out of the smart/type buckets — a labeled
   // stream lives under its label, not its automatic bucket, regardless of order.
   const labeledClaimed = new Set<string>()
+  const overflowBuckets = new Set<SectionKey>()
   for (const section of config.sections) {
     if (section.spec.kind === "custom") for (const id of section.spec.streamIds) customClaimed.add(id)
     if (section.spec.kind === "label") {
       const ids = input.streamIdsByLabel.get(section.spec.labelId)
       if (ids) for (const id of ids) labeledClaimed.add(id)
     }
+    if (section.spec.kind === "smart" && section.spec.bucket !== "other") {
+      overflowBuckets.add(section.spec.bucket)
+    }
   }
-  return config.sections.map((section) => {
+
+  const resolved = config.sections.map((section) => {
     const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed)
     // The Unread section never claims its streams: every other section already
     // excludes its members via `unreadStreamIds`, and claiming would also block a
@@ -114,6 +119,17 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
     if (section.spec.kind !== "unread") for (const item of items) claimed.add(item.id)
     return { section, items }
   })
+
+  const remainder = resolved.find(({ section }) => section.spec.kind === "smart" && section.spec.bucket === "other")
+  if (!remainder) return resolved
+
+  const overflow = [...input.processedStreams, ...input.virtualDmStreams].filter(
+    (stream) => !claimed.has(stream.id) && !input.unreadStreamIds.has(stream.id) && overflowBuckets.has(stream.section)
+  )
+  if (overflow.length === 0) return resolved
+
+  const items = sortStreams([...remainder.items, ...overflow], SMART_SECTIONS.other.sortType, input.getUnreadCount)
+  return resolved.map((entry) => (entry === remainder ? { ...entry, items } : entry))
 }
 
 function resolveItems(


### PR DESCRIPTION
## Problem

Moving a DM's newest messages into threads could make the DM and thread rows trade places in the sidebar. `Recent` caps read streams at five, but `resolveSections` discarded entries beyond that cap instead of placing them in `Everything Else`, so the sixth recent stream was unreachable even though it remained in the workspace bootstrap.

## Solution

After normal section resolution, move unclaimed entries from configured capped smart buckets into `Everything Else`.

- Existing claims still win, including custom sections, labels, type sections, and the five rows selected for `Recent`.
- Unread rows remain exclusive to the optional `Unread` section.
- The fallback follows the configured sections. Removing `Recent` or `Everything Else` still removes that surface, and reordering `Everything Else` above `Recent` does not let it consume the five selected rows.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.ts` | Routes capped, unclaimed smart-bucket entries into `Everything Else`. |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts` | Covers Recent overflow and reordered sections. |

## Test plan

- [x] `bun run --cwd apps/frontend test src/components/layout/sidebar/resolve-sections.test.ts` (24 passed)
- [x] `bun run typecheck`
- [x] `bun run lint`

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789336011&installation_model_id=20758&pr_number=1887&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1887&signature=86d05fe670828016448ed434b67241ad909ef1317dc12f8f177e6ed94dc34494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->