### PR TITLE
fix: calls recover from failed camera publishes and pulls

### DIFF
--- a/apps/backend/src/features/calls/cloudflare.ts
+++ b/apps/backend/src/features/calls/cloudflare.ts
@@ -22,31 +22,6 @@ export interface SessionDescription {
   sdp: string
 }
 
-/**
- * `mid:kind:direction` per m-section, in SDP order — the compact shape the
- * proxy logs for every publish/pull negotiation. Cross-device SDP bugs (a
- * dropped or reordered m-line, a wrong direction on a pulled track in CF's
- * answer) are otherwise invisible: the browser's rejection of a bad answer
- * happens client-side, after the proxy leg already returned 200.
- */
-export function summarizeSdpMSections(sdp: string | undefined): string {
-  if (!sdp) return "none"
-  const sections: Array<{ kind: string; mid: string; direction: string }> = []
-  let current: { kind: string; mid: string; direction: string } | null = null
-  for (const line of sdp.split(/\r?\n/)) {
-    if (line.startsWith("m=")) {
-      current = { kind: line.slice(2).split(" ")[0] ?? "?", mid: "?", direction: "?" }
-      sections.push(current)
-    } else if (current && line.startsWith("a=mid:")) {
-      current.mid = line.slice("a=mid:".length).trim()
-    } else if (current && /^a=(sendrecv|sendonly|recvonly|inactive)\s*$/.test(line)) {
-      current.direction = line.slice(2).trim()
-    }
-  }
-  if (sections.length === 0) return "none"
-  return sections.map((s) => `${s.mid}:${s.kind}:${s.direction}`).join(" ")
-}
-
 /** A track this endpoint publishes (offer carries it). */
 export interface LocalTrackRequest {
   location: "local"

--- a/apps/backend/src/features/calls/cloudflare.ts
+++ b/apps/backend/src/features/calls/cloudflare.ts
@@ -22,6 +22,31 @@ export interface SessionDescription {
   sdp: string
 }
 
+/**
+ * `mid:kind:direction` per m-section, in SDP order — the compact shape the
+ * proxy logs for every publish/pull negotiation. Cross-device SDP bugs (a
+ * dropped or reordered m-line, a wrong direction on a pulled track in CF's
+ * answer) are otherwise invisible: the browser's rejection of a bad answer
+ * happens client-side, after the proxy leg already returned 200.
+ */
+export function summarizeSdpMSections(sdp: string | undefined): string {
+  if (!sdp) return "none"
+  const sections: Array<{ kind: string; mid: string; direction: string }> = []
+  let current: { kind: string; mid: string; direction: string } | null = null
+  for (const line of sdp.split(/\r?\n/)) {
+    if (line.startsWith("m=")) {
+      current = { kind: line.slice(2).split(" ")[0] ?? "?", mid: "?", direction: "?" }
+      sections.push(current)
+    } else if (current && line.startsWith("a=mid:")) {
+      current.mid = line.slice("a=mid:".length).trim()
+    } else if (current && /^a=(sendrecv|sendonly|recvonly|inactive)\s*$/.test(line)) {
+      current.direction = line.slice(2).trim()
+    }
+  }
+  if (sections.length === 0) return "none"
+  return sections.map((s) => `${s.mid}:${s.kind}:${s.direction}`).join(" ")
+}
+
 /** A track this endpoint publishes (offer carries it). */
 export interface LocalTrackRequest {
   location: "local"

--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -61,12 +61,18 @@ const pullSchema = z.object({
     .max(64),
 })
 
-const closeTracksSchema = z.object({
-  mediaIncarnation: mediaIncarnationSchema,
-  mids: z.array(z.string().min(1).max(64)).min(1).max(16),
-  unpublishKinds: z.array(z.enum(PUBLISHED_TRACK_KINDS)).max(4).optional(),
-  sdp: sessionDescriptionSchema.optional(),
-})
+const closeTracksSchema = z
+  .object({
+    mediaIncarnation: mediaIncarnationSchema,
+    // Empty mids = registry-only cleanup of a publish that failed client-side
+    // before CF acknowledged an m-line; it must still name unpublishKinds.
+    mids: z.array(z.string().min(1).max(64)).max(16),
+    unpublishKinds: z.array(z.enum(PUBLISHED_TRACK_KINDS)).max(4).optional(),
+    sdp: sessionDescriptionSchema.optional(),
+  })
+  .refine((body) => body.mids.length > 0 || (body.unpublishKinds?.length ?? 0) > 0, {
+    message: "mids or unpublishKinds required",
+  })
 
 interface Dependencies {
   pool: Pool
@@ -306,7 +312,7 @@ export function createCallHandlers({ pool, io, callService, featureFlagService, 
         sdp: body.sdp,
       })
       if (result.snapshot) broadcastRoster(io, callId, result.snapshot)
-      res.json(result.cf)
+      res.json(result.cf ?? { tracks: [] })
     },
   }
 }

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -18,7 +18,7 @@ import * as dbModule from "../../db"
 import * as observabilityModule from "../../lib/observability"
 import { OutboxRepository } from "../../lib/outbox"
 import { CALL_PRODUCT_CAP } from "./config"
-import { CloudflareRealtimeError, summarizeSdpMSections } from "./cloudflare"
+import { CloudflareRealtimeError } from "./cloudflare"
 
 const NOW = new Date("2026-07-19T12:00:00.000Z")
 
@@ -2046,22 +2046,6 @@ describe("CallService.closeTracks", () => {
         mids: ["remote-0"],
       })
     ).rejects.toMatchObject({ code: "CALL_MEDIA_PROVIDER_ERROR" })
-  })
-})
-
-describe("summarizeSdpMSections", () => {
-  it("should list mid, kind, and direction per m-section in SDP order", () => {
-    const sdp = [
-      "v=0",
-      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
-      "a=mid:0",
-      "a=sendonly",
-      "m=video 9 UDP/TLS/RTP/SAVPF 96",
-      "a=mid:2",
-      "a=recvonly",
-    ].join("\r\n")
-    expect(summarizeSdpMSections(sdp)).toBe("0:audio:sendonly 2:video:recvonly")
-    expect(summarizeSdpMSections(undefined)).toBe("none")
   })
 })
 

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -18,6 +18,7 @@ import * as dbModule from "../../db"
 import * as observabilityModule from "../../lib/observability"
 import { OutboxRepository } from "../../lib/outbox"
 import { CALL_PRODUCT_CAP } from "./config"
+import { CloudflareRealtimeError, summarizeSdpMSections } from "./cloudflare"
 
 const NOW = new Date("2026-07-19T12:00:00.000Z")
 
@@ -1945,6 +1946,122 @@ describe("CallService.closeTracks", () => {
       expect.anything(),
       expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
     )
+  })
+
+  it("should prune the registry and return the snapshot even when CF's close fails", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [
+          { kind: "mic", trackName: "mic0" },
+          { kind: "camera", trackName: "cam1" },
+        ],
+      })
+    )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(8)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+    const cf = fakeCloudflare({
+      closeTracks: mock(async () => {
+        throw new CloudflareRealtimeError("session gone", { status: 502, code: "CF_HTTP_502" })
+      }),
+    })
+
+    // Peers pull from the registry; a phantom entry for a dead camera makes every
+    // peer's pull hang at CF until timeout — the prune must not ride on CF's health.
+    const result = await makeServiceWithCf(cf).closeTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mids: ["1"],
+      unpublishKinds: ["camera"],
+    })
+
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
+    )
+    expect(result).toMatchObject({ cf: null, snapshot: { rosterVersion: 8, roster: [] } })
+  })
+
+  it("should skip CF entirely on a mid-less unpublish (client-side publish failure cleanup)", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [
+          { kind: "mic", trackName: "mic0" },
+          { kind: "camera", trackName: "cam1" },
+        ],
+      })
+    )
+    const setTracks = spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(9)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+    const cf = fakeCloudflare()
+
+    const result = await makeServiceWithCf(cf).closeTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mids: [],
+      unpublishKinds: ["camera"],
+    })
+
+    expect(cf.closeTracks).not.toHaveBeenCalled()
+    expect(setTracks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
+    )
+    expect(result.snapshot).toEqual({ rosterVersion: 9, roster: [] })
+  })
+
+  it("should still fail loudly when a pull-side close (no unpublishKinds) hits a CF error", async () => {
+    stubWithClient()
+    stubFence(fakeEndpoint({ id: "callep_1", cfSessionId: "sess_1", mediaIncarnation: "inc_1" }))
+    const cf = fakeCloudflare({
+      closeTracks: mock(async () => {
+        throw new CloudflareRealtimeError("session gone", { status: 502, code: "CF_HTTP_502" })
+      }),
+    })
+
+    await expect(
+      makeServiceWithCf(cf).closeTracks({
+        workspaceId: "ws_1",
+        callId: "call_1",
+        userId: "usr_1",
+        endpointId: "callep_1",
+        mediaIncarnation: "inc_1",
+        mids: ["remote-0"],
+      })
+    ).rejects.toMatchObject({ code: "CALL_MEDIA_PROVIDER_ERROR" })
+  })
+})
+
+describe("summarizeSdpMSections", () => {
+  it("should list mid, kind, and direction per m-section in SDP order", () => {
+    const sdp = [
+      "v=0",
+      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+      "a=mid:0",
+      "a=sendonly",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96",
+      "a=mid:2",
+      "a=recvonly",
+    ].join("\r\n")
+    expect(summarizeSdpMSections(sdp)).toBe("0:audio:sendonly 2:video:recvonly")
+    expect(summarizeSdpMSections(undefined)).toBe("none")
   })
 })
 

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -3,6 +3,7 @@ import {
   StreamTypes,
   ActivityTypes,
   AuthorTypes,
+  summarizeSdpMSections,
   type CallStartedEventPayload,
   type CallEndedEventPayload,
   type Visibility,
@@ -54,7 +55,6 @@ import {
 } from "./config"
 import {
   CloudflareRealtimeError,
-  summarizeSdpMSections,
   type RealtimeMediaApi,
   type SessionDescription,
   type LocalTrackRequest,

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -54,6 +54,7 @@ import {
 } from "./config"
 import {
   CloudflareRealtimeError,
+  summarizeSdpMSections,
   type RealtimeMediaApi,
   type SessionDescription,
   type LocalTrackRequest,
@@ -985,6 +986,17 @@ export class CallService {
       })
     }
 
+    logger.info(
+      {
+        callId: params.callId,
+        endpointId: params.endpointId,
+        kinds: params.tracks.map((t) => t.kind),
+        offer: summarizeSdpMSections(params.sdp.sdp),
+        answer: summarizeSdpMSections(cfResult.sessionDescription?.sdp),
+      },
+      "CF publish negotiated"
+    )
+
     const declared: PublishedTrack[] = params.tracks.map((t) => ({ kind: t.kind, trackName: t.trackName }))
     const declaredKinds = new Set(declared.map((t) => t.kind))
     const snapshot = await this.mutateRegistry(params, (current) => [
@@ -1043,6 +1055,15 @@ export class CallService {
     const cfSessionId = this.requireCfSession(endpoint)
     await this.assertPullableRefs(params.workspaceId, params.callId, endpoint, params.tracks)
     const cfResult = await this.cfCall(() => cf.pullRemoteTracks(cfSessionId, { tracks: params.tracks }), "pull_tracks")
+    logger.info(
+      {
+        callId: params.callId,
+        endpointId: params.endpointId,
+        trackNames: params.tracks.map((t) => t.trackName),
+        offer: summarizeSdpMSections(cfResult.sessionDescription?.sdp),
+      },
+      "CF pull negotiated"
+    )
     return { cf: cfResult }
   }
 
@@ -1094,6 +1115,14 @@ export class CallService {
    * Close published tracks: CF `tracks/close` (outside any tx). When the caller
    * names the kinds it is unpublishing, prune them from the registry, bump the
    * roster, and return the fresh snapshot so peers stop pulling dead tracks.
+   *
+   * The registry prune comes FIRST and survives a CF failure: the registry is
+   * what peers pull from, and an entry for a track whose media is gone makes
+   * every peer's pull hang at CF until timeout. CF-side close is best-effort by
+   * nature (CF reaps inactive tracks; teardown already treats it that way), so a
+   * provider error on an unpublish is logged + counted, never allowed to keep
+   * the phantom alive. Mid-less calls (cleanup after a client-side publish
+   * failure — no acknowledged m-line to close) skip CF entirely.
    */
   async closeTracks(params: {
     workspaceId: string
@@ -1104,20 +1133,32 @@ export class CallService {
     mids: string[]
     unpublishKinds?: Array<PublishedTrack["kind"]>
     sdp?: SessionDescription
-  }): Promise<{ cf: CloseTracksResult; snapshot?: CallRosterSnapshot }> {
+  }): Promise<{ cf: CloseTracksResult | null; snapshot?: CallRosterSnapshot }> {
     const cf = this.requireCloudflare()
     const { endpoint } = await this.fenceEndpoint(params)
     const cfSessionId = this.requireCfSession(endpoint)
-    const cfResult = await this.cfCall(
-      () => cf.closeTracks(cfSessionId, { mids: params.mids, force: false, sdp: params.sdp }),
-      "close_tracks"
-    )
 
-    if (!params.unpublishKinds || params.unpublishKinds.length === 0) {
-      return { cf: cfResult }
+    let snapshot: CallRosterSnapshot | undefined
+    if (params.unpublishKinds && params.unpublishKinds.length > 0) {
+      const remove = new Set(params.unpublishKinds)
+      snapshot = await this.mutateRegistry(params, (current) => current.filter((t) => !remove.has(t.kind)))
     }
-    const remove = new Set(params.unpublishKinds)
-    const snapshot = await this.mutateRegistry(params, (current) => current.filter((t) => !remove.has(t.kind)))
+
+    if (params.mids.length === 0) return { cf: null, snapshot }
+    let cfResult: CloseTracksResult | null = null
+    try {
+      cfResult = await this.cfCall(
+        () => cf.closeTracks(cfSessionId, { mids: params.mids, force: false, sdp: params.sdp }),
+        "close_tracks"
+      )
+    } catch (err) {
+      const unpublishing = (params.unpublishKinds?.length ?? 0) > 0
+      if (!unpublishing || !(err instanceof HttpError) || err.code !== "CALL_MEDIA_PROVIDER_ERROR") throw err
+      logger.warn(
+        { err, callId: params.callId, endpointId: params.endpointId, mids: params.mids },
+        "CF close failed on unpublish; registry already pruned"
+      )
+    }
     return { cf: cfResult, snapshot }
   }
 

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -451,6 +451,42 @@ describe("CallManager", () => {
     expect(transport.pull).toHaveBeenCalledTimes(PULL_RETRY_MAX_ATTEMPTS + 1)
   })
 
+  it("should ignore a stale pull rejection after the track was removed and re-added mid-flight", async () => {
+    const socket = makeSocket()
+    const transport = makeTransport()
+    let rejectFirst!: (err: Error) => void
+    ;(transport.pull as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => new Promise((_, reject) => (rejectFirst = reject)))
+      .mockResolvedValue(undefined)
+    const manager = newManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    const peerRoster = (version: number) => ({
+      callId: "call_1",
+      rosterVersion: version,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "camera", trackName: "peer:camera" }],
+        }),
+      ],
+    })
+    socket.fire("call:roster", peerRoster(2))
+    // Track removed and re-added while the first pull is still in flight.
+    socket.fire("call:roster", { callId: "call_1", rosterVersion: 3, roster: [] })
+    socket.fire("call:roster", peerRoster(4))
+    expect(transport.pull).toHaveBeenCalledTimes(2)
+
+    // The STALE pull's rejection must not evict the replacement pull's entry —
+    // otherwise the next roster broadcast starts a duplicate pull.
+    rejectFirst(new Error("stale pull timed out"))
+    await vi.waitFor(() => expect(getCallState().rosterVersion).toBe(4))
+    socket.fire("call:roster", { ...peerRoster(5) })
+    expect(transport.pull).toHaveBeenCalledTimes(2)
+  })
+
   it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {
     const socket = makeSocket()
     const transport = makeTransport()

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -473,18 +473,19 @@ describe("CallManager", () => {
         }),
       ],
     })
+    const peerCameraRef = { sessionId: "cf-peer", trackName: "peer:camera" }
     socket.fire("call:roster", peerRoster(2))
     // Track removed and re-added while the first pull is still in flight.
     socket.fire("call:roster", { callId: "call_1", rosterVersion: 3, roster: [] })
     socket.fire("call:roster", peerRoster(4))
-    expect(transport.pull).toHaveBeenCalledTimes(2)
+    expect((transport.pull as ReturnType<typeof vi.fn>).mock.calls).toEqual([[peerCameraRef], [peerCameraRef]])
 
     // The STALE pull's rejection must not evict the replacement pull's entry —
     // otherwise the next roster broadcast starts a duplicate pull.
     rejectFirst(new Error("stale pull timed out"))
     await vi.waitFor(() => expect(getCallState().rosterVersion).toBe(4))
     socket.fire("call:roster", { ...peerRoster(5) })
-    expect(transport.pull).toHaveBeenCalledTimes(2)
+    expect((transport.pull as ReturnType<typeof vi.fn>).mock.calls).toEqual([[peerCameraRef], [peerCameraRef]])
   })
 
   it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -7,7 +7,12 @@ import {
   type CallSocket,
 } from "./call-manager"
 import type { MediaTransport } from "./media-transport"
-import { AUDIO_CAPTURE_CONSTRAINTS, VIDEO_CAPTURE_CONSTRAINTS } from "./config"
+import {
+  AUDIO_CAPTURE_CONSTRAINTS,
+  VIDEO_CAPTURE_CONSTRAINTS,
+  PULL_RETRY_DELAY_MS,
+  PULL_RETRY_MAX_ATTEMPTS,
+} from "./config"
 import { ApiError } from "@/api/client"
 import { getCallState, clearCallState, resetCallStoreCache, type CallRosterParticipant } from "@/stores/call-store"
 import { isDictationExternalHeld, setDictationExternalHold } from "@/contexts/dictation-coordinator-context"
@@ -352,6 +357,62 @@ describe("CallManager", () => {
     // Peer leaves the roster → stopPull.
     socket.fire("call:roster", { callId: "call_1", rosterVersion: 3, roster: [] })
     expect(transport.stopPull).toHaveBeenCalledWith({ sessionId: "cf-peer", trackName: "peer:mic" })
+  })
+
+  it("should retry a failed pull against the live roster instead of losing the track for the call", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const transport = makeTransport()
+    ;(transport.pull as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("pull timed out"))
+    const manager = newManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 2,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "camera", trackName: "peer:camera" }],
+        }),
+      ],
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(transport.pull).toHaveBeenCalledTimes(1)
+
+    // No further roster event arrives — the track didn't change. The retry
+    // timer re-diffs against the store's roster and pulls again.
+    await vi.advanceTimersByTimeAsync(PULL_RETRY_DELAY_MS)
+    expect(transport.pull).toHaveBeenCalledTimes(2)
+    expect(transport.pull).toHaveBeenLastCalledWith({ sessionId: "cf-peer", trackName: "peer:camera" })
+  })
+
+  it("should stop retrying a pull at the attempt cap", async () => {
+    vi.useFakeTimers()
+    const socket = makeSocket()
+    const transport = makeTransport()
+    ;(transport.pull as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("pull timed out"))
+    const manager = newManager(makeDeps(socket, transport), null)
+    await manager.startCall({ workspaceId: "ws_1", streamId: "stream_1", mode: "video" })
+
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 2,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "camera", trackName: "peer:camera" }],
+        }),
+      ],
+    })
+    for (let i = 0; i < PULL_RETRY_MAX_ATTEMPTS + 2; i++) {
+      await vi.advanceTimersByTimeAsync(PULL_RETRY_DELAY_MS)
+    }
+    expect(transport.pull).toHaveBeenCalledTimes(PULL_RETRY_MAX_ATTEMPTS)
   })
 
   it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {

--- a/apps/frontend/src/calls/call-manager.test.ts
+++ b/apps/frontend/src/calls/call-manager.test.ts
@@ -413,6 +413,42 @@ describe("CallManager", () => {
       await vi.advanceTimersByTimeAsync(PULL_RETRY_DELAY_MS)
     }
     expect(transport.pull).toHaveBeenCalledTimes(PULL_RETRY_MAX_ATTEMPTS)
+
+    // The cap also binds roster-driven re-diffs: any peer's mute toggle bumps
+    // the roster, and a capped dead track must not re-hold the negotiation
+    // queue on every such broadcast.
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 3,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "camera", trackName: "peer:camera" }],
+        }),
+      ],
+    })
+    await vi.advanceTimersByTimeAsync(PULL_RETRY_DELAY_MS)
+    expect(transport.pull).toHaveBeenCalledTimes(PULL_RETRY_MAX_ATTEMPTS)
+
+    // But a track that leaves the roster and comes back (peer republished the
+    // same trackName) gets fresh attempts.
+    socket.fire("call:roster", { callId: "call_1", rosterVersion: 4, roster: [] })
+    socket.fire("call:roster", {
+      callId: "call_1",
+      rosterVersion: 5,
+      roster: [
+        participant({
+          userId: "usr_1",
+          endpointId: "ep_peer",
+          cfSessionId: "cf-peer",
+          publishedTracks: [{ kind: "camera", trackName: "peer:camera" }],
+        }),
+      ],
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(transport.pull).toHaveBeenCalledTimes(PULL_RETRY_MAX_ATTEMPTS + 1)
   })
 
   it("skips peers with no cfSessionId (0.2 roster gap) rather than pulling an unaddressable ref", async () => {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -962,23 +962,31 @@ export class CallManager implements CallController {
       }
     }
     for (const [key, entry] of desired) {
-      if (!session.pulled.has(key)) {
-        session.pulled.set(key, entry)
-        void session.transport.pull(entry.ref).then(
-          () => session.pullAttempts.delete(key),
-          (err: unknown) => this.handlePullFailure(session, key, err)
-        )
-      }
+      if (session.pulled.has(key)) continue
+      // The cap binds every automatic path — the retry timer AND ordinary roster
+      // broadcasts (any peer's mute toggle bumps the roster): without this gate a
+      // permanently-dead track re-pulls on every unrelated roster change, holding
+      // the serial negotiation queue for the CF timeout each time.
+      if ((session.pullAttempts.get(key) ?? 0) >= PULL_RETRY_MAX_ATTEMPTS) continue
+      session.pulled.set(key, entry)
+      void session.transport.pull(entry.ref).then(
+        () => session.pullAttempts.delete(key),
+        (err: unknown) => this.handlePullFailure(session, key, err)
+      )
     }
     for (const [key, entry] of session.pulled) {
       if (!desired.has(key)) {
         session.pulled.delete(key)
-        session.pullAttempts.delete(key)
         void session.transport.stopPull(entry.ref).catch(() => {})
         this.detachRemoteAudio(session, key)
         this.detachRemoteVideo(session, key)
         session.remoteTrackOwner.delete(key)
       }
+    }
+    // A track the roster stopped advertising forgets its failure history: a peer
+    // that unpublishes and republishes (same trackName) deserves fresh attempts.
+    for (const key of session.pullAttempts.keys()) {
+      if (!desired.has(key)) session.pullAttempts.delete(key)
     }
   }
 

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -38,6 +38,8 @@ import {
   leaseRenewIntervalMs,
   WATCHDOG_SAMPLE_MS,
   WATCHDOG_HEALTHY_SAMPLES_TO_UPGRADE,
+  PULL_RETRY_DELAY_MS,
+  PULL_RETRY_MAX_ATTEMPTS,
   CAMERA_PUBLISH_LADDER,
   AUDIO_CAPTURE_CONSTRAINTS,
   VIDEO_CAPTURE_CONSTRAINTS,
@@ -194,6 +196,9 @@ interface CallSession {
   audioContext: AudioContext | null
   analyser: AnalyserNode | null
   pulled: Map<string, { ref: PeerTrackRef; kind: string }>
+  /** refKey → failed-pull count; capped retries re-diff against the live roster. */
+  pullAttempts: Map<string, number>
+  pullRetryTimer: ReturnType<typeof setTimeout> | null
   remoteAudioEls: Map<string, HTMLAudioElement>
   /**
    * refKey → owning endpoint id, recorded from the roster in `diffPulls` so an
@@ -426,6 +431,8 @@ export class CallManager implements CallController {
         audioContext,
         analyser: null,
         pulled: new Map(),
+        pullAttempts: new Map(),
+        pullRetryTimer: null,
         remoteAudioEls: new Map(),
         remoteTrackOwner: new Map(),
         videoStreams: new Map(),
@@ -957,18 +964,45 @@ export class CallManager implements CallController {
     for (const [key, entry] of desired) {
       if (!session.pulled.has(key)) {
         session.pulled.set(key, entry)
-        void session.transport.pull(entry.ref).catch(() => session.pulled.delete(key))
+        void session.transport.pull(entry.ref).then(
+          () => session.pullAttempts.delete(key),
+          (err: unknown) => this.handlePullFailure(session, key, err)
+        )
       }
     }
     for (const [key, entry] of session.pulled) {
       if (!desired.has(key)) {
         session.pulled.delete(key)
+        session.pullAttempts.delete(key)
         void session.transport.stopPull(entry.ref).catch(() => {})
         this.detachRemoteAudio(session, key)
         this.detachRemoteVideo(session, key)
         session.remoteTrackOwner.delete(key)
       }
     }
+  }
+
+  /**
+   * A failed pull only retries here: the roster diff keys on `pulled`, and no
+   * future roster event re-announces a track that didn't change — dropping the
+   * key alone loses the peer's audio/video for the rest of the call. Re-diff
+   * against the store's live roster (not the failing event's snapshot) after a
+   * delay, up to the cap; a track the roster no longer advertises (e.g. the
+   * publisher cleaned up a failed publish) just falls out of `desired`.
+   */
+  private handlePullFailure(session: CallSession, key: string, err: unknown): void {
+    if (this.sessionForGen(session.gen) !== session) return
+    session.pulled.delete(key)
+    const attempts = (session.pullAttempts.get(key) ?? 0) + 1
+    session.pullAttempts.set(key, attempts)
+    recordCallLifecycleEvent({ kind: "pull_failed", detail: `attempt ${attempts}: ${describeError(err)}` })
+    if (attempts >= PULL_RETRY_MAX_ATTEMPTS || session.pullRetryTimer) return
+    session.pullRetryTimer = setTimeout(() => {
+      session.pullRetryTimer = null
+      const live = this.sessionForGen(session.gen)
+      if (!live) return
+      this.diffPulls(live, getCallState().roster)
+    }, PULL_RETRY_DELAY_MS)
   }
 
   // ── media ──────────────────────────────────────────────────────────────────
@@ -1094,6 +1128,7 @@ export class CallManager implements CallController {
         session.micTrack = null
         session.cameraTrack = null
         session.micStream = null
+        recordCallLifecycleEvent({ kind: "publish_failed", detail: `mic: ${describeError(publishErr)}` })
         throw publishErr
       }
     }
@@ -1114,6 +1149,7 @@ export class CallManager implements CallController {
         cameraTrack.stop()
         session.cameraTrack = null
         this.clearVideoStream(session, session.endpointId)
+        recordCallLifecycleEvent({ kind: "publish_failed", detail: `camera: ${describeError(publishErr)}` })
         await session.transport.unpublish("camera").catch(() => {})
         setCallCaptureError({
           code: "capture_failed",
@@ -1635,9 +1671,11 @@ export class CallManager implements CallController {
   private clearTimers(session: CallSession): void {
     if (session.leaseTimer) clearInterval(session.leaseTimer)
     if (session.watchdogTimer) clearInterval(session.watchdogTimer)
+    if (session.pullRetryTimer) clearTimeout(session.pullRetryTimer)
     if (session.meterRaf !== null && typeof cancelAnimationFrame === "function") cancelAnimationFrame(session.meterRaf)
     session.leaseTimer = null
     session.watchdogTimer = null
+    session.pullRetryTimer = null
     session.meterRaf = null
   }
 }

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -969,9 +969,14 @@ export class CallManager implements CallController {
       // the serial negotiation queue for the CF timeout each time.
       if ((session.pullAttempts.get(key) ?? 0) >= PULL_RETRY_MAX_ATTEMPTS) continue
       session.pulled.set(key, entry)
+      // Settlements check entry identity: a remove-and-readd during the flight
+      // replaces the map entry, and the STALE pull's rejection must not evict
+      // (or count against) the replacement pull now in progress.
       void session.transport.pull(entry.ref).then(
-        () => session.pullAttempts.delete(key),
-        (err: unknown) => this.handlePullFailure(session, key, err)
+        () => {
+          if (session.pulled.get(key) === entry) session.pullAttempts.delete(key)
+        },
+        (err: unknown) => this.handlePullFailure(session, key, entry, err)
       )
     }
     for (const [key, entry] of session.pulled) {
@@ -998,8 +1003,14 @@ export class CallManager implements CallController {
    * delay, up to the cap; a track the roster no longer advertises (e.g. the
    * publisher cleaned up a failed publish) just falls out of `desired`.
    */
-  private handlePullFailure(session: CallSession, key: string, err: unknown): void {
+  private handlePullFailure(
+    session: CallSession,
+    key: string,
+    entry: { ref: PeerTrackRef; kind: string },
+    err: unknown
+  ): void {
     if (this.sessionForGen(session.gen) !== session) return
+    if (session.pulled.get(key) !== entry) return
     session.pulled.delete(key)
     const attempts = (session.pullAttempts.get(key) ?? 0) + 1
     session.pullAttempts.set(key, attempts)

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -175,6 +175,12 @@ export interface CallManagerDeps {
   singleActiveCapture: boolean
 }
 
+/** One desired peer track: the CF pull ref plus its registry kind. */
+interface PullEntry {
+  ref: PeerTrackRef
+  kind: string
+}
+
 interface CallSession {
   /** Monotonic generation claimed synchronously at `startCall`; identifies this incarnation. */
   gen: number
@@ -195,7 +201,7 @@ interface CallSession {
   captureConstraints: { constraints: MediaStreamConstraints; camera: boolean } | null
   audioContext: AudioContext | null
   analyser: AnalyserNode | null
-  pulled: Map<string, { ref: PeerTrackRef; kind: string }>
+  pulled: Map<string, PullEntry>
   /** refKey → failed-pull count; capped retries re-diff against the live roster. */
   pullAttempts: Map<string, number>
   pullRetryTimer: ReturnType<typeof setTimeout> | null
@@ -945,7 +951,7 @@ export class CallManager implements CallController {
 
   /** Diff the roster's track registry against what we pull; pull new, stop gone. */
   private diffPulls(session: CallSession, roster: CallRosterParticipant[]): void {
-    const desired = new Map<string, { ref: PeerTrackRef; kind: string }>()
+    const desired = new Map<string, PullEntry>()
     for (const p of roster) {
       if (!p.endpointId || p.endpointId === session.endpointId) continue
       if (p.connectionStatus !== "connected" && p.connectionStatus !== "reconnecting") continue
@@ -1003,12 +1009,7 @@ export class CallManager implements CallController {
    * delay, up to the cap; a track the roster no longer advertises (e.g. the
    * publisher cleaned up a failed publish) just falls out of `desired`.
    */
-  private handlePullFailure(
-    session: CallSession,
-    key: string,
-    entry: { ref: PeerTrackRef; kind: string },
-    err: unknown
-  ): void {
+  private handlePullFailure(session: CallSession, key: string, entry: PullEntry, err: unknown): void {
     if (this.sessionForGen(session.gen) !== session) return
     if (session.pulled.get(key) !== entry) return
     session.pulled.delete(key)

--- a/apps/frontend/src/calls/config.ts
+++ b/apps/frontend/src/calls/config.ts
@@ -61,6 +61,16 @@ export const SHARE_PUBLISH_LAYERS: Record<"detail" | "motion", PublishLayer> = {
 export const WATCHDOG_SAMPLE_MS = 3_000
 export const WATCHDOG_HEALTHY_SAMPLES_TO_UPGRADE = 4
 
+/**
+ * Failed peer-track pulls re-diff against the live roster after this delay, up
+ * to the attempt cap per track. Without it a single failed pull loses that
+ * peer's track for the rest of the call — no later roster event re-offers a
+ * track that didn't change. Capped because a pull against a dead track holds
+ * the transport's serial negotiation queue for the backend's full CF timeout.
+ */
+export const PULL_RETRY_DELAY_MS = 2_000
+export const PULL_RETRY_MAX_ATTEMPTS = 3
+
 /** Mic audio constraints: browser AEC/NS/AGC applied once at capture. (The combined mic+camera acquisition rule lives on captureAndPublish.) */
 export const AUDIO_CAPTURE_CONSTRAINTS: MediaTrackConstraints = {
   channelCount: 1,

--- a/apps/frontend/src/calls/lifecycle-log.ts
+++ b/apps/frontend/src/calls/lifecycle-log.ts
@@ -20,6 +20,8 @@ export const CALL_LIFECYCLE_KINDS = [
   "rejoin_same_endpoint",
   "rejoin_new_endpoint",
   "rejoin_failed",
+  "publish_failed",
+  "pull_failed",
   "teardown",
 ] as const
 

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { CloudflareSfuTransport, createCallProxyClient, type PeerTrackRef } from "./media-transport"
+import {
+  CloudflareSfuTransport,
+  createCallProxyClient,
+  summarizeSdpMSections,
+  type PeerTrackRef,
+} from "./media-transport"
 
 interface PostCall {
   path: string
@@ -74,6 +79,26 @@ function makeTransport(overrides?: {
   })
   return { transport, calls, pc, post }
 }
+
+describe("summarizeSdpMSections", () => {
+  it("should list mid, kind, and direction per m-section in SDP order", () => {
+    const sdp = [
+      "v=0",
+      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+      "a=mid:0",
+      "a=sendonly",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96",
+      "a=mid:2",
+      "a=recvonly",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96",
+      "a=mid:3",
+      "a=sendonly",
+    ].join("\r\n")
+    expect(summarizeSdpMSections(sdp)).toBe("0:audio:sendonly 2:video:recvonly 3:video:sendonly")
+    expect(summarizeSdpMSections(undefined)).toBe("none")
+    expect(summarizeSdpMSections("v=0")).toBe("none")
+  })
+})
 
 describe("createCallProxyClient", () => {
   it("carries mediaIncarnation in every proxy body", async () => {
@@ -191,6 +216,116 @@ describe("CloudflareSfuTransport", () => {
 
     await expect(transport.publish("camera", makeTrack("video"))).resolves.toBeUndefined()
     expect(pc.addTransceiver).toHaveBeenCalledTimes(2)
+  })
+
+  it("should retry a failed publish with a fresh transceiver, never replaceTrack into an unacknowledged one", async () => {
+    let publishCalls = 0
+    const { transport, pc } = makeTransport({
+      post: async (path: string, body: unknown) => {
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish")) {
+          publishCalls++
+          if (publishCalls === 1) throw new Error("CF publish failed")
+          return { requiresImmediateRenegotiation: false, tracks: [] }
+        }
+        void body
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await expect(transport.publish("camera", makeTrack("video"))).rejects.toThrow("CF publish failed")
+    // The failed transceiver was stopped and evicted — otherwise this retry takes
+    // the replaceTrack fast path into a transceiver CF never acknowledged, and
+    // the camera button "works" while no media ever reaches the SFU.
+    expect(pc.transceivers[0].stop).toHaveBeenCalled()
+    await expect(transport.publish("camera", makeTrack("video"))).resolves.toBeUndefined()
+    expect(pc.addTransceiver).toHaveBeenCalledTimes(2)
+    expect(publishCalls).toBe(2)
+  })
+
+  it("should roll back the local offer when CF's publish answer cannot be applied", async () => {
+    const pc = makeFakePc()
+    const withState = pc as unknown as { signalingState: string }
+    withState.signalingState = "stable"
+    pc.setLocalDescription = vi.fn(async (desc: { type?: string } | undefined) => {
+      withState.signalingState = desc?.type === "rollback" ? "stable" : "have-local-offer"
+    }) as typeof pc.setLocalDescription
+    pc.setRemoteDescription = vi.fn(async (desc: { type?: string }) => {
+      if (desc.type === "answer") throw new DOMException("bad answer", "InvalidAccessError")
+    }) as typeof pc.setRemoteDescription
+    const { transport } = makeTransport({
+      pc,
+      post: async (path: string) => {
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish"))
+          return {
+            requiresImmediateRenegotiation: false,
+            tracks: [],
+            sessionDescription: { type: "answer", sdp: "m=video 9 X\r\na=mid:1\r\na=recvonly" },
+          }
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await expect(transport.publish("camera", makeTrack("video"))).rejects.toThrow(/InvalidAccessError: bad answer/)
+    expect(pc.setLocalDescription).toHaveBeenCalledWith({ type: "rollback" })
+    expect(withState.signalingState).toBe("stable")
+  })
+
+  it("should close the registry entry even when no transceiver exists (phantom cleanup)", async () => {
+    const { transport, calls } = makeTransport()
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.unpublish("camera")
+    const close = calls.find((c) => c.path.endsWith("/tracks/close"))
+    expect(close?.body).toMatchObject({ mids: [], unpublishKinds: ["camera"] })
+    expect(close?.body.sdp).toBeUndefined()
+  })
+
+  it("should send the close SDP-less when the wedged PC cannot offer, instead of skipping it", async () => {
+    const pc = makeFakePc()
+    const { transport, calls } = makeTransport({ pc })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("camera", makeTrack("video"))
+    pc.createOffer = vi.fn(async () => {
+      throw new DOMException("wedged", "InvalidStateError")
+    })
+    await transport.unpublish("camera")
+    const close = calls.find((c) => c.path.endsWith("/tracks/close"))
+    expect(close?.body).toMatchObject({ mids: ["local-0"], unpublishKinds: ["camera"] })
+    expect(close?.body.sdp).toBeUndefined()
+  })
+
+  it("should unwind a failed pull so a retry re-registers its mids cleanly", async () => {
+    const pc = makeFakePc()
+    const withState = pc as unknown as { signalingState: string }
+    withState.signalingState = "stable"
+    let srdCalls = 0
+    pc.setRemoteDescription = vi.fn(async (desc: { type?: string }) => {
+      if (desc.type === "rollback") {
+        withState.signalingState = "stable"
+        return
+      }
+      srdCalls++
+      if (srdCalls === 1) {
+        withState.signalingState = "have-remote-offer"
+        throw new DOMException("bad offer", "OperationError")
+      }
+    }) as typeof pc.setRemoteDescription
+    const { transport } = makeTransport({ pc })
+    const seen: PeerTrackRef[] = []
+    transport.onRemoteTrack = (e) => seen.push(e.ref)
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+
+    const ref: PeerTrackRef = { sessionId: "cf-peer", trackName: "peer:camera" }
+    await expect(transport.pull(ref)).rejects.toThrow(/OperationError: bad offer/)
+    expect(pc.setRemoteDescription).toHaveBeenCalledWith({ type: "rollback" })
+    // The dead pull's mid attribution is gone: a track landing on it is ignored.
+    pc.ontrack?.({ transceiver: { mid: "remote-0" }, track: makeTrack("video") })
+    expect(seen).toEqual([])
+
+    await expect(transport.pull(ref)).resolves.toBeUndefined()
+    pc.ontrack?.({ transceiver: { mid: "remote-0" }, track: makeTrack("video") })
+    expect(seen).toEqual([ref])
   })
 
   it("keeps the queue alive after a failed job", async () => {

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import {
-  CloudflareSfuTransport,
-  createCallProxyClient,
-  summarizeSdpMSections,
-  type PeerTrackRef,
-} from "./media-transport"
+import { CloudflareSfuTransport, createCallProxyClient, type PeerTrackRef } from "./media-transport"
 
 interface PostCall {
   path: string
@@ -79,26 +74,6 @@ function makeTransport(overrides?: {
   })
   return { transport, calls, pc, post }
 }
-
-describe("summarizeSdpMSections", () => {
-  it("should list mid, kind, and direction per m-section in SDP order", () => {
-    const sdp = [
-      "v=0",
-      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
-      "a=mid:0",
-      "a=sendonly",
-      "m=video 9 UDP/TLS/RTP/SAVPF 96",
-      "a=mid:2",
-      "a=recvonly",
-      "m=video 9 UDP/TLS/RTP/SAVPF 96",
-      "a=mid:3",
-      "a=sendonly",
-    ].join("\r\n")
-    expect(summarizeSdpMSections(sdp)).toBe("0:audio:sendonly 2:video:recvonly 3:video:sendonly")
-    expect(summarizeSdpMSections(undefined)).toBe("none")
-    expect(summarizeSdpMSections("v=0")).toBe("none")
-  })
-})
 
 describe("createCallProxyClient", () => {
   it("carries mediaIncarnation in every proxy body", async () => {
@@ -315,6 +290,33 @@ describe("CloudflareSfuTransport", () => {
     await transport.publish("camera", makeTrack("video"))
     await expect(transport.unpublish("camera")).rejects.toThrow("network down")
     // The PC must not stay in have-local-offer — that wedges every later negotiation.
+    expect(withState.signalingState).toBe("stable")
+  })
+
+  it("should roll back when applying the close answer fails", async () => {
+    const pc = makeFakePc()
+    const withState = pc as unknown as { signalingState: string }
+    withState.signalingState = "stable"
+    pc.setLocalDescription = vi.fn(async (desc: { type?: string } | undefined) => {
+      withState.signalingState = desc?.type === "rollback" ? "stable" : "have-local-offer"
+    }) as typeof pc.setLocalDescription
+    pc.setRemoteDescription = vi.fn(async (desc: { type?: string; sdp?: string }) => {
+      if (desc.sdp === "close-answer") throw new DOMException("bad close answer", "InvalidAccessError")
+      withState.signalingState = "stable"
+    }) as typeof pc.setRemoteDescription
+    const { transport } = makeTransport({
+      pc,
+      post: async (path: string) => {
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish")) return { requiresImmediateRenegotiation: false, tracks: [] }
+        if (path.endsWith("/tracks/close"))
+          return { tracks: [], sessionDescription: { type: "answer", sdp: "close-answer" } }
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("camera", makeTrack("video"))
+    await expect(transport.unpublish("camera")).rejects.toThrow("bad close answer")
     expect(withState.signalingState).toBe("stable")
   })
 

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -295,6 +295,29 @@ describe("CloudflareSfuTransport", () => {
     expect(close?.body.sdp).toBeUndefined()
   })
 
+  it("should roll back the close offer when the REST close itself fails", async () => {
+    const pc = makeFakePc()
+    const withState = pc as unknown as { signalingState: string }
+    withState.signalingState = "stable"
+    pc.setLocalDescription = vi.fn(async (desc: { type?: string } | undefined) => {
+      withState.signalingState = desc?.type === "rollback" ? "stable" : "have-local-offer"
+    }) as typeof pc.setLocalDescription
+    const { transport } = makeTransport({
+      pc,
+      post: async (path: string) => {
+        if (path.endsWith("/session")) return { cfSessionId: "cf", idempotent: false }
+        if (path.endsWith("/tracks/publish")) return { requiresImmediateRenegotiation: false, tracks: [] }
+        if (path.endsWith("/tracks/close")) throw new Error("network down")
+        return {}
+      },
+    })
+    await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
+    await transport.publish("camera", makeTrack("video"))
+    await expect(transport.unpublish("camera")).rejects.toThrow("network down")
+    // The PC must not stay in have-local-offer — that wedges every later negotiation.
+    expect(withState.signalingState).toBe("stable")
+  })
+
   it("should unwind a failed pull so a retry re-registers its mids cleanly", async () => {
     const pc = makeFakePc()
     const withState = pc as unknown as { signalingState: string }

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -408,11 +408,19 @@ export class CloudflareSfuTransport implements MediaTransport {
           // A wedged PC must not block the server-side close; send it SDP-less.
         }
       }
-      const result = await this.proxy!.closeTracks({
-        mids: mid ? [mid] : [],
-        unpublishKinds: [kind],
-        sdp,
-      })
+      let result: CfCloseTracksResult
+      try {
+        result = await this.proxy!.closeTracks({
+          mids: mid ? [mid] : [],
+          unpublishKinds: [kind],
+          sdp,
+        })
+      } catch (err) {
+        // The REST leg itself failed (network, stale-incarnation fence) after we
+        // went have-local-offer — unwind before rethrowing or the PC is wedged.
+        if (sdp) await this.rollbackToStable(pc)
+        throw err
+      }
       // The close carried an offer (removing our m-line), so CF answers it. Apply
       // it — leaving the PC in `have-local-offer` corrupts the next negotiation and
       // the following publish (re-enabling the camera) fails. No answer back

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -151,6 +151,50 @@ interface CloudflareSfuTransportDeps {
   createPeerConnection?: () => RTCPeerConnection
 }
 
+/**
+ * One line per m-section — `mid:kind:direction` in SDP order. Small enough for a
+ * log/error message yet enough to spot the answer bugs that break renegotiation
+ * (dropped or reordered m-lines, a wrong direction on a pulled track).
+ */
+export function summarizeSdpMSections(sdp: string | undefined): string {
+  if (!sdp) return "none"
+  const sections: Array<{ kind: string; mid: string; direction: string }> = []
+  let current: { kind: string; mid: string; direction: string } | null = null
+  for (const line of sdp.split(/\r?\n/)) {
+    if (line.startsWith("m=")) {
+      current = { kind: line.slice(2).split(" ")[0] ?? "?", mid: "?", direction: "?" }
+      sections.push(current)
+    } else if (current && line.startsWith("a=mid:")) {
+      current.mid = line.slice("a=mid:".length).trim()
+    } else if (current && /^a=(sendrecv|sendonly|recvonly|inactive)\s*$/.test(line)) {
+      current.direction = line.slice(2).trim()
+    }
+  }
+  if (sections.length === 0) return "none"
+  return sections.map((s) => `${s.mid}:${s.kind}:${s.direction}`).join(" ")
+}
+
+/**
+ * Wrap a negotiation failure with the offer/answer m-section topology. The
+ * message flows into the capture-error surface and the lifecycle log — the only
+ * places a cross-device SDP failure is visible at all, since the REST leg
+ * already succeeded by the time the browser rejects the answer.
+ */
+function describeNegotiationFailure(
+  operation: string,
+  err: unknown,
+  offerSdp: string | undefined,
+  answerSdp: string | undefined
+): Error {
+  const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+  const wrapped = new Error(
+    `${operation} failed — ${detail} (offer: ${summarizeSdpMSections(offerSdp)}; answer: ${summarizeSdpMSections(answerSdp)})`,
+    { cause: err }
+  )
+  wrapped.name = "TransportNegotiationError"
+  return wrapped
+}
+
 function pickWorst(reasons: Array<string | undefined>): TransportStats["qualityLimitation"] {
   if (reasons.includes("bandwidth")) return "bandwidth"
   if (reasons.includes("cpu")) return "cpu"
@@ -287,13 +331,32 @@ export class CloudflareSfuTransport implements MediaTransport {
       }
       transceiver = pc.addTransceiver(track, { direction: "sendonly" })
       this.publishTransceivers.set(kind, transceiver)
-      const offer = await pc.createOffer()
-      await pc.setLocalDescription(offer)
-      const result = await this.proxy!.publishTracks({
-        sdp: { type: "offer", sdp: offer.sdp ?? "" },
-        tracks: [{ kind, mid: transceiver.mid ?? "", trackName }],
-      })
-      await this.applyAnswerAndMaybeRenegotiate(result)
+      let offerSdp = ""
+      let answerSdp: string | undefined
+      try {
+        const offer = await pc.createOffer()
+        await pc.setLocalDescription(offer)
+        offerSdp = offer.sdp ?? ""
+        const result = await this.proxy!.publishTracks({
+          sdp: { type: "offer", sdp: offerSdp },
+          tracks: [{ kind, mid: transceiver.mid ?? "", trackName }],
+        })
+        answerSdp = result.sessionDescription?.sdp
+        await this.applyAnswerAndMaybeRenegotiate(result)
+      } catch (err) {
+        // Unwind so the PC returns to stable and a RETRY renegotiates from
+        // scratch: the failed transceiver must leave the map, or the next
+        // publish takes the replaceTrack path into a transceiver CF never
+        // acknowledged — the camera button then "works" while no media flows.
+        this.publishTransceivers.delete(kind)
+        await this.rollbackToStable(pc)
+        try {
+          transceiver.stop()
+        } catch {
+          // Already stopping; ignore.
+        }
+        throw describeNegotiationFailure(`publish ${kind}`, err, offerSdp, answerSdp)
+      }
     })
   }
 
@@ -315,30 +378,49 @@ export class CloudflareSfuTransport implements MediaTransport {
 
   async unpublish(kind: PublishedTrackKind): Promise<void> {
     await this.enqueue(async () => {
+      // "Ensure kind is not published" — the registry close goes out even with no
+      // live transceiver: a publish that failed client-side after its REST call
+      // succeeded leaves a registry entry peers pull forever (they hang on a track
+      // whose media never flows), so the close is the phantom's only cleanup.
       const transceiver = this.publishTransceivers.get(kind)
-      if (!transceiver) return
       this.publishTransceivers.delete(kind)
-      const mid = transceiver.mid
-      await transceiver.sender.replaceTrack(null)
-      try {
-        transceiver.stop()
-      } catch {
-        // Some engines throw if the transceiver is already stopping; ignore.
+      const mid = transceiver?.mid ?? null
+      if (transceiver) {
+        try {
+          await transceiver.sender.replaceTrack(null)
+        } catch {
+          // Sender already gone; the close below still retires the track.
+        }
+        try {
+          transceiver.stop()
+        } catch {
+          // Some engines throw if the transceiver is already stopping; ignore.
+        }
       }
-      if (!mid) return
       const pc = this.requirePc()
-      const offer = await pc.createOffer()
-      await pc.setLocalDescription(offer)
+      let sdp: CfSessionDescription | undefined
+      if (mid) {
+        try {
+          const offer = await pc.createOffer()
+          await pc.setLocalDescription(offer)
+          sdp = { type: "offer", sdp: offer.sdp ?? "" }
+        } catch {
+          // A wedged PC must not block the server-side close; send it SDP-less.
+        }
+      }
       const result = await this.proxy!.closeTracks({
-        mids: [mid],
+        mids: mid ? [mid] : [],
         unpublishKinds: [kind],
-        sdp: { type: "offer", sdp: offer.sdp ?? "" },
+        sdp,
       })
       // The close carried an offer (removing our m-line), so CF answers it. Apply
       // it — leaving the PC in `have-local-offer` corrupts the next negotiation and
-      // the following publish (re-enabling the camera) fails.
-      if (result.sessionDescription?.type === "answer") {
+      // the following publish (re-enabling the camera) fails. No answer back
+      // (best-effort CF close failed) → roll back for the same reason.
+      if (sdp && result.sessionDescription?.type === "answer") {
         await pc.setRemoteDescription(result.sessionDescription)
+      } else if (sdp) {
+        await this.rollbackToStable(pc)
       }
     })
   }
@@ -346,19 +428,34 @@ export class CloudflareSfuTransport implements MediaTransport {
   async pull(ref: PeerTrackRef): Promise<void> {
     await this.enqueue(async () => {
       const pc = this.requirePc()
-      const result = await this.proxy!.pullTracks([ref])
-      for (const t of result.tracks) {
-        if (t.mid) this.pullByMid.set(t.mid, ref)
-      }
-      this.pulledRefs.set(this.refKey(ref), ref)
-      // A pull answers with an OFFER (CF adds the remote m-line); we answer it.
-      if (result.sessionDescription?.type === "offer") {
-        await pc.setRemoteDescription(result.sessionDescription)
-        const answer = await pc.createAnswer()
-        await pc.setLocalDescription(answer)
-        await this.proxy!.renegotiate({ type: "answer", sdp: answer.sdp ?? "" })
-      } else if (result.requiresImmediateRenegotiation) {
-        await this.renegotiateFromRemote()
+      let cfOfferSdp: string | undefined
+      try {
+        const result = await this.proxy!.pullTracks([ref])
+        cfOfferSdp = result.sessionDescription?.sdp
+        for (const t of result.tracks) {
+          if (t.mid) this.pullByMid.set(t.mid, ref)
+        }
+        this.pulledRefs.set(this.refKey(ref), ref)
+        // A pull answers with an OFFER (CF adds the remote m-line); we answer it.
+        if (result.sessionDescription?.type === "offer") {
+          await pc.setRemoteDescription(result.sessionDescription)
+          const answer = await pc.createAnswer()
+          await pc.setLocalDescription(answer)
+          await this.proxy!.renegotiate({ type: "answer", sdp: answer.sdp ?? "" })
+        } else if (result.requiresImmediateRenegotiation) {
+          await this.renegotiateFromRemote()
+        }
+      } catch (err) {
+        // Unwind fully so the caller's retry starts clean: stale mid→ref entries
+        // would attribute a future negotiation's ontrack to this dead pull, and a
+        // half-applied offer leaves the PC unable to negotiate anything else.
+        const key = this.refKey(ref)
+        this.pulledRefs.delete(key)
+        for (const [mid, r] of this.pullByMid) {
+          if (this.refKey(r) === key) this.pullByMid.delete(mid)
+        }
+        await this.rollbackToStable(pc)
+        throw describeNegotiationFailure(`pull ${ref.trackName}`, err, cfOfferSdp, undefined)
       }
     })
   }
@@ -455,6 +552,25 @@ export class CloudflareSfuTransport implements MediaTransport {
     const result = await this.proxy!.renegotiate({ type: "offer", sdp: offer.sdp ?? "" })
     if (result.sessionDescription?.type === "answer") {
       await pc.setRemoteDescription(result.sessionDescription)
+    }
+  }
+
+  /**
+   * Return a PC stuck mid-negotiation to `stable` so the next offer/answer
+   * exchange starts from known state. Rollback direction follows the wedge:
+   * our own unanswered offer rolls back locally, a half-applied remote offer
+   * rolls back remotely. Best-effort — a PC that rejects rollback is closed
+   * soon anyway (watchdog/teardown).
+   */
+  private async rollbackToStable(pc: RTCPeerConnection): Promise<void> {
+    try {
+      if (pc.signalingState === "have-local-offer") {
+        await pc.setLocalDescription({ type: "rollback" })
+      } else if (pc.signalingState === "have-remote-offer") {
+        await pc.setRemoteDescription({ type: "rollback" })
+      }
+    } catch {
+      // Best-effort; see doc.
     }
   }
 

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -1,3 +1,4 @@
+import { summarizeSdpMSections } from "@threa/types"
 import { api } from "@/api/client"
 import type { PublishedTrackKind } from "./config"
 
@@ -149,29 +150,6 @@ interface CloudflareSfuTransportDeps {
   post?: PostJson
   /** Injectable for tests; production uses the browser `RTCPeerConnection`. */
   createPeerConnection?: () => RTCPeerConnection
-}
-
-/**
- * One line per m-section — `mid:kind:direction` in SDP order. Small enough for a
- * log/error message yet enough to spot the answer bugs that break renegotiation
- * (dropped or reordered m-lines, a wrong direction on a pulled track).
- */
-export function summarizeSdpMSections(sdp: string | undefined): string {
-  if (!sdp) return "none"
-  const sections: Array<{ kind: string; mid: string; direction: string }> = []
-  let current: { kind: string; mid: string; direction: string } | null = null
-  for (const line of sdp.split(/\r?\n/)) {
-    if (line.startsWith("m=")) {
-      current = { kind: line.slice(2).split(" ")[0] ?? "?", mid: "?", direction: "?" }
-      sections.push(current)
-    } else if (current && line.startsWith("a=mid:")) {
-      current.mid = line.slice("a=mid:".length).trim()
-    } else if (current && /^a=(sendrecv|sendonly|recvonly|inactive)\s*$/.test(line)) {
-      current.direction = line.slice(2).trim()
-    }
-  }
-  if (sections.length === 0) return "none"
-  return sections.map((s) => `${s.mid}:${s.kind}:${s.direction}`).join(" ")
 }
 
 /**
@@ -424,9 +402,14 @@ export class CloudflareSfuTransport implements MediaTransport {
       // The close carried an offer (removing our m-line), so CF answers it. Apply
       // it — leaving the PC in `have-local-offer` corrupts the next negotiation and
       // the following publish (re-enabling the camera) fails. No answer back
-      // (best-effort CF close failed) → roll back for the same reason.
+      // (best-effort CF close failed) or a rejected answer → roll back, same reason.
       if (sdp && result.sessionDescription?.type === "answer") {
-        await pc.setRemoteDescription(result.sessionDescription)
+        try {
+          await pc.setRemoteDescription(result.sessionDescription)
+        } catch (err) {
+          await this.rollbackToStable(pc)
+          throw err
+        }
       } else if (sdp) {
         await this.rollbackToStable(pc)
       }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -377,6 +377,7 @@ export {
 
 // Board lens predicate (shared FE filter / BE seed, board-view-design.md § "Lenses")
 export { matchesBoardLens, degradeBoardLens } from "./board-lens"
+export { summarizeSdpMSections } from "./sdp"
 
 // Domain entities (wire format)
 export { getAvatarUrl, getBotAvatarUrl, getPersonaAvatarUrl } from "./domain"

--- a/packages/types/src/sdp.test.ts
+++ b/packages/types/src/sdp.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test"
+import { summarizeSdpMSections } from "./sdp"
+
+describe("summarizeSdpMSections", () => {
+  it("should list mid, kind, and direction per m-section in SDP order", () => {
+    const sdp = [
+      "v=0",
+      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+      "a=mid:0",
+      "a=sendonly",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96",
+      "a=mid:2",
+      "a=recvonly",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96",
+      "a=mid:3",
+      "a=sendonly",
+    ].join("\r\n")
+    expect(summarizeSdpMSections(sdp)).toBe("0:audio:sendonly 2:video:recvonly 3:video:sendonly")
+    expect(summarizeSdpMSections(undefined)).toBe("none")
+    expect(summarizeSdpMSections("v=0")).toBe("none")
+  })
+})

--- a/packages/types/src/sdp.ts
+++ b/packages/types/src/sdp.ts
@@ -1,0 +1,25 @@
+/**
+ * `mid:kind:direction` per m-section, in SDP order — the compact shape calls
+ * diagnostics log for every publish/pull negotiation. Cross-device SDP bugs (a
+ * dropped or reordered m-line, a wrong direction on a pulled track in the SFU's
+ * answer) are otherwise invisible: the browser's rejection of a bad answer
+ * happens client-side, after the proxy leg already returned 200. Shared by the
+ * backend CF proxy logs and the frontend transport's negotiation errors.
+ */
+export function summarizeSdpMSections(sdp: string | undefined): string {
+  if (!sdp) return "none"
+  const sections: Array<{ kind: string; mid: string; direction: string }> = []
+  let current: { kind: string; mid: string; direction: string } | null = null
+  for (const line of sdp.split(/\r?\n/)) {
+    if (line.startsWith("m=")) {
+      current = { kind: line.slice(2).split(" ")[0] ?? "?", mid: "?", direction: "?" }
+      sections.push(current)
+    } else if (current && line.startsWith("a=mid:")) {
+      current.mid = line.slice("a=mid:".length).trim()
+    } else if (current && /^a=(sendrecv|sendonly|recvonly|inactive)\s*$/.test(line)) {
+      current.direction = line.slice(2).trim()
+    }
+  }
+  if (sections.length === 0) return "none"
+  return sections.map((s) => `${s.mid}:${s.kind}:${s.direction}`).join(" ")
+}


### PR DESCRIPTION
## Problem

The second device to enable its camera in a cross-device call fails, order-independent of hardware (reproduced Samsung↔OnePlus both directions). Prod evidence for the 08:58–08:59Z test calls: the failing endpoint's camera IS in `published_tracks` but its `media_state.cameraOn` claim never landed — `setCameraOn` threw between the publish REST call and the claim, i.e. while applying CF's SDP answer, and only on a device whose PC already holds a pulled video m-line. Screenshots confirm: peer video rendering, camera hardware acquired (status-bar dot), then the capture-error banner + "Couldn't switch the camera" toast.

Three defects turned one client-side throw into a broken call:

- The registry kept the phantom camera entry, so the peer pulls a track whose media never flows — CF hangs, our proxy 504s (`tracks/pull` 504 logged at 08:58:50Z), and `diffPulls` dropped the failed pull forever (no roster event re-offers an unchanged track).
- The failed transceiver stayed in `publishTransceivers`, so every later camera tap took the replaceTrack fast path into a transceiver CF never acknowledged: button "works", no media, no error.
- `closeTracks` called CF before pruning the registry, so the cleanup's CF 502 (logged twice) preserved the phantom.

## Solution

Recovery + observability; the root cause (what exactly is wrong in CF's answer) needs the new logging to pin.

- `CloudflareSfuTransport.publish/pull` unwind on failure: evict/stop the transceiver, roll the PC back to `stable`, clear mid attributions; errors carry offer/answer m-section summaries.
- `unpublish` always sends the registry close — SDP-less when the PC can't offer, and even with no live transceiver (phantom cleanup); missing close answer → rollback.
- `diffPulls` retries a failed pull against the live store roster (`PULL_RETRY_DELAY_MS` 2s, cap 3 — each dead-track attempt holds the serial negotiation queue for the backend's CF timeout).
- Backend `closeTracks` prunes the registry and bumps the roster BEFORE the best-effort CF close; a CF provider error on an unpublish logs + counts instead of preserving the phantom (mids-only closes still fail loudly). Schema allows mid-less unpublish cleanup.
- Diagnostics: `publish_failed`/`pull_failed` lifecycle entries; the proxy logs `mid:kind:direction` topology for every publish answer and pull offer ("CF publish negotiated" / "CF pull negotiated") — the next real-device repro reveals CF's answer shape.

## Test plan

- [x] frontend `src/calls/` — 91 pass (new: publish retry gets a fresh transceiver, rollback on bad answer, phantom close without transceiver, SDP-less close on wedged PC, pull unwind, pull retry + cap)
- [x] frontend `src/components/call/` — 199 pass
- [x] backend calls unit+integration — 4065 + 157 pass (new: prune survives CF failure, mid-less close skips CF, mids-only close still throws)
- [ ] real S23↔OnePlus repro — needs this deployed; the new logs then pin CF's answer

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789810592&installation_model_id=20758&pr_number=1911&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1911&signature=c61a4fe84fb0620863ec6cb10eebf31c120fd137739d08d3f25ee3e23c649e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->