### PR TITLE
feat: camera publish failures land full diagnostics server-side

### DIFF
--- a/apps/backend/src/features/calls/handlers.ts
+++ b/apps/backend/src/features/calls/handlers.ts
@@ -69,6 +69,10 @@ const closeTracksSchema = z
     mids: z.array(z.string().min(1).max(64)).max(16),
     unpublishKinds: z.array(z.enum(PUBLISHED_TRACK_KINDS)).max(4).optional(),
     sdp: sessionDescriptionSchema.optional(),
+    // The client's local failure (e.g. a rejected SDP answer) on a cleanup
+    // close — logged by the service; a client-side throw is otherwise invisible
+    // server-side because the publish leg already returned 200.
+    reason: z.string().max(2048).optional(),
   })
   .refine((body) => body.mids.length > 0 || (body.unpublishKinds?.length ?? 0) > 0, {
     message: "mids or unpublishKinds required",
@@ -310,6 +314,7 @@ export function createCallHandlers({ pool, io, callService, featureFlagService, 
         mids: body.mids,
         unpublishKinds: body.unpublishKinds,
         sdp: body.sdp,
+        reason: body.reason,
       })
       if (result.snapshot) broadcastRoster(io, callId, result.snapshot)
       res.json(result.cf ?? { tracks: [] })

--- a/apps/backend/src/features/calls/service.test.ts
+++ b/apps/backend/src/features/calls/service.test.ts
@@ -19,6 +19,7 @@ import * as observabilityModule from "../../lib/observability"
 import { OutboxRepository } from "../../lib/outbox"
 import { CALL_PRODUCT_CAP } from "./config"
 import { CloudflareRealtimeError } from "./cloudflare"
+import { logger } from "../../lib/logger"
 
 const NOW = new Date("2026-07-19T12:00:00.000Z")
 
@@ -1988,6 +1989,43 @@ describe("CallService.closeTracks", () => {
       expect.objectContaining({ publishedTracks: [{ kind: "mic", trackName: "mic0" }] })
     )
     expect(result).toMatchObject({ cf: null, snapshot: { rosterVersion: 8, roster: [] } })
+  })
+
+  it("should log the client-reported failure reason riding a cleanup close", async () => {
+    stubWithClient()
+    stubTransaction()
+    stubFence(
+      fakeEndpoint({
+        id: "callep_1",
+        cfSessionId: "sess_1",
+        mediaIncarnation: "inc_1",
+        publishedTracks: [{ kind: "camera", trackName: "cam1" }],
+      })
+    )
+    spyOn(CallEndpointRepository, "setPublishedTracks").mockResolvedValue(fakeEndpoint())
+    spyOn(CallRepository, "bumpRosterVersion").mockResolvedValue(3)
+    spyOn(CallParticipantRepository, "listRoster").mockResolvedValue([])
+    const warn = spyOn(logger, "warn")
+
+    await makeServiceWithCf(fakeCloudflare()).closeTracks({
+      workspaceId: "ws_1",
+      callId: "call_1",
+      userId: "usr_1",
+      endpointId: "callep_1",
+      mediaIncarnation: "inc_1",
+      mids: [],
+      unpublishKinds: ["camera"],
+      reason: "InvalidAccessError: Failed to set remote answer sdp",
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callId: "call_1",
+        endpointId: "callep_1",
+        reason: "InvalidAccessError: Failed to set remote answer sdp",
+      }),
+      "Client reported a local failure on unpublish"
+    )
   })
 
   it("should skip CF entirely on a mid-less unpublish (client-side publish failure cleanup)", async () => {

--- a/apps/backend/src/features/calls/service.ts
+++ b/apps/backend/src/features/calls/service.ts
@@ -996,6 +996,21 @@ export class CallService {
       },
       "CF publish negotiated"
     )
+    if (params.tracks.some((t) => t.kind === "camera")) {
+      // Full SDP, camera publishes only (rare): the topology summary above has
+      // proven structurally correct on a publish the browser still rejected, so
+      // the defect hides in attribute-level detail (codecs, ICE creds, DTLS
+      // setup) that only the complete offer/answer text can show.
+      logger.info(
+        {
+          callId: params.callId,
+          endpointId: params.endpointId,
+          offerSdp: params.sdp.sdp,
+          answerSdp: cfResult.sessionDescription?.sdp,
+        },
+        "CF camera publish SDP"
+      )
+    }
 
     const declared: PublishedTrack[] = params.tracks.map((t) => ({ kind: t.kind, trackName: t.trackName }))
     const declaredKinds = new Set(declared.map((t) => t.kind))
@@ -1133,10 +1148,19 @@ export class CallService {
     mids: string[]
     unpublishKinds?: Array<PublishedTrack["kind"]>
     sdp?: SessionDescription
+    reason?: string
   }): Promise<{ cf: CloseTracksResult | null; snapshot?: CallRosterSnapshot }> {
     const cf = this.requireCloudflare()
     const { endpoint } = await this.fenceEndpoint(params)
     const cfSessionId = this.requireCfSession(endpoint)
+    if (params.reason) {
+      // The only server-side record of a client-side publish failure (the
+      // publish leg returned 200; the browser rejected the answer afterwards).
+      logger.warn(
+        { callId: params.callId, endpointId: params.endpointId, kinds: params.unpublishKinds, reason: params.reason },
+        "Client reported a local failure on unpublish"
+      )
+    }
 
     let snapshot: CallRosterSnapshot | undefined
     if (params.unpublishKinds && params.unpublishKinds.length > 0) {

--- a/apps/frontend/src/calls/call-manager.ts
+++ b/apps/frontend/src/calls/call-manager.ts
@@ -1170,7 +1170,9 @@ export class CallManager implements CallController {
         session.cameraTrack = null
         this.clearVideoStream(session, session.endpointId)
         recordCallLifecycleEvent({ kind: "publish_failed", detail: `camera: ${describeError(publishErr)}` })
-        await session.transport.unpublish("camera").catch(() => {})
+        // The cleanup close carries the browser's error so it lands in the proxy
+        // logs — the only server-visible record of a client-side SDP rejection.
+        await session.transport.unpublish("camera", { reason: describeError(publishErr) }).catch(() => {})
         setCallCaptureError({
           code: "capture_failed",
           kind: classifyMediaError(publishErr).kind,

--- a/apps/frontend/src/calls/media-transport.test.ts
+++ b/apps/frontend/src/calls/media-transport.test.ts
@@ -250,9 +250,14 @@ describe("CloudflareSfuTransport", () => {
   it("should close the registry entry even when no transceiver exists (phantom cleanup)", async () => {
     const { transport, calls } = makeTransport()
     await transport.connect({ endpointId: "ep_1", mediaIncarnation: INC })
-    await transport.unpublish("camera")
+    await transport.unpublish("camera", { reason: "InvalidAccessError: bad answer" })
     const close = calls.find((c) => c.path.endsWith("/tracks/close"))
-    expect(close?.body).toMatchObject({ mids: [], unpublishKinds: ["camera"] })
+    expect(close?.body).toMatchObject({
+      mids: [],
+      unpublishKinds: ["camera"],
+      // The client failure rides the close so the proxy can log it.
+      reason: "InvalidAccessError: bad answer",
+    })
     expect(close?.body.sdp).toBeUndefined()
   })
 

--- a/apps/frontend/src/calls/media-transport.ts
+++ b/apps/frontend/src/calls/media-transport.ts
@@ -50,7 +50,8 @@ export interface TransportStats {
 export interface MediaTransport {
   connect(descriptor: SessionDescriptor): Promise<void>
   publish(kind: PublishedTrackKind, track: MediaStreamTrack): Promise<void>
-  unpublish(kind: PublishedTrackKind): Promise<void>
+  /** `reason` marks a failure-cleanup close: the client error rides the wire so the proxy can log it. */
+  unpublish(kind: PublishedTrackKind, opts?: { reason?: string }): Promise<void>
   /** Cap a published track's encoder (watchdog ladder `maxBitrate`); no-op if unpublished. */
   setPublishEncoding(kind: PublishedTrackKind, params: { maxBitrate?: number }): Promise<void>
   pull(ref: PeerTrackRef): Promise<void>
@@ -120,6 +121,7 @@ export interface CallProxyClient {
     mids: string[]
     unpublishKinds?: PublishedTrackKind[]
     sdp?: CfSessionDescription
+    reason?: string
   }): Promise<CfCloseTracksResult>
 }
 
@@ -138,8 +140,8 @@ export function createCallProxyClient(args: {
     publishTracks: ({ sdp, tracks }) => post(`${base}/tracks/publish`, { mediaIncarnation, sdp, tracks }),
     pullTracks: (tracks) => post(`${base}/tracks/pull`, { mediaIncarnation, tracks }),
     renegotiate: (sdp) => post(`${base}/renegotiate`, { mediaIncarnation, sdp }),
-    closeTracks: ({ mids, unpublishKinds, sdp }) =>
-      post(`${base}/tracks/close`, { mediaIncarnation, mids, unpublishKinds, sdp }),
+    closeTracks: ({ mids, unpublishKinds, sdp, reason }) =>
+      post(`${base}/tracks/close`, { mediaIncarnation, mids, unpublishKinds, sdp, reason }),
   }
 }
 
@@ -354,7 +356,7 @@ export class CloudflareSfuTransport implements MediaTransport {
     }
   }
 
-  async unpublish(kind: PublishedTrackKind): Promise<void> {
+  async unpublish(kind: PublishedTrackKind, opts?: { reason?: string }): Promise<void> {
     await this.enqueue(async () => {
       // "Ensure kind is not published" — the registry close goes out even with no
       // live transceiver: a publish that failed client-side after its REST call
@@ -392,6 +394,7 @@ export class CloudflareSfuTransport implements MediaTransport {
           mids: mid ? [mid] : [],
           unpublishKinds: [kind],
           sdp,
+          reason: opts?.reason?.slice(0, 2048),
         })
       } catch (err) {
         // The REST leg itself failed (network, stale-incarnation fence) after we


### PR DESCRIPTION
## Problem

The second-camera failure reproduced today (call_01M0JAHP97, 14:10Z) with #1911's topology logging active — and Cloudflare's answer was structurally correct: `0:audio:sendonly 1:video:sendonly 2:audio:recvonly 3:video:recvonly`, exactly mirroring the offer. The browser still rejected it (same capture-error banner + toast on the accepting device). So the defect is in attribute-level SDP detail (codec parameters, ICE credentials, DTLS setup — plausibly tied to the callee's session being CF-offer-first, since it pulls before publishing), and the two facts that would pin it are both invisible today: the full answer SDP, and the client's exact DOMException, which never leaves the device because the publish REST leg returns 200 before the rejection.

## Solution

Two diagnostics, no behavior change:

- The failure-cleanup `unpublish` (added in #1911, already fires on every failed camera publish) threads the browser's error into `closeTracks` as `reason` (client-capped 2048, zod-capped 2048); `CallService.closeTracks` logs it as "Client reported a local failure on unpublish". The error message already embeds the offer/answer m-section summaries from `describeNegotiationFailure`.
- `publishTracks` logs full offer/answer SDP for camera publishes only ("CF camera publish SDP") — a handful of KB on a rare, user-initiated event; approved for prod by Kris on the scratchpad.

Next failing camera tap lands both in Railway logs with no action on the tester's device.

## Test plan

- [x] frontend `src/calls/` — 97 pass (reason rides the cleanup close body)
- [x] backend calls unit+integration — 157 pass (service logs the reason with call/endpoint context)
- [x] typecheck both apps

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789914143&installation_model_id=20758&pr_number=1913&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1913&signature=c1b0260e62c149e5c2548df5eb965e50a87abe76cd797cb577d993c2a12c5005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->