### PR TITLE
fix: make mobile composer fullscreen and always resizable

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -1146,7 +1146,8 @@ describe("MessageComposer", () => {
       }
     })
 
-    it("lets the minimize control leave fullscreen after the handle reaches its maximum", () => {
+    it("lets the minimize control return a max-dragged composer to its natural default", () => {
+      localStorage.setItem("threa:composer-drag-height", "260")
       const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
       const root = container.firstElementChild as HTMLElement
       const handle = screen.getByTestId("composer-resize-handle")
@@ -1161,6 +1162,7 @@ describe("MessageComposer", () => {
       expect(root).not.toHaveAttribute("data-composer-expanded")
       expect(root.style.minHeight).toBe("")
       expect(root.style.maxHeight).toBe("")
+      expect(localStorage.getItem("threa:composer-drag-height")).toBeNull()
     })
 
     it("ignores a stale keyboard-sized visual viewport until an editor is focused", () => {
@@ -1173,14 +1175,16 @@ describe("MessageComposer", () => {
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
         const root = container.firstElementChild as HTMLElement
+        root.parentElement!.style.paddingTop = "12px"
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
 
         fireEvent.click(screen.getByRole("button", { name: "Expand composer" }))
-        expect(root.style.minHeight).toBe("800px")
-        expect(root.style.maxHeight).toBe("800px")
+        expect(root.style.minHeight).toBe("788px")
+        expect(root.style.maxHeight).toBe("788px")
 
         act(() => screen.getByTestId("rich-editor").focus())
-        expect(root.style.minHeight).toBe("400px")
-        expect(root.style.maxHeight).toBe("400px")
+        expect(root.style.minHeight).toBe("388px")
+        expect(root.style.maxHeight).toBe("388px")
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
         else Reflect.deleteProperty(window, "visualViewport")

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -953,8 +953,11 @@ describe("MessageComposer", () => {
       expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("104px")
     })
 
-    it("grows the minimum height by the formatting toolbar so one editor line remains", () => {
-      localStorage.setItem("threa:composer-drag-height", "104")
+    it.each([
+      { savedHeight: 104, openHeight: 144, label: "minimum" },
+      { savedHeight: 200, openHeight: 240, label: "intermediate height with fullscreen headroom" },
+    ])("grows from $label before the formatting toolbar consumes editor space", ({ savedHeight, openHeight }) => {
+      localStorage.setItem("threa:composer-drag-height", String(savedHeight))
       const originalRect = HTMLElement.prototype.getBoundingClientRect
       vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
         if (this.getAttribute("data-testid") === "composer-format-toolbar") {
@@ -964,14 +967,14 @@ describe("MessageComposer", () => {
       })
       const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
       const root = container.firstElementChild as HTMLElement
-      expect(root.style.minHeight).toBe("104px")
+      expect(root.style.minHeight).toBe(`${savedHeight}px`)
 
       fireEvent.click(screen.getByRole("button", { name: "Formatting" }))
       expect(screen.getByTestId("composer-format-toolbar")).toBeInTheDocument()
-      expect(root.style.minHeight).toBe("144px")
+      expect(root.style.minHeight).toBe(`${openHeight}px`)
 
       fireEvent.click(screen.getByRole("button", { name: "Formatting" }))
-      expect(root.style.minHeight).toBe("104px")
+      expect(root.style.minHeight).toBe(`${savedHeight}px`)
     })
 
     it("keeps the floor when 75% of a short viewport would dip below it", () => {
@@ -1196,7 +1199,7 @@ describe("MessageComposer", () => {
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
         const root = container.firstElementChild as HTMLElement
-        root.parentElement!.style.paddingTop = "12px"
+        root.parentElement!.style.paddingBottom = "12px"
         act(() => visualViewport.dispatchEvent(new Event("resize")))
 
         fireEvent.click(screen.getByRole("button", { name: "Expand composer" }))
@@ -1211,6 +1214,27 @@ describe("MessageComposer", () => {
         else Reflect.deleteProperty(window, "visualViewport")
         if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
         else Reflect.deleteProperty(window, "innerHeight")
+      }
+    })
+
+    it("matches fullscreen top spacing to the shell bottom inset on coarse sm layouts", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const visualViewport = new EventTarget() as EventTarget & { height: number }
+      visualViewport.height = 800
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+        root.parentElement!.style.paddingTop = "24px"
+        root.parentElement!.style.paddingBottom = "16px"
+        act(() => visualViewport.dispatchEvent(new Event("resize")))
+
+        fireEvent.click(screen.getByRole("button", { name: "Expand composer" }))
+        expect(root.style.minHeight).toBe("784px")
+        expect(root.style.maxHeight).toBe("784px")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
       }
     })
 

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -156,10 +156,10 @@ const MockEditorActionBar = (props: Record<string, unknown>) => (
     </button>
     <button
       type="button"
-      aria-label="Expand composer"
-      onClick={() => (props.onMobileExpandedChange as (v: boolean) => void)?.(true)}
+      aria-label={props.mobileExpanded ? "Minimize composer" : "Expand composer"}
+      onClick={() => (props.onMobileExpandedChange as (v: boolean) => void)?.(!(props.mobileExpanded as boolean))}
     >
-      Expand
+      {props.mobileExpanded ? "Minimize" : "Expand"}
     </button>
     {props.trailingContent as any}
   </div>
@@ -1143,6 +1143,49 @@ describe("MessageComposer", () => {
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
         else Reflect.deleteProperty(window, "visualViewport")
+      }
+    })
+
+    it("lets the minimize control leave fullscreen after the handle reaches its maximum", () => {
+      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const root = container.firstElementChild as HTMLElement
+      const handle = screen.getByTestId("composer-resize-handle")
+
+      fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
+      fireEvent.pointerMove(handle, { pointerId: 1, clientY: -600 })
+      expect(root).toHaveAttribute("data-composer-expanded", "true")
+
+      fireEvent.pointerUp(handle, { pointerId: 1, clientY: -600 })
+      fireEvent.click(screen.getByRole("button", { name: "Minimize composer" }))
+
+      expect(root).not.toHaveAttribute("data-composer-expanded")
+      expect(root.style.minHeight).toBe("")
+      expect(root.style.maxHeight).toBe("")
+    })
+
+    it("ignores a stale keyboard-sized visual viewport until an editor is focused", () => {
+      const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+      const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
+      const visualViewport = new EventTarget() as EventTarget & { height: number }
+      visualViewport.height = 400
+      Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport })
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 })
+      try {
+        const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+        const root = container.firstElementChild as HTMLElement
+
+        fireEvent.click(screen.getByRole("button", { name: "Expand composer" }))
+        expect(root.style.minHeight).toBe("800px")
+        expect(root.style.maxHeight).toBe("800px")
+
+        act(() => screen.getByTestId("rich-editor").focus())
+        expect(root.style.minHeight).toBe("400px")
+        expect(root.style.maxHeight).toBe("400px")
+      } finally {
+        if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+        else Reflect.deleteProperty(window, "visualViewport")
+        if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
+        else Reflect.deleteProperty(window, "innerHeight")
       }
     })
 

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -953,6 +953,27 @@ describe("MessageComposer", () => {
       expect((container.firstElementChild as HTMLElement).style.maxHeight).toBe("104px")
     })
 
+    it("grows the minimum height by the formatting toolbar so one editor line remains", () => {
+      localStorage.setItem("threa:composer-drag-height", "104")
+      const originalRect = HTMLElement.prototype.getBoundingClientRect
+      vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+        if (this.getAttribute("data-testid") === "composer-format-toolbar") {
+          return { ...originalRect.call(this), height: 40, bottom: 40 }
+        }
+        return originalRect.call(this)
+      })
+      const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
+      const root = container.firstElementChild as HTMLElement
+      expect(root.style.minHeight).toBe("104px")
+
+      fireEvent.click(screen.getByRole("button", { name: "Formatting" }))
+      expect(screen.getByTestId("composer-format-toolbar")).toBeInTheDocument()
+      expect(root.style.minHeight).toBe("144px")
+
+      fireEvent.click(screen.getByRole("button", { name: "Formatting" }))
+      expect(root.style.minHeight).toBe("104px")
+    })
+
     it("keeps the floor when 75% of a short viewport would dip below it", () => {
       const originalInnerHeight = window.innerHeight
       Object.defineProperty(window, "innerHeight", { configurable: true, value: 100 })

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -894,6 +894,24 @@ describe("MessageComposer", () => {
     })
   })
 
+  it("reports focused mobile typing only while the draft has text", () => {
+    isMobileMockValue = true
+    const onMobileTypingChange = vi.fn()
+    const draft: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Draft" }] }],
+    }
+    const { rerender } = render(
+      <MessageComposer {...defaultProps} content={draft} onMobileTypingChange={onMobileTypingChange} />
+    )
+
+    fireEvent.focus(screen.getByTestId("rich-editor"))
+    expect(onMobileTypingChange).toHaveBeenLastCalledWith(true)
+
+    rerender(<MessageComposer {...defaultProps} content={EMPTY_DOC} onMobileTypingChange={onMobileTypingChange} />)
+    expect(onMobileTypingChange).toHaveBeenLastCalledWith(false)
+  })
+
   describe("mobile drag-resize", () => {
     beforeEach(() => {
       isMobileMockValue = true
@@ -921,6 +939,7 @@ describe("MessageComposer", () => {
       // one-line floor: a 260px upward pull lands at 260px.
       fireEvent.pointerDown(handle, { pointerId: 1, clientY: 600 })
       fireEvent.pointerMove(handle, { pointerId: 1, clientY: 340 })
+      expect(root.style.minHeight).toBe("260px")
       expect(root.style.maxHeight).toBe("260px")
       fireEvent.pointerUp(handle, { pointerId: 1, clientY: 340 })
       expect(localStorage.getItem("threa:composer-drag-height")).toBe("260")
@@ -1099,24 +1118,28 @@ describe("MessageComposer", () => {
       try {
         const { container } = render(<MessageComposer {...defaultProps} workspaceId="ws_1" initialMobileChromeOpen />)
         const root = container.firstElementChild as HTMLElement
-        expect(root.style.maxHeight).toBe("600px")
+        expect(root.style.minHeight).toBe("700px")
+        expect(root.style.maxHeight).toBe("700px")
         act(() => screen.getByTestId("rich-editor").focus())
 
         visualViewport.height = 400
         act(() => visualViewport.dispatchEvent(new Event("resize")))
 
-        expect(root.style.maxHeight).toBe("200px")
+        expect(root.style.minHeight).toBe("400px")
+        expect(root.style.maxHeight).toBe("400px")
 
         const handle = screen.getByTestId("composer-resize-handle")
         fireEvent.pointerDown(handle, { pointerId: 1, clientY: 300 })
         fireEvent.pointerMove(handle, { pointerId: 1, clientY: 280 })
         fireEvent.pointerUp(handle, { pointerId: 1, clientY: 280 })
-        expect(root.style.maxHeight).toBe("200px")
+        expect(root.style.minHeight).toBe("400px")
+        expect(root.style.maxHeight).toBe("400px")
         expect(localStorage.getItem("threa:composer-drag-height")).toBe("700")
 
         visualViewport.height = 800
         act(() => visualViewport.dispatchEvent(new Event("resize")))
-        expect(root.style.maxHeight).toBe("600px")
+        expect(root.style.minHeight).toBe("700px")
+        expect(root.style.maxHeight).toBe("700px")
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
         else Reflect.deleteProperty(window, "visualViewport")
@@ -1138,14 +1161,13 @@ describe("MessageComposer", () => {
         visualViewport.height = 400
         act(() => visualViewport.dispatchEvent(new Event("resize")))
 
-        expect(root.style.minHeight).toBe("200px")
-        expect(root.style.maxHeight).toBe("200px")
+        expect(root.style.minHeight).toBe("400px")
+        expect(root.style.maxHeight).toBe("400px")
 
         visualViewport.height = 800
         act(() => visualViewport.dispatchEvent(new Event("resize")))
-        expect(root.style.minHeight).toBe("")
-        expect(root.style.maxHeight).toBe("")
-        expect(root).toHaveClass("min-h-[75dvh]", "max-h-[75dvh]")
+        expect(root.style.minHeight).toBe("800px")
+        expect(root.style.maxHeight).toBe("800px")
       } finally {
         if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
         else Reflect.deleteProperty(window, "visualViewport")

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -64,7 +64,6 @@ import { consumeComposerCommandRequest, subscribeComposerCommandRequest } from "
 
 const MOBILE_COMPOSER_DEFAULT_MAX_PX = 380
 const MOBILE_COMPOSER_KEYBOARD_MAX_RATIO = 0.5
-const MOBILE_COMPOSER_DRAG_MAX_RATIO = 0.75
 const MOBILE_KEYBOARD_SETTLE_MS = 350
 const MOBILE_ORIENTATION_SETTLE_MS = 600
 
@@ -210,6 +209,8 @@ export interface MessageComposerProps {
   initialMobileChromeOpen?: boolean
   /** Reports mobile focus/chrome changes so hosts can retire temporary layout slots after the keyboard closes. */
   onMobileChromeOpenChange?: (open: boolean) => void
+  /** Reports focused mobile composition with text so timeline chrome can yield to the draft. */
+  onMobileTypingChange?: (typing: boolean) => void
 
   /** Scope identifier — when it changes, re-focus the editor (if autoFocus) */
   scopeId?: string
@@ -301,6 +302,7 @@ export function MessageComposer({
   autoFocus = false,
   initialMobileChromeOpen = false,
   onMobileChromeOpenChange,
+  onMobileTypingChange,
   scopeId,
   onEditLastMessage,
   onEscapeBlur,
@@ -345,6 +347,8 @@ export function MessageComposer({
     width: visibleViewportWidth(),
   })
   const [mobileViewportHeight, setMobileViewportHeight] = useState(visibleViewportHeight)
+  const [mobileFullscreenHeight, setMobileFullscreenHeight] = useState(visibleViewportHeight)
+  const mobileFullscreenHeightRef = useRef(mobileFullscreenHeight)
   const [, refreshMobileGeometry] = useState(0)
   const [mobileKeyboardOpen, setMobileKeyboardOpen] = useState(false)
   const mobileKeyboardOpenRef = useRef(false)
@@ -355,10 +359,9 @@ export function MessageComposer({
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
   // User-chosen composer height from the drag handle (mobile, chrome open).
-  // Applied as a max-height so the composer stays content-driven below it:
-  // dragging down shrinks an overgrown draft to free the timeline, dragging
-  // up raises the growth cap. Persisted per device on release; a drag exits
-  // the 75dvh expanded preset, whose classes would otherwise outrank it.
+  // Once chosen it is an explicit height, so even an empty draft follows the
+  // handle. A never-resized composer remains content-driven under its natural
+  // cap. Persisted per device on release.
   const [mobileDragHeight, setMobileDragHeightState] = useState<number | null>(() => loadMobileComposerDragHeight())
   const mobileDragHeightRef = useRef(mobileDragHeight)
   const resizeDragRef = useRef<{
@@ -399,13 +402,13 @@ export function MessageComposer({
   const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current
     if (!drag || e.pointerId !== drag.pointerId) return
-    const maxPx = Math.max(closedViewportHeightRef.current * MOBILE_COMPOSER_DRAG_MAX_RATIO, drag.minPx)
+    const maxPx = Math.max(mobileFullscreenHeightRef.current, drag.minPx)
     const delta = drag.startY - e.clientY
     const growing = delta >= 0
     const baseHeight = growing ? Math.max(drag.startHeight, drag.startPreferredHeight) : drag.startHeight
     const preferenceCeiling = growing ? Math.max(maxPx, drag.startPreferredHeight) : maxPx
     const next = Math.round(Math.min(Math.max(baseHeight + delta, drag.minPx), preferenceCeiling))
-    setMobileExpanded(false)
+    setMobileExpanded(next === maxPx)
     mobileDragHeightRef.current = next
     setMobileDragHeightState(next)
   }, [])
@@ -471,14 +474,26 @@ export function MessageComposer({
         if (isEditableFocused()) return
         const height = visibleViewportHeight()
         closedViewportHeightRef.current = closedViewportHeightEstimate()
-        setMobileViewportHeight(height)
+        applyViewportGeometry(height)
         applyKeyboardState(false)
       }, MOBILE_KEYBOARD_SETTLE_MS)
+    }
+    const applyViewportGeometry = (height: number) => {
+      setMobileViewportHeight((current) => (current === height ? current : height))
+      const viewportTop = visualViewport?.offsetTop ?? 0
+      const viewportBottom = viewportTop + height
+      const zoneTop = root?.closest<HTMLElement>("[data-editor-zone]")?.getBoundingClientRect().top
+      const measuredRootBottom = root?.getBoundingClientRect().bottom ?? 0
+      const top = Math.max(zoneTop ?? viewportTop, viewportTop)
+      const bottom = Math.min(measuredRootBottom, viewportBottom)
+      const available = bottom > top ? Math.round(bottom - top) : height
+      mobileFullscreenHeightRef.current = available
+      setMobileFullscreenHeight((current) => (current === available ? current : available))
     }
     const measureKeyboardState = () => {
       const height = visibleViewportHeight()
       const focusedInside = !!root?.contains(document.activeElement)
-      setMobileViewportHeight((current) => (current === height ? current : height))
+      applyViewportGeometry(height)
       if (!focusedInside) {
         if (mobileKeyboardOpenRef.current) settleClosedViewport()
         else applyKeyboardState(false)
@@ -509,7 +524,7 @@ export function MessageComposer({
         closedViewportHeightRef.current =
           keyboardOpen || anotherEditorOwnsFocus ? expectedClosedHeight : closedViewportHeightEstimate()
         committedOrientationRef.current = { angle: orientationAngle(), width }
-        setMobileViewportHeight(height)
+        applyViewportGeometry(height)
         refreshMobileGeometry((version) => version + 1)
         applyKeyboardState(keyboardOpen)
       }, MOBILE_ORIENTATION_SETTLE_MS)
@@ -520,7 +535,7 @@ export function MessageComposer({
         committed.angle !== orientationAngle() ||
         (committed.width > 0 && visibleViewportWidth() > 0 && committed.width !== visibleViewportWidth())
       if (geometryChanged) {
-        setMobileViewportHeight(visibleViewportHeight())
+        applyViewportGeometry(visibleViewportHeight())
         settleGeometry()
         return
       }
@@ -528,7 +543,11 @@ export function MessageComposer({
       measureKeyboardState()
     }
     measure()
+    const editorZone = root?.closest<HTMLElement>("[data-editor-zone]")
+    const zoneObserver = editorZone ? new ResizeObserver(measure) : null
+    if (editorZone && zoneObserver) zoneObserver.observe(editorZone)
     visualViewport?.addEventListener("resize", measure)
+    visualViewport?.addEventListener("scroll", measure)
     window.addEventListener("resize", measure)
     window.addEventListener("orientationchange", measure)
     document.addEventListener("focusin", measure)
@@ -536,7 +555,9 @@ export function MessageComposer({
     return () => {
       clearTimeout(keyboardSettleId)
       clearTimeout(geometrySettleId)
+      zoneObserver?.disconnect()
       visualViewport?.removeEventListener("resize", measure)
+      visualViewport?.removeEventListener("scroll", measure)
       window.removeEventListener("resize", measure)
       window.removeEventListener("orientationchange", measure)
       document.removeEventListener("focusin", measure)
@@ -560,9 +581,14 @@ export function MessageComposer({
   const mobileChromeOpen = mobileFocused || voiceActive
   const mobileChromeOpenRef = useRef(mobileChromeOpen)
   mobileChromeOpenRef.current = mobileChromeOpen
+  const mobileTyping = isMobile && mobileFocused && !isEmptyContent(content)
   useEffect(() => {
     if (isMobile) onMobileChromeOpenChange?.(mobileChromeOpen)
   }, [isMobile, mobileChromeOpen, onMobileChromeOpenChange])
+  useEffect(() => {
+    onMobileTypingChange?.(mobileTyping)
+  }, [mobileTyping, onMobileTypingChange])
+  useEffect(() => () => onMobileTypingChange?.(false), [onMobileTypingChange])
 
   useLayoutEffect(() => {
     const drag = resizeDragRef.current
@@ -1447,21 +1473,16 @@ export function MessageComposer({
     mobileComposerFloor,
     Math.round(mobileViewportHeight * MOBILE_COMPOSER_KEYBOARD_MAX_RATIO)
   )
-  const mobileInlineMax = Math.max(
-    mobileComposerFloor,
-    Math.min(mobileDragHeight ?? MOBILE_COMPOSER_DEFAULT_MAX_PX, mobileKeyboardCap)
-  )
+  const mobileFullscreenCap = Math.max(mobileComposerFloor, mobileFullscreenHeight)
+  mobileFullscreenHeightRef.current = mobileFullscreenCap
   const mobileRootStyle = (() => {
     if (!isMobile || !mobileChromeOpen) return undefined
-    if (mobileKeyboardOpen) {
-      return mobileExpanded
-        ? { minHeight: mobileKeyboardCap, maxHeight: mobileKeyboardCap }
-        : { maxHeight: mobileInlineMax }
+    if (mobileExpanded) return { minHeight: mobileFullscreenCap, maxHeight: mobileFullscreenCap }
+    if (mobileDragHeight !== null) {
+      const explicitHeight = Math.min(Math.max(mobileDragHeight, mobileComposerFloor), mobileFullscreenCap)
+      return { minHeight: explicitHeight, maxHeight: explicitHeight }
     }
-    if (!mobileExpanded && mobileDragHeight !== null) {
-      const closedMax = Math.max(mobileComposerFloor, closedViewportHeightRef.current * MOBILE_COMPOSER_DRAG_MAX_RATIO)
-      return { maxHeight: Math.min(Math.max(mobileDragHeight, mobileComposerFloor), closedMax) }
-    }
+    if (mobileKeyboardOpen) return { maxHeight: mobileKeyboardCap }
     return undefined
   })()
 
@@ -1480,7 +1501,7 @@ export function MessageComposer({
             // docs/stream-timeline-perceived-performance.md). Snap instead, same
             // as the keyboard choreography.
             "flex flex-col",
-            mobileExpanded && !mobileKeyboardOpen ? "max-h-[75dvh] min-h-[75dvh]" : "max-h-[380px] min-h-0",
+            "max-h-[380px] min-h-0",
             className
           )}
           style={mobileRootStyle}

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -46,6 +46,7 @@ import { cn } from "@/lib/utils"
 import { COLLAPSED_COMPOSER_ROW, COLLAPSED_COMPOSER_SHADOW } from "@/components/composer/collapsed-composer-bar"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import {
+  clearMobileComposerDragHeight,
   loadMobileComposerDragHeight,
   persistMobileComposerDragHeight,
   MOBILE_COMPOSER_DRAG_MIN_PX,
@@ -426,10 +427,27 @@ export function MessageComposer({
     drag.ended = true
     if (mobileDragHeightRef.current !== null) persistMobileComposerDragHeight(mobileDragHeightRef.current)
     const settledAnchor = resizeScrollBottomRef.current
+    const restoreAnchor = () => {
+      const editorScroll = mobileEditorScrollRef.current
+      if (!editorScroll || settledAnchor === null) return
+      editorScroll.scrollTop = Math.max(0, editorScroll.scrollHeight - editorScroll.clientHeight - settledAnchor)
+      mobileEditorBottomOffsetRef.current = settledAnchor
+    }
     requestAnimationFrame(() => {
-      if (resizeDragRef.current === drag) resizeDragRef.current = null
-      if (resizeScrollBottomRef.current === settledAnchor) resizeScrollBottomRef.current = null
+      restoreAnchor()
+      requestAnimationFrame(() => {
+        restoreAnchor()
+        if (resizeDragRef.current === drag) resizeDragRef.current = null
+        if (resizeScrollBottomRef.current === settledAnchor) resizeScrollBottomRef.current = null
+      })
     })
+  }, [])
+  const handleMobileExpandedChange = useCallback((next: boolean) => {
+    setMobileExpanded(next)
+    if (next) return
+    mobileDragHeightRef.current = null
+    setMobileDragHeightState(null)
+    clearMobileComposerDragHeight()
   }, [])
   // Expanded-mode FAB actions are always visible on desktop. Touch has no hover,
   // so a tap on the "+" toggles them instead.
@@ -499,7 +517,11 @@ export function MessageComposer({
       const measuredRootBottom = root?.getBoundingClientRect().bottom ?? 0
       const top = Math.max(zoneTop ?? viewportTop, viewportTop)
       const bottom = Math.min(measuredRootBottom, viewportBottom)
-      const available = bottom > top ? Math.round(bottom - top) : effectiveHeight
+      const parentPaddingTop = root?.parentElement
+        ? Number.parseFloat(getComputedStyle(root.parentElement).paddingTop)
+        : 0
+      const topInset = Number.isFinite(parentPaddingTop) ? parentPaddingTop : 0
+      const available = Math.max(0, (bottom > top ? Math.round(bottom - top) : effectiveHeight) - topInset)
       mobileFullscreenHeightRef.current = available
       setMobileFullscreenHeight((current) => (current === available ? current : available))
     }
@@ -1673,7 +1695,7 @@ export function MessageComposer({
                         formatOpen={formatOpen}
                         onFormatOpenChange={setFormatOpen}
                         mobileExpanded={mobileExpanded}
-                        onMobileExpandedChange={setMobileExpanded}
+                        onMobileExpandedChange={handleMobileExpandedChange}
                         showAttach
                         onAttachClick={handleAttachClick}
                         side={actionSide}
@@ -1727,11 +1749,13 @@ export function MessageComposer({
               </div>
             </div>
 
-            <div className={cn("flex px-1 pt-1", mirrored ? "justify-start" : "justify-end")}>
-              <span className="text-[10px] text-muted-foreground opacity-60 hidden sm:block select-none pointer-events-none">
-                {sendHint}
-              </span>
-            </div>
+            {!isMobile && (
+              <div className={cn("flex px-1 pt-1", mirrored ? "justify-start" : "justify-end")}>
+                <span className="text-[10px] text-muted-foreground opacity-60 select-none pointer-events-none">
+                  {sendHint}
+                </span>
+              </div>
+            )}
           </ComposerPillDndHost>
         </div>
       </StashedDraftsComposerBridgeContext.Provider>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -358,6 +358,8 @@ export function MessageComposer({
   const mobileFormatToolbarRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
   const [mobileFormatToolbarHeight, setMobileFormatToolbarHeight] = useState(0)
+  const mobileFormatToolbarHeightRef = useRef(mobileFormatToolbarHeight)
+  mobileFormatToolbarHeightRef.current = mobileFormatToolbarHeight
   const [formatOpen, setFormatOpen] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
@@ -418,8 +420,9 @@ export function MessageComposer({
       return
     }
     setMobileExpanded(false)
-    mobileDragHeightRef.current = next
-    setMobileDragHeightState(next)
+    const nextPreference = Math.max(drag.minPx, next - mobileFormatToolbarHeightRef.current)
+    mobileDragHeightRef.current = nextPreference
+    setMobileDragHeightState(nextPreference)
   }, [])
   const handleResizePointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current
@@ -533,11 +536,11 @@ export function MessageComposer({
       const measuredRootBottom = root?.getBoundingClientRect().bottom ?? 0
       const top = Math.max(zoneTop ?? viewportTop, viewportTop)
       const bottom = Math.min(measuredRootBottom, viewportBottom)
-      const parentPaddingTop = root?.parentElement
-        ? Number.parseFloat(getComputedStyle(root.parentElement).paddingTop)
+      const parentPaddingBottom = root?.parentElement
+        ? Number.parseFloat(getComputedStyle(root.parentElement).paddingBottom)
         : 0
-      const topInset = Number.isFinite(parentPaddingTop) ? parentPaddingTop : 0
-      const available = Math.max(0, (bottom > top ? Math.round(bottom - top) : effectiveHeight) - topInset)
+      const fullscreenInset = Number.isFinite(parentPaddingBottom) ? parentPaddingBottom : 0
+      const available = Math.max(0, (bottom > top ? Math.round(bottom - top) : effectiveHeight) - fullscreenInset)
       mobileFullscreenHeightRef.current = available
       setMobileFullscreenHeight((current) => (current === available ? current : available))
     }
@@ -1519,10 +1522,13 @@ export function MessageComposer({
     )
   }
 
-  const mobileComposerFloor = MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight + mobileFormatToolbarHeight
-  const mobileKeyboardCap = Math.max(
-    mobileComposerFloor,
-    Math.round(mobileViewportHeight * MOBILE_COMPOSER_KEYBOARD_MAX_RATIO)
+  const mobileComposerBaseFloor = MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight
+  const mobileComposerFloor = mobileComposerBaseFloor + mobileFormatToolbarHeight
+  const mobileNaturalCap = Math.max(
+    mobileComposerBaseFloor,
+    mobileKeyboardOpen
+      ? Math.round(mobileViewportHeight * MOBILE_COMPOSER_KEYBOARD_MAX_RATIO)
+      : MOBILE_COMPOSER_DEFAULT_MAX_PX
   )
   const mobileFullscreenCap = Math.max(mobileComposerFloor, mobileFullscreenHeight)
   mobileFullscreenHeightRef.current = mobileFullscreenCap
@@ -1530,10 +1536,17 @@ export function MessageComposer({
     if (!isMobile || !mobileChromeOpen) return undefined
     if (mobileExpanded) return { minHeight: mobileFullscreenCap, maxHeight: mobileFullscreenCap }
     if (mobileDragHeight !== null) {
-      const explicitHeight = Math.min(Math.max(mobileDragHeight, mobileComposerFloor), mobileFullscreenCap)
+      const requestedHeight = Math.max(mobileDragHeight, mobileComposerBaseFloor) + mobileFormatToolbarHeight
+      const explicitHeight = Math.min(requestedHeight, mobileFullscreenCap)
       return { minHeight: explicitHeight, maxHeight: explicitHeight }
     }
-    if (mobileKeyboardOpen) return { maxHeight: mobileKeyboardCap }
+    if (mobileKeyboardOpen || mobileFormatToolbarHeight > 0) {
+      const naturalCap = Math.min(
+        Math.max(mobileComposerFloor, mobileNaturalCap + mobileFormatToolbarHeight),
+        mobileFullscreenCap
+      )
+      return { maxHeight: naturalCap }
+    }
     return undefined
   })()
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -355,7 +355,9 @@ export function MessageComposer({
   const mobileKeyboardOpenRef = useRef(false)
   const expandedShellRef = useRef<HTMLDivElement>(null)
   const actionBarWrapperRef = useRef<HTMLDivElement>(null)
+  const mobileFormatToolbarRef = useRef<HTMLDivElement>(null)
   const [mobileToolbarEditor, setMobileToolbarEditor] = useState<Editor | null>(null)
+  const [mobileFormatToolbarHeight, setMobileFormatToolbarHeight] = useState(0)
   const [formatOpen, setFormatOpen] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
@@ -470,6 +472,20 @@ export function MessageComposer({
   // chips), so without this the card takes the whole deficit and its action bar
   // spills below the viewport.
   const [mobileExtrasHeight, setMobileExtrasHeight] = useState(0)
+  useLayoutEffect(() => {
+    if (!isMobile || !formatOpen) {
+      setMobileFormatToolbarHeight(0)
+      return
+    }
+    const toolbar = mobileFormatToolbarRef.current
+    if (!toolbar) return
+    const measure = () => setMobileFormatToolbarHeight(Math.round(toolbar.getBoundingClientRect().height))
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(toolbar)
+    return () => observer.disconnect()
+  }, [formatOpen, isMobile])
+
   useLayoutEffect(() => {
     const root = mobileRootRef.current
     if (!isMobile || !root) return
@@ -1503,7 +1519,7 @@ export function MessageComposer({
     )
   }
 
-  const mobileComposerFloor = MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight
+  const mobileComposerFloor = MOBILE_COMPOSER_DRAG_MIN_PX + mobileExtrasHeight + mobileFormatToolbarHeight
   const mobileKeyboardCap = Math.max(
     mobileComposerFloor,
     Math.round(mobileViewportHeight * MOBILE_COMPOSER_KEYBOARD_MAX_RATIO)
@@ -1736,15 +1752,17 @@ export function MessageComposer({
 
                 {/* Mobile formatting toolbar — rendered below action bar, above keyboard */}
                 {isMobile && formatOpen && (
-                  <EditorToolbar
-                    editor={mobileToolbarEditor}
-                    isVisible
-                    inline
-                    inlinePosition="below"
-                    linkPopoverOpen={mobileLinkPopoverOpen}
-                    onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
-                    showSpecialInputControls
-                  />
+                  <div ref={mobileFormatToolbarRef} data-testid="composer-format-toolbar">
+                    <EditorToolbar
+                      editor={mobileToolbarEditor}
+                      isVisible
+                      inline
+                      inlinePosition="below"
+                      linkPopoverOpen={mobileLinkPopoverOpen}
+                      onLinkPopoverOpenChange={setMobileLinkPopoverOpen}
+                      showSpecialInputControls
+                    />
+                  </div>
                 )}
               </div>
             </div>

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -371,6 +371,7 @@ export function MessageComposer({
     minPx: number
     scrollBottomPx: number
     startPreferredHeight: number
+    ended: boolean
   } | null>(null)
   const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const root = mobileRootRef.current
@@ -397,27 +398,36 @@ export function MessageComposer({
       minPx: MOBILE_COMPOSER_DRAG_MIN_PX + Math.max(0, rootHeight - (cardHeight ?? rootHeight)),
       scrollBottomPx,
       startPreferredHeight: mobileDragHeightRef.current ?? rootHeight,
+      ended: false,
     }
   }, [])
   const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current
-    if (!drag || e.pointerId !== drag.pointerId) return
+    if (!drag || drag.ended || e.pointerId !== drag.pointerId) return
     const maxPx = Math.max(mobileFullscreenHeightRef.current, drag.minPx)
     const delta = drag.startY - e.clientY
     const growing = delta >= 0
     const baseHeight = growing ? Math.max(drag.startHeight, drag.startPreferredHeight) : drag.startHeight
     const preferenceCeiling = growing ? Math.max(maxPx, drag.startPreferredHeight) : maxPx
     const next = Math.round(Math.min(Math.max(baseHeight + delta, drag.minPx), preferenceCeiling))
-    setMobileExpanded(next === maxPx)
+    if (next === maxPx) {
+      setMobileExpanded(true)
+      return
+    }
+    setMobileExpanded(false)
     mobileDragHeightRef.current = next
     setMobileDragHeightState(next)
   }, [])
   const handleResizePointerEnd = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (resizeDragRef.current?.pointerId !== e.pointerId) return
-    resizeDragRef.current = null
+    const drag = resizeDragRef.current
+    if (!drag || drag.pointerId !== e.pointerId) return
+    // The last pointermove and pointerup can batch before React commits; keep
+    // the anchor record through that commit so the layout effect can restore it.
+    drag.ended = true
     if (mobileDragHeightRef.current !== null) persistMobileComposerDragHeight(mobileDragHeightRef.current)
     const settledAnchor = resizeScrollBottomRef.current
     requestAnimationFrame(() => {
+      if (resizeDragRef.current === drag) resizeDragRef.current = null
       if (resizeScrollBottomRef.current === settledAnchor) resizeScrollBottomRef.current = null
     })
   }, [])
@@ -479,14 +489,17 @@ export function MessageComposer({
       }, MOBILE_KEYBOARD_SETTLE_MS)
     }
     const applyViewportGeometry = (height: number) => {
-      setMobileViewportHeight((current) => (current === height ? current : height))
+      const phantomShrink =
+        !!visualViewport && !isEditableFocused() && height < window.innerHeight - KEYBOARD_VIEWPORT_THRESHOLD_PX
+      const effectiveHeight = phantomShrink ? window.innerHeight : height
+      setMobileViewportHeight((current) => (current === effectiveHeight ? current : effectiveHeight))
       const viewportTop = visualViewport?.offsetTop ?? 0
-      const viewportBottom = viewportTop + height
+      const viewportBottom = viewportTop + effectiveHeight
       const zoneTop = root?.closest<HTMLElement>("[data-editor-zone]")?.getBoundingClientRect().top
       const measuredRootBottom = root?.getBoundingClientRect().bottom ?? 0
       const top = Math.max(zoneTop ?? viewportTop, viewportTop)
       const bottom = Math.min(measuredRootBottom, viewportBottom)
-      const available = bottom > top ? Math.round(bottom - top) : height
+      const available = bottom > top ? Math.round(bottom - top) : effectiveHeight
       mobileFullscreenHeightRef.current = available
       setMobileFullscreenHeight((current) => (current === available ? current : available))
     }

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -74,6 +74,8 @@ interface MessageInputProps {
    * synchronously instead of debouncing.
    */
   onComposerHeightChange?: (px: number, opts: { initial: boolean }) => void
+  /** Notifies the timeline when focused mobile typing should suppress floating chrome. */
+  onMobileTypingChange?: (typing: boolean) => void
 }
 
 function attachmentMatchKey(attachment: Pick<PendingAttachment, "filename" | "mimeType">): string {
@@ -256,6 +258,7 @@ function MessageInputComponent({
   disabledReason,
   autoFocus,
   onComposerHeightChange,
+  onMobileTypingChange,
 }: MessageInputProps) {
   const editLastCtx = useEditLastMessage()
   const triggerEditLast = editLastCtx?.triggerEditLast
@@ -1000,6 +1003,7 @@ function MessageInputComponent({
     messageSendMode,
     onComposerFocus,
     onMobileChromeOpenChange: handleMobileChromeOpenChange,
+    onMobileTypingChange,
     scopeId: streamId,
     onEditLastMessage: triggerEditLast
       ? () => {

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -293,16 +293,16 @@ describe("mobile rollup and drawer", () => {
     expect(screen.queryByText("context-ref-pill")).not.toBeInTheDocument()
   })
 
-  it("folds the chips away behind the rollup line and restores them", () => {
+  it("starts folded behind the rollup line and lets the user reveal the chips", () => {
     render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
-    expect(screen.getByText("ok.png")).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole("button", { name: "Hide attachment chips" }))
     expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Show all attachments" })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Show attachment chips" }))
     expect(screen.getByText("ok.png")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide attachment chips" }))
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
   })
 
   it("opens the drawer with full filenames, live status, and per-row recovery", () => {

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -305,6 +305,19 @@ describe("mobile rollup and drawer", () => {
     expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
   })
 
+  it("resets to each responsive mode's default when the input mode changes", () => {
+    const { rerender } = render(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
+
+    vi.mocked(usePointerModule.useIsMobileOrCoarse).mockReturnValue(false)
+    rerender(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(screen.getByText("ok.png")).toBeInTheDocument()
+
+    vi.mocked(usePointerModule.useIsMobileOrCoarse).mockReturnValue(true)
+    rerender(<PendingAttachments attachments={files} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(screen.queryByText("ok.png")).not.toBeInTheDocument()
+  })
+
   it("opens the drawer with full filenames, live status, and per-row recovery", () => {
     const retrySpy = vi.spyOn(uploadManager, "retryUpload").mockResolvedValue(undefined)
     const onRemove = vi.fn()

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -177,6 +177,8 @@ describe("tray pill drag", () => {
 
     vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
     const mobile = render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+    expect(screen.queryByText("screenshot.png")).toBeNull()
+    fireEvent.click(screen.getByRole("button", { name: "Show attachment chips" }))
     // A single horizontal row hid everything past the fold and fought the
     // page's own scroll axis — the tray wraps and scrolls vertically now.
     expect(mobile.container.querySelector(".overflow-x-auto")).toBeNull()

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -476,11 +476,10 @@ export function PendingAttachments({
 }: PendingAttachmentsProps) {
   const isMobile = useIsMobileOrCoarse()
   const dragHost = useComposerPillDragHost()
-  // Mobile space controls: the chips can be folded away to the one-line rollup
-  // (the composer already competes with the keyboard for the viewport), and the
-  // drawer holds the full list. Both are per-mount — a fresh composer starts
-  // with its chips showing.
-  const [collapsed, setCollapsed] = useState(false)
+  // Mobile space controls: start at the one-line rollup because the composer
+  // already competes with the keyboard for the viewport; the drawer holds the
+  // full list. Desktop keeps the chips open.
+  const [collapsed, setCollapsed] = useState(isMobile)
   const [drawerOpen, setDrawerOpen] = useState(false)
   // True from close until vaul's exit animation lands, so removing the last
   // attachment from the open sheet slides it out instead of snapping the whole

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from "react"
 import {
   Loader2,
   FileText,
@@ -480,6 +480,7 @@ export function PendingAttachments({
   // already competes with the keyboard for the viewport; the drawer holds the
   // full list. Desktop keeps the chips open.
   const [collapsed, setCollapsed] = useState(isMobile)
+  useLayoutEffect(() => setCollapsed(isMobile), [isMobile])
   const [drawerOpen, setDrawerOpen] = useState(false)
   // True from close until vaul's exit animation lands, so removing the last
   // attachment from the open sheet slides it out instead of snapping the whole

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -12,6 +12,7 @@ import {
   remapSuppressedWatermark,
   resolveStreamLanding,
   isChromeStripCollapsed,
+  isTypingChromeHidden,
   buildAgentActivitySummary,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
@@ -527,6 +528,14 @@ describe("isChromeStripCollapsed", () => {
   it("uses the strip (scroller minus composer), not the raw scroller height", () => {
     expect(isChromeStripCollapsed(800, 700)).toBe(true)
     expect(isChromeStripCollapsed(800, 0)).toBe(false)
+  })
+})
+
+describe("isTypingChromeHidden", () => {
+  it("hides date and jump chrome throughout focused mobile typing", () => {
+    expect(isTypingChromeHidden(false, true)).toBe(true)
+    expect(isTypingChromeHidden(true, false)).toBe(true)
+    expect(isTypingChromeHidden(false, false)).toBe(false)
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -460,6 +460,10 @@ export function isChromeStripCollapsed(scrollerClientHeightPx: number, composerH
   return scrollerClientHeightPx - composerHeightPx < CHROME_MIN_STRIP_PX
 }
 
+export function isTypingChromeHidden(stripCollapsed: boolean, mobileComposerTyping: boolean): boolean {
+  return stripCollapsed || mobileComposerTyping
+}
+
 /**
  * Atomic stream landing (INV-70): the ONE decision about where the viewport
  * starts when a stream opens. Exactly one verdict per stream open, priority:
@@ -651,6 +655,7 @@ export function StreamContent({
   const [deepLinkHoldExpired, setDeepLinkHoldExpired] = useState(false)
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [mobileComposerTyping, setMobileComposerTyping] = useState(false)
   // True while an out-of-window search navigation is fetching its event window —
   // drives the search bar's spinner so a tap that needs a round-trip is visibly
   // loading instead of appearing dead. Versioned so a superseding navigation's
@@ -1676,6 +1681,8 @@ export function StreamContent({
     // isLoading: the plain (thread) scroller mounts behind the loading
     // skeleton, and only a state dep re-runs this effect once it exists.
   }, [useVirtualized, virtualScrollerEl, plainScrollRef, isLoading, streamId])
+
+  const typingChromeHidden = isTypingChromeHidden(chromeCollapsed, mobileComposerTyping)
 
   const handleComposerHeightChange = useCallback(
     (_px: number, opts: { initial: boolean }) => {
@@ -2995,7 +3002,7 @@ export function StreamContent({
                           batchPointerHandlers={batchPointerHandlers}
                           conversationOverlay={activeConversationOverlay}
                           onJumpToDate={handleJumpToDate}
-                          chromeCollapsed={chromeCollapsed}
+                          floatingChromeHidden={typingChromeHidden}
                         />
                         {/* Overlay loading indicators — absolutely positioned so they
                     don't cause layout shift when prepending older messages. */}
@@ -3081,9 +3088,9 @@ export function StreamContent({
                     )}
                   </div>
                   {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
-              Positioned above the floating composer pill. Hidden while the
-              strip above the composer is too short to overlay (chromeCollapsed). */}
-                  {(isJumpMode || isScrolledFarFromBottom) && !chromeCollapsed && (
+              Positioned above the floating composer pill. Hidden when that
+              strip is too short or focused mobile typing needs the space. */}
+                  {(isJumpMode || isScrolledFarFromBottom) && !typingChromeHidden && (
                     <div
                       className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
                       style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
@@ -3213,6 +3220,7 @@ export function StreamContent({
                       disabledReason={disabledReason}
                       autoFocus={autoFocus}
                       onComposerHeightChange={handleComposerHeightChange}
+                      onMobileTypingChange={setMobileComposerTyping}
                     />
                   )}
                 </div>
@@ -3266,7 +3274,7 @@ function TimelineMessageList({
   batchPointerHandlers,
   conversationOverlay,
   onJumpToDate,
-  chromeCollapsed,
+  floatingChromeHidden,
 }: {
   visibleItems: TimelineItem[]
   cancelledFollowUpIds: Set<string>
@@ -3329,8 +3337,8 @@ function TimelineMessageList({
   conversationOverlay?: ConversationOverlayContext
   /** Jump to the first message on or after a date (floating date header). */
   onJumpToDate: (date: Date) => void
-  /** True while the strip above the composer is too short for floating chrome. */
-  chromeCollapsed: boolean
+  /** True while floating date/jump chrome must yield to the composer. */
+  floatingChromeHidden: boolean
 }) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
@@ -3711,7 +3719,7 @@ function TimelineMessageList({
       </div>
       <StreamDateHeader
         dayStartMs={topDayMs}
-        visible={datePillVisible && !chromeCollapsed}
+        visible={datePillVisible && !floatingChromeHidden}
         onJumpToDate={onJumpToDate}
         scrollerRef={scrollerRef}
       />

--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -3,6 +3,7 @@ import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile"
 import {
   applyPersistedComposerHeight,
   persistComposerHeight,
+  clearMobileComposerDragHeight,
   loadMobileComposerDragHeight,
   persistMobileComposerDragHeight,
   MOBILE_COMPOSER_DRAG_MIN_PX,
@@ -147,6 +148,12 @@ describe("mobile composer drag height", () => {
   it("accepts the compact one-line floor", () => {
     persistMobileComposerDragHeight(MOBILE_COMPOSER_DRAG_MIN_PX)
     expect(loadMobileComposerDragHeight()).toBe(104)
+  })
+
+  it("clears the dragged height when minimizing to the natural default", () => {
+    persistMobileComposerDragHeight(287)
+    clearMobileComposerDragHeight()
+    expect(loadMobileComposerDragHeight()).toBeNull()
   })
 
   it("returns null when never dragged", () => {

--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -156,6 +156,12 @@ describe("mobile composer drag height", () => {
     expect(loadMobileComposerDragHeight()).toBeNull()
   })
 
+  it("persists fullscreen heights allowed by a tall coarse-pointer viewport", () => {
+    vi.stubGlobal("visualViewport", { width: 1024, height: 1366 })
+    persistMobileComposerDragHeight(1300)
+    expect(loadMobileComposerDragHeight()).toBe(1300)
+  })
+
   it("returns null when never dragged", () => {
     expect(loadMobileComposerDragHeight()).toBeNull()
   })

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -174,6 +174,15 @@ export function persistMobileComposerDragHeight(heightPx: number): void {
   }
 }
 
+export function clearMobileComposerDragHeight(): void {
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.removeItem(STORAGE_KEY_DRAG_HEIGHT)
+  } catch {
+    // Storage failures shouldn't prevent the composer from minimizing.
+  }
+}
+
 /**
  * Persists a freshly-measured composer height for the next page load, keyed by
  * the current viewport so mobile and desktop never seed each other's fallback.

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -140,9 +140,20 @@ const STORAGE_KEY_DRAG_HEIGHT = "threa:composer-drag-height"
 
 /** Mobile card floor: border + padding + one editor line + gap + action bar. */
 export const MOBILE_COMPOSER_DRAG_MIN_PX = 104
-// Sanity ceiling for persisted values only — the live drag clamps to 75% of
-// the visual viewport, which no phone exceeds.
-const MAX_DRAG_HEIGHT_PX = 1200
+const MIN_DRAG_SANITY_CEILING_PX = 1200
+
+function mobileDragSanityCeiling(): number {
+  if (typeof window === "undefined") return MIN_DRAG_SANITY_CEILING_PX
+  return Math.max(
+    MIN_DRAG_SANITY_CEILING_PX,
+    window.innerWidth,
+    window.innerHeight,
+    window.screen?.width ?? 0,
+    window.screen?.height ?? 0,
+    window.visualViewport?.width ?? 0,
+    window.visualViewport?.height ?? 0
+  )
+}
 
 /**
  * The user-chosen mobile composer height from the drag handle (a max-height:
@@ -156,7 +167,7 @@ export function loadMobileComposerDragHeight(): number | null {
     if (!raw) return null
     const parsed = Number.parseInt(raw, 10)
     if (!Number.isFinite(parsed)) return null
-    if (parsed < MOBILE_COMPOSER_DRAG_MIN_PX || parsed > MAX_DRAG_HEIGHT_PX) return null
+    if (parsed < MOBILE_COMPOSER_DRAG_MIN_PX || parsed > mobileDragSanityCeiling()) return null
     return parsed
   } catch {
     return null
@@ -166,7 +177,7 @@ export function loadMobileComposerDragHeight(): number | null {
 export function persistMobileComposerDragHeight(heightPx: number): void {
   if (typeof localStorage === "undefined") return
   const rounded = Math.round(heightPx)
-  if (rounded < MOBILE_COMPOSER_DRAG_MIN_PX || rounded > MAX_DRAG_HEIGHT_PX) return
+  if (rounded < MOBILE_COMPOSER_DRAG_MIN_PX || rounded > mobileDragSanityCeiling()) return
   try {
     localStorage.setItem(STORAGE_KEY_DRAG_HEIGHT, String(rounded))
   } catch {

--- a/tests/browser/composer-attachment-tray-mobile.spec.ts
+++ b/tests/browser/composer-attachment-tray-mobile.spec.ts
@@ -48,7 +48,9 @@ test("dragging the composer down never slices the attachment chips", async ({ pa
     mimeType: "video/mp4",
     buffer: Buffer.alloc(2048, 7),
   })
-  await expect(page.getByTestId("attachment-chip-row")).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByRole("button", { name: "Show attachment chips" })).toBeVisible({ timeout: 20_000 })
+  await page.getByRole("button", { name: "Show attachment chips" }).click()
+  await expect(page.getByTestId("attachment-chip-row")).toBeVisible()
 
   await editor.click()
   await editor.pressSequentially(DRAFT.repeat(3), { delay: 1 })
@@ -104,6 +106,9 @@ test("dragging the composer down never slices the attachment chips", async ({ pa
       buffer: Buffer.alloc(1024, n),
     }))
   )
+  await expect(page.getByRole("button", { name: "Show attachment chips" })).toBeVisible({ timeout: 20_000 })
+  await page.getByRole("button", { name: "Show attachment chips" }).click()
+  await expect(page.getByTestId("attachment-chip-row")).toBeVisible()
   await expect
     .poll(
       () =>

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -131,11 +131,13 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120)
   await page.mouse.up()
 
+  await expect
+    .poll(async () => Math.abs((await measure()).scrollBottom - constrained.scrollBottom))
+    .toBeLessThanOrEqual(1)
   const after = await measure()
   expect(after.cardHeight).toBeLessThan(constrained.cardHeight)
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
-  expect(Math.abs(after.scrollBottom - constrained.scrollBottom)).toBeLessThanOrEqual(1)
   expect(await editor.textContent()).toBe(contentBeforeResize)
   await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -49,25 +49,6 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await expect(handle).toBeVisible()
   await page.setViewportSize(PHONE)
 
-  const emptyBefore = (await card.boundingBox())!
-  const emptyHandle = (await handle.boundingBox())!
-  await page.mouse.move(emptyHandle.x + emptyHandle.width / 2, emptyHandle.y + emptyHandle.height / 2)
-  await page.mouse.down()
-  await page.mouse.move(emptyHandle.x + emptyHandle.width / 2, emptyHandle.y + emptyHandle.height / 2 - 100)
-  await page.mouse.up()
-  const emptyAfter = (await card.boundingBox())!
-  expect(emptyAfter.height).toBeGreaterThan(emptyBefore.height + 80)
-  expect(emptyAfter.y + emptyAfter.height).toBeCloseTo(emptyBefore.y + emptyBefore.height, 0)
-
-  await page.getByRole("button", { name: "Expand editor" }).click()
-  await expect(page.getByRole("button", { name: "Minimize editor" })).toBeVisible()
-  const fullscreenTop = await card.evaluate((el) => Math.round(el.getBoundingClientRect().top))
-  const editorZoneTop = await page
-    .locator('[data-editor-zone="main"]')
-    .evaluate((el) => Math.round(el.getBoundingClientRect().top))
-  expect(Math.abs(fullscreenTop - editorZoneTop)).toBeLessThanOrEqual(1)
-  await page.getByRole("button", { name: "Minimize editor" }).click()
-
   await editor.click()
   for (let i = 1; i <= 24; i++) {
     await editor.pressSequentially(`line ${i}`)
@@ -150,13 +131,11 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120)
   await page.mouse.up()
 
-  await expect
-    .poll(async () => Math.abs((await measure()).scrollBottom - constrained.scrollBottom))
-    .toBeLessThanOrEqual(1)
   const after = await measure()
   expect(after.cardHeight).toBeLessThan(constrained.cardHeight)
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
+  expect(Math.abs(after.scrollBottom - constrained.scrollBottom)).toBeLessThanOrEqual(1)
   expect(await editor.textContent()).toBe(contentBeforeResize)
   await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -155,5 +155,17 @@ test("mobile composer resizes from its top edge without losing the editor bottom
 
   await page.getByRole("button", { name: "Minimize editor" }).click()
   await expect.poll(async () => Math.round((await card.boundingBox())!.height)).toBeLessThan(fullscreen.height)
+
+  const minHandle = (await handle.boundingBox())!
+  await page.mouse.move(minHandle.x + minHandle.width / 2, minHandle.y + minHandle.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(minHandle.x + minHandle.width / 2, minHandle.y + minHandle.height / 2 + 500)
+  await page.mouse.up()
+  const compactHeight = Math.round((await card.boundingBox())!.height)
+
+  await page.getByRole("button", { name: "Formatting" }).click()
+  await expect(page.getByTestId("composer-format-toolbar")).toBeVisible()
+  await expect.poll(async () => Math.round((await card.boundingBox())!.height)).toBeGreaterThan(compactHeight)
+  expect(Math.round((await scroller.boundingBox())!.height)).toBeGreaterThanOrEqual(20)
   await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -139,5 +139,21 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
   expect(await editor.textContent()).toBe(contentBeforeResize)
+
+  await page.getByRole("button", { name: "Expand editor" }).click()
+  await expect(page.getByRole("button", { name: "Minimize editor" })).toBeVisible()
+  const fullscreen = await page.evaluate(() => {
+    const zone = document.querySelector('[data-editor-zone="main"]')!.getBoundingClientRect()
+    const card = document.querySelector("[data-message-composer-root] [data-composer-card]")!.getBoundingClientRect()
+    return {
+      height: Math.round(card.height),
+      topGap: Math.round(card.top - zone.top),
+      bottomGap: Math.round(zone.bottom - card.bottom),
+    }
+  })
+  expect(Math.abs(fullscreen.topGap - fullscreen.bottomGap)).toBeLessThanOrEqual(1)
+
+  await page.getByRole("button", { name: "Minimize editor" }).click()
+  await expect.poll(async () => Math.round((await card.boundingBox())!.height)).toBeLessThan(fullscreen.height)
   await context.close()
 })

--- a/tests/browser/composer-resize-mobile.spec.ts
+++ b/tests/browser/composer-resize-mobile.spec.ts
@@ -49,6 +49,25 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await expect(handle).toBeVisible()
   await page.setViewportSize(PHONE)
 
+  const emptyBefore = (await card.boundingBox())!
+  const emptyHandle = (await handle.boundingBox())!
+  await page.mouse.move(emptyHandle.x + emptyHandle.width / 2, emptyHandle.y + emptyHandle.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(emptyHandle.x + emptyHandle.width / 2, emptyHandle.y + emptyHandle.height / 2 - 100)
+  await page.mouse.up()
+  const emptyAfter = (await card.boundingBox())!
+  expect(emptyAfter.height).toBeGreaterThan(emptyBefore.height + 80)
+  expect(emptyAfter.y + emptyAfter.height).toBeCloseTo(emptyBefore.y + emptyBefore.height, 0)
+
+  await page.getByRole("button", { name: "Expand editor" }).click()
+  await expect(page.getByRole("button", { name: "Minimize editor" })).toBeVisible()
+  const fullscreenTop = await card.evaluate((el) => Math.round(el.getBoundingClientRect().top))
+  const editorZoneTop = await page
+    .locator('[data-editor-zone="main"]')
+    .evaluate((el) => Math.round(el.getBoundingClientRect().top))
+  expect(Math.abs(fullscreenTop - editorZoneTop)).toBeLessThanOrEqual(1)
+  await page.getByRole("button", { name: "Minimize editor" }).click()
+
   await editor.click()
   for (let i = 1; i <= 24; i++) {
     await editor.pressSequentially(`line ${i}`)
@@ -131,11 +150,13 @@ test("mobile composer resizes from its top edge without losing the editor bottom
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120)
   await page.mouse.up()
 
+  await expect
+    .poll(async () => Math.abs((await measure()).scrollBottom - constrained.scrollBottom))
+    .toBeLessThanOrEqual(1)
   const after = await measure()
   expect(after.cardHeight).toBeLessThan(constrained.cardHeight)
   expect(after.cardTop).toBeGreaterThan(constrained.cardTop)
   expect(after.cardBottom).toBeCloseTo(constrained.cardBottom, 0)
-  expect(Math.abs(after.scrollBottom - constrained.scrollBottom)).toBeLessThanOrEqual(1)
   expect(await editor.textContent()).toBe(contentBeforeResize)
   await context.close()
 })


### PR DESCRIPTION
## Problem

The mobile resize handle only changed a content-driven maximum, so short and empty drafts did not visibly resize. The expand control stopped at 75% of the viewport, and keyboard-open mode capped the composer at 50%, leaving usable space above it. Attachment chips and floating timeline controls also competed with the draft for the remaining vertical space.

## Solution

- Treat a dragged size as an explicit height while preserving the existing natural-growth cap until the user resizes.
- Compute fullscreen height from the editor zone and visual viewport. Resize and scroll events keep it fitted during keyboard, orientation, and iOS viewport-pan changes.
- Make drag-to-maximum enter the expand preset without overwriting the previous size. Minimize clears the manual preference and returns to the natural default cap.
- Match the fullscreen top inset to the shell bottom padding, including coarse-pointer `sm` layouts where the responsive top and bottom paddings differ.
- Ignore keyboard-sized visual viewport reports without editable focus, matching the app shell phantom-shrink guard used during Android resume.
- Keep the editor bottom anchored when pointermove and pointerup land in one React commit and while the browser settles the next two frames.
- Measure the open mobile formatting toolbar and grow natural or manually sized composers by that height until fullscreen headroom is exhausted, retaining one visible text line at minimum.
- Start mobile attachment trays at the file-count row and reset to each mode default when responsive input mode changes; users can still reveal chips or open the full drawer.
- Derive the persisted drag-height sanity ceiling from live device and visual viewport geometry so tall coarse-pointer tablets retain their chosen size.
- Report focused mobile drafts with text to `StreamContent`, which hides the date pill and Jump to latest control until typing ends.

## Verification

- [x] 164 focused frontend tests; 1 Playwright mobile composer test; repository lint and all workspace typechecks via commit hooks.

## Residual risk

Physical iOS keyboard behavior is not available in CI. The implementation follows both `visualViewport.resize` and `visualViewport.scroll`, while browser coverage uses a simulated visual viewport.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_


