### PR TITLE
fix: only the first <title> element feeds the link preview title

### DIFF
--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -149,6 +149,21 @@ describe("parseHtmlMeta", () => {
     expect(result.title).toBe("Page Title")
   })
 
+  test("ignores <title> elements inside inline SVGs (githubstatus.com)", async () => {
+    const html = `
+      <html><head>
+        <title>GitHub Status</title>
+        <meta name="description" content="Welcome to GitHub's home for real-time and historical data on system performance.">
+      </head><body>
+        <svg><title>GitHub Octicon logo</title></svg>
+        <svg><title>GitHub text logo</title></svg>
+        <svg><title>GitHub X</title></svg>
+      </body></html>
+    `
+    const result = await parseHtmlMeta(html, "https://www.githubstatus.com/")
+    expect(result.title).toBe("GitHub Status")
+  })
+
   test("falls back to meta description", async () => {
     const html = `
       <html><head>

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -378,6 +378,7 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
 export async function parseHtmlMeta(html: string, url: string): Promise<UpdateLinkPreviewParams> {
   const meta: Record<string, string> = {}
   let titleText = ""
+  let titleIndex = -1
   let faviconHref = ""
 
   const rewriter = new HTMLRewriter()
@@ -400,8 +401,14 @@ export async function parseHtmlMeta(html: string, url: string): Promise<UpdateLi
       },
     })
     .on("title", {
+      // The selector matches every <title> in the document, including the accessibility
+      // <title> inside each inline <svg> icon (githubstatus.com has ten of those) — only
+      // the first one is the document title, so text from later matches is dropped.
+      element() {
+        titleIndex++
+      },
       text(chunk) {
-        titleText += chunk.text
+        if (titleIndex === 0) titleText += chunk.text
       },
     })
     .on('link[rel="icon"], link[rel="shortcut icon"]', {


### PR DESCRIPTION
## Problem

Link previews for pages without `og:title` can render garbage titles. `parseHtmlMeta` (`apps/backend/src/features/link-previews/worker.ts`) registers an HTMLRewriter text handler on the `title` selector, which matches every `<title>` in the document — including the accessibility `<title>` inside each inline `<svg>`. githubstatus.com has ten of those, so its preview title came out as `GitHub StatusGitHub Octicon logoGitHub text logoGitHub XGitHub Facebook…` (screenshot in the original report).

## Solution

Track the `<title>` element index in the rewriter and append text only while inside the first one; later matches are dropped. `og:title`/`twitter:title` priority is unchanged — this only affects the `<title>` fallback path. An empty first `<title>` now yields no fallback title rather than borrowing a later SVG title, which is the correct behavior anyway.

Verified against the live page: `parseHtmlMeta` on fetched githubstatus.com HTML now returns title `GitHub Status`, description `Welcome to GitHub's home for real-time and historical data on system performance.`

## Test plan

- [x] `bun test src/features/link-previews/worker.test.ts` — 45 pass, including new multi-`<title>` SVG case
- [x] Manual run of `parseHtmlMeta` over live githubstatus.com HTML

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_015cFCL6NqTSKP9TQCzEJuMt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789571848&installation_model_id=20758&pr_number=1902&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1902&signature=afd03d98e49d8eeedfe825347e479d160bca975f6d801c5b16fe097eecd52f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->