### PR TITLE
fix: make auto-read commits recoverable and ordered

### DIFF
--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -650,12 +650,21 @@ export class ActivityService {
   }
 
   async markStreamActivityAsRead(userId: string, workspaceId: string, streamId: string): Promise<void> {
-    await withTransaction(this.pool, async (client) => {
-      const cleared = await ActivityRepository.markStreamAsRead(client, workspaceId, userId, streamId)
-      if (cleared.length === 0) return
-      logger.debug({ userId, streamId, count: cleared.length }, "Marked stream activity as read")
-      await this.emitActivityRead(client, workspaceId, userId, cleared, true)
-    })
+    await withTransaction(this.pool, (client) =>
+      this.markStreamActivityAsReadInTransaction(client, userId, workspaceId, streamId)
+    )
+  }
+
+  async markStreamActivityAsReadInTransaction(
+    client: PoolClient,
+    userId: string,
+    workspaceId: string,
+    streamId: string
+  ): Promise<void> {
+    const cleared = await ActivityRepository.markStreamAsRead(client, workspaceId, userId, streamId)
+    if (cleared.length === 0) return
+    logger.debug({ userId, streamId, count: cleared.length }, "Marked stream activity as read")
+    await this.emitActivityRead(client, workspaceId, userId, cleared, true)
   }
 
   async markAllAsRead(userId: string, workspaceId: string): Promise<void> {

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -477,9 +477,12 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     streamService: Partial<StreamService>,
     activityService: { markStreamActivityAsRead: (userId: string, streamId: string) => Promise<void> }
   ) {
-    return createStreamHandlers({ streamService, activityService, pool: {} } as unknown as Parameters<
-      typeof createStreamHandlers
-    >[0])
+    return createStreamHandlers({
+      streamService,
+      streamReadService: { markAsRead: streamService.markAsRead },
+      activityService,
+      pool: {},
+    } as unknown as Parameters<typeof createStreamHandlers>[0])
   }
 
   function makeReq(): Request {
@@ -491,7 +494,7 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     } as unknown as Request
   }
 
-  it("clears stream activity and returns null membership for a non-member viewer", async () => {
+  it("returns null membership for a non-member viewer", async () => {
     const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
     const markAsRead = mock(() => Promise.resolve(null))
     const markStreamActivityAsRead = mock(() => Promise.resolve())
@@ -506,12 +509,17 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     // access from the root (INV-62) gets an activity-only read, not a 404.
     expect(captured.status).not.toBe(404)
     expect(captured.body).toEqual({ membership: null })
-    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "ws_1", "stream_thread")
+    expect(markAsRead).toHaveBeenCalledWith("ws_1", "stream_thread", "usr_viewer", "evt_1")
   })
 
   it("returns null membership for a non-member unread — the same-class 404 is gone", async () => {
     const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
-    const markUnread = mock(() => Promise.resolve(null))
+    const markUnread = mock(() =>
+      Promise.resolve({
+        membership: null,
+        readState: { lastReadEventId: "evt_0", lastReadSequence: "0", lastReadAt: null },
+      })
+    )
     const handlers = makeHandlers({ validateStreamAccess, markUnread } as Partial<StreamService>, {
       markStreamActivityAsRead: mock(() => Promise.resolve()),
     })
@@ -530,7 +538,10 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     // Access (not membership) gates the unread (INV-62): null membership is a
     // successful standalone-frontier regress, not a 404.
     expect(captured.status).not.toBe(404)
-    expect(captured.body).toEqual({ membership: null })
+    expect(captured.body).toEqual({
+      membership: null,
+      readState: { lastReadEventId: "evt_0", lastReadSequence: "0", lastReadAt: null },
+    })
   })
 
   it("surfaces MESSAGE_NOT_FOUND from the service when the message isn't in the stream", async () => {
@@ -556,7 +567,7 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     ).rejects.toMatchObject({ status: 404, code: "MESSAGE_NOT_FOUND" })
   })
 
-  it("returns the membership for a member read and still clears activity", async () => {
+  it("returns the membership for a member read", async () => {
     const membership = {
       streamId: "stream_thread",
       memberId: "usr_viewer",
@@ -575,6 +586,6 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
 
     expect(captured.status).toBe(200)
     expect(captured.body).toEqual({ membership })
-    expect(markStreamActivityAsRead).toHaveBeenCalledWith("usr_viewer", "ws_1", "stream_thread")
+    expect(markAsRead).toHaveBeenCalledWith("ws_1", "stream_thread", "usr_viewer", "evt_1")
   })
 })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import type { StreamService } from "./service"
+import type { StreamReadService } from "./read-service"
 import type { EventService } from "../messaging"
 import { collectSharedMessageIds, hydrateSharedMessageIds, toDualSlotMaps, type DualSlotMaps } from "../messaging"
 import type { ActivityService } from "../activity"
@@ -405,6 +406,7 @@ export {
 interface Dependencies {
   pool: Pool
   streamService: StreamService
+  streamReadService: StreamReadService
   eventService: EventService
   activityService?: ActivityService
   linkPreviewService: LinkPreviewService
@@ -551,6 +553,7 @@ function presenceMatchesRuntimeSessionLink(
 export function createStreamHandlers({
   pool,
   streamService,
+  streamReadService,
   eventService,
   activityService,
   linkPreviewService,
@@ -936,16 +939,7 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const membership = await streamService.markAsRead(workspaceId, streamId, userId, data.lastEventId)
-
-      // Unconditional: thread access is inherited from the root (INV-62), so a
-      // viewer can have access without a membership row (non-member thread leg,
-      // or a public channel never joined). Their activity rows are keyed to this
-      // stream, and viewing is reading for the activity surface — gating the
-      // clear on membership left those rows stuck until clicked one by one in
-      // the Activity feed. A null membership is a successful activity-only read
-      // (no watermark to advance), not a 404; access was validated above.
-      await activityService?.markStreamActivityAsRead(userId, workspaceId, streamId)
+      const membership = await streamReadService.markAsRead(workspaceId, streamId, userId, data.lastEventId)
 
       res.json({ membership: membership ?? null })
     },
@@ -962,9 +956,9 @@ export function createStreamHandlers({
       // A null membership is a successful unread by a viewer with access but no
       // membership row (INV-62) — the service throws MESSAGE_NOT_FOUND itself
       // when the message isn't in the stream; null here must not 404.
-      const membership = await streamService.markUnread(workspaceId, streamId, userId, data.messageId)
+      const { membership, readState } = await streamService.markUnread(workspaceId, streamId, userId, data.messageId)
 
-      res.json({ membership: membership ?? null })
+      res.json({ membership, readState })
     },
 
     async archive(req: Request, res: Response) {

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -1073,7 +1073,7 @@ export function createStreamHandlers({
       // Read frontier for EVERY viewer with access (non-member unlock): sourced
       // solely from stream_read_state; an access-without-membership viewer (INV-62)
       // with no row reads as never-read (everything unread).
-      const unreadCount = await streamService.getEffectiveUnreadCount(streamId, userId)
+      const { unreadCount, totalCount: messageCount } = await streamService.getEffectiveUnreadSummary(streamId, userId)
       // The viewer's frontier rides the per-stream response so non-member legs
       // resolve theirs on open (the workspace bootstrap stays member-keyed).
       // Sequence resolved off the watermark event, same as the workspace
@@ -1192,6 +1192,7 @@ export function createStreamHandlers({
         syncMode,
         threadStates,
         unreadCount,
+        messageCount,
         mentionCount: activityCounts?.mentionCount ?? 0,
         activityCount: activityCounts?.totalCount ?? 0,
         contextBag,

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -7,6 +7,7 @@ export { StreamBriefRepository } from "./brief-repository"
 export type { StreamBrief, BriefAuthorKind } from "./brief-repository"
 
 export { StreamService } from "./service"
+export { StreamReadService } from "./read-service"
 export type { CreateScratchpadParams, CreateChannelParams, CreateThreadParams } from "./service"
 
 // Canonical "can this user read this stream?" check (INV-8)

--- a/apps/backend/src/features/streams/read-service.test.ts
+++ b/apps/backend/src/features/streams/read-service.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Pool, PoolClient } from "pg"
+import * as dbModule from "../../db"
+import { StreamReadService } from "./read-service"
+
+const client = {} as PoolClient
+
+beforeEach(() => {
+  spyOn(dbModule, "withTransaction").mockImplementation((async (
+    _pool: Pool,
+    operation: (transactionClient: PoolClient) => Promise<unknown>
+  ) => operation(client)) as never)
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("StreamReadService.markAsRead", () => {
+  it("advances the frontier and clears activity on the same transaction client", async () => {
+    const membership = {
+      streamId: "stream_1",
+      memberId: "usr_1",
+      notificationLevel: null,
+      joinedAt: new Date(),
+    }
+    const markAsReadInTransaction = mock(() => Promise.resolve(membership))
+    const markStreamActivityAsReadInTransaction = mock(() => Promise.resolve())
+    const service = new StreamReadService({
+      pool: {} as never,
+      streamService: { markAsReadInTransaction } as never,
+      activityService: { markStreamActivityAsReadInTransaction },
+    })
+
+    const result = await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_1")
+
+    expect(result).toBe(membership)
+    expect(markAsReadInTransaction).toHaveBeenCalledWith(client, "ws_1", "stream_1", "usr_1", "evt_1")
+    expect(markStreamActivityAsReadInTransaction).toHaveBeenCalledWith(client, "usr_1", "ws_1", "stream_1")
+  })
+
+  it("fails the transaction when the activity clear fails", async () => {
+    const service = new StreamReadService({
+      pool: {} as never,
+      streamService: { markAsReadInTransaction: mock(() => Promise.resolve(null)) } as never,
+      activityService: {
+        markStreamActivityAsReadInTransaction: mock(() => Promise.reject(new Error("activity write failed"))),
+      },
+    })
+
+    await expect(service.markAsRead("ws_1", "stream_1", "usr_1", "evt_1")).rejects.toThrow("activity write failed")
+  })
+})

--- a/apps/backend/src/features/streams/read-service.ts
+++ b/apps/backend/src/features/streams/read-service.ts
@@ -1,0 +1,42 @@
+import type { Pool, PoolClient } from "pg"
+import { withTransaction } from "../../db"
+import type { StreamMember } from "./member-repository"
+import type { StreamService } from "./service"
+
+interface ActivityReadService {
+  markStreamActivityAsReadInTransaction(
+    client: PoolClient,
+    userId: string,
+    workspaceId: string,
+    streamId: string
+  ): Promise<void>
+}
+
+interface StreamReadServiceDeps {
+  pool: Pool
+  streamService: StreamService
+  activityService: ActivityReadService
+}
+
+export class StreamReadService {
+  constructor(private readonly deps: StreamReadServiceDeps) {}
+
+  async markAsRead(
+    workspaceId: string,
+    streamId: string,
+    userId: string,
+    eventId: string
+  ): Promise<StreamMember | null> {
+    return withTransaction(this.deps.pool, async (client) => {
+      const membership = await this.deps.streamService.markAsReadInTransaction(
+        client,
+        workspaceId,
+        streamId,
+        userId,
+        eventId
+      )
+      await this.deps.activityService.markStreamActivityAsReadInTransaction(client, userId, workspaceId, streamId)
+      return membership
+    })
+  }
+}

--- a/apps/backend/src/features/streams/read-state-repository.ts
+++ b/apps/backend/src/features/streams/read-state-repository.ts
@@ -85,8 +85,8 @@ export const ReadStateRepository = {
    * park the watermark before the first message. No sequence comparison: this
    * deliberately moves the pointer backward.
    */
-  async set(db: Querier, streamId: string, userId: string, eventId: string | null): Promise<void> {
-    await db.query(
+  async set(db: Querier, streamId: string, userId: string, eventId: string | null): Promise<StreamReadState | null> {
+    const result = await db.query<StreamReadStateRow>(
       `
       INSERT INTO stream_read_state (workspace_id, stream_id, user_id, last_read_event_id, last_read_at, updated_at)
       SELECT s.workspace_id, $1, $2, $3, NOW(), NOW()
@@ -96,9 +96,11 @@ export const ReadStateRepository = {
       SET last_read_event_id = EXCLUDED.last_read_event_id,
           last_read_at = EXCLUDED.last_read_at,
           updated_at = EXCLUDED.updated_at
+      RETURNING ${SELECT_FIELDS}
       `,
       [streamId, userId, eventId]
     )
+    return result.rows[0] ? mapRowToReadState(result.rows[0]) : null
   },
 
   /**

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -63,7 +63,7 @@ const mockListOverlayIds = spyOn(SparseReadRepository, "listOverlayIds").mockRes
 // Read-state shadow writes run inside every watermark write path; stub against
 // the fake `{}` client so unit tests never touch a real DB.
 const mockReadStateAdvance = spyOn(ReadStateRepository, "advance").mockResolvedValue(null)
-const mockReadStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+const mockReadStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(null)
 const mockReadStateBatchAdvance = spyOn(ReadStateRepository, "batchAdvance").mockResolvedValue([])
 const mockReadStateSetForUsers = spyOn(ReadStateRepository, "setForUsers").mockResolvedValue(undefined)
 const mockSlugExists = spyOn(StreamRepository, "slugExistsInWorkspace")
@@ -1819,7 +1819,10 @@ describe("StreamService.markUnread", () => {
 
     const result = await service.markUnread("ws_1", "stream_1", "usr_1", "msg_5")
 
-    expect(result).toBeNull()
+    expect(result).toEqual({
+      membership: null,
+      readState: { lastReadEventId: "evt_4", lastReadSequence: "40", lastReadAt: null },
+    })
     expect(mockFindByStreamAndMember).toHaveBeenCalledWith({}, "stream_1", "usr_1")
     expect(mockReadStateSet).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_4")
     expect(mockDeleteAtOrAbove).toHaveBeenCalledWith({}, "stream_1", "usr_1", 50n)

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -61,6 +61,7 @@ import {
   type JSONContent,
   type AuthorType,
   type DescriptionSetEventPayload,
+  type StreamReadFrontier,
   type StreamReadFrontierSnapshot,
   TitleSources,
 } from "@threa/types"
@@ -148,6 +149,11 @@ const createChannelParamsSchema = z.object({
 })
 
 export type CreateChannelParams = z.infer<typeof createChannelParamsSchema>
+
+export interface MarkUnreadResult {
+  membership: StreamMember | null
+  readState: StreamReadFrontier
+}
 
 const createThreadParamsSchema = z.object({
   workspaceId: z.string(),
@@ -2118,62 +2124,72 @@ export class StreamService {
     memberId: string,
     eventId: string
   ): Promise<StreamMember | null> {
-    return withTransaction(this.pool, async (client) => {
-      // The read pointer must reference a real event in THIS stream. A client can
-      // briefly hold an optimistic event id (temp_…) as its frontier right after a
-      // send, before the server echo swaps it for the persisted id. Persisting an
-      // id with no stream_events row pins last_read_seq to 0 (the unread query's
-      // COALESCE(sequence, 0)), so every message — including the author's own —
-      // reports unread until the watermark is overwritten. Resolve first, no-op on
-      // a miss rather than corrupting the pointer.
-      const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
-      if (!position) {
-        logger.warn({ workspaceId, streamId, memberId, eventId }, "Ignored mark-as-read: event not found in stream")
-        return StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
-      }
+    return withTransaction(this.pool, (client) =>
+      this.markAsReadInTransaction(client, workspaceId, streamId, memberId, eventId)
+    )
+  }
 
-      // Read state is user-anchored, not membership-gated: the advance runs for
-      // every viewer with access (validated in the handler) whether or not a
-      // membership row exists. Membership is fetched read-only for participation
-      // only — it is never written on a read (membership ≠ access ≠ read state).
-      const membership = await StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
-      // Source the payload from the post-write row: the store is monotonic, so a
-      // stale-device advance is rejected and the post-write frontier — not the raw
-      // event — is the read position this user's other sessions adopt.
-      const postWrite = await ReadStateRepository.advance(client, streamId, memberId, eventId)
-      let readEventId = eventId
-      let readPosition = position
-      if (postWrite?.lastReadEventId && postWrite.lastReadEventId !== eventId) {
-        const resolved = await StreamEventRepository.getMessageOrdinalForEvent(
-          client,
-          streamId,
-          postWrite.lastReadEventId
-        )
-        if (resolved) {
-          readEventId = postWrite.lastReadEventId
-          readPosition = resolved
-        }
-      }
-      // Overlay invariant: every overlay row sits strictly above the watermark.
-      // Advancing the watermark absorbs the run at/below it, so prune those rows
-      // in the same transaction at the effective (post-write) frontier; the
-      // remaining overlay is the absolute set the client keeps.
-      await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, readPosition.sequence)
-      const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
-      // Absolute read position (sync phase 2c): clients derive unread as
-      // latestOrdinal - lastReadOrdinal, so the event carries where this read
-      // lands in message-ordinal space.
-      await OutboxRepository.insert(client, "stream:read", {
-        workspaceId,
-        authorId: memberId,
+  async markAsReadInTransaction(
+    client: Querier,
+    workspaceId: string,
+    streamId: string,
+    memberId: string,
+    eventId: string
+  ): Promise<StreamMember | null> {
+    // The read pointer must reference a real event in THIS stream. A client can
+    // briefly hold an optimistic event id (temp_…) as its frontier right after a
+    // send, before the server echo swaps it for the persisted id. Persisting an
+    // id with no stream_events row pins last_read_seq to 0 (the unread query's
+    // COALESCE(sequence, 0)), so every message — including the author's own —
+    // reports unread until the watermark is overwritten. Resolve first, no-op on
+    // a miss rather than corrupting the pointer.
+    const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
+    if (!position) {
+      logger.warn({ workspaceId, streamId, memberId, eventId }, "Ignored mark-as-read: event not found in stream")
+      return StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
+    }
+
+    // Read state is user-anchored, not membership-gated: the advance runs for
+    // every viewer with access (validated in the handler) whether or not a
+    // membership row exists. Membership is fetched read-only for participation
+    // only — it is never written on a read (membership ≠ access ≠ read state).
+    const membership = await StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
+    // Source the payload from the post-write row: the store is monotonic, so a
+    // stale-device advance is rejected and the post-write frontier — not the raw
+    // event — is the read position this user's other sessions adopt.
+    const postWrite = await ReadStateRepository.advance(client, streamId, memberId, eventId)
+    let readEventId = eventId
+    let readPosition = position
+    if (postWrite?.lastReadEventId && postWrite.lastReadEventId !== eventId) {
+      const resolved = await StreamEventRepository.getMessageOrdinalForEvent(
+        client,
         streamId,
-        lastReadEventId: readEventId,
-        lastReadSequence: readPosition.sequence.toString(),
-        lastReadOrdinal: readPosition.messageOrdinal,
-        readMessageIds,
-      })
-      return membership
+        postWrite.lastReadEventId
+      )
+      if (resolved) {
+        readEventId = postWrite.lastReadEventId
+        readPosition = resolved
+      }
+    }
+    // Overlay invariant: every overlay row sits strictly above the watermark.
+    // Advancing the watermark absorbs the run at/below it, so prune those rows
+    // in the same transaction at the effective (post-write) frontier; the
+    // remaining overlay is the absolute set the client keeps.
+    await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, readPosition.sequence)
+    const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
+    // Absolute read position (sync phase 2c): clients derive unread as
+    // latestOrdinal - lastReadOrdinal, so the event carries where this read
+    // lands in message-ordinal space.
+    await OutboxRepository.insert(client, "stream:read", {
+      workspaceId,
+      authorId: memberId,
+      streamId,
+      lastReadEventId: readEventId,
+      lastReadSequence: readPosition.sequence.toString(),
+      lastReadOrdinal: readPosition.messageOrdinal,
+      readMessageIds,
     })
+    return membership
   }
 
   /**
@@ -2191,7 +2207,7 @@ export class StreamService {
     streamId: string,
     memberId: string,
     messageId: string
-  ): Promise<StreamMember | null> {
+  ): Promise<MarkUnreadResult> {
     return withTransaction(this.pool, async (client) => {
       const messageEvent = await StreamEventRepository.findByMessageId(client, streamId, messageId)
       if (!messageEvent) throw new MessageNotFoundError()
@@ -2206,7 +2222,7 @@ export class StreamService {
       // read-only for participation, never written — membership ≠ read state).
       // Explicit unread is one of the sanctioned downward moves.
       const membership = await StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
-      await ReadStateRepository.set(client, streamId, memberId, lastReadEventId)
+      const postWrite = await ReadStateRepository.set(client, streamId, memberId, lastReadEventId)
       // Mark-unread means "this message and everything after it is unread", so
       // overlay rows at/above the target contradict the intent — drop them. The
       // pointer lands just before the target, which can also ADVANCE it (target
@@ -2228,7 +2244,14 @@ export class StreamService {
         lastReadOrdinal,
         readMessageIds,
       })
-      return membership
+      return {
+        membership,
+        readState: {
+          lastReadEventId,
+          lastReadSequence: previous?.sequence.toString() ?? null,
+          lastReadAt: postWrite?.lastReadAt?.toISOString() ?? null,
+        },
+      }
     })
   }
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -2357,14 +2357,20 @@ export class StreamService {
   }
 
   /**
-   * Per-stream unread count sourced from the viewer's read frontier. An absent
+   * Per-stream unread and total counts sourced from the viewer's read frontier. An absent
    * read-state row reads as "never read" (frontier before the first message —
    * everything unread), so access-without-membership viewers (INV-62) work with
    * no special case.
    */
-  async getEffectiveUnreadCount(streamId: string, userId: string): Promise<number> {
+  async getEffectiveUnreadSummary(
+    streamId: string,
+    userId: string
+  ): Promise<{ unreadCount: number; totalCount: number }> {
     const effective = await getEffectiveReadState(this.pool, userId, [streamId])
-    return this.getUnreadCount(streamId, userId, effective.get(streamId)?.lastReadEventId ?? null)
+    const counts = await this.getUnreadCounts([
+      { streamId, memberId: userId, lastReadEventId: effective.get(streamId)?.lastReadEventId ?? null },
+    ])
+    return counts.get(streamId) ?? { unreadCount: 0, totalCount: 0 }
   }
 
   /** The viewer's standalone read-state row on one stream (per-stream bootstrap frontier). */

--- a/apps/backend/src/features/streams/sparse-read.test.ts
+++ b/apps/backend/src/features/streams/sparse-read.test.ts
@@ -167,7 +167,7 @@ describe("applySparseUnread", () => {
     spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 30n } as never)
     spyOn(StreamEventRepository, "findPreviousMessageEvent").mockResolvedValue({ id: "evt_4", sequence: 25n } as never)
     spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(2)
-    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(null)
     const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
 
     const snapshot = await applySparseUnread(db, {
@@ -197,7 +197,7 @@ describe("applySparseUnread", () => {
     spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 10n } as never)
     spyOn(StreamEventRepository, "findPreviousMessageEvent").mockResolvedValue(null)
     spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(0)
-    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(null)
 
     await applySparseUnread(db, { workspaceId: "ws_1", streamId: "stream_1", memberId: "usr_1", messageIds: ["msg_1"] })
 
@@ -216,7 +216,7 @@ describe("applySparseUnread", () => {
     spyOn(StreamEventRepository, "findEarliestMessageEvent").mockResolvedValue({ sequence: 30n } as never)
     spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
     spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue(["msg_9"])
-    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(undefined)
+    const readStateSet = spyOn(ReadStateRepository, "set").mockResolvedValue(null)
     const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
 
     const snapshot = await applySparseUnread(db, {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -15,7 +15,12 @@ import { createAuthHandlers } from "./auth/handlers"
 import { createWorkspaceHandlers, WorkspaceRepository } from "./features/workspaces"
 import { createWorkspaceMemberManagementHandlers } from "./features/workspace-members"
 import type { ControlPlaneClient } from "./lib/control-plane-client"
-import { createStreamHandlers, createStreamBriefHandlers, StreamBriefService } from "./features/streams"
+import {
+  createStreamHandlers,
+  createStreamBriefHandlers,
+  StreamBriefService,
+  StreamReadService,
+} from "./features/streams"
 import { createMessageHandlers, SteeredMessageService } from "./features/messaging"
 import { createAttachmentHandlers } from "./features/attachments"
 import { createSearchHandlers } from "./features/search"
@@ -309,9 +314,11 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   })
   const streamBriefService = new StreamBriefService({ pool })
   const streamBrief = createStreamBriefHandlers({ pool, streamBriefService })
+  const streamReadService = new StreamReadService({ pool, streamService, activityService })
   const stream = createStreamHandlers({
     pool,
     streamService,
+    streamReadService,
     eventService,
     activityService,
     linkPreviewService,

--- a/apps/backend/tests/e2e/sidebar-archived-roots.test.ts
+++ b/apps/backend/tests/e2e/sidebar-archived-roots.test.ts
@@ -32,6 +32,7 @@ function createSocket(client: TestClient): Socket {
     },
     transports: ["websocket"],
     autoConnect: false,
+    forceNew: true,
   })
 }
 

--- a/apps/backend/tests/integration/read-state-nonmember.test.ts
+++ b/apps/backend/tests/integration/read-state-nonmember.test.ts
@@ -242,8 +242,10 @@ describe("read state — non-member unlock", () => {
       await streamService.markAsRead(wid, sid, viewer, events[1].id)
       const result = await streamService.markUnread(wid, sid, viewer, msg2)
 
-      expect(result.membership).toBeNull()
-      expect(result.readState).toMatchObject({ lastReadEventId: events[0].id, lastReadSequence: "1" })
+      expect(result).toMatchObject({
+        membership: null,
+        readState: { lastReadEventId: events[0].id, lastReadSequence: "1" },
+      })
       expect(await membershipCount(sid, viewer)).toBe(0)
 
       const row = await ReadStateRepository.get(pool, sid, viewer)
@@ -273,8 +275,10 @@ describe("read state — non-member unlock", () => {
 
       const result = await streamService.markUnread(wid, sid, viewer, msg1)
 
-      expect(result.membership).toBeNull()
-      expect(result.readState).toMatchObject({ lastReadEventId: null, lastReadSequence: null })
+      expect(result).toMatchObject({
+        membership: null,
+        readState: { lastReadEventId: null, lastReadSequence: null },
+      })
       const row = await ReadStateRepository.get(pool, sid, viewer)
       expect(row).not.toBeNull()
       expect(row?.lastReadEventId).toBeNull()

--- a/apps/backend/tests/integration/read-state-nonmember.test.ts
+++ b/apps/backend/tests/integration/read-state-nonmember.test.ts
@@ -240,9 +240,10 @@ describe("read state — non-member unlock", () => {
       const events = await StreamEventRepository.list(pool, sid)
 
       await streamService.markAsRead(wid, sid, viewer, events[1].id)
-      const membership = await streamService.markUnread(wid, sid, viewer, msg2)
+      const result = await streamService.markUnread(wid, sid, viewer, msg2)
 
-      expect(membership).toBeNull()
+      expect(result.membership).toBeNull()
+      expect(result.readState).toMatchObject({ lastReadEventId: events[0].id, lastReadSequence: "1" })
       expect(await membershipCount(sid, viewer)).toBe(0)
 
       const row = await ReadStateRepository.get(pool, sid, viewer)
@@ -270,9 +271,10 @@ describe("read state — non-member unlock", () => {
       await seedChannel(wid, sid, author)
       const [msg1] = await sendMessages(wid, sid, author, 2)
 
-      const membership = await streamService.markUnread(wid, sid, viewer, msg1)
+      const result = await streamService.markUnread(wid, sid, viewer, msg1)
 
-      expect(membership).toBeNull()
+      expect(result.membership).toBeNull()
+      expect(result.readState).toMatchObject({ lastReadEventId: null, lastReadSequence: null })
       const row = await ReadStateRepository.get(pool, sid, viewer)
       expect(row).not.toBeNull()
       expect(row?.lastReadEventId).toBeNull()

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -13,6 +13,7 @@ import type {
   NotificationLevel,
   CompanionMode,
   ToolPrivacyPolicy,
+  StreamReadFrontier,
 } from "@threa/types"
 
 /**
@@ -217,14 +218,15 @@ export const streamsApi = {
     return res.membership
   },
 
-  async markUnread(workspaceId: string, streamId: string, messageId: string): Promise<StreamMember | null> {
-    // Null membership = a successful unread by a viewer with access but no
-    // membership row (INV-62) — the standalone frontier moved; there is no
-    // membership to return.
-    const res = await api.post<{ membership: StreamMember | null }>(
+  async markUnread(
+    workspaceId: string,
+    streamId: string,
+    messageId: string
+  ): Promise<{ membership: StreamMember | null; readState?: StreamReadFrontier }> {
+    const res = await api.post<{ membership: StreamMember | null; readState?: StreamReadFrontier }>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/unread`,
       { messageId }
     )
-    return res.membership
+    return res
   },
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -46,6 +46,7 @@ import {
   useWorkspaceStreamReadStates,
 } from "@/stores/workspace-store"
 import { resolveFrontierEventId, resolveFrontierSequence } from "@/lib/read-frontier"
+import { useReadCommitQueue } from "@/sync/read-commit-queue"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { useUser } from "@/auth"
 import { Button } from "@/components/ui/button"
@@ -1019,6 +1020,12 @@ export function StreamContent({
     () => (isThread ? remapSuppressedWatermark(lastReadEventId, events, displayEvents) : lastReadEventId),
     [isThread, lastReadEventId, events, displayEvents]
   )
+  const frontierLastReadSequence = useMemo(() => {
+    if (frontierLastReadEventId === lastReadEventId) return frontierSequence
+    if (frontierLastReadEventId == null) return frontierLastReadEventId
+    const remapped = displayEvents.find((event) => event.id === frontierLastReadEventId)
+    return remapped ? BigInt(remapped.sequence) : undefined
+  }, [displayEvents, frontierLastReadEventId, frontierSequence, lastReadEventId])
 
   // Conversation lookup for the always-on provenance chips (mechanism A below).
   const conversationsById = useMemo(() => {
@@ -2283,7 +2290,7 @@ export function StreamContent({
   // no settle phase (`isInitialSettling` would never clear there), so exempt it.
   const settledAtBottom = !useVirtualized || !virtualIsInitialSettling
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && settledAtBottom
-  const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
+  const { lastSeenEventId, atLastRow, tailVisible, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     // The virtualized scroller late-mounts via a ref callback, AFTER
     // `autoMarkEnabled` flips true — pass the mounted element so the read-frontier
@@ -2300,6 +2307,7 @@ export function StreamContent({
     events: displayEvents,
     streamId,
     lastReadEventId: frontierLastReadEventId,
+    lastReadSequence: frontierLastReadSequence,
     enabled: autoMarkEnabled,
     programmaticScrollAtRef,
   })
@@ -2309,10 +2317,12 @@ export function StreamContent({
     // Raw watermark, not the thread-remapped frontier seed: the heal's anchor
     // must be the id the server already stores so the advance stays a no-op.
     readPointerEventId: lastReadEventId,
+    activityHealEnabled: tailVisible,
   })
   const canAutoRead = useAutoReadAttention()
 
   const isMobile = useIsMobile()
+  const readCommitQueue = useReadCommitQueue()
   const { markAsRead, markUnread, getUnreadCount } = useUnreadCounts(workspaceId)
   const unreadCount = getUnreadCount(streamId)
 
@@ -2387,6 +2397,9 @@ export function StreamContent({
   markAsReadRef.current = markAsRead
   const markUnreadRef = useRef(markUnread)
   markUnreadRef.current = markUnread
+  useEffect(() => {
+    readCommitQueue.observeReadPointer(streamId, lastReadEventId)
+  }, [lastReadEventId, readCommitQueue, streamId])
 
   // "Escape the unread block": mark the stream fully read, dismiss the
   // persistent unread divider, and resume tailing the live bottom. Shared by
@@ -2455,9 +2468,11 @@ export function StreamContent({
   useEffect(() => {
     return addMarkUnreadListener((detail) => {
       if (detail.streamId !== streamId) return
-      markUnreadRef.current(streamId, detail.messageId)
+      void readCommitQueue
+        .runExplicitUnread(streamId, lastReadEventId, () => markUnreadRef.current(streamId, detail.messageId))
+        .catch(() => undefined)
     })
-  }, [streamId])
+  }, [lastReadEventId, readCommitQueue, streamId])
 
   const queryClient = useQueryClient()
   const isPublicChannel = stream?.type === StreamTypes.CHANNEL && stream?.visibility === Visibilities.PUBLIC

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -59,7 +59,11 @@ describe("useAutoMarkAsRead", () => {
 
     queue = new ReadCommitQueue({
       workspaceId: "ws_123",
-      commitRef: { current: (streamId, lastEventId, opts) => mockMarkAsRead(streamId, lastEventId, opts) },
+      commitRef: {
+        current: async (streamId, lastEventId, opts) => {
+          mockMarkAsRead(streamId, lastEventId, opts)
+        },
+      },
     })
 
     vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileViewport)
@@ -231,7 +235,7 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: true })
   })
 
-  it("re-fires a full mark when partial flips to false at the same event (scrolled on to the tail)", () => {
+  it("re-fires a full mark when partial flips to false at the same event (scrolled on to the tail)", async () => {
     const { rerender } = renderHook(
       ({ partial }) => useAutoMarkAsRead("ws_123", "stream_123", "event_123", { partial }),
       {
@@ -245,8 +249,8 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_123", "event_123", { partial: true })
 
     rerender({ partial: false })
-    act(() => {
-      vi.advanceTimersByTime(500)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
     })
 
     // Same event, now full — must re-fire so the badge clears optimistically
@@ -255,7 +259,7 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
   })
 
-  it("re-fires the same mark when activity arrives with an unchanged frontier", () => {
+  it("re-fires the same mark when activity arrives with an unchanged frontier", async () => {
     // A reaction while viewing raises activityCount with no new timeline event
     // — lastEventId stays put, so the re-fire rides on the count VALUE being an
     // effect dep. The old code re-ran by accident (markAsRead identity churn);
@@ -271,8 +275,8 @@ describe("useAutoMarkAsRead", () => {
 
     activityCount = 1
     rerender({ v: 1 })
-    act(() => {
-      vi.advanceTimersByTime(500)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
     })
 
     expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_123", "event_123", { partial: false })
@@ -351,6 +355,24 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_watermark", { partial: true })
+  })
+
+  it("does not heal pointer-only activity while the viewport is detached from the tail", () => {
+    unreadCount = 0
+    activityCount = 1
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", undefined, {
+        readPointerEventId: "event_watermark",
+        activityHealEnabled: false,
+      })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
   })
 
   it("does NOT heal while real unread remains — the frontier path owns that mark", () => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -27,6 +27,8 @@ interface UseAutoMarkAsReadOptions {
    * server-side; only the handler's activity clear has effect.
    */
   readPointerEventId?: string | null
+  /** Whether the timeline tail is actually visible; required for pointer-only activity healing. */
+  activityHealEnabled?: boolean
 }
 
 /**
@@ -68,7 +70,7 @@ export function useAutoMarkAsRead(
   lastEventId: string | undefined,
   options: UseAutoMarkAsReadOptions = {}
 ) {
-  const { enabled = true, partial = false, readPointerEventId = null } = options
+  const { enabled = true, partial = false, readPointerEventId = null, activityHealEnabled = true } = options
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
   const canAutoRead = useAutoReadAttention()
@@ -106,7 +108,9 @@ export function useAutoMarkAsRead(
     // below, the normal frontier path owns the (partial) mark that clears
     // activity, and healing early would race a mark-unread's restored badges.
     const healEventId =
-      !lastEventId && activityCount > 0 && unreadCount === 0 && readPointerEventId ? readPointerEventId : undefined
+      activityHealEnabled && !lastEventId && activityCount > 0 && unreadCount === 0 && readPointerEventId
+        ? readPointerEventId
+        : undefined
     const reportEventId = lastEventId ?? healEventId
     const reportPartial = lastEventId ? partial : true
     if (!enabled || !reportEventId || !canAutoRead) {
@@ -153,7 +157,18 @@ export function useAutoMarkAsRead(
       // replaces the pending mark instead.
       if (streamIdRef.current !== streamId) queue.flush(streamId)
     }
-  }, [enabled, streamId, lastEventId, partial, queue, unreadCount, activityCount, canAutoRead, readPointerEventId])
+  }, [
+    enabled,
+    streamId,
+    lastEventId,
+    partial,
+    queue,
+    unreadCount,
+    activityCount,
+    canAutoRead,
+    readPointerEventId,
+    activityHealEnabled,
+  ])
 
   // Unmounting the stream page entirely (navigating to drafts/board) is the
   // other leave path — flush whatever stream was current.

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -680,6 +680,43 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.atLastRow).toBe(true)
   })
 
+  it("pins a backward read-set that moves an outside-window pointer into the loaded window", () => {
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    const events = ["e0", "e1", "e2"].map((id, index) => ({
+      id,
+      sequence: String(100 + index),
+    })) as unknown as StreamEvent[]
+    for (const [index, event] of events.entries()) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", event.id)
+      row.getBoundingClientRect = () => rect(5 + index * 30, 30 + index * 30)
+      container.appendChild(row)
+    }
+    const scrollContainerRef = { current: container }
+
+    const { result, rerender } = renderHook(
+      ({ lastReadEventId, lastReadSequence }) =>
+        useLastSeenEvent({
+          scrollContainerRef,
+          events,
+          streamId: "stream_1",
+          lastReadEventId,
+          lastReadSequence,
+          enabled: true,
+        }),
+      { initialProps: { lastReadEventId: "newer_outside_window", lastReadSequence: 200n } }
+    )
+
+    expect(result.current.lastSeenEventId).toBeUndefined()
+    act(() => rerender({ lastReadEventId: "e0", lastReadSequence: 100n }))
+    expect(result.current.lastSeenEventId).toBeUndefined()
+    expect(result.current.atLastRow).toBe(false)
+
+    act(() => container.dispatchEvent(new Event("scroll")))
+    expect(result.current.lastSeenEventId).toBe("e2")
+  })
+
   it("does not emit a mark target while the read pointer sits outside the loaded window", () => {
     // Mark-as-unread on the oldest loaded row moves the pointer to a message below
     // the loaded window, so it is unresolvable in `events`. Emitting the stale

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -122,6 +122,8 @@ interface UseLastSeenEventOptions {
    * frontier so marking resumes from where the viewer left off.
    */
   lastReadEventId: string | null | undefined
+  /** Authoritative sequence, including when the pointer's event is outside the loaded window. */
+  lastReadSequence?: bigint | null
   /** Off while loading/jumping/draft — no scroller to read, nothing to track. */
   enabled: boolean
   /**
@@ -141,8 +143,10 @@ interface UseLastSeenEventResult {
    * scroll down through it (or press Escape) for the pointer to advance.
    */
   lastSeenEventId: string | undefined
-  /** Whether the read frontier has reached the last rendered row (a full read). */
+  /** Whether the read frontier has reached the last loaded row (a full read). */
   atLastRow: boolean
+  /** Whether the last rendered row currently intersects the viewport. */
+  tailVisible: boolean
   /**
    * Whether unread sits above the current viewport — i.e. the first unread row
    * is scrolled off the top. Drives the "N new ↑" jump affordance.
@@ -164,11 +168,13 @@ export function useLastSeenEvent({
   events,
   streamId,
   lastReadEventId,
+  lastReadSequence,
   enabled,
   programmaticScrollAtRef,
 }: UseLastSeenEventOptions): UseLastSeenEventResult {
   const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
   const [atLastRow, setAtLastRow] = useState(false)
+  const [tailVisible, setTailVisible] = useState(false)
   const [unreadAboveViewport, setUnreadAboveViewport] = useState(false)
 
   const indexById = useMemo(() => {
@@ -194,9 +200,10 @@ export function useLastSeenEvent({
   // the pointer's OWN past sequence (see below), so it is sequence- not index-based.
   const readSeq = useMemo<bigint | null>(() => {
     if (lastReadEventId == null) return -1n
+    if (lastReadSequence !== undefined) return lastReadSequence ?? -1n
     const ev = readIndex >= 0 ? events[readIndex] : undefined
     return ev ? BigInt(ev.sequence) : null
-  }, [lastReadEventId, readIndex, events])
+  }, [lastReadEventId, lastReadSequence, readIndex, events])
   const readSeqRef = useRef(readSeq)
   readSeqRef.current = readSeq
 
@@ -256,7 +263,7 @@ export function useLastSeenEvent({
     const topIdx = map.get(range.topId)
     const botIdx = map.get(range.bottomId)
     if (topIdx === undefined || botIdx === undefined) return
-    const lastRenderedIdx = map.get(rows[rows.length - 1].id) ?? botIdx
+    const lastLoadedIdx = eventsRef.current.length - 1
 
     // Sweep-link with the previous scan: within SWEEP_LINK_MS and with no
     // programmatic scroll write since that scan, the movement between the two
@@ -288,10 +295,11 @@ export function useLastSeenEvent({
     }
 
     const frontier = frontierRef.current
-    setAtLastRow(frontier >= lastRenderedIdx)
+    setAtLastRow(frontier >= lastLoadedIdx)
+    setTailVisible(botIdx >= lastLoadedIdx)
     // Unread sits above the viewport when the first unread row (frontier + 1)
     // exists in the window and is scrolled off the top.
-    setUnreadAboveViewport(frontier + 1 <= lastRenderedIdx && frontier + 1 < topIdx)
+    setUnreadAboveViewport(frontier + 1 <= lastLoadedIdx && frontier + 1 < topIdx)
     // `lastSeenEventId` is derived, not a forward-only latch: it names the
     // frontier's row only while the frontier sits PAST the read pointer. Once the
     // pointer catches up to (or passes) the frontier — the round-trip landed, or a
@@ -302,7 +310,7 @@ export function useLastSeenEvent({
     // window (e.g. mark-as-unread on the oldest loaded row moves it below the
     // window) — read progress is then unknowable, so emit nothing rather than
     // re-marking up to the stale frontier.
-    const pointerResolved = readSeqRef.current != null
+    const pointerResolved = readSeqRef.current != null && (readIndexRef.current >= 0 || readSeqRef.current === -1n)
     if (pointerResolved && frontier > readIndexRef.current && frontier >= 0) {
       const id = eventsRef.current[frontier]?.id
       if (id) setLastSeenEventId((prev) => (prev === id ? prev : id))
@@ -320,6 +328,7 @@ export function useLastSeenEvent({
     prevScanRef.current = null
     setLastSeenEventId(undefined)
     setAtLastRow(false)
+    setTailVisible(false)
     setUnreadAboveViewport(false)
   }, [streamId])
 
@@ -405,5 +414,5 @@ export function useLastSeenEvent({
     return () => cancelAnimationFrame(raf)
   }, [enabled, events, streamId, lastReadEventId, readIndex, recompute])
 
-  return { lastSeenEventId, atLastRow, unreadAboveViewport }
+  return { lastSeenEventId, atLastRow, tailVisible, unreadAboveViewport }
 }

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -20,8 +20,9 @@ import { useUnreadCounts } from "./use-unread-counts"
 
 const mockMarkAsRead =
   vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember | null>>()
+type MarkUnreadResponse = { membership: StreamMember | null; readState: StreamReadFrontier }
 const mockMarkUnread =
-  vi.fn<(workspaceId: string, streamId: string, messageId: string) => Promise<StreamMember | null>>()
+  vi.fn<(workspaceId: string, streamId: string, messageId: string) => Promise<MarkUnreadResponse>>()
 const mockMarkAllAsRead = vi.fn<(workspaceId: string) => Promise<MarkAllAsReadResponse>>()
 const mockPostMessage = vi.fn()
 const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
@@ -708,10 +709,7 @@ describe("useUnreadCounts", () => {
     expect(updated?.streamReadState?.stream_thread?.lastReadEventId).toBe("event_new")
   })
 
-  it("markUnread writes nothing optimistically even with a membership — the stream:read_set echo owns the frontier", async () => {
-    // The unread response carries participation only (no watermark), so the
-    // optimistic path writes nothing for members and non-members alike; the
-    // echo SETs the standalone frontier.
+  it("markUnread applies the returned frontier without writing membership", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
     await db.streamMemberships.put({
@@ -725,10 +723,13 @@ describe("useUnreadCounts", () => {
     })
 
     mockMarkUnread.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
+      membership: {
+        streamId: "stream_1",
+        memberId: "member_1",
+        notificationLevel: "everything",
+        joinedAt: new Date().toISOString(),
+      },
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "1", lastReadAt: null },
     })
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
@@ -737,18 +738,23 @@ describe("useUnreadCounts", () => {
     })
 
     await waitFor(() => expect(mockMarkUnread).toHaveBeenCalledWith("ws_1", "stream_1", "msg_target"))
-    expect(await db.streamReadState.get("ws_1:stream_1")).toBeUndefined()
+    await waitFor(async () => {
+      expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+        lastReadEventId: "evt_1",
+        lastReadSequence: "1",
+      })
+    })
     expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ notificationLevel: "everything" })
   })
 
-  it("markUnread with a null membership writes nothing optimistically — the stream:read_set echo owns the frontier", async () => {
-    // A non-member's unread succeeds with a null membership; the response
-    // carries no watermark, so the optimistic path must not fabricate
-    // membership-shaped rows — the echo SETs the standalone frontier.
+  it("markUnread applies the returned frontier for a non-member without fabricating membership", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
 
-    mockMarkUnread.mockResolvedValue(null)
+    mockMarkUnread.mockResolvedValue({
+      membership: null,
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "1", lastReadAt: null },
+    })
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -757,7 +763,9 @@ describe("useUnreadCounts", () => {
 
     await waitFor(() => expect(mockMarkUnread).toHaveBeenCalledWith("ws_1", "stream_thread", "msg_target"))
     expect(await db.streamMemberships.get("ws_1:stream_thread")).toBeUndefined()
-    expect(await db.streamReadState.get("ws_1:stream_thread")).toBeUndefined()
+    await waitFor(async () => {
+      expect(await db.streamReadState.get("ws_1:stream_thread")).toMatchObject({ lastReadEventId: "evt_1" })
+    })
   })
 
   it("applies the returned frontier snapshot to the cache and IDB when marking all as read (initiating device)", async () => {
@@ -992,7 +1000,7 @@ describe("useUnreadCounts", () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
 
-    let resolveUnread!: (membership: StreamMember | null) => void
+    let resolveUnread!: (response: MarkUnreadResponse) => void
     mockMarkUnread.mockReturnValue(new Promise((resolve) => (resolveUnread = resolve)))
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
@@ -1017,7 +1025,10 @@ describe("useUnreadCounts", () => {
     // the response carries participation only, nothing applies optimistically,
     // and the echo owns the frontier.
     await act(async () => {
-      resolveUnread(memberResponse())
+      resolveUnread({
+        membership: memberResponse(),
+        readState: { lastReadEventId: "evt_50", lastReadSequence: "50", lastReadAt: null },
+      })
       await new Promise((resolve) => setTimeout(resolve, 10))
     })
 

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -747,6 +747,39 @@ describe("useUnreadCounts", () => {
     expect(await db.streamMemberships.get("ws_1:stream_1")).toMatchObject({ notificationLevel: "everything" })
   })
 
+  it("returns the newer locally reconciled pointer when it supersedes the unread response", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    let resolveUnread!: (value: Awaited<ReturnType<typeof mockMarkUnread>>) => void
+    mockMarkUnread.mockImplementationOnce(() => new Promise((resolve) => (resolveUnread = resolve)))
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    let operation!: Promise<string | null | undefined>
+    act(() => {
+      operation = result.current.markUnread("stream_1", "msg_target")
+    })
+    await waitFor(() => expect(mockMarkUnread).toHaveBeenCalledWith("ws_1", "stream_1", "msg_target"))
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_newer",
+      lastReadSequence: "3",
+      lastReadAt: null,
+      _cachedAt: Date.now() + 10_000,
+    })
+    resolveUnread({
+      membership: null,
+      readState: { lastReadEventId: "evt_response", lastReadSequence: "1", lastReadAt: null },
+    })
+
+    await expect(operation).resolves.toBe("evt_newer")
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_newer",
+      lastReadSequence: "3",
+    })
+  })
+
   it("markUnread applies the returned frontier for a non-member without fabricating membership", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -12,6 +12,7 @@ import {
   publishReadAllFrontiersToCache,
   putReadAllFrontiersIdb,
   putReadStateIdb,
+  putReadStateIdbIfUntouchedSince,
   readStateTouchedSince,
   resolveReadAllFrontiers,
   type ReadStateSnapshot,
@@ -275,9 +276,7 @@ export function useUnreadCounts(workspaceId: string) {
       return { ...result, startedAt }
     },
     onSuccess: async ({ readState, startedAt }, { streamId }) => {
-      if (!readState || (await readStateTouchedSince(workspaceId, streamId, startedAt))) return
-      const now = Date.now()
-      await putReadStateIdb(workspaceId, streamId, readState, now)
+      if (!readState || !(await putReadStateIdbIfUntouchedSince(workspaceId, streamId, readState, startedAt))) return
       mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, readState)
       queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
         if (!old || typeof old !== "object") return old

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -268,14 +268,22 @@ export function useUnreadCounts(workspaceId: string) {
     },
   })
 
-  // Mark a message (and everything after it) unread. The response carries
-  // participation only — no watermark — so nothing moves optimistically: the
-  // `stream:read_set` echo SETs the standalone frontier (an authorized downward
-  // move) and raises the count on the round-trip. Membership is never written on
-  // a read (membership ≠ read state).
   const markUnreadMutation = useMutation({
-    mutationFn: ({ streamId, messageId }: { streamId: string; messageId: string }) =>
-      streamService.markUnread(workspaceId, streamId, messageId),
+    mutationFn: async ({ streamId, messageId }: { streamId: string; messageId: string }) => {
+      const startedAt = Date.now()
+      const result = await streamService.markUnread(workspaceId, streamId, messageId)
+      return { ...result, startedAt }
+    },
+    onSuccess: async ({ readState, startedAt }, { streamId }) => {
+      if (!readState || (await readStateTouchedSince(workspaceId, streamId, startedAt))) return
+      const now = Date.now()
+      await putReadStateIdb(workspaceId, streamId, readState, now)
+      mergeReadStateIntoBootstrapCache(queryClient, workspaceId, streamId, readState)
+      queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
+        if (!old || typeof old !== "object") return old
+        return { ...old, readState }
+      })
+    },
   })
 
   const markAllAsReadMutation = useMutation({
@@ -385,8 +393,8 @@ export function useUnreadCounts(workspaceId: string) {
       // and reports the whole stream — including the user's own messages — as
       // unread. The auto-read effect re-fires with the real id once the server echo
       // swaps it in.
-      if (lastEventId.startsWith("temp_")) return
-      markAsReadMutation.mutate({ streamId, lastEventId, partial: opts?.partial })
+      if (lastEventId.startsWith("temp_")) return Promise.resolve()
+      const commit = markAsReadMutation.mutateAsync({ streamId, lastEventId, partial: opts?.partial })
       // Dismiss any push notification for this stream — advancing the read pointer
       // (auto-read, manual "Mark as read", or Escape) means the user is here, so
       // the banner is noise. Centralized on this single-stream read-advance funnel
@@ -395,6 +403,7 @@ export function useUnreadCounts(workspaceId: string) {
       // their own socket echo when open, or the bootstrap sweep on next open
       // (lib/notification-sweep.ts) — never via push, which would burn quota.
       navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })
+      return commit.then(() => undefined)
     },
     [markAsReadMutation]
   )
@@ -404,9 +413,8 @@ export function useUnreadCounts(workspaceId: string) {
   }, [markAllAsReadMutation])
 
   const markUnread = useCallback(
-    (streamId: string, messageId: string) => {
-      markUnreadMutation.mutate({ streamId, messageId })
-    },
+    (streamId: string, messageId: string) =>
+      markUnreadMutation.mutateAsync({ streamId, messageId }).then(({ readState }) => readState?.lastReadEventId),
     [markUnreadMutation]
   )
 

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -412,9 +412,12 @@ export function useUnreadCounts(workspaceId: string) {
   }, [markAllAsReadMutation])
 
   const markUnread = useCallback(
-    (streamId: string, messageId: string) =>
-      markUnreadMutation.mutateAsync({ streamId, messageId }).then(({ readState }) => readState?.lastReadEventId),
-    [markUnreadMutation]
+    async (streamId: string, messageId: string) => {
+      const { readState } = await markUnreadMutation.mutateAsync({ streamId, messageId })
+      const reconciled = await db.streamReadState.get(`${workspaceId}:${streamId}`)
+      return reconciled ? reconciled.lastReadEventId : readState?.lastReadEventId
+    },
+    [markUnreadMutation, workspaceId]
   )
 
   return {

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -242,6 +242,21 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_6", { partial: false })
   })
 
+  it("keeps unread blocked when an unresolved pointer is observed after the operation", async () => {
+    const unread = queue.runExplicitUnread("stream_a", "event_5", async () => undefined)
+    await unread
+
+    queue.observeReadPointer("stream_a", undefined)
+    queue.report("stream_a", "event_6", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).not.toHaveBeenCalled()
+
+    queue.observeReadPointer("stream_a", "event_4")
+    queue.report("stream_a", "event_6", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_6", { partial: false })
+  })
+
   it("releases unread when its expected pointer was observed before a later cross-device read", async () => {
     let resolveUnread!: (eventId: string | null) => void
     const unread = queue.runExplicitUnread(

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -179,6 +179,36 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledTimes(2)
   })
 
+  it("serializes overlapping explicit unread requests so the newer request cannot complete first", async () => {
+    const starts: string[] = []
+    let resolveFirst!: (eventId: string | null) => void
+    let resolveSecond!: (eventId: string | null) => void
+    const first = queue.runExplicitUnread("stream_a", "event_5", () => {
+      starts.push("first")
+      return new Promise<string | null>((resolve) => (resolveFirst = resolve))
+    })
+    await Promise.resolve()
+
+    const second = queue.runExplicitUnread("stream_a", "event_5", () => {
+      starts.push("second")
+      return new Promise<string | null>((resolve) => (resolveSecond = resolve))
+    })
+    await Promise.resolve()
+    expect(starts).toEqual(["first"])
+
+    resolveFirst("event_3")
+    await first
+    await Promise.resolve()
+    expect(starts).toEqual(["first", "second"])
+
+    resolveSecond("event_1")
+    await second
+    queue.observeReadPointer("stream_a", "event_1")
+    queue.report("stream_a", "event_6", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_6", { partial: false })
+  })
+
   it("releases unread when its expected pointer was observed before a later cross-device read", async () => {
     let resolveUnread!: (eventId: string | null) => void
     const unread = queue.runExplicitUnread(

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -209,6 +209,24 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_6", { partial: false })
   })
 
+  it("releases unread against the locally reconciled pointer when a newer frontier superseded the response", async () => {
+    let resolveUnread!: (eventId: string | null) => void
+    const unread = queue.runExplicitUnread(
+      "stream_a",
+      "event_3",
+      () => new Promise<string | null>((resolve) => (resolveUnread = resolve))
+    )
+    await Promise.resolve()
+
+    queue.observeReadPointer("stream_a", "event_4")
+    resolveUnread("event_4")
+    await unread
+
+    queue.report("stream_a", "event_5", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_5", { partial: false })
+  })
+
   it("releases unread when its expected pointer was observed before a later cross-device read", async () => {
     let resolveUnread!: (eventId: string | null) => void
     const unread = queue.runExplicitUnread(
@@ -226,6 +244,42 @@ describe("ReadCommitQueue", () => {
     queue.report("stream_a", "event_5", false)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
     expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_5", { partial: false })
+  })
+
+  it("drains a newer mark queued behind an in-flight request during disposal", async () => {
+    let releaseFirst!: () => void
+    commit.mockImplementationOnce(() => new Promise<void>((resolve) => (releaseFirst = resolve)))
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    queue.report("stream_a", "event_2", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    queue.dispose()
+    releaseFirst()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(commit.mock.calls).toEqual([
+      ["stream_a", "event_1", { partial: false }],
+      ["stream_a", "event_2", { partial: false }],
+    ])
+  })
+
+  it("retries an in-flight request that fails after disposal", async () => {
+    let rejectFirst!: (error: Error) => void
+    commit
+      .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => (rejectFirst = reject)))
+      .mockResolvedValueOnce(undefined)
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    queue.dispose()
+    rejectFirst(new Error("offline"))
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_RETRY_MS)
+
+    expect(commit).toHaveBeenCalledTimes(2)
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_1", partial: false })
   })
 
   it("dispose flushes pending marks (a microtask later — it can run in render) and refuses further reports", async () => {

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { ReadCommitQueue, READ_COMMIT_DEBOUNCE_MS } from "./read-commit-queue"
+import {
+  ReadCommitQueue,
+  READ_COMMIT_DEBOUNCE_MS,
+  READ_COMMIT_MAX_RETRIES,
+  READ_COMMIT_RETRY_MS,
+} from "./read-commit-queue"
 
-const commit = vi.fn()
+const commit = vi.fn<(streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<void>>()
 
 function makeQueue() {
   return new ReadCommitQueue({
@@ -16,6 +21,7 @@ describe("ReadCommitQueue", () => {
   beforeEach(() => {
     vi.useFakeTimers()
     commit.mockReset()
+    commit.mockResolvedValue(undefined)
     queue = makeQueue()
   })
 
@@ -24,7 +30,7 @@ describe("ReadCommitQueue", () => {
     vi.useRealTimers()
   })
 
-  it("debounces a report and commits the newest mark (coalescing per stream)", () => {
+  it("debounces a report and commits the newest mark (coalescing per stream)", async () => {
     queue.report("stream_a", "event_1", true)
     vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS - 100)
     queue.report("stream_a", "event_2", false)
@@ -33,6 +39,7 @@ describe("ReadCommitQueue", () => {
 
     vi.advanceTimersByTime(100)
     expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_2", { partial: false })
+    await vi.runAllTimersAsync()
     expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_2", partial: false })
   })
 
@@ -70,12 +77,90 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledWith("stream_b", "event_b", { partial: true })
   })
 
-  it("resetCommitted forgets the record so a fresh open can re-commit the same mark", () => {
+  it("resetCommitted forgets the record so a fresh open can re-commit the same mark", async () => {
     queue.report("stream_a", "event_1", false)
-    vi.advanceTimersByTime(READ_COMMIT_DEBOUNCE_MS)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
     expect(queue.lastCommitted("stream_a")).not.toBeNull()
     queue.resetCommitted("stream_a")
     expect(queue.lastCommitted("stream_a")).toBeNull()
+  })
+
+  it("retries a rejected request and records it only after acknowledgement", async () => {
+    commit.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce(undefined)
+    queue.report("stream_a", "event_1", false)
+
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(queue.lastCommitted("stream_a")).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_RETRY_MS)
+    expect(commit).toHaveBeenCalledTimes(2)
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_1", partial: false })
+  })
+
+  it("drops a failed older retry when a newer frontier is already queued", async () => {
+    let rejectRead!: (error: Error) => void
+    commit.mockImplementationOnce(() => new Promise<void>((_resolve, reject) => (rejectRead = reject)))
+    queue.report("stream_a", "event_1", true)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    queue.report("stream_a", "event_2", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    rejectRead(new Error("offline"))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(commit.mock.calls).toEqual([
+      ["stream_a", "event_1", { partial: true }],
+      ["stream_a", "event_2", { partial: false }],
+    ])
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_RETRY_MS * 2)
+    expect(commit).toHaveBeenCalledTimes(2)
+  })
+
+  it("wakes an exhausted failed mark when the app regains focus", async () => {
+    commit.mockRejectedValue(new Error("offline"))
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(
+      READ_COMMIT_DEBOUNCE_MS + READ_COMMIT_RETRY_MS * (2 ** READ_COMMIT_MAX_RETRIES - 1)
+    )
+    expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 1)
+    expect(queue.lastCommitted("stream_a")).toBeNull()
+
+    commit.mockResolvedValue(undefined)
+    window.dispatchEvent(new Event("focus"))
+    await Promise.resolve()
+
+    expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 2)
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_1", partial: false })
+  })
+
+  it("serializes explicit unread behind an in-flight read and blocks reports until the pointer changes", async () => {
+    let releaseRead!: () => void
+    commit.mockImplementationOnce(() => new Promise<void>((resolve) => (releaseRead = resolve)))
+    queue.report("stream_a", "event_3", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    const order: string[] = []
+    const unread = queue.runExplicitUnread("stream_a", "event_3", async () => {
+      order.push("unread")
+      return "event_1"
+    })
+    queue.report("stream_a", "event_4", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(order).toEqual([])
+
+    releaseRead()
+    await unread
+    expect(order).toEqual(["unread"])
+
+    queue.report("stream_a", "event_4", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledTimes(1)
+
+    queue.observeReadPointer("stream_a", "event_1")
+    queue.report("stream_a", "event_4", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledTimes(2)
   })
 
   it("dispose flushes pending marks (a microtask later — it can run in render) and refuses further reports", async () => {

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -227,6 +227,21 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_5", { partial: false })
   })
 
+  it("releases unread when a newer pointer arrives after the operation resolves", async () => {
+    const unread = queue.runExplicitUnread("stream_a", "event_5", async () => "event_3")
+    await unread
+
+    queue.report("stream_a", "event_6", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).not.toHaveBeenCalled()
+
+    queue.observeReadPointer("stream_a", "event_4")
+    queue.report("stream_a", "event_6", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_6", { partial: false })
+  })
+
   it("releases unread when its expected pointer was observed before a later cross-device read", async () => {
     let resolveUnread!: (eventId: string | null) => void
     const unread = queue.runExplicitUnread(

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -3,6 +3,7 @@ import {
   ReadCommitQueue,
   READ_COMMIT_DEBOUNCE_MS,
   READ_COMMIT_MAX_RETRIES,
+  READ_COMMIT_PARKED_RETRY_MS,
   READ_COMMIT_RETRY_MS,
 } from "./read-commit-queue"
 
@@ -117,6 +118,21 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledTimes(2)
   })
 
+  it("keeps probing at a bounded interval after the fast retries are exhausted", async () => {
+    commit.mockRejectedValue(new Error("offline"))
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(
+      READ_COMMIT_DEBOUNCE_MS + READ_COMMIT_RETRY_MS * (2 ** READ_COMMIT_MAX_RETRIES - 1)
+    )
+    expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 1)
+
+    commit.mockResolvedValue(undefined)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_PARKED_RETRY_MS)
+
+    expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 2)
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_1", partial: false })
+  })
+
   it("wakes an exhausted failed mark when the app regains focus", async () => {
     commit.mockRejectedValue(new Error("offline"))
     queue.report("stream_a", "event_1", false)
@@ -161,6 +177,25 @@ describe("ReadCommitQueue", () => {
     queue.report("stream_a", "event_4", false)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
     expect(commit).toHaveBeenCalledTimes(2)
+  })
+
+  it("releases unread when its expected pointer was observed before a later cross-device read", async () => {
+    let resolveUnread!: (eventId: string | null) => void
+    const unread = queue.runExplicitUnread(
+      "stream_a",
+      "event_3",
+      () => new Promise<string | null>((resolve) => (resolveUnread = resolve))
+    )
+    await Promise.resolve()
+
+    queue.observeReadPointer("stream_a", "event_1")
+    queue.observeReadPointer("stream_a", "event_4")
+    resolveUnread("event_1")
+    await unread
+
+    queue.report("stream_a", "event_5", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_5", { partial: false })
   })
 
   it("dispose flushes pending marks (a microtask later — it can run in render) and refuses further reports", async () => {

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -253,7 +253,9 @@ export class ReadCommitQueue {
       state.postOperationPointerChanged ||
       (state.expectedReadEventId !== undefined
         ? state.observedReadEventIds.has(state.expectedReadEventId)
-        : [...state.observedReadEventIds].some((eventId) => eventId !== state.initialReadEventId))
+        : [...state.observedReadEventIds].some(
+            (eventId) => eventId !== undefined && eventId !== state.initialReadEventId
+          ))
     if (!pointerMatches) return
     this.explicitUnread.delete(streamId)
     this.committed.delete(streamId)

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -26,6 +26,7 @@ interface ExplicitUnread {
   observedReadEventIds: Set<string | null | undefined>
   expectedReadEventId: string | null | undefined
   operationDone: boolean
+  postOperationPointerChanged: boolean
 }
 
 /**
@@ -129,6 +130,9 @@ export class ReadCommitQueue {
     const state = this.explicitUnread.get(streamId)
     if (!state) return
     state.observedReadEventIds.add(readEventId)
+    if (state.operationDone && readEventId !== undefined && readEventId !== state.initialReadEventId) {
+      state.postOperationPointerChanged = true
+    }
     this.releaseExplicitUnreadIfReady(streamId, state)
   }
 
@@ -228,6 +232,7 @@ export class ReadCommitQueue {
       observedReadEventIds: new Set([initialReadEventId]),
       expectedReadEventId: undefined,
       operationDone: false,
+      postOperationPointerChanged: false,
     }
     this.explicitUnread.set(streamId, state)
     const inFlight = this.inFlight.get(streamId)
@@ -245,9 +250,10 @@ export class ReadCommitQueue {
   private releaseExplicitUnreadIfReady(streamId: string, state: ExplicitUnread): void {
     if (!state.operationDone || this.explicitUnread.get(streamId) !== state) return
     const pointerMatches =
-      state.expectedReadEventId !== undefined
+      state.postOperationPointerChanged ||
+      (state.expectedReadEventId !== undefined
         ? state.observedReadEventIds.has(state.expectedReadEventId)
-        : [...state.observedReadEventIds].some((eventId) => eventId !== state.initialReadEventId)
+        : [...state.observedReadEventIds].some((eventId) => eventId !== state.initialReadEventId))
     if (!pointerMatches) return
     this.explicitUnread.delete(streamId)
     this.committed.delete(streamId)

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -45,6 +45,7 @@ export class ReadCommitQueue {
   private readonly committed = new Map<string, ReadCommitMark>()
   private readonly explicitUnread = new Map<string, ExplicitUnread>()
   private readonly explicitUnreadTail = new Map<string, Promise<void>>()
+  private readonly draining = new Set<string>()
   private disposed = false
 
   private readonly onPageHide = () => this.flushAll()
@@ -105,7 +106,7 @@ export class ReadCommitQueue {
 
   /**
    * Serialize an explicit unread behind any older read request, then hold new
-   * read reports until the canonical read pointer reflects the read-set echo.
+   * read reports until the operation's locally reconciled pointer is observed.
    */
   async runExplicitUnread(
     streamId: string,
@@ -145,10 +146,14 @@ export class ReadCommitQueue {
     const marks = [...this.pending.entries()]
     this.pending.clear()
     for (const [, mark] of marks) clearTimeout(mark.timer)
-    if (marks.length === 0) return
-    queueMicrotask(() => {
-      for (const [streamId, mark] of marks) this.dispatch(streamId, mark, true)
-    })
+    for (const streamId of new Set([...this.inFlight.keys(), ...this.queued.keys(), ...marks.map(([id]) => id)])) {
+      this.draining.add(streamId)
+    }
+    if (marks.length > 0) {
+      queueMicrotask(() => {
+        for (const [streamId, mark] of marks) this.dispatch(streamId, mark, true)
+      })
+    }
   }
 
   private schedule(streamId: string, mark: ReadCommitMark, attempt: number, delay: number): void {
@@ -164,13 +169,14 @@ export class ReadCommitQueue {
   }
 
   private dispatch(streamId: string, mark: QueuedMark, allowDisposed = false): void {
-    if ((!allowDisposed && this.disposed) || this.hasExplicitUnread(streamId)) return
+    const canDrain = allowDisposed || this.draining.has(streamId)
+    if ((!canDrain && this.disposed) || this.hasExplicitUnread(streamId)) return
     if (this.inFlight.has(streamId)) {
       this.queued.set(streamId, mark)
       return
     }
 
-    const promise = this.execute(streamId, mark, allowDisposed)
+    const promise = this.execute(streamId, mark, canDrain)
     this.inFlight.set(streamId, promise)
   }
 
@@ -187,10 +193,11 @@ export class ReadCommitQueue {
       this.failed.delete(streamId)
     } catch {
       const newerMarkExists = this.pending.has(streamId) || this.queued.has(streamId)
-      if (!newerMarkExists && !this.hasExplicitUnread(streamId) && !this.disposed) {
+      const canRetry = !this.disposed || allowDisposed || this.draining.has(streamId)
+      if (!newerMarkExists && !this.hasExplicitUnread(streamId) && canRetry) {
         if (mark.attempt < READ_COMMIT_MAX_RETRIES) {
           this.schedule(streamId, mark, mark.attempt + 1, READ_COMMIT_RETRY_MS * 2 ** mark.attempt)
-        } else {
+        } else if (!this.disposed) {
           this.failed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
           this.schedule(streamId, mark, READ_COMMIT_MAX_RETRIES, READ_COMMIT_PARKED_RETRY_MS)
         }
@@ -201,6 +208,8 @@ export class ReadCommitQueue {
       if (next) {
         this.queued.delete(streamId)
         this.dispatch(streamId, next, allowDisposed)
+      } else if (!this.pending.has(streamId)) {
+        this.draining.delete(streamId)
       }
     }
   }

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -6,82 +6,76 @@ export interface ReadCommitMark {
 }
 
 export const READ_COMMIT_DEBOUNCE_MS = 500
+export const READ_COMMIT_RETRY_MS = 1_000
+export const READ_COMMIT_MAX_RETRIES = 3
 
-interface PendingMark extends ReadCommitMark {
+type CommitRead = (streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<void>
+
+interface ScheduledMark extends ReadCommitMark {
   timer: ReturnType<typeof setTimeout>
+  attempt: number
+}
+
+interface QueuedMark extends ReadCommitMark {
+  attempt: number
+}
+
+interface ExplicitUnread {
+  initialReadEventId: string | null | undefined
+  observedReadEventId: string | null | undefined
+  expectedReadEventId: string | null | undefined
+  operationDone: boolean
 }
 
 /**
- * The one owner of the OUTBOUND read-commit pipeline for a workspace: view
- * components observe what was painted (the read frontier) and `report` it
- * here; this queue owns everything that used to live in component effect
- * lifecycle — debouncing, newest-wins coalescing per stream, flush on leave,
- * flush-all on pagehide, and the committed-mark dedup record. Teardown
- * semantics were read-loss semantics twice (#1881: the fling and glance-triage
- * bugs) precisely because the commit pipeline lived inside React effects; a
- * mark that the frontier has counted as seen must survive whatever the
- * component tree does next.
- *
- * Constructed per workspace by the workspace layout (the SyncEngine pattern)
- * and provided via `ReadCommitQueueContext`. The commit dependency is read
- * through `commitRef` at fire time so the layout can keep it fresh across
- * renders without reconstructing the queue — and so a queue being disposed at
- * workspace switch still flushes through the OLD workspace's commit.
- *
- * Semantics preserved from the hook era:
- * - `report` (re)arms a trailing debounce; a newer report replaces the pending
- *   mark and resets the timer.
- * - `cancel` drops the pending mark without committing (the attention gate
- *   closing — blur — keeps its cancel semantics; content seen just before a
- *   blur stays unread rather than over-marking).
- * - `flush` commits the pending mark immediately (stream switch, unmount).
- * - A fired or flushed mark is recorded in `lastCommitted` for the caller's
- *   dedup; `resetCommitted` clears it on a fresh stream open so the
- *   caught-up-open heal (D5) still fires once per open.
+ * Workspace-scoped owner of outbound read commits. A mark becomes committed
+ * only after the request and its local reconciliation succeed. Failed requests
+ * retry here rather than depending on a React render to report the same
+ * frontier again.
  */
 export class ReadCommitQueue {
   readonly workspaceId: string
-  readonly commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
+  readonly commitRef: { current: CommitRead }
   private readonly debounceMs: number
-  private readonly pending = new Map<string, PendingMark>()
+  private readonly pending = new Map<string, ScheduledMark>()
+  private readonly queued = new Map<string, QueuedMark>()
+  private readonly failed = new Map<string, ReadCommitMark>()
+  private readonly inFlight = new Map<string, Promise<void>>()
   private readonly committed = new Map<string, ReadCommitMark>()
+  private readonly explicitUnread = new Map<string, ExplicitUnread>()
   private disposed = false
-  // Leaving the page entirely (navigation away, tab close, mobile app kill)
-  // gives no effect cleanup a chance to run — commit whatever is pending.
-  // Best-effort: the request is a normal fetch, so an unload racing it can
-  // still drop it, but that is strictly better than the guaranteed drop a
-  // cancelled timer was.
-  private readonly onPageHide = () => this.flushAll()
 
-  constructor(deps: {
-    workspaceId: string
-    commitRef: { current: (streamId: string, lastEventId: string, opts: { partial: boolean }) => void }
-    debounceMs?: number
-  }) {
+  private readonly onPageHide = () => this.flushAll()
+  private readonly onWake = () => {
+    if (document.visibilityState === "hidden") return
+    for (const [streamId, mark] of this.failed) {
+      this.failed.delete(streamId)
+      this.dispatch(streamId, { ...mark, attempt: 0 })
+    }
+  }
+
+  constructor(deps: { workspaceId: string; commitRef: { current: CommitRead }; debounceMs?: number }) {
     this.workspaceId = deps.workspaceId
     this.commitRef = deps.commitRef
     this.debounceMs = deps.debounceMs ?? READ_COMMIT_DEBOUNCE_MS
     window.addEventListener("pagehide", this.onPageHide)
+    window.addEventListener("online", this.onWake)
+    window.addEventListener("focus", this.onWake)
+    document.addEventListener("visibilitychange", this.onWake)
   }
 
   report(streamId: string, lastEventId: string, partial: boolean): void {
-    if (this.disposed) return
-    const existing = this.pending.get(streamId)
-    if (existing) clearTimeout(existing.timer)
-    const timer = setTimeout(() => {
-      const mark = this.pending.get(streamId)
-      if (!mark) return
-      this.pending.delete(streamId)
-      this.send(streamId, mark)
-    }, this.debounceMs)
-    this.pending.set(streamId, { lastEventId, partial, timer })
+    if (this.disposed || this.explicitUnread.has(streamId)) return
+    this.failed.delete(streamId)
+    this.schedule(streamId, { lastEventId, partial }, 0, this.debounceMs)
   }
 
   cancel(streamId: string): void {
     const mark = this.pending.get(streamId)
-    if (!mark) return
-    clearTimeout(mark.timer)
+    if (mark) clearTimeout(mark.timer)
     this.pending.delete(streamId)
+    this.queued.delete(streamId)
+    this.failed.delete(streamId)
   }
 
   flush(streamId: string): void {
@@ -89,53 +83,138 @@ export class ReadCommitQueue {
     if (!mark) return
     clearTimeout(mark.timer)
     this.pending.delete(streamId)
-    this.send(streamId, mark)
+    this.dispatch(streamId, mark)
   }
 
   flushAll(): void {
     for (const streamId of [...this.pending.keys()]) this.flush(streamId)
   }
 
-  /** The last mark actually sent for this stream — pending/cancelled marks
-   *  never appear here, so a blur-cancelled mark re-reports after refocus. */
   lastCommitted(streamId: string): ReadCommitMark | null {
     return this.committed.get(streamId) ?? null
   }
 
-  /** A fresh open of the stream forgets the committed record so the once-per-
-   *  open caught-up heal can fire again. */
   resetCommitted(streamId: string): void {
     this.committed.delete(streamId)
+  }
+
+  /**
+   * Serialize an explicit unread behind any older read request, then hold new
+   * read reports until the canonical read pointer reflects the read-set echo.
+   */
+  async runExplicitUnread(
+    streamId: string,
+    initialReadEventId: string | null | undefined,
+    operation: () => Promise<string | null | undefined>
+  ): Promise<void> {
+    this.cancel(streamId)
+    const state: ExplicitUnread = {
+      initialReadEventId,
+      observedReadEventId: initialReadEventId,
+      expectedReadEventId: undefined,
+      operationDone: false,
+    }
+    this.explicitUnread.set(streamId, state)
+    await this.inFlight.get(streamId)
+    try {
+      state.expectedReadEventId = await operation()
+      state.operationDone = true
+      this.releaseExplicitUnreadIfReady(streamId, state)
+    } catch (error) {
+      if (this.explicitUnread.get(streamId) === state) this.explicitUnread.delete(streamId)
+      throw error
+    }
+  }
+
+  observeReadPointer(streamId: string, readEventId: string | null | undefined): void {
+    const state = this.explicitUnread.get(streamId)
+    if (!state) return
+    state.observedReadEventId = readEventId
+    this.releaseExplicitUnreadIfReady(streamId, state)
   }
 
   get isDisposed(): boolean {
     return this.disposed
   }
 
-  /** Detach immediately, commit what was pending a microtask later. Called on
-   *  workspace switch — which happens during the owner's RENDER (the
-   *  SyncEngine-style recreate check), where running the commit's cache writes
-   *  would be a render-phase side effect — and on layout unmount. The captured
-   *  marks still send through this queue's own commitRef, so a switch flushes
-   *  into the outgoing workspace. The owner recreates on the next render if it
-   *  finds a disposed queue in its ref (StrictMode's mount→cleanup→remount
-   *  cycle). */
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
     window.removeEventListener("pagehide", this.onPageHide)
+    window.removeEventListener("online", this.onWake)
+    window.removeEventListener("focus", this.onWake)
+    document.removeEventListener("visibilitychange", this.onWake)
     const marks = [...this.pending.entries()]
     this.pending.clear()
     for (const [, mark] of marks) clearTimeout(mark.timer)
     if (marks.length === 0) return
     queueMicrotask(() => {
-      for (const [streamId, mark] of marks) this.send(streamId, mark)
+      for (const [streamId, mark] of marks) this.dispatch(streamId, mark, true)
     })
   }
 
-  private send(streamId: string, mark: ReadCommitMark): void {
-    this.committed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
-    this.commitRef.current(streamId, mark.lastEventId, { partial: mark.partial })
+  private schedule(streamId: string, mark: ReadCommitMark, attempt: number, delay: number): void {
+    const existing = this.pending.get(streamId)
+    if (existing) clearTimeout(existing.timer)
+    const timer = setTimeout(() => {
+      const scheduled = this.pending.get(streamId)
+      if (!scheduled) return
+      this.pending.delete(streamId)
+      this.dispatch(streamId, scheduled)
+    }, delay)
+    this.pending.set(streamId, { ...mark, attempt, timer })
+  }
+
+  private dispatch(streamId: string, mark: QueuedMark, allowDisposed = false): void {
+    if ((!allowDisposed && this.disposed) || this.explicitUnread.has(streamId)) return
+    if (this.inFlight.has(streamId)) {
+      this.queued.set(streamId, mark)
+      return
+    }
+
+    const promise = this.execute(streamId, mark, allowDisposed)
+    this.inFlight.set(streamId, promise)
+  }
+
+  private async execute(streamId: string, mark: QueuedMark, allowDisposed: boolean): Promise<void> {
+    try {
+      let operation: Promise<void>
+      try {
+        operation = this.commitRef.current(streamId, mark.lastEventId, { partial: mark.partial })
+      } catch (error) {
+        operation = Promise.reject(error)
+      }
+      await operation
+      this.committed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
+      this.failed.delete(streamId)
+    } catch {
+      const newerMarkExists = this.pending.has(streamId) || this.queued.has(streamId)
+      if (!newerMarkExists && !this.explicitUnread.has(streamId) && !this.disposed) {
+        if (mark.attempt < READ_COMMIT_MAX_RETRIES) {
+          this.schedule(streamId, mark, mark.attempt + 1, READ_COMMIT_RETRY_MS * 2 ** mark.attempt)
+        } else {
+          this.failed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
+        }
+      }
+    } finally {
+      this.inFlight.delete(streamId)
+      const next = this.queued.get(streamId)
+      if (next) {
+        this.queued.delete(streamId)
+        this.dispatch(streamId, next, allowDisposed)
+      }
+    }
+  }
+
+  private releaseExplicitUnreadIfReady(streamId: string, state: ExplicitUnread): void {
+    if (!state.operationDone || this.explicitUnread.get(streamId) !== state) return
+    const pointerMatches =
+      state.expectedReadEventId !== undefined
+        ? state.observedReadEventId === state.expectedReadEventId
+        : state.observedReadEventId !== state.initialReadEventId
+    if (!pointerMatches) return
+    this.explicitUnread.delete(streamId)
+    this.committed.delete(streamId)
   }
 }
 

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -44,6 +44,7 @@ export class ReadCommitQueue {
   private readonly inFlight = new Map<string, Promise<void>>()
   private readonly committed = new Map<string, ReadCommitMark>()
   private readonly explicitUnread = new Map<string, ExplicitUnread>()
+  private readonly explicitUnreadTail = new Map<string, Promise<void>>()
   private disposed = false
 
   private readonly onPageHide = () => this.flushAll()
@@ -69,7 +70,7 @@ export class ReadCommitQueue {
   }
 
   report(streamId: string, lastEventId: string, partial: boolean): void {
-    if (this.disposed || this.explicitUnread.has(streamId)) return
+    if (this.disposed || this.hasExplicitUnread(streamId)) return
     this.failed.delete(streamId)
     this.schedule(streamId, { lastEventId, partial }, 0, this.debounceMs)
   }
@@ -112,21 +113,14 @@ export class ReadCommitQueue {
     operation: () => Promise<string | null | undefined>
   ): Promise<void> {
     this.cancel(streamId)
-    const state: ExplicitUnread = {
-      initialReadEventId,
-      observedReadEventIds: new Set([initialReadEventId]),
-      expectedReadEventId: undefined,
-      operationDone: false,
-    }
-    this.explicitUnread.set(streamId, state)
-    await this.inFlight.get(streamId)
+    const previous = this.explicitUnreadTail.get(streamId)
+    const start = () => this.executeExplicitUnread(streamId, initialReadEventId, operation)
+    const current = previous ? previous.then(start, start) : start()
+    this.explicitUnreadTail.set(streamId, current)
     try {
-      state.expectedReadEventId = await operation()
-      state.operationDone = true
-      this.releaseExplicitUnreadIfReady(streamId, state)
-    } catch (error) {
-      if (this.explicitUnread.get(streamId) === state) this.explicitUnread.delete(streamId)
-      throw error
+      await current
+    } finally {
+      if (this.explicitUnreadTail.get(streamId) === current) this.explicitUnreadTail.delete(streamId)
     }
   }
 
@@ -170,7 +164,7 @@ export class ReadCommitQueue {
   }
 
   private dispatch(streamId: string, mark: QueuedMark, allowDisposed = false): void {
-    if ((!allowDisposed && this.disposed) || this.explicitUnread.has(streamId)) return
+    if ((!allowDisposed && this.disposed) || this.hasExplicitUnread(streamId)) return
     if (this.inFlight.has(streamId)) {
       this.queued.set(streamId, mark)
       return
@@ -193,7 +187,7 @@ export class ReadCommitQueue {
       this.failed.delete(streamId)
     } catch {
       const newerMarkExists = this.pending.has(streamId) || this.queued.has(streamId)
-      if (!newerMarkExists && !this.explicitUnread.has(streamId) && !this.disposed) {
+      if (!newerMarkExists && !this.hasExplicitUnread(streamId) && !this.disposed) {
         if (mark.attempt < READ_COMMIT_MAX_RETRIES) {
           this.schedule(streamId, mark, mark.attempt + 1, READ_COMMIT_RETRY_MS * 2 ** mark.attempt)
         } else {
@@ -208,6 +202,34 @@ export class ReadCommitQueue {
         this.queued.delete(streamId)
         this.dispatch(streamId, next, allowDisposed)
       }
+    }
+  }
+
+  private hasExplicitUnread(streamId: string): boolean {
+    return this.explicitUnread.has(streamId) || this.explicitUnreadTail.has(streamId)
+  }
+
+  private async executeExplicitUnread(
+    streamId: string,
+    initialReadEventId: string | null | undefined,
+    operation: () => Promise<string | null | undefined>
+  ): Promise<void> {
+    const state: ExplicitUnread = {
+      initialReadEventId,
+      observedReadEventIds: new Set([initialReadEventId]),
+      expectedReadEventId: undefined,
+      operationDone: false,
+    }
+    this.explicitUnread.set(streamId, state)
+    const inFlight = this.inFlight.get(streamId)
+    if (inFlight) await inFlight
+    try {
+      state.expectedReadEventId = await operation()
+      state.operationDone = true
+      this.releaseExplicitUnreadIfReady(streamId, state)
+    } catch (error) {
+      if (this.explicitUnread.get(streamId) === state) this.explicitUnread.delete(streamId)
+      throw error
     }
   }
 

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -8,6 +8,7 @@ export interface ReadCommitMark {
 export const READ_COMMIT_DEBOUNCE_MS = 500
 export const READ_COMMIT_RETRY_MS = 1_000
 export const READ_COMMIT_MAX_RETRIES = 3
+export const READ_COMMIT_PARKED_RETRY_MS = 30_000
 
 type CommitRead = (streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<void>
 
@@ -22,7 +23,7 @@ interface QueuedMark extends ReadCommitMark {
 
 interface ExplicitUnread {
   initialReadEventId: string | null | undefined
-  observedReadEventId: string | null | undefined
+  observedReadEventIds: Set<string | null | undefined>
   expectedReadEventId: string | null | undefined
   operationDone: boolean
 }
@@ -49,6 +50,9 @@ export class ReadCommitQueue {
   private readonly onWake = () => {
     if (document.visibilityState === "hidden") return
     for (const [streamId, mark] of this.failed) {
+      const scheduled = this.pending.get(streamId)
+      if (scheduled) clearTimeout(scheduled.timer)
+      this.pending.delete(streamId)
       this.failed.delete(streamId)
       this.dispatch(streamId, { ...mark, attempt: 0 })
     }
@@ -110,7 +114,7 @@ export class ReadCommitQueue {
     this.cancel(streamId)
     const state: ExplicitUnread = {
       initialReadEventId,
-      observedReadEventId: initialReadEventId,
+      observedReadEventIds: new Set([initialReadEventId]),
       expectedReadEventId: undefined,
       operationDone: false,
     }
@@ -129,7 +133,7 @@ export class ReadCommitQueue {
   observeReadPointer(streamId: string, readEventId: string | null | undefined): void {
     const state = this.explicitUnread.get(streamId)
     if (!state) return
-    state.observedReadEventId = readEventId
+    state.observedReadEventIds.add(readEventId)
     this.releaseExplicitUnreadIfReady(streamId, state)
   }
 
@@ -194,6 +198,7 @@ export class ReadCommitQueue {
           this.schedule(streamId, mark, mark.attempt + 1, READ_COMMIT_RETRY_MS * 2 ** mark.attempt)
         } else {
           this.failed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
+          this.schedule(streamId, mark, READ_COMMIT_MAX_RETRIES, READ_COMMIT_PARKED_RETRY_MS)
         }
       }
     } finally {
@@ -210,8 +215,8 @@ export class ReadCommitQueue {
     if (!state.operationDone || this.explicitUnread.get(streamId) !== state) return
     const pointerMatches =
       state.expectedReadEventId !== undefined
-        ? state.observedReadEventId === state.expectedReadEventId
-        : state.observedReadEventId !== state.initialReadEventId
+        ? state.observedReadEventIds.has(state.expectedReadEventId)
+        : [...state.observedReadEventIds].some((eventId) => eventId !== state.initialReadEventId)
     if (!pointerMatches) return
     this.explicitUnread.delete(streamId)
     this.committed.delete(streamId)

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -12,6 +12,7 @@ import {
   applyReadStateSnapshotsIdb,
   commitReadAll,
   commitReadStateSnapshot,
+  putReadStateIdbIfUntouchedSince,
   resolveReadAllFrontiers,
   type ReadStateSnapshot,
 } from "./read-state"
@@ -72,6 +73,67 @@ async function seedMembership() {
     _cachedAt: Date.now(),
   })
 }
+
+describe("putReadStateIdbIfUntouchedSince", () => {
+  beforeEach(async () => {
+    resetRowConfirmations()
+    await db.streamReadState.clear()
+  })
+
+  it("checks freshness and writes the replacement in one transaction", async () => {
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_old",
+      lastReadSequence: "1",
+      lastReadAt: null,
+      _cachedAt: 10,
+    })
+
+    await expect(
+      putReadStateIdbIfUntouchedSince(
+        "ws_1",
+        "stream_1",
+        { lastReadEventId: "evt_response", lastReadSequence: "2", lastReadAt: null },
+        11,
+        12
+      )
+    ).resolves.toBe(true)
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_response",
+      lastReadSequence: "2",
+      _cachedAt: 12,
+    })
+  })
+
+  it("rejects a response when a newer frontier already owns the stream", async () => {
+    await db.streamReadState.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      lastReadEventId: "evt_newer",
+      lastReadSequence: "3",
+      lastReadAt: null,
+      _cachedAt: 13,
+    })
+
+    await expect(
+      putReadStateIdbIfUntouchedSince(
+        "ws_1",
+        "stream_1",
+        { lastReadEventId: "evt_stale", lastReadSequence: "2", lastReadAt: null },
+        11,
+        14
+      )
+    ).resolves.toBe(false)
+    expect(await db.streamReadState.get("ws_1:stream_1")).toMatchObject({
+      lastReadEventId: "evt_newer",
+      lastReadSequence: "3",
+      _cachedAt: 13,
+    })
+  })
+})
 
 describe("applyReadStateSnapshotsIdb", () => {
   beforeEach(async () => {

--- a/apps/frontend/src/sync/read-state.ts
+++ b/apps/frontend/src/sync/read-state.ts
@@ -54,6 +54,20 @@ export async function readStateTouchedSince(workspaceId: string, streamId: strin
   return effectiveFreshness(workspaceId, "streamReadState", row.id, row._cachedAt) >= since
 }
 
+export async function putReadStateIdbIfUntouchedSince(
+  workspaceId: string,
+  streamId: string,
+  fields: StreamReadFrontier,
+  since: number,
+  now = Date.now()
+): Promise<boolean> {
+  return db.transaction("rw", [db.streamReadState], async () => {
+    if (await readStateTouchedSince(workspaceId, streamId, since)) return false
+    await putReadStateIdb(workspaceId, streamId, fields, now)
+    return true
+  })
+}
+
 /** Merge one stream's standalone frontier into the workspace bootstrap query cache. */
 export function mergeReadStateIntoBootstrapCache(
   queryClient: QueryClient,

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -900,6 +900,63 @@ describe("applyStreamBootstrap (real IndexedDB)", () => {
   })
 })
 
+describe("applyStreamBootstrap — per-stream unread count", () => {
+  beforeEach(async () => {
+    await Promise.all([db.unreadState.clear(), db.events.clear(), db.streams.clear()])
+  })
+
+  it("publishes the stream bootstrap count for access-without-membership viewers", async () => {
+    const streamId = "stream_public"
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: {},
+      mutedStreamIds: [],
+      counterTouchedAt: {},
+      _cachedAt: Date.now(),
+    })
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      unreadCounts: {},
+    } as WorkspaceBootstrap)
+    const bootstrap = { ...makeBootstrap([], streamId), unreadCount: 4 }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt: Date.now(), queryClient })
+
+    expect((await db.unreadState.get("ws_1"))?.unreadCounts[streamId]).toBe(4)
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts[streamId]).toBe(
+      4
+    )
+  })
+
+  it("preserves a counter touched after the bootstrap request departed", async () => {
+    const streamId = "stream_public"
+    const fetchStartedAt = Date.now() - 100
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { [streamId]: 3 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: {},
+      mutedStreamIds: [],
+      counterTouchedAt: { [streamId]: Date.now() },
+      _cachedAt: Date.now(),
+    })
+
+    await applyStreamBootstrap("ws_1", streamId, { ...makeBootstrap([], streamId), unreadCount: 1 }, { fetchStartedAt })
+
+    expect((await db.unreadState.get("ws_1"))?.unreadCounts[streamId]).toBe(3)
+  })
+})
+
 describe("applyStreamBootstrap — read-state freshness (stale response guard)", () => {
   // A bootstrap snapshot begun at T0 may apply its `readState` only when the
   // local frontier row was NOT touched at/after T0 (socket echo or optimistic

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -21,6 +21,7 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 import { NO_CAPTURE, PerfCapture, armPerfCapture } from "@/lib/perf/capture"
+import { applyStreamReadOrdinal } from "./unread-counters"
 import { sharedMessageSlotKey } from "@threa/types"
 import type {
   AttachmentSummary,
@@ -924,14 +925,21 @@ describe("applyStreamBootstrap — per-stream unread count", () => {
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
       unreadCounts: {},
     } as WorkspaceBootstrap)
-    const bootstrap = { ...makeBootstrap([], streamId), unreadCount: 4 }
+    const bootstrap = { ...makeBootstrap([], streamId), unreadCount: 4, messageCount: 6 }
 
     await applyStreamBootstrap("ws_1", streamId, bootstrap, { fetchStartedAt: Date.now(), queryClient })
 
-    expect((await db.unreadState.get("ws_1"))?.unreadCounts[streamId]).toBe(4)
-    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts[streamId]).toBe(
-      4
-    )
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.unreadCounts[streamId]).toBe(4)
+    expect(state?.latestOrdinals?.[streamId]).toBe(6)
+    expect(
+      applyStreamReadOrdinal({ ...state!, unreadActivities: state?.unreadActivities ?? [] }, streamId, 3).unreadCounts[
+        streamId
+      ]
+    ).toBe(3)
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached?.unreadCounts[streamId]).toBe(4)
+    expect(cached?.messageCounts?.[streamId]).toBe(6)
   })
 
   it("preserves a counter touched after the bootstrap request departed", async () => {

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -942,6 +942,56 @@ describe("applyStreamBootstrap — per-stream unread count", () => {
     expect(cached?.messageCounts?.[streamId]).toBe(6)
   })
 
+  it("skips query-cache publication when a newer counter lands after the IDB transaction", async () => {
+    const streamId = "stream_public"
+    const fetchStartedAt = 100
+    const seeded = {
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { [streamId]: 3 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { [streamId]: 10 },
+      mutedStreamIds: [],
+      counterTouchedAt: {},
+      _cachedAt: 90,
+    }
+    await db.unreadState.put(seeded)
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      unreadCounts: { [streamId]: 3 },
+      messageCounts: { [streamId]: 10 },
+    } as unknown as WorkspaceBootstrap)
+    const get = vi
+      .spyOn(db.unreadState, "get")
+      .mockResolvedValueOnce(seeded)
+      .mockResolvedValueOnce({
+        ...seeded,
+        unreadCounts: { [streamId]: 4 },
+        latestOrdinals: { [streamId]: 11 },
+        counterTouchedAt: { [streamId]: 101 },
+      })
+
+    try {
+      await applyStreamBootstrap(
+        "ws_1",
+        streamId,
+        { ...makeBootstrap([], streamId), unreadCount: 1, messageCount: 8 },
+        { fetchStartedAt, queryClient }
+      )
+    } finally {
+      get.mockRestore()
+    }
+
+    const cached = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached).toMatchObject({
+      unreadCounts: { [streamId]: 3 },
+      messageCounts: { [streamId]: 10 },
+    })
+  })
+
   it("preserves a counter touched after the bootstrap request departed", async () => {
     const streamId = "stream_public"
     const fetchStartedAt = Date.now() - 100

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -722,18 +722,25 @@ export async function applyStreamBootstrap(
     mergeReadStateIntoBootstrapCache(options.queryClient, workspaceId, streamId, preservedReadState)
   }
   if (appliedUnreadCount && options?.queryClient) {
-    options.queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (current) =>
-      current
-        ? {
-            ...current,
-            unreadCounts: { ...current.unreadCounts, [streamId]: bootstrap.unreadCount },
-            messageCounts:
-              bootstrap.messageCount !== undefined
-                ? { ...current.messageCounts, [streamId]: bootstrap.messageCount }
-                : current.messageCounts,
-          }
-        : current
-    )
+    const unreadState = await db.unreadState.get(workspaceId)
+    const touchedAt = unreadState?.counterTouchedAt?.[streamId]
+    const remainsCurrent =
+      unreadState !== undefined &&
+      (options.fetchStartedAt === undefined || touchedAt === undefined || touchedAt < options.fetchStartedAt)
+    if (remainsCurrent) {
+      options.queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (current) =>
+        current
+          ? {
+              ...current,
+              unreadCounts: { ...current.unreadCounts, [streamId]: unreadState.unreadCounts[streamId] ?? 0 },
+              messageCounts:
+                bootstrap.messageCount !== undefined
+                  ? { ...current.messageCounts, [streamId]: unreadState.latestOrdinals?.[streamId] ?? 0 }
+                  : current.messageCounts,
+            }
+          : current
+      )
+    }
   }
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -708,6 +708,10 @@ export async function applyStreamBootstrap(
         await db.unreadState.put({
           ...unreadState,
           unreadCounts: { ...unreadState.unreadCounts, [streamId]: bootstrap.unreadCount },
+          latestOrdinals:
+            bootstrap.messageCount !== undefined
+              ? { ...unreadState.latestOrdinals, [streamId]: bootstrap.messageCount }
+              : unreadState.latestOrdinals,
           _cachedAt: now,
         })
         appliedUnreadCount = true
@@ -719,7 +723,16 @@ export async function applyStreamBootstrap(
   }
   if (appliedUnreadCount && options?.queryClient) {
     options.queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (current) =>
-      current ? { ...current, unreadCounts: { ...current.unreadCounts, [streamId]: bootstrap.unreadCount } } : current
+      current
+        ? {
+            ...current,
+            unreadCounts: { ...current.unreadCounts, [streamId]: bootstrap.unreadCount },
+            messageCounts:
+              bootstrap.messageCount !== undefined
+                ? { ...current.messageCounts, [streamId]: bootstrap.messageCount }
+                : current.messageCounts,
+          }
+        : current
     )
   }
   seedStreamActiveCall(workspaceId, streamId, bootstrap)

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -687,9 +687,10 @@ export async function applyStreamBootstrap(
 ): Promise<void> {
   const now = Date.now()
   let preservedReadState: StreamReadFrontier | undefined
+  let appliedUnreadCount = false
   await db.transaction(
     "rw",
-    [db.events, db.streams, db.streamReadState, db.pendingMessages, db.pendingOperations, db.slots],
+    [db.events, db.streams, db.streamReadState, db.unreadState, db.pendingMessages, db.pendingOperations, db.slots],
     async () => {
       preservedReadState = await writeBootstrapEventsAndStream(
         workspaceId,
@@ -698,10 +699,28 @@ export async function applyStreamBootstrap(
         now,
         options?.fetchStartedAt
       )
+      const unreadState = await db.unreadState.get(workspaceId)
+      const touchedAt = unreadState?.counterTouchedAt?.[streamId]
+      if (
+        unreadState &&
+        (options?.fetchStartedAt === undefined || touchedAt === undefined || touchedAt < options.fetchStartedAt)
+      ) {
+        await db.unreadState.put({
+          ...unreadState,
+          unreadCounts: { ...unreadState.unreadCounts, [streamId]: bootstrap.unreadCount },
+          _cachedAt: now,
+        })
+        appliedUnreadCount = true
+      }
     }
   )
   if (preservedReadState && options?.queryClient) {
     mergeReadStateIntoBootstrapCache(options.queryClient, workspaceId, streamId, preservedReadState)
+  }
+  if (appliedUnreadCount && options?.queryClient) {
+    options.queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (current) =>
+      current ? { ...current, unreadCounts: { ...current.unreadCounts, [streamId]: bootstrap.unreadCount } } : current
+    )
   }
   seedStreamActiveCall(workspaceId, streamId, bootstrap)
 }

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -65,64 +65,59 @@ describe("applyStreamActivityOrdinal", () => {
   const seeded = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 5 } })
 
   it("sets unread from the ordinal delta for others' messages", () => {
-    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false })
     expect(next.unreadCounts.s1).toBe(2)
     expect(next.latestOrdinals?.s1).toBe(6)
   })
 
   it("converges on duplicate apply", () => {
-    const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
-    const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false, isViewing: false })
+    const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false })
+    const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false })
     expect(twice).toEqual(once)
   })
 
   it("converges on out-of-order apply (sweep-rescued late sync ids)", () => {
     const inOrder = applyStreamActivityOrdinal(
-      applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false }),
+      applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false }),
       "s1",
       7,
-      { isOwnMessage: false, isViewing: false }
+      { isOwnMessage: false }
     )
     const outOfOrder = applyStreamActivityOrdinal(
-      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false }),
+      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false }),
       "s1",
       6,
-      { isOwnMessage: false, isViewing: false }
+      { isOwnMessage: false }
     )
     expect(outOfOrder).toEqual(inOrder)
     expect(outOfOrder.unreadCounts.s1).toBe(3)
   })
 
   it("advances the read position to the message for own sends (server auto-advance mirror)", () => {
-    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: true, isViewing: false })
+    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: true })
     expect(next.unreadCounts.s1).toBe(0)
     expect(next.latestOrdinals?.s1).toBe(6)
   })
 
   it("keeps newer messages unread when an own send applies out of order", () => {
-    const other = applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false })
-    const own = applyStreamActivityOrdinal(other, "s1", 6, { isOwnMessage: true, isViewing: false })
+    const other = applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false })
+    const own = applyStreamActivityOrdinal(other, "s1", 6, { isOwnMessage: true })
     expect(own.unreadCounts.s1).toBe(1)
     expect(own.latestOrdinals?.s1).toBe(7)
   })
 
-  it("pins the read position to latest while viewing", () => {
-    const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: true })
-    expect(next.unreadCounts.s1).toBe(0)
-  })
-
   it("seeds a baseline as the legacy increment when none exists", () => {
     const noBaseline = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: undefined })
-    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: false, isViewing: false })
+    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: false })
     expect(next.unreadCounts.s1).toBe(3)
     expect(next.latestOrdinals?.s1).toBe(9)
-    const again = applyStreamActivityOrdinal(next, "s1", 9, { isOwnMessage: false, isViewing: false })
+    const again = applyStreamActivityOrdinal(next, "s1", 9, { isOwnMessage: false })
     expect(again.unreadCounts.s1).toBe(3)
   })
 
   it("seeds a zero-unread baseline for own sends without a baseline", () => {
     const noBaseline = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: undefined })
-    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: true, isViewing: false })
+    const next = applyStreamActivityOrdinal(noBaseline, "s1", 9, { isOwnMessage: true })
     expect(next.unreadCounts.s1).toBe(0)
   })
 })
@@ -365,7 +360,7 @@ describe("sparse read overlay invariant", () => {
         readMessageIds: { s1: ["m8", "m9"] },
       })
       // A new other-message arrives: unread rises by one, overlay unchanged.
-      const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+      const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false })
       expect(next.unreadCounts.s1).toBe(2)
       expect(next.latestOrdinals?.s1).toBe(6)
       expect(next.readMessageIds?.s1).toEqual(["m8", "m9"])
@@ -377,8 +372,8 @@ describe("sparse read overlay invariant", () => {
         latestOrdinals: { s1: 5 },
         readMessageIds: { s1: ["m9"] },
       })
-      const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
-      const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false, isViewing: false })
+      const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false })
+      const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false })
       expect(twice).toEqual(once)
     })
   })
@@ -527,7 +522,7 @@ describe("applyMovedSourceOrdinal", () => {
 
   it("heals the phantom-unread move sequence (activity 2 → move to 1 → read 1 → 0)", () => {
     let state = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 1 } })
-    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false, isViewing: false })
+    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false })
     expect(state.unreadCounts.s1).toBe(2)
     state = applyMovedSourceOrdinal(state, "s1", 1)
     expect(state.latestOrdinals?.s1).toBe(1)
@@ -563,7 +558,7 @@ describe("applyMovedSourceOrdinal", () => {
 
   it("without the source-ordinal fix the read cannot clear the phantom (regression guard)", () => {
     let state = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 1 } })
-    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false, isViewing: false })
+    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false })
     // Skip applyMovedSourceOrdinal: latest stays inflated at 2 (max-merge only).
     const read = applyStreamReadOrdinal(state, "s1", 1)
     expect(read.unreadCounts.s1).toBe(1) // stuck — the exact bug the fix removes
@@ -764,15 +759,15 @@ describe("coalesced live commit", () => {
 
     const batch = new LiveCommitBatch(queryClient, workspaceId)
     // Two activities for one stream, delivered in the wrong order in one task.
-    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 7, { isOwnMessage: false, isViewing: false }))
-    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 6, { isOwnMessage: false, isViewing: false }))
+    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 7, { isOwnMessage: false }))
+    batch.applyCounter((state) => applyStreamActivityOrdinal(state, "s1", 6, { isOwnMessage: false }))
     await batch.flush()
 
     const perEvent = applyStreamActivityOrdinal(
-      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false, isViewing: false }),
+      applyStreamActivityOrdinal(seeded, "s1", 7, { isOwnMessage: false }),
       "s1",
       6,
-      { isOwnMessage: false, isViewing: false }
+      { isOwnMessage: false }
     )
     const folded = queryClient.getQueryData<{
       unreadCounts: Record<string, number>

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -176,19 +176,18 @@ export function clearActivities(state: UnreadCounterState): UnreadCounterState {
 
 /**
  * Apply a `stream:activity` message ordinal. Latest max-merges; the implied
- * read position advances to the message for the author's own sends (the
- * server auto-advances the author's read pointer in the send transaction
- * without emitting `stream:read`) and pins to latest while the user is
- * viewing the stream (optimistic — auto-mark-read confirms server-side).
+ * read position advances only for the author's own sends, which the server
+ * also advances in the send transaction. Opening a route does not prove that
+ * another author's message was visible.
  *
  * Without a baseline the event seeds one: others' messages land as the
- * legacy increment would have; own/viewing land read = latest.
+ * legacy increment would have; own messages land read = latest.
  */
 export function applyStreamActivityOrdinal(
   state: UnreadCounterState,
   streamId: string,
   messageOrdinal: number,
-  opts: { isOwnMessage: boolean; isViewing: boolean }
+  opts: { isOwnMessage: boolean }
 ): UnreadCounterState {
   const ov = overlaySize(state, streamId)
   const prevLatest = state.latestOrdinals?.[streamId]
@@ -196,13 +195,11 @@ export function applyStreamActivityOrdinal(
   let read: number
   if (prevLatest === undefined) {
     latest = messageOrdinal
-    read =
-      opts.isOwnMessage || opts.isViewing ? latest : Math.max(0, latest - (state.unreadCounts[streamId] ?? 0) - 1 - ov)
+    read = opts.isOwnMessage ? latest : Math.max(0, latest - (state.unreadCounts[streamId] ?? 0) - 1 - ov)
   } else {
     const prevRead = Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0) - ov)
     latest = Math.max(prevLatest, messageOrdinal)
     read = opts.isOwnMessage ? Math.max(prevRead, messageOrdinal) : prevRead
-    if (opts.isViewing) read = latest
   }
   return {
     ...state,

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -3660,8 +3660,7 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     cleanup()
   })
 
-  it("pins the read position to latest while viewing the stream attentively", async () => {
-    const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true)
+  it("raises unread for another author's message even while its route is focused", async () => {
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)
     const { emit, cleanup } = register(queryClient, "stream_1")
@@ -3675,19 +3674,15 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
       lastMessagePreview: preview,
     })
 
-    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(0)
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(2)
     await vi.waitFor(async () => {
-      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(0)
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(2)
     })
 
     cleanup()
-    focusSpy.mockRestore()
   })
 
-  it("does NOT pin while the viewed stream's window is unfocused — unread rises like any other stream", async () => {
-    // The pin is optimistic against the auto-read confirm, which only fires
-    // when attentive (useAutoReadAttention). Pinning here would zero the local
-    // count with no server confirm coming — the sticky-zero divergence bug.
+  it("raises unread for the viewed stream while its window is unfocused", async () => {
     const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false)
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)
@@ -3822,12 +3817,7 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     cleanup()
   })
 
-  it("does not hold an activity for the stream being viewed attentively (no lit-row flash)", async () => {
-    // The counter is already pinned while viewing, so holding the activity row
-    // lit the sidebar row — via activityCount — for the whole auto-read round
-    // trip, on a stream the user was looking at, and without it ever entering
-    // the Unread section. Same gate as the counter pin.
-    const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true)
+  it("holds activity for a focused route until a viewport read clears it", async () => {
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)
     const { emit, cleanup } = register(queryClient, "stream_1")
@@ -3851,16 +3841,13 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     })
 
     const after = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
-    expect(after?.activityCounts.stream_1).toBe(before?.activityCounts.stream_1)
-    expect(after?.unreadActivityCount).toBe(before?.unreadActivityCount)
+    expect(after?.activityCounts.stream_1).toBe((before?.activityCounts.stream_1 ?? 0) + 1)
+    expect(after?.unreadActivityCount).toBe((before?.unreadActivityCount ?? 0) + 1)
 
     cleanup()
-    focusSpy.mockRestore()
   })
 
-  it("holds an activity for the viewed stream when unfocused, and for other streams always", async () => {
-    // The mirror of the counter pin's guard: suppressing while unattentive
-    // would zero a count no auto-read confirm is coming for.
+  it("holds an activity for the viewed stream when unfocused, and for other streams", async () => {
     const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false)
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -3682,6 +3682,31 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
     cleanup()
   })
 
+  it("raises unread for the currently viewed stream without a direct membership", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient)
+    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"), (current) =>
+      current ? { ...current, streamMemberships: [] } : current
+    )
+    const { emit, cleanup } = register(queryClient, "stream_1")
+
+    emit("stream:activity", {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      authorId: "member_2",
+      sequence: "9",
+      messageOrdinal: 6,
+      lastMessagePreview: preview,
+    })
+
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(2)
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(2)
+    })
+
+    cleanup()
+  })
+
   it("raises unread for the viewed stream while its window is unfocused", async () => {
     const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false)
     const queryClient = new QueryClient()

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1325,7 +1325,7 @@ export function registerWorkspaceSocketHandlers(
       const old = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
       if (!old) return
       const isMember = old.streamMemberships.some((m: StreamMember) => m.streamId === payload.streamId)
-      if (!isMember) return
+      if (!isMember && !isViewingStream) return
       const currentUser = refs.getCurrentUser()
       const currentMember = currentUser && getWorkspaceUsers(old).find((u) => u.workosUserId === currentUser.id)
       const isOwnMessage = Boolean(currentMember && payload.authorId === currentMember.id)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -124,7 +124,6 @@ import {
   pruneCounterTouches,
   upsertActivity,
 } from "./unread-counters"
-import { isAutoReadAttentiveNow } from "@/lib/auto-read-attention"
 import {
   commitCounterMutation,
   commitStreamPreview,
@@ -1318,16 +1317,11 @@ export function registerWorkspaceSocketHandlers(
       commitPreview(payload.streamId, payload.lastMessagePreview)
 
       // Counter: membership and author identity resolve from the workspace
-      // bootstrap (the synchronous read model both reactive surfaces share), then
-      // the absolute ordinal apply folds through commitCounter. Own messages never
-      // raise unread (authorId is a userId — match via user.workosUserId): the
-      // server auto-advances the author's read pointer in the send transaction
-      // without emitting stream:read. Viewing pins the read position to latest —
-      // gated on the SAME attention signal `useAutoMarkAsRead` uses: the pin is
-      // optimistic against the auto-read confirm, so pinning while unattentive
-      // (stream open in a blurred window, reconnect catch-up replays) zeroes the
-      // local count with no server confirm ever coming, and the stream vanishes
-      // from the sidebar's Unread section while genuinely unread.
+      // bootstrap, then the absolute ordinal apply folds through commitCounter.
+      // Own messages never raise unread because the server advances the author's
+      // pointer in the send transaction. An open route is not evidence that an
+      // incoming message crossed the viewport frontier, so other authors always
+      // raise unread until the read commit acknowledges it.
       const old = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
       if (!old) return
       const isMember = old.streamMemberships.some((m: StreamMember) => m.streamId === payload.streamId)
@@ -1337,10 +1331,7 @@ export function registerWorkspaceSocketHandlers(
       const isOwnMessage = Boolean(currentMember && payload.authorId === currentMember.id)
 
       commitCounter((state) =>
-        applyStreamActivityOrdinal(state, payload.streamId, payload.messageOrdinal, {
-          isOwnMessage,
-          isViewing: isViewingStream && isAutoReadAttentiveNow(),
-        })
+        applyStreamActivityOrdinal(state, payload.streamId, payload.messageOrdinal, { isOwnMessage })
       )
     } finally {
       stopActivityApply()
@@ -1842,21 +1833,9 @@ export function registerWorkspaceSocketHandlers(
     if (payload.workspaceId !== workspaceId) return
 
     const a = payload.activity
-    // Viewing pins activity exactly as it pins the message counter above: a row
-    // for the stream the viewer is attentively looking at is about to be cleared
-    // by the auto-read confirm, so holding it lights the sidebar row and the
-    // activity badge for the whole debounce + round trip — on a stream the user
-    // is staring at. That flash reads as a bug precisely because the counter IS
-    // pinned: the row lit up while never entering the Unread section. Gated on
-    // the SAME `isAutoReadAttentiveNow()` signal for the same reason documented
-    // there — suppressing while unattentive would zero a count no confirm is
-    // coming for. A row suppressed but never read server-side (the viewer is
-    // parked above the fold, so the frontier never advances past it) comes back
-    // on the next bootstrap, which is the counter pin's recovery too.
-    if (a.streamId && refs.getCurrentStreamId() === a.streamId && isAutoReadAttentiveNow()) {
-      invalidateActivityFeed(true)
-      return
-    }
+    // Route focus alone cannot dismiss an activity: the viewer may be detached
+    // above the tail or have the timeline covered. Hold the row until a concrete
+    // viewport frontier produces the coupled read commit.
     // The held set is the source of truth (D3/D4): upsert the row by its stable
     // id so a replayed event (sync-log catch-up, INV-53) updates in place rather
     // than duplicating; the derived counts follow. Self rows are skipped inside

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -245,6 +245,8 @@ export interface StreamBootstrap {
     threadSummary: ThreadSummary | null
   }>
   unreadCount: number
+  /** Total message ordinal used with unreadCount to seed the per-stream counter model. */
+  messageCount?: number
   mentionCount: number
   activityCount: number
   /**


### PR DESCRIPTION
## Problem

Auto-read recorded dispatched requests as committed, so one network failure could leave a visible message unread until focus changed. Route focus also hid unread content above or below the viewport, access-only viewers lacked complete counter state, and an older read could overwrite an explicit mark-unread.

## Solution

- Acknowledge commits only after the request and local reconciliation succeed. Failures use bounded backoff, a 30-second parked retry, and online/focus wake-ups.
- Serialize explicit unread behind earlier reads and block new commits until its canonical read-set frontier is observed. The unread endpoint now returns that frontier.
- Derive reads from viewport state. Incoming content stays unread while detached, and pointer-only activity healing requires a visible tail.
- Seed unread count plus total message ordinal during per-stream bootstrap, including inherited-access threads and unjoined public channels. Live activity now updates a viewed access-only stream.
- Compare frontier movement with the authoritative sequence when the prior watermark is outside the loaded window.
- Commit the stream frontier, activity clear, and both outbox events in one backend transaction.

The sidebar can now show unread briefly while an on-screen read awaits acknowledgement. This replaces an optimistic zero that could hide unseen content.

## Verification

- Frontend: 6,741 tests passed
- Backend: 4,056 unit, 951 integration, and 372 E2E tests passed
- Targeted Chromium auto-read spec passed
- Typecheck and lint passed

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make viewport-derived read state recover from failures and preserve explicit unread ordering across HTTP, socket, bootstrap, and IndexedDB paths.

## Work

1. Add acknowledged retries and per-stream read/unread serialization.
2. Remove route-focus inference and publish complete access-only counter baselines.
3. Use authoritative sequences for outside-window rollback.
4. Couple backend frontier and activity writes in one transaction.
5. Add regression coverage and run frontend, backend, integration, E2E, and browser verification.

## Status

- [x] Complete

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789427239&installation_model_id=20758&pr_number=1895&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1895&signature=6431acee04011c00303b3b5245142b40fb61d2395e7247bc6b7527387d0915c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->