### PR TITLE
fix: wake frozen timelines when the app regains focus

### DIFF
--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -4,29 +4,9 @@ import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { useConversationBackfillMessages } from "@/stores/conversation-messages-store"
 import type { RenderableMessage } from "@/components/message/message-item"
-import { StreamTypes, BOARD_EVENT_ROW_TYPES, type AuthorType, type EventType } from "@threa/types"
+import { StreamTypes, type AuthorType } from "@threa/types"
+import { BOARD_RAIL_EVENT_TYPES } from "@/lib/board/board-rail-event-types"
 import type { BoardViewPost } from "./use-stable-board-view"
-
-/**
- * Event types the board rail reads alongside `message_created`: the non-message
- * rows the board draws (agent sessions, memo captures, follow-ups, delegations,
- * command chips — the whole command lifecycle derives, so completed/failed reach
- * the card that its dispatch named —
- * derived from the shared STREAM_ROW_SPEC) plus the two patches that carry no row
- * of their own: `agent:follow_up_cancelled` flips a scheduled card to "Cancelled",
- * `delegation:status_changed` advances a delegation card's status. Registering a
- * new conversation-scoped row kind in the spec adds it here automatically; a
- * PATCH-classed type never derives, so it is listed by hand. Adding a row type
- * whose live updates arrive as a patch means adding that patch HERE too —
- * `board-event-rows.test.ts` ("BOARD_RAIL_EVENT_TYPES covers every patch
- * belonging to a board row type") holds this list to it.
- */
-export const BOARD_RAIL_EVENT_TYPES: EventType[] = [
-  ...BOARD_EVENT_ROW_TYPES,
-  "agent:follow_up_cancelled",
-  "delegation:status_changed",
-  "message_created",
-]
 
 interface MessageCreatedPayloadShape {
   messageId?: string

--- a/apps/frontend/src/hooks/use-page-resume.test.ts
+++ b/apps/frontend/src/hooks/use-page-resume.test.ts
@@ -61,6 +61,19 @@ describe("usePageResume", () => {
     expect(onResume).not.toHaveBeenCalled()
   })
 
+  it("reports short away durations when the caller uses a zero threshold", () => {
+    const onResume = vi.fn()
+    renderHook(() => usePageResume(onResume, 0))
+
+    act(() => {
+      setVisibility("hidden")
+      vi.advanceTimersByTime(2_500)
+      setVisibility("visible")
+    })
+
+    expect(onResume).toHaveBeenCalledWith(2_500)
+  })
+
   it("fires exactly once when hide meets the threshold", () => {
     const onResume = vi.fn()
     renderHook(() => usePageResume(onResume, 10_000))

--- a/apps/frontend/src/hooks/use-page-resume.ts
+++ b/apps/frontend/src/hooks/use-page-resume.ts
@@ -32,9 +32,13 @@ const DEFAULT_AWAY_THRESHOLD_MS = 10_000
  * both `visibilitychange` and a window `blur`/`focus` pair (and, on a bfcache
  * round-trip, `pagehide`/`pageshow` too) — still resumes exactly once.
  *
- * `onResume` is stored in a ref so consumers don't need to memoize.
+ * `onResume` receives the elapsed away time and is stored in a ref so
+ * consumers don't need to memoize.
  */
-export function usePageResume(onResume: () => void, awayThresholdMs: number = DEFAULT_AWAY_THRESHOLD_MS): void {
+export function usePageResume(
+  onResume: (awayDurationMs: number) => void,
+  awayThresholdMs: number = DEFAULT_AWAY_THRESHOLD_MS
+): void {
   const onResumeRef = useRef(onResume)
   onResumeRef.current = onResume
 
@@ -49,8 +53,9 @@ export function usePageResume(onResume: () => void, awayThresholdMs: number = DE
       // Only resume once the page is genuinely active again — a stray focus
       // event while the tab is still hidden must not consume the away window.
       if (document.visibilityState !== "visible") return
-      if (awaySince !== null && Date.now() - awaySince >= awayThresholdMs) {
-        onResumeRef.current()
+      const awayDurationMs = awaySince === null ? null : Date.now() - awaySince
+      if (awayDurationMs !== null && awayDurationMs >= awayThresholdMs) {
+        onResumeRef.current(awayDurationMs)
       }
       awaySince = null
     }

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { BOARD_EVENT_ROW_TYPES, EVENT_TYPES, STREAM_ROW_SPEC, type EventType } from "@threa/types"
 import type { CachedEvent } from "@/db"
-import { BOARD_RAIL_EVENT_TYPES } from "@/hooks/use-board-card-messages"
+import { BOARD_RAIL_EVENT_TYPES } from "./board-rail-event-types"
 import { resolveBoardEventRows } from "./board-event-rows"
 
 let seq = 0

--- a/apps/frontend/src/lib/board/board-rail-event-types.ts
+++ b/apps/frontend/src/lib/board/board-rail-event-types.ts
@@ -1,0 +1,9 @@
+import { BOARD_EVENT_ROW_TYPES, type EventType } from "@threa/types"
+
+/** Messages, board rows, and the patch-only events folded into scheduled and delegation cards. */
+export const BOARD_RAIL_EVENT_TYPES: EventType[] = [
+  ...BOARD_EVENT_ROW_TYPES,
+  "agent:follow_up_cancelled",
+  "delegation:status_changed",
+  "message_created",
+]

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -312,17 +312,17 @@ function WorkspaceSyncHandler({
     }
   }, [isOnline, socket, syncEngine])
 
-  // Visibility-resume trigger: on phone/tab resume after a background gap,
-  // probe the socket and refresh state. navigator.onLine doesn't flap in that
-  // scenario and socket.io's native pingTimeout can take 20–25s to notice a
-  // zombie transport. The 5s threshold is tight enough that a few seconds away
-  // (a notification-shade peek that delivered a push, a brief tab switch) still
-  // triggers a catch-up — the engine owns the whole resume window now, so there
-  // is no separate lighter freshness hook below the probe threshold. The hook
-  // stores the callback in a ref, so no memoization needed.
-  usePageResume(() => {
+  // Re-read visible event windows after every real away/back cycle: Android can
+  // freeze the PWA and let the service worker write a pushed message even during
+  // a sub-5s app switch. Socket probing and network catch-up keep the threshold
+  // because those are unnecessary for momentary focus loss.
+  usePageResume((awayDurationMs) => {
+    if (awayDurationMs < PAGE_RESUME_THRESHOLD_MS) {
+      void syncEngine.refreshVisibleEventReads()
+      return
+    }
     void syncEngine.handlePageResume()
-  }, PAGE_RESUME_THRESHOLD_MS)
+  }, 0)
 
   // No destroy effect — StrictMode's effect cleanup cycle would destroy the
   // engine before the socket connect effect re-runs. The engine is destroyed

--- a/apps/frontend/src/stores/stream-event-read-refresh.ts
+++ b/apps/frontend/src/stores/stream-event-read-refresh.ts
@@ -1,11 +1,12 @@
 import Dexie from "dexie"
-import { db } from "@/db"
+import { db, type CachedEvent } from "@/db"
+import { BOARD_RAIL_EVENT_TYPES } from "@/lib/board/board-rail-event-types"
 
 /**
  * Wake the main thread's event live queries after a backgrounded service worker
- * may have written rows while the page was frozen. Touching the newest row is
- * enough for Dexie to invalidate the stream's indexed ranges and re-read every
- * row the worker added; a plain read cannot restore a missed mutation signal.
+ * may have written rows while the page was frozen. Touch one row in each index
+ * range shape mounted event consumers observe; a plain read cannot restore a
+ * missed mutation signal.
  */
 export async function requestStreamEventReadRefresh(streamIds: string[]): Promise<void> {
   const table = db.events
@@ -18,8 +19,18 @@ export async function requestStreamEventReadRefresh(streamIds: string[]): Promis
         .where("[streamId+_sequenceNum]")
         .between([streamId, Dexie.minKey], [streamId, Dexie.maxKey], true, true)
         .last()
-      if (!latest) continue
-      await table.put({ ...latest, _cachedAt: Math.max(Date.now(), latest._cachedAt + 1) })
+      const latestBoardRailEvent = await table
+        .where("[streamId+eventType]")
+        .anyOf(BOARD_RAIL_EVENT_TYPES.map((eventType) => [streamId, eventType]))
+        .first()
+      const latestMessage = await table.where("[streamId+eventType]").equals([streamId, "message_created"]).last()
+      const rowsToTouch = new Map<string, CachedEvent>()
+      if (latest) rowsToTouch.set(latest.id, latest)
+      if (latestBoardRailEvent) rowsToTouch.set(latestBoardRailEvent.id, latestBoardRailEvent)
+      if (latestMessage) rowsToTouch.set(latestMessage.id, latestMessage)
+      for (const event of rowsToTouch.values()) {
+        await table.put({ ...event, _cachedAt: Math.max(Date.now(), event._cachedAt + 1) })
+      }
     }
   })
 }

--- a/apps/frontend/src/stores/stream-event-read-refresh.ts
+++ b/apps/frontend/src/stores/stream-event-read-refresh.ts
@@ -1,0 +1,25 @@
+import Dexie from "dexie"
+import { db } from "@/db"
+
+/**
+ * Wake the main thread's event live queries after a backgrounded service worker
+ * may have written rows while the page was frozen. Touching the newest row is
+ * enough for Dexie to invalidate the stream's indexed ranges and re-read every
+ * row the worker added; a plain read cannot restore a missed mutation signal.
+ */
+export async function requestStreamEventReadRefresh(streamIds: string[]): Promise<void> {
+  const table = db.events
+  const uniqueStreamIds = [...new Set(streamIds)]
+  if (uniqueStreamIds.length === 0) return
+
+  await table.db.transaction("rw", table, async () => {
+    for (const streamId of uniqueStreamIds) {
+      const latest = await table
+        .where("[streamId+_sequenceNum]")
+        .between([streamId, Dexie.minKey], [streamId, Dexie.maxKey], true, true)
+        .last()
+      if (!latest) continue
+      await table.put({ ...latest, _cachedAt: Math.max(Date.now(), latest._cachedAt + 1) })
+    }
+  })
+}

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import Dexie, { liveQuery } from "dexie"
 import { db, sequenceToNum, type CachedEvent, type CachedStream } from "@/db"
 import { computeTimelineHoles } from "@/sync/contiguity"
@@ -23,6 +23,7 @@ import {
 } from "./workspace-table-registry"
 import { makeCachedStream } from "@/test/workspace-rows"
 import { bumpLaterOptimisticAnchors } from "@/sync/stream-sync"
+import { requestStreamEventReadRefresh } from "./stream-event-read-refresh"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -40,6 +41,26 @@ function makeRealEvent(streamId: string, sequence: string): CachedEvent {
     actorType: "user",
     createdAt: new Date(2026, 0, 1, 0, 0, sequenceNum).toISOString(),
     _cachedAt: Date.now(),
+  }
+}
+
+async function putRawEvent(event: CachedEvent): Promise<void> {
+  const request = indexedDB.open(db.name)
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const transaction = database.transaction("events", "readwrite")
+      transaction.objectStore("events").put(event)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+      transaction.onabort = () => reject(transaction.error)
+    })
+  } finally {
+    database.close()
   }
 }
 
@@ -875,6 +896,24 @@ describe("useStreamEvents with the bounded read armed", () => {
 
   beforeEach(async () => {
     await db.events.clear()
+  })
+
+  it("re-reads IDB on resume when a frozen page missed the service worker's write notification", async () => {
+    await seed(STREAM, 1)
+    const { result } = renderHook(() => useStreamEvents(STREAM, 1))
+    await waitFor(() => expect(result.current?.map((event) => event.sequence)).toEqual(["1"]))
+
+    await putRawEvent(makeRealEvent(STREAM, "2"))
+    expect((await db.events.where("streamId").equals(STREAM).toArray()).map((event) => event.sequence)).toEqual([
+      "1",
+      "2",
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(result.current?.map((event) => event.sequence)).toEqual(["1"])
+
+    await act(() => requestStreamEventReadRefresh([STREAM]))
+
+    await waitFor(() => expect(result.current?.map((event) => event.sequence)).toEqual(["1", "2"]))
   })
 
   it("paging older widens the prefix and never re-opens the tail range", async () => {

--- a/apps/frontend/src/stores/stream-store.test.ts
+++ b/apps/frontend/src/stores/stream-store.test.ts
@@ -24,6 +24,7 @@ import {
 import { makeCachedStream } from "@/test/workspace-rows"
 import { bumpLaterOptimisticAnchors } from "@/sync/stream-sync"
 import { requestStreamEventReadRefresh } from "./stream-event-read-refresh"
+import { BOARD_RAIL_EVENT_TYPES } from "@/lib/board/board-rail-event-types"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -914,6 +915,56 @@ describe("useStreamEvents with the bounded read armed", () => {
     await act(() => requestStreamEventReadRefresh([STREAM]))
 
     await waitFor(() => expect(result.current?.map((event) => event.sequence)).toEqual(["1", "2"]))
+  })
+
+  it("re-reads event-type rails when a newer event falls outside their observed index ranges", async () => {
+    await db.events.bulkPut([
+      { ...makeRealEvent(STREAM, "0"), eventType: "agent:follow_up_scheduled", payload: {} },
+      makeRealEvent(STREAM, "1"),
+    ])
+    let boardEventIds: string[] = []
+    let messageEventIds: string[] = []
+    const boardSubscription = liveQuery(() =>
+      db.events
+        .where("[streamId+eventType]")
+        .anyOf(BOARD_RAIL_EVENT_TYPES.map((eventType) => [STREAM, eventType]))
+        .toArray()
+    ).subscribe((events) => {
+      boardEventIds = events.map((event) => event.id).sort()
+    })
+    const messageSubscription = liveQuery(() =>
+      db.events.where("[streamId+eventType]").equals([STREAM, "message_created"]).toArray()
+    ).subscribe((events) => {
+      messageEventIds = events.map((event) => event.id).sort()
+    })
+
+    try {
+      await waitFor(() =>
+        expect({ boardEventIds, messageEventIds }).toEqual({
+          boardEventIds: [`evt_${STREAM}_0`, `evt_${STREAM}_1`],
+          messageEventIds: [`evt_${STREAM}_1`],
+        })
+      )
+      await putRawEvent(makeRealEvent(STREAM, "2"))
+      await putRawEvent({ ...makeRealEvent(STREAM, "3"), eventType: "member_joined", payload: {} })
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect({ boardEventIds, messageEventIds }).toEqual({
+        boardEventIds: [`evt_${STREAM}_0`, `evt_${STREAM}_1`],
+        messageEventIds: [`evt_${STREAM}_1`],
+      })
+
+      await act(() => requestStreamEventReadRefresh([STREAM]))
+
+      await waitFor(() =>
+        expect({ boardEventIds, messageEventIds }).toEqual({
+          boardEventIds: [`evt_${STREAM}_0`, `evt_${STREAM}_1`, `evt_${STREAM}_2`],
+          messageEventIds: [`evt_${STREAM}_1`, `evt_${STREAM}_2`],
+        })
+      )
+    } finally {
+      boardSubscription.unsubscribe()
+      messageSubscription.unsubscribe()
+    }
   })
 
   it("paging older widens the prefix and never re-opens the tail range", async () => {

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -86,13 +86,36 @@ describe("SyncEngine.handlePageResume", () => {
     ])
   })
 
-  it("is a no-op when the engine has never connected", async () => {
+  it("skips network work when the engine has never connected", async () => {
     const engine = new SyncEngine(makeDeps())
     const refreshSpy = vi.spyOn(engine, "refreshAfterConnectivityResume")
 
     await engine.handlePageResume()
 
     expect(refreshSpy).not.toHaveBeenCalled()
+  })
+
+  it("wakes the current stream's IDB read before socket work", async () => {
+    const engine = new SyncEngine(makeDeps())
+    engine.setCurrentStreamId("stream_1")
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    await db.events.put({
+      id: "evt_resume",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      sequence: "1",
+      _sequenceNum: 1,
+      eventType: "message_created",
+      payload: { messageId: "msg_resume", contentMarkdown: "new" },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _cachedAt: 1,
+    })
+
+    await engine.handlePageResume()
+
+    await vi.waitFor(async () => expect((await db.events.get("evt_resume"))?._cachedAt).toBeGreaterThan(1))
   })
 
   it("soft refreshes visible data even before the first socket connect", async () => {

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -95,27 +95,37 @@ describe("SyncEngine.handlePageResume", () => {
     expect(refreshSpy).not.toHaveBeenCalled()
   })
 
-  it("wakes the current stream's IDB read before socket work", async () => {
+  it("wakes every visible stream source before socket work", async () => {
     const engine = new SyncEngine(makeDeps())
-    engine.setCurrentStreamId("stream_1")
+    engine.setCurrentStreamId("stream_route")
+    engine.setVisibleStreamIds(["stream_panel"])
+    engine.setBoardStreamIds(["stream_board"])
+    engine.setPanelStreamIds(["stream_conversation"])
     await new Promise((resolve) => setTimeout(resolve, 25))
-    await db.events.put({
-      id: "evt_resume",
-      workspaceId: "ws_1",
-      streamId: "stream_1",
-      sequence: "1",
-      _sequenceNum: 1,
-      eventType: "message_created",
-      payload: { messageId: "msg_resume", contentMarkdown: "new" },
-      actorId: "user_1",
-      actorType: "user",
-      createdAt: new Date().toISOString(),
-      _cachedAt: 1,
-    })
 
-    await engine.handlePageResume()
+    const streamIds = ["stream_route", "stream_panel", "stream_board", "stream_conversation"]
+    await db.events.bulkPut(
+      streamIds.map((streamId) => ({
+        id: `evt_${streamId}`,
+        workspaceId: "ws_1",
+        streamId,
+        sequence: "1",
+        _sequenceNum: 1,
+        eventType: "message_created" as const,
+        payload: { messageId: `msg_${streamId}`, contentMarkdown: "new" },
+        actorId: "user_1",
+        actorType: "user" as const,
+        createdAt: new Date().toISOString(),
+        _cachedAt: 1,
+      }))
+    )
 
-    await vi.waitFor(async () => expect((await db.events.get("evt_resume"))?._cachedAt).toBeGreaterThan(1))
+    await engine.refreshVisibleEventReads()
+
+    const refreshed = await db.events.bulkGet(streamIds.map((streamId) => `evt_${streamId}`))
+    expect(refreshed.map((event) => ({ streamId: event?.streamId, refreshed: (event?._cachedAt ?? 0) > 1 }))).toEqual(
+      streamIds.map((streamId) => ({ streamId, refreshed: true }))
+    )
   })
 
   it("soft refreshes visible data even before the first socket connect", async () => {

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -441,6 +441,15 @@ export class SyncEngine {
     void this.runCatchUp("resume")
   }
 
+  async refreshVisibleEventReads(): Promise<void> {
+    if (this.isDestroyed) return
+    try {
+      await requestStreamEventReadRefresh(this.getVisibleServerStreamIds())
+    } catch (error) {
+      console.error("Stream event read refresh failed", { workspaceId: this.workspaceId, error })
+    }
+  }
+
   /**
    * Called when the page resumes from a long hidden period (e.g. phone
    * unlocked after app-switch). Probes the socket for liveness; if the
@@ -454,11 +463,7 @@ export class SyncEngine {
     // frozen the page, so Dexie's live query misses the cross-context wake-up.
     // Re-read mounted event windows even when the HTTP delta below is empty
     // because its cursor already sees that service-worker write.
-    void requestStreamEventReadRefresh(
-      [this.currentStreamId, ...this.visibleStreamIds].filter(
-        (streamId): streamId is string => !!streamId && isServerStreamId(streamId)
-      )
-    ).catch((error) => console.error("Stream event read refresh failed", { workspaceId: this.workspaceId, error }))
+    void this.refreshVisibleEventReads()
     if (!this.socket || !this.hasEverConnected) return
     // Warm the open stream over plain HTTP before anything socket-shaped runs.
     // The socket is the slowest thing on a phone resume — a zombie transport

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -25,6 +25,7 @@ import { SyncLogCursor } from "./sync-log-cursor"
 import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { CatchUpBatch, LiveCommitBatch } from "./catch-up-batch"
 import { beginApplyWindow, endApplyWindow } from "@/stores/apply-window"
+import { requestStreamEventReadRefresh } from "@/stores/stream-event-read-refresh"
 import { getPerfCapture } from "@/lib/perf/capture"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
@@ -448,7 +449,17 @@ export class SyncEngine {
    * events may have been missed while the page was backgrounded.
    */
   async handlePageResume(): Promise<void> {
-    if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
+    if (this.isDestroyed) return
+    // A service worker can write the pushed message into IDB while Android has
+    // frozen the page, so Dexie's live query misses the cross-context wake-up.
+    // Re-read mounted event windows even when the HTTP delta below is empty
+    // because its cursor already sees that service-worker write.
+    void requestStreamEventReadRefresh(
+      [this.currentStreamId, ...this.visibleStreamIds].filter(
+        (streamId): streamId is string => !!streamId && isServerStreamId(streamId)
+      )
+    ).catch((error) => console.error("Stream event read refresh failed", { workspaceId: this.workspaceId, error }))
+    if (!this.socket || !this.hasEverConnected) return
     // Warm the open stream over plain HTTP before anything socket-shaped runs.
     // The socket is the slowest thing on a phone resume — a zombie transport
     // takes a ping timeout to detect and seconds more to reconnect and rejoin


### PR DESCRIPTION
## Problem

When Android freezes a backgrounded PWA, the service worker can prefetch a pushed message into the account's IndexedDB while the page's Dexie live query misses the cross-context mutation signal. On restore, the HTTP delta starts after that persisted row, and the no-op rewrite optimization skips writing the duplicate event. That leaves the message on disk but absent from mounted event surfaces until a hard refresh. This became reliable after the event-write optimization was made unconditional in [#1831](https://github.com/threahq/threa/pull/1831).

## Solution

Every real away/back cycle now wakes IndexedDB event reads immediately, including Android restores shorter than five seconds. Socket probing and network catch-up retain their five-second threshold.

`SyncEngine.refreshVisibleEventReads` reuses `getVisibleServerStreamIds()`, covering the route stream, bare panels, board cards, and conversation-panel streams. Inside one Dexie transaction, `requestStreamEventReadRefresh` re-puts a row in each mounted query range shape: timeline sequence ranges, board/conversation event-type unions, and exact message ranges. This invalidates every mounted event observer without risking a concurrent patch being overwritten. The board rail event types now have one shared definition used by both the rail and the wake.

The existing HTTP warm fetch, socket probe, reconnect, and catch-up paths remain unchanged.

## Verification

- 155 focused frontend tests passed, including raw IndexedDB writes missed by timeline, board/conversation, and exact-message live queries; mixed event-type ordering; every visible-stream source; and sub-five-second restores.
- Monorepo typecheck and the full pre-commit lint, migration, Dockerfile, and OpenAPI checks passed.
- The full frontend suite did not finish within the 10-minute harness timeout; it produced no failure result before termination.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789384857&installation_model_id=20758&pr_number=1892&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1892&signature=dde2073fca9d3e07dff44886c3baf589833956a185c7990fcac76c5b4f6dbdb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->