### PR TITLE
chore: drop the autoReadRevamp kill-switch

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -28,7 +28,6 @@ import {
   useEditLastMessageTrigger,
   useKeyboardShortcuts,
   useEffectiveArchived,
-  useFeatureFlag,
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
@@ -2277,7 +2276,6 @@ export function StreamContent({
   // no settle phase (`isInitialSettling` would never clear there), so exempt it.
   const settledAtBottom = !useVirtualized || !virtualIsInitialSettling
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && settledAtBottom
-  const autoReadRevamp = useFeatureFlag(workspaceId, "autoReadRevamp") === "on"
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     // The virtualized scroller late-mounts via a ref callback, AFTER
@@ -2297,9 +2295,6 @@ export function StreamContent({
     lastReadEventId: frontierLastReadEventId,
     enabled: autoMarkEnabled,
     programmaticScrollAtRef,
-    // Kill-switch (autoReadRevamp "off" reverts to strict scan-overlap
-    // contiguity); the flush half of the switch lives on the ReadCommitQueue.
-    sweepLinkEnabled: autoReadRevamp,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
   const canAutoRead = useAutoReadAttention()

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -71,38 +71,38 @@ describe("advanceFrontier", () => {
     // Read up to row 4; viewport shows rows 27..30 (the tail). The gap 5..26 is
     // unseen, so the frontier must stay at 4 — opening at the bottom keeps the
     // unread above unread.
-    expect(advanceFrontier(4, 27, 30)).toBe(4)
+    expect(advanceFrontier(4, 27, 30, 5)).toBe(4)
   })
 
   it("advances to the bottom of the viewport when contiguous with the frontier", () => {
     // Jumped to the first unread (row 5, frontier+1) and it's at the top; advance
     // through what's on screen.
-    expect(advanceFrontier(4, 5, 8)).toBe(8)
+    expect(advanceFrontier(4, 5, 8, 5)).toBe(8)
   })
 
   it("advances when the viewport top sits above the frontier (overlap)", () => {
-    expect(advanceFrontier(7, 5, 12)).toBe(12)
+    expect(advanceFrontier(7, 5, 12, 8)).toBe(12)
   })
 
   it("does not advance when flinging past leaves a gap above the viewport", () => {
     // Frontier at 7, but a fast scroll put rows 20..25 on screen without 8..19
     // ever being visible — they stay unseen.
-    expect(advanceFrontier(7, 20, 25)).toBe(7)
+    expect(advanceFrontier(7, 20, 25, 8)).toBe(7)
   })
 
   it("does not retract when scrolling back up (bottom below the frontier)", () => {
-    expect(advanceFrontier(20, 10, 15)).toBe(20)
+    expect(advanceFrontier(20, 10, 15, 21)).toBe(20)
   })
 
   it("advances past bridged chrome when the gate says the first unread message is further down", () => {
     // Frontier at 1, a session card at 2 that never came on screen, the unread
     // message at 3. Raw adjacency (gate = 2) blocks; the real gate is 3.
-    expect(advanceFrontier(1, 3, 3)).toBe(1)
+    expect(advanceFrontier(1, 3, 3, 2)).toBe(1)
     expect(advanceFrontier(1, 3, 3, 3)).toBe(3)
   })
 
   it("treats an exactly-contiguous top (frontier + 1) as no gap", () => {
-    expect(advanceFrontier(9, 10, 14)).toBe(14)
+    expect(advanceFrontier(9, 10, 14, 10)).toBe(14)
   })
 })
 

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -124,12 +124,6 @@ interface UseLastSeenEventOptions {
    * SWEEP_LINK_MS): a jump must remain a gap, not a read-through.
    */
   programmaticScrollAtRef?: React.RefObject<number>
-  /**
-   * The `autoReadRevamp` kill-switch: false disables sweep-linking entirely,
-   * reverting to strict scan-overlap contiguity (pre-#1881 semantics).
-   * Defaults true.
-   */
-  sweepLinkEnabled?: boolean
 }
 
 interface UseLastSeenEventResult {
@@ -166,7 +160,6 @@ export function useLastSeenEvent({
   lastReadEventId,
   enabled,
   programmaticScrollAtRef,
-  sweepLinkEnabled = true,
 }: UseLastSeenEventOptions): UseLastSeenEventResult {
   const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
   const [atLastRow, setAtLastRow] = useState(false)
@@ -224,10 +217,6 @@ export function useLastSeenEvent({
   // by event id, not index: a prepend shifts every index but virtua holds the
   // viewport on the same rows, and an id re-resolves to its post-shift index.
   const prevScanRef = useRef<{ topId: string; at: number } | null>(null)
-  // Ref so a live flag flip applies on the next scan without re-creating the
-  // stable recompute closure (which would re-arm listeners mid-gesture).
-  const sweepLinkEnabledRef = useRef(sweepLinkEnabled)
-  sweepLinkEnabledRef.current = sweepLinkEnabled
 
   const recompute = useCallback(() => {
     const el = scrollContainerRef.current
@@ -272,12 +261,7 @@ export function useLastSeenEvent({
     const now = performance.now()
     const prevScan = prevScanRef.current
     let effTopIdx = topIdx
-    if (
-      sweepLinkEnabledRef.current &&
-      prevScan &&
-      now - prevScan.at <= SWEEP_LINK_MS &&
-      (programmaticScrollAtRef?.current ?? 0) < prevScan.at
-    ) {
+    if (prevScan && now - prevScan.at <= SWEEP_LINK_MS && (programmaticScrollAtRef?.current ?? 0) < prevScan.at) {
       const prevTopIdx = map.get(prevScan.topId)
       if (prevTopIdx !== undefined && prevTopIdx < effTopIdx) effTopIdx = prevTopIdx
     }

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -33,16 +33,22 @@ export function pickVisibleRange(rows: VisibleRow[], viewportTop: number, viewpo
 
 /**
  * Advance the read frontier through a contiguous run only. The frontier moves to
- * the bottom of the viewport when the viewport's top is at or above the first
- * unread row (`frontier + 1`) — i.e. there is no gap of unseen rows between the
- * read frontier and what's on screen. Landing at the live bottom leaves such a
- * gap, so the frontier (and the read pointer) stays put. `topIdx` is the
- * sweep-effective top: recompute substitutes the previous scan's top when two
- * scans link into one continuous user scroll (see SWEEP_LINK_MS), so a fast
- * fling — whose per-frame viewport jumps exceed the viewport height — still
- * reads as the continuous sweep it visually was.
+ * the bottom of the viewport when the viewport's top is at or above `gateIdx` —
+ * i.e. no unread content sits between the read frontier and what's on screen.
+ * Landing at the live bottom leaves such a gap, so the frontier (and the read
+ * pointer) stays put.
+ *
+ * `gateIdx` is {@link readGateIndex}: the first unread MESSAGE after the
+ * frontier, so rows carrying nothing to read are bridged. It is required rather
+ * than defaulted to `frontier + 1` — that default was the old rule, and it wedged
+ * every stream whose bot replies are bracketed by agent-session events.
+ *
+ * `topIdx` is the sweep-effective top: recompute substitutes the previous scan's
+ * top when two scans link into one continuous user scroll (see SWEEP_LINK_MS), so
+ * a fast fling — whose per-frame viewport jumps exceed the viewport height —
+ * still reads as the continuous sweep it visually was.
  */
-export function advanceFrontier(frontier: number, topIdx: number, botIdx: number, gateIdx = frontier + 1): number {
+export function advanceFrontier(frontier: number, topIdx: number, botIdx: number, gateIdx: number): number {
   if (topIdx <= gateIdx && botIdx > frontier) return botIdx
   return frontier
 }

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -39,9 +39,9 @@ export function pickVisibleRange(rows: VisibleRow[], viewportTop: number, viewpo
  * pointer) stays put.
  *
  * `gateIdx` is {@link readGateIndex}: the first unread MESSAGE after the
- * frontier, so rows carrying nothing to read are bridged. It is required rather
- * than defaulted to `frontier + 1` — that default was the old rule, and it wedged
- * every stream whose bot replies are bracketed by agent-session events.
+ * frontier, so rows carrying nothing to read are bridged. Never give it a
+ * `frontier + 1` default: raw adjacency cannot advance past chrome the viewport
+ * never showed, which strands replies bracketed by agent-session events unread.
  *
  * `topIdx` is the sweep-effective top: recompute substitutes the previous scan's
  * top when two scans link into one continuous user scroll (see SWEEP_LINK_MS), so

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -57,7 +57,6 @@ import {
   useBackgroundBootstrapSync,
 } from "@/hooks"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
-import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { usePageResume } from "@/hooks/use-page-resume"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { isServerStreamId } from "@/lib/stream-ids"
@@ -342,20 +341,14 @@ function WorkspaceSyncHandler({
   // only below once the current-workspace check has passed — so a pending mark
   // never lands in the wrong workspace on a switch.
   const { markAsRead } = useUnreadCounts(workspaceId)
-  const autoReadRevamp = useFeatureFlag(workspaceId, "autoReadRevamp") === "on"
   const readCommitQueueRef = useRef<ReadCommitQueue | null>(null)
   let readCommitQueue = readCommitQueueRef.current
   if (!readCommitQueue || readCommitQueue.workspaceId !== workspaceId || readCommitQueue.isDisposed) {
     readCommitQueue?.dispose()
-    readCommitQueue = new ReadCommitQueue({
-      workspaceId,
-      commitRef: { current: markAsRead },
-      flushOnLeaveRef: { current: autoReadRevamp },
-    })
+    readCommitQueue = new ReadCommitQueue({ workspaceId, commitRef: { current: markAsRead } })
     readCommitQueueRef.current = readCommitQueue
   }
   readCommitQueue.commitRef.current = markAsRead
-  readCommitQueue.flushOnLeaveRef.current = autoReadRevamp
   // Unlike the SyncEngine (whose destroy would break the socket-connect
   // effect under StrictMode), the queue is safe to dispose on unmount — the
   // recreate check above sees a disposed queue and builds a fresh one on the

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -70,31 +70,6 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledWith("stream_b", "event_b", { partial: true })
   })
 
-  it("flush and pagehide DROP pending marks when the autoReadRevamp kill-switch is off", () => {
-    const flushOnLeaveRef = { current: false }
-    const gated = new ReadCommitQueue({
-      workspaceId: "ws_1",
-      commitRef: { current: (streamId, lastEventId, opts) => commit(streamId, lastEventId, opts) },
-      flushOnLeaveRef,
-    })
-    try {
-      gated.report("stream_a", "event_1", false)
-      gated.flush("stream_a")
-      window.dispatchEvent(new Event("pagehide"))
-      vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS * 2)
-      expect(commit).not.toHaveBeenCalled()
-      expect(gated.lastCommitted("stream_a")).toBeNull()
-
-      // The debounce fire itself is NOT gated — only leave-flushes are.
-      flushOnLeaveRef.current = false
-      gated.report("stream_a", "event_2", false)
-      vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)
-      expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_2", { partial: false })
-    } finally {
-      gated.dispose()
-    }
-  })
-
   it("resetCommitted forgets the record so a fresh open can re-commit the same mark", () => {
     queue.report("stream_a", "event_1", false)
     vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -53,20 +53,13 @@ export class ReadCommitQueue {
   // cancelled timer was.
   private readonly onPageHide = () => this.flushAll()
 
-  /** The `autoReadRevamp` kill-switch, kept fresh by the owning layout: false
-   *  makes `flush`/`flushAll`/dispose DROP pending marks instead of committing
-   *  them — the pre-#1881 leave semantics. The debounce fire is unaffected. */
-  readonly flushOnLeaveRef: { current: boolean }
-
   constructor(deps: {
     workspaceId: string
     commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
-    flushOnLeaveRef?: { current: boolean }
     debounceMs?: number
   }) {
     this.workspaceId = deps.workspaceId
     this.commitRef = deps.commitRef
-    this.flushOnLeaveRef = deps.flushOnLeaveRef ?? { current: true }
     this.debounceMs = deps.debounceMs ?? READ_COMMIT_DEBOUNCE_MS
     window.addEventListener("pagehide", this.onPageHide)
   }
@@ -92,10 +85,6 @@ export class ReadCommitQueue {
   }
 
   flush(streamId: string): void {
-    if (!this.flushOnLeaveRef.current) {
-      this.cancel(streamId)
-      return
-    }
     const mark = this.pending.get(streamId)
     if (!mark) return
     clearTimeout(mark.timer)
@@ -138,7 +127,7 @@ export class ReadCommitQueue {
     const marks = [...this.pending.entries()]
     this.pending.clear()
     for (const [, mark] of marks) clearTimeout(mark.timer)
-    if (marks.length === 0 || !this.flushOnLeaveRef.current) return
+    if (marks.length === 0) return
     queueMicrotask(() => {
       for (const [streamId, mark] of marks) this.send(streamId, mark)
     })

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -54,13 +54,6 @@ export function defineFlag<
  * the moment the rollout is done. A flag that survives long here is a smell.
  */
 export const FEATURE_FLAGS = {
-  // Kill-switch for the revamped auto-read semantics (#1881/#1882): "on" is
-  // the shipped behavior — sweep-linked frontier scans (a fling reads what it
-  // painted past) and flush-on-leave/pagehide for the pending mark. "off"
-  // reverts BOTH to the pre-#1881 semantics (strict scan-overlap contiguity;
-  // leaving a stream drops a still-debouncing mark) without touching the
-  // ReadCommitQueue plumbing. Delete after rollout confidence.
-  autoReadRevamp: defineFlag({ values: ["off", "on"], scopes: ["workspace", "user"], default: "on" }),
   calls: defineFlag({ values: ["off", "on"], scopes: ["workspace"], default: "on" }),
   composeTraces: defineFlag({ values: ["off", "capture"], scopes: ["workspace"], default: "off" }),
   // Availability only: "available" offers the Diagnostics settings toggle. The


### PR DESCRIPTION
## Problem

`autoReadRevamp` was the kill-switch for the reworked auto-read semantics in [#1881](https://github.com/threahq/threa/pull/1881)/[#1882](https://github.com/threahq/threa/pull/1882). The rollout is done, and the registry's own contract is that a flag is deleted the moment it is: *"Add a flag while rolling a feature out; delete it the moment the rollout is done. A flag that survives long here is a smell."*

Prod backs the removal. The watermark-vs-tail query that surfaced the original miss signature instantly — a read pointer sitting one message behind a stream's tail — now returns **zero** rows over a 12-hour window covering 11 read advances and 22 incoming messages.

## Solution

Delete the flag and both of its gates: `sweepLinkEnabled` on `useLastSeenEvent` (sweep-linked scans are now unconditional) and `flushOnLeaveRef` on `ReadCommitQueue` (leave/pagehide always flushes the pending mark). Any lingering DB override rows go inert on their own — the resolver filters overrides through the registry at read time, which is what makes retiring a flag a one-line change.

Scope note: the flag never covered [#1886](https://github.com/threahq/threa/pull/1886) (read-frontier bridging) or [#1884](https://github.com/threahq/threa/pull/1884) (activity viewing-pin) — both shipped unflagged — so this removes a partial lever, not a full undo of current behaviour.

## Files

| File | Change |
| ---- | ------ |
| `packages/types/src/feature-flags.ts` | Registry entry removed |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | `sweepLinkEnabled` option + its ref |
| `apps/frontend/src/sync/read-commit-queue.ts` | `flushOnLeaveRef` and its two branches |
| `apps/frontend/src/sync/read-commit-queue.test.ts` | The flag-off test (its behaviour no longer exists) |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Flag read + option pass-through |
| `apps/frontend/src/pages/workspace-layout.tsx` | Flag read + queue wiring |

## Test plan

- [x] Rebased onto `77675f41` (after #1886 and #1884) with no conflicts; no references to the flag or either gate remain anywhere in `apps/` or `packages/`
- [x] Frontend units 6694; typecheck clean
- [x] Browser `auto-read` 7/7, `unread-marker-open` 2/2 — the behaviours the flag used to gate, now unconditional

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01GceYF7UEshN3QRAjGQDagJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789337304&installation_model_id=20758&pr_number=1889&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1889&signature=bcfe93aa5f9c5806f0edda3a6761fec2a8a82980f25c23d45112fda6ca79dcad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->