### PR TITLE
fix: restore auto-read after mobile resume

### DIFF
--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -149,6 +149,26 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
   })
 
+  it("reopens phone auto-read after a bfcache restore without visibility or focus events", () => {
+    visibilityState = "hidden"
+    hasFocus = false
+    isMobileViewport = true
+    isCoarsePointer = true
+
+    const { rerender } = renderHook(({ lastEventId }) => useAutoMarkAsRead("ws_123", "stream_123", lastEventId), {
+      initialProps: { lastEventId: undefined as string | undefined },
+    })
+
+    visibilityState = "visible"
+    const pageShow = new Event("pageshow")
+    Object.defineProperty(pageShow, "persisted", { value: true, configurable: true })
+    act(() => window.dispatchEvent(pageShow))
+    rerender({ lastEventId: "event_after_resume" })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(mockMarkAsRead).toHaveBeenCalledExactlyOnceWith("stream_123", "event_after_resume", { partial: false })
+  })
+
   it("does NOT mark read on a coarse-but-wide device (tablet / iPad split view) while unfocused", () => {
     // A coarse pointer alone is not "phone-like": an iPad in Split View / Stage
     // Manager is coarse but wide, and an unfocused pane there means the user is

--- a/apps/frontend/src/hooks/use-page-activity.ts
+++ b/apps/frontend/src/hooks/use-page-activity.ts
@@ -35,6 +35,10 @@ export function usePageActivity(): PageActivityState {
 
     const updateVisibility = () => setIsVisible(document.visibilityState === "visible")
     const updateFocus = () => setIsFocused(document.hasFocus())
+    const updatePageShow = () => {
+      updateVisibility()
+      updateFocus()
+    }
 
     updateVisibility()
     updateFocus()
@@ -42,11 +46,13 @@ export function usePageActivity(): PageActivityState {
     document.addEventListener("visibilitychange", updateVisibility)
     window.addEventListener("focus", updateFocus)
     window.addEventListener("blur", updateFocus)
+    window.addEventListener("pageshow", updatePageShow)
 
     return () => {
       document.removeEventListener("visibilitychange", updateVisibility)
       window.removeEventListener("focus", updateFocus)
       window.removeEventListener("blur", updateFocus)
+      window.removeEventListener("pageshow", updatePageShow)
     }
   }, [])
 


### PR DESCRIPTION
## Problem

A mobile page restored from the back/forward cache can emit `pageshow` without the matching `visibilitychange` or `focus` events. `usePageActivity` then retains the hidden state recorded when the phone locked, so catch-up messages render while auto-read remains disabled until the stream component remounts or the page reloads.

## Solution

- Resample `document.visibilityState` and `document.hasFocus()` when `pageshow` fires.
- Cover a phone restore that receives only `pageshow`, then appends a visible event and verifies the read commit fires.

A normal `pageshow` only reapplies the current browser state.

## Verification

Frontend: 6,752 tests passed. Repository typecheck, lint, Dockerfile checks, and migration checks passed.

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483951&installation_model_id=20758&pr_number=1896&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1896&signature=e43defbba3652c8d28448b4210ec1c24a80eaa8815999740e3f40324bfa97b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->