### PR TITLE
fix: merge the published-track registry by kind instead of overwriting

### DIFF
--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -1699,6 +1699,126 @@ describe("CallService.publishTracks", () => {
     expect(result.snapshot.rosterVersion).toBe(4)
   })
 
+  it("should keep the mic entry when a camera publish declares only the camera", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [{ kind: "mic", trackName: "mic0" }],
+      })
+    )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(5)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+
+    await makeServiceWithCf(fakeCloudflare()).publishTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ kind: "camera", mid: "1", trackName: "cam1" }],
+    })
+
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        publishedTracks: [
+          { kind: "mic", trackName: "mic0" },
+          { kind: "camera", trackName: "cam1" },
+        ],
+      })
+    )
+  })
+
+  it("should replace the entry when the same kind republishes", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [
+          { kind: "mic", trackName: "mic-old" },
+          { kind: "camera", trackName: "cam1" },
+        ],
+      })
+    )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(6)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+
+    await makeServiceWithCf(fakeCloudflare()).publishTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ kind: "mic", mid: "0", trackName: "mic-new" }],
+    })
+
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        publishedTracks: [
+          { kind: "camera", trackName: "cam1" },
+          { kind: "mic", trackName: "mic-new" },
+        ],
+      })
+    )
+  })
+
+  it("should not carry another incarnation's entries into the write", async () => {
+    stubWithClient()
+    stubTransaction()
+    spyOn(CallRepository, "findById").mockResolvedValue(fakeCall())
+    spyOn(CallParticipantRepository, "findByUser").mockResolvedValue(fakeParticipant({ id: "callp_1" }))
+    // The endpoint rebinds between the fence read and the in-tx re-read: the
+    // fence sees inc_1, the transaction sees a row re-leased under inc_0 whose
+    // registry must not leak into this writer's merge.
+    spyOn(CallEndpointRepository, "findById")
+      .mockResolvedValueOnce(
+        fakeEndpoint({
+          id: "callep_1",
+          cfSessionId: "sess_1",
+          mediaIncarnation: "inc_1",
+          publishedTracks: [{ kind: "mic", trackName: "mic0" }],
+        })
+      )
+      .mockResolvedValueOnce(
+        fakeEndpoint({
+          id: "callep_1",
+          cfSessionId: "sess_1",
+          mediaIncarnation: "inc_0",
+          publishedTracks: [{ kind: "mic", trackName: "stale-mic" }],
+        })
+      )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(7)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+
+    await makeServiceWithCf(fakeCloudflare()).publishTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      sdp: { type: "offer", sdp: "o" },
+      tracks: [{ kind: "camera", mid: "1", trackName: "cam1" }],
+    })
+
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ publishedTracks: [{ kind: "camera", trackName: "cam1" }] })
+    )
+  })
+
   it("throws 502 and writes no registry when CF reports a per-track error (S7)", async () => {
     stubWithClient()
     stubTransaction()
@@ -1787,6 +1907,44 @@ describe("CallService.publishTracks", () => {
 
     expect(cf.addLocalTracks).toHaveBeenCalledTimes(1)
     expect(result.snapshot.rosterVersion).toBe(5)
+  })
+})
+
+describe("CallService.closeTracks", () => {
+  afterEach(() => mock.restore())
+
+  it("should prune only the unpublished kinds from the registry", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [
+          { kind: "mic", trackName: "mic0" },
+          { kind: "camera", trackName: "cam1" },
+        ],
+      })
+    )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(8)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+
+    await makeServiceWithCf(fakeCloudflare()).closeTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mids: ["1"],
+      unpublishKinds: ["camera"],
+    })
+
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
+    )
   })
 })
 

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -926,10 +926,13 @@ export class CallService {
   }
 
   /**
-   * Publish local tracks: CF `addLocalTracks` (outside any tx), then overwrite the
-   * endpoint's published-track registry to the declared set, bump the roster
+   * Publish local tracks: CF `addLocalTracks` (outside any tx), then merge the
+   * declared tracks into the endpoint's registry by kind, bump the roster
    * version, and return the CF answer plus the fresh snapshot. Peers pull these
-   * tracks on the roster change (CF pushes no notification).
+   * tracks on the roster change (CF pushes no notification). Merge, never
+   * overwrite: the client declares one track per publish (mic, then camera), so
+   * writing the declared set verbatim dropped the mic entry on every camera
+   * publish — peers pull from this registry, so video calls went silent.
    */
   async publishTracks(params: {
     workspaceId: string
@@ -982,15 +985,38 @@ export class CallService {
       })
     }
 
-    const registry: PublishedTrack[] = params.tracks.map((t) => ({ kind: t.kind, trackName: t.trackName }))
-    const snapshot = await withTransaction(this.pool, async (client) => {
+    const declared: PublishedTrack[] = params.tracks.map((t) => ({ kind: t.kind, trackName: t.trackName }))
+    const declaredKinds = new Set(declared.map((t) => t.kind))
+    const snapshot = await this.mutateRegistry(params, (current) => [
+      ...current.filter((t) => !declaredKinds.has(t.kind)),
+      ...declared,
+    ])
+    return { cf: cfResult, snapshot }
+  }
+
+  /**
+   * Rewrite an endpoint's published-track registry under the call lock. The
+   * base registry is re-read INSIDE the transaction: publish and unpublish each
+   * declare only their own kinds, and computing the write from a read taken
+   * before the CF round-trip loses whichever concurrent declaration commits
+   * first. Entries from another incarnation never carry over — a rebind resets
+   * the registry at cf/session create, and the fenced write rejects stale
+   * writers.
+   */
+  private async mutateRegistry(
+    params: { workspaceId: string; callId: string; endpointId: string; mediaIncarnation: string },
+    mutate: (current: PublishedTrack[]) => PublishedTrack[]
+  ): Promise<CallRosterSnapshot> {
+    return withTransaction(this.pool, async (client) => {
       // Lock the call row before the endpoint write (call→endpoint lock order).
       await CallRepository.findByIdForUpdate(client, params.workspaceId, params.callId)
+      const current = await CallEndpointRepository.findById(client, params.workspaceId, params.endpointId)
+      const base = current?.mediaIncarnation === params.mediaIncarnation ? current.publishedTracks : []
       const updated = await CallEndpointRepository.setPublishedTracks(client, {
         workspaceId: params.workspaceId,
         id: params.endpointId,
         mediaIncarnation: params.mediaIncarnation,
-        publishedTracks: registry,
+        publishedTracks: mutate(base),
       })
       if (!updated) {
         // The endpoint was closed (concurrent takeover/reap) between the fence read
@@ -1001,7 +1027,6 @@ export class CallService {
       const roster = await CallParticipantRepository.listRoster(client, params.workspaceId, params.callId)
       return { rosterVersion: rosterVersion ?? 0, roster }
     })
-    return { cf: cfResult, snapshot }
   }
 
   /** Pull peer tracks: a thin CF `tracks/new` (remote) pass-through, incarnation-fenced. No DB write. */
@@ -1092,24 +1117,7 @@ export class CallService {
       return { cf: cfResult }
     }
     const remove = new Set(params.unpublishKinds)
-    const registry = endpoint.publishedTracks.filter((t) => !remove.has(t.kind))
-    const snapshot = await withTransaction(this.pool, async (client) => {
-      // Lock the call row before the endpoint write (call→endpoint lock order).
-      await CallRepository.findByIdForUpdate(client, params.workspaceId, params.callId)
-      const updated = await CallEndpointRepository.setPublishedTracks(client, {
-        workspaceId: params.workspaceId,
-        id: params.endpointId,
-        mediaIncarnation: params.mediaIncarnation,
-        publishedTracks: registry,
-      })
-      if (!updated) {
-        // The endpoint was closed concurrently — skip the bump for an unpersisted registry.
-        throw new HttpError("Endpoint is no longer live", { status: 409, code: "CALL_ENDPOINT_NOT_LIVE" })
-      }
-      const rosterVersion = await CallRepository.bumpRosterVersion(client, params.workspaceId, params.callId)
-      const roster = await CallParticipantRepository.listRoster(client, params.workspaceId, params.callId)
-      return { rosterVersion: rosterVersion ?? 0, roster }
-    })
+    const snapshot = await this.mutateRegistry(params, (current) => current.filter((t) => !remove.has(t.kind)))
     return { cf: cfResult, snapshot }
   }
 


### PR DESCRIPTION
## Problem

Every camera-on video call is silent in both directions. `CallService.publishTracks` overwrites `call_endpoints.published_tracks` with the declared set, but the client transport (`CloudflareSfuTransport.publish`) declares one track per call — mic first, then camera — so the camera publish erases the mic entry. Peers pull only what the registry advertises, and `CallManager.applyRoster`'s prune then tears down the transient mic pull that briefly existed. Prod evidence from the 2026-08-19 08:28/08:29 UTC calls in `ws_01KJDZZV5H57W3H2SJ11PA554B`: all four endpoints ended with camera-only or empty registries, no mic entry anywhere. Audio-only calls never hit this (single publish), which is why earlier desktop tests sounded fine.

## Solution

Registry writes become read-merge-write under the call lock, shared by publish and unpublish.

- `publishTracks` merges the declared tracks into the current registry by kind (same kind → replaced, other kinds → kept).
- `closeTracks` prunes from the same in-tx re-read instead of the `fenceEndpoint` read taken before the CF round-trip — the old shape could lose a concurrent publish that committed between fence and write.
- Both go through a new private `mutateRegistry`: lock call row → re-read endpoint → mutate → fenced `setPublishedTracks` → roster bump + snapshot, all in one transaction (INV-20). Entries from another `media_incarnation` never carry into the write (rebind resets the registry at cf/session create; the fenced write already 409s stale writers).
- Backend-only over client-declares-full-set: CF `addLocalTracks` adds tracks, so re-declaring already-published tracks to CF on every publish would churn SDP for nothing; the registry is the backend's row, so the merge belongs where the write is.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/calls/service.ts` | `mutateRegistry` (read-merge-write under call lock); `publishTracks` merges by kind; `closeTracks` prunes in-tx |
| `apps/backend/src/features/calls/service.test.ts` | Regression: camera publish keeps mic; same-kind republish replaces; cross-incarnation entries dropped; closeTracks prune |

## Test plan

- [x] `bun test src/features/calls/` — 153 pass (81 in service.test.ts)
- [x] monorepo lint + typecheck + migration check (pre-commit hook, observed green)
- [ ] live two-device call — needs a deploy; the prod rows above are the failing baseline to compare against

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763501&installation_model_id=20758&pr_number=1907&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1907&signature=b9607dcf4220e017f0365814299a5318613ccc7d689e80d8f54d97a8b34f4402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->