### PR TITLE
feat: open code blocks full screen

### DIFF
--- a/apps/frontend/src/components/code-viewer.test.tsx
+++ b/apps/frontend/src/components/code-viewer.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { CodeBlockWrap } from "@threa/types"
+import { CodeViewerProvider, useCodeViewerOptional } from "@/contexts/code-viewer-context"
+import * as preferencesModule from "@/contexts/preferences-context"
+import * as highlighterModule from "@/lib/markdown/highlighter"
+
+const CODE = "SELECT *\nFROM users\nWHERE id = 1"
+
+let currentPrefs: { codeBlockWrap?: CodeBlockWrap; codeBlockWrapOverrides?: Record<string, CodeBlockWrap> } = {}
+
+function Trigger({ languageId = "sql" }: { languageId?: string }) {
+  const viewer = useCodeViewerOptional()
+  return (
+    <button type="button" onClick={() => viewer?.open({ code: CODE, languageId })}>
+      open viewer
+    </button>
+  )
+}
+
+function mount(languageId?: string) {
+  render(
+    <CodeViewerProvider>
+      <Trigger languageId={languageId} />
+    </CodeViewerProvider>
+  )
+}
+
+function body() {
+  return document.querySelector<HTMLElement>("[role='dialog'] [data-wrap]")
+}
+
+describe("CodeViewer", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    currentPrefs = {}
+    vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(
+      () => ({ preferences: currentPrefs }) as unknown as ReturnType<typeof preferencesModule.usePreferences>
+    )
+    vi.spyOn(highlighterModule, "tryHighlightSync").mockImplementation(
+      (code) => `<pre class="shiki"><code>${code}</code></pre>`
+    )
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("should open full screen with the block's code, label, and line count", async () => {
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveTextContent("SQL")
+    expect(dialog).toHaveTextContent("3 lines")
+    expect(body()?.textContent).toBe(CODE)
+  })
+
+  it("should seed the wrap toggle from the language override and flip it without writing the preference", async () => {
+    currentPrefs = { codeBlockWrap: "scroll", codeBlockWrapOverrides: { sql: "wrap" } }
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    await screen.findByRole("dialog")
+    expect(body()).toHaveAttribute("data-wrap", "wrap")
+    const toggle = screen.getByRole("button", { name: "Wrap lines" })
+    expect(toggle).toHaveAttribute("aria-pressed", "true")
+    await userEvent.click(toggle)
+    expect(body()).toHaveAttribute("data-wrap", "scroll")
+    expect(toggle).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("should reset the toggle to the preference on the next open", async () => {
+    currentPrefs = { codeBlockWrap: "scroll" }
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    await screen.findByRole("dialog")
+    await userEvent.click(screen.getByRole("button", { name: "Wrap lines" }))
+    expect(body()).toHaveAttribute("data-wrap", "wrap")
+    await userEvent.click(screen.getByRole("button", { name: "Close" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    await screen.findByRole("dialog")
+    expect(body()).toHaveAttribute("data-wrap", "scroll")
+  })
+
+  it("should copy the code and confirm in place", async () => {
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    await screen.findByRole("dialog")
+    await userEvent.click(screen.getByRole("button", { name: "Copy code" }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CODE)
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument()
+  })
+
+  it("should close on Escape", async () => {
+    mount()
+    await userEvent.click(screen.getByRole("button", { name: "open viewer" }))
+    await screen.findByRole("dialog")
+    await userEvent.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+  })
+})

--- a/apps/frontend/src/components/code-viewer.tsx
+++ b/apps/frontend/src/components/code-viewer.tsx
@@ -95,7 +95,12 @@ export function CodeViewer({ item, onClose }: CodeViewerProps) {
             size="icon"
             className={cn("h-10 w-10", copied && "text-green-600 dark:text-green-400")}
             onClick={() => {
-              void navigator.clipboard.writeText(code).then(() => setCopied(true))
+              // A denied clipboard write has nothing actionable for the user;
+              // same posture as the inline block and the gallery.
+              navigator.clipboard.writeText(code).then(
+                () => setCopied(true),
+                () => {}
+              )
             }}
           >
             {copied ? <Check className="h-5 w-5" /> : <Copy className="h-5 w-5" />}

--- a/apps/frontend/src/components/code-viewer.tsx
+++ b/apps/frontend/src/components/code-viewer.tsx
@@ -82,7 +82,7 @@ export function CodeViewer({ item, onClose }: CodeViewerProps) {
             type="button"
             variant="ghost"
             size="icon"
-            className="h-10 w-10"
+            className={cn("h-10 w-10", wrap === "wrap" && "bg-accent text-accent-foreground")}
             aria-pressed={wrap === "wrap"}
             onClick={() => setWrap((mode) => (mode === "wrap" ? "scroll" : "wrap"))}
           >
@@ -94,13 +94,14 @@ export function CodeViewer({ item, onClose }: CodeViewerProps) {
             variant="ghost"
             size="icon"
             className={cn("h-10 w-10", copied && "text-green-600 dark:text-green-400")}
-            onClick={() => {
-              // A denied clipboard write has nothing actionable for the user;
-              // same posture as the inline block and the gallery.
-              navigator.clipboard.writeText(code).then(
-                () => setCopied(true),
-                () => {}
-              )
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(code)
+                setCopied(true)
+              } catch {
+                // A denied or unavailable clipboard has nothing actionable for
+                // the user; same posture as the inline block and the gallery.
+              }
             }}
           >
             {copied ? <Check className="h-5 w-5" /> : <Copy className="h-5 w-5" />}
@@ -115,6 +116,9 @@ export function CodeViewer({ item, onClose }: CodeViewerProps) {
         <div
           data-native-context="true"
           data-wrap={wrap}
+          tabIndex={0}
+          role="region"
+          aria-label={`${label} code`}
           className={cn(
             "min-h-0 flex-1 overflow-auto overscroll-contain select-text [-webkit-touch-callout:default]",
             "[&>pre]:m-0 [&>pre]:p-4 [&>pre]:font-mono [&>pre]:text-sm [&>pre]:leading-relaxed [&>pre]:bg-transparent",

--- a/apps/frontend/src/components/code-viewer.tsx
+++ b/apps/frontend/src/components/code-viewer.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react"
+import { Check, Copy, WrapText, X } from "lucide-react"
+import { formatCodeLanguage, resolveCodeBlockWrap, type CodeBlockWrap } from "@threa/types"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import { usePreferencesOptional } from "@/contexts/preferences-context"
+import { ensureHighlight, tryHighlightSync } from "@/lib/markdown/highlighter"
+
+export interface CodeViewerItem {
+  code: string
+  languageId: string
+}
+
+interface CodeViewerProps {
+  item: CodeViewerItem
+  onClose: () => void
+}
+
+// The body is the scroll container for both axes, so the <pre> itself never
+// scrolls: in scroll mode it just keeps its lines unbroken and the body pans.
+const SCROLL_PRE_CLASSES = "[&>pre]:whitespace-pre [&>pre]:w-max [&>pre]:min-w-full"
+const WRAP_PRE_CLASSES = "[&>pre]:whitespace-pre-wrap [&>pre]:[overflow-wrap:anywhere]"
+
+function escapeHtml(code: string): string {
+  return code.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+}
+
+/**
+ * Full-screen reader for one code block: same Dialog sizing as the media
+ * gallery (full-bleed on phones), larger type than the inline block, a
+ * session-local wrap toggle seeded from the user's preference, copy, close.
+ * Mobile back and Escape come from Dialog.
+ */
+export function CodeViewer({ item, onClose }: CodeViewerProps) {
+  const { code, languageId } = item
+  const preferences = usePreferencesOptional()?.preferences
+  const [wrap, setWrap] = useState<CodeBlockWrap>(() => resolveCodeBlockWrap(preferences ?? {}, languageId))
+  const [copied, setCopied] = useState(false)
+  const [html, setHtml] = useState<string | null>(() => tryHighlightSync(code, languageId))
+
+  useEffect(() => {
+    if (html) return
+    let cancelled = false
+    ensureHighlight(code, languageId).then((result) => {
+      if (cancelled) return
+      setHtml(result ?? `<pre><code>${escapeHtml(code)}</code></pre>`)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [html, code, languageId])
+
+  useEffect(() => {
+    if (!copied) return
+    const timer = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(timer)
+  }, [copied])
+
+  const label = formatCodeLanguage(languageId)
+  const lineCount = code.split("\n").length
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        hideCloseButton
+        className="p-0 max-sm:p-0 gap-0 max-sm:gap-0 overflow-hidden max-sm:overflow-hidden sm:flex sm:flex-col sm:max-w-[90vw] sm:h-[90dvh]"
+      >
+        <DialogTitle className="sr-only">{label} code</DialogTitle>
+        <DialogDescription className="sr-only">
+          {lineCount} line{lineCount === 1 ? "" : "s"}
+        </DialogDescription>
+
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-3">
+          <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+            {label}
+            <span className="ml-2 tabular-nums">
+              {lineCount} line{lineCount === 1 ? "" : "s"}
+            </span>
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10"
+            aria-pressed={wrap === "wrap"}
+            onClick={() => setWrap((mode) => (mode === "wrap" ? "scroll" : "wrap"))}
+          >
+            <WrapText className="h-5 w-5" />
+            <span className="sr-only">Wrap lines</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={cn("h-10 w-10", copied && "text-green-600 dark:text-green-400")}
+            onClick={() => {
+              void navigator.clipboard.writeText(code).then(() => setCopied(true))
+            }}
+          >
+            {copied ? <Check className="h-5 w-5" /> : <Copy className="h-5 w-5" />}
+            <span className="sr-only">{copied ? "Copied" : "Copy code"}</span>
+          </Button>
+          <Button type="button" variant="ghost" size="icon" className="h-10 w-10" onClick={onClose}>
+            <X className="h-5 w-5" />
+            <span className="sr-only">Close</span>
+          </Button>
+        </div>
+
+        <div
+          data-native-context="true"
+          data-wrap={wrap}
+          className={cn(
+            "min-h-0 flex-1 overflow-auto overscroll-contain select-text [-webkit-touch-callout:default]",
+            "[&>pre]:m-0 [&>pre]:p-4 [&>pre]:font-mono [&>pre]:text-sm [&>pre]:leading-relaxed [&>pre]:bg-transparent",
+            wrap === "wrap" ? WRAP_PRE_CLASSES : SCROLL_PRE_CLASSES
+          )}
+          // Safe: Shiki generates this HTML from the code string; the fallback is escaped above.
+          dangerouslySetInnerHTML={{ __html: html ?? `<pre><code>${escapeHtml(code)}</code></pre>` }}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -701,10 +701,11 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   useEffect(() => {
     if (!isOpen) return
     function onKeyDown(e: KeyboardEvent) {
-      // A dialog stacked over the gallery (the code viewer opened from a
-      // markdown slide) owns its own keys; arrows there must not flip slides.
-      const dialog = e.target instanceof Element ? e.target.closest('[role="dialog"]') : null
-      if (dialog && !dialog.hasAttribute("data-media-gallery")) return
+      // A dialog or menu stacked over the gallery (the code viewer opened from
+      // a markdown slide, the download menu) owns its own keys; arrows there
+      // must not flip slides.
+      const owner = e.target instanceof Element ? e.target.closest('[role="dialog"],[role="menu"]') : null
+      if (owner && !owner.hasAttribute("data-media-gallery")) return
       if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
         e.preventDefault()
         goTo(currentIndex - 1)

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -701,6 +701,10 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   useEffect(() => {
     if (!isOpen) return
     function onKeyDown(e: KeyboardEvent) {
+      // A dialog stacked over the gallery (the code viewer opened from a
+      // markdown slide) owns its own keys; arrows there must not flip slides.
+      const dialog = e.target instanceof Element ? e.target.closest('[role="dialog"]') : null
+      if (dialog && !dialog.hasAttribute("data-media-gallery")) return
       if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
         e.preventDefault()
         goTo(currentIndex - 1)
@@ -1021,6 +1025,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       {!current ? null : (
         <DialogContent
+          data-media-gallery=""
           className={cn(
             // <sm keeps the base DialogContent full-bleed layout (inset-0), which
             // tracks the dynamic viewport — a sized 90vh card measures the LARGE

--- a/apps/frontend/src/components/ui/history-back-close.test.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.test.tsx
@@ -7,6 +7,8 @@ import { __resetOverlayHistoryForTests, attachOverlayHistoryRouter, OverlayHisto
 import { Drawer, DrawerContent, DrawerTitle } from "./drawer"
 import { Dialog, DialogContent, DialogTitle } from "./dialog"
 import { MediaGalleryProvider, useMediaGallery } from "@/contexts/media-gallery-context"
+import { CodeViewerProvider, useCodeViewerOptional } from "@/contexts/code-viewer-context"
+import * as highlighterModule from "@/lib/markdown/highlighter"
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -359,6 +361,84 @@ describe("HistoryBackClose with the URL-driven media gallery (mobile)", () => {
     await waitFor(() => expect(screen.getByText("gallery-closed")).toBeInTheDocument())
     await waitFor(() => expect(router.state.location.key).toBe(initialKey))
     expect(router.state.location.pathname).toBe(STREAM_PATH)
+    expect(router.state.location.search).toBe("")
+
+    // History is balanced: the next back leaves the page
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+  })
+})
+
+/**
+ * The real two-overlay stack this feature introduces: a markdown attachment
+ * open in the gallery (`?media=`, which deepens history itself) with a code
+ * block inside it opened full screen on top. One back press must peel exactly
+ * one overlay.
+ */
+function GalleryWithCodeViewerHarness() {
+  const { mediaAttachmentId, openMedia, closeMedia } = useMediaGallery()
+  const codeViewer = useCodeViewerOptional()
+  const open = mediaAttachmentId !== null
+  return (
+    <div>
+      <span>{open ? "gallery-open" : "gallery-closed"}</span>
+      <button onClick={() => openMedia("attach_1")}>open-gallery</button>
+      <Dialog open={open} onOpenChange={(next) => !next && closeMedia()}>
+        <DialogContent>
+          <DialogTitle>Media</DialogTitle>
+          <button onClick={() => codeViewer?.open({ code: "const a = 1", languageId: "typescript" })}>
+            open-code-viewer
+          </button>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+describe("HistoryBackClose with the code viewer stacked over the gallery (mobile)", () => {
+  beforeEach(() => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+    // Deterministic first paint: the shiki singleton is unwarmed in jsdom, so
+    // the viewer would otherwise swap in highlighted HTML mid-assertion.
+    vi.spyOn(highlighterModule, "tryHighlightSync").mockReturnValue("<pre><code>const a = 1</code></pre>")
+  })
+
+  it("peels one overlay per back press: viewer first, then the gallery", async () => {
+    const router = makeRouter(
+      <MediaGalleryProvider>
+        <CodeViewerProvider>
+          <GalleryWithCodeViewerHarness />
+        </CodeViewerProvider>
+      </MediaGalleryProvider>
+    )
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    fireEvent.click(screen.getByText("open-gallery"))
+    await waitFor(() => expect(screen.getByText("gallery-open")).toBeInTheDocument())
+    await waitFor(() => expect(router.state.location.search).toBe("?media=attach_1"))
+    await act(async () => {})
+
+    fireEvent.click(screen.getByText("open-code-viewer"))
+    await waitFor(() => expect(screen.getByRole("button", { name: "Wrap lines" })).toBeInTheDocument())
+    await act(async () => {})
+
+    // First back: the viewer goes, the gallery stays open on ?media=
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Wrap lines" })).not.toBeInTheDocument())
+    expect(screen.getByText("gallery-open")).toBeInTheDocument()
+    expect(router.state.location.search).toBe("?media=attach_1")
+
+    // Second back: the gallery goes, and we are back where we started
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(screen.getByText("gallery-closed")).toBeInTheDocument())
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
     expect(router.state.location.search).toBe("")
 
     // History is balanced: the next back leaves the page

--- a/apps/frontend/src/contexts/code-viewer-context.tsx
+++ b/apps/frontend/src/contexts/code-viewer-context.tsx
@@ -1,0 +1,45 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { CodeViewer, type CodeViewerItem } from "@/components/code-viewer"
+
+interface CodeViewerContextValue {
+  open: (item: CodeViewerItem) => void
+  close: () => void
+}
+
+const CodeViewerContext = createContext<CodeViewerContextValue | null>(null)
+
+interface CodeViewerProviderProps {
+  children: ReactNode
+}
+
+/**
+ * Owns the single full-screen code viewer for the workspace shell. Any rendered
+ * code block opens it imperatively with its code; the dialog is mounted once
+ * here so the block itself never nests a Dialog per message.
+ */
+export function CodeViewerProvider({ children }: CodeViewerProviderProps) {
+  const [item, setItem] = useState<CodeViewerItem | null>(null)
+  // Bumped per open so the viewer remounts with fresh session state (wrap
+  // toggle, copy feedback) instead of inheriting the previous block's.
+  const [openId, setOpenId] = useState(0)
+
+  const open = useCallback((next: CodeViewerItem) => {
+    setItem(next)
+    setOpenId((id) => id + 1)
+  }, [])
+  const close = useCallback(() => setItem(null), [])
+
+  const value = useMemo<CodeViewerContextValue>(() => ({ open, close }), [open, close])
+
+  return (
+    <CodeViewerContext.Provider value={value}>
+      {children}
+      {item && <CodeViewer key={openId} item={item} onClose={close} />}
+    </CodeViewerContext.Provider>
+  )
+}
+
+/** Null outside the workspace shell (standalone previews, tests) — callers hide their trigger. */
+export function useCodeViewerOptional(): CodeViewerContextValue | null {
+  return useContext(CodeViewerContext)
+}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -71,6 +71,7 @@ export {
 } from "./sidebar-context"
 export { TraceProvider, useTrace } from "./trace-context"
 export { MediaGalleryProvider, useMediaGallery } from "./media-gallery-context"
+export { CodeViewerProvider, useCodeViewerOptional } from "./code-viewer-context"
 export {
   DictationCoordinatorProvider,
   useDictationCoordinator,

--- a/apps/frontend/src/lib/markdown/code-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.test.tsx
@@ -9,6 +9,7 @@ import { hydrateCollapseCache } from "./collapse-cache"
 import * as preferencesModule from "@/contexts/preferences-context"
 import * as lineMeasureModule from "./use-measured-line-count"
 import * as highlighterModule from "./highlighter"
+import * as codeViewerModule from "@/contexts/code-viewer-context"
 
 // Stubbable preferences mock: each test can override via `currentPrefs`.
 let currentPrefs: {
@@ -307,5 +308,27 @@ describe("CodeBlock line wrapping", () => {
     expect(document.querySelector("pre.invisible")?.className).toContain("whitespace-pre")
     await waitFor(() => expect(document.querySelector("pre:not(.invisible)")).toBeInTheDocument())
     expect(document.querySelector("pre:not(.invisible)")?.parentElement?.className).toContain("[&>pre]:whitespace-pre ")
+  })
+})
+
+describe("CodeBlock full-screen trigger", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(preferencesModule, "usePreferencesOptional").mockImplementation(() => buildPreferencesContext())
+    vi.spyOn(lineMeasureModule, "useMeasuredLineCount").mockImplementation(() => measure)
+  })
+
+  it("should not offer full screen without a viewer provider", () => {
+    vi.spyOn(codeViewerModule, "useCodeViewerOptional").mockReturnValue(null)
+    renderCodeBlock("const a = 1")
+    expect(screen.queryByRole("button", { name: "Open full screen" })).not.toBeInTheDocument()
+  })
+
+  it("should open the viewer with the trimmed code and normalized language", async () => {
+    const open = vi.fn()
+    vi.spyOn(codeViewerModule, "useCodeViewerOptional").mockReturnValue({ open, close: vi.fn() })
+    renderCodeBlock("\nconst a = 1\n", "msg_test", "js")
+    await userEvent.click(screen.getByRole("button", { name: "Open full screen" }))
+    expect(open).toHaveBeenCalledWith({ code: "const a = 1", languageId: "javascript" })
   })
 })

--- a/apps/frontend/src/lib/markdown/code-block.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Copy, Check, ChevronDown, ChevronRight } from "lucide-react"
+import { Copy, Check, ChevronDown, ChevronRight, Maximize2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
   DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
@@ -8,6 +8,7 @@ import {
   resolveCodeBlockWrap,
 } from "@threa/types"
 import { usePreferencesOptional } from "@/contexts/preferences-context"
+import { useCodeViewerOptional } from "@/contexts/code-viewer-context"
 import { useBlockCollapse } from "./use-block-collapse"
 import { useMeasuredLineCount } from "./use-measured-line-count"
 import { ensureHighlight, tryHighlightSync } from "./highlighter"
@@ -27,6 +28,7 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
 
   // Preferences context may not exist in all rendering contexts (e.g. tests).
   const preferencesContext = usePreferencesOptional()
+  const codeViewer = useCodeViewerOptional()
   const threshold = preferencesContext?.preferences?.codeBlockCollapseThreshold ?? DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD
 
   const trimmedCode = useMemo(() => children.trim(), [children])
@@ -142,6 +144,20 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
           </span>
         )}
       </button>
+      {codeViewer && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            codeViewer.open({ code: trimmedCode, languageId })
+          }}
+          className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-all duration-150 hover:bg-primary/15 hover:text-primary"
+          title="Open full screen"
+          aria-label="Open full screen"
+        >
+          <Maximize2 className="h-3 w-3" />
+        </button>
+      )}
       <button
         type="button"
         onClick={handleCopy}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -40,6 +40,7 @@ import {
   TraceProvider,
   useTrace,
   MediaGalleryProvider,
+  CodeViewerProvider,
   usePanel,
   isDraftPanel,
   isConversationPanel,
@@ -529,39 +530,41 @@ export function WorkspaceLayout() {
                                       <StreamLinkKeyboardHandler workspaceId={workspaceId} mainStreamId={streamId} />
                                       <EnclaveRewrapNudgeListener workspaceId={workspaceId} />
                                       <MediaGalleryProvider>
-                                        <TraceProvider>
-                                          <SidebarProvider>
-                                            <SearchPanelProvider workspaceId={workspaceId}>
-                                              <SidebarKeyboardHandler />
-                                              <SearchKeyboardHandler />
-                                              <CoordinatedLoadingGate>
-                                                <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
-                                                  <MainContentGate>
-                                                    <Outlet />
-                                                  </MainContentGate>
-                                                </AppShell>
-                                              </CoordinatedLoadingGate>
-                                              <QuickSwitcher
-                                                workspaceId={workspaceId}
-                                                open={switcherOpen}
-                                                onOpenChange={setSwitcherOpen}
-                                                initialMode={switcherMode}
-                                                currentStreamId={streamId}
-                                              />
-                                              <ComposeOverlayMount workspaceId={workspaceId} />
-                                            </SearchPanelProvider>
-                                          </SidebarProvider>
-                                          <SettingsDialog />
-                                          <WorkspaceSettingsDialog workspaceId={workspaceId} />
-                                          <AccountSwitcherDialog />
-                                          <LogoutScopeDialog />
-                                          <StreamSettingsDialog workspaceId={workspaceId} />
-                                          <CreateChannelDialog workspaceId={workspaceId} />
-                                          <AttachmentExplorer workspaceId={workspaceId} />
-                                          <AgentOutcomesExplorer workspaceId={workspaceId} />
-                                          <TraceDialogContainer />
-                                          <Toaster />
-                                        </TraceProvider>
+                                        <CodeViewerProvider>
+                                          <TraceProvider>
+                                            <SidebarProvider>
+                                              <SearchPanelProvider workspaceId={workspaceId}>
+                                                <SidebarKeyboardHandler />
+                                                <SearchKeyboardHandler />
+                                                <CoordinatedLoadingGate>
+                                                  <AppShell sidebar={<Sidebar workspaceId={workspaceId} />}>
+                                                    <MainContentGate>
+                                                      <Outlet />
+                                                    </MainContentGate>
+                                                  </AppShell>
+                                                </CoordinatedLoadingGate>
+                                                <QuickSwitcher
+                                                  workspaceId={workspaceId}
+                                                  open={switcherOpen}
+                                                  onOpenChange={setSwitcherOpen}
+                                                  initialMode={switcherMode}
+                                                  currentStreamId={streamId}
+                                                />
+                                                <ComposeOverlayMount workspaceId={workspaceId} />
+                                              </SearchPanelProvider>
+                                            </SidebarProvider>
+                                            <SettingsDialog />
+                                            <WorkspaceSettingsDialog workspaceId={workspaceId} />
+                                            <AccountSwitcherDialog />
+                                            <LogoutScopeDialog />
+                                            <StreamSettingsDialog workspaceId={workspaceId} />
+                                            <CreateChannelDialog workspaceId={workspaceId} />
+                                            <AttachmentExplorer workspaceId={workspaceId} />
+                                            <AgentOutcomesExplorer workspaceId={workspaceId} />
+                                            <TraceDialogContainer />
+                                            <Toaster />
+                                          </TraceProvider>
+                                        </CodeViewerProvider>
                                       </MediaGalleryProvider>
                                     </PanelProvider>
                                   </QuickSwitcherProvider>

--- a/tests/browser/code-block-viewer-mobile.spec.ts
+++ b/tests/browser/code-block-viewer-mobile.spec.ts
@@ -56,3 +56,41 @@ test("a code block opens full screen, wraps on demand, and closes on back", asyn
   await expect(dialog).toBeHidden()
   expect(page.url()).toBe(streamUrl)
 })
+
+test("the wrap preference and a language override reach the inline block", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "code-wrap")
+  await createChannel(page, `wrap-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+  await seedCodeBlock(page, workspaceId!, streamId!)
+  await page.setViewportSize(PHONE)
+
+  const pre = page.locator("[data-wrap] pre").first()
+  const overflows = () => pre.evaluate((el) => el.scrollWidth > el.clientWidth)
+
+  await page.reload()
+  await expect(page.locator("[data-wrap='scroll']").first()).toBeVisible({ timeout: 30_000 })
+  await expect.poll(overflows).toBe(true)
+
+  await expectApiOk(
+    await page.request.patch(`/api/workspaces/${workspaceId}/preferences`, { data: { codeBlockWrap: "wrap" } }),
+    "Set wrap preference"
+  )
+  await page.reload()
+  await expect(page.locator("[data-wrap='wrap']").first()).toBeVisible({ timeout: 30_000 })
+  await expect.poll(overflows).toBe(false)
+
+  // The fence says `ts`; the override is keyed by the registry id.
+  await expectApiOk(
+    await page.request.patch(`/api/workspaces/${workspaceId}/preferences`, {
+      data: { codeBlockWrapOverrides: { typescript: "scroll" } },
+    }),
+    "Set language override"
+  )
+  await page.reload()
+  await expect(page.locator("[data-wrap='scroll']").first()).toBeVisible({ timeout: 30_000 })
+  await expect.poll(overflows).toBe(true)
+})

--- a/tests/browser/code-block-viewer-mobile.spec.ts
+++ b/tests/browser/code-block-viewer-mobile.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * The full-screen code viewer at phone width: open from a message's code block,
+ * long lines pan in scroll mode and stop panning once wrapped, and the OS back
+ * gesture closes the viewer without leaving the stream. Layout overflow and
+ * history integration are the two things jsdom cannot answer.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+const PHONE = { width: 390, height: 800 }
+
+const LONG_LINE = `const unbreakable = "${"abcdef0123456789".repeat(8)}"`
+const CODE_MARKDOWN = ["```ts", LONG_LINE, "export function f() {", "  return unbreakable", "}", "```"].join("\n")
+
+async function seedCodeBlock(page: Page, workspaceId: string, streamId: string): Promise<void> {
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: { streamId, content: CODE_MARKDOWN },
+  })
+  await expectApiOk(response, "Send code block message")
+}
+
+test("a code block opens full screen, wraps on demand, and closes on back", async ({ page }) => {
+  await loginAndCreateWorkspace(page, "code-viewer")
+  await createChannel(page, `code-${Date.now().toString(36)}`)
+
+  const url = page.url()
+  const workspaceId = url.match(/\/w\/([^/]+)/)?.[1]
+  const streamId = url.match(/\/s\/([^/?]+)/)?.[1]
+  expect(workspaceId && streamId, `ids in URL: ${url}`).toBeTruthy()
+
+  await seedCodeBlock(page, workspaceId!, streamId!)
+  await page.setViewportSize(PHONE)
+  await page.reload()
+  const streamUrl = page.url()
+
+  const block = page.locator("[data-wrap]").first()
+  await expect(block).toBeVisible({ timeout: 30_000 })
+  await block.getByRole("button", { name: "Open full screen" }).click()
+
+  const dialog = page.getByRole("dialog")
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText("TypeScript")
+  await expect(dialog).toContainText("4 lines")
+  const body = dialog.locator("[data-wrap]")
+  await expect(body).toHaveAttribute("data-wrap", "scroll")
+  await expect.poll(() => body.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true)
+
+  await dialog.getByRole("button", { name: "Wrap lines" }).click()
+  await expect(body).toHaveAttribute("data-wrap", "wrap")
+  await expect.poll(() => body.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true)
+
+  await page.goBack()
+  await expect(dialog).toBeHidden()
+  expect(page.url()).toBe(streamUrl)
+})


### PR DESCRIPTION
Top of the code-block stack, on [#1916](https://github.com/threahq/threa/pull/1916) (plan: https://seer.build/ws_vbyzjvdg6g/b/code-block-wrap-plan/).

**Problem.** Reading a code block on a phone means panning a tiny box inside the timeline. Markdown and other attachments already open full screen in the gallery; code in a message had no equivalent.

**Solution.** Every rendered code block gets an always-visible expand control in its header, beside copy (touch has no hover, same rule as the copy button; it works on collapsed blocks too). It opens `CodeViewer`: a Dialog with the gallery's sizing (full-bleed under `sm`, 90vw/90dvh above) showing the language label, line count, a wrap toggle, copy, and close over the Shiki-highlighted code at `text-sm`. The body is the scroll container for both axes and keeps native text selection (`data-native-context`).

The wrap toggle is session-local: it starts from `resolveCodeBlockWrap` for the block's language and never writes the preference (Settings owns persistence, per the agreed plan). `CodeViewerProvider` mounts the dialog once in the workspace shell and remounts it per open, so toggle and copy state never leak between blocks; `CodeBlock` reads `useCodeViewerOptional()` and hides the control when no provider is present (standalone previews, tests). Copy confirms in place with the check icon (INV-63) and tolerates a denied or missing clipboard (plain-HTTP origins) like the inline block; the code region is focusable and named so keyboard users can scroll it; the pressed wrap toggle gets a same-footprint accent background.

Stacking over the gallery surfaced one pre-existing gap: the gallery's window keydown handler flipped slides on arrow keys even when another dialog had focus; it now ignores keys whose target sits inside a dialog or menu other than its own content (`data-media-gallery`).

No URL state by decision: a code block has no shareable id. Mobile back and Escape come from `Dialog`'s `HistoryBackClose`, so a code block opened from a markdown attachment in the gallery stacks a second overlay and back peels one at a time.

| Inline block, 390px | Full screen, scroll | Full screen, wrapped |
| --- | --- | --- |
| ![inline](https://seer.build/ws_vbyzjvdg6g/i/img_zdgvhq6ph0/codeblock-1-inline.webp) | ![scroll](https://seer.build/ws_vbyzjvdg6g/i/img_0hbphym262/codeblock-2-viewer-scroll.webp) | ![wrapped](https://seer.build/ws_vbyzjvdg6g/i/img_p521nf7zrt/codeblock-3-viewer-wrap.webp) |

**Proof.** `code-viewer.test.tsx` (opens with code/label/line count; toggle seeded from a language override and flips without writing prefs; reset on next open; copy + in-place confirmation; Escape closes), `history-back-close.test.tsx` (viewer stacked over the URL-driven gallery: the first back closes the viewer and leaves the gallery on `?media=`, the second closes the gallery, history balanced — verified failing when `Dialog` stops registering with the overlay coordinator), `code-block.test.tsx` (no control without a provider; opens with trimmed code and normalized language). Browser spec `tests/browser/code-block-viewer-mobile.spec.ts` at 390×800: open from a seeded message, scroll mode overflows horizontally, wrap removes the overflow, `page.goBack()` closes the viewer and stays on the stream; a second case sets `codeBlockWrap: wrap` then `codeBlockWrapOverrides: { typescript: scroll }` through the preferences API and asserts the inline block's overflow flips accordingly (fence `ts` → registry id). Both pass locally and run in the browser-tests shards.

**Caveats.** No line numbers or font-size controls in the viewer; composer code blocks and the gallery's plain-text file viewer are unchanged (agreed follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9QSLmTNfdR8ZihLe5U6LM




