### PR TITLE
fix: ring-notification accept resolves against the server

### DIFF
--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -443,6 +443,24 @@ describe("CallDock — pre-join permission taxonomy", () => {
     })
   })
 
+  it("should toast 'This call has ended' with no retry surface when the bound call is gone", async () => {
+    const { toast } = await import("sonner")
+    const info = vi.spyOn(toast, "info").mockReturnValue("t" as never)
+    const error = vi.spyOn(toast, "error").mockReturnValue("t" as never)
+    // The server's expectedCallId guard: the accepted call no longer exists.
+    const startCall = vi.fn(async () => {
+      throw new ApiError(409, "CALL_ENDED", "Call has ended")
+    })
+    renderDock(makeManager({ startCall }))
+
+    await userEvent.click(screen.getByText("launch"))
+
+    expect(info).toHaveBeenCalledWith("This call has ended")
+    // Not a join_error: retrying would join a different call than accepted.
+    expect(error).not.toHaveBeenCalled()
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull()
+  })
+
   it("never takes over on a first attempt", async () => {
     const manager = makeManager()
     renderDock(manager)

--- a/apps/frontend/src/components/call/call-dock.test.tsx
+++ b/apps/frontend/src/components/call/call-dock.test.tsx
@@ -443,6 +443,24 @@ describe("CallDock — pre-join permission taxonomy", () => {
     })
   })
 
+  it("should ignore a second launch while the first is still awaiting the server", async () => {
+    // phase stays "idle" until the REST start resolves, so only the provider's
+    // synchronous in-flight guard separates this from startCall's "already
+    // active" throw — which would paint a false join_error over a live join
+    // (StrictMode double effect on the ?call= path, or a double-tap).
+    const { toast } = await import("sonner")
+    const error = vi.spyOn(toast, "error").mockReturnValue("t" as never)
+    const startCall = vi.fn(() => new Promise<void>(() => {}))
+    renderDock(makeManager({ startCall }))
+
+    await userEvent.click(screen.getByText("launch"))
+    await userEvent.click(screen.getByText("launch"))
+
+    expect(startCall).toHaveBeenCalledTimes(1)
+    expect(error).not.toHaveBeenCalled()
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull()
+  })
+
   it("should toast 'This call has ended' with no retry surface when the bound call is gone", async () => {
     const { toast } = await import("sonner")
     const info = vi.spyOn(toast, "info").mockReturnValue("t" as never)

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -101,6 +101,14 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
           setState({ status: "takeover_prompt", request })
           return
         }
+        // The bound call is gone (expectedCallId guard). A retry would join
+        // whatever call now lives in the stream — not what the user accepted, so
+        // no join_error retry surface; just say what happened.
+        if (ApiError.isApiError(err) && err.code === "CALL_ENDED") {
+          setState({ status: "idle" })
+          toast.info("This call has ended")
+          return
+        }
         const message = err instanceof Error ? err.message : String(err)
         setState({ status: "join_error", request, message })
         toast.error("Couldn't start the call")

--- a/apps/frontend/src/components/call/call-launch-context.tsx
+++ b/apps/frontend/src/components/call/call-launch-context.tsx
@@ -62,6 +62,12 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<CallLaunchState>({ status: "idle" })
   // Guards against a stale async settling over a newer launch/cancel.
   const runIdRef = useRef(0)
+  // Synchronous re-entrancy guard. `phase` alone is not enough: it flips off
+  // "idle" only after the REST start resolves, so a second launch inside that
+  // window (a StrictMode double effect on the `?call=` path, a double-tap racing
+  // the re-render) would pass the phase check and hit startCall's synchronous
+  // "already active" throw — surfacing a false join_error over a live join.
+  const inFlightRef = useRef(false)
 
   const run = useCallback(
     async (request: CallLaunchRequest) => {
@@ -69,8 +75,9 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
       // a plain Error, which the catch below would surface as a stale join_error
       // carrying the wrong request (and a "Try again" that starts an unintended
       // call). Ignore the launch — entry points also gate their affordance.
-      if (getCallState().phase !== "idle") return
+      if (inFlightRef.current || getCallState().phase !== "idle") return
       const runId = ++runIdRef.current
+      inFlightRef.current = true
       setState({ status: "requesting", request })
       // startCall is the single media acquisition and must run synchronously in the
       // click's transient activation — it creates+resumes the AudioContext before
@@ -112,6 +119,8 @@ export function CallLaunchProvider({ children }: { children: ReactNode }) {
         const message = err instanceof Error ? err.message : String(err)
         setState({ status: "join_error", request, message })
         toast.error("Couldn't start the call")
+      } finally {
+        inFlightRef.current = false
       }
     },
     [manager]

--- a/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.test.tsx
@@ -188,7 +188,46 @@ describe("IncomingCallOverlay", () => {
     expect(ringTone.startRing).toHaveBeenCalled()
   })
 
-  it("tells the user when a ?call deep-link has no matching live ring", () => {
+  it("should join through the server when a ?call deep-link finds no ring in-store", () => {
+    // Cold PWA open from a notification tap: the socket hasn't delivered the
+    // ring yet, so an empty store is not evidence the call ended — the server's
+    // expectedCallId guard decides.
+    const info = vi.spyOn(toast, "info").mockReturnValue("t" as never)
+
+    render(
+      <MemoryRouter initialEntries={["/w/ws_1/s/stream_dm?call=call_cold"]}>
+        <IncomingCallOverlay workspaceId="ws_1" />
+      </MemoryRouter>
+    )
+
+    expect(launch).toHaveBeenCalledWith({
+      workspaceId: "ws_1",
+      streamId: "stream_dm",
+      mode: "audio_only",
+      expectedCallId: "call_cold",
+    })
+    expect(info).not.toHaveBeenCalled()
+  })
+
+  it("should accept the in-store ring on a ?call deep-link without a server round-trip", () => {
+    act(() => addIncomingCall(makeCall()))
+
+    render(
+      <MemoryRouter initialEntries={["/w/ws_1/s/stream_dm?call=call_1"]}>
+        <IncomingCallOverlay workspaceId="ws_1" />
+      </MemoryRouter>
+    )
+
+    expect(launch).toHaveBeenCalledWith({
+      workspaceId: "ws_1",
+      streamId: "stream_dm",
+      mode: "video",
+      expectedCallId: "call_1",
+    })
+    expect(getIncomingCalls()).toEqual([])
+  })
+
+  it("should fall back to a toast when a ?call deep-link lands outside a stream", () => {
     const info = vi.spyOn(toast, "info").mockReturnValue("t" as never)
 
     render(
@@ -197,7 +236,8 @@ describe("IncomingCallOverlay", () => {
       </MemoryRouter>
     )
 
-    expect(info).toHaveBeenCalledWith("This call has ended")
+    expect(launch).not.toHaveBeenCalled()
+    expect(info).toHaveBeenCalledWith("Couldn't open this call")
   })
 
   it("ignores stale mobile fullscreen state when clearing a desktop sidebar", () => {

--- a/apps/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/apps/frontend/src/components/call/incoming-call-overlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
-import { useSearchParams } from "react-router-dom"
+import { useMatch, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { Phone, PhoneOff, BellOff, Video } from "lucide-react"
 import { PrefNotificationLevels, resolveNotificationPause } from "@threa/types"
@@ -213,19 +213,29 @@ export function IncomingCallOverlay({ workspaceId }: { workspaceId: string }) {
     })
   }, [])
 
-  // Accept-intent from a ring notification click (`?call=<callId>`). Accept when
-  // the ring is still live in-store; otherwise (cold open, push-only, or the call
-  // already ended) tell the user rather than silently stripping the param.
+  // Accept-intent from a ring notification click (`?call=<callId>`). A cold PWA
+  // open runs this before the socket delivers the ring (rings are socket-only,
+  // no bootstrap fetch), so an empty store is NOT evidence the call ended —
+  // join through the server instead: the start guard 409s CALL_ENDED (handled
+  // by CallLaunchProvider as "This call has ended") rather than starting a new
+  // call, and a live one is simply joined. The in-store ring still short-circuits
+  // to accept() so the local overlay settles immediately.
   const callParam = searchParams.get("call")
+  const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
+  const streamIdFromUrl = streamMatch?.params.streamId ?? null
   useEffect(() => {
     if (!callParam) return
     const ring = calls.find((c) => c.callId === callParam)
     if (ring) accept(ring)
-    else toast.info("This call has ended")
+    else if (streamIdFromUrl) {
+      // The notification URL always targets the call's host stream. Mode is
+      // server-owned on join; audio_only just means no camera auto-on.
+      launch({ workspaceId, streamId: streamIdFromUrl, mode: "audio_only", expectedCallId: callParam })
+    } else toast.info("Couldn't open this call")
     const next = new URLSearchParams(searchParams)
     next.delete("call")
     setSearchParams(next, { replace: true })
-  }, [callParam, calls, accept, searchParams, setSearchParams])
+  }, [callParam, calls, accept, launch, workspaceId, streamIdFromUrl, searchParams, setSearchParams])
 
   if (calls.length === 0) return null
 


### PR DESCRIPTION
## Problem

Tapping an incoming-call notification on a cold PWA open shows "This call has ended" while the call is still ringing, and drops the accept. The `?call=<callId>` accept-intent in `IncomingCallOverlay` resolved against the in-memory ring store, but rings arrive only over the live socket (`call:invitation:created` in `workspace-sync.ts` — no bootstrap fetch), so the effect always ran against an empty store on a cold open. Reported by Kris on today's S23↔OnePlus cross-device calls.

## Solution

The server becomes the authority for a deep-linked accept; the store stays a fast path.

- No in-store ring → `launch({ streamId (from `useMatch("/w/:workspaceId/s/:streamId")`), mode: "audio_only", expectedCallId })`. `CallService.startCall`'s expectedCallId guard 409s `CALL_ENDED` (insert rolls back) rather than starting a new call, so a dead link can never create one; a live call is simply joined. Mode is server-owned on join — `audio_only` only means no camera auto-on.
- `CallLaunchProvider` maps `CALL_ENDED` to `toast.info("This call has ended")` and idle — deliberately not `join_error`: a retry would join whatever call now lives in the stream, not the one accepted. This also fixes the generic "Couldn't start the call" toast on every other Join surface racing a call's end.
- In-store ring still short-circuits to `accept()` so the local overlay settles immediately.
- URL outside a stream (push without `streamId`, rare) → "Couldn't open this call" — honest unknown, not a claimed ending.

Out of scope: a rings bootstrap fetch (INV-53 pairing) — the server-resolve makes the accept correct without it; the overlay's card still fills from the socket.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/call/incoming-call-overlay.tsx` | `?call=` no-ring path launches with `expectedCallId` instead of toasting |
| `apps/frontend/src/components/call/call-launch-context.tsx` | `CALL_ENDED` → info toast + idle, no retry surface |
| `apps/frontend/src/components/call/incoming-call-overlay.test.tsx` | cold-open launch, in-store accept, outside-stream fallback |
| `apps/frontend/src/components/call/call-dock.test.tsx` | `CALL_ENDED` through the real provider: info toast, no `toast.error`, no Try again |

## Test plan

- [x] `vitest run` overlay + dock — 60 pass
- [x] monorepo lint + typecheck (pre-commit hook, observed green)
- [ ] real notification tap on Android PWA — needs a deploy; covered by the cold-open test at the component layer

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763853&installation_model_id=20758&pr_number=1908&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1908&signature=23ba6394c3b324688a9ffa47800acb28664cd3e76f97d49f17472dae9c3578ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->