### PR TITLE
fix: answered rings stop announcing "call ended"

### DIFF
--- a/apps/backend/src/features/push/service.test.ts
+++ b/apps/backend/src/features/push/service.test.ts
@@ -189,11 +189,13 @@ describe("PushService delivery options", () => {
     })
 
     const [, payload, options] = sendNotification.mock.calls[0] as [unknown, string, Record<string, unknown>]
-    // Inviter name rides the cancel so the SW's offline "Call ended" fallback can name the caller.
+    // Inviter name and outcome ride the cancel: the name lets the SW's fallback
+    // title the caller, the outcome keeps an answered ring from reading "ended".
     expect(JSON.parse(payload).data).toMatchObject({
       kind: "call_ring_cancel",
       attemptId: "callinv_01ABCDEF",
       inviterName: "Ada",
+      outcome: "cancelled",
     })
     expect(options).toEqual({ timeout: 10_000, TTL: 45, urgency: "high", topic: "01ABCDEFc" })
   })

--- a/apps/backend/src/features/push/service.ts
+++ b/apps/backend/src/features/push/service.ts
@@ -638,7 +638,15 @@ export class PushService {
     if (subscriptions.length === 0) return
 
     const pushPayload = JSON.stringify({
-      data: { kind: "call_ring_cancel", workspaceId, attemptId, inviterName: inviterName ?? undefined },
+      data: {
+        kind: "call_ring_cancel",
+        workspaceId,
+        attemptId,
+        inviterName: inviterName ?? undefined,
+        // The SW's no-ring-shown fallback branches on this: the user's own act
+        // (accepted/declined) must not render as "call ended".
+        outcome: payload.outcome,
+      },
     })
 
     await this.sendAndEvictStale(workspaceId, subscriptions, pushPayload, {

--- a/apps/frontend/src/calls/call-ring-cancel.test.ts
+++ b/apps/frontend/src/calls/call-ring-cancel.test.ts
@@ -22,4 +22,25 @@ describe("planRingCancel", () => {
     const plan = planRingCancel(0, { attemptId: "callinv_1" })
     expect(plan).toMatchObject({ show: true, title: "Call ended" })
   })
+
+  it("should say the call was answered when the settle outcome is accepted", () => {
+    // Tapping the ring notification closes it, so the accept's own settle push
+    // finds nothing to close — "call ended" here read as the caller hanging up.
+    const plan = planRingCancel(0, { attemptId: "callinv_1", inviterName: "Ada", outcome: "accepted" })
+    expect(plan).toMatchObject({ show: true, title: "Call answered", options: { silent: true } })
+  })
+
+  it("should say the call was declined when the settle outcome is declined", () => {
+    const plan = planRingCancel(0, { attemptId: "callinv_1", inviterName: "Ada", outcome: "declined" })
+    expect(plan).toMatchObject({ show: true, title: "Call declined" })
+  })
+
+  it("should keep the ended copy for caller-side outcomes", () => {
+    expect(planRingCancel(0, { inviterName: "Ada", outcome: "cancelled" })).toMatchObject({
+      title: "Ada's call ended",
+    })
+    expect(planRingCancel(0, { inviterName: "Ada", outcome: "expired" })).toMatchObject({
+      title: "Ada's call ended",
+    })
+  })
 })

--- a/apps/frontend/src/calls/call-ring-cancel.test.ts
+++ b/apps/frontend/src/calls/call-ring-cancel.test.ts
@@ -42,5 +42,8 @@ describe("planRingCancel", () => {
     expect(planRingCancel(0, { inviterName: "Ada", outcome: "expired" })).toMatchObject({
       title: "Ada's call ended",
     })
+    expect(planRingCancel(0, { inviterName: "Ada", outcome: "superseded" })).toMatchObject({
+      title: "Ada's call ended",
+    })
   })
 })

--- a/apps/frontend/src/calls/call-ring-cancel.ts
+++ b/apps/frontend/src/calls/call-ring-cancel.ts
@@ -6,6 +6,8 @@
 export interface RingCancelData {
   attemptId?: string
   inviterName?: string
+  /** Why the ring settled; absent on payloads from older backends. */
+  outcome?: "accepted" | "declined" | "cancelled" | "expired" | "superseded"
 }
 
 /** A shown fallback notification, or nothing when a tagged ring was closed. */
@@ -19,17 +21,25 @@ export type RingCancelPlan =
  *
  * - One or more are shown ⇒ the caller closes them; there is nothing new to show.
  * - None are shown ⇒ the cancel collapsed a ring this device never displayed
- *   (offline topic-collapse: the cancel replaced the queued ring). A push that
- *   results in no visible notification burns the browser's silent-push quota
- *   (Firefox revokes the subscription at 0, iOS after 3), so show a minimal,
- *   silent "Call ended" instead — reusing the ring tag so a late ring push
- *   replaces it, and never vibrating (the ring is over; keep it quiet).
+ *   (offline topic-collapse: the cancel replaced the queued ring), OR the user
+ *   answered from THIS device's ring notification — the click already closed it,
+ *   and this cancel is the settle catching up. A push that results in no visible
+ *   notification burns the browser's silent-push quota (Firefox revokes the
+ *   subscription at 0, iOS after 3), so show a minimal, silent notification —
+ *   reusing the ring tag so a late ring push replaces it, and never vibrating.
+ *   The copy follows the settle outcome: the user's own act (accepted/declined)
+ *   must not read as the caller hanging up — "call ended" right after answering
+ *   is the reported confusion this branches on.
  */
 export function planRingCancel(shownCount: number, data: RingCancelData): RingCancelPlan {
   if (shownCount > 0) return { show: false }
+  let title: string
+  if (data.outcome === "accepted") title = "Call answered"
+  else if (data.outcome === "declined") title = "Call declined"
+  else title = data.inviterName ? `${data.inviterName}'s call ended` : "Call ended"
   return {
     show: true,
-    title: data.inviterName ? `${data.inviterName}'s call ended` : "Call ended",
+    title,
     options: {
       icon: "/threa-logo-192.png",
       badge: "/threa-logo-192.png",

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { resolveTag } from "./lib/sw-notification-format"
-import { planRingCancel } from "./calls/call-ring-cancel"
+import { planRingCancel, type RingCancelData } from "./calls/call-ring-cancel"
 import { isDevicePresent, PRESENCE_CACHE } from "./lib/sw-presence"
 import { readVisibleStreams } from "./lib/visible-streams"
 import {
@@ -364,6 +364,8 @@ interface PushData {
   callId?: string
   /** Inviter display name for the ring notification title. */
   inviterName?: string
+  /** Why a ring settled ("accepted" | "declined" | …) — drives the cancel fallback copy. */
+  outcome?: RingCancelData["outcome"]
   /** Ring media mode ("video" | "audio_only"). */
   mode?: string
   /** ISO deadline the ring lapses at. */


### PR DESCRIPTION
## Problem

Answering a call from its ring notification produces a push saying "«caller»'s call ended" on the very device that just joined (Kris's screenshot: "Kristoffer Östlund's call ended" over "Call in progress · In this call"). Mechanism: `notificationclick` closes the ring notification (`sw.ts:611`), the join settles the invitation server-side, and the resulting `call_ring_cancel` push finds zero tagged notifications to retract — so `planRingCancel`'s quota-preserving fallback (`call-ring-cancel.ts`) fires with its one hardcoded title, written for the caller-hung-up case.

## Solution

Branch the fallback copy on the settle outcome, which the outbox payload already carries.

- `PushService.deliverCallRingCancel` forwards `payload.outcome` into the push data (it was already on `CallInvitationSettledOutboxPayload`, just dropped at the wire).
- `planRingCancel`: no-ring-shown fallback titles `accepted` → "Call answered", `declined` → "Call declined"; `cancelled`/`expired`/`superseded`/absent keep "«caller»'s call ended". Still silent, still ring-tagged, still non-vibrating — the fallback must show *something* (a notification-less push burns silent-push quota; Firefox revokes at 0), so accuracy is the fix, not suppression.
- Deploy-safe both directions: old SWs ignore the new field; pushes from an old backend lack it and keep today's copy.

Considered and rejected: closing the fallback via the socket `SW_MSG_CLEAR_NOTIFICATIONS` path — the fallback push races the socket settle, so a close can run before the notification exists; copy accuracy doesn't race anything.

## Test plan

- [x] `vitest run` call-ring-cancel — 6 pass (accepted/declined/caller-side outcomes)
- [x] `bun test` push service — 13 pass (outcome rides the cancel payload)
- [x] monorepo lint + typecheck (pre-commit hook, observed green)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789803077&installation_model_id=20758&pr_number=1910&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1910&signature=4351597913e0559a5433344499ee035eca4d8c38fc630a7246e4faa8df799dab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->