### PR TITLE
feat: messages carry their own revision

### DIFF
--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -86,6 +86,7 @@ function toMessage(
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/evals/suites/memorizer/suite.ts
+++ b/apps/backend/evals/suites/memorizer/suite.ts
@@ -58,6 +58,7 @@ function toMessages(input: MemorizerInput, now: Date): { messages: Message[]; fo
         reactions: {},
         metadata: {},
         conversationIntent: null,
+        revision: 1,
         clientMessageId: null,
         sentVia: null,
         editedAt: null,

--- a/apps/backend/src/db/migrations/20260821120000_messages_revision.sql
+++ b/apps/backend/src/db/migrations/20260821120000_messages_revision.sql
@@ -1,0 +1,10 @@
+-- Revision 1 is the original body; every edit adds one. The number was until now
+-- derived as MAX(message_versions.version_number) + 1, which cannot be pinned by
+-- a reference without a second query per message. Backfill reproduces that
+-- derivation once, set-based, so historical rows agree with it.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS revision INTEGER NOT NULL DEFAULT 1;
+
+UPDATE messages m
+SET revision = v.max_version + 1
+FROM (SELECT message_id, MAX(version_number) AS max_version FROM message_versions GROUP BY message_id) v
+WHERE v.message_id = m.id;

--- a/apps/backend/src/features/agents/conversation-summary-service.test.ts
+++ b/apps/backend/src/features/agents/conversation-summary-service.test.ts
@@ -19,6 +19,7 @@ function makeMessage(sequence: bigint, content: string): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/agents/episode-summary-service.test.ts
+++ b/apps/backend/src/features/agents/episode-summary-service.test.ts
@@ -51,6 +51,7 @@ function makeMessage(id: string, content: string): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/agents/quote-resolver.test.ts
+++ b/apps/backend/src/features/agents/quote-resolver.test.ts
@@ -43,6 +43,7 @@ function createMessage(overrides: Partial<Message> & { id: string }): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/agents/reflective-capture-service.test.ts
+++ b/apps/backend/src/features/agents/reflective-capture-service.test.ts
@@ -49,6 +49,7 @@ function makeMessage(id: string, content: string): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/agents/session-digest.test.ts
+++ b/apps/backend/src/features/agents/session-digest.test.ts
@@ -48,6 +48,7 @@ function makeMessage(id: string, content: string, authorType = "user", authorId 
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/agents/thread-anchor-context.ts
+++ b/apps/backend/src/features/agents/thread-anchor-context.ts
@@ -57,6 +57,7 @@ export async function findThreadAnchorContext(db: Querier, stream: Stream): Prom
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     editedAt: null,
     deletedAt: null,
     createdAt: event.createdAt,

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -44,6 +44,7 @@ function createMockMessage(overrides: Partial<Message> = {}): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/src/features/labels/label-message-service.test.ts
+++ b/apps/backend/src/features/labels/label-message-service.test.ts
@@ -39,6 +39,7 @@ function fakeMessage(overrides: Partial<Message> = {}): Message {
     clientMessageId: null,
     sentVia: null,
     conversationIntent: null,
+    revision: 1,
     reactions: {},
     metadata: {},
     editedAt: null,

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -587,6 +587,7 @@ describe("EventService.editMessage version capture", () => {
     contentMarkdown: "original",
     authorId: "usr_1",
     authorType: "user",
+    revision: 2,
   }
   let findByIdForUpdateSpy: ReturnType<typeof spyOn>
   let isMemberSpy: ReturnType<typeof spyOn>
@@ -695,6 +696,7 @@ describe("EventService.editMessage version capture", () => {
       expect.anything(),
       expect.objectContaining({
         messageId: "msg_1",
+        versionNumber: 2,
         contentJson: existingMessage.contentJson,
         contentMarkdown: "original",
         editedBy: "usr_1",

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -105,6 +105,12 @@ export interface MessageCreatedPayload {
   messageId: string
   contentJson: JSONContent
   contentMarkdown: string
+  /**
+   * The revision `contentJson` is. `1` on emission; bootstrap enrichment
+   * overlays the projection's current value alongside the edited body, so a
+   * reference pinned from a rendered row pins what the viewer actually saw.
+   */
+  revision: number
   attachments?: AttachmentSummary[]
   sources?: SourceItem[]
   sessionId?: string
@@ -158,6 +164,8 @@ export interface MessageEditedPayload {
   messageId: string
   contentJson: JSONContent
   contentMarkdown: string
+  /** The revision this edit produced (the pre-edit revision + 1). */
+  revision: number
   /**
    * Always present, empty array included — unlike the create payload. The client
    * applies an edit by spreading it over the stored payload, so an omitted key
@@ -872,6 +880,7 @@ export class EventService {
         messageId: msgId,
         contentJson: params.contentJson,
         contentMarkdown: params.contentMarkdown,
+        revision: 1,
         ...(attachmentSummaries && { attachments: attachmentSummaries }),
         ...(params.sources && params.sources.length > 0 && { sources: params.sources }),
         ...(params.sessionId && { sessionId: params.sessionId }),
@@ -1260,6 +1269,7 @@ export class EventService {
         await MessageVersionRepository.insert(client, {
           id: messageVersionId(),
           messageId: params.messageId,
+          versionNumber: existing.revision,
           contentJson: existing.contentJson,
           contentMarkdown: existing.contentMarkdown,
           editedBy: params.actorId,
@@ -1281,6 +1291,7 @@ export class EventService {
             messageId: params.messageId,
             contentJson: params.contentJson,
             contentMarkdown: params.contentMarkdown,
+            revision: existing.revision + 1,
             memoEmbeds,
           } satisfies MessageEditedPayload,
           actorId: params.actorId,
@@ -2617,6 +2628,9 @@ export class EventService {
         const message = messagesMap.get(payload.messageId)
 
         const enrichments: Record<string, unknown> = {}
+        if (message) {
+          enrichments.revision = message.revision
+        }
         if (threadData) {
           enrichments.threadId = threadData.threadId
           enrichments.replyCount = threadData.replyCount

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1266,7 +1266,7 @@ export class EventService {
           params.contentMarkdown = deriveContentMarkdown(resolvedEdit.contentJson)
         }
 
-        await MessageVersionRepository.insert(client, {
+        const snapshot = await MessageVersionRepository.insert(client, {
           id: messageVersionId(),
           messageId: params.messageId,
           versionNumber: existing.revision,
@@ -1291,7 +1291,7 @@ export class EventService {
             messageId: params.messageId,
             contentJson: params.contentJson,
             contentMarkdown: params.contentMarkdown,
-            revision: existing.revision + 1,
+            revision: snapshot.versionNumber + 1,
             memoEmbeds,
           } satisfies MessageEditedPayload,
           actorId: params.actorId,

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -681,7 +681,10 @@ export const MessageRepository = {
     const result = await db.query<MessageRow>(sql`
       UPDATE messages
       SET content_json = ${JSON.stringify(contentJson)}, content_markdown = ${contentMarkdown}, edited_at = NOW(),
-          revision = revision + 1
+          revision = GREATEST(
+            revision + 1,
+            (SELECT COALESCE(MAX(version_number), 0) + 1 FROM message_versions WHERE message_id = messages.id)
+          )
       WHERE id = ${id}
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -16,6 +16,7 @@ interface MessageRow {
   sent_via: string | null
   metadata: Record<string, string>
   conversation_intent: string | null
+  revision: number
   edited_at: Date | null
   deleted_at: Date | null
   created_at: Date
@@ -51,6 +52,8 @@ export interface Message {
    * reassigns it).
    */
   conversationIntent: ConversationIntent | null
+  /** 1 for the original body, +1 per edit. Maintained by `updateContent`. */
+  revision: number
   editedAt: Date | null
   deletedAt: Date | null
   createdAt: Date
@@ -104,6 +107,7 @@ function mapRowToMessage(row: MessageRow, reactions: Record<string, string[]> = 
     // JSONB comes back parsed; the column has NOT NULL DEFAULT '{}' so it's always an object.
     metadata: row.metadata ?? {},
     conversationIntent: row.conversation_intent as ConversationIntent | null,
+    revision: row.revision,
     editedAt: row.edited_at,
     deletedAt: row.deleted_at,
     createdAt: row.created_at,
@@ -166,7 +170,7 @@ export const REPLY_COUNT_SUBQUERY = (messageAlias: string) => `
 const SELECT_FIELDS = `
   id, stream_id, sequence, author_id, author_type,
   content_json, content_markdown, ${REPLY_COUNT_SUBQUERY("messages")}, client_message_id, sent_via,
-  metadata, conversation_intent,
+  metadata, conversation_intent, revision,
   edited_at, deleted_at, created_at,
   ciphertext, envelope, e2e_version
 `
@@ -174,7 +178,7 @@ const SELECT_FIELDS = `
 const QUALIFIED_SELECT_FIELDS = `
   m.id, m.stream_id, m.sequence, m.author_id, m.author_type,
   m.content_json, m.content_markdown, ${REPLY_COUNT_SUBQUERY("m")}, m.client_message_id, m.sent_via,
-  m.metadata, m.conversation_intent,
+  m.metadata, m.conversation_intent, m.revision,
   m.edited_at, m.deleted_at, m.created_at,
   m.ciphertext, m.envelope, m.e2e_version
 `
@@ -676,7 +680,8 @@ export const MessageRepository = {
   ): Promise<Message | null> {
     const result = await db.query<MessageRow>(sql`
       UPDATE messages
-      SET content_json = ${JSON.stringify(contentJson)}, content_markdown = ${contentMarkdown}, edited_at = NOW()
+      SET content_json = ${JSON.stringify(contentJson)}, content_markdown = ${contentMarkdown}, edited_at = NOW(),
+          revision = revision + 1
       WHERE id = ${id}
       RETURNING ${sql.raw(SELECT_FIELDS)}
     `)

--- a/apps/backend/src/features/messaging/version-repository.ts
+++ b/apps/backend/src/features/messaging/version-repository.ts
@@ -51,7 +51,10 @@ export const MessageVersionRepository = {
       VALUES (
         ${params.id},
         ${params.messageId},
-        ${params.versionNumber},
+        GREATEST(
+          ${params.versionNumber},
+          COALESCE((SELECT MAX(version_number) FROM message_versions WHERE message_id = ${params.messageId}), 0) + 1
+        ),
         ${JSON.stringify(params.contentJson)},
         ${params.contentMarkdown},
         ${params.editedBy}

--- a/apps/backend/src/features/messaging/version-repository.ts
+++ b/apps/backend/src/features/messaging/version-repository.ts
@@ -25,6 +25,8 @@ export interface MessageVersion {
 interface InsertParams {
   id: string
   messageId: string
+  /** The revision this snapshot IS — the message's pre-edit `revision`. */
+  versionNumber: number
   contentJson: JSONContent
   contentMarkdown: string
   editedBy: string
@@ -49,7 +51,7 @@ export const MessageVersionRepository = {
       VALUES (
         ${params.id},
         ${params.messageId},
-        COALESCE((SELECT MAX(version_number) FROM message_versions WHERE message_id = ${params.messageId}), 0) + 1,
+        ${params.versionNumber},
         ${JSON.stringify(params.contentJson)},
         ${params.contentMarkdown},
         ${params.editedBy}
@@ -87,12 +89,8 @@ export const MessageVersionRepository = {
    * - Each edit increments revision by 1
    */
   async getCurrentRevision(db: Querier, messageId: string): Promise<number | null> {
-    const result = await db.query<{ revision: number | null }>(sql`
-      SELECT CASE
-        WHEN EXISTS (SELECT 1 FROM messages WHERE id = ${messageId})
-        THEN COALESCE((SELECT MAX(version_number) FROM message_versions WHERE message_id = ${messageId}), 0) + 1
-        ELSE NULL
-      END AS revision
+    const result = await db.query<{ revision: number }>(sql`
+      SELECT revision FROM messages WHERE id = ${messageId}
     `)
 
     return result.rows[0]?.revision ?? null

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -201,6 +201,7 @@ function serializeMessage(
     clientMessageId?: string | null
     sentVia?: string | null
     metadata?: Record<string, string>
+    revision: number
     editedAt: Date | null
     createdAt: Date
   },
@@ -222,6 +223,7 @@ function serializeMessage(
     metadata: message.metadata ?? {},
     ...(opts?.attachments &&
       opts.attachments.length > 0 && { attachments: opts.attachments.map((a) => toAttachmentSummary(a)) }),
+    revision: message.revision,
     ...(message.editedAt != null && { editedAt: message.editedAt.toISOString() }),
     createdAt: message.createdAt.toISOString(),
   }

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -121,6 +121,7 @@ const messageSchema = z.object({
     .record(z.string(), z.string())
     .describe("External references attached by the sender. Always present; empty when unset."),
   attachments: z.array(attachmentSummarySchema).optional(),
+  revision: z.number().int().positive().describe("1 for the original body, +1 per edit"),
   editedAt: z.string().datetime().optional(),
   createdAt: z.string().datetime(),
 })

--- a/apps/backend/src/features/saved-messages/service.test.ts
+++ b/apps/backend/src/features/saved-messages/service.test.ts
@@ -65,6 +65,7 @@ function fakeMessage(overrides: Partial<Message> = {}): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     editedAt: null,
     deletedAt: null,
     createdAt: NOW,

--- a/apps/backend/src/lib/ai/message-formatter.test.ts
+++ b/apps/backend/src/lib/ai/message-formatter.test.ts
@@ -25,6 +25,7 @@ function createMessage(overrides: Partial<Message> = {}): Message {
     reactions: {},
     metadata: {},
     conversationIntent: null,
+    revision: 1,
     clientMessageId: null,
     sentVia: null,
     editedAt: null,

--- a/apps/backend/tests/integration/message-revision.test.ts
+++ b/apps/backend/tests/integration/message-revision.test.ts
@@ -161,6 +161,11 @@ describe("message revision", () => {
     const versions = await MessageVersionRepository.listByMessageId(pool, message.id)
     expect(versions.map((v) => v.versionNumber)).toEqual([1, 2, 3])
     expect((await MessageRepository.findById(pool, message.id))?.revision).toBe(4)
+    const lastEdit = (await eventService.listEvents(channel, { limit: 200 }))
+      .filter((e) => e.eventType === "message_edited" && (e.payload as MessageEditedPayload).messageId === message.id)
+      .map((e) => (e.payload as MessageEditedPayload).revision)
+      .at(-1)
+    expect(lastEdit).toBe(4)
   })
 
   test("getCurrentRevision is null for a message that does not exist", async () => {

--- a/apps/backend/tests/integration/message-revision.test.ts
+++ b/apps/backend/tests/integration/message-revision.test.ts
@@ -15,7 +15,7 @@ import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamRepository } from "../../src/features/streams"
 import { EventService, MessageRepository, MessageVersionRepository } from "../../src/features/messaging"
 import type { MessageCreatedPayload, MessageEditedPayload } from "../../src/features/messaging"
-import { userId, workspaceId, streamId } from "../../src/lib/id"
+import { userId, workspaceId, streamId, messageVersionId } from "../../src/lib/id"
 
 const MIGRATION_PATH = resolve(import.meta.dir, "../../src/db/migrations/20260821120000_messages_revision.sql")
 
@@ -121,6 +121,46 @@ describe("message revision", () => {
     )?.payload as MessageCreatedPayload
     expect(created.revision).toBe(3)
     expect(created.contentMarkdown).toBe("v3 body")
+  })
+
+  test("heals after a pre-column writer snapshotted a version without bumping revision", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("v1 body"),
+    })
+    await eventService.editMessageInternal({
+      workspaceId: testWorkspaceId,
+      messageId: message.id,
+      streamId: channel,
+      actorId: testUserId,
+      ...testMessageContent("v2 body"),
+    })
+
+    // An old-code replica during the rollout: it inserts MAX+1 and rewrites the
+    // body without touching `revision`.
+    await pool.query(
+      `INSERT INTO message_versions (id, message_id, version_number, content_json, content_markdown, edited_by)
+       SELECT $1, $2, COALESCE(MAX(version_number), 0) + 1, '{"type":"doc"}', 'v2 body', $3
+       FROM message_versions WHERE message_id = $2`,
+      [messageVersionId(), message.id, testUserId]
+    )
+    await pool.query(`UPDATE messages SET content_markdown = 'v3 body (old writer)' WHERE id = $1`, [message.id])
+    expect((await MessageRepository.findById(pool, message.id))?.revision).toBe(2)
+
+    await eventService.editMessageInternal({
+      workspaceId: testWorkspaceId,
+      messageId: message.id,
+      streamId: channel,
+      actorId: testUserId,
+      ...testMessageContent("v4 body"),
+    })
+
+    const versions = await MessageVersionRepository.listByMessageId(pool, message.id)
+    expect(versions.map((v) => v.versionNumber)).toEqual([1, 2, 3])
+    expect((await MessageRepository.findById(pool, message.id))?.revision).toBe(4)
   })
 
   test("getCurrentRevision is null for a message that does not exist", async () => {

--- a/apps/backend/tests/integration/message-revision.test.ts
+++ b/apps/backend/tests/integration/message-revision.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `messages.revision` — the number a pinned reference resolves against.
+ *
+ * It used to be derived as `MAX(message_versions.version_number) + 1`. The
+ * column has to agree with that derivation for rows written before it existed
+ * and for every row written after, so both the live edit path and the
+ * migration's backfill are exercised against the real schema (INV-68).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { resolve } from "node:path"
+import { setupTestDatabase, withTransaction, withTestTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository } from "../../src/features/streams"
+import { EventService, MessageRepository, MessageVersionRepository } from "../../src/features/messaging"
+import type { MessageCreatedPayload, MessageEditedPayload } from "../../src/features/messaging"
+import { userId, workspaceId, streamId } from "../../src/lib/id"
+
+const MIGRATION_PATH = resolve(import.meta.dir, "../../src/db/migrations/20260821120000_messages_revision.sql")
+
+describe("message revision", () => {
+  let pool: Pool
+  let eventService: EventService
+  let testWorkspaceId: string
+  let testUserId: string
+  let channel: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    eventService = new EventService(pool)
+    testWorkspaceId = workspaceId()
+    testUserId = userId()
+    channel = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Message Revision",
+        slug: `message-revision-${testWorkspaceId}`,
+        createdBy: testUserId,
+      })
+      testUserId = (await addTestMember(client, testWorkspaceId, testUserId)).id
+      await StreamRepository.insert(client, {
+        id: channel,
+        workspaceId: testWorkspaceId,
+        type: "channel",
+        visibility: "private",
+        slug: `s-${channel.slice(-8)}`,
+        createdBy: testUserId,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("a created message is revision 1 and says so on its payload", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("first"),
+    })
+
+    expect(message.revision).toBe(1)
+    expect(await MessageVersionRepository.getCurrentRevision(pool, message.id)).toBe(1)
+
+    const events = await eventService.listEvents(channel, { limit: 200 })
+    const created = events.find(
+      (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+    )?.payload as MessageCreatedPayload
+    expect(created.revision).toBe(1)
+  })
+
+  test("two edits leave the message at revision 3, snapshotting 1 and 2", async () => {
+    const message = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+      authorId: testUserId,
+      authorType: "user",
+      ...testMessageContent("v1 body"),
+    })
+
+    for (const body of ["v2 body", "v3 body"]) {
+      await eventService.editMessageInternal({
+        workspaceId: testWorkspaceId,
+        messageId: message.id,
+        streamId: channel,
+        actorId: testUserId,
+        ...testMessageContent(body),
+      })
+    }
+
+    const stored = await MessageRepository.findById(pool, message.id)
+    expect(stored?.revision).toBe(3)
+    expect(await MessageVersionRepository.getCurrentRevision(pool, message.id)).toBe(3)
+
+    const versions = await MessageVersionRepository.listByMessageId(pool, message.id)
+    expect(versions.map((v) => ({ versionNumber: v.versionNumber, contentMarkdown: v.contentMarkdown }))).toEqual([
+      { versionNumber: 1, contentMarkdown: "v1 body" },
+      { versionNumber: 2, contentMarkdown: "v2 body" },
+    ])
+
+    const events = await eventService.listEvents(channel, { limit: 200 })
+    const edits = events
+      .filter((e) => e.eventType === "message_edited" && (e.payload as MessageEditedPayload).messageId === message.id)
+      .map((e) => (e.payload as MessageEditedPayload).revision)
+    expect(edits).toEqual([2, 3])
+
+    // `message_edited` is filtered out of a bootstrap window, so the pin a
+    // client can read comes from the overlaid `message_created` payload.
+    const enriched = await eventService.enrichBootstrapEvents(events, new Map(), new Map(), {
+      workspaceId: testWorkspaceId,
+      streamId: channel,
+    })
+    const created = enriched.find(
+      (e) => e.eventType === "message_created" && (e.payload as MessageCreatedPayload).messageId === message.id
+    )?.payload as MessageCreatedPayload
+    expect(created.revision).toBe(3)
+    expect(created.contentMarkdown).toBe("v3 body")
+  })
+
+  test("getCurrentRevision is null for a message that does not exist", async () => {
+    expect(await MessageVersionRepository.getCurrentRevision(pool, "msg_missing")).toBeNull()
+  })
+
+  describe("migration backfill", () => {
+    test("historical rows land on MAX(version_number) + 1, unedited rows stay at 1", async () => {
+      const migrationSql = await Bun.file(MIGRATION_PATH).text()
+
+      await withTestTransaction(pool, async (client) => {
+        const edited = "msg_backfill_edited"
+        const untouched = "msg_backfill_untouched"
+        for (const id of [edited, untouched]) {
+          await MessageRepository.insert(client, {
+            id,
+            streamId: channel,
+            sequence: BigInt(id === edited ? 900001 : 900002),
+            authorId: testUserId,
+            authorType: "user",
+            ...testMessageContent("body"),
+          })
+        }
+        // Pre-migration state: the derived number lived only in message_versions.
+        await client.query(`UPDATE messages SET revision = 1 WHERE id = ANY($1)`, [[edited, untouched]])
+        await client.query(
+          `INSERT INTO message_versions (id, message_id, version_number, content_json, content_markdown, edited_by)
+           VALUES ('mver_bf1', $1, 1, '{"type":"doc","content":[]}', 'v1', $2),
+                  ('mver_bf2', $1, 2, '{"type":"doc","content":[]}', 'v2', $2)`,
+          [edited, testUserId]
+        )
+
+        await client.query(migrationSql)
+
+        const rows = await client.query<{ id: string; revision: number }>(
+          `SELECT id, revision FROM messages WHERE id = ANY($1) ORDER BY id`,
+          [[edited, untouched]]
+        )
+        expect(rows.rows).toEqual([
+          { id: edited, revision: 3 },
+          { id: untouched, revision: 1 },
+        ])
+      })
+    })
+  })
+})

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -103,6 +103,8 @@ interface MessagePayload {
   messageId: string
   contentMarkdown: string
   contentJson?: JSONContent
+  /** Optional: events cached in IDB before the field shipped carry no revision. */
+  revision?: number
   attachments?: AttachmentSummary[]
   linkPreviews?: LinkPreviewSummary[]
   memoEmbeds?: MemoEmbedSummary[]

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -2978,6 +2978,12 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "revision": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "1 for the original body, +1 per edit"
+                                },
                                 "editedAt": { "type": "string", "format": "date-time" },
                                 "createdAt": { "type": "string", "format": "date-time" }
                               },
@@ -2990,6 +2996,7 @@
                                 "content",
                                 "replyCount",
                                 "metadata",
+                                "revision",
                                 "createdAt"
                               ],
                               "additionalProperties": false
@@ -4726,6 +4733,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -4738,6 +4751,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5026,6 +5040,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -5038,6 +5058,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -5548,6 +5569,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5560,6 +5587,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5840,6 +5868,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5852,6 +5886,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -6109,6 +6144,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -6121,6 +6162,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false

--- a/docs/public-api/versions/2026-07-12.json
+++ b/docs/public-api/versions/2026-07-12.json
@@ -2857,6 +2857,12 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "revision": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "1 for the original body, +1 per edit"
+                                },
                                 "editedAt": { "type": "string", "format": "date-time" },
                                 "createdAt": { "type": "string", "format": "date-time" }
                               },
@@ -2869,6 +2875,7 @@
                                 "content",
                                 "replyCount",
                                 "metadata",
+                                "revision",
                                 "createdAt"
                               ],
                               "additionalProperties": false
@@ -4475,6 +4482,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -4487,6 +4500,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -4654,6 +4668,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -4666,6 +4686,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -5055,6 +5076,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5067,6 +5094,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5226,6 +5254,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5238,6 +5272,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5374,6 +5409,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -5386,6 +5427,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false

--- a/docs/public-api/versions/2026-07-22.json
+++ b/docs/public-api/versions/2026-07-22.json
@@ -2857,6 +2857,12 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "revision": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "1 for the original body, +1 per edit"
+                                },
                                 "editedAt": { "type": "string", "format": "date-time" },
                                 "createdAt": { "type": "string", "format": "date-time" }
                               },
@@ -2869,6 +2875,7 @@
                                 "content",
                                 "replyCount",
                                 "metadata",
+                                "revision",
                                 "createdAt"
                               ],
                               "additionalProperties": false
@@ -4484,6 +4491,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -4496,6 +4509,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -4663,6 +4677,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -4675,6 +4695,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -5064,6 +5085,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5076,6 +5103,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5235,6 +5263,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5247,6 +5281,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5383,6 +5418,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -5395,6 +5436,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false

--- a/docs/public-api/versions/2026-07-24.json
+++ b/docs/public-api/versions/2026-07-24.json
@@ -2978,6 +2978,12 @@
                                     "additionalProperties": false
                                   }
                                 },
+                                "revision": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991,
+                                  "description": "1 for the original body, +1 per edit"
+                                },
                                 "editedAt": { "type": "string", "format": "date-time" },
                                 "createdAt": { "type": "string", "format": "date-time" }
                               },
@@ -2990,6 +2996,7 @@
                                 "content",
                                 "replyCount",
                                 "metadata",
+                                "revision",
                                 "createdAt"
                               ],
                               "additionalProperties": false
@@ -4726,6 +4733,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -4738,6 +4751,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5026,6 +5040,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -5038,6 +5058,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -5548,6 +5569,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5560,6 +5587,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -5840,6 +5868,12 @@
                               "additionalProperties": false
                             }
                           },
+                          "revision": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "description": "1 for the original body, +1 per edit"
+                          },
                           "editedAt": { "type": "string", "format": "date-time" },
                           "createdAt": { "type": "string", "format": "date-time" }
                         },
@@ -5852,6 +5886,7 @@
                           "content",
                           "replyCount",
                           "metadata",
+                          "revision",
                           "createdAt"
                         ],
                         "additionalProperties": false
@@ -6109,6 +6144,12 @@
                             "additionalProperties": false
                           }
                         },
+                        "revision": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "description": "1 for the original body, +1 per edit"
+                        },
                         "editedAt": { "type": "string", "format": "date-time" },
                         "createdAt": { "type": "string", "format": "date-time" }
                       },
@@ -6121,6 +6162,7 @@
                         "content",
                         "replyCount",
                         "metadata",
+                        "revision",
                         "createdAt"
                       ],
                       "additionalProperties": false

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -554,6 +554,8 @@ export interface Message {
    * Queried with AND-containment semantics via the public API.
    */
   metadata: Record<string, string>
+  /** 1 for the original body, +1 per edit. What a pinned reference resolves against. */
+  revision: number
   editedAt: string | null
   deletedAt: string | null
   createdAt: string


### PR DESCRIPTION
Bottom of the quote/share-by-pinned-version stack (plan: https://seer.build/ws_vbyzjvdg6g/b/share-quoted-plan/). A reference to a message version needs the revision number on the row and on the wire; today it is derived as `MAX(message_versions.version_number) + 1` on demand, which nothing can pin without a second query per message.

**Changes**
- `messages.revision INTEGER NOT NULL DEFAULT 1` (migration `20260821120000`), backfilled in one set-based UPDATE from `message_versions` (INV-56, INV-66: integer version, never timestamps).
- `MessageRepository.updateContent` increments `revision` in the same UPDATE as the body; `MessageVersionRepository.insert` takes the explicit pre-edit `versionNumber` instead of recomputing `MAX+1`; `getCurrentRevision` is a single-column read (callers unchanged).
- Wire: `Message.revision`, `message_created` payload carries `revision` (1 on emission, bootstrap enrichment overlays the projection's current value next to the edited body), `message_edited` carries the post-edit value; public API message object gains `revision` (openapi regenerated). Frontend timeline payload type gets an optional `revision` (IDB-cached events predate it).

**Verification**
`tests/integration/message-revision.test.ts` (real schema, INV-68): create → 1; two edits → row 3, versions `[1, 2]`, `getCurrentRevision` 3, edited payloads `[2, 3]`, bootstrap overlay 3; migration backfill run from the real file → edited row 3, unedited row 1. Backend unit (`messaging`, `agents`, `public-api`, `db` guard), related integration/e2e files, root typecheck, lint, `check:migrations`, `generate:api-docs:check` all green.

**Risk**
Additive column with a default; old code ignores it. The backfill runs once in the migration. During the rolling deploy an old replica can still edit without bumping the column; both writes are self-healing (`GREATEST` of the column path and the `MAX(version_number)+1` path) so the next new-code edit corrects the number instead of colliding on the unique `(message_id, version_number)` index — covered by the "heals after a pre-column writer" test. `message_edited.revision` is computed under the existing `FOR UPDATE` lock.
