### PR TITLE
fix: reconcile read commits from the mark-read response

### DIFF
--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -496,7 +496,14 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
 
   it("returns null membership for a non-member viewer", async () => {
     const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
-    const markAsRead = mock(() => Promise.resolve(null))
+    const markAsRead = mock(() =>
+      Promise.resolve({
+        membership: null,
+        readState: { lastReadEventId: "evt_1", lastReadSequence: "42", lastReadAt: null },
+        lastReadOrdinal: 7,
+        readMessageIds: [],
+      })
+    )
     const markStreamActivityAsRead = mock(() => Promise.resolve())
     const handlers = makeHandlers({ validateStreamAccess, markAsRead } as Partial<StreamService>, {
       markStreamActivityAsRead,
@@ -508,7 +515,12 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     // Access (not membership) gates the read: a viewer who inherits thread
     // access from the root (INV-62) gets an activity-only read, not a 404.
     expect(captured.status).not.toBe(404)
-    expect(captured.body).toEqual({ membership: null })
+    expect(captured.body).toEqual({
+      membership: null,
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "42", lastReadAt: null },
+      lastReadOrdinal: 7,
+      readMessageIds: [],
+    })
     expect(markAsRead).toHaveBeenCalledWith("ws_1", "stream_thread", "usr_viewer", "evt_1")
   })
 
@@ -575,7 +587,14 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
       joinedAt: new Date(),
     }
     const validateStreamAccess = mock(() => Promise.resolve({ id: "stream_thread" } as never))
-    const markAsRead = mock(() => Promise.resolve(membership))
+    const markAsRead = mock(() =>
+      Promise.resolve({
+        membership,
+        readState: { lastReadEventId: "evt_1", lastReadSequence: "42", lastReadAt: null },
+        lastReadOrdinal: 7,
+        readMessageIds: [],
+      })
+    )
     const markStreamActivityAsRead = mock(() => Promise.resolve())
     const handlers = makeHandlers({ validateStreamAccess, markAsRead } as Partial<StreamService>, {
       markStreamActivityAsRead,
@@ -585,7 +604,12 @@ describe("createStreamHandlers.markAsRead — access without membership", () => 
     await handlers.markAsRead(makeReq(), res)
 
     expect(captured.status).toBe(200)
-    expect(captured.body).toEqual({ membership })
+    expect(captured.body).toEqual({
+      membership,
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "42", lastReadAt: null },
+      lastReadOrdinal: 7,
+      readMessageIds: [],
+    })
     expect(markAsRead).toHaveBeenCalledWith("ws_1", "stream_thread", "usr_viewer", "evt_1")
   })
 })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -939,9 +939,14 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const membership = await streamReadService.markAsRead(workspaceId, streamId, userId, data.lastEventId)
+      const { membership, readState, lastReadOrdinal, readMessageIds } = await streamReadService.markAsRead(
+        workspaceId,
+        streamId,
+        userId,
+        data.lastEventId
+      )
 
-      res.json({ membership: membership ?? null })
+      res.json({ membership: membership ?? null, readState, lastReadOrdinal, readMessageIds })
     },
 
     async markUnread(req: Request, res: Response) {

--- a/apps/backend/src/features/streams/read-service.test.ts
+++ b/apps/backend/src/features/streams/read-service.test.ts
@@ -24,7 +24,13 @@ describe("StreamReadService.markAsRead", () => {
       notificationLevel: null,
       joinedAt: new Date(),
     }
-    const markAsReadInTransaction = mock(() => Promise.resolve(membership))
+    const markResult = {
+      membership,
+      readState: { lastReadEventId: "evt_1", lastReadSequence: "42", lastReadAt: null },
+      lastReadOrdinal: 7,
+      readMessageIds: [],
+    }
+    const markAsReadInTransaction = mock(() => Promise.resolve(markResult))
     const markStreamActivityAsReadInTransaction = mock(() => Promise.resolve())
     const service = new StreamReadService({
       pool: {} as never,
@@ -34,7 +40,7 @@ describe("StreamReadService.markAsRead", () => {
 
     const result = await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_1")
 
-    expect(result).toBe(membership)
+    expect(result).toBe(markResult)
     expect(markAsReadInTransaction).toHaveBeenCalledWith(client, "ws_1", "stream_1", "usr_1", "evt_1")
     expect(markStreamActivityAsReadInTransaction).toHaveBeenCalledWith(client, "usr_1", "ws_1", "stream_1")
   })
@@ -42,7 +48,11 @@ describe("StreamReadService.markAsRead", () => {
   it("fails the transaction when the activity clear fails", async () => {
     const service = new StreamReadService({
       pool: {} as never,
-      streamService: { markAsReadInTransaction: mock(() => Promise.resolve(null)) } as never,
+      streamService: {
+        markAsReadInTransaction: mock(() =>
+          Promise.resolve({ membership: null, readState: null, lastReadOrdinal: null, readMessageIds: null })
+        ),
+      } as never,
       activityService: {
         markStreamActivityAsReadInTransaction: mock(() => Promise.reject(new Error("activity write failed"))),
       },

--- a/apps/backend/src/features/streams/read-service.ts
+++ b/apps/backend/src/features/streams/read-service.ts
@@ -1,7 +1,6 @@
 import type { Pool, PoolClient } from "pg"
 import { withTransaction } from "../../db"
-import type { StreamMember } from "./member-repository"
-import type { StreamService } from "./service"
+import type { MarkAsReadResult, StreamService } from "./service"
 
 interface ActivityReadService {
   markStreamActivityAsReadInTransaction(
@@ -21,14 +20,9 @@ interface StreamReadServiceDeps {
 export class StreamReadService {
   constructor(private readonly deps: StreamReadServiceDeps) {}
 
-  async markAsRead(
-    workspaceId: string,
-    streamId: string,
-    userId: string,
-    eventId: string
-  ): Promise<StreamMember | null> {
+  async markAsRead(workspaceId: string, streamId: string, userId: string, eventId: string): Promise<MarkAsReadResult> {
     return withTransaction(this.deps.pool, async (client) => {
-      const membership = await this.deps.streamService.markAsReadInTransaction(
+      const result = await this.deps.streamService.markAsReadInTransaction(
         client,
         workspaceId,
         streamId,
@@ -36,7 +30,7 @@ export class StreamReadService {
         eventId
       )
       await this.deps.activityService.markStreamActivityAsReadInTransaction(client, userId, workspaceId, streamId)
-      return membership
+      return result
     })
   }
 }

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1712,7 +1712,12 @@ describe("StreamService.markAsRead", () => {
 
     expect(mockInsertOutbox).not.toHaveBeenCalled()
     expect(mockReadStateAdvance).not.toHaveBeenCalled()
-    expect(result?.memberId).toBe("usr_1")
+    expect(result).toEqual({
+      membership: { streamId: "stream_1", memberId: "usr_1" } as never,
+      readState: null,
+      lastReadOrdinal: null,
+      readMessageIds: null,
+    })
   })
 
   test("advances the frontier and emits stream:read for a non-member — membership fetched read-only, never written", async () => {
@@ -1724,7 +1729,12 @@ describe("StreamService.markAsRead", () => {
 
     const result = await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")
 
-    expect(result).toBeNull()
+    expect(result).toEqual({
+      membership: null,
+      readState: { lastReadEventId: "evt_9", lastReadSequence: "42", lastReadAt: null },
+      lastReadOrdinal: 7,
+      readMessageIds: [],
+    })
     expect(mockFindByStreamAndMember).toHaveBeenCalledWith({}, "stream_1", "usr_1")
     expect(mockReadStateAdvance).toHaveBeenCalledWith({}, "stream_1", "usr_1", "evt_9")
     expect(mockPruneAtOrBelow).toHaveBeenCalledWith({}, "stream_1", "usr_1", 42n)

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -155,6 +155,18 @@ export interface MarkUnreadResult {
   readState: StreamReadFrontier
 }
 
+/**
+ * A mark-as-read outcome. `readState` is null exactly when the read was a
+ * no-op (the event id resolved to no row in this stream): nothing was written,
+ * no `stream:read` was emitted, and the caller must not reconcile from it.
+ */
+export interface MarkAsReadResult {
+  membership: StreamMember | null
+  readState: StreamReadFrontier | null
+  lastReadOrdinal: number | null
+  readMessageIds: string[] | null
+}
+
 const createThreadParamsSchema = z.object({
   workspaceId: z.string(),
   parentStreamId: z.string(),
@@ -2123,7 +2135,7 @@ export class StreamService {
     streamId: string,
     memberId: string,
     eventId: string
-  ): Promise<StreamMember | null> {
+  ): Promise<MarkAsReadResult> {
     return withTransaction(this.pool, (client) =>
       this.markAsReadInTransaction(client, workspaceId, streamId, memberId, eventId)
     )
@@ -2135,7 +2147,7 @@ export class StreamService {
     streamId: string,
     memberId: string,
     eventId: string
-  ): Promise<StreamMember | null> {
+  ): Promise<MarkAsReadResult> {
     // The read pointer must reference a real event in THIS stream. A client can
     // briefly hold an optimistic event id (temp_…) as its frontier right after a
     // send, before the server echo swaps it for the persisted id. Persisting an
@@ -2146,7 +2158,14 @@ export class StreamService {
     const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
     if (!position) {
       logger.warn({ workspaceId, streamId, memberId, eventId }, "Ignored mark-as-read: event not found in stream")
-      return StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
+      // Explicit no-op: a null readState tells the caller nothing was written,
+      // so a 200 can never be mistaken for a committed frontier.
+      return {
+        membership: await StreamMemberRepository.findByStreamAndMember(client, streamId, memberId),
+        readState: null,
+        lastReadOrdinal: null,
+        readMessageIds: null,
+      }
     }
 
     // Read state is user-anchored, not membership-gated: the advance runs for
@@ -2189,7 +2208,16 @@ export class StreamService {
       lastReadOrdinal: readPosition.messageOrdinal,
       readMessageIds,
     })
-    return membership
+    return {
+      membership,
+      readState: {
+        lastReadEventId: readEventId,
+        lastReadSequence: readPosition.sequence.toString(),
+        lastReadAt: postWrite?.lastReadAt?.toISOString() ?? null,
+      },
+      lastReadOrdinal: readPosition.messageOrdinal,
+      readMessageIds,
+    }
   }
 
   /**

--- a/apps/backend/tests/integration/read-state-nonmember.test.ts
+++ b/apps/backend/tests/integration/read-state-nonmember.test.ts
@@ -187,7 +187,7 @@ describe("read state — non-member unlock", () => {
       await sendMessages(wid, sid, author, 3)
       const events = await StreamEventRepository.list(pool, sid)
 
-      const membership = await streamService.markAsRead(wid, sid, viewer, events[1].id)
+      const { membership } = await streamService.markAsRead(wid, sid, viewer, events[1].id)
 
       expect(membership).toBeNull()
       expect(await membershipCount(sid, viewer)).toBe(0)
@@ -263,6 +263,57 @@ describe("read state — non-member unlock", () => {
           readMessageIds: [],
         },
       ])
+    })
+
+    test("markAsRead returns the post-write truth — frontier, ordinal, overlay", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      await sendMessages(wid, sid, author, 3)
+      const events = await StreamEventRepository.list(pool, sid)
+
+      const result = await streamService.markAsRead(wid, sid, viewer, events[1].id)
+
+      expect(result).toEqual({
+        membership: null,
+        readState: {
+          lastReadEventId: events[1].id,
+          lastReadSequence: events[1].sequence.toString(),
+          lastReadAt: (await ReadStateRepository.get(pool, sid, viewer))!.lastReadAt!.toISOString(),
+        },
+        lastReadOrdinal: 2,
+        readMessageIds: [],
+      })
+      expect((await outboxFor("stream:read", sid)).length).toBe(1)
+    })
+
+    test("an event id from another stream is a no-op — null readState, no write, no stream:read", async () => {
+      const wid = workspaceId()
+      const sid = streamId()
+      const otherSid = streamId()
+      const author = userId()
+      const viewer = userId()
+      await seedChannel(wid, sid, author)
+      await seedChannel(wid, otherSid, author)
+      await sendMessages(wid, sid, author, 2)
+      await sendMessages(wid, otherSid, author, 1)
+      const events = await StreamEventRepository.list(pool, sid)
+      const foreign = await StreamEventRepository.list(pool, otherSid)
+
+      // Seed a real frontier first: the no-op must leave it exactly where it was.
+      await streamService.markAsRead(wid, sid, viewer, events[0].id)
+
+      const unknown = await streamService.markAsRead(wid, sid, viewer, "event_does_not_exist")
+      const crossStream = await streamService.markAsRead(wid, sid, viewer, foreign[0].id)
+
+      expect(unknown).toEqual({ membership: null, readState: null, lastReadOrdinal: null, readMessageIds: null })
+      expect(crossStream).toEqual({ membership: null, readState: null, lastReadOrdinal: null, readMessageIds: null })
+      const row = await ReadStateRepository.get(pool, sid, viewer)
+      expect(row?.lastReadEventId).toBe(events[0].id)
+      // Only the seeding read emitted — neither no-op did.
+      expect((await outboxFor("stream:read", sid)).map((p) => p.lastReadEventId)).toEqual([events[0].id])
     })
 
     test("markUnread on the first message parks the frontier before it (null watermark)", async () => {

--- a/apps/backend/tests/integration/read-state-nonmember.test.ts
+++ b/apps/backend/tests/integration/read-state-nonmember.test.ts
@@ -286,7 +286,17 @@ describe("read state — non-member unlock", () => {
         lastReadOrdinal: 2,
         readMessageIds: [],
       })
-      expect((await outboxFor("stream:read", sid)).length).toBe(1)
+      expect(await outboxFor("stream:read", sid)).toEqual([
+        {
+          workspaceId: wid,
+          authorId: viewer,
+          streamId: sid,
+          lastReadEventId: events[1].id,
+          lastReadSequence: events[1].sequence.toString(),
+          lastReadOrdinal: 2,
+          readMessageIds: [],
+        },
+      ])
     })
 
     test("an event id from another stream is a no-op — null readState, no write, no stream:read", async () => {

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -14,6 +14,7 @@ import type {
   CompanionMode,
   ToolPrivacyPolicy,
   StreamReadFrontier,
+  MarkAsReadResponse,
 } from "@threa/types"
 
 /**
@@ -210,12 +211,10 @@ export const streamsApi = {
     return res.data.membership
   },
 
-  async markAsRead(workspaceId: string, streamId: string, lastEventId: string): Promise<StreamMember | null> {
-    const res = await api.post<{ membership: StreamMember | null }>(
-      `/api/workspaces/${workspaceId}/streams/${streamId}/read`,
-      { lastEventId }
-    )
-    return res.membership
+  /** Returns the whole envelope: the post-write frontier/ordinal/overlay are the
+   *  reconciliation source. An older backend omits them — callers fall back. */
+  async markAsRead(workspaceId: string, streamId: string, lastEventId: string): Promise<MarkAsReadResponse> {
+    return api.post<MarkAsReadResponse>(`/api/workspaces/${workspaceId}/streams/${streamId}/read`, { lastEventId })
   },
 
   async markUnread(

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -62,6 +62,7 @@ describe("useAutoMarkAsRead", () => {
       commitRef: {
         current: async (streamId, lastEventId, opts) => {
           mockMarkAsRead(streamId, lastEventId, opts)
+          return { applied: true }
         },
       },
     })

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_WORKSPACE_SETTINGS,
   type Activity,
   type MarkAllAsReadResponse,
+  type MarkAsReadResponse,
   type StreamMember,
   type StreamReadFrontier,
   type WorkspaceBootstrap,
@@ -19,7 +20,21 @@ import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
 const mockMarkAsRead =
-  vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember | null>>()
+  vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<MarkAsReadResponse>>()
+
+/** A response from a backend that predates the post-write reconciliation fields. */
+function legacyReadResponse(membership: StreamMember | null = memberRow()): MarkAsReadResponse {
+  return { membership }
+}
+
+function memberRow(): StreamMember {
+  return {
+    streamId: "stream_1",
+    memberId: "member_1",
+    notificationLevel: "everything",
+    joinedAt: new Date().toISOString(),
+  }
+}
 type MarkUnreadResponse = { membership: StreamMember | null; readState: StreamReadFrontier }
 const mockMarkUnread =
   vi.fn<(workspaceId: string, streamId: string, messageId: string) => Promise<MarkUnreadResponse>>()
@@ -225,12 +240,7 @@ describe("useUnreadCounts", () => {
     })
     await seedEvent("event_new", "stream_1", "77")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), {
       wrapper: createWrapper(queryClient),
@@ -269,12 +279,7 @@ describe("useUnreadCounts", () => {
     })
     await seedEvent("evt_5", "stream_1", "42")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -308,12 +313,7 @@ describe("useUnreadCounts", () => {
     })
     await seedEvent("evt_5", "stream_1", "42")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -346,12 +346,7 @@ describe("useUnreadCounts", () => {
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
     await seedEvent("evt_5", "stream_1", "42")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -391,12 +386,7 @@ describe("useUnreadCounts", () => {
     await seedEvent("client_pending", "stream_1", String(Date.now()))
     await db.events.update("client_pending", { _clientId: "client_pending", _status: "pending" })
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -434,12 +424,7 @@ describe("useUnreadCounts", () => {
     })
     await seedEvent("evt_300", "stream_1", "300")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -493,12 +478,7 @@ describe("useUnreadCounts", () => {
       _cachedAt: Date.now(),
     })
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
     act(() => {
@@ -533,12 +513,7 @@ describe("useUnreadCounts", () => {
 
     await seedEvent("event_mid", "stream_1", "33")
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), {
       wrapper: createWrapper(queryClient),
@@ -560,16 +535,99 @@ describe("useUnreadCounts", () => {
     expect(await db.unreadState.get("ws_1")).toMatchObject({ unreadCounts: { stream_1: 2 } })
   })
 
+  it("reconciles a partial read's badge from the response ordinal, with no socket echo", async () => {
+    // The response's post-write ordinal IS the authoritative remainder, so the
+    // partial path no longer waits for `stream:read` to resolve the badge.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      ...makeBootstrap(),
+      unreadCounts: { stream_1: 5 },
+      messageCounts: { stream_1: 10 },
+    })
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 5 },
+      mentionCounts: { stream_1: 0 },
+      activityCounts: { stream_1: 0 },
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { stream_1: 10 },
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    mockMarkAsRead.mockResolvedValue({
+      membership: memberRow(),
+      readState: { lastReadEventId: "event_mid", lastReadSequence: "33", lastReadAt: new Date().toISOString() },
+      lastReadOrdinal: 8,
+      readMessageIds: [],
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "event_mid", { partial: true })
+    })
+
+    await waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(2)
+    })
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(2)
+    // The frontier comes straight from the response — no cached event needed.
+    expect(bootstrap?.streamReadState?.stream_1).toMatchObject({
+      lastReadEventId: "event_mid",
+      lastReadSequence: "33",
+    })
+    await expect(db.streamReadState.get("ws_1:stream_1")).resolves.toMatchObject({
+      lastReadEventId: "event_mid",
+      lastReadSequence: "33",
+    })
+  })
+
+  it("writes nothing when the server reports the read as a no-op", async () => {
+    // A 200 with a null readState means the event id resolved to nothing: the
+    // server wrote nothing, so neither counters nor frontier may move locally.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 2 },
+      mentionCounts: { stream_1: 0 },
+      activityCounts: { stream_1: 0 },
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+    await seedEvent("event_new", "stream_1", "77")
+
+    mockMarkAsRead.mockResolvedValue({
+      membership: null,
+      readState: null,
+      lastReadOrdinal: null,
+      readMessageIds: null,
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
+    act(() => {
+      result.current.markAsRead("stream_1", "event_new")
+    })
+
+    await waitForReadHandlerToSettle(queryClient)
+    expect(await db.streamReadState.get("ws_1:stream_1")).toBeUndefined()
+    expect(await db.unreadState.get("ws_1")).toMatchObject({ unreadCounts: { stream_1: 2 } })
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(2)
+    expect(bootstrap?.streamReadState?.stream_1).toBeUndefined()
+  })
+
   it("skips an optimistic temp_ read pointer but still sends a confirmed event id", async () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), {
       wrapper: createWrapper(queryClient),
@@ -599,12 +657,7 @@ describe("useUnreadCounts", () => {
     const queryClient = new QueryClient()
     queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
 
-    mockMarkAsRead.mockResolvedValue({
-      streamId: "stream_1",
-      memberId: "member_1",
-      notificationLevel: "everything",
-      joinedAt: new Date().toISOString(),
-    })
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse())
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), {
       wrapper: createWrapper(queryClient),
@@ -676,7 +729,7 @@ describe("useUnreadCounts", () => {
 
     await seedEvent("event_new", "stream_thread", "88")
 
-    mockMarkAsRead.mockResolvedValue(null)
+    mockMarkAsRead.mockResolvedValue(legacyReadResponse(null))
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), {
       wrapper: createWrapper(queryClient),
@@ -991,7 +1044,7 @@ describe("useUnreadCounts", () => {
       _cachedAt: Date.now() - 5000,
     })
 
-    let resolveRead!: (membership: StreamMember | null) => void
+    let resolveRead!: (response: MarkAsReadResponse) => void
     mockMarkAsRead.mockReturnValue(new Promise((resolve) => (resolveRead = resolve)))
 
     const { result } = renderHook(() => useUnreadCounts("ws_1"), { wrapper: createWrapper(queryClient) })
@@ -1015,7 +1068,7 @@ describe("useUnreadCounts", () => {
 
     // The stale read response finally resolves — it must NOT restore evt_100.
     await act(async () => {
-      resolveRead(memberResponse())
+      resolveRead({ membership: memberResponse() })
       await new Promise((resolve) => setTimeout(resolve, 10))
     })
 

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -5,7 +5,8 @@ import { workspaceKeys } from "./use-workspaces"
 import { streamKeys } from "./use-streams"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { db } from "@/db"
-import { deriveActivityCounts } from "@/sync/unread-counters"
+import { applyStreamReadOrdinal, deriveActivityCounts } from "@/sync/unread-counters"
+import { commitCounterMutation } from "@/sync/catch-up-batch"
 import {
   applyReadStateSnapshotsIdb,
   mergeReadStateIntoBootstrapCache,
@@ -35,6 +36,29 @@ function withoutOverlay(
   const next = { ...map }
   delete next[streamId]
   return next
+}
+
+/**
+ * The counter patch a mark-as-read applies when the response carries no
+ * ordinal (older backend): drop the stream's held activity rows on both paths,
+ * and on a full read zero its message unread and overlay.
+ */
+function localCounterPatch(
+  state: Pick<WorkspaceBootstrap, "unreadActivities" | "unreadCounts" | "readMessageIds">,
+  streamId: string,
+  partial: boolean | undefined
+) {
+  const rows = (state.unreadActivities ?? []).filter((a) => a.streamId !== streamId)
+  return {
+    unreadActivities: rows,
+    ...deriveActivityCounts(rows),
+    ...(partial
+      ? {}
+      : {
+          unreadCounts: { ...state.unreadCounts, [streamId]: 0 },
+          readMessageIds: withoutOverlay(state.readMessageIds, streamId),
+        }),
+  }
 }
 
 /**
@@ -98,10 +122,17 @@ export function useUnreadCounts(workspaceId: string) {
   const markAsReadMutation = useMutation({
     mutationFn: async ({ streamId, lastEventId }: { streamId: string; lastEventId: string; partial?: boolean }) => {
       const startedAt = Date.now()
-      const membership = await streamService.markAsRead(workspaceId, streamId, lastEventId)
-      return { membership, startedAt }
+      const response = await streamService.markAsRead(workspaceId, streamId, lastEventId)
+      return { ...response, startedAt }
     },
-    onSuccess: async ({ membership, startedAt }, { streamId, lastEventId, partial }) => {
+    onSuccess: async (
+      { membership, readState, lastReadOrdinal, readMessageIds, startedAt },
+      { streamId, lastEventId, partial }
+    ) => {
+      // A null readState is the server saying the read was a no-op — the event
+      // id resolved to nothing, so nothing was written and nothing local may
+      // move. Absent (older backend) keeps the legacy local-resolution path.
+      if (readState === null) return
       // Ordering guard (touched-at): a read-state write that landed after this
       // mutation departed — the request's own socket echo, or a later action
       // (an explicit unread this stale read must not erase) — owns the stream.
@@ -116,36 +147,26 @@ export function useUnreadCounts(workspaceId: string) {
       // membership row in IDB.
       const hasMembership = membership !== null
 
-      // Coupling (D2/D4): reading a stream clears its held activity rows on BOTH
-      // the partial and full paths — activity (e.g. a reaction) is read by opening
-      // the stream regardless of message scroll position. The derived activity/
-      // mention counts follow the rows.
-      //
-      // Message unread (`unreadCounts`) is separate and stays on the FULL path
-      // only: a partial read advances the read pointer to a mid-window event with
-      // unread still below it. Zeroing it optimistically would be wrong AND
-      // sticky — the ordinal read position MAX-merges (see `applyStreamReadOrdinal`),
-      // so once forced to "read = latest" the server's `stream:read` for the mid
-      // event can never restore the remaining count. So for a partial read only
-      // the read POINTER moves; the badge resolves to the true remainder on the
-      // `stream:read` round-trip.
+      // The response's post-write ordinal IS the authoritative remainder, so it
+      // reconciles the counters on BOTH paths through the same pure apply the
+      // `stream:read` echo uses (INV-35) — the partial path no longer waits for
+      // the echo to resolve the badge, and the full path lands on the same
+      // zero. Without an ordinal (older backend) the legacy optimistic patch
+      // stands: activity drop on both paths, message unread on the full path
+      // only, since a partial read leaves unread below the pointer and the
+      // ordinal read position MAX-merges — forcing "read = latest" there would
+      // be sticky.
+      const reconcileFromOrdinal = typeof lastReadOrdinal === "number"
+      if (reconcileFromOrdinal) {
+        commitCounterMutation(queryClient, workspaceId, (state) =>
+          applyStreamReadOrdinal(state, streamId, lastReadOrdinal, readMessageIds ?? undefined)
+        )
+      }
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
-        const rows = (old.unreadActivities ?? []).filter((a) => a.streamId !== streamId)
-        // A full read advances the watermark to latest, so every overlay message
-        // for this stream is now below it and pruned server-side — clear the set
-        // optimistically to keep the invariant (the server echo re-SETs it).
-        const messageCounters = partial
-          ? {}
-          : {
-              unreadCounts: { ...old.unreadCounts, [streamId]: 0 },
-              readMessageIds: withoutOverlay(old.readMessageIds, streamId),
-            }
         return {
           ...old,
-          unreadActivities: rows,
-          ...deriveActivityCounts(rows),
-          ...messageCounters,
+          ...(reconcileFromOrdinal ? {} : localCounterPatch(old, streamId, partial)),
           // Membership is participation only — merge the fresh row (no watermark).
           streamMemberships: hasMembership
             ? old.streamMemberships.map((existingMembership) =>
@@ -157,10 +178,12 @@ export function useUnreadCounts(workspaceId: string) {
 
       // Read frontier (sole source): the optimistic advance must move it for
       // EVERY viewer with access — member or not — or the divider stalls until
-      // the socket echo. The response carries no sequence, so resolve the read
-      // event's real one from the cache — an id advanced without its sequence
-      // reads as "never read" downstream. Resolution happens before the
-      // transaction below so the transaction stays as narrow as it was.
+      // the socket echo. The response's `readState` is the server's post-write
+      // truth, so it is used verbatim when present. Without it (older backend)
+      // the id has no sequence, so resolve the read event's real one from the
+      // cache — an id advanced without its sequence reads as "never read"
+      // downstream. Resolution happens before the transaction below so the
+      // transaction stays as narrow as it was.
       // An unconfirmed row is cached under its client id with a Date.now()-scale
       // placeholder sequence (`nextOptimisticSequence`), so it resolves here even
       // though the server has no such event — it no-ops the read and emits no
@@ -169,9 +192,9 @@ export function useUnreadCounts(workspaceId: string) {
       // since every later echo and bootstrap merge is monotonic. Treat it as
       // unresolvable, like an id with no row at all. Reachable whenever the
       // viewer's own send is the bottom row when auto-read fires.
-      const cached = await db.events.get(lastEventId)
+      const cached = readState ? undefined : await db.events.get(lastEventId)
       const readEvent = cached && (cached._status === "pending" || cached._status === "failed") ? undefined : cached
-      if (!readEvent) {
+      if (!readState && !readEvent) {
         console.warn("Read frontier not advanced — read pointer has no confirmed event", { streamId, lastEventId })
       }
       // Monotonic, like the server: `ReadStateRepository.advance` rejects a
@@ -181,16 +204,19 @@ export function useUnreadCounts(workspaceId: string) {
       // unread until the echo lands. A sanctioned downward move is markUnread's
       // `stream:read_set`, not this path.
       const storedSequence = (await db.streamReadState.get(`${workspaceId}:${streamId}`))?.lastReadSequence
+      const advanceSequence = readState ? readState.lastReadSequence : (readEvent?.sequence ?? null)
       const movesBackward =
-        readEvent != null && storedSequence != null && BigInt(readEvent.sequence) < BigInt(storedSequence)
-      const frontier =
-        readEvent && !movesBackward
-          ? {
-              lastReadEventId: lastEventId,
-              lastReadSequence: readEvent.sequence,
-              lastReadAt: new Date().toISOString(),
-            }
-          : null
+        advanceSequence != null && storedSequence != null && BigInt(advanceSequence) < BigInt(storedSequence)
+      const frontier = movesBackward
+        ? null
+        : readState ||
+          (readEvent
+            ? {
+                lastReadEventId: lastEventId,
+                lastReadSequence: readEvent.sequence,
+                lastReadAt: new Date().toISOString(),
+              }
+            : null)
       // Re-check before the cache writes, not just before the IDB write below:
       // the two resolution reads above are await points the old synchronous path
       // did not have, so an echo landing in that window would otherwise leave the
@@ -214,21 +240,14 @@ export function useUnreadCounts(workspaceId: string) {
         // transaction still wins over the stale response.
         if (await readStateTouchedSince(workspaceId, streamId, startedAt)) return
         const now = Date.now()
-        const state = await db.unreadState.get(workspaceId)
+        // `commitCounterMutation` owns the counter row when the response
+        // reconciled it (it persists and stamps `counterTouchedAt` itself);
+        // writing a snapshot read here would race it back.
+        const state = reconcileFromOrdinal ? undefined : await db.unreadState.get(workspaceId)
         if (state) {
-          // Activity drop applies on both paths; `unreadCounts` only on the full
-          // path (mirrors the query-cache branch above).
-          const rows = (state.unreadActivities ?? []).filter((a) => a.streamId !== streamId)
           await db.unreadState.put({
             ...state,
-            unreadActivities: rows,
-            ...deriveActivityCounts(rows),
-            ...(partial
-              ? {}
-              : {
-                  unreadCounts: { ...state.unreadCounts, [streamId]: 0 },
-                  readMessageIds: withoutOverlay(state.readMessageIds, streamId),
-                }),
+            ...localCounterPatch(state, streamId, partial),
             // Touch stamp: an in-flight bootstrap's per-stream merge must not
             // resurrect the pre-read snapshot (mergeBootstrapUnreadFields).
             counterTouchedAt: { ...state.counterTouchedAt, [streamId]: now },
@@ -392,7 +411,7 @@ export function useUnreadCounts(workspaceId: string) {
       // and reports the whole stream — including the user's own messages — as
       // unread. The auto-read effect re-fires with the real id once the server echo
       // swaps it in.
-      if (lastEventId.startsWith("temp_")) return Promise.resolve()
+      if (lastEventId.startsWith("temp_")) return Promise.resolve({ applied: false })
       const commit = markAsReadMutation.mutateAsync({ streamId, lastEventId, partial: opts?.partial })
       // Dismiss any push notification for this stream — advancing the read pointer
       // (auto-read, manual "Mark as read", or Escape) means the user is here, so
@@ -402,7 +421,10 @@ export function useUnreadCounts(workspaceId: string) {
       // their own socket echo when open, or the bootstrap sweep on next open
       // (lib/notification-sweep.ts) — never via push, which would burn quota.
       navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })
-      return commit.then(() => undefined)
+      // `applied: false` = the server no-op'd (the event id resolved to nothing),
+      // so the queue must not record the frontier as committed. An older backend
+      // omits `readState`; that keeps today's meaning — a 200 is a commit.
+      return commit.then((response) => ({ applied: response.readState !== null }))
     },
     [markAsReadMutation]
   )

--- a/apps/frontend/src/sync/read-commit-queue.test.ts
+++ b/apps/frontend/src/sync/read-commit-queue.test.ts
@@ -5,9 +5,11 @@ import {
   READ_COMMIT_MAX_RETRIES,
   READ_COMMIT_PARKED_RETRY_MS,
   READ_COMMIT_RETRY_MS,
+  type ReadCommitOutcome,
 } from "./read-commit-queue"
 
-const commit = vi.fn<(streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<void>>()
+const commit =
+  vi.fn<(streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<ReadCommitOutcome>>()
 
 function makeQueue() {
   return new ReadCommitQueue({
@@ -22,7 +24,7 @@ describe("ReadCommitQueue", () => {
   beforeEach(() => {
     vi.useFakeTimers()
     commit.mockReset()
-    commit.mockResolvedValue(undefined)
+    commit.mockResolvedValue({ applied: true })
     queue = makeQueue()
   })
 
@@ -86,8 +88,48 @@ describe("ReadCommitQueue", () => {
     expect(queue.lastCommitted("stream_a")).toBeNull()
   })
 
+  it("does not record a resolved-but-not-applied commit, so the same frontier can be re-reported", async () => {
+    // The server no-op'd (the event id resolved to nothing). A 200 is not a
+    // commit: dedup must not block the retry that carries the real id.
+    commit.mockResolvedValueOnce({ applied: false })
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith("stream_a", "event_1", { partial: false })
+    expect(queue.lastCommitted("stream_a")).toBeNull()
+
+    // Clean, not failed: no retry fires on its own, and the next report commits.
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_PARKED_RETRY_MS)
+    expect(commit).toHaveBeenCalledTimes(1)
+
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    expect(commit).toHaveBeenCalledTimes(2)
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_1", partial: false })
+  })
+
+  it("drains a mark queued behind a not-applied commit", async () => {
+    let releaseFirst!: () => void
+    commit.mockImplementationOnce(
+      () => new Promise<ReadCommitOutcome>((resolve) => (releaseFirst = () => resolve({ applied: false })))
+    )
+    queue.report("stream_a", "event_1", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+    queue.report("stream_a", "event_2", false)
+    await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
+
+    releaseFirst()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(commit.mock.calls).toEqual([
+      ["stream_a", "event_1", { partial: false }],
+      ["stream_a", "event_2", { partial: false }],
+    ])
+    expect(queue.lastCommitted("stream_a")).toEqual({ lastEventId: "event_2", partial: false })
+  })
+
   it("retries a rejected request and records it only after acknowledgement", async () => {
-    commit.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce(undefined)
+    commit.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce({ applied: true })
     queue.report("stream_a", "event_1", false)
 
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
@@ -100,7 +142,7 @@ describe("ReadCommitQueue", () => {
 
   it("drops a failed older retry when a newer frontier is already queued", async () => {
     let rejectRead!: (error: Error) => void
-    commit.mockImplementationOnce(() => new Promise<void>((_resolve, reject) => (rejectRead = reject)))
+    commit.mockImplementationOnce(() => new Promise<ReadCommitOutcome>((_resolve, reject) => (rejectRead = reject)))
     queue.report("stream_a", "event_1", true)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
 
@@ -126,7 +168,7 @@ describe("ReadCommitQueue", () => {
     )
     expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 1)
 
-    commit.mockResolvedValue(undefined)
+    commit.mockResolvedValue({ applied: true })
     await vi.advanceTimersByTimeAsync(READ_COMMIT_PARKED_RETRY_MS)
 
     expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 2)
@@ -142,7 +184,7 @@ describe("ReadCommitQueue", () => {
     expect(commit).toHaveBeenCalledTimes(READ_COMMIT_MAX_RETRIES + 1)
     expect(queue.lastCommitted("stream_a")).toBeNull()
 
-    commit.mockResolvedValue(undefined)
+    commit.mockResolvedValue({ applied: true })
     window.dispatchEvent(new Event("focus"))
     await Promise.resolve()
 
@@ -152,7 +194,9 @@ describe("ReadCommitQueue", () => {
 
   it("serializes explicit unread behind an in-flight read and blocks reports until the pointer changes", async () => {
     let releaseRead!: () => void
-    commit.mockImplementationOnce(() => new Promise<void>((resolve) => (releaseRead = resolve)))
+    commit.mockImplementationOnce(
+      () => new Promise<ReadCommitOutcome>((resolve) => (releaseRead = () => resolve({ applied: true })))
+    )
     queue.report("stream_a", "event_3", false)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
 
@@ -278,7 +322,9 @@ describe("ReadCommitQueue", () => {
 
   it("drains a newer mark queued behind an in-flight request during disposal", async () => {
     let releaseFirst!: () => void
-    commit.mockImplementationOnce(() => new Promise<void>((resolve) => (releaseFirst = resolve)))
+    commit.mockImplementationOnce(
+      () => new Promise<ReadCommitOutcome>((resolve) => (releaseFirst = () => resolve({ applied: true })))
+    )
     queue.report("stream_a", "event_1", false)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
     queue.report("stream_a", "event_2", false)
@@ -298,8 +344,8 @@ describe("ReadCommitQueue", () => {
   it("retries an in-flight request that fails after disposal", async () => {
     let rejectFirst!: (error: Error) => void
     commit
-      .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => (rejectFirst = reject)))
-      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(() => new Promise<ReadCommitOutcome>((_resolve, reject) => (rejectFirst = reject)))
+      .mockResolvedValueOnce({ applied: true })
     queue.report("stream_a", "event_1", false)
     await vi.advanceTimersByTimeAsync(READ_COMMIT_DEBOUNCE_MS)
 

--- a/apps/frontend/src/sync/read-commit-queue.ts
+++ b/apps/frontend/src/sync/read-commit-queue.ts
@@ -10,7 +10,16 @@ export const READ_COMMIT_RETRY_MS = 1_000
 export const READ_COMMIT_MAX_RETRIES = 3
 export const READ_COMMIT_PARKED_RETRY_MS = 30_000
 
-type CommitRead = (streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<void>
+/**
+ * Resolves with whether the server actually moved the frontier. `applied:
+ * false` is a clean no-op (the server ignored the read pointer), not a failure:
+ * the frontier stays uncommitted so the same mark can be reported again.
+ */
+export interface ReadCommitOutcome {
+  applied: boolean
+}
+
+type CommitRead = (streamId: string, lastEventId: string, opts: { partial: boolean }) => Promise<ReadCommitOutcome>
 
 interface ScheduledMark extends ReadCommitMark {
   timer: ReturnType<typeof setTimeout>
@@ -186,14 +195,16 @@ export class ReadCommitQueue {
 
   private async execute(streamId: string, mark: QueuedMark, allowDisposed: boolean): Promise<void> {
     try {
-      let operation: Promise<void>
+      let operation: Promise<ReadCommitOutcome>
       try {
         operation = this.commitRef.current(streamId, mark.lastEventId, { partial: mark.partial })
       } catch (error) {
         operation = Promise.reject(error)
       }
-      await operation
-      this.committed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
+      const outcome = await operation
+      // A no-op commit is clean but NOT committed: recording it would let dedup
+      // block re-reporting a frontier the server never took.
+      if (outcome.applied) this.committed.set(streamId, { lastEventId: mark.lastEventId, partial: mark.partial })
       this.failed.delete(streamId)
     } catch {
       const newerMarkExists = this.pending.has(streamId) || this.queued.has(streamId)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1957,6 +1957,17 @@ export interface MarkAsReadInput {
 export interface MarkAsReadResponse {
   /** Null when the viewer has access but no membership row (INV-62: non-member thread leg, unjoined public channel) — an activity-only read. */
   membership: StreamMember | null
+  /**
+   * The canonical post-write read frontier. `null` means the request was a
+   * no-op — the event id resolved to no row in this stream, so nothing moved
+   * and the client must write nothing locally. Absent only on responses from
+   * before the field shipped.
+   */
+  readState?: StreamReadFrontier | null
+  /** Absolute message ordinal of the post-write frontier — the counter's authoritative read position. Null on the no-op path. */
+  lastReadOrdinal?: number | null
+  /** The post-write sparse read overlay (message ids above the watermark). Null on the no-op path. */
+  readMessageIds?: string[] | null
 }
 
 export interface MarkAllAsReadResponse {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -630,6 +630,7 @@ export type {
   StreamReadFrontier,
   StreamReadFrontierSnapshot,
   MarkAllAsReadResponse,
+  MarkAsReadResponse,
   ActiveAgentSession,
   ActiveCall,
   StreamActiveCall,


### PR DESCRIPTION
## Why

Two truthfulness gaps in the read-commit loop. (1) A mark-as-read whose event id resolves to nothing returns HTTP 200 while writing nothing — the client records the frontier as committed and its dedup then blocks re-reporting the same frontier until a stream switch. (2) After a successful commit, local reconciliation of the unread badge on the partial path depended entirely on the `stream:read` socket echo (and the frontier write on a local `db.events.get` that can miss) — any echo gap left the stream you were reading lit indefinitely, with both heal paths unable to re-fire (see #1897).

## Changes

- `markAsRead` returns the post-write truth the service already computes: `readState` (id, sequence, lastReadAt), `lastReadOrdinal`, `readMessageIds`; the event-not-found path is an explicit `readState: null` no-op. Mirrors #1895's own `markUnread` response change. Additive fields — old clients ignore them, and the client keeps the legacy resolution when they are absent (deploy skew).
- Client `onSuccess` reconciles counters and frontier from the response via the same `applyStreamReadOrdinal` apply the socket echo uses (INV-35) — the partial-path badge lands on the authoritative remainder without waiting for the echo. When the response reconciles, `commitCounterMutation` owns the counter row (it stamps `counterTouchedAt`); the old snapshot put is skipped to avoid racing it.
- `ReadCommitQueue` commit outcomes: `applied: false` (server no-op, or the temp_-id short-circuit) is a clean no-op that is never recorded as committed — no dedup wedge, no retry.

## Verification

Backend 4056 unit + 372 e2e green; new INV-68 integration tests (real schema) cover the happy path, the no-op, and a cross-stream event id (no `stream_read_state` write, no `stream:read` outbox row). Frontend 6762 green including new response-reconciliation and outcome tests.

## Residual risk

On the ordinal path the counter write is a separate fire-and-forget transaction from the membership/frontier transaction — same semantics as the socket echo it now shares code with.
