### PR TITLE
fix: stream bootstrap counters require a known fetch start

### DIFF
--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -992,6 +992,47 @@ describe("applyStreamBootstrap — per-stream unread count", () => {
     })
   })
 
+  it("skips counter publication entirely when the caller provides no fetchStartedAt", async () => {
+    // Without a fetch-start timestamp the touched-at guard cannot order the
+    // snapshot against a live ordinal, so the counters must not apply at all —
+    // a caller that wants counter publication passes `fetchStartedAt`.
+    const streamId = "stream_public"
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { [streamId]: 3 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { [streamId]: 10 },
+      mutedStreamIds: [],
+      counterTouchedAt: {},
+      _cachedAt: Date.now(),
+    })
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      unreadCounts: { [streamId]: 3 },
+      messageCounts: { [streamId]: 10 },
+    } as unknown as WorkspaceBootstrap)
+
+    await applyStreamBootstrap(
+      "ws_1",
+      streamId,
+      { ...makeBootstrap([], streamId), unreadCount: 1, messageCount: 8 },
+      { queryClient }
+    )
+
+    expect(await db.unreadState.get("ws_1")).toMatchObject({
+      unreadCounts: { [streamId]: 3 },
+      latestOrdinals: { [streamId]: 10 },
+    })
+    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))).toMatchObject({
+      unreadCounts: { [streamId]: 3 },
+      messageCounts: { [streamId]: 10 },
+    })
+  })
+
   it("preserves a counter touched after the bootstrap request departed", async () => {
     const streamId = "stream_public"
     const fetchStartedAt = Date.now() - 100

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -701,9 +701,15 @@ export async function applyStreamBootstrap(
       )
       const unreadState = await db.unreadState.get(workspaceId)
       const touchedAt = unreadState?.counterTouchedAt?.[streamId]
+      // Counters apply only under a known fetch start: without `fetchStartedAt`
+      // the touched-at guard cannot order this snapshot against a live ordinal
+      // that raised the count while the fetch was in flight, and applying
+      // anyway would absorb that ordinal into `latestOrdinals` (max-merge) so
+      // the re-delivered activity could never raise unread again.
       if (
         unreadState &&
-        (options?.fetchStartedAt === undefined || touchedAt === undefined || touchedAt < options.fetchStartedAt)
+        options?.fetchStartedAt !== undefined &&
+        (touchedAt === undefined || touchedAt < options.fetchStartedAt)
       ) {
         await db.unreadState.put({
           ...unreadState,
@@ -726,7 +732,8 @@ export async function applyStreamBootstrap(
     const touchedAt = unreadState?.counterTouchedAt?.[streamId]
     const remainsCurrent =
       unreadState !== undefined &&
-      (options.fetchStartedAt === undefined || touchedAt === undefined || touchedAt < options.fetchStartedAt)
+      options.fetchStartedAt !== undefined &&
+      (touchedAt === undefined || touchedAt < options.fetchStartedAt)
     if (remainsCurrent) {
       options.queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (current) =>
         current


### PR DESCRIPTION
## Why

`applyStreamBootstrap`'s counter publication guards against restoring a pre-message snapshot with a `fetchStartedAt`-vs-`counterTouchedAt` comparison (#1895 added this and tested it), but bypassed the guard entirely when `fetchStartedAt` was `undefined`. Every current call site passes the timestamp, so the bypass is latent — but a future call site omitting it silently reopens the race: a bootstrap snapshotted before a live message and resolved after it restores the stale count, and because `latestOrdinals` max-merges, the absorbed ordinal means the re-delivered `stream:activity` can never raise unread again — the auto-read report is then suppressed entirely (`use-auto-mark-as-read` sees 0/0 on a partial mark).

## Changes

Counter apply and post-transaction publication now require a known `fetchStartedAt`; without one the counters are skipped (read-state application is unchanged — it has its own freshness path). Test pins the closed bypass: no timestamp → no counter write, IDB and query cache both untouched.

## Verification

`stream-sync.test.ts` 148/148 green (includes #1895's existing in-flight-ordinal races plus the new bypass pin); monorepo lint+typecheck green via pre-commit.

## Residual risk

None beyond the intended behavior change: a hypothetical caller relying on timestamp-less counter publication would now not publish counters — no such caller exists.
