### PR TITLE
fix: resample page activity on user interaction

### DIFF
--- a/apps/frontend/src/hooks/use-page-activity.test.ts
+++ b/apps/frontend/src/hooks/use-page-activity.test.ts
@@ -78,6 +78,25 @@ describe("usePageActivity", () => {
     expect(result.current).toEqual({ isVisible: false, isFocused: false, isActive: false })
   })
 
+  it("removes every interaction listener on unmount, each with its registered callback and capture flag", () => {
+    const added = vi.spyOn(window, "addEventListener")
+    const removed = vi.spyOn(window, "removeEventListener")
+    const { unmount } = renderHook(() => usePageActivity())
+
+    const interactionTypes = ["pointerdown", "keydown", "wheel", "touchstart"]
+    const registered = new Map(
+      added.mock.calls.filter(([type]) => interactionTypes.includes(type as string)).map(([type, cb]) => [type, cb])
+    )
+    expect([...registered.keys()].sort()).toEqual([...interactionTypes].sort())
+
+    unmount()
+
+    const removedInteraction = removed.mock.calls.filter(([type]) => interactionTypes.includes(type as string))
+    expect(removedInteraction.sort()).toEqual(
+      [...registered.entries()].map(([type, cb]) => [type, cb, { capture: true }]).sort()
+    )
+  })
+
   it("still tracks visibilitychange", () => {
     const { result } = renderHook(() => usePageActivity())
 

--- a/apps/frontend/src/hooks/use-page-activity.test.ts
+++ b/apps/frontend/src/hooks/use-page-activity.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { usePageActivity, INTERACTION_RESAMPLE_THROTTLE_MS } from "./use-page-activity"
+
+let visibilityState: DocumentVisibilityState = "hidden"
+let hasFocus = false
+
+const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState")
+
+function setPageState(next: { visibilityState: DocumentVisibilityState; hasFocus: boolean }) {
+  visibilityState = next.visibilityState
+  hasFocus = next.hasFocus
+}
+
+describe("usePageActivity", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setPageState({ visibilityState: "hidden", hasFocus: false })
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    })
+    vi.spyOn(document, "hasFocus").mockImplementation(() => hasFocus)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    if (originalVisibilityState) {
+      Object.defineProperty(document, "visibilityState", originalVisibilityState)
+    } else {
+      Reflect.deleteProperty(document, "visibilityState")
+    }
+  })
+
+  it("recovers from a stuck-hidden resume on pointerdown, with no lifecycle event", () => {
+    const { result } = renderHook(() => usePageActivity())
+    expect(result.current).toEqual({ isVisible: false, isFocused: false, isActive: false })
+
+    setPageState({ visibilityState: "visible", hasFocus: true })
+    act(() => {
+      window.dispatchEvent(new Event("pointerdown"))
+    })
+
+    expect(result.current).toEqual({ isVisible: true, isFocused: true, isActive: true })
+  })
+
+  it("recovers from a stuck-hidden resume on keydown, with no lifecycle event", () => {
+    const { result } = renderHook(() => usePageActivity())
+
+    setPageState({ visibilityState: "visible", hasFocus: true })
+    act(() => {
+      window.dispatchEvent(new Event("keydown"))
+    })
+
+    expect(result.current).toEqual({ isVisible: true, isFocused: true, isActive: true })
+  })
+
+  it("throttles resampling: a second interaction inside the window is ignored, the next one after it lands", () => {
+    const { result } = renderHook(() => usePageActivity())
+
+    setPageState({ visibilityState: "visible", hasFocus: true })
+    act(() => {
+      window.dispatchEvent(new Event("pointerdown"))
+    })
+    expect(result.current).toEqual({ isVisible: true, isFocused: true, isActive: true })
+
+    setPageState({ visibilityState: "hidden", hasFocus: false })
+    act(() => {
+      window.dispatchEvent(new Event("keydown"))
+    })
+    expect(result.current).toEqual({ isVisible: true, isFocused: true, isActive: true })
+
+    act(() => {
+      vi.advanceTimersByTime(INTERACTION_RESAMPLE_THROTTLE_MS)
+      window.dispatchEvent(new Event("keydown"))
+    })
+    expect(result.current).toEqual({ isVisible: false, isFocused: false, isActive: false })
+  })
+
+  it("still tracks visibilitychange", () => {
+    const { result } = renderHook(() => usePageActivity())
+
+    setPageState({ visibilityState: "visible", hasFocus: true })
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    expect(result.current).toEqual({ isVisible: true, isFocused: false, isActive: false })
+  })
+})

--- a/apps/frontend/src/hooks/use-page-activity.ts
+++ b/apps/frontend/src/hooks/use-page-activity.ts
@@ -1,4 +1,8 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
+
+export const INTERACTION_RESAMPLE_THROTTLE_MS = 1000
+
+const INTERACTION_EVENTS = ["pointerdown", "keydown", "wheel", "touchstart"] as const
 
 export interface PageActivityState {
   isVisible: boolean
@@ -29,6 +33,7 @@ export function usePageActivity(): PageActivityState {
   const initial = getPageActivityState()
   const [isVisible, setIsVisible] = useState(initial.isVisible)
   const [isFocused, setIsFocused] = useState(initial.isFocused)
+  const lastInteractionResampleRef = useRef(0)
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") return
@@ -40,6 +45,16 @@ export function usePageActivity(): PageActivityState {
       updateFocus()
     }
 
+    // Some mobile resumes fire none of the lifecycle events above, so live
+    // interaction is the only reliable signal that the page is back.
+    const resampleFromInteraction = () => {
+      const now = Date.now()
+      if (now - lastInteractionResampleRef.current < INTERACTION_RESAMPLE_THROTTLE_MS) return
+      lastInteractionResampleRef.current = now
+      updateVisibility()
+      updateFocus()
+    }
+
     updateVisibility()
     updateFocus()
 
@@ -47,12 +62,18 @@ export function usePageActivity(): PageActivityState {
     window.addEventListener("focus", updateFocus)
     window.addEventListener("blur", updateFocus)
     window.addEventListener("pageshow", updatePageShow)
+    for (const type of INTERACTION_EVENTS) {
+      window.addEventListener(type, resampleFromInteraction, { capture: true, passive: true })
+    }
 
     return () => {
       document.removeEventListener("visibilitychange", updateVisibility)
       window.removeEventListener("focus", updateFocus)
       window.removeEventListener("blur", updateFocus)
       window.removeEventListener("pageshow", updatePageShow)
+      for (const type of INTERACTION_EVENTS) {
+        window.removeEventListener(type, resampleFromInteraction, { capture: true })
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Why

`usePageActivity` learns visibility/focus only from lifecycle events (`visibilitychange`, `focus`, `blur`, and #1896's `pageshow`). Field behavior shows some mobile resumes fire none of them: the hook stays stuck at its pre-lock hidden snapshot while the user actively scrolls and types, `computeAutoReadAttention` stays false, and every auto-read is suppressed until an app switch finally fires an event — matching the prod watermark lag pattern (bot-message reads committing minutes late, exactly at refocus). `document.visibilityState`/`hasFocus()` return correct values throughout; the hook just never re-reads them.

## Changes

Resample both signals on real user interaction — `pointerdown`, `keydown`, `wheel`, `touchstart` (window, capture, passive) — throttled to once per second. An interacting user is definitionally attentive, so this retires the per-device guessing about which lifecycle event a given browser fires on resume. Lifecycle listeners and the imperative `getPageActivityState` are unchanged.

## Verification

New `use-page-activity.test.ts`: stuck-hidden recovery via pointerdown and keydown with no lifecycle event dispatched, throttle suppression inside the window plus resample after it, and a visibilitychange regression guard. Suite green with `use-auto-mark-as-read` tests; frontend typecheck+lint green.

## Residual risk

A page that is genuinely hidden cannot receive user interaction events, so the resample can only correct toward truth; the 1s throttle bounds overhead on scroll/typing bursts.
