### PR TITLE
fix: retry Pi remote link until persisted

### DIFF
--- a/extensions/harness-daemon/src/resume.test.ts
+++ b/extensions/harness-daemon/src/resume.test.ts
@@ -442,9 +442,11 @@ test("reconstructs the current Claude channel launch with stable runtime identit
 
 test("Pi revival reuses an exact recorded session id bound to the expected root", () => {
   expect(piLaunchArgs("pi", "019f-session")).toEqual(["pi", "--session-id", "019f-session"])
-  const launch = piLaunchCommand("pi", "019f-session")
+  const launch = piLaunchCommand("pi", "019f-session", "pi-instance")
   expect(launch).toContain("'THREA_HARNESSD_ENTRYPOINT=")
   expect(launch).toContain(`'THREA_HARNESSD_BUN_BIN=${process.execPath}'`)
+  expect(launch).toContain("'THREA_INSTANCE_ID=pi-instance'")
+  expect(launch).toContain("'THREA_RUNTIME_SESSION_ID=019f-session'")
   const resume = piResumeCommand("pi", "019f-session", "stream_expected")
   expect(resume).toContain(`'THREA_HARNESSD_BUN_BIN=${process.execPath}'`)
   expect(resume).toContain("'THREA_EXPECTED_ROOT_STREAM_ID=stream_expected'")

--- a/extensions/harness-daemon/src/spawners.test.ts
+++ b/extensions/harness-daemon/src/spawners.test.ts
@@ -8,6 +8,7 @@ import {
   mcpConfigDir,
   mcpConfigPath,
   parkPiSessionFiles,
+  piLaunchCommand,
   writeChannelMcpConfig,
 } from "./spawners"
 import { profileForWorktree, recordProfileSnapshot } from "./identity-store"
@@ -76,6 +77,14 @@ test("a resume writes the new key and leaves the old name-keyed file in place", 
   })
 })
 
+test("a managed Pi launch carries one stable instance identity into every remote retry", () => {
+  const launch = piLaunchCommand("/opt/pi", "runtime-session", "pi-launch-instance")
+
+  expect(launch).toContain("'THREA_INSTANCE_ID=pi-launch-instance'")
+  expect(launch).toContain("'THREA_RUNTIME_SESSION_ID=runtime-session'")
+  expect(launch).toContain("'/opt/pi' '--session-id' 'runtime-session'")
+})
+
 test("Pi remote linking retries a command lost during startup and stops after the link is persisted", async () => {
   const linked = {
     instanceId: "pi-instance",
@@ -87,6 +96,7 @@ test("Pi remote linking retries a command lost during startup and stops after th
   let session: typeof linked | undefined
 
   const result = await linkPiRemoteSession({
+    expectedInstanceId: linked.instanceId,
     attempts: 3,
     bootWaitMs: 8_000,
     responseWaitMs: 6_000,
@@ -104,6 +114,28 @@ test("Pi remote linking retries a command lost during startup and stops after th
 
   expect(result).toEqual(linked)
   expect({ commands, sleeps }).toEqual({ commands: 2, sleeps: [8_000, 6_000, 1_000, 6_000] })
+})
+
+test("Pi remote linking rejects a persisted link from another instance", async () => {
+  await expect(
+    linkPiRemoteSession({
+      expectedInstanceId: "pi-launch-instance",
+      attempts: 3,
+      bootWaitMs: 0,
+      responseWaitMs: 0,
+      retryBackoffMs: 0,
+      maxRetryBackoffMs: 0,
+      sleep: async () => {},
+      sendRemoteCommand: () => {
+        throw new Error("must not send after finding a link")
+      },
+      readSession: () => ({
+        instanceId: "pi-other-instance",
+        rootStreamId: "stream_other",
+        scratchpadUrl: "https://app.threa.io/w/workspace/s/stream_other",
+      }),
+    })
+  ).rejects.toThrow("pi-other-instance")
 })
 
 test("a Pi spawn records the profile its directory was provisioned under", () => {

--- a/extensions/harness-daemon/src/spawners.test.ts
+++ b/extensions/harness-daemon/src/spawners.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   claudeResumeSessionId,
+  linkPiRemoteSession,
   mcpConfigDir,
   mcpConfigPath,
   parkPiSessionFiles,
@@ -73,6 +74,36 @@ test("a resume writes the new key and leaves the old name-keyed file in place", 
   expect(JSON.parse(readFileSync(legacy, "utf8"))).toMatchObject({
     mcpServers: { "threa-channel": { args: ["/old/entry.ts"] } },
   })
+})
+
+test("Pi remote linking retries a command lost during startup and stops after the link is persisted", async () => {
+  const linked = {
+    instanceId: "pi-instance",
+    rootStreamId: "stream_scratchpad",
+    scratchpadUrl: "https://app.threa.io/w/workspace/s/stream_scratchpad",
+  }
+  const sleeps: number[] = []
+  let commands = 0
+  let session: typeof linked | undefined
+
+  const result = await linkPiRemoteSession({
+    attempts: 3,
+    bootWaitMs: 8_000,
+    responseWaitMs: 6_000,
+    retryBackoffMs: 1_000,
+    maxRetryBackoffMs: 4_000,
+    sleep: async (ms) => {
+      sleeps.push(ms)
+      if (commands === 2 && ms === 6_000) session = linked
+    },
+    sendRemoteCommand: () => {
+      commands++
+    },
+    readSession: () => session,
+  })
+
+  expect(result).toEqual(linked)
+  expect({ commands, sleeps }).toEqual({ commands: 2, sleeps: [8_000, 6_000, 1_000, 6_000] })
 })
 
 test("a Pi spawn records the profile its directory was provisioned under", () => {

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -182,6 +182,35 @@ export function readPiRemoteSession(runtimeSessionId: string): PiRemoteSession |
   }
 }
 
+export interface PiRemoteLinkDeps {
+  attempts: number
+  bootWaitMs: number
+  responseWaitMs: number
+  retryBackoffMs: number
+  maxRetryBackoffMs: number
+  sleep: (ms: number) => Promise<void>
+  sendRemoteCommand: () => void
+  readSession: () => PiRemoteSession | undefined
+}
+
+export async function linkPiRemoteSession(deps: PiRemoteLinkDeps): Promise<PiRemoteSession | undefined> {
+  await deps.sleep(deps.bootWaitMs)
+  for (let attempt = 0; attempt < deps.attempts; attempt++) {
+    const existing = deps.readSession()
+    if (existing) return existing
+
+    deps.sendRemoteCommand()
+    await deps.sleep(deps.responseWaitMs)
+
+    const linked = deps.readSession()
+    if (linked) return linked
+    if (attempt + 1 < deps.attempts) {
+      await deps.sleep(Math.min(deps.retryBackoffMs * 2 ** attempt, deps.maxRetryBackoffMs))
+    }
+  }
+  return undefined
+}
+
 export interface PiSessionParkDeps {
   sessionsDir?: string
   readdir?: (path: string) => string[]
@@ -289,14 +318,25 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
       Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Pi in tmux ${session}:${window} (${windowId})`)
 
-      if (!options.noRemote) {
-        await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000))
-        sendKeys(paneId, ["/remote-control", "Enter"])
-        await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_REMOTE_WAIT_MS ?? 6000))
+      const configuredAttempts = Math.trunc(Number(process.env.THREA_HARNESSD_PI_REMOTE_ATTEMPTS ?? 3))
+      const attempts = Number.isFinite(configuredAttempts) ? Math.max(1, Math.min(configuredAttempts, 10)) : 3
+      const link = options.noRemote
+        ? undefined
+        : await linkPiRemoteSession({
+            attempts,
+            bootWaitMs: Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000),
+            responseWaitMs: Number(process.env.THREA_HARNESSD_PI_REMOTE_WAIT_MS ?? 6000),
+            retryBackoffMs: Number(process.env.THREA_HARNESSD_PI_REMOTE_RETRY_BACKOFF_MS ?? 1000),
+            maxRetryBackoffMs: Number(process.env.THREA_HARNESSD_PI_REMOTE_MAX_BACKOFF_MS ?? 4000),
+            sleep: Bun.sleep,
+            sendRemoteCommand: () => sendKeys(paneId, ["/remote-control", "Enter"]),
+            readSession: () => readPiRemoteSession(runtimeSessionId),
+          })
+      if (!options.noRemote && !link) {
+        die(`Pi started but remains unlinked after ${attempts} Threa remote attempts`)
       }
 
       const outputText = capturePane(paneId)
-      const link = readPiRemoteSession(runtimeSessionId)
       return {
         worktree,
         branch,
@@ -304,7 +344,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
         tmuxWindow: window,
         tmuxWindowId: windowId,
         tmuxPaneId: paneId,
-        scratchpadUrl: link?.scratchpadUrl ?? firstScratchpadUrl(outputText),
+        scratchpadUrl: link?.scratchpadUrl ?? (options.noRemote ? firstScratchpadUrl(outputText) : undefined),
         instanceId: link?.instanceId,
         runtimeSessionId,
         output: outputText,

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -44,8 +44,16 @@ function harnessDaemonEnvironment(): string[] {
   ]
 }
 
-export function piLaunchCommand(piBin: string, runtimeSessionId: string): string {
-  return ["env", ...harnessDaemonEnvironment(), ...piLaunchArgs(piBin, runtimeSessionId)].map(shellQuote).join(" ")
+export function piLaunchCommand(piBin: string, runtimeSessionId: string, instanceId: string): string {
+  return [
+    "env",
+    ...harnessDaemonEnvironment(),
+    `THREA_INSTANCE_ID=${instanceId}`,
+    `THREA_RUNTIME_SESSION_ID=${runtimeSessionId}`,
+    ...piLaunchArgs(piBin, runtimeSessionId),
+  ]
+    .map(shellQuote)
+    .join(" ")
 }
 
 export function piResumeCommand(piBin: string, runtimeSessionId: string, expectedRootStreamId: string): string {
@@ -183,6 +191,7 @@ export function readPiRemoteSession(runtimeSessionId: string): PiRemoteSession |
 }
 
 export interface PiRemoteLinkDeps {
+  expectedInstanceId: string
   attempts: number
   bootWaitMs: number
   responseWaitMs: number
@@ -194,15 +203,23 @@ export interface PiRemoteLinkDeps {
 }
 
 export async function linkPiRemoteSession(deps: PiRemoteLinkDeps): Promise<PiRemoteSession | undefined> {
+  const readExpectedSession = (): PiRemoteSession | undefined => {
+    const link = deps.readSession()
+    if (link && link.instanceId !== deps.expectedInstanceId) {
+      die(`Pi remote link instance ${link.instanceId} does not match launched instance ${deps.expectedInstanceId}`)
+    }
+    return link
+  }
+
   await deps.sleep(deps.bootWaitMs)
   for (let attempt = 0; attempt < deps.attempts; attempt++) {
-    const existing = deps.readSession()
+    const existing = readExpectedSession()
     if (existing) return existing
 
     deps.sendRemoteCommand()
     await deps.sleep(deps.responseWaitMs)
 
-    const linked = deps.readSession()
+    const linked = readExpectedSession()
     if (linked) return linked
     if (attempt + 1 < deps.attempts) {
       await deps.sleep(Math.min(deps.retryBackoffMs * 2 ** attempt, deps.maxRetryBackoffMs))
@@ -305,16 +322,22 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
     const profile = this.profileFor(options)
     const { worktree, branch } = this.createWorktree(options, profile)
     const runtimeSessionId = randomUUID()
+    const instanceId = `pi-${randomUUID()}`
     // Pi does not mint, but the mint record is where the profile snapshot lives
     // and the reaper reads it by worktree — `pi-local` links are reaped too. With
     // no snapshot the reaper falls back to the built-in default, which commits,
     // pushes and reclaims: exactly the wrong answer for a `--cwd` directory the
     // operator owns, and it would drop the declared teardown silently.
     recordProfileSnapshot({ worktree, runtimeSessionId, runtimeKind: "pi-local", profile })
-    const partial: Partial<SpawnResult> = { worktree, branch, tmuxSession: session, runtimeSessionId }
+    const partial: Partial<SpawnResult> = { worktree, branch, tmuxSession: session, instanceId, runtimeSessionId }
     try {
       const window = pickTmuxWindow(session, options.name)
-      const { windowId, paneId } = createWindow(session, window, worktree, piLaunchCommand(piBin, runtimeSessionId))
+      const { windowId, paneId } = createWindow(
+        session,
+        window,
+        worktree,
+        piLaunchCommand(piBin, runtimeSessionId, instanceId)
+      )
       Object.assign(partial, { tmuxWindow: window, tmuxWindowId: windowId, tmuxPaneId: paneId })
       console.log(`harnessd: launched Pi in tmux ${session}:${window} (${windowId})`)
 
@@ -323,6 +346,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
       const link = options.noRemote
         ? undefined
         : await linkPiRemoteSession({
+            expectedInstanceId: instanceId,
             attempts,
             bootWaitMs: Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000),
             responseWaitMs: Number(process.env.THREA_HARNESSD_PI_REMOTE_WAIT_MS ?? 6000),
@@ -345,7 +369,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
         tmuxWindowId: windowId,
         tmuxPaneId: paneId,
         scratchpadUrl: link?.scratchpadUrl ?? (options.noRemote ? firstScratchpadUrl(outputText) : undefined),
-        instanceId: link?.instanceId,
+        instanceId,
         runtimeSessionId,
         output: outputText,
       }

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -673,6 +673,40 @@ describe("sanitizeInstanceIdSegment", () => {
   })
 })
 
+describe("instanceIdForRemoteCreate", () => {
+  test("reuses a supervised launch identity across attempts and keeps inherited or manual sessions independent", () => {
+    const savedInstanceId = process.env.THREA_INSTANCE_ID
+    const savedRuntimeSessionId = process.env.THREA_RUNTIME_SESSION_ID
+    try {
+      process.env.THREA_INSTANCE_ID = "pi-launch-instance"
+      process.env.THREA_RUNTIME_SESSION_ID = "runtime-launch"
+      expect([
+        __testing.instanceIdForRemoteCreate("runtime-launch"),
+        __testing.instanceIdForRemoteCreate("runtime-launch"),
+      ]).toEqual(["pi-launch-instance", "pi-launch-instance"])
+
+      expect(__testing.instanceIdForRemoteCreate("runtime-child")).not.toBe(
+        __testing.instanceIdForRemoteCreate("runtime-child")
+      )
+
+      delete process.env.THREA_INSTANCE_ID
+      delete process.env.THREA_RUNTIME_SESSION_ID
+      expect(__testing.instanceIdForRemoteCreate("runtime-manual")).not.toBe(
+        __testing.instanceIdForRemoteCreate("runtime-manual")
+      )
+
+      process.env.THREA_INSTANCE_ID = "pi.invalid"
+      process.env.THREA_RUNTIME_SESSION_ID = "runtime-invalid"
+      expect(() => __testing.instanceIdForRemoteCreate("runtime-invalid")).toThrow("THREA_INSTANCE_ID")
+    } finally {
+      if (savedInstanceId === undefined) delete process.env.THREA_INSTANCE_ID
+      else process.env.THREA_INSTANCE_ID = savedInstanceId
+      if (savedRuntimeSessionId === undefined) delete process.env.THREA_RUNTIME_SESSION_ID
+      else process.env.THREA_RUNTIME_SESSION_ID = savedRuntimeSessionId
+    }
+  })
+})
+
 describe("migrateInstanceId", () => {
   test("rewrites a dotted macOS-hostname id without losing the random suffix", () => {
     // Realistic shape of a macOS-derived id (`hostname()` returns `*.lan`).

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -553,6 +553,19 @@ function createInstanceId(): string {
   return trimmedHost.length > 0 ? `pi-${trimmedHost}-${suffix}` : `pi-${suffix}`
 }
 
+function instanceIdForRemoteCreate(runtimeSessionId: string): string {
+  if (process.env.THREA_RUNTIME_SESSION_ID !== runtimeSessionId) return createInstanceId()
+  const launchedInstanceId = process.env.THREA_INSTANCE_ID
+  if (
+    launchedInstanceId === undefined ||
+    !INSTANCE_ID_REGEX.test(launchedInstanceId) ||
+    launchedInstanceId.length > INSTANCE_ID_MAX_CHARS
+  ) {
+    throw new Error("THREA_INSTANCE_ID must be 1-64 letters, numbers, underscores, or hyphens")
+  }
+  return launchedInstanceId
+}
+
 function migrateInstanceId(stored: unknown): string {
   // `config.instanceId` is loaded via `JSON.parse` and `readConfig` only
   // type-checks the three required fields. A hand-edited config could put
@@ -1424,7 +1437,7 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
     throw new Error("Supervised revival cannot create or relink a Pi scratchpad")
   }
   const runtimeSessionId = getRuntimeSessionId(ctx)
-  const instanceId = createInstanceId()
+  const instanceId = instanceIdForRemoteCreate(runtimeSessionId)
   const displayName = args.trim() || defaultDisplayNameFor(ctx.cwd, config.defaultDisplayName)
   const e2e = config.e2e ? await resolveE2eCreateBlock() : undefined
 
@@ -4417,6 +4430,7 @@ export const __testing = {
   formatLocalTime,
   sanitizeInstanceIdSegment,
   createInstanceId,
+  instanceIdForRemoteCreate,
   migrateInstanceId,
   appendCapped,
   formatShellResult,


### PR DESCRIPTION
## Problem

`PiRuntimeSpawner.spawn` waited eight seconds, sent `/remote-control` once, waited six more seconds, and recorded the runtime online even when `threa-remote.json` contained no session link. Recent Pi launches repeatedly needed the same command to be sent again after startup before a scratchpad appeared. The startup-timing explanation is still a hypothesis, not a proven cause: process existence and prompt rendering may precede slash-command readiness.

## Solution

Pi startup now treats the persisted remote-session link as the acknowledgement:

- Harnessd mints one instance ID per launch and exports it with the Pi runtime session ID. Every retry therefore reaches the backend with the same generation identity.
- The Pi extension uses that identity only when the current Pi session matches the exported runtime session, so nested or manual Pi sessions do not inherit it accidentally.
- `linkPiRemoteSession` retries `/remote-control` up to three times by default with bounded backoff, stops after persistence, and rejects a link from another instance.
- Exhausted attempts record the runtime as `error` instead of `online`; `--no-remote` retains its opt-out behavior.

## Verification

Harness-daemon tests (377 pass), Pi remote tests (154 pass), harness-daemon typecheck, and repository pre-commit lint, typecheck, migration, Dockerfile, and generated API checks passed.

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Link a newly launched Pi despite delayed slash-command readiness without creating multiple scratchpads or reporting an unlinked runtime as healthy.

## What Was Built

- Bounded `/remote-control` retries that require a persisted, enabled link before spawn succeeds.
- A launch-scoped `(instanceId, runtimeSessionId)` exported by harnessd and reused by the Pi extension across retries.
- Identity validation between the launched process, persisted Pi config, and inventory.
- Regression coverage for a lost first command, stable retry identity, inherited-session isolation, and mismatched persisted links.

## Design Decisions

- Reuse the backend's existing identity-based session idempotence rather than add pending state to shared Pi config.
- Scope the exported instance ID to the matching runtime session so child Pi processes fall back to independent identities.
- Keep the startup-timing explanation as a hypothesis; persisted link state is the acknowledgement.

## Status

- [x] Retry after delayed readiness
- [x] Prevent duplicate scratchpads across partial create failures
- [x] Fail unlinked or identity-mismatched spawns
- [x] Preserve `--no-remote`

</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789337085&installation_model_id=20758&pr_number=1888&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1888&signature=fce86d36d60473566f9cfeac6dc13f611a098481506095aff0b5ba9380783492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
