### PR TITLE
fix: dismiss the 'you were added' activity by visiting the stream

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2301,7 +2301,13 @@ export function StreamContent({
     // contiguity); the flush half of the switch lives on the ReadCommitQueue.
     sweepLinkEnabled: autoReadRevamp,
   })
-  useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
+  useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, {
+    enabled: autoMarkEnabled,
+    partial: !atLastRow,
+    // Raw watermark, not the thread-remapped frontier seed: the heal's anchor
+    // must be the id the server already stores so the advance stays a no-op.
+    readPointerEventId: lastReadEventId,
+  })
   const canAutoRead = useAutoReadAttention()
 
   const isMobile = useIsMobile()

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -334,6 +334,83 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).not.toHaveBeenCalled()
   })
 
+  it("heals an undismissable activity at the watermark when no frontier advance exists (born-read member_added)", () => {
+    // Being added to a stream born-reads the member_added event — the watermark
+    // IS the tail, so the frontier never advances and lastEventId stays
+    // undefined. The MEMBER_ADDED activity row still lights the sidebar, and
+    // its only dismissal is the mark this hook fires. The heal anchors the
+    // mark at the watermark itself: monotonic no-op advance, activity clear
+    // runs. Partial, so nothing is optimistically zeroed.
+    unreadCount = 0
+    activityCount = 1
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_watermark" }))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_watermark", { partial: true })
+  })
+
+  it("does NOT heal while real unread remains — the frontier path owns that mark", () => {
+    unreadCount = 2
+    activityCount = 1
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_watermark" }))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("does NOT heal with no elevated activity (a quiet fully-read open stays silent)", () => {
+    unreadCount = 0
+    activityCount = 0
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_watermark" }))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("heal respects the attention gate (unfocused desktop never heals)", () => {
+    unreadCount = 0
+    activityCount = 1
+    hasFocus = false
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_watermark" }))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("prefers the frontier mark over the heal when both are available", () => {
+    // A trailing chrome row let the frontier advance: the real lastEventId is
+    // the truthful (further) anchor, and the heal must not override it.
+    unreadCount = 0
+    activityCount = 1
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", "event_frontier", { readPointerEventId: "event_watermark" })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_frontier", { partial: false })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(1)
+  })
+
   it("clears the dedup on stream switch so the next stream's first mark always fires", () => {
     // The consumer isn't keyed by streamId, so the hook persists across switches.
     // The dedup refs must reset per stream — otherwise a prior stream's marked

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -407,8 +407,8 @@ describe("useAutoMarkAsRead", () => {
       vi.advanceTimersByTime(500)
     })
 
-    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_frontier", { partial: false })
-    expect(mockMarkAsRead).toHaveBeenCalledTimes(1)
+    // Exact call list: the frontier mark and NOTHING at the watermark.
+    expect(mockMarkAsRead.mock.calls).toEqual([["stream_123", "event_frontier", { partial: false }]])
   })
 
   it("clears the dedup on stream switch so the next stream's first mark always fires", () => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -17,6 +17,16 @@ interface UseAutoMarkAsReadOptions {
    * (Slack-style progressive read). Defaults false: mark fully read as before.
    */
   partial?: boolean
+  /**
+   * The viewer's persisted read pointer (server watermark). Fallback anchor for
+   * the activity heal: an activity whose stream has nothing unread AND nothing
+   * trailing the watermark (a `member_added` born-read at the tail pins exactly
+   * that) produces no frontier advance, so without this anchor the mark that
+   * dismisses it can never fire and the sidebar row stays lit through every
+   * visit. Committing the pointer itself is a monotonic no-op advance
+   * server-side; only the handler's activity clear has effect.
+   */
+  readPointerEventId?: string | null
 }
 
 /**
@@ -58,7 +68,7 @@ export function useAutoMarkAsRead(
   lastEventId: string | undefined,
   options: UseAutoMarkAsReadOptions = {}
 ) {
-  const { enabled = true, partial = false } = options
+  const { enabled = true, partial = false, readPointerEventId = null } = options
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
   const canAutoRead = useAutoReadAttention()
@@ -85,7 +95,21 @@ export function useAutoMarkAsRead(
   }, [queue, streamId])
 
   useEffect(() => {
-    if (!enabled || !lastEventId || !canAutoRead) {
+    // Activity heal at the watermark: an elevated activity count with NO
+    // frontier advance available — nothing unread, nothing trailing the read
+    // pointer (born-read `member_added` pins the pointer at the tail) — would
+    // otherwise be permanently undismissable, because the dismissal signal
+    // rides on the mark this hook fires. Anchor the mark at the pointer
+    // itself: the server advance is a monotonic no-op, the activity clear
+    // runs. Sent partial so no counter is optimistically zeroed off a
+    // possibly-stale local 0. Gated on `unreadCount === 0`: with real unread
+    // below, the normal frontier path owns the (partial) mark that clears
+    // activity, and healing early would race a mark-unread's restored badges.
+    const healEventId =
+      !lastEventId && activityCount > 0 && unreadCount === 0 && readPointerEventId ? readPointerEventId : undefined
+    const reportEventId = lastEventId ?? healEventId
+    const reportPartial = lastEventId ? partial : true
+    if (!enabled || !reportEventId || !canAutoRead) {
       // The gate closed with a mark still debouncing: drop it, matching the
       // pre-queue semantics — a blur cancels rather than commits, so content
       // glimpsed right before switching windows stays unread (never
@@ -101,7 +125,7 @@ export function useAutoMarkAsRead(
     // other devices. The committed record gates it to once per caught-up tail.
     // A PARTIAL (mid-window frontier) open with nothing elevated still no-ops —
     // its `lastEventId` isn't the tail, so emitting `stream:read` would be wrong.
-    if (unreadCount === 0 && activityCount === 0 && partial) return
+    if (unreadCount === 0 && activityCount === 0 && reportPartial) return
 
     // Skip if this exact mark was already committed AND no pending activities
     // to clear. Activities can arrive via activity:created while we're viewing
@@ -111,11 +135,16 @@ export function useAutoMarkAsRead(
     // (never-sent) marks are not in the committed record, so a blur-parked
     // mark re-reports after refocus.
     const committed = queue.lastCommitted(streamId)
-    if (committed && committed.lastEventId === lastEventId && committed.partial === partial && activityCount === 0) {
+    if (
+      committed &&
+      committed.lastEventId === reportEventId &&
+      committed.partial === reportPartial &&
+      activityCount === 0
+    ) {
       return
     }
 
-    queue.report(streamId, lastEventId, partial)
+    queue.report(streamId, reportEventId, reportPartial)
 
     return () => {
       // Leaving the stream flushes its pending mark — the frontier already
@@ -124,7 +153,7 @@ export function useAutoMarkAsRead(
       // replaces the pending mark instead.
       if (streamIdRef.current !== streamId) queue.flush(streamId)
     }
-  }, [enabled, streamId, lastEventId, partial, queue, unreadCount, activityCount, canAutoRead])
+  }, [enabled, streamId, lastEventId, partial, queue, unreadCount, activityCount, canAutoRead, readPointerEventId])
 
   // Unmounting the stream page entirely (navigating to drafts/board) is the
   // other leave path — flush whatever stream was current.

--- a/tests/browser/auto-read.spec.ts
+++ b/tests/browser/auto-read.spec.ts
@@ -49,6 +49,15 @@ async function serverUnreadCount(page: Page, workspaceId: string, streamId: stri
   return counts[streamId] ?? 0
 }
 
+async function serverActivityCount(page: Page, workspaceId: string, streamId: string): Promise<number> {
+  const res = await page.request.get(`/api/workspaces/${workspaceId}/bootstrap`)
+  await expectApiOk(res, "Workspace bootstrap")
+  const body = (await res.json()) as { data?: { activityCounts?: Record<string, number> } }
+  const counts = body.data?.activityCounts
+  if (!counts) throw new Error(`Bootstrap response missing activityCounts; keys: ${Object.keys(body).join(",")}`)
+  return counts[streamId] ?? 0
+}
+
 async function distanceFromBottom(page: Page): Promise<number | null> {
   return page.evaluate(() => {
     const el = document.querySelector("[data-suppress-pull-refresh]")
@@ -451,5 +460,64 @@ test.describe("Timeline auto-read", () => {
       .toBe(0)
 
     await otherContext.close()
+  })
+
+  test("being added to a channel: visiting it dismisses the 'you were added' activity", async ({ page, browser }) => {
+    // The add born-reads the member_added event for the added user — their
+    // watermark IS the stream's tail, so no frontier advance is ever available
+    // — while also creating a MEMBER_ADDED activity that lights their sidebar.
+    // The activity's only dismissal is a markAsRead, so without the
+    // watermark-anchored heal the row stays lit through every visit.
+    const owner = await loginAndCreateWorkspace(page, "auto-read")
+    const testId = owner.testId
+    const prefix = `[${testId}]`
+
+    await createChannel(page, `added-${testId}`)
+    const { workspaceId, streamId } = extractIds(page)
+    await seedFrom(page, workspaceId, streamId, 5, prefix)
+
+    const other = await loginInNewContext(browser, `added-b-${testId}@example.com`, `Added B ${testId}`)
+    const joinRes = await other.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+      data: { role: "member", name: `Added B ${testId}` },
+    })
+    await expectApiOk(joinRes, "Second user joins workspace")
+    const joined = (await joinRes.json()) as { user?: { id?: string } }
+    if (!joined.user?.id) throw new Error("dev workspace join did not return the joined user")
+
+    await expectApiOk(
+      await page.request.post(`/api/workspaces/${workspaceId}/streams/${streamId}/members`, {
+        data: { memberId: joined.user.id },
+      }),
+      "Owner adds second user to the channel"
+    )
+
+    // The wedge state is real server-side: an unread activity with zero unread
+    // messages — nothing for a scroll to ever mark.
+    await expect
+      .poll(() => serverActivityCount(other.page, workspaceId, streamId), {
+        timeout: 10000,
+        message: "the add should create an unread MEMBER_ADDED activity",
+      })
+      .toBeGreaterThan(0)
+    expect(await serverUnreadCount(other.page, workspaceId, streamId)).toBe(0)
+
+    await other.page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      other.page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix} msg-005` })
+    ).toBeVisible({ timeout: 20000 })
+
+    await expect
+      .poll(() => serverActivityCount(other.page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "visiting the stream should dismiss the added activity",
+      })
+      .toBe(0)
+    // The heal anchors at the watermark — read state must be undisturbed.
+    expect(await serverUnreadCount(other.page, workspaceId, streamId)).toBe(0)
+
+    await other.context.close()
   })
 })

--- a/tests/browser/auto-read.spec.ts
+++ b/tests/browser/auto-read.spec.ts
@@ -491,14 +491,23 @@ test.describe("Timeline auto-read", () => {
       "Owner adds second user to the channel"
     )
 
-    // The wedge state is real server-side: an unread activity with zero unread
-    // messages — nothing for a scroll to ever mark.
+    // The wedge state is real server-side: an unread MEMBER_ADDED activity for
+    // THIS stream, with zero unread messages — nothing for a scroll to ever mark.
+    const unreadMemberAdded = async () => {
+      const res = await other.page.request.get(`/api/workspaces/${workspaceId}/activity?unreadOnly=true`)
+      await expectApiOk(res, "Activity feed")
+      const body = (await res.json()) as {
+        activities?: Array<{ activityType?: string; streamId?: string }>
+      }
+      return (body.activities ?? []).filter((a) => a.activityType === "member_added" && a.streamId === streamId)
+    }
     await expect
-      .poll(() => serverActivityCount(other.page, workspaceId, streamId), {
+      .poll(async () => (await unreadMemberAdded()).length, {
         timeout: 10000,
-        message: "the add should create an unread MEMBER_ADDED activity",
+        message: "the add should create an unread MEMBER_ADDED activity for the channel",
       })
-      .toBeGreaterThan(0)
+      .toBe(1)
+    expect(await serverActivityCount(other.page, workspaceId, streamId)).toBeGreaterThan(0)
     expect(await serverUnreadCount(other.page, workspaceId, streamId)).toBe(0)
 
     await other.page.goto(`/w/${workspaceId}/s/${streamId}`)
@@ -510,11 +519,12 @@ test.describe("Timeline auto-read", () => {
     ).toBeVisible({ timeout: 20000 })
 
     await expect
-      .poll(() => serverActivityCount(other.page, workspaceId, streamId), {
+      .poll(async () => (await unreadMemberAdded()).length, {
         timeout: 15000,
-        message: "visiting the stream should dismiss the added activity",
+        message: "visiting the stream should dismiss the MEMBER_ADDED activity",
       })
       .toBe(0)
+    expect(await serverActivityCount(other.page, workspaceId, streamId)).toBe(0)
     // The heal anchors at the watermark — read state must be undisturbed.
     expect(await serverUnreadCount(other.page, workspaceId, streamId)).toBe(0)
 


### PR DESCRIPTION
## Problem

Being added to a stream wedges its sidebar row lit ("unread") with nothing to mark. `addToStream` born-reads the `member_added` event for the added member — the watermark lands on the stream's tail — while `processMemberAdded` creates a MEMBER_ADDED activity row for them. A stream's activities clear only via `markAsRead` (`streams/handlers.ts` runs `markStreamActivityAsRead` there), and the client fired `markAsRead` only when the read frontier advanced past the watermark. Born-read guarantees no row ever trails the watermark, so the dismissal signal was unreachable for exactly the event that creates it: the row stays lit through every visit, until an unrelated message arrives and gets read. Self-joins hit the same wedge (no self-skip in the activity path). Reported from staging.

## Solution

Anchor the heal at the watermark itself. `useAutoMarkAsRead` gains a `readPointerEventId` option (StreamContent passes the raw server watermark, not the thread-remapped frontier seed): when attention is on, activity is elevated, nothing is unread, and no frontier advance is available, it reports a mark at the read pointer — a monotonic no-op advance server-side (`ReadStateRepository.advance` rejects it), but the handler's unconditional activity clear runs.

- Sent `partial: true` — the partial path optimistically clears only activity rows, never counters, so a stale local `unreadCount === 0` can't zero a real badge.
- Gated on `unreadCount === 0`: with real unread below, the frontier path owns the mark; healing early would also race mark-unread's deliberately-restored badges.
- A real frontier mark always wins over the heal (newest-wins in the ReadCommitQueue; the heal only arms when `lastSeenEventId` is undefined).
- Out of scope: whether a self-join should create a self-activity at all (`processMemberAdded` has no `addedBy === memberId` skip) — the heal dismisses it on visit either way.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | Watermark-anchored heal when no frontier advance exists |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Pass the raw watermark as `readPointerEventId` |
| `apps/frontend/src/hooks/use-auto-mark-as-read.test.ts` | 5 heal cases: fires, unread-gated, quiet-gated, attention-gated, frontier-wins |
| `tests/browser/auto-read.spec.ts` | Added-member visit dismisses the activity server-side (bootstrap `activityCounts` truth) |

## Test plan

- [x] `use-auto-mark-as-read` units — 19 pass
- [x] `auto-read` browser suite — 8/8 (new added-member spec included; one unrelated jump-to-latest flake passed on rerun and in isolation)
- [x] Full frontend units — 6715 pass; frontend typecheck clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789396059&installation_model_id=20758&pr_number=1893&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1893&signature=dee9be96304a839f02d201b6f4267429bd655dc2ca95968ec0a35fbfb2fa13ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->