### PR TITLE
fix: vendor attachment-files.ts into both extension installers

### DIFF
--- a/extensions/claude-code-remote/install-local.ts
+++ b/extensions/claude-code-remote/install-local.ts
@@ -40,6 +40,7 @@ const VENDORED = [
       "tmux-window.ts",
       "archive-grace.ts",
       "harness-links.ts",
+      "attachment-files.ts",
     ],
     dir: "bot-runtime-client",
   },

--- a/extensions/pi-remote/install-local.ts
+++ b/extensions/pi-remote/install-local.ts
@@ -35,6 +35,7 @@ const VENDOR_FILES = [
   "tmux-window.ts",
   "archive-grace.ts",
   "harness-links.ts",
+  "attachment-files.ts",
 ]
 
 // 1. Clean any prior install — both the legacy single-file form and the dir form.


### PR DESCRIPTION
## Problem

[#1903](https://github.com/threahq/threa/pull/1903) added `extensions/bot-runtime-client/src/attachment-files.ts` and re-exported it from that package's barrel, but both standalone installers vendor `bot-runtime-client` through an explicit file allowlist — `VENDOR_FILES` in `extensions/pi-remote/install-local.ts` and `VENDORED[].files` in `extensions/claude-code-remote/install-local.ts`. A file in the barrel but missing from the list produces an install that can't resolve its own import, so `bun run extensions/pi-remote/install-local.ts` failed:

```
error: vendored bot-runtime-client is incomplete — add these to VENDOR_FILES:
  index.ts imports ./attachment-files
```

The installers' own guards caught it at install time (they walk the vendored sources' relative imports and throw), so nothing shipped broken — but neither connector could be installed locally until the lists were updated.

## Solution

Add `"attachment-files.ts"` to both allowlists. Nothing else changes.

## Test plan

- [x] `bun run extensions/pi-remote/install-local.ts` — installs to `~/.pi/agent/extensions/threa-remote`, vendored `attachment-files.ts` present
- [x] `bun run extensions/claude-code-remote/install-local.ts` — installs to `~/.threa/claude-code-remote`, vendored copy present in both `bot-runtime-client/` and via `remote-session/attachments.ts`
- [x] both installed copies verified to carry the per-attachment-id path and the byte-aware filename cap

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789627609&installation_model_id=20758&pr_number=1904&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1904&signature=c89bc57b52d64b75e80402f9cbb9bd0e45788c94a0bd29c1870b08a615eb18f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->