### PR TITLE
feat(streams): aside stream type foundations

### DIFF
--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -94,6 +94,7 @@ const STREAM_TYPE_TO_DB_STREAM_TYPE: Record<
   thread: StreamTypes.THREAD,
   dm: StreamTypes.DM,
   system: StreamTypes.SYSTEM,
+  aside: StreamTypes.ASIDE,
 }
 
 function mapStreamTypeToDbStreamType(

--- a/apps/backend/scripts/generate-api-docs.ts
+++ b/apps/backend/scripts/generate-api-docs.ts
@@ -72,7 +72,7 @@ function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
 // (INV-11) instead of shipping a group with no heading.
 const TAG_DEFS: { name: string; description: string }[] = [
   { name: "Identity", description: "Confirm who a key belongs to and list the bots you own." },
-  { name: "Streams", description: "List and inspect streams (channels, scratchpads, threads)" },
+  { name: "Streams", description: "List and inspect accessible streams" },
   { name: "Messages", description: "Read, send, update, and delete messages" },
   {
     name: "Conversations",

--- a/apps/backend/src/db/migrations/20260820211237_thread_scoped_anchor_index.sql
+++ b/apps/backend/src/db/migrations/20260820211237_thread_scoped_anchor_index.sql
@@ -1,6 +1,9 @@
 -- Thread-scoped replacement for idx_streams_thread_anchor: anchor uniqueness is
--- a THREAD invariant only — asides share anchors freely. Standalone so
--- PostgreSQL can build the index concurrently without blocking writes.
+-- a THREAD invariant only. The untyped index is dropped by a later migration
+-- (after every replica names this index as its ON CONFLICT arbiter); until
+-- then it still rejects a second stream of any type on one anchor, so asides
+-- cannot yet share an anchor. Standalone so PostgreSQL can build the index
+-- concurrently without blocking writes.
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_streams_thread_anchor_typed
 ON streams (parent_stream_id, parent_anchor_id)
 WHERE parent_anchor_id IS NOT NULL AND type = 'thread';

--- a/apps/backend/src/db/migrations/20260820211237_thread_scoped_anchor_index.sql
+++ b/apps/backend/src/db/migrations/20260820211237_thread_scoped_anchor_index.sql
@@ -1,0 +1,6 @@
+-- Thread-scoped replacement for idx_streams_thread_anchor: anchor uniqueness is
+-- a THREAD invariant only — asides share anchors freely. Standalone so
+-- PostgreSQL can build the index concurrently without blocking writes.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_streams_thread_anchor_typed
+ON streams (parent_stream_id, parent_anchor_id)
+WHERE parent_anchor_id IS NOT NULL AND type = 'thread';

--- a/apps/backend/src/db/migrations/20260820211238_drop_untyped_thread_anchor_index.sql
+++ b/apps/backend/src/db/migrations/20260820211238_drop_untyped_thread_anchor_index.sql
@@ -1,0 +1,5 @@
+-- Drop the untyped anchor uniqueness index now that the thread-scoped
+-- idx_streams_thread_anchor_typed exists; keeping it would 500 a second aside
+-- on the same anchor. Standalone: DROP INDEX CONCURRENTLY cannot run inside a
+-- transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS idx_streams_thread_anchor;

--- a/apps/backend/src/db/migrations/20260820211238_drop_untyped_thread_anchor_index.sql
+++ b/apps/backend/src/db/migrations/20260820211238_drop_untyped_thread_anchor_index.sql
@@ -1,5 +1,0 @@
--- Drop the untyped anchor uniqueness index now that the thread-scoped
--- idx_streams_thread_anchor_typed exists; keeping it would 500 a second aside
--- on the same anchor. Standalone: DROP INDEX CONCURRENTLY cannot run inside a
--- transaction block.
-DROP INDEX CONCURRENTLY IF EXISTS idx_streams_thread_anchor;

--- a/apps/backend/src/features/agents/companion-outbox-handler.ts
+++ b/apps/backend/src/features/agents/companion-outbox-handler.ts
@@ -87,7 +87,11 @@ export class CompanionHandler extends DebouncedOutboxHandler {
     let companionSource = stream
     if (stream.companionMode !== CompanionModes.ON && stream.rootStreamId) {
       const rootStream = await StreamRepository.findById(this.db, stream.rootStreamId)
-      if (rootStream && rootStream.type === StreamTypes.SCRATCHPAD && rootStream.companionMode === CompanionModes.ON) {
+      if (
+        rootStream &&
+        (rootStream.type === StreamTypes.SCRATCHPAD || rootStream.type === StreamTypes.ASIDE) &&
+        rootStream.companionMode === CompanionModes.ON
+      ) {
         companionSource = rootStream
       }
     }

--- a/apps/backend/src/features/agents/context-bag-precompute-handler.ts
+++ b/apps/backend/src/features/agents/context-bag-precompute-handler.ts
@@ -42,7 +42,7 @@ export class ContextBagPrecomputeHandler extends DebouncedOutboxHandler {
     }
 
     const { workspaceId, streamId, stream } = event.payload
-    if (stream.type !== StreamTypes.SCRATCHPAD) {
+    if (stream.type !== StreamTypes.SCRATCHPAD && stream.type !== StreamTypes.ASIDE) {
       return
     }
     if (stream.companionMode !== CompanionModes.ON) {

--- a/apps/backend/src/features/agents/researcher/access-spec.ts
+++ b/apps/backend/src/features/agents/researcher/access-spec.ts
@@ -57,6 +57,10 @@ export async function computeAgentAccessSpec(db: Querier, params: ComputeAccessS
         ? { type: "user_full_access", userId: invokingUserId }
         : { type: "public_only" }
 
+    case StreamTypes.ASIDE:
+      // An aside is always private to its creator: scratchpad semantics.
+      return { type: "user_full_access", userId: invokingUserId }
+
     case StreamTypes.CHANNEL:
       // Private channel: public streams + this channel
       // Public channel: only public streams

--- a/apps/backend/src/features/agents/tools/save-memo-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/save-memo-tool.test.ts
@@ -24,6 +24,7 @@ describe("save_memo tool", () => {
         ok: true,
         memoId: "memo_new",
         title: input.title,
+        scope: "workspace",
         deduped: false,
       })
     )
@@ -42,6 +43,7 @@ describe("save_memo tool", () => {
       async (): Promise<SaveMemoToolResult> => ({
         ok: true,
         memoId: "memo_existing",
+        scope: "workspace",
         title: "Existing",
         deduped: true,
       })
@@ -83,15 +85,17 @@ describe("save_memo effects", () => {
   }
 
   it("declares the memo it captured", async () => {
-    expect(await effectsOf({ ok: true, memoId: "memo_new", title: input.title, deduped: false })).toEqual([
-      { kind: "memo", label: input.title, target: "memo_new" },
-    ])
+    expect(
+      await effectsOf({ ok: true, memoId: "memo_new", title: input.title, deduped: false, scope: "workspace" })
+    ).toEqual([{ kind: "memo", label: input.title, target: "memo_new" }])
   })
 
   // A deduped save returned the memo that was already there; nothing was
   // written, so claiming a capture would be a lie the fallback can't tell apart.
   it("declares nothing when the save deduped", async () => {
-    expect(await effectsOf({ ok: true, memoId: "memo_existing", title: "Existing", deduped: true })).toEqual([])
+    expect(
+      await effectsOf({ ok: true, memoId: "memo_existing", title: "Existing", deduped: true, scope: "workspace" })
+    ).toEqual([])
   })
 
   it("declares nothing when the write failed", async () => {

--- a/apps/backend/src/features/agents/tools/save-memo-tool.ts
+++ b/apps/backend/src/features/agents/tools/save-memo-tool.ts
@@ -102,8 +102,12 @@ Use when the user asks you to remember something, or when something clearly wort
             memoId: result.memoId,
             title: result.title,
             deduped: result.deduped,
+            scope: result.scope,
             ...(result.deduped
               ? { note: "This knowledge was already captured in this stream; returned the existing memo." }
+              : {}),
+            ...(input.scope && input.scope !== result.scope
+              ? { note: `Saved at ${result.scope} scope: this stream's content never lands ${input.scope}-wide.` }
               : {}),
           }),
         }

--- a/apps/backend/src/features/agents/tools/tool-deps.ts
+++ b/apps/backend/src/features/agents/tools/tool-deps.ts
@@ -165,7 +165,9 @@ export interface DelegateTaskToolDeps {
  * tool surfaces `deduped` so the model learns "already remembered" rather than
  * re-saving.
  */
-export type SaveMemoToolResult = { ok: true; memoId: string; title: string; deduped: boolean } | { ok: false }
+export type SaveMemoToolResult =
+  | { ok: true; memoId: string; title: string; deduped: boolean; scope: MemoScope }
+  | { ok: false }
 
 /**
  * Callback for the `save_memo` tool, bound to the running persona's

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -351,10 +351,10 @@ export class BoundaryExtractionService {
     // Phase 2: determine conversation (AI call only for channels/threads).
     let decision: ConversationDecision
 
-    if (stream.type === StreamTypes.SCRATCHPAD) {
-      // Scratchpad = one conversation, by decision (board-view-design.md). The
-      // staleness sweep may have faded it to stalled/resolved, so fall back to
-      // the most-recently-active conversation and let the assignment
+    if (!isClusteredStreamType(stream.type)) {
+      // Scratchpad/aside = one conversation, by decision (board-view-design.md).
+      // The staleness sweep may have faded it to stalled/resolved, so fall back
+      // to the most-recently-active conversation and let the assignment
       // reactivation flip it — never mint a second same-named conversation.
       const existingConversation =
         scratchpadConversations?.find((c) => c.status === ConversationStatuses.ACTIVE) ?? scratchpadConversations?.[0]
@@ -405,7 +405,7 @@ export class BoundaryExtractionService {
       // For scratchpads: race-safe re-check that the active conversation still
       // exists / doesn't exist (another process may have created it).
       if (
-        stream.type === StreamTypes.SCRATCHPAD &&
+        !isClusteredStreamType(stream.type) &&
         decision.assignments.length === 1 &&
         decision.assignments[0].conversationId === null
       ) {
@@ -851,7 +851,7 @@ export class BoundaryExtractionService {
       // session and a new conversation is correct.
       const existing =
         (await ConversationRepository.findActiveByStream(client, stream.id))[0] ??
-        (stream.type === StreamTypes.SCRATCHPAD
+        (!isClusteredStreamType(stream.type)
           ? (await ConversationRepository.findByStream(client, stream.id, { limit: 1 }))[0]
           : undefined)
       const isNew = !existing

--- a/apps/backend/src/features/conversations/extraction-eligibility.ts
+++ b/apps/backend/src/features/conversations/extraction-eligibility.ts
@@ -15,9 +15,9 @@ export function isClusteredAuthorType(authorType: AuthorType | string): boolean 
   return authorType === AuthorTypes.USER
 }
 
-/** A scratchpad is one conversation by decision — no clustering. */
+/** Scratchpads and asides are one conversation by decision — no clustering. */
 export function isClusteredStreamType(streamType: StreamType | string): boolean {
-  return streamType !== StreamTypes.SCRATCHPAD
+  return streamType !== StreamTypes.SCRATCHPAD && streamType !== StreamTypes.ASIDE
 }
 
 /**

--- a/apps/backend/src/features/dynamic-naming/conversation-target.ts
+++ b/apps/backend/src/features/dynamic-naming/conversation-target.ts
@@ -60,7 +60,8 @@ export class DynamicNamingConversationTarget implements DynamicNamingTargetAdapt
     const conversation = await ConversationRepository.findByIdForUpdate(client, params.workspaceId, params.targetId)
     if (!conversation) return null
     const stream = await StreamRepository.findById(client, conversation.streamId)
-    if (!stream || stream.workspaceId !== params.workspaceId || stream.type === StreamTypes.SCRATCHPAD) return null
+    if (!stream || stream.workspaceId !== params.workspaceId) return null
+    if (stream.type === StreamTypes.SCRATCHPAD || stream.type === StreamTypes.ASIDE) return null
     if (await E2eStreamsRepository.isE2eStream(client, params.workspaceId, conversation.streamId)) return null
     const source = conversation.topicSummarySource ?? (conversation.topicSummary ? TitleSources.LEGACY : null)
     if (source !== null && source !== TitleSources.GENERATED) return null
@@ -87,7 +88,7 @@ export class DynamicNamingConversationTarget implements DynamicNamingTargetAdapt
       const conversation = await ConversationRepository.findById(client, target.targetId)
       if (!conversation || conversation.workspaceId !== target.workspaceId) return null
       const stream = await StreamRepository.findById(client, conversation.streamId)
-      if (!stream || stream.type === StreamTypes.SCRATCHPAD) return null
+      if (!stream || stream.type === StreamTypes.SCRATCHPAD || stream.type === StreamTypes.ASIDE) return null
       if (await E2eStreamsRepository.isE2eStream(client, target.workspaceId, conversation.streamId)) return null
       const byId = await MessageRepository.findByIdsInWorkspace(client, target.workspaceId, conversation.messageIds)
       const messages = orderedPrimaryMessages(conversation, byId).slice(-DYNAMIC_NAMING_MAX_MESSAGES)

--- a/apps/backend/src/features/dynamic-naming/outbox-handler.ts
+++ b/apps/backend/src/features/dynamic-naming/outbox-handler.ts
@@ -189,7 +189,12 @@ export class DynamicNamingOutboxHandler extends DebouncedOutboxHandler {
 
     const stream = await StreamRepository.findById(this.db, payload.streamId)
     if (!stream || stream.workspaceId !== payload.workspaceId || stream.archivedAt) return
-    if (stream.type !== StreamTypes.SCRATCHPAD && stream.type !== StreamTypes.THREAD) return
+    if (
+      stream.type !== StreamTypes.SCRATCHPAD &&
+      stream.type !== StreamTypes.THREAD &&
+      stream.type !== StreamTypes.ASIDE
+    )
+      return
     if (await E2eStreamsRepository.isE2eStream(this.db, payload.workspaceId, payload.streamId)) return
     const source = stream.displayNameSource ?? (stream.displayName ? TitleSources.LEGACY : null)
     if (source !== null && source !== TitleSources.GENERATED) return
@@ -217,7 +222,8 @@ export class DynamicNamingOutboxHandler extends DebouncedOutboxHandler {
     const conversation = await ConversationRepository.findById(this.db, conversationId)
     if (!conversation || conversation.workspaceId !== workspaceId) return false
     const stream = await StreamRepository.findById(this.db, conversation.streamId)
-    if (!stream || stream.workspaceId !== workspaceId || stream.type === StreamTypes.SCRATCHPAD) return false
+    if (!stream || stream.workspaceId !== workspaceId) return false
+    if (stream.type === StreamTypes.SCRATCHPAD || stream.type === StreamTypes.ASIDE) return false
     if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, conversation.streamId)) return false
     const source = conversation.topicSummarySource ?? (conversation.topicSummary ? TitleSources.LEGACY : null)
     if (source !== null && source !== TitleSources.GENERATED) return false

--- a/apps/backend/src/features/dynamic-naming/stream-target.ts
+++ b/apps/backend/src/features/dynamic-naming/stream-target.ts
@@ -45,7 +45,12 @@ export class DynamicNamingStreamTarget implements DynamicNamingTargetAdapter {
     // acknowledge and permanently lose an eligible checkpoint.
     const stream = await StreamRepository.findByIdForUpdateBlocking(client, params.targetId)
     if (!stream || stream.workspaceId !== params.workspaceId || stream.archivedAt) return null
-    if (stream.type !== StreamTypes.SCRATCHPAD && stream.type !== StreamTypes.THREAD) return null
+    if (
+      stream.type !== StreamTypes.SCRATCHPAD &&
+      stream.type !== StreamTypes.THREAD &&
+      stream.type !== StreamTypes.ASIDE
+    )
+      return null
     if (await E2eStreamsRepository.isE2eStream(client, params.workspaceId, params.targetId)) return null
 
     const source = stream.displayNameSource ?? (stream.displayName ? TitleSources.LEGACY : null)

--- a/apps/backend/src/features/dynamic-naming/stream-target.ts
+++ b/apps/backend/src/features/dynamic-naming/stream-target.ts
@@ -79,7 +79,11 @@ export class DynamicNamingStreamTarget implements DynamicNamingTargetAdapter {
       if (await E2eStreamsRepository.isE2eStream(client, target.workspaceId, target.targetId)) return null
       const replies = await MessageRepository.list(client, stream.id, { limit: DYNAMIC_NAMING_MAX_MESSAGES })
       const messages = await prependThreadNamingAnchor(client, stream, replies)
-      const siblings = await StreamRepository.list(client, stream.workspaceId, { types: [stream.type] })
+      const sameType = await StreamRepository.list(client, stream.workspaceId, { types: [stream.type] })
+      // Aside titles are private to their creator; only the creator's own asides
+      // may inform a title, never another member's.
+      const siblings =
+        stream.type === StreamTypes.ASIDE ? sameType.filter((s) => s.createdBy === stream.createdBy) : sameType
       const attachmentsByMessage = await AttachmentRepository.findByMessageIds(
         client,
         messages.map((message) => message.id)

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -138,6 +138,7 @@ export const MEMO_STREAM_TYPE_BOOST: Record<StreamType, number> = {
   dm: 1.0,
   thread: 1.0,
   system: 0.9,
+  aside: 1.05,
 }
 
 /**

--- a/apps/backend/src/features/memos/service.stub.ts
+++ b/apps/backend/src/features/memos/service.stub.ts
@@ -6,6 +6,7 @@ import type {
   CaptureSessionReflectionParams,
   CaptureSessionReflectionResult,
 } from "./service"
+import { MemoScopes } from "@threa/types"
 import { memoId } from "../../lib/id"
 import { logger } from "../../lib/logger"
 import type { StreamWritePrincipal } from "../streams"
@@ -19,7 +20,7 @@ export class StubMemoService implements MemoServiceLike {
   async saveMemo(params: SaveMemoParams): Promise<SaveMemoResult> {
     logger.debug({ workspaceId: params.workspaceId, streamId: params.streamId }, "Stub memo service - save_memo no-op")
     if (params.sourceMessageIds.length === 0) return { ok: false, reason: "no_source_messages" }
-    return { ok: true, memoId: memoId(), title: params.title, deduped: false }
+    return { ok: true, memoId: memoId(), title: params.title, deduped: false, scope: MemoScopes.WORKSPACE }
   }
 
   async saveMemoGenerated(_principal: StreamWritePrincipal, params: SaveMemoParams): Promise<SaveMemoResult> {

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -833,7 +833,7 @@ describe("MemoService.saveMemo — agent-authored memo (roadmap 6.2)", () => {
 
     const result = await service.saveMemo(saveMemoInput)
 
-    expect(result).toEqual({ ok: true, memoId: "memo_existing", title: "Existing", deduped: true })
+    expect(result).toEqual({ ok: true, memoId: "memo_existing", title: "Existing", deduped: true, scope: "workspace" })
     expect(insert).not.toHaveBeenCalled()
     expect(streamEventInsertMany).not.toHaveBeenCalled()
     expect(outboxInsert).not.toHaveBeenCalled()

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -201,7 +201,7 @@ export interface SaveMemoParams {
  * remembered rather than stacking a near-duplicate.
  */
 export type SaveMemoResult =
-  | { ok: true; memoId: string; title: string; deduped: boolean }
+  | { ok: true; memoId: string; title: string; deduped: boolean; scope: MemoScope }
   | { ok: false; reason: "no_source_messages" }
 
 /**
@@ -1011,8 +1011,8 @@ export class MemoService implements MemoServiceLike {
       let resolvedScopeUserId = natural.scopeUserId
       if (scopeOverride === MemoScopes.WORKSPACE) {
         // Aside content never lands workspace-scoped: the tool's LLM-supplied
-        // override silently downgrades to the aside's natural user tier, and the
-        // returned memo carries its actual scope.
+        // override downgrades to the aside's natural user tier, and the result
+        // reports the scope it actually landed in.
         const root = await StreamRepository.findById(client, natural.rootStreamId)
         if (root?.type !== StreamTypes.ASIDE) {
           resolvedScope = MemoScopes.WORKSPACE
@@ -1050,7 +1050,7 @@ export class MemoService implements MemoServiceLike {
           { streamId, existingMemoId: duplicate.memo.id, distance: duplicate.distance },
           "save_memo: knowledge already captured in this stream — returning existing memo"
         )
-        return { ok: true, memoId: duplicate.memo.id, title: duplicate.memo.title, deduped: true }
+        return { ok: true, memoId: duplicate.memo.id, title: duplicate.memo.title, deduped: true, scope: resolvedScope }
       }
 
       await MemoRepository.insert(client, {
@@ -1119,7 +1119,7 @@ export class MemoService implements MemoServiceLike {
       }
 
       logger.info({ streamId, memoId: newMemoId, sessionId, scope: resolvedScope }, "save_memo: agent memo created")
-      return { ok: true, memoId: newMemoId, title, deduped: false }
+      return { ok: true, memoId: newMemoId, title, deduped: false, scope: resolvedScope }
     })
   }
 

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -1010,8 +1010,14 @@ export class MemoService implements MemoServiceLike {
       let resolvedScope = natural.scope
       let resolvedScopeUserId = natural.scopeUserId
       if (scopeOverride === MemoScopes.WORKSPACE) {
-        resolvedScope = MemoScopes.WORKSPACE
-        resolvedScopeUserId = null
+        // Aside content never lands workspace-scoped: the tool's LLM-supplied
+        // override silently downgrades to the aside's natural user tier, and the
+        // returned memo carries its actual scope.
+        const root = await StreamRepository.findById(client, natural.rootStreamId)
+        if (root?.type !== StreamTypes.ASIDE) {
+          resolvedScope = MemoScopes.WORKSPACE
+          resolvedScopeUserId = null
+        }
       } else if (scopeOverride === MemoScopes.USER && invokingUserId) {
         resolvedScope = MemoScopes.USER
         resolvedScopeUserId = invokingUserId

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -87,7 +87,11 @@ function localeToLanguageName(locale: string): string {
  * (INV-62); `save_memo` can still opt an individual memo into `user` scope.
  */
 function resolveExtractedMemoScope(stream: Stream | null): { scope: MemoScope; scopeUserId: string | null } {
-  if (stream && stream.type === StreamTypes.SCRATCHPAD && stream.visibility === Visibilities.PRIVATE) {
+  if (
+    stream &&
+    (stream.type === StreamTypes.ASIDE ||
+      (stream.type === StreamTypes.SCRATCHPAD && stream.visibility === Visibilities.PRIVATE))
+  ) {
     return { scope: MemoScopes.USER, scopeUserId: stream.createdBy }
   }
   return { scope: MemoScopes.WORKSPACE, scopeUserId: null }

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -153,7 +153,7 @@ function aggregateReactionsByMessage(rows: ReactionRow[]): Map<string, Record<st
 // thread stream anchored on it (`streams.parent_anchor_id = <message id>`), so
 // the count is that thread row's maintained `reply_count` (0 when no thread).
 // Correlate BOTH anchor columns (`parent_stream_id = <msg>.stream_id AND
-// parent_anchor_id = <msg>.id`) so the lookup seeks `idx_streams_thread_anchor
+// parent_anchor_id = <msg>.id`) so the lookup seeks `idx_streams_thread_anchor_typed
 // (parent_stream_id, parent_anchor_id)` instead of scanning `streams` per row —
 // this fires on every message read (lists, search, bootstrap). A thread's parent
 // stream is always its anchor's stream (the move path relinks both together).

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -319,6 +319,65 @@ describe("hydrateSharedMessageRefs", () => {
     expect(findStreams).toHaveBeenCalledTimes(2)
   })
 
+  it("presents an aside source as scratchpad in the private placeholder", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubNoAccess()
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      {
+        id: "stream_source",
+        type: "aside",
+        visibility: "private",
+        rootStreamId: null,
+      } as any,
+    ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toEqual({
+      type: "sharedMessage",
+      state: "private",
+      messageId: "msg_a",
+      sourceStreamKind: "scratchpad",
+      sourceVisibility: "private",
+    })
+  })
+
+  it("presents a thread inside an aside as scratchpad in the private placeholder", async () => {
+    spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
+      new Map([["msg_a", makeMessage({ id: "msg_a" })]])
+    )
+    stubAuthorLookups()
+    stubNoAccess()
+    spyOn(StreamRepository, "findByIds")
+      .mockResolvedValueOnce([
+        {
+          id: "stream_source",
+          type: "thread",
+          visibility: "private",
+          rootStreamId: "stream_aside",
+        } as any,
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "stream_aside",
+          type: "aside",
+          visibility: "private",
+          rootStreamId: null,
+        } as any,
+      ])
+
+    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
+    expect(result.msg_a).toEqual({
+      type: "sharedMessage",
+      state: "private",
+      messageId: "msg_a",
+      sourceStreamKind: "scratchpad",
+      sourceVisibility: "private",
+    })
+  })
+
   it("treats source-via-share-grant as accessible even when not a stream member", async () => {
     spyOn(MessageRepository, "findByIdsInWorkspace").mockResolvedValue(
       new Map([["msg_a", makeMessage({ id: "msg_a" })]])

--- a/apps/backend/src/features/messaging/sharing/hydration.test.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.test.ts
@@ -334,8 +334,8 @@ describe("hydrateSharedMessageRefs", () => {
       } as any,
     ])
 
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
-    expect(result.msg_a).toEqual({
+    const result = await hydrateSharedMessageRefs({} as any, "ws_1", VIEWER_ID, [ref("msg_a")])
+    expect(result[key("msg_a")]).toEqual({
       type: "sharedMessage",
       state: "private",
       messageId: "msg_a",
@@ -368,8 +368,8 @@ describe("hydrateSharedMessageRefs", () => {
         } as any,
       ])
 
-    const result = await hydrateSharedMessageIds({} as any, "ws_1", VIEWER_ID, ["msg_a"])
-    expect(result.msg_a).toEqual({
+    const result = await hydrateSharedMessageRefs({} as any, "ws_1", VIEWER_ID, [ref("msg_a")])
+    expect(result[key("msg_a")]).toEqual({
       type: "sharedMessage",
       state: "private",
       messageId: "msg_a",

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -4,6 +4,7 @@ import {
   type ContentRange,
   type JSONContent,
   type SharedMessageRef,
+  type SharedSourceStreamKind,
   type StreamType,
   type Visibility,
   StreamTypes,
@@ -76,7 +77,7 @@ export type HydratedSharedMessage =
       type: "sharedMessage"
       state: "private"
       messageId: string
-      sourceStreamKind: StreamType
+      sourceStreamKind: SharedSourceStreamKind
       sourceVisibility: Visibility
     }
   | { type: "sharedMessage"; state: "truncated"; messageId: string; streamId: string }
@@ -144,8 +145,19 @@ export function collectSharedMessageRefs(node: JSONContent | undefined, into: Ma
 }
 
 /**
+ * An aside presents as a scratchpad to non-viewers: neither a direct aside
+ * source nor a thread whose root is an aside may leak the kind. Both branches
+ * of {@link resolveSourceForPrivatePlaceholder} route through this map, which
+ * is also why the placeholder vocabulary is `SharedSourceStreamKind`, not
+ * `StreamType`.
+ */
+function presentedSourceStreamKind(type: StreamType): SharedSourceStreamKind {
+  return type === StreamTypes.ASIDE ? StreamTypes.SCRATCHPAD : type
+}
+
+/**
  * Resolve the (kind, visibility) the `private` placeholder should report.
- * For thread sources we surface the parent's kind/visibility so the
+ * For thread sources we surface the root's kind/visibility so the
  * placeholder vocabulary stays in {channel, dm, scratchpad} —
  * "thread" by itself wouldn't tell the viewer what kind of stream sits
  * behind the wall.
@@ -153,17 +165,12 @@ export function collectSharedMessageRefs(node: JSONContent | undefined, into: Ma
 function resolveSourceForPrivatePlaceholder(
   source: Stream,
   byStreamId: ReadonlyMap<string, Stream>
-): { kind: StreamType; visibility: Visibility } {
+): { kind: SharedSourceStreamKind; visibility: Visibility } {
   if (source.type === StreamTypes.THREAD && source.rootStreamId) {
     const root = byStreamId.get(source.rootStreamId)
-    if (root) return { kind: root.type, visibility: root.visibility }
+    if (root) return { kind: presentedSourceStreamKind(root.type), visibility: root.visibility }
   }
-  // An aside presents as a scratchpad to non-viewers: even the placeholder must
-  // not disclose that an aside exists.
-  if (source.type === StreamTypes.ASIDE) {
-    return { kind: StreamTypes.SCRATCHPAD, visibility: source.visibility }
-  }
-  return { kind: source.type, visibility: source.visibility }
+  return { kind: presentedSourceStreamKind(source.type), visibility: source.visibility }
 }
 
 /** An accessible, live source resolved down to the body its reference pins. */

--- a/apps/backend/src/features/messaging/sharing/hydration.ts
+++ b/apps/backend/src/features/messaging/sharing/hydration.ts
@@ -158,6 +158,11 @@ function resolveSourceForPrivatePlaceholder(
     const root = byStreamId.get(source.rootStreamId)
     if (root) return { kind: root.type, visibility: root.visibility }
   }
+  // An aside presents as a scratchpad to non-viewers: even the placeholder must
+  // not disclose that an aside exists.
+  if (source.type === StreamTypes.ASIDE) {
+    return { kind: StreamTypes.SCRATCHPAD, visibility: source.visibility }
+  }
   return { kind: source.type, visibility: source.visibility }
 }
 

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -14,6 +14,7 @@ import {
   BOT_TRAITS,
   CONVERSATION_STATUSES,
   WORKSPACE_PERMISSION_SCOPES,
+  SHARED_SOURCE_STREAM_KINDS,
   STREAM_TYPES,
   VISIBILITY_OPTIONS,
   MEMORY_MODES,
@@ -195,7 +196,7 @@ const sharedMessageSlotSchema = z.discriminatedUnion("state", [
     type: z.literal("sharedMessage"),
     state: z.literal("private"),
     messageId: z.string(),
-    sourceStreamKind: z.enum(STREAM_TYPES),
+    sourceStreamKind: z.enum(SHARED_SOURCE_STREAM_KINDS),
     sourceVisibility: z.enum(VISIBILITY_OPTIONS),
   }),
   z.object({

--- a/apps/backend/src/features/stream-context/backfill.ts
+++ b/apps/backend/src/features/stream-context/backfill.ts
@@ -147,6 +147,7 @@ export async function plan(ctx: BackfillContext, workspaceId: string): Promise<S
     WHERE workspace_id = ${workspaceId}
       AND parent_stream_id = ANY(${streamIds})
       AND parent_anchor_id IS NOT NULL
+      AND type = 'thread'
   `)
 
   const chunks: StreamContextChunk[] = []
@@ -523,6 +524,7 @@ async function processThreadsChunk(
     WHERE workspace_id = ${workspaceId}
       AND parent_stream_id = ${chunk.streamId}
       AND parent_anchor_id IS NOT NULL
+      AND type = 'thread'
     ORDER BY id
   `)
   if (threads.rows.length === 0) return []

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -455,6 +455,52 @@ describe("createStreamHandlers.create — allowedToolCategories", () => {
     expect(resolveSpy).not.toHaveBeenCalled()
     expect(create.mock.calls[0]![0].companionPersonaId).toBeUndefined()
   })
+
+  it("forces Ariadne companion on an aside create, ignoring a client-sent persona", async () => {
+    const create = mock(
+      async (_params: { companionMode?: string; companionPersonaId?: string; parentAnchorId?: string }) => ({
+        id: "stream_aside",
+      })
+    )
+    const findBySlug = spyOn(agentsBarrel.PersonaRepository, "findBySlug").mockResolvedValue({
+      id: "persona_system_ariadne",
+    } as never)
+    try {
+      const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+      const { res, captured } = makeRes()
+
+      await handlers.create(
+        makeCreateReq({
+          type: "aside",
+          parentStreamId: "stream_channel",
+          parentAnchorId: "msg_1",
+          companionPersonaId: "persona_foreign",
+        }),
+        res
+      )
+
+      expect(captured.status).toBe(201)
+      expect(assertSpy).not.toHaveBeenCalled()
+      expect(create.mock.calls[0]![0]).toMatchObject({
+        type: "aside",
+        parentStreamId: "stream_channel",
+        parentAnchorId: "msg_1",
+        companionMode: "on",
+        companionPersonaId: "persona_system_ariadne",
+      })
+    } finally {
+      findBySlug.mockRestore()
+    }
+  })
+
+  it("rejects an aside without parentStreamId and never creates", async () => {
+    const create = mock(async () => ({ id: "stream_aside" }))
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res } = makeRes()
+
+    await expect(handlers.create(makeCreateReq({ type: "aside" }), res)).rejects.toMatchObject({ status: 400 })
+    expect(create).not.toHaveBeenCalled()
+  })
 })
 
 describe("createStreamHandlers.markAsRead — access without membership", () => {

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -56,7 +56,7 @@ import {
 
 const createStreamSchema = z
   .object({
-    type: streamTypeSchema.extract(["scratchpad", "channel", "thread"]),
+    type: streamTypeSchema.extract(["scratchpad", "channel", "thread", "aside"]),
     slug: z
       .string()
       .regex(SLUG_PATTERN, {
@@ -113,8 +113,12 @@ const createStreamSchema = z
     message: "parentAnchorId is required for threads",
     path: ["parentAnchorId"],
   })
-  .refine((data) => !data.contextBag || data.type === "scratchpad", {
-    message: "contextBag is only supported on scratchpad creation",
+  .refine((data) => data.type !== "aside" || !!data.parentStreamId, {
+    message: "parentStreamId is required for asides",
+    path: ["parentStreamId"],
+  })
+  .refine((data) => !data.contextBag || data.type === "scratchpad" || data.type === "aside", {
+    message: "contextBag is only supported on scratchpad or aside creation",
     path: ["contextBag"],
   })
   .refine((data) => !data.e2eEnabled || data.type === "scratchpad", {
@@ -129,8 +133,8 @@ const createStreamSchema = z
     message: "contextBag and E2E are mutually exclusive in Phase 1",
     path: ["e2eEnabled"],
   })
-  .refine((data) => data.allowedToolCategories === undefined || data.type === "scratchpad", {
-    message: "allowedToolCategories is only supported on scratchpad creation",
+  .refine((data) => data.allowedToolCategories === undefined || data.type === "scratchpad" || data.type === "aside", {
+    message: "allowedToolCategories is only supported on scratchpad or aside creation",
     path: ["allowedToolCategories"],
   })
 
@@ -365,6 +369,7 @@ const addMemberAllowed: Record<StreamType, boolean> = {
   [StreamTypes.SCRATCHPAD]: false,
   [StreamTypes.DM]: false,
   [StreamTypes.SYSTEM]: false,
+  [StreamTypes.ASIDE]: false,
 }
 
 const disallowedUpdateFields: Record<StreamType, Record<string, string> | null> = {
@@ -381,6 +386,11 @@ const disallowedUpdateFields: Record<StreamType, Record<string, string> | null> 
     visibility: "Direct messages are always private",
   },
   [StreamTypes.SYSTEM]: null,
+  [StreamTypes.ASIDE]: {
+    slug: "Asides do not have slugs",
+    visibility: "Asides are always private",
+    memoryMode: "Asides never extract memory",
+  },
 }
 
 function updateSchemaForType(streamType: StreamType) {
@@ -650,7 +660,9 @@ export function createStreamHandlers({
         for (const ref of contextBag.refs) {
           await assertRefAccess(pool, ref, userId, workspaceId)
         }
-
+      }
+      // An aside is always a companion chat with Ariadne, bag or no bag.
+      if (contextBag || type === StreamTypes.ASIDE) {
         const ariadne = await PersonaRepository.findBySlug(pool, ARIADNE_PERSONA_SLUG, workspaceId)
         if (!ariadne) {
           // Workspace-config state, not an internal error: 503 + a domain
@@ -674,7 +686,7 @@ export function createStreamHandlers({
       // degrading at dispatch. The e2e/contextBag branches force/omit the id
       // server-side (validated or Ariadne), and the default-resolution branch
       // below only runs when no explicit id was given, so those stay untouched.
-      if (companionPersonaId != null && !e2eEnabled && !contextBag) {
+      if (companionPersonaId != null && !e2eEnabled && !contextBag && type !== StreamTypes.ASIDE) {
         await assertAssignablePersona(pool, companionPersonaId, workspaceId, { callerUserId: userId })
       }
       if (type === StreamTypes.SCRATCHPAD && !e2eEnabled && !resolvedPersonaId) {

--- a/apps/backend/src/features/streams/member-repository.ts
+++ b/apps/backend/src/features/streams/member-repository.ts
@@ -308,9 +308,9 @@ export const StreamMemberRepository = {
   async deleteByMemberInDescendants(db: Querier, memberId: string, ancestorStreamId: string): Promise<string[]> {
     const result = await db.query<{ stream_id: string }>(
       `WITH RECURSIVE descendants AS (
-        SELECT id FROM streams WHERE parent_stream_id = $2
+        SELECT id FROM streams WHERE parent_stream_id = $2 AND type = 'thread'
         UNION ALL
-        SELECT s.id FROM streams s JOIN descendants d ON s.parent_stream_id = d.id
+        SELECT s.id FROM streams s JOIN descendants d ON s.parent_stream_id = d.id AND s.type = 'thread'
       )
       DELETE FROM stream_members
       WHERE member_id = $1 AND stream_id IN (SELECT id FROM descendants)

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -1427,7 +1427,7 @@ export const StreamRepository = {
    * is covered by a test that asserts both entry points return the same
    * `ThreadSummary` for a given parent.
    *
-   * `parentStreamId` correlates the leading column of `idx_streams_thread_anchor
+   * `parentStreamId` correlates the leading column of `idx_streams_thread_anchor_typed
    * (parent_stream_id, parent_anchor_id)` so this runs as an index seek — it fires
    * on every reply create/edit/delete via `emitThreadUpdate`, so a per-row streams
    * scan on the anchor alone would be a hot-path footgun (INV-20 sibling concern).

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -1003,7 +1003,7 @@ export const StreamRepository = {
         ${params.uniquenessKey ?? null},
         ${params.createdBy}
       )
-      ON CONFLICT (parent_stream_id, parent_anchor_id) WHERE parent_anchor_id IS NOT NULL DO NOTHING
+      ON CONFLICT (parent_stream_id, parent_anchor_id) WHERE parent_anchor_id IS NOT NULL AND type = 'thread' DO NOTHING
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)
 
@@ -1168,6 +1168,7 @@ export const StreamRepository = {
       SELECT ${sql.raw(SELECT_FIELDS)} FROM streams
       WHERE parent_stream_id = ${parentStreamId}
         AND parent_anchor_id = ${parentAnchorId}
+        AND type = 'thread'
     `)
     return result.rows[0] ? mapRowToStream(result.rows[0]) : null
   },
@@ -1181,6 +1182,7 @@ export const StreamRepository = {
       SELECT parent_anchor_id AS anchor_id, id FROM streams
       WHERE parent_stream_id = ${parentStreamId}
         AND parent_anchor_id IS NOT NULL
+        AND type = 'thread'
     `)
     const map = new Map<string, string>()
     for (const row of result.rows) {
@@ -1203,6 +1205,7 @@ export const StreamRepository = {
       SELECT parent_anchor_id AS anchor_id, id FROM streams
       WHERE parent_stream_id = ${parentStreamId}
         AND parent_anchor_id = ANY(${messageIds})
+        AND type = 'thread'
     `)
     const map = new Map<string, string>()
     for (const row of result.rows) {

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -675,7 +675,9 @@ export class StreamService {
       const anchorId = params.parentAnchorId
       if (anchorId !== undefined) {
         if (anchorId.startsWith("msg_")) {
-          const anchorMessage = await MessageRepository.findById(client, anchorId)
+          // Locked like the thread path: a concurrent move would re-parent the
+          // message between an unlocked read and the insert (INV-20).
+          const anchorMessage = await MessageRepository.findByIdForUpdate(client, anchorId)
           if (!anchorMessage || anchorMessage.streamId !== params.parentStreamId) {
             throw new MessageNotFoundError()
           }
@@ -1046,11 +1048,17 @@ export class StreamService {
     actingUserId: string
   ): Promise<Stream> {
     return withTransaction(this.pool, async (client) => {
-      await assertStreamWritable(client, {
+      const { target } = await assertStreamWritable(client, {
         workspaceId,
         streamId,
         principal: { kind: "user", userId: actingUserId },
       })
+      if (target.type === StreamTypes.ASIDE) {
+        throw new HttpError("An aside is always a companion conversation", {
+          status: 400,
+          code: "INVALID_STREAM_TYPE",
+        })
+      }
       await assertAssignablePersona(client, companionPersonaId, workspaceId, { callerUserId: actingUserId })
       const stream = await StreamRepository.update(client, streamId, {
         companionMode,

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -89,6 +89,14 @@ import { normalizeStreamDescription } from "./description"
 
 const DM_UNIQUENESS_KEY_PREFIX = "dm"
 
+/** Streams an aside may anchor to: no aside-on-aside, no system hosts. */
+const ASIDE_HOST_TYPES: readonly StreamType[] = [
+  StreamTypes.CHANNEL,
+  StreamTypes.DM,
+  StreamTypes.SCRATCHPAD,
+  StreamTypes.THREAD,
+]
+
 const createScratchpadParamsSchema = z.object({
   workspaceId: z.string(),
   displayName: z.string().optional(),
@@ -638,6 +646,13 @@ export class StreamService {
       const parent = await checkStreamAccess(client, params.parentStreamId, params.workspaceId, params.createdBy)
       if (!parent) throw new StreamNotFoundError()
 
+      if (!ASIDE_HOST_TYPES.includes(parent.type)) {
+        throw new HttpError("An aside cannot be opened on this stream type", {
+          status: 400,
+          code: "ASIDE_HOST_TYPE_INVALID",
+        })
+      }
+
       // An aside's viewport snapshot and context bag are plaintext; an E2E host
       // has no server-readable content to snapshot, so refuse loudly (INV-11)
       // rather than create a snapshot-less aside silently.
@@ -896,10 +911,10 @@ export class StreamService {
     const rootStream =
       rootStreamId === parentStream.id ? parentStream : await StreamRepository.findById(client, rootStreamId)
     const inheritedVisibility = rootStream?.visibility ?? Visibilities.PRIVATE
-    const inheritedCompanionMode =
-      rootStream?.type === StreamTypes.SCRATCHPAD ? rootStream.companionMode : CompanionModes.OFF
-    const inheritedCompanionPersonaId =
-      rootStream?.type === StreamTypes.SCRATCHPAD ? (rootStream.companionPersonaId ?? undefined) : undefined
+    const companionRoot =
+      rootStream?.type === StreamTypes.SCRATCHPAD || rootStream?.type === StreamTypes.ASIDE ? rootStream : null
+    const inheritedCompanionMode = companionRoot?.companionMode ?? CompanionModes.OFF
+    const inheritedCompanionPersonaId = companionRoot?.companionPersonaId ?? undefined
     // Threads carry no memory setting of their own — the memo gate resolves to
     // the root (INV-62) — but copy the root's value onto the thread row at
     // creation so the persisted row matches its effective behavior.

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -638,8 +638,9 @@ export class StreamService {
    * a spot in a host stream. `parentStreamId`/`parentAnchorId` are contextual
    * pointers only — never access-bearing (INV-62): access resolves through the
    * aside's own creator membership, which is what lets a private aside sit
-   * inside a public channel. Not idempotent per anchor — multiple asides may
-   * share one.
+   * inside a public channel. Not idempotent per anchor by design; until the
+   * untyped anchor index is dropped in the stack's final layer, the database
+   * still rejects a second stream (of any type) on the same anchor.
    */
   async createAside(params: CreateAsideParams): Promise<Stream> {
     return withTransaction(this.pool, async (client) => {
@@ -662,6 +663,14 @@ export class StreamService {
           code: "ASIDE_E2E_HOST_NOT_ALLOWED",
         })
       }
+
+      // An aside inherits its host's archive state (lockEffectiveStreams), so an
+      // aside opened on an archived host would be born read-only.
+      await assertStreamWritable(client, {
+        workspaceId: params.workspaceId,
+        streamId: params.parentStreamId,
+        principal: { kind: "user", userId: params.createdBy },
+      })
 
       const anchorId = params.parentAnchorId
       if (anchorId !== undefined) {

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -183,6 +183,21 @@ const createThreadParamsSchema = z.object({
 
 export type CreateThreadParams = z.infer<typeof createThreadParamsSchema>
 
+const createAsideParamsSchema = z.object({
+  workspaceId: z.string(),
+  parentStreamId: z.string(),
+  /** Optional anchor (`msg_…` / `event_…`) in the host stream; composer/palette asides carry none. */
+  parentAnchorId: z.string().optional(),
+  displayName: z.string().optional(),
+  companionPersonaId: z.string().optional(),
+  createdBy: z.string(),
+})
+
+export type CreateAsideParams = z.infer<typeof createAsideParamsSchema> & {
+  contextBag?: ContextBag
+  allowedToolCategories?: ToolPrivacyPolicy
+}
+
 const createStreamParamsSchema = z.object({
   workspaceId: z.string(),
   type: streamTypeSchema,
@@ -499,6 +514,21 @@ export class StreamService {
           principal: { kind: "user", userId: params.createdBy },
         })
       }
+      case StreamTypes.ASIDE: {
+        if (!params.parentStreamId) {
+          throw new Error("parentStreamId is required for asides")
+        }
+        return this.createAside({
+          workspaceId: params.workspaceId,
+          parentStreamId: params.parentStreamId,
+          parentAnchorId: params.parentAnchorId,
+          displayName: params.displayName,
+          companionPersonaId: params.companionPersonaId,
+          createdBy: params.createdBy,
+          contextBag: params.contextBag,
+          allowedToolCategories: params.allowedToolCategories,
+        })
+      }
       default:
         throw new Error(`Unsupported stream type for create: ${params.type}`)
     }
@@ -593,6 +623,95 @@ export class StreamService {
     }
 
     return stream
+  }
+
+  /**
+   * An aside: a private, creator-only, companion-backed root stream anchored to
+   * a spot in a host stream. `parentStreamId`/`parentAnchorId` are contextual
+   * pointers only — never access-bearing (INV-62): access resolves through the
+   * aside's own creator membership, which is what lets a private aside sit
+   * inside a public channel. Not idempotent per anchor — multiple asides may
+   * share one.
+   */
+  async createAside(params: CreateAsideParams): Promise<Stream> {
+    return withTransaction(this.pool, async (client) => {
+      const parent = await checkStreamAccess(client, params.parentStreamId, params.workspaceId, params.createdBy)
+      if (!parent) throw new StreamNotFoundError()
+
+      // An aside's viewport snapshot and context bag are plaintext; an E2E host
+      // has no server-readable content to snapshot, so refuse loudly (INV-11)
+      // rather than create a snapshot-less aside silently.
+      if (parent.e2eEnabled === true) {
+        throw new HttpError("Asides cannot be opened on an end-to-end encrypted stream", {
+          status: 400,
+          code: "ASIDE_E2E_HOST_NOT_ALLOWED",
+        })
+      }
+
+      const anchorId = params.parentAnchorId
+      if (anchorId !== undefined) {
+        if (anchorId.startsWith("msg_")) {
+          const anchorMessage = await MessageRepository.findById(client, anchorId)
+          if (!anchorMessage || anchorMessage.streamId !== params.parentStreamId) {
+            throw new MessageNotFoundError()
+          }
+        } else if (anchorId.startsWith("event_")) {
+          const anchorEvent = await StreamEventRepository.findById(client, anchorId)
+          if (!anchorEvent || anchorEvent.streamId !== params.parentStreamId) {
+            throw new HttpError("Aside anchor event not found", { status: 404, code: "ANCHOR_NOT_FOUND" })
+          }
+        } else {
+          throw new HttpError("Unrecognized aside anchor id", { status: 400, code: "ANCHOR_INVALID" })
+        }
+      }
+
+      const stream = await StreamRepository.insert(client, {
+        id: streamId(),
+        workspaceId: params.workspaceId,
+        type: StreamTypes.ASIDE,
+        displayName: params.displayName,
+        displayNameSource: params.displayName === undefined ? undefined : TitleSources.EXPLICIT,
+        displayNameUpdatedByUserId: params.displayName === undefined ? undefined : params.createdBy,
+        visibility: Visibilities.PRIVATE,
+        companionMode: CompanionModes.ON,
+        companionPersonaId: params.companionPersonaId,
+        // Pinned off: the raw insert defaults 'auto', and an aside is a private
+        // thinking surface — never passively extracted.
+        memoryMode: MemoryModes.OFF,
+        parentStreamId: params.parentStreamId,
+        parentAnchorId: anchorId,
+        createdBy: params.createdBy,
+      })
+
+      await StreamMemberRepository.insert(client, stream.id, params.createdBy)
+
+      if (params.contextBag) {
+        await ContextBagRepository.insert(client, {
+          workspaceId: params.workspaceId,
+          streamId: stream.id,
+          intent: params.contextBag.intent,
+          refs: params.contextBag.refs,
+          createdBy: params.createdBy,
+        })
+      }
+
+      if (params.allowedToolCategories !== undefined) {
+        await StreamPoliciesRepository.setToolPolicy(
+          client,
+          params.workspaceId,
+          stream.id,
+          params.allowedToolCategories
+        )
+      }
+
+      await OutboxRepository.insert(client, "stream:created", {
+        workspaceId: params.workspaceId,
+        streamId: stream.id,
+        stream,
+      })
+
+      return stream
+    })
   }
 
   async createChannel(params: CreateChannelParams): Promise<Stream> {
@@ -941,15 +1060,15 @@ export class StreamService {
   ): Promise<ToolPrivacyPolicy> {
     return withTransaction(this.pool, async (client) => {
       const { target } = await assertStreamWritable(client, { workspaceId, streamId, principal })
-      if (target.type !== StreamTypes.SCRATCHPAD) {
-        throw new HttpError("Tool policy can only be set on a scratchpad", {
+      if (target.type !== StreamTypes.SCRATCHPAD && target.type !== StreamTypes.ASIDE) {
+        throw new HttpError("Tool policy can only be set on a scratchpad or aside", {
           status: 400,
           code: "INVALID_STREAM_TYPE",
         })
       }
       const ownerId = principal.kind === "user" ? principal.userId : null
       if (target.createdBy !== ownerId) {
-        throw new HttpError("Only the scratchpad owner can change its tool policy", {
+        throw new HttpError("Only the stream owner can change its tool policy", {
           status: 403,
           code: "FORBIDDEN",
         })

--- a/apps/backend/src/features/streams/write-authority.ts
+++ b/apps/backend/src/features/streams/write-authority.ts
@@ -31,8 +31,14 @@ export function deriveStreamViewerState(params: {
   target: Pick<AuthorityStream, "type" | "archivedAt">
   root: Pick<AuthorityStream, "archivedAt">
   participates: boolean
+  /**
+   * Asides only: whether the host (parent) stream is effectively archived.
+   * An aside is a root of its own, so root-archival never covers the host —
+   * it reads read-only while the host it annotates is archived.
+   */
+  parentEffectivelyArchived?: boolean
 }): StreamViewerState {
-  if (params.target.archivedAt || params.root.archivedAt) {
+  if (params.target.archivedAt || params.root.archivedAt || params.parentEffectivelyArchived) {
     return { readOnly: true, readOnlyReason: StreamReadOnlyReasons.ARCHIVED }
   }
   if (params.target.type === StreamTypes.SYSTEM) {
@@ -123,17 +129,31 @@ export async function lockEffectiveStreams(
   workspaceId: string,
   streamIds: readonly string[],
   suppliedSnapshots?: readonly Stream[]
-): Promise<Array<{ target: Stream; root: Stream }>> {
+): Promise<Array<{ target: Stream; root: Stream; parentEffectivelyArchived: boolean }>> {
   const targetIds = [...new Set(streamIds)].sort()
   if (targetIds.length === 0) return []
   const snapshots = suppliedSnapshots ?? (await StreamRepository.findByIdsInWorkspace(db, workspaceId, targetIds))
   const snapshotById = new Map(snapshots.map((stream) => [stream.id, stream]))
   const lockIds = new Set<string>()
+  const asideParentIds = new Set<string>()
   for (const targetId of targetIds) {
     const target = snapshotById.get(targetId)
     if (!target || target.workspaceId !== workspaceId) throw inaccessibleStream()
     lockIds.add(target.id)
     lockIds.add(target.rootStreamId ?? target.id)
+    if (target.type === StreamTypes.ASIDE && target.parentStreamId) {
+      asideParentIds.add(target.parentStreamId)
+    }
+  }
+  // An aside's effective archive state includes its host (parent) chain, so the
+  // parent and the parent's root join the same id-ordered lock set.
+  if (asideParentIds.size > 0) {
+    const parents = await StreamRepository.findByIdsInWorkspace(db, workspaceId, [...asideParentIds])
+    if (parents.length !== asideParentIds.size) throw inaccessibleStream()
+    for (const parent of parents) {
+      lockIds.add(parent.id)
+      lockIds.add(parent.rootStreamId ?? parent.id)
+    }
   }
   const locked = await StreamRepository.findByIdsForUpdateBlocking(db, workspaceId, [...lockIds])
   const lockedById = new Map(locked.map((stream) => [stream.id, stream]))
@@ -143,7 +163,14 @@ export async function lockEffectiveStreams(
     if (!target || !root || target.workspaceId !== workspaceId || root.workspaceId !== workspaceId) {
       throw inaccessibleStream()
     }
-    return { target, root }
+    let parentEffectivelyArchived = false
+    if (target.type === StreamTypes.ASIDE && target.parentStreamId) {
+      const parent = lockedById.get(target.parentStreamId)
+      const parentRoot = parent && lockedById.get(parent.rootStreamId ?? parent.id)
+      if (!parent || !parentRoot) throw inaccessibleStream()
+      parentEffectivelyArchived = Boolean(parent.archivedAt || parentRoot.archivedAt)
+    }
+    return { target, root, parentEffectivelyArchived }
   })
 }
 
@@ -168,10 +195,10 @@ export async function resolveLockedStreamAuthorities(
       ? await StreamMemberRepository.lockMemberships(db, rootIds, params.principal.userId)
       : await BotChannelAccessRepository.lockGrants(db, params.workspaceId, params.principal.botId, rootIds)
 
-  return facts.map(({ target, root }) => {
+  return facts.map(({ target, root, parentEffectivelyArchived }) => {
     const participates = participatingRootIds.has(root.id)
     if (root.visibility !== Visibilities.PUBLIC && !participates) throw inaccessibleStream()
-    return { target, root, state: deriveStreamViewerState({ target, root, participates }) }
+    return { target, root, state: deriveStreamViewerState({ target, root, participates, parentEffectivelyArchived }) }
   })
 }
 

--- a/apps/backend/src/features/streams/write-authority.ts
+++ b/apps/backend/src/features/streams/write-authority.ts
@@ -32,9 +32,10 @@ export function deriveStreamViewerState(params: {
   root: Pick<AuthorityStream, "archivedAt">
   participates: boolean
   /**
-   * Asides only: whether the host (parent) stream is effectively archived.
-   * An aside is a root of its own, so root-archival never covers the host —
-   * it reads read-only while the host it annotates is archived.
+   * Whether the host (parent) of the effective aside root is archived. An aside
+   * is a root of its own, so root-archival never covers the host — the aside,
+   * and every thread rooted in it, reads read-only while the host it annotates
+   * is archived.
    */
   parentEffectivelyArchived?: boolean
 }): StreamViewerState {
@@ -135,28 +136,37 @@ export async function lockEffectiveStreams(
   const snapshots = suppliedSnapshots ?? (await StreamRepository.findByIdsInWorkspace(db, workspaceId, targetIds))
   const snapshotById = new Map(snapshots.map((stream) => [stream.id, stream]))
   const lockIds = new Set<string>()
-  const asideParentIds = new Set<string>()
   for (const targetId of targetIds) {
     const target = snapshotById.get(targetId)
     if (!target || target.workspaceId !== workspaceId) throw inaccessibleStream()
     lockIds.add(target.id)
     lockIds.add(target.rootStreamId ?? target.id)
-    if (target.type === StreamTypes.ASIDE && target.parentStreamId) {
-      asideParentIds.add(target.parentStreamId)
-    }
-  }
-  // An aside's effective archive state includes its host (parent) chain, so the
-  // parent and the parent's root join the same id-ordered lock set.
-  if (asideParentIds.size > 0) {
-    const parents = await StreamRepository.findByIdsInWorkspace(db, workspaceId, [...asideParentIds])
-    if (parents.length !== asideParentIds.size) throw inaccessibleStream()
-    for (const parent of parents) {
-      lockIds.add(parent.id)
-      lockIds.add(parent.rootStreamId ?? parent.id)
-    }
   }
   const locked = await StreamRepository.findByIdsForUpdateBlocking(db, workspaceId, [...lockIds])
   const lockedById = new Map(locked.map((stream) => [stream.id, stream]))
+  // An aside's effective archive state includes its host (parent) chain — for
+  // the aside itself and for every thread rooted in it. The root row is only
+  // known once locked, so the host and the host's root join in a second round;
+  // only the aside's creator and its companion ever write here, and both lock
+  // in this same order, so the two rounds cannot form a cycle.
+  const hostIds = new Set<string>()
+  for (const stream of lockedById.values()) {
+    if (stream.type === StreamTypes.ASIDE && stream.parentStreamId && !lockedById.has(stream.parentStreamId)) {
+      hostIds.add(stream.parentStreamId)
+    }
+  }
+  if (hostIds.size > 0) {
+    const hosts = await StreamRepository.findByIdsInWorkspace(db, workspaceId, [...hostIds])
+    if (hosts.length !== hostIds.size) throw inaccessibleStream()
+    const hostLockIds = new Set<string>()
+    for (const host of hosts) {
+      hostLockIds.add(host.id)
+      hostLockIds.add(host.rootStreamId ?? host.id)
+    }
+    for (const stream of await StreamRepository.findByIdsForUpdateBlocking(db, workspaceId, [...hostLockIds])) {
+      lockedById.set(stream.id, stream)
+    }
+  }
   return targetIds.map((targetId) => {
     const target = lockedById.get(targetId)
     const root = target && lockedById.get(target.rootStreamId ?? target.id)
@@ -164,11 +174,11 @@ export async function lockEffectiveStreams(
       throw inaccessibleStream()
     }
     let parentEffectivelyArchived = false
-    if (target.type === StreamTypes.ASIDE && target.parentStreamId) {
-      const parent = lockedById.get(target.parentStreamId)
-      const parentRoot = parent && lockedById.get(parent.rootStreamId ?? parent.id)
-      if (!parent || !parentRoot) throw inaccessibleStream()
-      parentEffectivelyArchived = Boolean(parent.archivedAt || parentRoot.archivedAt)
+    if (root.type === StreamTypes.ASIDE && root.parentStreamId) {
+      const host = lockedById.get(root.parentStreamId)
+      const hostRoot = host && lockedById.get(host.rootStreamId ?? host.id)
+      if (!host || !hostRoot) throw inaccessibleStream()
+      parentEffectivelyArchived = Boolean(host.archivedAt || hostRoot.archivedAt)
     }
     return { target, root, parentEffectivelyArchived }
   })

--- a/apps/backend/src/lib/outbox/broadcast-handler.test.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.test.ts
@@ -252,7 +252,7 @@ describe("BroadcastHandler", () => {
     const event = makeEvent(1n, "stream:created", {
       workspaceId: "ws_1",
       streamId: "stream_parent",
-      stream: { id: "stream_thread", parentAnchorId: "msg_1" },
+      stream: { id: "stream_thread", type: "thread", parentAnchorId: "msg_1" },
     })
 
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])
@@ -272,7 +272,7 @@ describe("BroadcastHandler", () => {
     const event = makeEvent(1n, "stream:created", {
       workspaceId: "ws_1",
       streamId: "stream_parent",
-      stream: { id: "stream_thread", parentAnchorId: "event_call" },
+      stream: { id: "stream_thread", type: "thread", parentAnchorId: "event_call" },
     })
 
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event])

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -186,12 +186,14 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
   }
 
   // stream:created — threads go to the parent stream's audience; DMs to the
-  // two participants; private streams (scratchpads, private channels) to the
-  // creator only (additional members learn via stream:member_added); public
-  // streams to the whole workspace.
+  // two participants; private streams (scratchpads, asides, private channels)
+  // to the creator only (additional members learn via stream:member_added);
+  // public streams to the whole workspace. The anchored branch is thread-only:
+  // an aside is anchored too, but routing it to the parent's audience would
+  // broadcast a private stream to every host-stream member.
   if (isOutboxEventType(event, "stream:created")) {
     const payload = event.payload as StreamCreatedOutboxPayload
-    if (payload.stream.parentAnchorId) {
+    if (payload.stream.parentAnchorId && payload.stream.type === StreamTypes.THREAD) {
       return [streamGroup(payload.streamId)]
     }
     if (payload.stream.type === StreamTypes.DM && payload.dmUserIds?.length === 2) {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1149,7 +1149,7 @@ export async function startServer(): Promise<ServerInstance> {
         }
       )
       return result.ok
-        ? { ok: true, memoId: result.memoId, title: result.title, deduped: result.deduped }
+        ? { ok: true, memoId: result.memoId, title: result.title, deduped: result.deduped, scope: result.scope }
         : { ok: false }
     },
   })

--- a/apps/backend/tests/integration/aside-foundations.test.ts
+++ b/apps/backend/tests/integration/aside-foundations.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Aside stream-type foundations (PR1): is the new type safe and private at the
+ * data layer?
+ *
+ * An aside is a private, creator-only, companion-backed root stream whose
+ * `parent_stream_id`/`parent_anchor_id` are contextual pointers only — never
+ * access-bearing (INV-62). These tests pin the seams a default branch would
+ * silently break: access, anchor uniqueness, the descendant membership sweep,
+ * memo scope, archive inheritance, outbox routing, and the "In this stream"
+ * projection.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService, StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { resolveMemoScopeForStreamId } from "../../src/features/memos"
+import { resolveDeliveryGroups, userGroup, type OutboxEvent } from "../../src/lib/outbox"
+import { HttpError } from "../../src/lib/errors"
+import { userId, workspaceId, messageId } from "../../src/lib/id"
+import { MemoScopes, StreamTypes, StreamErrorCodes, type Stream } from "@threa/types"
+
+describe("Aside foundations", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let wsId: string
+  let creator: string
+  let member: string
+  let sequence = 1n
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    wsId = workspaceId()
+    await withTransaction(pool, async (client) => {
+      creator = (await addTestMember(client, wsId, userId())).id
+      member = (await addTestMember(client, wsId, userId())).id
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Aside Test Workspace",
+        slug: `aside-ws-${wsId.toLowerCase()}`,
+        createdBy: creator,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function createChannel(slug: string, memberIds: string[] = []): Promise<Stream> {
+    return streamService.createChannel({
+      workspaceId: wsId,
+      slug,
+      visibility: "public",
+      createdBy: creator,
+      memberIds,
+    })
+  }
+
+  async function insertMessage(streamId: string, authorId: string): Promise<string> {
+    const id = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id,
+        streamId,
+        sequence: sequence++,
+        authorId,
+        authorType: "user",
+        ...testMessageContent("host message"),
+      })
+    })
+    return id
+  }
+
+  async function outboxStreamCreatedFor(streamId: string): Promise<OutboxEvent> {
+    const result = await pool.query<{ id: string; event_type: string; payload: Record<string, unknown> }>(
+      `SELECT id, event_type, payload FROM outbox
+       WHERE event_type = 'stream:created' AND payload->>'streamId' = $1`,
+      [streamId]
+    )
+    expect(result.rows).toHaveLength(1)
+    const row = result.rows[0]
+    return { id: BigInt(row.id), eventType: row.event_type, payload: row.payload, createdAt: new Date() } as OutboxEvent
+  }
+
+  test("aside is creator-only, including a thread inside it (INV-62)", async () => {
+    const channel = await createChannel("aside-access", [member])
+    const anchorId = await insertMessage(channel.id, member)
+
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+    expect(aside).toMatchObject({
+      type: StreamTypes.ASIDE,
+      visibility: "private",
+      companionMode: "on",
+      memoryMode: "off",
+      rootStreamId: null,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+    })
+
+    expect(await streamService.tryAccess(aside.id, wsId, creator)).not.toBeNull()
+    expect(await streamService.tryAccess(aside.id, wsId, member)).toBeNull()
+
+    const asideMessage = await insertMessage(aside.id, creator)
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: aside.id,
+      parentAnchorId: asideMessage,
+      createdBy: creator,
+      principal: { kind: "user", userId: creator },
+    })
+    expect(thread.rootStreamId).toBe(aside.id)
+    expect(await streamService.tryAccess(thread.id, wsId, creator)).not.toBeNull()
+    expect(await streamService.tryAccess(thread.id, wsId, member)).toBeNull()
+  })
+
+  test("multiple asides share an anchor; a thread on the same anchor is a real thread", async () => {
+    const channel = await createChannel("aside-anchor")
+    const anchorId = await insertMessage(channel.id, creator)
+
+    const first = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+    const second = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+    expect(second.id).not.toBe(first.id)
+    expect(second.type).toBe(StreamTypes.ASIDE)
+
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+      principal: { kind: "user", userId: creator },
+    })
+    expect(thread.type).toBe(StreamTypes.THREAD)
+    expect([first.id, second.id]).not.toContain(thread.id)
+
+    const threadsByAnchor = await StreamRepository.findThreadsForMessages(pool, channel.id)
+    expect(threadsByAnchor.get(anchorId)).toBe(thread.id)
+  })
+
+  test("channel kick sweeps thread membership but preserves the member's aside", async () => {
+    const channel = await createChannel("aside-kick", [member])
+    const anchorId = await insertMessage(channel.id, creator)
+
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: member,
+    })
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: member,
+      principal: { kind: "user", userId: member },
+    })
+    expect(await StreamMemberRepository.isMember(pool, thread.id, member)).toBe(true)
+
+    await streamService.removeMember(channel.id, member, wsId, creator)
+
+    expect(await StreamMemberRepository.isMember(pool, channel.id, member)).toBe(false)
+    expect(await StreamMemberRepository.isMember(pool, thread.id, member)).toBe(false)
+    expect(await StreamMemberRepository.isMember(pool, aside.id, member)).toBe(true)
+  })
+
+  test("memo scope for an aside is the creator's user tier", async () => {
+    const channel = await createChannel("aside-memo")
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      createdBy: creator,
+    })
+
+    const scope = await resolveMemoScopeForStreamId(pool, aside.id)
+    expect(scope).toEqual({ scope: MemoScopes.USER, scopeUserId: creator, rootStreamId: aside.id })
+  })
+
+  test("aside is read-only while its direct parent is archived", async () => {
+    const channel = await createChannel("aside-archive-direct")
+    const anchorId = await insertMessage(channel.id, creator)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+
+    await streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })
+
+    await streamService.archiveStream(channel.id, wsId, creator)
+    expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject({
+      code: StreamErrorCodes.READ_ONLY,
+      details: { reason: "archived" },
+    })
+
+    await streamService.unarchiveStream(channel.id, wsId, creator)
+    await streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })
+  })
+
+  test("aside anchored in a thread is read-only when the thread's root is archived", async () => {
+    const channel = await createChannel("aside-archive-root")
+    const anchorId = await insertMessage(channel.id, creator)
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+      principal: { kind: "user", userId: creator },
+    })
+    const threadMessage = await insertMessage(thread.id, creator)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: thread.id,
+      parentAnchorId: threadMessage,
+      createdBy: creator,
+    })
+
+    await streamService.archiveStream(channel.id, wsId, creator)
+    expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject({
+      code: StreamErrorCodes.READ_ONLY,
+      details: { reason: "archived" },
+    })
+  })
+
+  test("aside stream:created routes to the creator group only", async () => {
+    const channel = await createChannel("aside-routing", [member])
+    const anchorId = await insertMessage(channel.id, creator)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+
+    const event = await outboxStreamCreatedFor(aside.id)
+    expect(resolveDeliveryGroups(event)).toEqual([userGroup(creator)])
+  })
+
+  test("anchor must belong to the parent stream", async () => {
+    const channel = await createChannel("aside-anchor-mismatch")
+    const otherChannel = await createChannel("aside-anchor-elsewhere")
+    const foreignAnchor = await insertMessage(otherChannel.id, creator)
+
+    expect(
+      streamService.createAside({
+        workspaceId: wsId,
+        parentStreamId: channel.id,
+        parentAnchorId: foreignAnchor,
+        createdBy: creator,
+      })
+    ).rejects.toBeInstanceOf(HttpError)
+  })
+
+  test("threads project into stream_context_items; asides never do", async () => {
+    const channel = await createChannel("aside-context")
+    const anchorId = await insertMessage(channel.id, creator)
+
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+      principal: { kind: "user", userId: creator },
+    })
+
+    const items = await pool.query<{ ref_id: string }>(`SELECT ref_id FROM stream_context_items WHERE stream_id = $1`, [
+      channel.id,
+    ])
+    const refIds = items.rows.map((row) => row.ref_id)
+    expect(refIds).toContain(thread.id)
+    expect(refIds).not.toContain(aside.id)
+  })
+})

--- a/apps/backend/tests/integration/aside-foundations.test.ts
+++ b/apps/backend/tests/integration/aside-foundations.test.ts
@@ -5,34 +5,57 @@
  * An aside is a private, creator-only, companion-backed root stream whose
  * `parent_stream_id`/`parent_anchor_id` are contextual pointers only — never
  * access-bearing (INV-62). These tests pin the seams a default branch would
- * silently break: access, anchor uniqueness, the descendant membership sweep,
- * memo scope, archive inheritance, outbox routing, and the "In this stream"
- * projection.
+ * silently break: access, the descendant membership sweep, memo scope, archive
+ * inheritance, outbox routing, and the "In this stream" projection.
+ *
+ * Cross-type anchor sharing (aside + thread on ONE anchor, multiple asides per
+ * anchor) is deliberately absent: it needs the untyped anchor index dropped,
+ * which happens in the stack's final layer. Those tests are parked in the
+ * aside-build scratchpad (`pr8-parked-tests/`) until then; everything here
+ * passes with BOTH indexes present.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
 import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
 import { WorkspaceRepository } from "../../src/features/workspaces"
-import { StreamService, StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import { StreamService, StreamMemberRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
-import { resolveMemoScopeForStreamId } from "../../src/features/memos"
+import { MemoService, resolveMemoScopeForStreamId } from "../../src/features/memos"
+import type { EmbeddingServiceLike } from "../../src/features/memos"
 import { resolveDeliveryGroups, userGroup, type OutboxEvent } from "../../src/lib/outbox"
-import { HttpError } from "../../src/lib/errors"
 import { userId, workspaceId, messageId } from "../../src/lib/id"
 import { MemoScopes, StreamTypes, StreamErrorCodes, type Stream } from "@threa/types"
+
+const EMBEDDING_DIMENSIONS = 1536
 
 describe("Aside foundations", () => {
   let pool: Pool
   let streamService: StreamService
+  let memoService: MemoService
   let wsId: string
   let creator: string
   let member: string
   let sequence = 1n
+  let embeddingsIssued = 0
 
   beforeAll(async () => {
     pool = await setupTestDatabase()
     streamService = new StreamService(pool)
+    memoService = new MemoService({
+      pool,
+      classifier: {} as never,
+      memorizer: {} as never,
+      messageFormatter: {} as never,
+      embeddingService: {
+        embedBatch: async (texts: string[]) =>
+          texts.map(() => {
+            const vector = new Array(EMBEDDING_DIMENSIONS).fill(0)
+            vector[embeddingsIssued++ % EMBEDDING_DIMENSIONS] = 1
+            return vector
+          }),
+      } as unknown as EmbeddingServiceLike,
+    })
     wsId = workspaceId()
     await withTransaction(pool, async (client) => {
       creator = (await addTestMember(client, wsId, userId())).id
@@ -118,57 +141,27 @@ describe("Aside foundations", () => {
       principal: { kind: "user", userId: creator },
     })
     expect(thread.rootStreamId).toBe(aside.id)
+    // The persisted thread row copies the aside's companion setting (C2).
+    expect(thread.companionMode).toBe("on")
     expect(await streamService.tryAccess(thread.id, wsId, creator)).not.toBeNull()
     expect(await streamService.tryAccess(thread.id, wsId, member)).toBeNull()
   })
 
-  test("multiple asides share an anchor; a thread on the same anchor is a real thread", async () => {
-    const channel = await createChannel("aside-anchor")
-    const anchorId = await insertMessage(channel.id, creator)
-
-    const first = await streamService.createAside({
-      workspaceId: wsId,
-      parentStreamId: channel.id,
-      parentAnchorId: anchorId,
-      createdBy: creator,
-    })
-    const second = await streamService.createAside({
-      workspaceId: wsId,
-      parentStreamId: channel.id,
-      parentAnchorId: anchorId,
-      createdBy: creator,
-    })
-    expect(second.id).not.toBe(first.id)
-    expect(second.type).toBe(StreamTypes.ASIDE)
-
-    const thread = await streamService.createThread({
-      workspaceId: wsId,
-      parentStreamId: channel.id,
-      parentAnchorId: anchorId,
-      createdBy: creator,
-      principal: { kind: "user", userId: creator },
-    })
-    expect(thread.type).toBe(StreamTypes.THREAD)
-    expect([first.id, second.id]).not.toContain(thread.id)
-
-    const threadsByAnchor = await StreamRepository.findThreadsForMessages(pool, channel.id)
-    expect(threadsByAnchor.get(anchorId)).toBe(thread.id)
-  })
-
   test("channel kick sweeps thread membership but preserves the member's aside", async () => {
     const channel = await createChannel("aside-kick", [member])
-    const anchorId = await insertMessage(channel.id, creator)
+    const asideAnchor = await insertMessage(channel.id, creator)
+    const threadAnchor = await insertMessage(channel.id, creator)
 
     const aside = await streamService.createAside({
       workspaceId: wsId,
       parentStreamId: channel.id,
-      parentAnchorId: anchorId,
+      parentAnchorId: asideAnchor,
       createdBy: member,
     })
     const thread = await streamService.createThread({
       workspaceId: wsId,
       parentStreamId: channel.id,
-      parentAnchorId: anchorId,
+      parentAnchorId: threadAnchor,
       createdBy: member,
       principal: { kind: "user", userId: member },
     })
@@ -193,6 +186,38 @@ describe("Aside foundations", () => {
     expect(scope).toEqual({ scope: MemoScopes.USER, scopeUserId: creator, rootStreamId: aside.id })
   })
 
+  test("save_memo with a workspace override from an aside lands user-scoped", async () => {
+    const channel = await createChannel("aside-memo-clamp")
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      createdBy: creator,
+    })
+    const sourceId = await insertMessage(aside.id, creator)
+
+    const saved = await memoService.saveMemo({
+      workspaceId: wsId,
+      streamId: aside.id,
+      sessionId: null,
+      sourceStreamIds: [aside.id],
+      title: "Churn numbers are quarterly",
+      abstract: "The churn figures in the deck are quarterly, not monthly.",
+      keyPoints: ["quarterly"],
+      tags: ["metrics"],
+      knowledgeType: "context",
+      sourceMessageIds: [sourceId],
+      invokingUserId: creator,
+      scope: MemoScopes.WORKSPACE,
+    })
+    expect(saved).toMatchObject({ ok: true })
+
+    const memo = await pool.query<{ scope: string; scope_user_id: string | null }>(
+      `SELECT scope, scope_user_id FROM memos WHERE id = $1`,
+      [(saved as { memoId: string }).memoId]
+    )
+    expect(memo.rows[0]).toEqual({ scope: MemoScopes.USER, scope_user_id: creator })
+  })
+
   test("aside is read-only while its direct parent is archived", async () => {
     const channel = await createChannel("aside-archive-direct")
     const anchorId = await insertMessage(channel.id, creator)
@@ -206,10 +231,12 @@ describe("Aside foundations", () => {
     await streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })
 
     await streamService.archiveStream(channel.id, wsId, creator)
-    expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject({
-      code: StreamErrorCodes.READ_ONLY,
-      details: { reason: "archived" },
-    })
+    await expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject(
+      {
+        code: StreamErrorCodes.READ_ONLY,
+        details: { reason: "archived" },
+      }
+    )
 
     await streamService.unarchiveStream(channel.id, wsId, creator)
     await streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })
@@ -234,10 +261,12 @@ describe("Aside foundations", () => {
     })
 
     await streamService.archiveStream(channel.id, wsId, creator)
-    expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject({
-      code: StreamErrorCodes.READ_ONLY,
-      details: { reason: "archived" },
-    })
+    await expect(streamService.assertWritable(aside.id, wsId, { kind: "user", userId: creator })).rejects.toMatchObject(
+      {
+        code: StreamErrorCodes.READ_ONLY,
+        details: { reason: "archived" },
+      }
+    )
   })
 
   test("aside stream:created routes to the creator group only", async () => {
@@ -259,30 +288,48 @@ describe("Aside foundations", () => {
     const otherChannel = await createChannel("aside-anchor-elsewhere")
     const foreignAnchor = await insertMessage(otherChannel.id, creator)
 
-    expect(
+    await expect(
       streamService.createAside({
         workspaceId: wsId,
         parentStreamId: channel.id,
         parentAnchorId: foreignAnchor,
         createdBy: creator,
       })
-    ).rejects.toBeInstanceOf(HttpError)
+    ).rejects.toMatchObject({ code: "MESSAGE_NOT_FOUND" })
+  })
+
+  test("an aside cannot host another aside", async () => {
+    const channel = await createChannel("aside-no-nesting")
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      createdBy: creator,
+    })
+
+    await expect(
+      streamService.createAside({
+        workspaceId: wsId,
+        parentStreamId: aside.id,
+        createdBy: creator,
+      })
+    ).rejects.toMatchObject({ code: "ASIDE_HOST_TYPE_INVALID" })
   })
 
   test("threads project into stream_context_items; asides never do", async () => {
     const channel = await createChannel("aside-context")
-    const anchorId = await insertMessage(channel.id, creator)
+    const asideAnchor = await insertMessage(channel.id, creator)
+    const threadAnchor = await insertMessage(channel.id, creator)
 
     const aside = await streamService.createAside({
       workspaceId: wsId,
       parentStreamId: channel.id,
-      parentAnchorId: anchorId,
+      parentAnchorId: asideAnchor,
       createdBy: creator,
     })
     const thread = await streamService.createThread({
       workspaceId: wsId,
       parentStreamId: channel.id,
-      parentAnchorId: anchorId,
+      parentAnchorId: threadAnchor,
       createdBy: creator,
       principal: { kind: "user", userId: creator },
     })

--- a/apps/backend/tests/integration/aside-foundations.test.ts
+++ b/apps/backend/tests/integration/aside-foundations.test.ts
@@ -211,7 +211,7 @@ describe("Aside foundations", () => {
       invokingUserId: creator,
       scope: MemoScopes.WORKSPACE,
     })
-    expect(saved).toMatchObject({ ok: true })
+    expect(saved).toMatchObject({ ok: true, scope: MemoScopes.USER })
 
     const memo = await pool.query<{ scope: string; scope_user_id: string | null }>(
       `SELECT scope, scope_user_id FROM memos WHERE id = $1`,
@@ -269,6 +269,39 @@ describe("Aside foundations", () => {
         details: { reason: "archived" },
       }
     )
+  })
+
+  test("a thread inside an aside is read-only when the aside's host is archived", async () => {
+    const channel = await createChannel("aside-archive-thread-in-aside")
+    const aside = await streamService.createAside({ workspaceId: wsId, parentStreamId: channel.id, createdBy: creator })
+    const asideMessage = await insertMessage(aside.id, creator)
+    const thread = await streamService.createThread({
+      workspaceId: wsId,
+      parentStreamId: aside.id,
+      parentAnchorId: asideMessage,
+      createdBy: creator,
+      principal: { kind: "user", userId: creator },
+    })
+    await expect(
+      streamService.assertWritable(thread.id, wsId, { kind: "user", userId: creator })
+    ).resolves.toBeUndefined()
+
+    await streamService.archiveStream(channel.id, wsId, creator)
+    await expect(
+      streamService.assertWritable(thread.id, wsId, { kind: "user", userId: creator })
+    ).rejects.toMatchObject({
+      code: StreamErrorCodes.READ_ONLY,
+      details: { reason: "archived" },
+    })
+  })
+
+  test("an aside's companion cannot be switched off or replaced", async () => {
+    const channel = await createChannel("aside-companion-pinned")
+    const aside = await streamService.createAside({ workspaceId: wsId, parentStreamId: channel.id, createdBy: creator })
+    await expect(streamService.updateCompanionMode(aside.id, wsId, "off", null, creator)).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_STREAM_TYPE",
+    })
   })
 
   test("aside stream:created routes to the creator group only", async () => {

--- a/apps/backend/tests/integration/aside-foundations.test.ts
+++ b/apps/backend/tests/integration/aside-foundations.test.ts
@@ -21,6 +21,8 @@ import { setupTestDatabase, withTransaction, addTestMember, testMessageContent }
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamService, StreamMemberRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
+import { DynamicNamingStreamTarget } from "../../src/features/dynamic-naming"
+import { MessageFormatter } from "../../src/lib/ai/message-formatter"
 import { MemoService, resolveMemoScopeForStreamId } from "../../src/features/memos"
 import type { EmbeddingServiceLike } from "../../src/features/memos"
 import { resolveDeliveryGroups, userGroup, type OutboxEvent } from "../../src/lib/outbox"
@@ -313,6 +315,52 @@ describe("Aside foundations", () => {
         createdBy: creator,
       })
     ).rejects.toMatchObject({ code: "ASIDE_HOST_TYPE_INVALID" })
+  })
+
+  test("an aside cannot be opened on an archived host", async () => {
+    const channel = await createChannel("aside-archived-host")
+    const anchorId = await insertMessage(channel.id, creator)
+    await streamService.archiveStream(channel.id, wsId, creator)
+
+    await expect(
+      streamService.createAside({
+        workspaceId: wsId,
+        parentStreamId: channel.id,
+        parentAnchorId: anchorId,
+        createdBy: creator,
+      })
+    ).rejects.toMatchObject({ code: StreamErrorCodes.READ_ONLY, details: { reason: "archived" } })
+  })
+
+  test("naming context for an aside lists only the creator's own aside titles", async () => {
+    const channel = await createChannel("aside-naming-titles", [member])
+    const asideOf = (userId: string, displayName?: string) =>
+      insertMessage(channel.id, creator).then((anchorId) =>
+        streamService.createAside({
+          workspaceId: wsId,
+          parentStreamId: channel.id,
+          parentAnchorId: anchorId,
+          createdBy: userId,
+          displayName,
+        })
+      )
+    await asideOf(creator, "Creator's other aside")
+    await asideOf(member, "Member's private aside")
+    const target = await asideOf(creator)
+    await insertMessage(target.id, creator)
+
+    const context = await new DynamicNamingStreamTarget(pool, new MessageFormatter()).loadContext({
+      workspaceId: wsId,
+      targetKind: "stream",
+      targetId: target.id,
+      messageCount: 1,
+      latestMessageAt: new Date(),
+      title: null,
+      titleSource: null,
+      titleRevision: 0,
+    })
+
+    expect(context?.existingTitles).toEqual(["Creator's other aside"])
   })
 
   test("threads project into stream_context_items; asides never do", async () => {

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -1,6 +1,6 @@
 import { StreamTypes } from "@threa/types"
 import type { StreamType } from "@threa/types"
-import { Bell, FileText, Hash, MessageSquare } from "lucide-react"
+import { Bell, FileText, Hash, MessageSquare, MessageSquareDashed } from "lucide-react"
 import type { ComponentType } from "react"
 
 /**
@@ -14,6 +14,7 @@ export const STREAM_ICONS: Record<StreamType, ComponentType<{ className?: string
   [StreamTypes.DM]: MessageSquare,
   [StreamTypes.THREAD]: MessageSquare,
   [StreamTypes.SYSTEM]: Bell,
+  [StreamTypes.ASIDE]: MessageSquareDashed,
 }
 
 /**
@@ -39,6 +40,8 @@ export function getStreamTypeLabel(type: StreamType): string {
       return "DM"
     case StreamTypes.THREAD:
       return "Thread"
+    case StreamTypes.ASIDE:
+      return "Aside"
     default:
       return type
   }
@@ -98,6 +101,7 @@ const FALLBACK_LABELS: Record<string, Record<FallbackContext, string>> = {
   channel: { sidebar: "Untitled", activity: "a channel", breadcrumb: "...", generic: "Untitled", noun: "channel" },
   dm: { sidebar: "Direct message", activity: "a conversation", breadcrumb: "DM", generic: "DM", noun: "DM" },
   system: { sidebar: "System", activity: "system", breadcrumb: "System", generic: "System", noun: "system stream" },
+  aside: { sidebar: "New aside", activity: "an aside", breadcrumb: "Aside", generic: "Aside", noun: "aside" },
 }
 
 /** Context-appropriate fallback text for streams that truly have no name yet. */

--- a/apps/frontend/src/pages/share-picker.tsx
+++ b/apps/frontend/src/pages/share-picker.tsx
@@ -4,6 +4,7 @@ import {
   FileText,
   Hash,
   MessageSquare,
+  MessageSquareDashed,
   Bell,
   Search,
   Plus,
@@ -42,6 +43,7 @@ const STREAM_ICONS: Record<StreamType, React.ComponentType<{ className?: string 
   [StreamTypes.DM]: MessageSquare,
   [StreamTypes.THREAD]: MessageSquare,
   [StreamTypes.SYSTEM]: Bell,
+  [StreamTypes.ASIDE]: MessageSquareDashed,
 }
 
 const TYPE_LABELS: Partial<Record<StreamType, string>> = {

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -7646,7 +7646,7 @@
   },
   "tags": [
     { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
-    { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
+    { "name": "Streams", "description": "List and inspect accessible streams" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     {
       "name": "Conversations",

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -40,7 +40,7 @@
                   "from": { "type": "string" },
                   "type": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] }
+                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"] }
                   },
                   "before": { "type": "string", "format": "date-time" },
                   "after": { "type": "string", "format": "date-time" },
@@ -233,7 +233,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -3169,7 +3169,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -4333,7 +4333,10 @@
                         "type": "object",
                         "properties": {
                           "id": { "type": "string" },
-                          "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                          "type": {
+                            "type": "string",
+                            "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                          },
                           "displayName": { "type": "string" },
                           "slug": { "type": "string" },
                           "description": { "type": "string" },
@@ -4431,7 +4434,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4540,7 +4546,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4950,7 +4959,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5290,7 +5299,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5849,7 +5858,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6177,7 +6186,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6483,7 +6492,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -233,7 +233,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -3169,7 +3169,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -4959,7 +4959,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5299,7 +5299,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5858,7 +5858,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6186,7 +6186,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6492,7 +6492,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -6573,7 +6573,7 @@
   },
   "tags": [
     { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
-    { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
+    { "name": "Streams", "description": "List and inspect accessible streams" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     {
       "name": "Conversations",

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -40,7 +40,7 @@
                   "from": { "type": "string" },
                   "type": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] }
+                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"] }
                   },
                   "before": { "type": "string", "format": "date-time" },
                   "after": { "type": "string", "format": "date-time" },
@@ -4029,7 +4029,10 @@
                         "type": "object",
                         "properties": {
                           "id": { "type": "string" },
-                          "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                          "type": {
+                            "type": "string",
+                            "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                          },
                           "displayName": { "type": "string" },
                           "slug": { "type": "string" },
                           "description": { "type": "string" },
@@ -4124,7 +4127,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4230,7 +4236,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },

--- a/docs/public-api/versions/2026-07-22.json
+++ b/docs/public-api/versions/2026-07-22.json
@@ -6582,7 +6582,7 @@
   },
   "tags": [
     { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
-    { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
+    { "name": "Streams", "description": "List and inspect accessible streams" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     {
       "name": "Conversations",

--- a/docs/public-api/versions/2026-07-22.json
+++ b/docs/public-api/versions/2026-07-22.json
@@ -40,7 +40,7 @@
                   "from": { "type": "string" },
                   "type": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] }
+                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"] }
                   },
                   "before": { "type": "string", "format": "date-time" },
                   "after": { "type": "string", "format": "date-time" },
@@ -4029,7 +4029,10 @@
                         "type": "object",
                         "properties": {
                           "id": { "type": "string" },
-                          "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                          "type": {
+                            "type": "string",
+                            "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                          },
                           "displayName": { "type": "string" },
                           "slug": { "type": "string" },
                           "description": { "type": "string" },
@@ -4127,7 +4130,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4236,7 +4242,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -40,7 +40,7 @@
                   "from": { "type": "string" },
                   "type": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] }
+                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"] }
                   },
                   "before": { "type": "string", "format": "date-time" },
                   "after": { "type": "string", "format": "date-time" },
@@ -202,7 +202,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -3107,7 +3107,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -4271,7 +4271,10 @@
                         "type": "object",
                         "properties": {
                           "id": { "type": "string" },
-                          "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                          "type": {
+                            "type": "string",
+                            "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                          },
                           "displayName": { "type": "string" },
                           "slug": { "type": "string" },
                           "description": { "type": "string" },
@@ -4369,7 +4372,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4478,7 +4484,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4857,7 +4866,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5166,7 +5175,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5694,7 +5703,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5991,7 +6000,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6266,7 +6275,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -7429,7 +7429,7 @@
   },
   "tags": [
     { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
-    { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
+    { "name": "Streams", "description": "List and inspect accessible streams" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     {
       "name": "Conversations",

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -202,7 +202,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -3107,7 +3107,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -4866,7 +4866,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5175,7 +5175,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -5703,7 +5703,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6000,7 +6000,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },
@@ -6275,7 +6275,7 @@
                               "messageId": { "type": "string" },
                               "sourceStreamKind": {
                                 "type": "string",
-                                "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                                "enum": ["scratchpad", "channel", "dm", "thread", "system"]
                               },
                               "sourceVisibility": { "type": "string", "enum": ["public", "private"] }
                             },

--- a/docs/public-api/versions/2026-08-21.json
+++ b/docs/public-api/versions/2026-08-21.json
@@ -40,7 +40,7 @@
                   "from": { "type": "string" },
                   "type": {
                     "type": "array",
-                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] }
+                    "items": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"] }
                   },
                   "before": { "type": "string", "format": "date-time" },
                   "after": { "type": "string", "format": "date-time" },
@@ -4333,7 +4333,10 @@
                         "type": "object",
                         "properties": {
                           "id": { "type": "string" },
-                          "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                          "type": {
+                            "type": "string",
+                            "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                          },
                           "displayName": { "type": "string" },
                           "slug": { "type": "string" },
                           "description": { "type": "string" },
@@ -4431,7 +4434,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -4540,7 +4546,10 @@
                       "type": "object",
                       "properties": {
                         "id": { "type": "string" },
-                        "type": { "type": "string", "enum": ["scratchpad", "channel", "dm", "thread", "system"] },
+                        "type": {
+                          "type": "string",
+                          "enum": ["scratchpad", "channel", "dm", "thread", "system", "aside"]
+                        },
                         "displayName": { "type": "string" },
                         "slug": { "type": "string" },
                         "description": { "type": "string" },
@@ -7637,7 +7646,7 @@
   },
   "tags": [
     { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
-    { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
+    { "name": "Streams", "description": "List and inspect accessible streams" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     {
       "name": "Conversations",

--- a/packages/cli/src/tools/constants.ts
+++ b/packages/cli/src/tools/constants.ts
@@ -1,7 +1,7 @@
 // Mirrors @threa/types constants; inlined because @threa/cli stays dependency-light
 // against the version-pinned public API.
 export const CALLBACK_TOKEN_HEADER = "X-Threa-Callback-Token"
-export const STREAM_TYPES = ["scratchpad", "channel", "dm", "thread", "system"] as const
+export const STREAM_TYPES = ["scratchpad", "channel", "dm", "thread", "system", "aside"] as const
 export const CONVERSATION_STATUSES = ["active", "stalled", "resolved"] as const
 export const MEMO_TYPES = ["message", "conversation"] as const
 export const KNOWLEDGE_TYPES = ["decision", "learning", "procedure", "context", "reference"] as const

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -7,7 +7,7 @@ export const TitleSources = {
   LEGACY: "legacy",
 } as const satisfies Record<string, TitleSource>
 
-export const STREAM_TYPES = ["scratchpad", "channel", "dm", "thread", "system"] as const
+export const STREAM_TYPES = ["scratchpad", "channel", "dm", "thread", "system", "aside"] as const
 export type StreamType = (typeof STREAM_TYPES)[number]
 
 export const StreamTypes = {
@@ -16,6 +16,7 @@ export const StreamTypes = {
   DM: "dm",
   THREAD: "thread",
   SYSTEM: "system",
+  ASIDE: "aside",
 } as const satisfies Record<string, StreamType>
 
 export const DM_PARTICIPANT_COUNT = 2
@@ -268,6 +269,8 @@ export const NOTIFICATION_CONFIG: Record<StreamType, NotificationConfig> = {
   system: { defaultLevel: "everything", allowedLevels: ["everything", "muted"] },
   channel: { defaultLevel: "mentions", allowedLevels: ["everything", "activity", "mentions", "muted"] },
   thread: { defaultLevel: "activity", allowedLevels: ["everything", "activity", "mentions", "muted"] },
+  // Asides are a silent pull surface: the anchor row is the whole signal.
+  aside: { defaultLevel: "muted", allowedLevels: ["muted"] },
 }
 
 export const ACTIVITY_TYPES = [

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -19,6 +19,20 @@ export const StreamTypes = {
   ASIDE: "aside",
 } as const satisfies Record<string, StreamType>
 
+/**
+ * Stream kinds a shared-message `private` placeholder may report. Derived from
+ * `STREAM_TYPES` minus `aside`: an aside presents as a scratchpad to
+ * non-viewers, so the placeholder vocabulary never discloses one exists.
+ */
+export const SHARED_SOURCE_STREAM_KINDS = [
+  "scratchpad",
+  "channel",
+  "dm",
+  "thread",
+  "system",
+] as const satisfies readonly Exclude<StreamType, "aside">[]
+export type SharedSourceStreamKind = (typeof SHARED_SOURCE_STREAM_KINDS)[number]
+
 export const DM_PARTICIPANT_COUNT = 2
 
 export const STREAM_READ_ONLY_REASONS = ["archived", "system_stream", "not_a_member"] as const

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,9 @@ export {
   STREAM_TYPES,
   type StreamType,
   StreamTypes,
+  // Shared-message private-placeholder kinds (STREAM_TYPES minus aside)
+  SHARED_SOURCE_STREAM_KINDS,
+  type SharedSourceStreamKind,
   DM_PARTICIPANT_COUNT,
   STREAM_READ_ONLY_REASONS,
   type StreamReadOnlyReason,

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -9,7 +9,7 @@
  * a future slot type adds a union member and its own namespace without
  * reinterpreting these keys. Wire shape only — strings/dates, never `Date`.
  */
-import type { StreamType, Visibility } from "./constants"
+import type { SharedSourceStreamKind, Visibility } from "./constants"
 import type { AttachmentSummary } from "./domain"
 import type { ContentRange } from "./prosemirror"
 
@@ -53,7 +53,7 @@ export type SharedMessageSlot =
       type: "sharedMessage"
       state: "private"
       messageId: string
-      sourceStreamKind: StreamType
+      sourceStreamKind: SharedSourceStreamKind
       sourceVisibility: Visibility
     }
   | { type: "sharedMessage"; state: "truncated"; messageId: string; streamId: string }


### PR DESCRIPTION
_🤖 by Claude Fable 5_

## Problem

Aside (plan: [Seer project](https://seer.build/ws_vbyzjvdg6g/p/aside), [spec](https://seer.build/ws_vbyzjvdg6g/b/aside-plan/)) needs a stream type that can sit privately inside a public channel: self-rooted access like a scratchpad, with contextual parent pointers like a thread. Nothing in the current data layer supports that safely — the anchor uniqueness index would let a thread-create silently return an aside, a channel kick would delete the creator's aside membership, and `stream:created` routing would broadcast the private stream to the whole host channel.

## Solution

Stack bottom (1/8): the `aside` type and every data-layer safety pin, no UI. Creation clones the scratchpad arm (self-rooted, private, creator-only membership, companion on, `memoryMode` pinned off) plus parent validation: anchor must belong to the parent, host type restricted to channel|dm|scratchpad|thread, E2E hosts refused. Pins, each closing a verified leak or corruption path: typed anchor uniqueness index (threads only; `insertThreadOrFind` retargeted), thread-only membership sweep, creator-only outbox routing, user-tier memo scope including a clamp on explicit `save_memo` workspace overrides, researcher access = creator's access, no conversation clustering, no `stream_context_items` projection, sharing hydration presents asides as scratchpads even via thread roots (`sourceStreamKind` publicly narrowed to exclude `aside`), archival inherited from the parent through the write-authority lock set.

Deploy sequencing: this PR only **adds** the typed index. The untyped-index drop is deliberately parked for the stack's final layer so it deploys after this code is fully live — old replicas cannot infer an `ON CONFLICT` arbiter once the untyped index is gone. Until that drop lands, an anchor holds at most one of thread/aside — the create endpoint accepts `aside` from this layer on, so an aside on a message that already carries a thread fails at the index until the stack's final layer; the stack merges atomically, so production never sees the gap.

## Proof

New integration suite (real schema, 14): creator-only access incl. non-member thread-in-aside, kick preserves membership, both archive-inheritance cases, creator-only outbox row, memo-scope clamp (the result reports the scope it landed in), hydration masking, thread-inside-aside inherits the host's archive, anchor locked against a concurrent move, companion pinned on, host-type and anchor validation, no projection rows. Plus 51 adjacent integration tests, 746 backend unit tests, typecheck, lint — all observed green locally on a fresh test DB with both indexes present (the exact intermediate production state).

## Caveats

- Cross-type anchor sharing (aside beside an existing thread) 500s until the final layer's drop migration; tests for it are parked with that migration.
- `event-service.ts`'s message-move thread mint doesn't copy companion fields for aside roots — moves can't target asides in v1.

---

_[Claude Fable 5](https://www.anthropic.com/news/claude-fable-5-mythos-5) in [Claude Code](https://claude.com/claude-code)_

