### PR TITLE
fix: keep push notification targets visible before IDB catches up

### DIFF
--- a/apps/frontend/src/hooks/use-events.test.ts
+++ b/apps/frontend/src/hooks/use-events.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ServicesProvider, type StreamService } from "@/contexts"
 import type { StreamEvent } from "@threa/types"
 import { db, type CachedEvent } from "@/db"
 import { loadStreamPrefix, loadStreamTail, unionStreamRanges } from "@/stores/stream-store"
@@ -13,7 +17,9 @@ import {
   getOldestSequence,
   getRenderableEvents,
   cacheToIndexedDB,
+  useEvents,
 } from "./use-events"
+import * as streamStoreModule from "@/stores/stream-store"
 
 describe("useEvents helpers", () => {
   it("uses the lower older-page floor when scrollback extends past bootstrap", () => {
@@ -278,6 +284,97 @@ describe("cacheToIndexedDB with eventWriteChunking on", () => {
 
     const healed = await db.events.get("evt_120")
     expect(healed?.payload).toMatchObject({ threadId: "str_t", replyCount: 3 })
+  })
+})
+
+describe("useEvents live-tail jump bridge", () => {
+  const workspaceId = "ws_push"
+  const streamId = "stream_push"
+  const getEventsAround = vi.fn<StreamService["getEventsAround"]>()
+
+  function event(id: string, sequence: number, targetStreamId = streamId): CachedEvent {
+    return {
+      id: `event_${id}`,
+      workspaceId,
+      streamId: targetStreamId,
+      sequence: String(sequence),
+      broadcastSequence: String(sequence),
+      _sequenceNum: sequence,
+      _cachedAt: 1,
+      eventType: "message_created",
+      payload: { messageId: `msg_${id}`, contentMarkdown: id },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(2026, 0, 1, 0, 0, sequence).toISOString(),
+    }
+  }
+
+  function wrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(ServicesProvider, {
+          services: { streams: { getEventsAround } as unknown as StreamService },
+          children,
+        })
+      )
+    }
+  }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    getEventsAround.mockReset()
+    await db.events.clear()
+  })
+
+  it("renders a fetched latest message even when the IndexedDB observer misses the write", async () => {
+    const stale = event("stale", 1)
+    const target = event("target", 2)
+    vi.spyOn(streamStoreModule, "useStreamEvents").mockImplementation((requestedStreamId) =>
+      requestedStreamId === streamId ? [stale] : []
+    )
+    getEventsAround.mockResolvedValue({
+      events: [stale, target],
+      hasOlder: false,
+      hasNewer: false,
+    })
+
+    const { result } = renderHook(() => useEvents(workspaceId, streamId), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.events.map((candidate) => candidate.id)).toEqual([stale.id]))
+
+    let jumpResult: boolean | "superseded" | undefined
+    await act(async () => {
+      jumpResult = await result.current.jumpToEvent("msg_target")
+    })
+
+    expect(jumpResult).toBe(true)
+    expect(result.current.isJumpMode).toBe(false)
+    expect(result.current.events.map((candidate) => candidate.id)).toEqual([stale.id, target.id])
+    expect(getEventsAround).toHaveBeenCalledWith(workspaceId, streamId, "msg_target", 50)
+  })
+
+  it("does not carry a live-tail bridge into another stream", async () => {
+    const stale = event("stale", 1)
+    const target = event("target", 2)
+    const other = event("other", 1, "stream_other")
+    vi.spyOn(streamStoreModule, "useStreamEvents").mockImplementation((requestedStreamId) =>
+      requestedStreamId === streamId ? [stale] : [other]
+    )
+    getEventsAround.mockResolvedValue({ events: [stale, target], hasOlder: false, hasNewer: false })
+
+    const { result, rerender } = renderHook(({ currentStreamId }) => useEvents(workspaceId, currentStreamId), {
+      initialProps: { currentStreamId: streamId },
+      wrapper: wrapper(),
+    })
+    await act(async () => {
+      await result.current.jumpToEvent("msg_target")
+    })
+    expect(result.current.events.map((candidate) => candidate.id)).toContain(target.id)
+
+    rerender({ currentStreamId: "stream_other" })
+    await waitFor(() => expect(result.current.events.map((candidate) => candidate.id)).toEqual([other.id]))
   })
 })
 

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -34,7 +34,7 @@ interface JumpState {
 }
 
 type SequencedEvent = Pick<StreamEvent, "sequence">
-type DisplayableEvent = SequencedEvent & { _status?: string | null }
+type DisplayableEvent = SequencedEvent & { id?: string; _status?: string | null }
 export interface BootstrapFloorState {
   streamId: string
   floor: bigint
@@ -336,6 +336,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
 
   // Jump-to-message state: when set, replaces bootstrap as the anchor window
   const [jumpState, setJumpState] = useState<JumpState | null>(null)
+  const [liveTailBridge, setLiveTailBridge] = useState<{ streamId: string; events: StreamEvent[] } | null>(null)
   const lastSuppressedErrorKeyRef = useRef<string | null>(null)
 
   // Infinite query for older events (backward pagination).
@@ -466,7 +467,20 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
   // race where bootstrap has finished but Dexie change events haven't yet
   // propagated to useLiveQuery (see getEffectiveEvents docstring).
   const effectiveEvents: DisplayableEvent[] = getEffectiveEvents(idbResolved, idbEvents ?? [], bootstrap?.events ?? [])
-  const hasAnyEvents = effectiveEvents.length > 0
+  const hasAnyEvents =
+    effectiveEvents.length > 0 || (liveTailBridge?.streamId === streamId && liveTailBridge.events.length > 0)
+
+  useEffect(() => {
+    if (!liveTailBridge) return
+    if (liveTailBridge.streamId !== streamId) {
+      setLiveTailBridge((current) => (current === liveTailBridge ? null : current))
+      return
+    }
+    const persistedIds = new Set(effectiveEvents.map((event) => event.id))
+    if (liveTailBridge.events.every((event) => persistedIds.has(event.id))) {
+      setLiveTailBridge((current) => (current === liveTailBridge ? null : current))
+    }
+  }, [effectiveEvents, liveTailBridge, streamId])
 
   const cachedWindowFloor = useMemo(() => getCachedWindowFloor(effectiveEvents, EVENT_PAGE_SIZE), [effectiveEvents])
   const displayFloor = useMemo(() => {
@@ -492,8 +506,10 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     // local cache, widen back out to the full cached timeline. The floor must
     // never hide the entire cached set — a non-empty IDB always renders
     // something (see getRenderableEvents).
-    return getRenderableEvents(effectiveEvents, displayFloor) as unknown as StreamEvent[]
-  }, [effectiveEvents, olderData, newerData, jumpState, displayFloor])
+    const liveEvents = getRenderableEvents(effectiveEvents, displayFloor) as unknown as StreamEvent[]
+    if (!liveTailBridge || liveTailBridge.streamId !== streamId) return liveEvents
+    return dedupeAndSort([liveTailBridge.events, liveEvents])
+  }, [effectiveEvents, olderData, newerData, jumpState, displayFloor, liveTailBridge, streamId])
 
   // Contiguity gate (INV-61): detect holes in the broadcast chain of the
   // rendered window. Each hole renders as an in-place loading placeholder
@@ -682,17 +698,17 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
       await cacheToIndexedDB(workspaceId, streamId, result.events, result)
       if (generation !== jumpGenerationRef.current) return "superseded"
 
-      // If there are no newer events, the target is already at the bottom —
-      // skip jump mode and let the live tail render from IDB. A previous jump
-      // may still be active; its window renders instead of IDB, so exit it —
-      // otherwise the timeline stays frozen on the old window and this
-      // navigation silently does nothing.
+      const sorted = sortBySequence([...result.events])
+
+      // A tail target should stay in the normal live view, but do not rely on
+      // the IndexedDB live query noticing this write before rendering it. Some
+      // mobile engines miss that invalidation until a reload.
       if (!result.hasNewer) {
+        setLiveTailBridge({ streamId, events: sorted })
         exitJumpMode()
         return true
       }
 
-      const sorted = sortBySequence([...result.events])
       setJumpState({
         events: sorted,
         hasOlder: result.hasOlder,
@@ -726,15 +742,16 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
       await cacheToIndexedDB(workspaceId, streamId, result.events, result)
       if (generation !== jumpGenerationRef.current) return "superseded"
 
-      // No newer events means the anchor sits at the live tail — skip jump mode
-      // and let IDB render the tail; the caller still scrolls to the anchor.
-      // Exit any active jump first: its window would render instead of IDB.
+      const sorted = sortBySequence([...result.events])
+
+      // Keep the fetched tail window renderable until the IndexedDB observer
+      // confirms its write, for the same reason as the message-id jump above.
       if (!result.hasNewer) {
+        setLiveTailBridge({ streamId, events: sorted })
         exitJumpMode()
         return result.anchorMessageId
       }
 
-      const sorted = sortBySequence([...result.events])
       setJumpState({
         events: sorted,
         hasOlder: result.hasOlder,


### PR DESCRIPTION
## Problem

Push notification deep links to the newest message use `jumpToEvent`, but the no-newer-events branch has relied only on the IndexedDB live query to expose the fetched window since [#279](https://github.com/threahq/threa/pull/279). On affected mobile sessions, that observer can miss or delay the cache write. The events-around request succeeds, but the target never enters render state, so the pending scroll expires on the old window and the message appears only after a hard refresh.

This predates the recent atomic landing and reload-position work. Those changes affect where an available target lands; this failure happens earlier, while making the fetched target available to the timeline.

## Solution

`useEvents` now bridges fetched live-tail windows into normal render state until the IndexedDB observer confirms every returned event:

- The bridge keeps the timeline in live mode instead of falsely entering jump mode at the tail.
- Current IndexedDB rows win deduplication, so socket edits and other newer state are not overwritten.
- Bridge cleanup is identity-guarded and stream-scoped. A late cleanup or stream switch cannot remove or leak another navigation’s target.
- Date jumps use the same path.

## Verification

94 focused timeline/event tests pass, including a hook test with a deliberately stale IndexedDB observer and a stream-switch isolation case. Repository lint, typecheck, migration checks, Dockerfile checks, and API-doc checks pass through the commit hooks. The full frontend suite was also started, but did not complete within a 15-minute harness timeout.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789338081&installation_model_id=20758&pr_number=1890&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1890&signature=912377f354ea2c39ae25f075122eb991d73914d1440b10070c755a52f0e8e9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->