### PR TITLE
feat: reference core for quoting and sharing a pinned range

### DIFF
--- a/apps/frontend/src/components/editor/prosemirror-positions.contract.test.ts
+++ b/apps/frontend/src/components/editor/prosemirror-positions.contract.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest"
+import { getSchema } from "@tiptap/core"
+import type { JSONContent } from "@tiptap/react"
+import { CONTAINER_NODE_TYPES, LEAF_NODE_TYPES, docContentSize, sliceContent } from "@threa/prosemirror"
+import { createEditorExtensions } from "./editor-extensions"
+
+/**
+ * `@threa/prosemirror` computes document positions from JSON alone, with no
+ * schema — the backend and the workers have no editor to ask. This file is the
+ * drift guard: it builds the real tiptap schema and proves the schema-less
+ * numbers are the schema's numbers. It fails when an extension adds a node, or
+ * turns a leaf into a container, without the shared sets following.
+ */
+
+const schema = getSchema(createEditorExtensions({ placeholder: "" }))
+
+/** Wire-format alias for the editor's `slashCommand` node, accepted by the public API. */
+const NON_SCHEMA_LEAF_TYPES = ["command"]
+
+const fixture: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Release notes" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello " },
+        { type: "text", text: "brave", marks: [{ type: "bold" }] },
+        { type: "text", text: " world, " },
+        { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } },
+        { type: "text", text: " and " },
+        { type: "channelLink", attrs: { id: "stream_1", slug: "general" } },
+        { type: "hardBreak" },
+        { type: "text", text: "run " },
+        { type: "slashCommand", attrs: { name: "compact" } },
+        { type: "emoji", attrs: { shortcode: "tada" } },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "attachmentReference",
+          attrs: {
+            id: "att_1",
+            filename: "spec.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 1024,
+            status: "uploaded",
+          },
+        },
+        { type: "memoEmbed", attrs: { memoId: "memo_1", title: "Decision" } },
+        { type: "giphyEmbed", attrs: { giphyUrl: "https://media.giphy.com/media/abc/giphy.gif", title: "GIF" } },
+        { type: "inAppLink", attrs: { url: "https://app.threa.io/streams/stream_1", name: "general" } },
+      ],
+    },
+    {
+      type: "bulletList",
+      content: [
+        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "first item" }] }] },
+        { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "second item" }] }] },
+      ],
+    },
+    {
+      type: "orderedList",
+      attrs: { start: 1 },
+      content: [{ type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "step one" }] }] }],
+    },
+    {
+      type: "blockquote",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "quoted line" }] }, { type: "paragraph" }],
+    },
+    { type: "codeBlock", attrs: { language: "ts" }, content: [{ type: "text", text: "const a = 1\nconst b = 2" }] },
+    { type: "horizontalRule" },
+    {
+      type: "table",
+      content: [
+        {
+          type: "tableRow",
+          content: [
+            { type: "tableHeader", content: [{ type: "paragraph", content: [{ type: "text", text: "h1" }] }] },
+            { type: "tableHeader", content: [{ type: "paragraph", content: [{ type: "text", text: "h2" }] }] },
+          ],
+        },
+        {
+          type: "tableRow",
+          content: [
+            { type: "tableCell", content: [{ type: "paragraph", content: [{ type: "text", text: "c1" }] }] },
+            { type: "tableCell", content: [{ type: "paragraph", content: [{ type: "text", text: "c2" }] }] },
+          ],
+        },
+      ],
+    },
+    {
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_1",
+        streamId: "stream_1",
+        authorName: "Alice",
+        authorId: "usr_1",
+        actorType: "user",
+        snippet: "quoted",
+      },
+    },
+    {
+      type: "sharedMessage",
+      attrs: { messageId: "msg_2", streamId: "stream_2", authorName: "Bob", authorId: "usr_2", actorType: "user" },
+    },
+    { type: "paragraph" },
+  ],
+}
+
+// Attrs come back from the schema with their defaults filled in, so comparing
+// a slice to a `cut` compares content and not attribute normalisation.
+const node = schema.nodeFromJSON(fixture)
+const doc = node.toJSON() as JSONContent
+
+describe("LEAF_NODE_TYPES", () => {
+  it("holds exactly the leaf nodes of the real editor schema", () => {
+    const schemaLeaves = Object.keys(schema.nodes)
+      .filter((name) => schema.nodes[name].isLeaf)
+      .sort()
+    expect([...LEAF_NODE_TYPES].filter((name) => name in schema.nodes).sort()).toEqual(schemaLeaves)
+    expect([...LEAF_NODE_TYPES].filter((name) => !(name in schema.nodes)).sort()).toEqual(NON_SCHEMA_LEAF_TYPES)
+  })
+
+  it("holds every non-leaf node of the real editor schema in the container set", () => {
+    const schemaContainers = Object.keys(schema.nodes)
+      .filter((name) => !schema.nodes[name].isLeaf)
+      .sort()
+    expect([...CONTAINER_NODE_TYPES].filter((name) => name in schema.nodes).sort()).toEqual(schemaContainers)
+  })
+})
+
+describe("docContentSize", () => {
+  it("matches the schema's own content size", () => {
+    expect(docContentSize(doc)).toBe(node.content.size)
+  })
+
+  it("uses every node type the schema defines", () => {
+    const used = new Set<string>()
+    node.descendants((child) => {
+      used.add(child.type.name)
+      return true
+    })
+    expect([...Object.keys(schema.nodes)].filter((name) => name !== "doc" && !used.has(name))).toEqual([])
+  })
+})
+
+describe("sliceContent", () => {
+  const cut = (from: number, to: number): unknown => node.cut(from, to).toJSON()
+
+  it.each([
+    ["mid-word across a mark boundary", 18, 25],
+    ["across an inline atom", 30, 40],
+    ["across two list items", 60, 80],
+    ["from a block leaf into the table after it", 143, 150],
+    ["the whole document", 0, 178],
+  ])("matches Node.cut for a range %s", (_name, from, to) => {
+    expect(sliceContent(doc, from, to)).toEqual(cut(from, to))
+  })
+
+  it("reads the fixture as 178 positions, so the ranges above stay meaningful", () => {
+    expect(node.content.size).toBe(178)
+  })
+
+  it("matches Node.cut for every range in the document", () => {
+    const size = node.content.size
+    const mismatches: Array<[number, number]> = []
+    for (let from = 0; from <= size; from++) {
+      for (let to = from; to <= size; to++) {
+        if (JSON.stringify(sliceContent(doc, from, to)) !== JSON.stringify(cut(from, to))) {
+          mismatches.push([from, to])
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+})

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -26,6 +26,7 @@ export {
 } from "./attachment-markdown"
 export {
   buildQuoteHref,
+  isValidPin,
   parseQuoteHref,
   buildSharedMessageHref,
   parseSharedMessageHref,

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -34,6 +34,7 @@ export {
   buildGiphyHref,
   parseGiphyHref,
   parseMentionPointerHref,
+  type ReferencePin,
   type QuoteHref,
   type SharedMessageHref,
   type MemoHref,
@@ -43,6 +44,9 @@ export {
   type ChannelHrefPointer,
   type ActorHrefPointer,
 } from "./pointer-urls"
+export { LEAF_NODE_TYPES, CONTAINER_NODE_TYPES, UnknownNodeTypeError, nodeSize, docContentSize } from "./positions"
+export { sliceContent, isRangeValid, normalizeRange, isEmptySlice } from "./slice"
+export { resolveSelectionRange, type SelectionRangeInput } from "./selection-range"
 export {
   collectAttachmentReferenceIds,
   collectGiphyEmbeds,
@@ -57,4 +61,4 @@ export {
   type GiphyEmbedRef,
 } from "./extractors"
 
-export type { JSONContent, JSONContentMark, ThreaDocument } from "@threa/types"
+export type { ContentRange, JSONContent, JSONContentMark, ThreaDocument } from "@threa/types"

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1313,3 +1313,93 @@ describe("@threa/prosemirror blockquote empty-paragraph round-trip", () => {
     expect(parseMarkdown(markdown)).toEqual(doc)
   })
 })
+
+describe("@threa/prosemirror reference pins", () => {
+  const pinnedQuote: JSONContent = {
+    type: "quoteReply",
+    attrs: {
+      messageId: "msg_01ABC",
+      streamId: "stream_01XYZ",
+      authorName: "Kristoffer",
+      authorId: "usr_01KR",
+      actorType: "user",
+      snippet: "**world**",
+      version: 3,
+      range: { from: 7, to: 12 },
+    },
+  }
+
+  it("round-trips a quote pinned to a version and a range", () => {
+    const markdown = serializeToMarkdown({ type: "doc", content: [pinnedQuote] })
+    expect(markdown).toBe("> **world**\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user?v=3&r=7-12)")
+    expect(parseMarkdown(markdown).content?.[0]).toEqual(pinnedQuote)
+  })
+
+  it("round-trips a quote pinned to a whole version", () => {
+    const node: JSONContent = { ...pinnedQuote, attrs: { ...pinnedQuote.attrs, range: undefined, version: 2 } }
+    const markdown = serializeToMarkdown({ type: "doc", content: [node] })
+    expect(markdown).toBe("> **world**\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user?v=2)")
+    expect(parseMarkdown(markdown).content?.[0]?.attrs).toEqual({
+      messageId: "msg_01ABC",
+      streamId: "stream_01XYZ",
+      authorName: "Kristoffer",
+      authorId: "usr_01KR",
+      actorType: "user",
+      snippet: "**world**",
+      version: 2,
+    })
+  })
+
+  it("parses a legacy unpinned quote without inventing pin attrs", () => {
+    const parsed = parseMarkdown("> Hello\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user)")
+    expect(parsed.content?.[0]?.attrs).toEqual({
+      messageId: "msg_01ABC",
+      streamId: "stream_01XYZ",
+      authorName: "Kristoffer",
+      authorId: "usr_01KR",
+      actorType: "user",
+      snippet: "Hello",
+    })
+  })
+
+  it("falls back to a plain blockquote when the pin query is malformed", () => {
+    const parsed = parseMarkdown("> Hello\n>\n> — [Kristoffer](quote:stream_01XYZ/msg_01ABC/usr_01KR/user?v=0)")
+    expect(parsed.content?.[0]?.type).toBe("blockquote")
+  })
+
+  it("round-trips a shared message pinned to a version and a range", () => {
+    const node: JSONContent = {
+      type: "sharedMessage",
+      attrs: {
+        messageId: "msg_01XYZ",
+        streamId: "stream_01ABC",
+        authorName: "Alice",
+        authorId: "",
+        actorType: "user",
+        version: 4,
+        range: { from: 1, to: 6 },
+      },
+    }
+    const markdown = serializeToMarkdown({ type: "doc", content: [node] })
+    expect(markdown).toBe("Shared a message from [Alice](shared-message:stream_01ABC/msg_01XYZ?v=4&r=1-6)")
+    expect(parseMarkdown(markdown).content?.[0]).toEqual(node)
+  })
+
+  it("round-trips a pinned shared message with a conversation origin", () => {
+    const node: JSONContent = {
+      type: "sharedMessage",
+      attrs: {
+        messageId: "msg_01XYZ",
+        streamId: "stream_01ABC",
+        conversationId: "conv_01DEF",
+        authorName: "Alice",
+        authorId: "",
+        actorType: "user",
+        version: 4,
+      },
+    }
+    const markdown = serializeToMarkdown({ type: "doc", content: [node] })
+    expect(markdown).toBe("Shared a message from [Alice](shared-message:stream_01ABC/msg_01XYZ/conv_01DEF?v=4)")
+    expect(parseMarkdown(markdown).content?.[0]).toEqual(node)
+  })
+})

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -6,7 +6,7 @@
  * backend (AI agents, external integrators).
  */
 
-import type { JSONContent, JSONContentMark } from "@threa/types"
+import type { ContentRange, JSONContent, JSONContentMark } from "@threa/types"
 import { actorTypeFromMentionId, isResolvedChannelLinkId } from "@threa/types"
 import {
   escapeMarkdownLinkText,
@@ -21,6 +21,9 @@ import {
   buildSharedMessageHref,
   parseGiphyHref,
   parseMentionPointerHref,
+  parseQuoteHref,
+  parseSharedMessageHref,
+  type ReferencePin,
 } from "./pointer-urls"
 
 /**
@@ -107,13 +110,15 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
     }
 
     case "quoteReply": {
-      const { messageId, streamId, authorName, authorId, actorType, snippet } = node.attrs as {
+      const { messageId, streamId, authorName, authorId, actorType, snippet, version, range } = node.attrs as {
         messageId: string
         streamId: string
         authorName: string
         authorId: string
         actorType: string
         snippet: string
+        version?: number | null
+        range?: ContentRange | null
       }
       const quotedLines = snippet
         .split("\n")
@@ -123,16 +128,18 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
       const escapedAuthor = authorName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
       // Blank `>` line forces a paragraph break so react-markdown creates separate
       // <p> elements for the snippet and attribution (needed for display extraction).
-      const href = buildQuoteHref({ streamId, messageId, authorId, actorType })
+      const href = buildQuoteHref({ streamId, messageId, authorId, actorType, version, range })
       return `${quotedLines}\n>\n> — [${escapedAuthor}](${href})`
     }
 
     case "sharedMessage": {
-      const { messageId, streamId, authorName, conversationId } = node.attrs as {
+      const { messageId, streamId, authorName, conversationId, version, range } = node.attrs as {
         messageId: string
         streamId: string
         authorName?: string
         conversationId?: string
+        version?: number | null
+        range?: ContentRange | null
       }
       // Wire-format serialization only — the frontend hydrates live content
       // on render, so this fallback is what external API consumers see and
@@ -141,7 +148,7 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
       // the line to a clean sentence: "Shared a message from Alice".
       const rawName = authorName && authorName.length > 0 ? authorName : "another stream"
       const escapedName = rawName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
-      return `Shared a message from [${escapedName}](${buildSharedMessageHref({ streamId, messageId, conversationId })})`
+      return `Shared a message from [${escapedName}](${buildSharedMessageHref({ streamId, messageId, conversationId, version, range })})`
     }
 
     case "bulletList":
@@ -622,21 +629,18 @@ export function parseMarkdown(
         i++
       }
 
-      // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId/authorId/actorType)
+      // Check if last line is a quote-reply attribution: — [Author](quote:streamId/messageId/authorId/actorType[?v=n&r=from-to])
       // Author name may contain escaped brackets: \] and \\
-      // authorId and actorType are optional for backward compat with old messages.
+      // The href itself is decoded by `parseQuoteHref`, which owns the optional
+      // segments and the pin suffix; an href it rejects falls back to a plain
+      // blockquote.
       const lastLine = quoteLines[quoteLines.length - 1]
-      const quoteReplyMatch = lastLine?.match(
-        /^—\s*\[((?:\\.|[^\]])+)\]\(quote:([\w-]+)\/([\w-]+)(?:\/([\w-]+)\/([\w-]+))?\)$/
-      )
+      const quoteReplyMatch = lastLine?.match(/^—\s*\[((?:\\.|[^\]])+)\]\((quote:[\w\-/]+(?:\?[\w=&-]+)?)\)$/)
+      const quoteHref = quoteReplyMatch ? parseQuoteHref(quoteReplyMatch[2]) : null
 
-      if (quoteReplyMatch) {
+      if (quoteReplyMatch && quoteHref) {
         // Unescape \] and \\ in author name
         const authorName = quoteReplyMatch[1].replace(/\\([\]\\])/g, "$1")
-        const streamId = quoteReplyMatch[2]
-        const messageId = quoteReplyMatch[3]
-        const authorId = quoteReplyMatch[4] ?? ""
-        const actorType = quoteReplyMatch[5] ?? "user"
         // Strip the attribution line and any blank separator line before it
         const snippetLines = quoteLines.slice(0, -1)
         while (snippetLines.length > 0 && snippetLines[snippetLines.length - 1] === "") {
@@ -645,7 +649,15 @@ export function parseMarkdown(
         const snippet = snippetLines.join("\n")
         content.push({
           type: "quoteReply",
-          attrs: { messageId, streamId, authorName, authorId, actorType, snippet },
+          attrs: {
+            messageId: quoteHref.messageId,
+            streamId: quoteHref.streamId,
+            authorName,
+            authorId: quoteHref.authorId,
+            actorType: quoteHref.actorType,
+            snippet,
+            ...referencePinAttrs(quoteHref),
+          },
         })
       } else {
         // One paragraph per quoted line — the inverse of the serializer, which
@@ -729,6 +741,7 @@ export function parseMarkdown(
           ...(sharedMessageMatch.conversationId && { conversationId: sharedMessageMatch.conversationId }),
           authorId: "",
           actorType: "user",
+          ...referencePinAttrs(sharedMessageMatch),
         },
       })
       i++
@@ -757,13 +770,26 @@ export function parseMarkdown(
  */
 function parseSharedMessageLine(
   line: string
-): { authorName: string; streamId: string; messageId: string; conversationId?: string } | null {
+): ({ authorName: string; streamId: string; messageId: string; conversationId?: string } & ReferencePin) | null {
   const match = line.match(
-    /^Shared a message from \[((?:\\.|[^\]])+)\]\(shared-message:([\w-]+)\/([\w-]+)(?:\/([\w-]+))?\)\s*$/
+    /^Shared a message from \[((?:\\.|[^\]])+)\]\((shared-message:[\w\-/]+(?:\?[\w=&-]+)?)\)\s*$/
   )
   if (!match) return null
+  const href = parseSharedMessageHref(match[2])
+  if (!href) return null
   const authorName = match[1].replace(/\\([\]\\])/g, "$1")
-  return { authorName, streamId: match[2], messageId: match[3], conversationId: match[4] || undefined }
+  return { authorName, ...href }
+}
+
+/**
+ * Spread the pin onto node attrs only when the href carried one: an unpinned
+ * legacy link must round-trip to exactly the attrs it parsed from before.
+ */
+function referencePinAttrs(pin: ReferencePin): ReferencePin {
+  return {
+    ...(pin.version != null && { version: pin.version }),
+    ...(pin.range != null && { range: pin.range }),
+  }
 }
 
 /**

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -156,9 +156,7 @@ describe("reference pins", () => {
   })
 
   it("refuses to serialize a range without the version it indexes into", () => {
-    expect(() => buildQuoteHref({ ...quote, range: { from: 1, to: 2 } })).toThrow(
-      "A reference range requires a pinned version"
-    )
+    expect(() => buildQuoteHref({ ...quote, range: { from: 1, to: 2 } })).toThrow("Invalid reference pin")
   })
 
   it("parses a pinned href back to the same values", () => {
@@ -187,6 +185,26 @@ describe("reference pins", () => {
     expect(parseQuoteHref("quote:stream_1/msg_1?v=2&r=9-4")).toBeNull()
     expect(parseQuoteHref("quote:stream_1/msg_1?v=2&r=four")).toBeNull()
     expect(parseSharedMessageHref("shared-message:stream_1/msg_1?v=-1")).toBeNull()
+  })
+
+  it("rejects quote paths that are not the 2- or 4-segment shapes the builder emits", () => {
+    expect(parseQuoteHref("quote:stream_1/msg_1/usr_1")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1/usr_1/user/extra")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1//usr_1/user")).toBeNull()
+  })
+
+  it("builds and parses by the same pin rule", () => {
+    expect(() =>
+      buildQuoteHref({ streamId: "s", messageId: "m", authorId: "", actorType: "user", version: 0 })
+    ).toThrow()
+    expect(() =>
+      buildQuoteHref({ streamId: "s", messageId: "m", authorId: "", actorType: "user", version: 1.5 })
+    ).toThrow()
+    expect(() =>
+      buildSharedMessageHref({ streamId: "s", messageId: "m", version: 2, range: { from: 9, to: 4 } })
+    ).toThrow()
+    expect(parseQuoteHref(`quote:stream_1/msg_1?v=${"9".repeat(400)}`)).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=2&r=99999999999999999999-999999999999999999999")).toBeNull()
   })
 
   it("ignores query parameters it does not know", () => {

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import {
   buildMemoHref,
+  buildQuoteHref,
   buildSharedMessageHref,
   parseMemoHref,
   parseMentionPointerHref,
+  parseQuoteHref,
   parseSharedMessageHref,
 } from "./pointer-urls"
 
@@ -60,6 +62,8 @@ describe("shared-message href", () => {
       streamId: "stream_01ABC",
       messageId: "msg_01XYZ",
       conversationId: undefined,
+      version: null,
+      range: null,
     })
   })
 
@@ -74,6 +78,8 @@ describe("shared-message href", () => {
       streamId: "stream_01ABC",
       messageId: "msg_01XYZ",
       conversationId: "conv_01DEF",
+      version: null,
+      range: null,
     })
   })
 
@@ -82,6 +88,8 @@ describe("shared-message href", () => {
       streamId: "stream_1",
       messageId: "msg_1",
       conversationId: undefined,
+      version: null,
+      range: null,
     })
   })
 
@@ -115,5 +123,74 @@ describe("parseMemoHref", () => {
     expect(parseMemoHref("memo:memo_123?x=1")).toBeNull()
     expect(parseMemoHref("memo:memo_123#frag")).toBeNull()
     expect(parseMemoHref("memo:memo_123:more")).toBeNull()
+  })
+})
+
+describe("reference pins", () => {
+  const quote = { streamId: "stream_1", messageId: "msg_1", authorId: "usr_1", actorType: "user" }
+
+  it("appends the version, and the range only alongside it", () => {
+    expect(buildQuoteHref({ ...quote, version: 3 })).toBe("quote:stream_1/msg_1/usr_1/user?v=3")
+    expect(buildQuoteHref({ ...quote, version: 3, range: { from: 4, to: 9 } })).toBe(
+      "quote:stream_1/msg_1/usr_1/user?v=3&r=4-9"
+    )
+    expect(buildSharedMessageHref({ streamId: "stream_1", messageId: "msg_1", version: 2 })).toBe(
+      "shared-message:stream_1/msg_1?v=2"
+    )
+    expect(
+      buildSharedMessageHref({
+        streamId: "stream_1",
+        messageId: "msg_1",
+        conversationId: "conv_1",
+        version: 2,
+        range: { from: 0, to: 3 },
+      })
+    ).toBe("shared-message:stream_1/msg_1/conv_1?v=2&r=0-3")
+  })
+
+  it("keeps the legacy suffix-free form when nothing is pinned", () => {
+    expect(buildQuoteHref({ ...quote, version: null, range: null })).toBe("quote:stream_1/msg_1/usr_1/user")
+    expect(
+      buildQuoteHref({ streamId: "stream_1", messageId: "msg_1", authorId: "", actorType: "user", version: 5 })
+    ).toBe("quote:stream_1/msg_1?v=5")
+  })
+
+  it("refuses to serialize a range without the version it indexes into", () => {
+    expect(() => buildQuoteHref({ ...quote, range: { from: 1, to: 2 } })).toThrow(
+      "A reference range requires a pinned version"
+    )
+  })
+
+  it("parses a pinned href back to the same values", () => {
+    expect(parseQuoteHref("quote:stream_1/msg_1/usr_1/user?v=3&r=4-9")).toEqual({
+      streamId: "stream_1",
+      messageId: "msg_1",
+      authorId: "usr_1",
+      actorType: "user",
+      version: 3,
+      range: { from: 4, to: 9 },
+    })
+    expect(parseQuoteHref("quote:stream_1/msg_1")).toEqual({
+      streamId: "stream_1",
+      messageId: "msg_1",
+      authorId: "",
+      actorType: "user",
+      version: null,
+      range: null,
+    })
+  })
+
+  it("rejects a malformed pin instead of reading the href as unpinned", () => {
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=abc")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=0")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1?r=4-9")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=2&r=9-4")).toBeNull()
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=2&r=four")).toBeNull()
+    expect(parseSharedMessageHref("shared-message:stream_1/msg_1?v=-1")).toBeNull()
+  })
+
+  it("ignores query parameters it does not know", () => {
+    expect(parseQuoteHref("quote:stream_1/msg_1?v=2&x=1")?.version).toBe(2)
+    expect(parseSharedMessageHref("shared-message:stream_1/msg_1?x=1")?.version).toBeNull()
   })
 })

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -73,7 +73,8 @@ export function parseQuoteHref(href: string): QuoteHref | null {
   const split = splitReferenceQuery(href.slice("quote:".length))
   if (!split) return null
   const parts = split.path.split("/")
-  if (parts.length < 2) return null
+  // Exactly the 2-segment (legacy) or 4-segment shapes `buildQuoteHref` emits.
+  if ((parts.length !== 2 && parts.length !== 4) || parts.some((part) => part.length === 0)) return null
   return {
     streamId: parts[0],
     messageId: parts[1],
@@ -135,12 +136,22 @@ export function parseSharedMessageHref(href: string): SharedMessageHref | null {
 function buildReferenceQuery(pin: ReferencePin): string {
   const version = pin.version ?? null
   const range = pin.range ?? null
-  if (version === null) {
-    if (range !== null) throw new Error("A reference range requires a pinned version")
-    return ""
-  }
+  if (!isValidPin(version, range)) throw new Error(`Invalid reference pin: ${JSON.stringify({ version, range })}`)
+  if (version === null) return ""
   if (range === null) return `?v=${version}`
   return `?v=${version}&r=${range.from}-${range.to}`
+}
+
+/**
+ * One validity rule for both directions: a version is a positive safe integer,
+ * a range is `0 <= from < to` in safe integers, and a range needs a version
+ * (positions only exist inside a known revision).
+ */
+export function isValidPin(version: number | null, range: ContentRange | null): boolean {
+  if (version !== null && (!Number.isSafeInteger(version) || version < 1)) return false
+  if (range === null) return true
+  if (version === null) return false
+  return Number.isSafeInteger(range.from) && Number.isSafeInteger(range.to) && range.from >= 0 && range.from < range.to
 }
 
 /**
@@ -161,14 +172,11 @@ function splitReferenceQuery(body: string): { path: string; pin: Required<Refere
   }
   if (!/^\d+$/.test(rawVersion)) return null
   const version = Number(rawVersion)
-  if (version < 1) return null
-  if (rawRange === null) return { path, pin: { version, range: null } }
+  if (rawRange === null) return isValidPin(version, null) ? { path, pin: { version, range: null } } : null
   const match = rawRange.match(/^(\d+)-(\d+)$/)
   if (!match) return null
-  const from = Number(match[1])
-  const to = Number(match[2])
-  if (from >= to) return null
-  return { path, pin: { version, range: { from, to } } }
+  const range = { from: Number(match[1]), to: Number(match[2]) }
+  return isValidPin(version, range) ? { path, pin: { version, range } } : null
 }
 
 export interface MemoHref {

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -3,11 +3,12 @@
  *
  * Three custom protocols ride on top of regular markdown link syntax:
  *
- *   - `quote:streamId/messageId/authorId/actorType` — the attribution
- *     link inside a `quoteReply` block. `authorId`/`actorType` are
+ *   - `quote:streamId/messageId/authorId/actorType[?v=n&r=from-to]` — the
+ *     attribution link inside a `quoteReply` block. `authorId`/`actorType` are
  *     optional for backward compat with messages serialized before
- *     denormalised author metadata was added.
- *   - `shared-message:streamId/messageId[/conversationId]` — the inline
+ *     denormalised author metadata was added; the `?v=`/`&r=` suffix pins the
+ *     source revision and the quoted span (see `ReferencePin`).
+ *   - `shared-message:streamId/messageId[/conversationId][?v=n&r=from-to]` — the inline
  *     pointer link a `sharedMessage` block serialises to. The optional third
  *     segment is the conversation the message was shared from; when present the
  *     card's back-link reopens the source in that conversation's side panel
@@ -28,12 +29,26 @@
 
 import {
   actorTypeFromMentionId,
+  type ContentRange,
   isResolvedChannelLinkId,
   MENTION_BROADCAST_CHANNEL,
   MENTION_BROADCAST_HERE,
 } from "@threa/types"
 
-export interface QuoteHref {
+/**
+ * The pin a `quote:`/`shared-message:` href can carry as a `?v=<n>[&r=<from>-<to>]`
+ * suffix: which revision of the source the reference points at, and which span of
+ * that revision's content. Absent on legacy hrefs, which mean "current revision,
+ * whole message".
+ */
+export interface ReferencePin {
+  /** Source message revision; `null`/absent = unpinned. */
+  version?: number | null
+  /** Position span inside the pinned revision; `null`/absent = the whole message. */
+  range?: ContentRange | null
+}
+
+export interface QuoteHref extends ReferencePin {
   streamId: string
   messageId: string
   /** Empty string when the message was serialized pre-denormalisation. */
@@ -43,28 +58,33 @@ export interface QuoteHref {
 }
 
 export function buildQuoteHref(params: QuoteHref): string {
+  const query = buildReferenceQuery(params)
   // Emit the legacy two-segment form when authorId is empty, otherwise the
   // four-segment string with `//user` in the middle wouldn't match the
   // parser's `[\w-]+` segment regex on roundtrip.
   if (!params.authorId) {
-    return `quote:${params.streamId}/${params.messageId}`
+    return `quote:${params.streamId}/${params.messageId}${query}`
   }
-  return `quote:${params.streamId}/${params.messageId}/${params.authorId}/${params.actorType}`
+  return `quote:${params.streamId}/${params.messageId}/${params.authorId}/${params.actorType}${query}`
 }
 
 export function parseQuoteHref(href: string): QuoteHref | null {
   if (!href.startsWith("quote:")) return null
-  const parts = href.slice("quote:".length).split("/")
+  const split = splitReferenceQuery(href.slice("quote:".length))
+  if (!split) return null
+  const parts = split.path.split("/")
   if (parts.length < 2) return null
   return {
     streamId: parts[0],
     messageId: parts[1],
     authorId: parts[2] ?? "",
     actorType: parts[3] ?? "user",
+    version: split.pin.version,
+    range: split.pin.range,
   }
 }
 
-export interface SharedMessageHref {
+export interface SharedMessageHref extends ReferencePin {
   streamId: string
   messageId: string
   /**
@@ -77,24 +97,78 @@ export interface SharedMessageHref {
 }
 
 export function buildSharedMessageHref(params: SharedMessageHref): string {
+  const query = buildReferenceQuery(params)
   // Emit the legacy two-segment form when there's no conversation origin so
   // older readers keep parsing it and the wire form stays stable for the common
   // in-stream case; append the third segment only when it carries information.
   if (!params.conversationId) {
-    return `shared-message:${params.streamId}/${params.messageId}`
+    return `shared-message:${params.streamId}/${params.messageId}${query}`
   }
-  return `shared-message:${params.streamId}/${params.messageId}/${params.conversationId}`
+  return `shared-message:${params.streamId}/${params.messageId}/${params.conversationId}${query}`
 }
 
 export function parseSharedMessageHref(href: string): SharedMessageHref | null {
   if (!href.startsWith("shared-message:")) return null
-  const parts = href.slice("shared-message:".length).split("/")
+  const split = splitReferenceQuery(href.slice("shared-message:".length))
+  if (!split) return null
+  const parts = split.path.split("/")
   // Exactly the 2-segment (legacy / in-stream) or 3-segment (conversation
   // origin) shapes `buildSharedMessageHref` emits — reject anything longer so a
   // malformed href can't silently drop trailing data, matching the strictness
   // of the regex-anchored `parseSharedMessageLine` in markdown.ts.
   if (parts.length < 2 || parts.length > 3) return null
-  return { streamId: parts[0], messageId: parts[1], conversationId: parts[2] || undefined }
+  return {
+    streamId: parts[0],
+    messageId: parts[1],
+    conversationId: parts[2] || undefined,
+    version: split.pin.version,
+    range: split.pin.range,
+  }
+}
+
+/**
+ * `?v=<n>` when pinned, plus `&r=<from>-<to>` when the reference covers a span
+ * of that revision. A range without a version has no meaning — positions only
+ * exist inside a known revision — so it's a programming error, not a value to
+ * drop silently (INV-11).
+ */
+function buildReferenceQuery(pin: ReferencePin): string {
+  const version = pin.version ?? null
+  const range = pin.range ?? null
+  if (version === null) {
+    if (range !== null) throw new Error("A reference range requires a pinned version")
+    return ""
+  }
+  if (range === null) return `?v=${version}`
+  return `?v=${version}&r=${range.from}-${range.to}`
+}
+
+/**
+ * Split a pointer body into its path and its pin. Returns `null` when the query
+ * is malformed — the caller then treats the whole href as unparseable rather
+ * than silently reading a reference as unpinned. Unrecognised parameters are
+ * ignored so a future one doesn't invalidate today's links.
+ */
+function splitReferenceQuery(body: string): { path: string; pin: Required<ReferencePin> } | null {
+  const queryAt = body.indexOf("?")
+  if (queryAt < 0) return { path: body, pin: { version: null, range: null } }
+  const path = body.slice(0, queryAt)
+  const params = new URLSearchParams(body.slice(queryAt + 1))
+  const rawVersion = params.get("v")
+  const rawRange = params.get("r")
+  if (rawVersion === null) {
+    return rawRange === null ? { path, pin: { version: null, range: null } } : null
+  }
+  if (!/^\d+$/.test(rawVersion)) return null
+  const version = Number(rawVersion)
+  if (version < 1) return null
+  if (rawRange === null) return { path, pin: { version, range: null } }
+  const match = rawRange.match(/^(\d+)-(\d+)$/)
+  if (!match) return null
+  const from = Number(match[1])
+  const to = Number(match[2])
+  if (from >= to) return null
+  return { path, pin: { version, range: { from, to } } }
 }
 
 export interface MemoHref {

--- a/packages/prosemirror/src/positions.test.ts
+++ b/packages/prosemirror/src/positions.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test"
+import type { JSONContent } from "@threa/types"
+
+import { CONTAINER_NODE_TYPES, docContentSize, LEAF_NODE_TYPES, nodeSize, UnknownNodeTypeError } from "./positions"
+
+const fixture: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello " },
+        { type: "text", text: "world", marks: [{ type: "bold" }] },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "a" },
+        { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } },
+        { type: "text", text: "b" },
+      ],
+    },
+  ],
+}
+
+describe("nodeSize", () => {
+  it("sizes a text node as its character length", () => {
+    expect(nodeSize({ type: "text", text: "Hello" })).toBe(5)
+    expect(nodeSize({ type: "text", text: "" })).toBe(0)
+    expect(nodeSize({ type: "text", text: "a\u{1F600}b" })).toBe(4)
+  })
+
+  it("sizes every non-text leaf node as 1", () => {
+    for (const type of LEAF_NODE_TYPES) {
+      if (type === "text") continue
+      expect([type, nodeSize({ type })]).toEqual([type, 1])
+    }
+  })
+
+  it("sizes an empty container as 2, with or without a content key", () => {
+    expect(nodeSize({ type: "paragraph" })).toBe(2)
+    expect(nodeSize({ type: "paragraph", content: [] })).toBe(2)
+  })
+
+  it("sizes a container as 2 + its children", () => {
+    expect(nodeSize(fixture.content![0])).toBe(13)
+    expect(nodeSize(fixture.content![1])).toBe(5)
+    expect(
+      nodeSize({
+        type: "bulletList",
+        content: [{ type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] }],
+      })
+    ).toBe(8)
+  })
+
+  it("treats an unrecognised node with children as a container", () => {
+    expect(nodeSize({ type: "future", content: [{ type: "text", text: "hi" }] })).toBe(4)
+  })
+
+  it("throws on an unrecognised childless node instead of guessing its size", () => {
+    expect(() => nodeSize({ type: "future" })).toThrow(UnknownNodeTypeError)
+  })
+
+  it("keeps the leaf and container sets disjoint", () => {
+    for (const type of LEAF_NODE_TYPES) {
+      expect([type, CONTAINER_NODE_TYPES.has(type)]).toEqual([type, false])
+    }
+  })
+})
+
+describe("docContentSize", () => {
+  it("sums the top-level children", () => {
+    expect(docContentSize(fixture)).toBe(18)
+  })
+
+  it("is 0 for an empty document", () => {
+    expect(docContentSize({ type: "doc", content: [] })).toBe(0)
+    expect(docContentSize({ type: "doc" })).toBe(0)
+  })
+})

--- a/packages/prosemirror/src/positions.ts
+++ b/packages/prosemirror/src/positions.ts
@@ -1,0 +1,84 @@
+/**
+ * ProseMirror document positions computed straight from the JSON tree, with no
+ * `Schema` and no `prosemirror-model` dependency — the backend, the workers and
+ * the editor all need the same numbers, and only the editor ships a schema.
+ *
+ * The sizing rules are ProseMirror's own: a text node is `text.length`, a
+ * leaf/atom node is `1`, any other node is `2 + sum(children)`. A range of
+ * positions therefore means the same thing here as it does inside a live
+ * editor; `prosemirror-positions.contract.test.ts` in the frontend proves the
+ * two agree against the real tiptap schema.
+ */
+
+import type { JSONContent } from "@threa/types"
+
+/**
+ * Node types with no children — size 1 (or `text.length` for text). Kept in
+ * sync with the tiptap schema by the frontend contract test, which fails when
+ * an extension adds or changes a leaf node.
+ *
+ * `command` is the API-only alias for the editor's `slashCommand` node: the
+ * public API accepts it and the markdown serializer treats both as atoms, so a
+ * stored document can carry either name.
+ */
+export const LEAF_NODE_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "hardBreak",
+  "horizontalRule",
+  "mention",
+  "channelLink",
+  "slashCommand",
+  "command",
+  "emoji",
+  "attachmentReference",
+  "memoEmbed",
+  "giphyEmbed",
+  "inAppLink",
+  "quoteReply",
+  "sharedMessage",
+])
+
+/** Node types that hold children — size `2 + sum(children)`, even when empty. */
+export const CONTAINER_NODE_TYPES: ReadonlySet<string> = new Set([
+  "doc",
+  "paragraph",
+  "heading",
+  "codeBlock",
+  "blockquote",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "table",
+  "tableRow",
+  "tableHeader",
+  "tableCell",
+])
+
+export class UnknownNodeTypeError extends Error {
+  constructor(public readonly nodeType: string) {
+    super(`Cannot size unknown ProseMirror node type "${nodeType}"`)
+    this.name = "UnknownNodeTypeError"
+  }
+}
+
+/** ProseMirror `Node.nodeSize` for a JSON node. */
+export function nodeSize(node: JSONContent): number {
+  if (node.type === "text") return node.text?.length ?? 0
+  const type = node.type ?? ""
+  if (LEAF_NODE_TYPES.has(type)) return 1
+  if (CONTAINER_NODE_TYPES.has(type) || node.content) return 2 + contentSize(node)
+  throw new UnknownNodeTypeError(type)
+}
+
+/** ProseMirror `Node.content.size` for a JSON node — the doc's position space. */
+export function docContentSize(doc: JSONContent): number {
+  return contentSize(doc)
+}
+
+function contentSize(node: JSONContent): number {
+  let size = 0
+  for (const child of node.content ?? []) {
+    size += nodeSize(child)
+  }
+  return size
+}

--- a/packages/prosemirror/src/selection-range.test.ts
+++ b/packages/prosemirror/src/selection-range.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test"
+import type { JSONContent } from "@threa/types"
+
+import { resolveSelectionRange } from "./selection-range"
+import { sliceContent } from "./slice"
+
+const mention: JSONContent = { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } }
+
+const paragraph = (...content: JSONContent[]): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content }],
+})
+
+const text = (value: string, ...marks: string[]): JSONContent =>
+  marks.length > 0
+    ? { type: "text", text: value, marks: marks.map((type) => ({ type })) }
+    : { type: "text", text: value }
+
+describe("resolveSelectionRange", () => {
+  it("locates a word sequence inside a paragraph", () => {
+    const doc = paragraph(text("The quick brown fox"))
+    expect(resolveSelectionRange(doc, { text: "quick brown" })).toEqual({ from: 5, to: 16 })
+  })
+
+  it("locates a word that marks split across text nodes", () => {
+    const doc = paragraph(text("Hel"), text("lo", "bold"), text(" world"))
+    const range = resolveSelectionRange(doc, { text: "Hello world" })
+    expect(range).toEqual({ from: 1, to: 12 })
+    expect(sliceContent(doc, range!.from, range!.to)).toEqual(doc)
+  })
+
+  it("matches partial first and last words", () => {
+    const doc = paragraph(text("Hello world"))
+    expect(resolveSelectionRange(doc, { text: "llo wor" })).toEqual({ from: 3, to: 10 })
+  })
+
+  it("consumes a mention's rendered label between two words", () => {
+    const doc = paragraph(text("hi "), mention, text(" there"))
+    expect(resolveSelectionRange(doc, { text: "hi @alice there" })).toEqual({ from: 1, to: 11 })
+  })
+
+  it("starts at a mention when the selection opens with its label", () => {
+    const doc = paragraph(mention, text(" hi"))
+    expect(resolveSelectionRange(doc, { text: "@alice hi" })).toEqual({ from: 1, to: 5 })
+  })
+
+  it("ends at a mention when the selection closes with its label", () => {
+    const doc = paragraph(text("hi "), mention)
+    expect(resolveSelectionRange(doc, { text: "hi @alice" })).toEqual({ from: 1, to: 5 })
+  })
+
+  it("selects the mention alone when only its label is selected", () => {
+    const doc = paragraph(text("hi "), mention, text(" there"))
+    expect(resolveSelectionRange(doc, { text: "@alice" })).toEqual({ from: 4, to: 5 })
+  })
+
+  it("spans paragraphs when the selection crosses a block boundary", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [text("first line")] },
+        { type: "paragraph", content: [text("second line")] },
+      ],
+    }
+    expect(resolveSelectionRange(doc, { text: "line second" })).toEqual({ from: 7, to: 19 })
+  })
+
+  it("picks the repeat closest to the prefix text's word count", () => {
+    const doc = paragraph(text("foo bar baz foo bar"))
+    expect(resolveSelectionRange(doc, { text: "foo bar" })).toEqual({ from: 1, to: 8 })
+    expect(resolveSelectionRange(doc, { text: "foo bar", prefixText: "foo bar baz " })).toEqual({ from: 13, to: 20 })
+  })
+
+  it("normalises non-breaking and zero-width whitespace", () => {
+    const doc = paragraph(text("alpha\u00A0beta\u200Bgamma"))
+    expect(resolveSelectionRange(doc, { text: "beta gamma" })).toEqual({ from: 7, to: 17 })
+  })
+
+  it("returns null when the selection has no words or matches nothing", () => {
+    const doc = paragraph(text("Hello world"))
+    expect(resolveSelectionRange(doc, { text: "   " })).toBeNull()
+    expect(resolveSelectionRange(doc, { text: "goodbye" })).toBeNull()
+    expect(resolveSelectionRange({ type: "doc", content: [] }, { text: "anything" })).toBeNull()
+  })
+})

--- a/packages/prosemirror/src/selection-range.test.ts
+++ b/packages/prosemirror/src/selection-range.test.ts
@@ -71,6 +71,12 @@ describe("resolveSelectionRange", () => {
     expect(resolveSelectionRange(doc, { text: "foo bar", prefixText: "foo bar baz " })).toEqual({ from: 13, to: 20 })
   })
 
+  it("counts an atom as one word when scoring the prefix text", () => {
+    const doc = paragraph(text("foo "), mention, text(" foo foo foo"))
+    expect(resolveSelectionRange(doc, { text: "foo", prefixText: "foo @alice " })).toEqual({ from: 7, to: 10 })
+    expect(resolveSelectionRange(doc, { text: "foo", prefixText: "foo @alice foo foo " })).toEqual({ from: 15, to: 18 })
+  })
+
   it("normalises non-breaking and zero-width whitespace", () => {
     const doc = paragraph(text("alpha\u00A0beta\u200Bgamma"))
     expect(resolveSelectionRange(doc, { text: "beta gamma" })).toEqual({ from: 7, to: 17 })

--- a/packages/prosemirror/src/selection-range.ts
+++ b/packages/prosemirror/src/selection-range.ts
@@ -106,7 +106,8 @@ export function resolveSelectionRange(doc: JSONContent, input: SelectionRangeInp
         bestDistance = distance
       }
     }
-    if (tokens[i].kind === "word") wordsBefore++
+    // An atom renders as one label the prefix text counts as a word too.
+    wordsBefore++
   }
   return best
 }

--- a/packages/prosemirror/src/selection-range.ts
+++ b/packages/prosemirror/src/selection-range.ts
@@ -1,0 +1,199 @@
+/**
+ * Mapping a rendered text selection back to a position range in the document
+ * it was rendered from.
+ *
+ * The browser hands us a string, not positions: marks split one word across
+ * several text nodes, mentions and other atoms render a label that exists
+ * nowhere in the JSON, and the timeline renderer is free to add whitespace.
+ * So we project the document to a word sequence that remembers where every
+ * character lives, tokenize the selection the same way, and match the two as a
+ * word sequence. Matching is deliberately forgiving at the edges (a selection
+ * may start mid-word and end mid-word) and around atoms (their label is
+ * consumed as up to a handful of unmatched words).
+ */
+
+import type { ContentRange, JSONContent } from "@threa/types"
+
+import { LEAF_NODE_TYPES, nodeSize } from "./positions"
+
+export interface SelectionRangeInput {
+  /** The selected text as the DOM reports it. */
+  text: string
+  /** The rendered text before the selection, used to choose between repeated matches. */
+  prefixText?: string
+}
+
+/** Longest run of selected words an atom's rendered label may account for. */
+const MAX_ATOM_LABEL_WORDS = 5
+
+/**
+ * The position range covering `text` inside `doc`, or `null` when the selection
+ * can't be located (the caller then falls back to referencing the whole
+ * message). Pure and deterministic.
+ */
+export function resolveSelectionRange(doc: JSONContent, input: SelectionRangeInput): ContentRange | null {
+  const selected = toWords(input.text)
+  if (selected.length === 0) return null
+
+  const tokens = project(doc)
+  if (tokens.length === 0) return null
+
+  const memo = new Map<string, number | null>()
+
+  const matchTail = (tokenIndex: number, wordIndex: number): number | null => {
+    const key = `${tokenIndex}:${wordIndex}`
+    const cached = memo.get(key)
+    if (cached !== undefined) return cached
+    const result = computeTail(tokenIndex, wordIndex)
+    memo.set(key, result)
+    return result
+  }
+
+  const computeTail = (tokenIndex: number, wordIndex: number): number | null => {
+    const token = tokens[tokenIndex]
+    if (!token) return null
+    if (token.kind === "atom") {
+      const maxConsumed = Math.min(MAX_ATOM_LABEL_WORDS, selected.length - wordIndex)
+      for (let consumed = 0; consumed <= maxConsumed; consumed++) {
+        if (wordIndex + consumed === selected.length) return token.to
+        const end = matchTail(tokenIndex + 1, wordIndex + consumed)
+        if (end !== null) return end
+      }
+      return null
+    }
+    const word = selected[wordIndex]
+    if (wordIndex === selected.length - 1) {
+      return token.text.startsWith(word) ? token.positions[word.length - 1] + 1 : null
+    }
+    if (token.text !== word) return null
+    return matchTail(tokenIndex + 1, wordIndex + 1)
+  }
+
+  const matchAt = (tokenIndex: number): ContentRange | null => {
+    const token = tokens[tokenIndex]
+    if (token.kind === "atom") {
+      const maxConsumed = Math.min(MAX_ATOM_LABEL_WORDS, selected.length)
+      for (let consumed = 1; consumed <= maxConsumed; consumed++) {
+        if (consumed === selected.length) return { from: token.from, to: token.to }
+        const end = matchTail(tokenIndex + 1, consumed)
+        if (end !== null) return { from: token.from, to: end }
+      }
+      return null
+    }
+    const first = selected[0]
+    if (selected.length === 1) {
+      const at = token.text.indexOf(first)
+      if (at < 0) return null
+      return { from: token.positions[at], to: token.positions[at + first.length - 1] + 1 }
+    }
+    if (!token.text.endsWith(first)) return null
+    const end = matchTail(tokenIndex + 1, 1)
+    if (end === null) return null
+    return { from: token.positions[token.text.length - first.length], to: end }
+  }
+
+  const targetWordsBefore = input.prefixText === undefined ? null : toWords(input.prefixText).length
+  let best: ContentRange | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+  let wordsBefore = 0
+  for (let i = 0; i < tokens.length; i++) {
+    const range = matchAt(i)
+    if (range) {
+      if (targetWordsBefore === null) return range
+      const distance = Math.abs(wordsBefore - targetWordsBefore)
+      if (distance < bestDistance) {
+        best = range
+        bestDistance = distance
+      }
+    }
+    if (tokens[i].kind === "word") wordsBefore++
+  }
+  return best
+}
+
+interface WordToken {
+  kind: "word"
+  text: string
+  /** Document position of each character in `text`. */
+  positions: number[]
+}
+
+interface AtomToken {
+  kind: "atom"
+  from: number
+  to: number
+}
+
+type ProjectionToken = WordToken | AtomToken
+
+function project(doc: JSONContent): ProjectionToken[] {
+  const tokens: ProjectionToken[] = []
+  let chars: string[] = []
+  let positions: number[] = []
+
+  const flush = (): void => {
+    if (chars.length === 0) return
+    tokens.push({ kind: "word", text: chars.join(""), positions })
+    chars = []
+    positions = []
+  }
+
+  const walk = (node: JSONContent, contentStart: number): void => {
+    let pos = contentStart
+    for (const child of node.content ?? []) {
+      const size = nodeSize(child)
+      const type = child.type ?? ""
+      if (type === "text") {
+        const text = child.text ?? ""
+        for (let i = 0; i < text.length; i++) {
+          const ch = normalizeChar(text[i])
+          if (ch === " ") {
+            flush()
+          } else {
+            chars.push(ch)
+            positions.push(pos + i)
+          }
+        }
+      } else if (LEAF_NODE_TYPES.has(type)) {
+        flush()
+        if (type !== "hardBreak") tokens.push({ kind: "atom", from: pos, to: pos + 1 })
+      } else {
+        flush()
+        walk(child, pos + 1)
+        flush()
+      }
+      pos += size
+    }
+  }
+
+  walk(doc, 0)
+  flush()
+  return tokens
+}
+
+// Non-breaking and zero-width characters are invisible word separators in the
+// rendered text; folding them to a space keeps projection and selection aligned
+// without shifting any character's position.
+const SPACE_LIKE = /[\s\u200B\u200C\u200D]/
+
+function normalizeChar(ch: string): string {
+  if (SPACE_LIKE.test(ch)) return " "
+  const composed = ch.normalize("NFC")
+  return composed.length === 1 ? composed : ch
+}
+
+function toWords(text: string): string[] {
+  const words: string[] = []
+  let current = ""
+  for (let i = 0; i < text.length; i++) {
+    const ch = normalizeChar(text[i])
+    if (ch === " ") {
+      if (current.length > 0) words.push(current)
+      current = ""
+    } else {
+      current += ch
+    }
+  }
+  if (current.length > 0) words.push(current)
+  return words
+}

--- a/packages/prosemirror/src/slice.test.ts
+++ b/packages/prosemirror/src/slice.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test"
+import type { JSONContent } from "@threa/types"
+
+import { isEmptySlice, isRangeValid, normalizeRange, sliceContent } from "./slice"
+
+const mention: JSONContent = { type: "mention", attrs: { id: "usr_1", slug: "alice", mentionType: "user" } }
+
+// Positions: paragraph one spans 0–13 ("Hello " at 1–6, "world" at 7–11),
+// paragraph two spans 13–18 ("a" at 14, the mention at 15, "b" at 16).
+const doc: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello " },
+        { type: "text", text: "world", marks: [{ type: "bold" }] },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "a" }, mention, { type: "text", text: "b" }],
+    },
+  ],
+}
+
+describe("sliceContent", () => {
+  it("cuts text on character boundaries and keeps marks", () => {
+    expect(sliceContent(doc, 3, 9)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "llo " },
+            { type: "text", text: "wo", marks: [{ type: "bold" }] },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("keeps the ancestors of a cut that spans two blocks", () => {
+    expect(sliceContent(doc, 7, 16)).toEqual({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "world", marks: [{ type: "bold" }] }] },
+        { type: "paragraph", content: [{ type: "text", text: "a" }, mention] },
+      ],
+    })
+  })
+
+  it("keeps an atom whole and drops one the range only touches", () => {
+    expect(sliceContent(doc, 15, 16)).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph", content: [mention] }],
+    })
+    expect(sliceContent(doc, 16, 17)).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "b" }] }],
+    })
+  })
+
+  it("leaves an emptied container behind, as ProseMirror does", () => {
+    expect(sliceContent(doc, 13, 14)).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+  })
+
+  it("returns the document itself for a whole-document range", () => {
+    expect(sliceContent(doc, 0, 18)).toEqual(doc)
+  })
+
+  it("returns an empty document for an empty range", () => {
+    expect(sliceContent(doc, 5, 5)).toEqual({ type: "doc" })
+  })
+})
+
+describe("isRangeValid", () => {
+  it("accepts a non-empty in-bounds integer range", () => {
+    expect(isRangeValid(doc, { from: 0, to: 18 })).toBe(true)
+    expect(isRangeValid(doc, { from: 3, to: 9 })).toBe(true)
+  })
+
+  it("rejects reversed, empty, out-of-bounds and non-integer ranges", () => {
+    expect(isRangeValid(doc, { from: 9, to: 3 })).toBe(false)
+    expect(isRangeValid(doc, { from: 3, to: 3 })).toBe(false)
+    expect(isRangeValid(doc, { from: -1, to: 5 })).toBe(false)
+    expect(isRangeValid(doc, { from: 0, to: 19 })).toBe(false)
+    expect(isRangeValid(doc, { from: 0.5, to: 5 })).toBe(false)
+  })
+})
+
+describe("normalizeRange", () => {
+  it("collapses a whole-document range and an absent range to null", () => {
+    expect(normalizeRange(doc, { from: 0, to: 18 })).toBeNull()
+    expect(normalizeRange(doc, null)).toBeNull()
+    expect(normalizeRange(doc, undefined)).toBeNull()
+  })
+
+  it("passes a partial range through", () => {
+    expect(normalizeRange(doc, { from: 3, to: 9 })).toEqual({ from: 3, to: 9 })
+  })
+})
+
+describe("isEmptySlice", () => {
+  it("is false for a slice with visible text or an atom", () => {
+    expect(isEmptySlice(sliceContent(doc, 3, 9))).toBe(false)
+    expect(isEmptySlice(sliceContent(doc, 15, 16))).toBe(false)
+  })
+
+  it("is true for a slice with no atoms and no non-whitespace text", () => {
+    expect(isEmptySlice({ type: "doc", content: [{ type: "paragraph" }] })).toBe(true)
+    expect(
+      isEmptySlice({ type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "  " }] }] })
+    ).toBe(true)
+    expect(isEmptySlice({ type: "doc", content: [{ type: "paragraph", content: [{ type: "hardBreak" }] }] })).toBe(true)
+  })
+})

--- a/packages/prosemirror/src/slice.ts
+++ b/packages/prosemirror/src/slice.ts
@@ -1,0 +1,105 @@
+/**
+ * Cutting a document down to a position range, matching ProseMirror's
+ * `Node.cut` exactly: ancestors of the cut are kept, text nodes are cut on
+ * character boundaries with their marks intact, atoms are kept whole or dropped
+ * whole, and containers the cut empties out stay behind as empty nodes.
+ */
+
+import type { ContentRange, JSONContent } from "@threa/types"
+
+import { docContentSize, LEAF_NODE_TYPES, nodeSize } from "./positions"
+
+/**
+ * The sub-document covered by `[from, to)`, as a `doc` node. Positions are the
+ * doc's own content positions (see `positions.ts`) — validate them with
+ * `isRangeValid` first; like `Fragment.cut` this stops at the document's edges
+ * rather than reporting a position that isn't there.
+ */
+export function sliceContent(doc: JSONContent, from: number, to: number): JSONContent {
+  return cutNode(doc, from, to)
+}
+
+/** Integers, in bounds, non-empty. `to` is exclusive. */
+export function isRangeValid(doc: JSONContent, range: ContentRange): boolean {
+  const { from, to } = range
+  if (!Number.isInteger(from) || !Number.isInteger(to)) return false
+  return from >= 0 && from < to && to <= docContentSize(doc)
+}
+
+/**
+ * `null` for "the whole message" — both for an absent range and for one that
+ * covers the entire document, so a full-message reference has one wire form.
+ */
+export function normalizeRange(doc: JSONContent, range: ContentRange | null | undefined): ContentRange | null {
+  if (!range) return null
+  if (range.from === 0 && range.to === docContentSize(doc)) return null
+  return { from: range.from, to: range.to }
+}
+
+/**
+ * True when a slice carries nothing a reader would see: no atom nodes and no
+ * non-whitespace text. Hard breaks alone don't make a slice worth quoting.
+ */
+export function isEmptySlice(doc: JSONContent): boolean {
+  let empty = true
+  const walk = (node: JSONContent): void => {
+    if (!empty) return
+    if (node.type === "text") {
+      if ((node.text ?? "").trim().length > 0) empty = false
+      return
+    }
+    if (node.type !== "hardBreak" && LEAF_NODE_TYPES.has(node.type ?? "")) {
+      empty = false
+      return
+    }
+    for (const child of node.content ?? []) {
+      walk(child)
+    }
+  }
+  walk(doc)
+  return empty
+}
+
+function cutNode(node: JSONContent, from: number, to: number): JSONContent {
+  if (node.type === "text") {
+    const text = node.text ?? ""
+    if (from === 0 && to === text.length) return node
+    return { ...node, text: text.slice(from, to) }
+  }
+  const size = docContentSize(node)
+  if (from === 0 && to === size) return node
+  return withContent(node, cutChildren(node.content ?? [], from, to))
+}
+
+function cutChildren(children: JSONContent[], from: number, to: number): JSONContent[] {
+  if (to <= from) return []
+  const result: JSONContent[] = []
+  let pos = 0
+  for (const child of children) {
+    if (pos >= to) break
+    const size = nodeSize(child)
+    const end = pos + size
+    if (end > from) {
+      if (pos < from || end > to) {
+        result.push(
+          child.type === "text"
+            ? cutNode(child, Math.max(0, from - pos), Math.min((child.text ?? "").length, to - pos))
+            : cutNode(child, Math.max(0, from - pos - 1), Math.min(docContentSize(child), to - pos - 1))
+        )
+      } else {
+        result.push(child)
+      }
+    }
+    pos = end
+  }
+  return result
+}
+
+function withContent(node: JSONContent, content: JSONContent[]): JSONContent {
+  const next: JSONContent = { ...node }
+  // `Node.toJSON()` omits `content` for an empty fragment; keeping the key
+  // would make an otherwise identical slice compare unequal to a cut node.
+  if (content.length > 0) next.content = content
+  else delete next.content
+  return next
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -778,6 +778,7 @@ export type {
   ThreaHeading,
   ThreaCodeBlock,
   ThreaBlockquote,
+  ContentRange,
   ThreaQuoteReply,
   ThreaSharedMessage,
   ThreaBulletList,

--- a/packages/types/src/prosemirror.test.ts
+++ b/packages/types/src/prosemirror.test.ts
@@ -44,6 +44,12 @@ describe("reference pins survive validation", () => {
     expect(isThreaDocument(pinnedQuote({}))).toBe(true)
   })
 
+  it("rejects a reversed range and a range without a version", () => {
+    expect(isThreaDocument(pinnedQuote({ version: 1, range: { from: 3, to: 2 } }))).toBe(false)
+    expect(isThreaDocument(pinnedQuote({ range: { from: 0, to: 3 } }))).toBe(false)
+    expect(isThreaDocument(pinnedQuote({ version: null, range: { from: 0, to: 3 } }))).toBe(false)
+  })
+
   it("rejects a non-positive version and a fractional or negative range", () => {
     expect(isThreaDocument(pinnedQuote({ version: 0 }))).toBe(false)
     expect(isThreaDocument(pinnedQuote({ version: 1.5 }))).toBe(false)

--- a/packages/types/src/prosemirror.test.ts
+++ b/packages/types/src/prosemirror.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test"
+
+import { isThreaDocument, validateContent, type JSONContent } from "./prosemirror"
+
+const pinnedQuote = (attrs: Record<string, unknown>): JSONContent => ({
+  type: "doc",
+  content: [
+    {
+      type: "quoteReply",
+      attrs: {
+        messageId: "msg_1",
+        streamId: "stream_1",
+        authorName: "Alice",
+        authorId: "usr_1",
+        actorType: "user",
+        snippet: "hello",
+        ...attrs,
+      },
+    },
+  ],
+})
+
+describe("reference pins survive validation", () => {
+  it("keeps version and range on a quoteReply", () => {
+    const doc = pinnedQuote({ version: 2, range: { from: 1, to: 6 } })
+    expect(validateContent(doc) as JSONContent).toEqual(doc)
+  })
+
+  it("keeps version and range on a sharedMessage", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "sharedMessage",
+          attrs: { messageId: "msg_1", streamId: "stream_1", version: 4, range: { from: 0, to: 3 } },
+        },
+      ],
+    }
+    expect(validateContent(doc) as JSONContent).toEqual(doc)
+  })
+
+  it("accepts an explicit null pin and a legacy node with no pin at all", () => {
+    expect(isThreaDocument(pinnedQuote({ version: null, range: null }))).toBe(true)
+    expect(isThreaDocument(pinnedQuote({}))).toBe(true)
+  })
+
+  it("rejects a non-positive version and a fractional or negative range", () => {
+    expect(isThreaDocument(pinnedQuote({ version: 0 }))).toBe(false)
+    expect(isThreaDocument(pinnedQuote({ version: 1.5 }))).toBe(false)
+    expect(isThreaDocument(pinnedQuote({ version: 1, range: { from: -1, to: 3 } }))).toBe(false)
+    expect(isThreaDocument(pinnedQuote({ version: 1, range: { from: 0, to: 0 } }))).toBe(false)
+  })
+})

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -93,6 +93,17 @@ export interface ThreaBlockquote {
 }
 
 /**
+ * A half-open span of ProseMirror document positions inside a message's
+ * `contentJson` — `from` inclusive, `to` exclusive, both counted with
+ * ProseMirror's own sizing rules (text node = text length, leaf/atom = 1,
+ * other node = 2 + children). `null` on a reference means the whole message.
+ */
+export interface ContentRange {
+  from: number
+  to: number
+}
+
+/**
  * Quote reply - quotes a specific message (or part of it) with attribution.
  * Serializes to markdown as a blockquote with a `quote:` attribution link.
  */
@@ -111,6 +122,10 @@ export interface ThreaQuoteReply {
     actorType: string
     /** The quoted text snippet */
     snippet: string
+    /** Source message revision the quote is pinned to; null/absent = unpinned legacy node */
+    version?: number | null
+    /** Span inside the pinned version's content; null/absent = the whole message */
+    range?: ContentRange | null
   }
 }
 
@@ -133,6 +148,10 @@ export interface ThreaSharedMessage {
     authorId?: string
     /** The actor type of the source author, cached for the same reason */
     actorType?: string
+    /** Source message revision the pointer is pinned to; null/absent = unpinned legacy node */
+    version?: number | null
+    /** Span inside the pinned version's content; null/absent = the whole message */
+    range?: ContentRange | null
   }
 }
 
@@ -515,6 +534,11 @@ const blockquoteNodeSchema = z.object({
   content: z.array(blockNodeSchema),
 })
 
+const contentRangeSchema = z.object({
+  from: z.number().int().nonnegative(),
+  to: z.number().int().positive(),
+})
+
 const quoteReplyNodeSchema = z.object({
   type: z.literal("quoteReply"),
   attrs: z.object({
@@ -524,6 +548,8 @@ const quoteReplyNodeSchema = z.object({
     authorId: z.string(),
     actorType: z.string(),
     snippet: z.string(),
+    version: z.number().int().positive().nullish(),
+    range: contentRangeSchema.nullish(),
   }),
 })
 
@@ -535,6 +561,8 @@ const sharedMessageNodeSchema = z.object({
     authorName: z.string().optional(),
     authorId: z.string().optional(),
     actorType: z.string().optional(),
+    version: z.number().int().positive().nullish(),
+    range: contentRangeSchema.nullish(),
   }),
 })
 

--- a/packages/types/src/prosemirror.ts
+++ b/packages/types/src/prosemirror.ts
@@ -534,36 +534,46 @@ const blockquoteNodeSchema = z.object({
   content: z.array(blockNodeSchema),
 })
 
-const contentRangeSchema = z.object({
-  from: z.number().int().nonnegative(),
-  to: z.number().int().positive(),
-})
+const contentRangeSchema = z
+  .object({
+    from: z.number().int().nonnegative(),
+    to: z.number().int().positive(),
+  })
+  .refine((range) => range.from < range.to, { message: "range.from must be less than range.to" })
+
+const pinnedAttrs = { version: z.number().int().positive().nullish(), range: contentRangeSchema.nullish() }
+const rangeRequiresVersion = {
+  check: (attrs: { version?: number | null; range?: unknown }) => attrs.range == null || attrs.version != null,
+  message: "A reference range requires a pinned version",
+}
 
 const quoteReplyNodeSchema = z.object({
   type: z.literal("quoteReply"),
-  attrs: z.object({
-    messageId: z.string(),
-    streamId: z.string(),
-    authorName: z.string(),
-    authorId: z.string(),
-    actorType: z.string(),
-    snippet: z.string(),
-    version: z.number().int().positive().nullish(),
-    range: contentRangeSchema.nullish(),
-  }),
+  attrs: z
+    .object({
+      messageId: z.string(),
+      streamId: z.string(),
+      authorName: z.string(),
+      authorId: z.string(),
+      actorType: z.string(),
+      snippet: z.string(),
+      ...pinnedAttrs,
+    })
+    .refine(rangeRequiresVersion.check, { message: rangeRequiresVersion.message }),
 })
 
 const sharedMessageNodeSchema = z.object({
   type: z.literal("sharedMessage"),
-  attrs: z.object({
-    messageId: z.string(),
-    streamId: z.string(),
-    authorName: z.string().optional(),
-    authorId: z.string().optional(),
-    actorType: z.string().optional(),
-    version: z.number().int().positive().nullish(),
-    range: contentRangeSchema.nullish(),
-  }),
+  attrs: z
+    .object({
+      messageId: z.string(),
+      streamId: z.string(),
+      authorName: z.string().optional(),
+      authorId: z.string().optional(),
+      actorType: z.string().optional(),
+      ...pinnedAttrs,
+    })
+    .refine(rangeRequiresVersion.check, { message: rangeRequiresVersion.message }),
 })
 
 const bulletListNodeSchema = z.object({


### PR DESCRIPTION
Second layer of the quote/share-by-pinned-version stack (plan: https://seer.build/ws_vbyzjvdg6g/b/share-quoted-plan/, on top of #1915). Contract first: the primitives both apps need to talk about "this span of that revision" without either depending on a ProseMirror schema. No consumer behavior changes here; the server resolution (next PR) and the quote/share UI build on these.

**Changes** (`packages/prosemirror`, `packages/types`, one frontend test)
- `positions.ts`: `LEAF_NODE_TYPES` / `CONTAINER_NODE_TYPES`, `nodeSize`, `docContentSize` — ProseMirror's own sizing rules (text = length, leaf = 1, container = 2 + children) computed from `JSONContent`; unknown node types throw (INV-11).
- `slice.ts`: `sliceContent(doc, from, to)` with `Node.cut` semantics, `isRangeValid`, `normalizeRange` (whole doc → `null`), `isEmptySlice`.
- `selection-range.ts`: `resolveSelectionRange(doc, { text, prefixText? })` maps a DOM selection's text back to positions by word-sequence matching (marks split text nodes, atoms consume unmatched label words, `prefixText` disambiguates repeats). Same function will run on client and server.
- `pointer-urls.ts` / `markdown.ts`: `quote:` and `shared-message:` hrefs carry `?v=<n>[&r=<from>-<to>]`; legacy forms parse unchanged; both markdown parsers now route through `parseQuoteHref` / `parseSharedMessageHref`. A range without a version throws on build; a malformed pin makes the href unparseable rather than silently unpinned.
- `packages/types`: `ContentRange`; `version`/`range` (`.nullish()`) on `quoteReply` and `sharedMessage` node types + Zod.

**Verification**
`packages/prosemirror` 198/198, `packages/types` 171/171 (incl. a new test that `validateContent` keeps the pin), frontend contract test `prosemirror-positions.contract.test.ts` 11/11: leaf and container sets equal the real tiptap schema in both directions, and `sliceContent` equals `Node.cut(...).toJSON()` for every `(from, to)` pair of a fixture using every node type. Full frontend vitest 6801/6801, backend unit 4064/4064, root typecheck, lint.

**Notes for review**
`LEAF_NODE_TYPES` keeps `command` (the public-API alias of `slashCommand`) although the editor schema lacks it; the contract test asserts that single exception explicitly. Parsers omit `version`/`range` when a href has no pin (legacy parse output unchanged); consumers read `attrs.version ?? null`.
