### PR TITLE
fix: bridge trailing zero-height chrome in the read frontier tail

### DIFF
--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -185,9 +185,9 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -287,6 +287,144 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.lastSeenEventId).toBeUndefined()
   })
 
+  // Trailing chrome (agent-session terminals, command terminals, reactions)
+  // renders NO `[data-event-id]` row, so the last loaded index is unreachable by
+  // the frontier and by the viewport's bottom row. Before the gate bridged them,
+  // every bot reply left atLastRow/tailVisible pinned false: auto-read went
+  // permanently partial and the activity heal (gated on tailVisible) was dead.
+  function mountWithRows(
+    positions: Record<string, { top: number; bottom: number }>,
+    events: StreamEvent[],
+    lastReadEventId: string | null
+  ) {
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+    return renderHook(() =>
+      useLastSeenEvent({
+        scrollContainerRef: { current: container },
+        events,
+        streamId: "stream_1",
+        lastReadEventId,
+        enabled: true,
+      })
+    )
+  }
+
+  it("counts a full read when the loaded window ends in agent-session chrome that renders no row", () => {
+    const { result } = mountWithRows(
+      {
+        e0: { top: -50, bottom: -10 }, // the read pointer, scrolled above
+        e1: { top: 10, bottom: 60 }, // the bot reply — the last rendered row
+      },
+      [
+        { id: "e0", sequence: "0", eventType: "message_created" },
+        { id: "e1", sequence: "1", eventType: "message_created" },
+        { id: "e2", sequence: "2", eventType: "agent_session:started" },
+        { id: "e3", sequence: "3", eventType: "agent_session:completed" },
+      ] as unknown as StreamEvent[],
+      "e0"
+    )
+
+    expect({
+      lastSeenEventId: result.current.lastSeenEventId,
+      atLastRow: result.current.atLastRow,
+      tailVisible: result.current.tailVisible,
+    }).toEqual({ lastSeenEventId: "e1", atLastRow: true, tailVisible: true })
+  })
+
+  it.each(["reaction_added", "command_completed"])(
+    "counts a full read when the window ends in a zero-height %s event",
+    (trailingType) => {
+      const { result } = mountWithRows(
+        {
+          e0: { top: -50, bottom: -10 },
+          e1: { top: 10, bottom: 60 },
+        },
+        [
+          { id: "e0", sequence: "0", eventType: "message_created" },
+          { id: "e1", sequence: "1", eventType: "message_created" },
+          { id: "e2", sequence: "2", eventType: trailingType },
+        ] as unknown as StreamEvent[],
+        "e0"
+      )
+
+      expect({
+        lastSeenEventId: result.current.lastSeenEventId,
+        atLastRow: result.current.atLastRow,
+        tailVisible: result.current.tailVisible,
+      }).toEqual({ lastSeenEventId: "e1", atLastRow: true, tailVisible: true })
+    }
+  )
+
+  it("still reports a partial read when a trailing MESSAGE sits below the viewport", () => {
+    // The counterpart to the bridging above: a real message at the tail blocks,
+    // so auto-read stays partial and the heal stays off.
+    const { result } = mountWithRows(
+      {
+        e0: { top: -50, bottom: -10 },
+        e1: { top: 10, bottom: 60 },
+        e2: { top: 130, bottom: 180 }, // below the fold — unread content
+      },
+      [
+        { id: "e0", sequence: "0", eventType: "message_created" },
+        { id: "e1", sequence: "1", eventType: "message_created" },
+        { id: "e2", sequence: "2", eventType: "message_created" },
+      ] as unknown as StreamEvent[],
+      "e0"
+    )
+
+    expect({
+      lastSeenEventId: result.current.lastSeenEventId,
+      atLastRow: result.current.atLastRow,
+      tailVisible: result.current.tailVisible,
+    }).toEqual({ lastSeenEventId: "e1", atLastRow: false, tailVisible: false })
+  })
+
+  it("drives unreadAboveViewport off the first unread MESSAGE, not the trailing chrome", () => {
+    const { result } = mountWithRows(
+      {
+        e0: { top: -260, bottom: -210 }, // the read pointer
+        e1: { top: -180, bottom: -140 }, // an unread message, scrolled off the top
+        e2: { top: 10, bottom: 60 }, // what the viewer is looking at
+      },
+      [
+        { id: "e0", sequence: "0", eventType: "message_created" },
+        { id: "e1", sequence: "1", eventType: "message_created" },
+        { id: "e2", sequence: "2", eventType: "message_created" },
+        { id: "e3", sequence: "3", eventType: "agent_session:completed" },
+      ] as unknown as StreamEvent[],
+      "e0"
+    )
+
+    expect({
+      unreadAboveViewport: result.current.unreadAboveViewport,
+      atLastRow: result.current.atLastRow,
+    }).toEqual({ unreadAboveViewport: true, atLastRow: false })
+  })
+
+  it("clears unreadAboveViewport once the last unread MESSAGE is read, trailing chrome notwithstanding", () => {
+    const { result } = mountWithRows(
+      {
+        e0: { top: -50, bottom: -10 },
+        e1: { top: 10, bottom: 60 },
+      },
+      [
+        { id: "e0", sequence: "0", eventType: "message_created" },
+        { id: "e1", sequence: "1", eventType: "message_created" },
+        { id: "e2", sequence: "2", eventType: "agent_session:completed" },
+      ] as unknown as StreamEvent[],
+      "e0"
+    )
+
+    expect(result.current.unreadAboveViewport).toBe(false)
+  })
+
   it("re-arms the scan when the virtualized scroller late-mounts after enabled (scrollContainerEl)", () => {
     // The bug behind the stuck-unread divider: the virtualized timeline flips
     // `enabled` true BEFORE virtua mounts its scroller (a ref callback). The
@@ -309,9 +447,9 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     // The ref starts null (scroller not mounted) and is populated by virtua's ref
     // callback when it mounts — mirrored here by mutating `.current`.
@@ -372,8 +510,8 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -417,10 +555,10 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
-      { id: "e3", sequence: "3" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+      { id: "e3", sequence: "3", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -465,7 +603,7 @@ describe("useLastSeenEvent re-scan triggers", () => {
     row.getBoundingClientRect = () => rect(positions.e0.top, positions.e0.bottom)
     container.appendChild(row)
 
-    const events = [{ id: "e0", sequence: "0" }] as unknown as StreamEvent[]
+    const events = [{ id: "e0", sequence: "0", eventType: "message_created" }] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
     const { result, rerender } = renderHook(
@@ -516,11 +654,11 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
-      { id: "e3", sequence: "3" },
-      { id: "e4", sequence: "4" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+      { id: "e3", sequence: "3", eventType: "message_created" },
+      { id: "e4", sequence: "4", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -565,11 +703,11 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
-      { id: "e3", sequence: "3" },
-      { id: "e4", sequence: "4" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+      { id: "e3", sequence: "3", eventType: "message_created" },
+      { id: "e4", sequence: "4", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -613,8 +751,8 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const optimisticEvents = [
-      { id: "e0", sequence: "0" },
-      { id: "temp_abc", sequence: "1" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "temp_abc", sequence: "1", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
@@ -631,8 +769,8 @@ describe("useLastSeenEvent re-scan triggers", () => {
     // array length — no scroll or resize accompanies this.
     container.querySelector('[data-event-id="temp_abc"]')!.setAttribute("data-event-id", "evt_real")
     const reconciledEvents = [
-      { id: "e0", sequence: "0" },
-      { id: "evt_real", sequence: "1" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "evt_real", sequence: "1", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     act(() => rerender({ events: reconciledEvents }))
 
@@ -661,7 +799,7 @@ describe("useLastSeenEvent re-scan triggers", () => {
       container.appendChild(row)
     }
 
-    const events = [{ id: "e0", sequence: "2" }] as unknown as StreamEvent[]
+    const events = [{ id: "e0", sequence: "2", eventType: "message_created" }] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 
     const { result } = renderHook(() =>
@@ -686,6 +824,7 @@ describe("useLastSeenEvent re-scan triggers", () => {
     const events = ["e0", "e1", "e2"].map((id, index) => ({
       id,
       sequence: String(100 + index),
+      eventType: "message_created",
     })) as unknown as StreamEvent[]
     for (const [index, event] of events.entries()) {
       const row = document.createElement("div")
@@ -739,11 +878,11 @@ describe("useLastSeenEvent re-scan triggers", () => {
     }
 
     const events = [
-      { id: "e0", sequence: "0" },
-      { id: "e1", sequence: "1" },
-      { id: "e2", sequence: "2" },
-      { id: "e3", sequence: "3" },
-      { id: "e4", sequence: "4" },
+      { id: "e0", sequence: "0", eventType: "message_created" },
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+      { id: "e3", sequence: "3", eventType: "message_created" },
+      { id: "e4", sequence: "4", eventType: "message_created" },
     ] as unknown as StreamEvent[]
     const scrollContainerRef = { current: container }
 

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -143,9 +143,9 @@ interface UseLastSeenEventResult {
    * scroll down through it (or press Escape) for the pointer to advance.
    */
   lastSeenEventId: string | undefined
-  /** Whether the read frontier has reached the last loaded row (a full read). */
+  /** Whether no read-blocking content remains after the read frontier (a full read). */
   atLastRow: boolean
-  /** Whether the last rendered row currently intersects the viewport. */
+  /** Whether no read-blocking content remains after the viewport's bottom row. */
   tailVisible: boolean
   /**
    * Whether unread sits above the current viewport — i.e. the first unread row
@@ -295,11 +295,13 @@ export function useLastSeenEvent({
     }
 
     const frontier = frontierRef.current
-    setAtLastRow(frontier >= lastLoadedIdx)
-    setTailVisible(botIdx >= lastLoadedIdx)
-    // Unread sits above the viewport when the first unread row (frontier + 1)
-    // exists in the window and is scrolled off the top.
-    setUnreadAboveViewport(frontier + 1 <= lastLoadedIdx && frontier + 1 < topIdx)
+    // Trailing non-read-blocking chrome (agent-session/command terminals,
+    // reactions) renders no `[data-event-id]` row, so `lastLoadedIdx` itself is
+    // unreachable by the frontier or the viewport — both bridge through the gate.
+    const firstUnreadIdx = readGateIndex(eventsRef.current, frontier)
+    setAtLastRow(firstUnreadIdx > lastLoadedIdx)
+    setTailVisible(readGateIndex(eventsRef.current, botIdx) > lastLoadedIdx)
+    setUnreadAboveViewport(firstUnreadIdx <= lastLoadedIdx && firstUnreadIdx < topIdx)
     // `lastSeenEventId` is derived, not a forward-only latch: it names the
     // frontier's row only while the frontier sits PAST the read pointer. Once the
     // pointer catches up to (or passes) the frontier — the round-trip landed, or a

--- a/packages/types/src/stream-rows.test.ts
+++ b/packages/types/src/stream-rows.test.ts
@@ -64,6 +64,17 @@ describe("STREAM_ROW_SPEC", () => {
     for (const type of THREAD_ANCHORABLE_EVENT_TYPES) expect(STREAM_ROW_SPEC[type].rendersAsOwnRow).toBe(true)
   })
 
+  test("every read-blocking type renders as its own row", () => {
+    // The read frontier advances through visible rows only, so a read-blocking
+    // type that renders no row of its own could never be passed: the gate would
+    // point at an index the viewport can never reach and auto-read would wedge
+    // permanently (the regression class behind #1895).
+    for (const type of EVENT_TYPES) {
+      const spec = STREAM_ROW_SPEC[type]
+      if (spec.readBlocking) expect(spec.rendersAsOwnRow).toBe(true)
+    }
+  })
+
   test("a grouped or patched row is never also its own standalone row", () => {
     for (const type of EVENT_TYPES) {
       const spec = STREAM_ROW_SPEC[type]

--- a/tests/browser/auto-read.spec.ts
+++ b/tests/browser/auto-read.spec.ts
@@ -232,6 +232,103 @@ test.describe("Timeline auto-read", () => {
     await otherContext.close()
   })
 
+  test("a caught-up stream trailed by zero-height chrome (reaction) still heals its activity", async ({
+    page,
+    browser,
+  }) => {
+    // The #1895 regression class: a trailing event that renders no timeline row
+    // of its own (a reaction, an agent-session terminal, a command terminal)
+    // left the last loaded index unreachable, pinning `tailVisible` false and
+    // killing the watermark-anchored activity heal — the reaction activity on a
+    // fully-read stream stayed lit through every visit. The watermark cannot
+    // advance here (nothing unread), so the heal is the ONLY dismissal path and
+    // the assert fails deterministically without the gate-bridged tail.
+    const owner = await loginAndCreateWorkspace(page, "auto-read")
+    const testId = owner.testId
+    const prefix = `[${testId}]`
+
+    await createChannel(page, `healreact-${testId}`)
+    const { workspaceId, streamId } = extractIds(page)
+    // Reactions notify a channel message's author only at the ACTIVITY /
+    // EVERYTHING notification level — the default level drops them.
+    await expectApiOk(
+      await page.request.post(`/api/workspaces/${workspaceId}/streams/${streamId}/notification-level`, {
+        data: { notificationLevel: "everything" },
+      }),
+      "Owner opts into reaction activity"
+    )
+    await seedFrom(page, workspaceId, streamId, 4, prefix)
+
+    // The second user joins BEFORE the reaction target is posted: their
+    // member_joined chrome renders a row, and a rendered row above the trailing
+    // reaction would give the frontier something to advance onto — the ordinary
+    // mark path would then clear the activity and mask a dead heal.
+    const other = await loginInNewContext(browser, `healreact-b-${testId}@example.com`, `HealReact B ${testId}`)
+    await expectApiOk(
+      await other.page.request.post(`/api/dev/workspaces/${workspaceId}/join`, {
+        data: { role: "member", name: `HealReact B ${testId}` },
+      }),
+      "Second user joins workspace"
+    )
+    await expectApiOk(
+      await other.page.request.post(`/api/workspaces/${workspaceId}/streams/${streamId}/join`, { data: {} }),
+      "Second user joins the channel"
+    )
+
+    // The reaction target, posted directly so its id is known. The owner's own
+    // send advances their watermark server-side, so the trailing
+    // `reaction_added` — which draws no row of its own — becomes the ONLY event
+    // past the watermark: an activity with zero unread messages and no frontier
+    // advance available. The heal is the only dismissal path.
+    const targetRes = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+      data: { streamId, content: `${prefix} target msg-005` },
+    })
+    await expectApiOk(targetRes, "Reaction target message")
+    const { message } = (await targetRes.json()) as { message: { id: string } }
+
+    await page.goto(`/w/${workspaceId}/drafts`)
+    await expect(page).toHaveURL(new RegExp(`/w/${workspaceId}/drafts`))
+
+    await expect
+      .poll(
+        async () =>
+          (
+            await other.page.request.post(`/api/workspaces/${workspaceId}/messages/${message.id}/reactions`, {
+              data: { emoji: "👍" },
+            })
+          ).ok(),
+        { timeout: 10000, message: "second user's reaction should be accepted after joining" }
+      )
+      .toBe(true)
+
+    await expect
+      .poll(() => serverActivityCount(page, workspaceId, streamId), {
+        timeout: 10000,
+        message: "the reaction should create an unread activity for the owner",
+      })
+      .toBeGreaterThan(0)
+    expect(await serverUnreadCount(page, workspaceId, streamId)).toBe(0)
+
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(
+      page
+        .getByRole("main")
+        .locator(".message-item")
+        .filter({ hasText: `${prefix} target msg-005` })
+    ).toBeVisible({ timeout: 20000 })
+
+    await expect
+      .poll(() => serverActivityCount(page, workspaceId, streamId), {
+        timeout: 15000,
+        message: "visiting the caught-up stream must heal the reaction activity despite the trailing chrome",
+      })
+      .toBe(0)
+    // The heal anchors at the watermark — read state must be undisturbed.
+    expect(await serverUnreadCount(page, workspaceId, streamId)).toBe(0)
+
+    await other.context.close()
+  })
+
   test("blur → arrival → refocus → another arrival: every step re-marks once attentive", async ({ page, browser }) => {
     // The prod trace for the reported miss: watermark wrote seconds after a
     // refocus (the parked mark firing), then a message arrived 4s later while


### PR DESCRIPTION
## Why

Prod `stream_read_state` shows bot-message reads committing 5–50 minutes late (app-switch flushes) while own-send/archive reads commit in ≤1s. One verified cause is a #1895 regression: `useLastSeenEvent` began measuring `atLastRow`/`tailVisible` against `events.length - 1`, but every bot reply is trailed within ~30ms by a zero-height `agent_session:completed` (and command chrome / reactions) that renders no `[data-event-id]` row — the last loaded index became unreachable. Every mark in an agent stream was forced `partial`, which disables the local counter clear, the D5 caught-up heal, and the watermark-anchored activity heal (`activityHealEnabled: tailVisible`).

## Changes

- `atLastRow`/`tailVisible`/`unreadAboveViewport` bridge trailing non-read-blocking events via `readGateIndex` — the same bridging the frontier gate already uses (#1886). "Fully read" now means "no read-blocking content remains", not "index n-1 reached".
- `STREAM_ROW_SPEC` guard test: `readBlocking ⟹ rendersAsOwnRow`. A future event type that blocks reads but renders no row is a red test instead of a silent permanent wedge.
- Browser spec: a caught-up stream whose tail is trailed by a real `reaction_added` must heal its activity on visit. **Verified red on the pre-fix hook** — the suite's existing arrival spec passes with the bug present (the watermark still advances on the partial path), which is why CI never caught this.

## Verification

Unit 73/73 + types 11/11; full frontend suite green; full auto-read browser suite green with the new spec red→green across the fix; monorepo lint+typecheck green.

## Residual risk

`escapeUnread` still targets the raw last event id (may be chrome) — server-side ordinal resolution handles any event id, unchanged behavior.


<details>
<summary>📋 Full implementation plan</summary>

## Goal

Make live auto-read work in agent streams again and make the failure class structurally impossible to reintroduce. Root-caused from prod `stream_read_state` forensics: own-send/archive reads commit in ≤1s, bot-message reads only on app-switch/leave flushes (5–50 min), across rows predating and postdating #1895. Four stacked PRs (stack #1901), each with its own regression guard.

## What Was Built

### PR #1897 — frontier bridging (this PR)
`useLastSeenEvent` measures `atLastRow`/`tailVisible`/`unreadAboveViewport` via `readGateIndex` (no read-blocking content remaining) instead of `events.length - 1`, which trailing zero-height chrome (`agent_session:completed`, `command_completed`, reactions) made unreachable.
**Files:** `apps/frontend/src/hooks/use-last-seen-event.ts`, its test, `packages/types/src/stream-rows.test.ts` (spec-coupling guard `readBlocking ⟹ rendersAsOwnRow`), `tests/browser/auto-read.spec.ts` (reaction-trailed heal spec, proven red pre-fix).

### PR #1898 — truthful commits
`markAsRead` returns the post-write frontier/ordinal/overlay (`readState: null` = explicit no-op); client reconciles counters+frontier from the response through the same `applyStreamReadOrdinal` the socket echo uses; `ReadCommitQueue` records only `applied: true` outcomes as committed.

### PR #1899 — bootstrap counter guard
`applyStreamBootstrap` counter publication requires a known `fetchStartedAt`; the latent `undefined` bypass of the touched-at guard is closed and pinned by a test.

### PR #1900 — attention resample on interaction
`usePageActivity` resamples visibility+focus on `pointerdown`/`keydown`/`wheel`/`touchstart` (1s throttle) — some mobile resumes fire no lifecycle event, leaving the attention gate stuck and suppressing all auto-reads until an app switch (#1896's `pageshow` patch didn't cover the field failure).

## Design Decisions

**Gate-based tail semantics over rendering-aware indices.** "Fully read" = `readGateIndex(events, frontier) === events.length`, reusing the exact bridging #1886 introduced for the advance gate — one semantics for both.

**Browser guard asserts the activity heal, not the unread count.** The regression's partial-forcing never blocks the server watermark advance, so a `serverUnreadCount == 0` assertion passes with the bug present (why CI stayed green). The heal on a caught-up reaction-trailed stream fails deterministically pre-fix; verified red→green.

**Response-driven reconciliation over echo hardening.** The server already computes post-write truth in the mark-read transaction; returning it removes the echo as a single point of failure instead of adding retry machinery to the echo path.

## What's NOT Included

- No change to `escapeUnread` (raw last-event-id target; server resolves any event id).
- No mark-read wire-format changes beyond additive response fields (deploy-skew tolerant both directions).
- The `stream:activity` optimistic viewing pin removed in #1895 stays removed; the response reconciliation supersedes it.

## Status

- [x] PR #1897 frontier bridging + guards
- [x] PR #1898 truthful commits
- [x] PR #1899 bootstrap counter guard
- [x] PR #1900 interaction resample
- [ ] Post-deploy: re-run prod watermark-lag query (bot-message commits must drop from minutes to ~1s)

</details>
