### PR TITLE
feat(streams): aside anchor event and attention suppression

### DIFF
--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -4,6 +4,7 @@ import {
   ActivityTypes,
   ConversationStatuses,
   LabelableResourceTypes,
+  StreamTypes,
   type ConversationStatus,
   type BoardLens,
   type TitleSource,
@@ -598,7 +599,9 @@ export const ConversationRepository = {
     const scopeCond = boardScopeCondSql(options?.scopeStreamIds)
     const typeCond = boardTypeCondSql(options?.scopeStreamTypes)
     const scopeExcludeCond = boardScopeExcludeCondSql(options?.excludeStreamIds)
-    const typeExcludeCond = boardTypeExcludeCondSql(options?.excludeStreamTypes)
+    // An aside never lists: its own conversation stays off the board — the
+    // anchor row on the host's card is its trace — so the veto always names it.
+    const typeExcludeCond = boardTypeExcludeCondSql([...(options?.excludeStreamTypes ?? []), StreamTypes.ASIDE])
     const labelCond = boardLabelCondSql(userId, options?.scopeLabelIds)
     const labelExcludeCond = boardLabelExcludeCondSql(userId, options?.excludeLabelIds)
     const hiddenCond = boardHiddenExcludeSql(userId)

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -2,7 +2,7 @@ import type { Querier } from "../../db"
 import { sql } from "../../db"
 import {
   AGENT_SESSION_EVENT_TYPES,
-  COMMAND_EVENT_TYPES,
+  AUTHOR_SCOPED_EVENT_TYPES,
   isTimelineBroadcastEventType,
   type AgentSessionRerunContext,
   type AuthorType,
@@ -240,8 +240,9 @@ export const StreamEventRepository = {
     const afterSequence = filters?.afterSequence
     const beforeSequence = filters?.beforeSequence
 
-    // Command events are author-only: when viewerId is set, hide other users'
-    // command events. Without viewerId, all events return (internal callers).
+    // Author-scoped events (command lifecycle, aside anchors) are actor-only:
+    // when viewerId is set, hide other actors' rows. Without viewerId, all
+    // events return (internal callers).
     const conditions: string[] = ["stream_id = $1"]
     const params: unknown[] = [streamId]
     let paramIndex = 2
@@ -266,7 +267,7 @@ export const StreamEventRepository = {
 
     if (viewerId) {
       conditions.push(`(event_type != ALL($${paramIndex}) OR actor_id = $${paramIndex + 1})`)
-      params.push(COMMAND_EVENT_TYPES)
+      params.push(AUTHOR_SCOPED_EVENT_TYPES)
       params.push(viewerId)
       paramIndex += 2
     }

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -43,6 +43,7 @@ import {
   resolveDefaultPersona,
 } from "../agents"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
+import { ConversationRepository } from "../conversations"
 import { HttpError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
 import { sendBootstrapJson } from "../../lib/observability"
@@ -71,6 +72,12 @@ const createStreamSchema = z
     parentStreamId: z.string().optional(),
     /** Canonical thread anchor (`msg_…` message / `event_…` card). */
     parentAnchorId: z.string().optional(),
+    /**
+     * Aside only: the conversation it was opened from (board card / conversation
+     * panel). Must belong to `parentStreamId`; stamped on the anchor row so the
+     * board projection places it on that card.
+     */
+    conversationId: z.string().optional(),
     memberIds: z.array(z.string().min(1)).max(50).optional(),
     /**
      * Optional context-bag attached at creation time. Powers "Discuss with
@@ -116,6 +123,10 @@ const createStreamSchema = z
   .refine((data) => data.type !== "aside" || !!data.parentStreamId, {
     message: "parentStreamId is required for asides",
     path: ["parentStreamId"],
+  })
+  .refine((data) => data.conversationId === undefined || data.type === "aside", {
+    message: "conversationId is only supported on aside creation",
+    path: ["conversationId"],
   })
   .refine((data) => !data.contextBag || data.type === "scratchpad" || data.type === "aside", {
     message: "contextBag is only supported on scratchpad or aside creation",
@@ -607,12 +618,25 @@ export function createStreamHandlers({
         companionPersonaId,
         parentStreamId,
         parentAnchorId,
+        conversationId,
         memberIds,
         contextBag,
         e2eEnabled,
         e2eOwnerKeyId,
         allowedToolCategories,
       } = data
+
+      if (conversationId !== undefined) {
+        // Workspace-scoped load so a cross-tenant id can't confirm existence;
+        // the conversation's own stream is the authoritative host (INV-62).
+        const [conversation] = await ConversationRepository.findByIds(pool, workspaceId, [conversationId])
+        if (!conversation || conversation.streamId !== parentStreamId) {
+          throw new HttpError("Aside conversation not found in the host stream", {
+            status: 400,
+            code: "ASIDE_CONVERSATION_INVALID",
+          })
+        }
+      }
 
       // Verify the caller owns the referenced E2E key BEFORE we hand off to
       // the service. Phase 1 invariant: the stream's `owner_user_key_id`
@@ -710,6 +734,7 @@ export function createStreamHandlers({
         companionPersonaId: resolvedPersonaId,
         parentStreamId,
         parentAnchorId,
+        conversationId,
         memberIds,
         createdBy: userId,
         contextBag,

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -43,7 +43,6 @@ import {
   resolveDefaultPersona,
 } from "../agents"
 import { UserE2eKeysRepository } from "../user-e2e-keys"
-import { ConversationRepository } from "../conversations"
 import { HttpError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
 import { sendBootstrapJson } from "../../lib/observability"
@@ -625,18 +624,6 @@ export function createStreamHandlers({
         e2eOwnerKeyId,
         allowedToolCategories,
       } = data
-
-      if (conversationId !== undefined) {
-        // Workspace-scoped load so a cross-tenant id can't confirm existence;
-        // the conversation's own stream is the authoritative host (INV-62).
-        const [conversation] = await ConversationRepository.findByIds(pool, workspaceId, [conversationId])
-        if (!conversation || conversation.streamId !== parentStreamId) {
-          throw new HttpError("Aside conversation not found in the host stream", {
-            status: 400,
-            code: "ASIDE_CONVERSATION_INVALID",
-          })
-        }
-      }
 
       // Verify the caller owns the referenced E2E key BEFORE we hand off to
       // the service. Phase 1 invariant: the stream's `owner_user_key_id`

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -15,6 +15,7 @@ import { getEffectiveReadState, type EffectiveReadState } from "./effective-read
 import { StreamEventRepository, type StreamEvent } from "./event-repository"
 import { SparseReadRepository } from "./sparse-read-repository"
 import { MessageRepository, type Message } from "../messaging"
+import { ConversationRepository } from "../conversations"
 import { StreamContextRepository, contextSnippet } from "../stream-context"
 import { OutboxRepository } from "../../lib/outbox"
 import { streamId, eventId, streamContextItemId } from "../../lib/id"
@@ -693,6 +694,21 @@ export class StreamService {
           }
         } else {
           throw new HttpError("Unrecognized aside anchor id", { status: 400, code: "ANCHOR_INVALID" })
+        }
+      }
+
+      if (params.conversationId !== undefined) {
+        // After the host access check (a non-member learns nothing about the
+        // conversation), workspace-scoped: the conversation's own stream is the
+        // authoritative host (INV-62).
+        const [conversation] = await ConversationRepository.findByIds(client, params.workspaceId, [
+          params.conversationId,
+        ])
+        if (!conversation || conversation.streamId !== params.parentStreamId) {
+          throw new HttpError("Aside conversation not found in the host stream", {
+            status: 400,
+            code: "ASIDE_CONVERSATION_INVALID",
+          })
         }
       }
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -58,6 +58,7 @@ import {
   type E2eKeyRollInput,
   type E2eActorRewrapInput,
   type ToolPrivacyPolicy,
+  type AsideAnchoredEventPayload,
   type JSONContent,
   type AuthorType,
   type DescriptionSetEventPayload,
@@ -196,6 +197,8 @@ const createAsideParamsSchema = z.object({
   parentStreamId: z.string(),
   /** Optional anchor (`msg_…` / `event_…`) in the host stream; composer/palette asides carry none. */
   parentAnchorId: z.string().optional(),
+  /** Set when opened from a conversation surface (board card / panel); stamped on the anchor row. */
+  conversationId: z.string().optional(),
   displayName: z.string().optional(),
   companionPersonaId: z.string().optional(),
   createdBy: z.string(),
@@ -219,6 +222,7 @@ const createStreamParamsSchema = z.object({
   parentStreamId: z.string().optional(),
   /** Canonical thread anchor (`msg_…` / `event_…`). */
   parentAnchorId: z.string().optional(),
+  conversationId: z.string().optional(),
   memberIds: z.array(z.string()).optional(),
   createdBy: z.string(),
 })
@@ -530,6 +534,7 @@ export class StreamService {
           workspaceId: params.workspaceId,
           parentStreamId: params.parentStreamId,
           parentAnchorId: params.parentAnchorId,
+          conversationId: params.conversationId,
           displayName: params.displayName,
           companionPersonaId: params.companionPersonaId,
           createdBy: params.createdBy,
@@ -734,6 +739,30 @@ export class StreamService {
         workspaceId: params.workspaceId,
         streamId: stream.id,
         stream,
+      })
+
+      // The creator-only anchor row in the host stream, same transaction as the
+      // aside (INV-4). Author-scoped: the repo viewer filter and the outbox
+      // routing both key off the actor, so no other member ever receives it.
+      // Inserted after `stream:created` so the creator's client has the aside
+      // row (title) before the anchor row that joins against it.
+      const anchorEvent = await StreamEventRepository.insert(client, {
+        id: eventId(),
+        streamId: params.parentStreamId,
+        eventType: "aside:anchored",
+        payload: {
+          asideId: stream.id,
+          anchorId: anchorId ?? null,
+          ...(params.conversationId && { conversationId: params.conversationId }),
+        } satisfies AsideAnchoredEventPayload,
+        actorId: params.createdBy,
+        actorType: "user",
+      })
+      await OutboxRepository.insert(client, "stream:aside_anchored", {
+        workspaceId: params.workspaceId,
+        streamId: params.parentStreamId,
+        authorId: params.createdBy,
+        event: anchorEvent,
       })
 
       return stream

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -651,9 +651,9 @@ export interface CommandFailedOutboxPayload extends StreamScopedPayload {
 }
 
 /**
- * The `aside:anchored` row of a freshly created aside, delivered to its creator
- * alone (`AUTHOR_SCOPED_EVENTS`). Unlike command events it is NOT stream-scoped:
- * a private aside's trace must never reach the host stream's room.
+ * The `aside:anchored` row of a freshly created aside. Carries the host
+ * `streamId` but routes via `AUTHOR_SCOPED_EVENTS` to the creator's user group
+ * only — never the host stream's room.
  */
 export interface StreamAsideAnchoredOutboxPayload extends StreamScopedPayload {
   authorId: string

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -66,6 +66,7 @@ export type OutboxEventType =
   | "command:dispatched"
   | "command:completed"
   | "command:failed"
+  | "stream:aside_anchored"
   | "agent_session:started"
   | "agent_session:completed"
   | "agent_session:failed"
@@ -645,6 +646,16 @@ export interface CommandCompletedOutboxPayload extends StreamScopedPayload {
 }
 
 export interface CommandFailedOutboxPayload extends StreamScopedPayload {
+  authorId: string
+  event: StreamEvent
+}
+
+/**
+ * The `aside:anchored` row of a freshly created aside, delivered to its creator
+ * alone (`AUTHOR_SCOPED_EVENTS`). Unlike command events it is NOT stream-scoped:
+ * a private aside's trace must never reach the host stream's room.
+ */
+export interface StreamAsideAnchoredOutboxPayload extends StreamScopedPayload {
   authorId: string
   event: StreamEvent
 }
@@ -1245,6 +1256,7 @@ export interface OutboxEventPayloadMap {
   "command:dispatched": CommandDispatchedOutboxPayload
   "command:completed": CommandCompletedOutboxPayload
   "command:failed": CommandFailedOutboxPayload
+  "stream:aside_anchored": StreamAsideAnchoredOutboxPayload
   "agent_session:started": AgentSessionStartedOutboxPayload
   "agent_session:completed": AgentSessionCompletedOutboxPayload
   "agent_session:failed": AgentSessionFailedOutboxPayload
@@ -1395,8 +1407,10 @@ export type AuthorScopedEventType =
   | "user_preferences:updated"
   | "sidebar_config:updated"
   | "link_preview:dismissed"
+  | "stream:aside_anchored"
 
 const AUTHOR_SCOPED_EVENTS: AuthorScopedEventType[] = [
+  "stream:aside_anchored",
   "stream:read",
   "stream:read_set",
   "stream:read_all",

--- a/apps/backend/tests/integration/aside-anchor-event.test.ts
+++ b/apps/backend/tests/integration/aside-anchor-event.test.ts
@@ -93,6 +93,10 @@ describe("Aside anchor event", () => {
     )
     expect(result.rows).toHaveLength(1)
     const row = result.rows[0]
+    expect(row).toMatchObject({
+      event_type: "stream:aside_anchored",
+      payload: { event: { eventType: "aside:anchored", payload: { asideId } } },
+    })
     return { id: BigInt(row.id), eventType: row.event_type, payload: row.payload, createdAt: new Date() } as OutboxEvent
   }
 

--- a/apps/backend/tests/integration/aside-anchor-event.test.ts
+++ b/apps/backend/tests/integration/aside-anchor-event.test.ts
@@ -11,6 +11,7 @@ import { setupTestDatabase, withTransaction, addTestMember, testMessageContent }
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamService, StreamEventRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
+import { ConversationRepository } from "../../src/features/conversations"
 import { SyncLogRepository } from "../../src/features/sync"
 import { resolveDeliveryGroups, userGroup, type OutboxEvent } from "../../src/lib/outbox"
 import { userId, workspaceId, messageId, conversationId } from "../../src/lib/id"
@@ -65,6 +66,14 @@ describe("Aside anchor event", () => {
         authorType: "user",
         ...testMessageContent("host message"),
       })
+    })
+    return id
+  }
+
+  async function insertConversation(streamId: string): Promise<string> {
+    const id = conversationId()
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.insert(client, { id, streamId, workspaceId: wsId })
     })
     return id
   }
@@ -151,7 +160,7 @@ describe("Aside anchor event", () => {
   test("a conversation-anchored aside stamps the conversation on its row", async () => {
     const channel = await createChannel("aside-anchor-conversation")
     const anchorId = await insertMessage(channel.id, member)
-    const convId = conversationId()
+    const convId = await insertConversation(channel.id)
     const aside = await streamService.createAside({
       workspaceId: wsId,
       parentStreamId: channel.id,
@@ -162,6 +171,37 @@ describe("Aside anchor event", () => {
 
     const rows = await anchorRowsFor(channel.id, creator)
     expect(rows.map((row) => row.payload)).toEqual([{ asideId: aside.id, anchorId, conversationId: convId }])
+  })
+
+  test("a conversation outside the host is rejected; a non-member sees only the host 404", async () => {
+    const channel = await createChannel("aside-anchor-conv-host")
+    const elsewhere = await streamService.createChannel({
+      workspaceId: wsId,
+      slug: "aside-anchor-conv-elsewhere",
+      visibility: "private",
+      createdBy: creator,
+    })
+    const foreignConversation = await insertConversation(elsewhere.id)
+    await expect(
+      streamService.createAside({
+        workspaceId: wsId,
+        parentStreamId: channel.id,
+        conversationId: foreignConversation,
+        createdBy: creator,
+      })
+    ).rejects.toMatchObject({ status: 400, code: "ASIDE_CONVERSATION_INVALID" })
+
+    // The host access check runs first: a non-member gets the same 404 whether
+    // or not the conversation id is real, so the check is no existence oracle.
+    const hostConversation = await insertConversation(elsewhere.id)
+    await expect(
+      streamService.createAside({
+        workspaceId: wsId,
+        parentStreamId: elsewhere.id,
+        conversationId: hostConversation,
+        createdBy: member,
+      })
+    ).rejects.toMatchObject({ status: 404, code: "STREAM_NOT_FOUND" })
   })
 
   test("outbox delivery targets the creator alone, in live routing and in catch-up", async () => {

--- a/apps/backend/tests/integration/aside-anchor-event.test.ts
+++ b/apps/backend/tests/integration/aside-anchor-event.test.ts
@@ -223,4 +223,22 @@ describe("Aside anchor event", () => {
     expect(groups).toEqual([userGroup(creator)])
     expect(await catchUpReceivers(event, groups!, [creator, member])).toEqual([creator])
   })
+
+  test("the aside's own conversation never lists on the creator's board", async () => {
+    const channel = await createChannel("aside-board-feed")
+    const hostMessage = await insertMessage(channel.id, creator)
+    const hostConversation = await insertConversation(channel.id)
+    const aside = await streamService.createAside({ workspaceId: wsId, parentStreamId: channel.id, createdBy: creator })
+    const asideMessage = await insertMessage(aside.id, creator)
+    const asideConversation = await insertConversation(aside.id)
+    await withTransaction(pool, async (client) => {
+      await ConversationRepository.addPrimaryMessage(client, wsId, hostConversation, hostMessage, creator)
+      await ConversationRepository.addPrimaryMessage(client, wsId, asideConversation, asideMessage, creator)
+    })
+
+    const board = await ConversationRepository.findByWorkspaceForViewer(pool, wsId, creator)
+    const listed = new Set(board.map((conversation) => conversation.id))
+    expect(listed.has(hostConversation)).toBe(true)
+    expect(listed.has(asideConversation)).toBe(false)
+  })
 })

--- a/apps/backend/tests/integration/aside-anchor-event.test.ts
+++ b/apps/backend/tests/integration/aside-anchor-event.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Aside anchor event (PR2): the `aside:anchored` row is visible exactly to the
+ * creator — in the events fetch, in catch-up, and on the wire — and nowhere
+ * else. Emitted in the aside-creation transaction (INV-4), author-scoped like
+ * command events, with no broadcast slot (INV-61).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService, StreamEventRepository } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { SyncLogRepository } from "../../src/features/sync"
+import { resolveDeliveryGroups, userGroup, type OutboxEvent } from "../../src/lib/outbox"
+import { userId, workspaceId, messageId, conversationId } from "../../src/lib/id"
+import type { AsideAnchoredEventPayload, Stream } from "@threa/types"
+
+describe("Aside anchor event", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let wsId: string
+  let creator: string
+  let member: string
+  let sequence = 1n
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    wsId = workspaceId()
+    await withTransaction(pool, async (client) => {
+      creator = (await addTestMember(client, wsId, userId())).id
+      member = (await addTestMember(client, wsId, userId())).id
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Aside Anchor Test Workspace",
+        slug: `aside-anchor-ws-${wsId.toLowerCase()}`,
+        createdBy: creator,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function createChannel(slug: string): Promise<Stream> {
+    return streamService.createChannel({
+      workspaceId: wsId,
+      slug,
+      visibility: "public",
+      createdBy: creator,
+      memberIds: [member],
+    })
+  }
+
+  async function insertMessage(streamId: string, authorId: string): Promise<string> {
+    const id = messageId()
+    await withTransaction(pool, async (client) => {
+      await MessageRepository.insert(client, {
+        id,
+        streamId,
+        sequence: sequence++,
+        authorId,
+        authorType: "user",
+        ...testMessageContent("host message"),
+      })
+    })
+    return id
+  }
+
+  /** The anchor rows one viewer gets back from the host stream's events fetch. */
+  async function anchorRowsFor(hostStreamId: string, viewerId: string) {
+    const events = await StreamEventRepository.list(pool, hostStreamId, { viewerId })
+    return events.filter((event) => event.eventType === "aside:anchored")
+  }
+
+  /** The `stream:aside_anchored` outbox row for one aside, as the dispatcher reads it. */
+  async function outboxRowFor(asideId: string): Promise<OutboxEvent> {
+    const result = await pool.query<{ id: string; event_type: string; payload: Record<string, unknown> }>(
+      `SELECT id, event_type, payload FROM outbox
+       WHERE event_type = 'stream:aside_anchored' AND payload->'event'->'payload'->>'asideId' = $1`,
+      [asideId]
+    )
+    expect(result.rows).toHaveLength(1)
+    const row = result.rows[0]
+    return { id: BigInt(row.id), eventType: row.event_type, payload: row.payload, createdAt: new Date() } as OutboxEvent
+  }
+
+  /** Logs the event under its resolved groups, exactly as the BroadcastHandler
+   *  does, and answers who catch-up hands it back to. */
+  async function catchUpReceivers(event: OutboxEvent, groups: string[], users: string[]): Promise<string[]> {
+    await SyncLogRepository.appendForWorkspace(pool, wsId, [
+      { outboxEventId: event.id, eventType: event.eventType, groups, payload: event.payload },
+    ])
+    const eventId = (event.payload as { event: { id: string } }).event.id
+    const received: string[] = []
+    for (const user of users) {
+      const entries = await SyncLogRepository.listEntriesForUser(pool, {
+        workspaceId: wsId,
+        userId: user,
+        permissionGroups: [],
+        after: 0n,
+        limit: 100,
+      })
+      if (entries.some((e) => (e.payload as { event?: { id?: string } }).event?.id === eventId)) received.push(user)
+    }
+    return received
+  }
+
+  test("the anchor row reaches the creator's fetch and never another member's", async () => {
+    const channel = await createChannel("aside-anchor-fetch")
+    const anchorId = await insertMessage(channel.id, member)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+
+    const creatorRows = await anchorRowsFor(channel.id, creator)
+    expect(creatorRows).toHaveLength(1)
+    expect(creatorRows[0]).toMatchObject({
+      streamId: channel.id,
+      actorId: creator,
+      actorType: "user",
+      // No broadcast slot: the row is invisible to every other viewer, so a slot
+      // would be a permanent hole in their chain (INV-61).
+      broadcastSequence: null,
+      payload: { asideId: aside.id, anchorId } satisfies AsideAnchoredEventPayload,
+    })
+
+    expect(await anchorRowsFor(channel.id, member)).toEqual([])
+  })
+
+  test("a message-less aside still gets one anchor row, at creation position", async () => {
+    const channel = await createChannel("aside-anchor-composer")
+    await insertMessage(channel.id, creator)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      createdBy: creator,
+    })
+
+    const rows = await anchorRowsFor(channel.id, creator)
+    expect(rows.map((row) => row.payload)).toEqual([{ asideId: aside.id, anchorId: null }])
+    const all = await StreamEventRepository.list(pool, channel.id, { viewerId: creator })
+    expect(all[all.length - 1].id).toBe(rows[0].id)
+  })
+
+  test("a conversation-anchored aside stamps the conversation on its row", async () => {
+    const channel = await createChannel("aside-anchor-conversation")
+    const anchorId = await insertMessage(channel.id, member)
+    const convId = conversationId()
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      conversationId: convId,
+      createdBy: creator,
+    })
+
+    const rows = await anchorRowsFor(channel.id, creator)
+    expect(rows.map((row) => row.payload)).toEqual([{ asideId: aside.id, anchorId, conversationId: convId }])
+  })
+
+  test("outbox delivery targets the creator alone, in live routing and in catch-up", async () => {
+    const channel = await createChannel("aside-anchor-routing")
+    const anchorId = await insertMessage(channel.id, member)
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchorId,
+      createdBy: creator,
+    })
+
+    const event = await outboxRowFor(aside.id)
+    const groups = resolveDeliveryGroups(event)
+    expect(groups).toEqual([userGroup(creator)])
+    expect(await catchUpReceivers(event, groups!, [creator, member])).toEqual([creator])
+  })
+})

--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -419,3 +419,59 @@ describe("BoardCard running agent sessions", () => {
     expect(screen.queryByText("Ariadne is working…")).toBeNull()
   })
 })
+
+describe("BoardCard aside anchor rows", () => {
+  const MINE = "stream_aside_mine"
+  const THEIRS = "stream_aside_theirs"
+
+  async function seedAsides() {
+    await db.streams.bulkPut([
+      { ...cachedStream(MINE, StreamTypes.ASIDE), displayName: "churn number sanity-check", visibility: "private" },
+      {
+        ...cachedStream(THEIRS, StreamTypes.ASIDE),
+        displayName: "Member's private aside",
+        visibility: "private",
+        createdBy: "usr_other",
+      },
+    ])
+  }
+
+  function asideEvent(id: string, seconds: number, asideId: string, actorId: string): CachedEvent {
+    return { ...event("aside:anchored", seconds, { asideId, anchorId: "r1", conversationId: CONV }, id), actorId }
+  }
+
+  it("renders the creator's row in the full-tail region and never another member's", async () => {
+    await seedAsides()
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      messageEvent("r2", 11, "Second reply."),
+      messageEvent("r3", 12, "Third reply."),
+      asideEvent("evt_aside_mine", 13, MINE, "usr_me"),
+      asideEvent("evt_aside_theirs", 14, THEIRS, "usr_other"),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    const title = await screen.findByText("churn number sanity-check")
+    expect(title.closest("[data-aside-id]")).toHaveAttribute("data-aside-id", MINE)
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument()
+    expect(screen.queryByText("Member's private aside")).toBeNull()
+    expect(document.querySelector(`[data-aside-id="${THEIRS}"]`)).toBeNull()
+  })
+
+  it("folds the creator's row into a ledger line carrying the aside's title", async () => {
+    await seedAsides()
+    await db.events.bulkPut([
+      messageEvent("r1", 10, "First reply."),
+      asideEvent("evt_aside_mine", 11, MINE, "usr_me"),
+      asideEvent("evt_aside_theirs", 12, THEIRS, "usr_other"),
+      messageEvent("r2", 13, "Second reply."),
+      messageEvent("r3", 14, "Third reply."),
+    ])
+    await db.conversations.put(post())
+    mount()
+
+    await screen.findByText("Aside: churn number sanity-check")
+    expect(screen.queryByText(/Member's private aside/)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
+++ b/apps/frontend/src/components/board/board-card.ledger-events.test.tsx
@@ -454,7 +454,6 @@ describe("BoardCard aside anchor rows", () => {
 
     const title = await screen.findByText("churn number sanity-check")
     expect(title.closest("[data-aside-id]")).toHaveAttribute("data-aside-id", MINE)
-    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument()
     expect(screen.queryByText("Member's private aside")).toBeNull()
     expect(document.querySelector(`[data-aside-id="${THEIRS}"]`)).toBeNull()
   })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -51,6 +51,7 @@ import { DeletedMessageEvent } from "@/components/timeline/deleted-message-event
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams, useEffectiveArchived } from "@/hooks"
+import { useArchivedAsideIds } from "@/hooks/use-archived-aside-ids"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { conversationArchivedReason } from "@/components/composer/composer-disabled-notice"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -337,9 +338,16 @@ export function BoardCard({
     for (const message of knownMessages) set.add(message.id)
     return set
   }, [conversation.messageIds, knownMessages])
+  const archivedAsideIds = useArchivedAsideIds(workspaceId)
   const eventRows = useMemo(
-    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds, currentUserId }),
-    [railEvents, conversation.id, memberMessageIds, currentUserId]
+    () =>
+      resolveBoardEventRows(railEvents, {
+        conversationId: conversation.id,
+        memberMessageIds,
+        currentUserId,
+        archivedAsideIds,
+      }),
+    [railEvents, conversation.id, memberMessageIds, currentUserId, archivedAsideIds]
   )
 
   // The card's own running agent sessions: session ids come from the rows the

--- a/apps/frontend/src/components/board/board-row-item.render.test.tsx
+++ b/apps/frontend/src/components/board/board-row-item.render.test.tsx
@@ -92,6 +92,9 @@ const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
       sourceConversationId: CONV,
     }),
   ],
+  "aside:anchored": [
+    cachedEvent("aside:anchored", { asideId: "stream_aside_1", anchorId: MEMBER_MESSAGE, conversationId: CONV }),
+  ],
 }
 
 function rowsFor(events: CachedEvent[]): BoardEventRow[] {
@@ -156,6 +159,7 @@ describe("BoardEventRowItem renders every spec-declared board row", () => {
       "memos:captured": ["memo"],
       "agent:follow_up_scheduled": ["followUp"],
       "delegation:created": ["delegation"],
+      "aside:anchored": ["aside"],
       command_dispatched: ["command"],
       command_completed: ["command"],
       command_failed: ["command"],

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react"
-import { Bot, Clock, Sparkles, SquareSlash, TerminalSquare } from "lucide-react"
+import { Bot, Clock, MessageSquareDashed, Sparkles, SquareSlash, TerminalSquare } from "lucide-react"
 import type { StreamEvent } from "@threa/types"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { isContinuation } from "@/lib/message-grouping"
@@ -10,9 +10,12 @@ import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import { DelegationEvent } from "@/components/timeline/delegation-event"
 import { CommandEvent } from "@/components/timeline/command-event"
+import { AsideAnchorEvent } from "@/components/timeline/aside-anchor-event"
 import { getSessionId } from "@/components/timeline/session-grouping"
 import { useSocket, useTrace } from "@/contexts"
 import { useAgentSessionActivity } from "@/stores/agent-activity-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { streamLabel } from "@/lib/streams"
 import { LedgerEventGroup, LedgerEventRow, type LedgerEventDescriptor } from "@/components/board/ledger-row"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import { coalesceLedgerItems, ledgerEventContent, type LedgerItemKind } from "@/lib/board/ledger"
@@ -506,6 +509,8 @@ export function BoardEventRowItem({
       )
     case "memo":
       return <MemoCapturedEvent event={row.event as StreamEvent} workspaceId={workspaceId} />
+    case "aside":
+      return <AsideAnchorEvent event={row.event as StreamEvent} workspaceId={workspaceId} />
     case "followUp":
       return (
         <FollowUpScheduledEvent
@@ -536,6 +541,7 @@ const LEDGER_EVENT_ICONS: Record<BoardEventRow["kind"], ReactNode> = {
   memo: <Sparkles className="size-3 text-amber-500" />,
   followUp: <Clock className="size-3" />,
   delegation: <TerminalSquare className="size-3" />,
+  aside: <MessageSquareDashed className="size-3 text-primary" />,
 }
 
 type OpenMemo = { memoId: string; title: string }
@@ -543,9 +549,10 @@ type OpenMemo = { memoId: string; title: string }
 function ledgerDescriptor(
   row: BoardEventRow,
   traceUrl: (sessionId: string) => string,
+  asideTitle: (asideId: string) => string | null,
   onOpenMemo: (memo: OpenMemo) => void
 ) {
-  const content = ledgerEventContent(row, { traceUrl })
+  const content = ledgerEventContent(row, { traceUrl, asideTitle })
   return {
     key: content.key,
     icon: LEDGER_EVENT_ICONS[content.kind],
@@ -566,8 +573,9 @@ function ledgerDescriptor(
  */
 export function LedgerBoardEventRow({ row, workspaceId }: { row: BoardEventRow; workspaceId: string }) {
   const { getTraceUrl } = useTrace()
+  const asideTitle = useAsideTitle(workspaceId)
   const [openMemo, setOpenMemo] = useState<OpenMemo | null>(null)
-  const descriptor = ledgerDescriptor(row, getTraceUrl, setOpenMemo)
+  const descriptor = ledgerDescriptor(row, getTraceUrl, asideTitle, setOpenMemo)
   return (
     <>
       <LedgerEventRow
@@ -595,17 +603,27 @@ export function LedgerBoardEventGroup({
   onToggle: () => void
 }) {
   const { getTraceUrl } = useTrace()
+  const asideTitle = useAsideTitle(workspaceId)
   const [openMemo, setOpenMemo] = useState<OpenMemo | null>(null)
   return (
     <>
       <LedgerEventGroup
-        events={rows.map((row) => ledgerDescriptor(row, getTraceUrl, setOpenMemo))}
+        events={rows.map((row) => ledgerDescriptor(row, getTraceUrl, asideTitle, setOpenMemo))}
         expanded={expanded}
         onToggle={onToggle}
       />
       <LedgerMemoPreview workspaceId={workspaceId} memo={openMemo} onClose={() => setOpenMemo(null)} />
     </>
   )
+}
+
+/** The ledger line's title join against the creator's cached aside stream row. */
+function useAsideTitle(workspaceId: string): (asideId: string) => string | null {
+  const streams = useWorkspaceStreams(workspaceId)
+  return (asideId: string) => {
+    const aside = streams.find((stream) => stream.id === asideId)
+    return aside ? streamLabel(aside) : null
+  }
 }
 
 function LedgerMemoPreview({

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -69,6 +69,7 @@ import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
 import { useActors, useVisibleStreams, useEffectiveArchived } from "@/hooks"
+import { useArchivedAsideIds } from "@/hooks/use-archived-aside-ids"
 import { useStashParamDraftRow } from "@/hooks/use-stash-composer"
 import { boardReplyDraftKey, boardBranchReplyDraftKey } from "@/lib/board/draft-keys"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -654,9 +655,16 @@ function ConversationPanelBody({
     for (const message of all) set.add(message.id)
     return set
   }, [conversation.messageIds, all])
+  const archivedAsideIds = useArchivedAsideIds(workspaceId)
   const eventRows = useMemo(
-    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds, currentUserId }),
-    [railEvents, conversation.id, memberMessageIds, currentUserId]
+    () =>
+      resolveBoardEventRows(railEvents, {
+        conversationId: conversation.id,
+        memberMessageIds,
+        currentUserId,
+        archivedAsideIds,
+      }),
+    [railEvents, conversation.id, memberMessageIds, currentUserId, archivedAsideIds]
   )
 
   // Per-thread-boundary grouping — same derivation as the board card (the panel

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -229,6 +229,11 @@ describe("isSidebarStreamVisible", () => {
     expect(isSidebarStreamVisible(thread, memberStreamIds, archivedStreamIds)).toBe(true)
   })
 
+  it("hides an aside even though the viewer is its only member (anchor rows are its listing)", () => {
+    const aside = makeStream({ id: "stream_aside", type: StreamTypes.ASIDE, visibility: Visibilities.PRIVATE })
+    expect(isSidebarStreamVisible(aside, memberStreamIds, archivedStreamIds)).toBe(false)
+  })
+
   it("shows a public stream the viewer is a member of", () => {
     const stream = makeStream({ id: "stream_member", visibility: Visibilities.PUBLIC })
     expect(isSidebarStreamVisible(stream, memberStreamIds, archivedStreamIds)).toBe(true)

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -9,7 +9,7 @@ import {
 } from "@threa/types"
 import { createDmDraftId } from "@/hooks/use-stream-or-draft"
 import { stripMarkdownToInline, truncateInline } from "@/lib/markdown"
-import { getStreamName } from "@/lib/streams"
+import { getStreamName, isHiddenStreamType } from "@/lib/streams"
 import type { SectionKey, SortType, StreamItemData, UrgencyLevel } from "./types"
 
 /** Minimal workspace-user shape needed to synthesize a DM draft row. */
@@ -70,16 +70,18 @@ export function buildVirtualDmDrafts(args: {
 /** Minimal stream shape for the sidebar visibility filter. */
 interface SidebarVisibilityStream {
   id: string
+  type: string
   archivedAt: string | null
   rootStreamId: string | null
   visibility: string
 }
 
 /**
- * Whether a stream should appear in the sidebar. A stream is hidden when it is
- * archived, or when it is a thread whose root stream is archived — archiving
- * marks only the root row, so without the root check every nested thread under
- * an archived scratchpad/channel would still surface. Non-public streams are
+ * Whether a stream should appear in the sidebar. A stream is hidden when its
+ * type never lists (`isHiddenStreamType`), when it is archived, or when it is a
+ * thread whose root stream is archived — archiving marks only the root row, so
+ * without the root check every nested thread under an archived
+ * scratchpad/channel would still surface. Non-public streams are otherwise
  * always visible (bootstrap only includes them when the viewer has access);
  * public ones require explicit membership.
  */
@@ -88,6 +90,7 @@ export function isSidebarStreamVisible(
   memberStreamIds: ReadonlySet<string>,
   archivedStreamIds: ReadonlySet<string>
 ): boolean {
+  if (isHiddenStreamType(stream)) return false
   if (stream.archivedAt) return false
   if (stream.rootStreamId && archivedStreamIds.has(stream.rootStreamId)) return false
   if (stream.visibility !== Visibilities.PUBLIC) return true

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -8,7 +8,8 @@ import { Router } from "react-router-dom"
 import { QuickSwitcher } from "./quick-switcher"
 import { SidebarProvider } from "@/contexts/sidebar-context"
 import { SearchPanelProvider, useSearchPanel } from "@/components/search/search-panel-context"
-import { mockStreamsList } from "@/test/fixtures"
+import { StreamTypes } from "@threa/types"
+import { createMockStream, mockStreamsList } from "@/test/fixtures"
 import { mockUsersList } from "@/test/fixtures/users"
 import { mockSearchResultsList } from "@/test/fixtures/messages"
 import * as hooksModule from "@/hooks"
@@ -320,6 +321,28 @@ describe("QuickSwitcher Integration Tests", () => {
       renderWithProviders(<QuickSwitcher {...defaultProps} open={true} />)
 
       expect(screen.queryByText("Archived QS Channel")).not.toBeInTheDocument()
+    })
+
+    it("lists the viewer's own asides (palette reachability) and never another member's", () => {
+      mockWorkspaceBootstrap.data.streams = [
+        ...mockStreamsList,
+        createMockStream({
+          id: "stream_aside_mine",
+          type: StreamTypes.ASIDE,
+          displayName: "churn number sanity-check",
+          createdBy: "member_1",
+        }),
+        createMockStream({
+          id: "stream_aside_theirs",
+          type: StreamTypes.ASIDE,
+          displayName: "Member's private aside",
+          createdBy: "member_2",
+        }),
+      ]
+      renderWithProviders(<QuickSwitcher {...defaultProps} open={true} />)
+
+      expect(screen.getByText("churn number sanity-check")).toBeInTheDocument()
+      expect(screen.queryByText("Member's private aside")).not.toBeInTheDocument()
     })
 
     it("should not render dialog content when open=false", () => {

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -54,6 +54,8 @@ function getStreamTypeLabel(type: StreamType): string {
       return "System"
     case StreamTypes.THREAD:
       return "Thread"
+    case StreamTypes.ASIDE:
+      return "Aside"
     default:
       return type
   }
@@ -149,12 +151,15 @@ export function useStreamItems(context: ModeContext): ModeResult {
       ...(showArchived && archivedStreams ? archivedStreams : []),
     ]
 
+    // Own asides are palette-reachable — the one list surface they appear on
+    // besides their anchor row (the sidebar and pickers hide them).
     let filteredStreams = allStreams.filter(
       (s) =>
         s.type === StreamTypes.SCRATCHPAD ||
         s.type === StreamTypes.CHANNEL ||
         s.type === StreamTypes.DM ||
-        s.type === StreamTypes.SYSTEM
+        s.type === StreamTypes.SYSTEM ||
+        (s.type === StreamTypes.ASIDE && s.createdBy === currentUserId)
     )
 
     if (typeFilters.length > 0) {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { StreamTypes, type StreamEvent } from "@threa/types"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import { createMockStream } from "@/test/fixtures"
+import { groupTimelineItems, TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
+
+const CREATOR = "usr_creator"
+const OTHER = "usr_other"
+const ASIDE = "stream_aside_1"
+
+const aside = createMockStream({
+  id: ASIDE,
+  type: StreamTypes.ASIDE,
+  displayName: "churn number sanity-check",
+  createdBy: CREATOR,
+  parentStreamId: "stream_host",
+})
+
+function anchorEvent(overrides: Partial<StreamEvent> = {}): StreamEvent {
+  return {
+    id: "evt_aside",
+    streamId: "stream_host",
+    sequence: "7",
+    broadcastSequence: null,
+    eventType: "aside:anchored",
+    payload: { asideId: ASIDE, anchorId: "msg_1" },
+    actorId: CREATOR,
+    actorType: "user",
+    createdAt: new Date(Date.now() - 9 * 60_000).toISOString(),
+    ...overrides,
+  }
+}
+
+const ctx: TimelineItemRenderContext = {
+  workspaceId: "ws_1",
+  streamId: "stream_host",
+  sessionLiveCounts: new Map(),
+  sessionLiveSubsteps: new Map(),
+  cancelledFollowUpIds: new Set(),
+  delegationStatusPatches: new Map(),
+  botAccessStatusPatches: new Map(),
+  callEndedPatches: new Map(),
+}
+
+/** The timeline as one viewer sees it: the author gate runs in grouping, the row renders through the real item path. */
+function renderTimeline(events: StreamEvent[], viewerId: string) {
+  const items = groupTimelineItems(events, viewerId)
+  return render(
+    <>
+      {items.map((item, index) => (
+        <TimelineItemContent key={index} item={item} ctx={ctx} deferSecondaryHydration={false} />
+      ))}
+    </>
+  )
+}
+
+beforeEach(() => {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([aside] as never)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("AsideAnchorEvent", () => {
+  it("renders the creator's row: title joined from the aside stream, age, and a Resume affordance", () => {
+    renderTimeline([anchorEvent()], CREATOR)
+
+    const row = document.querySelector('[data-event-id="evt_aside"]')
+    expect(row).not.toBeNull()
+    expect(row).toHaveTextContent("churn number sanity-check")
+    expect(row).toHaveTextContent("9m ago")
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument()
+    expect(row?.querySelector("[data-aside-id]")).toHaveAttribute("data-aside-id", ASIDE)
+  })
+
+  it("renders nothing for another viewer of the same host stream", () => {
+    renderTimeline([anchorEvent()], OTHER)
+
+    expect(document.querySelector('[data-event-id="evt_aside"]')).toBeNull()
+    expect(screen.queryByText("churn number sanity-check")).toBeNull()
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull()
+  })
+
+  it("leaves no row once the aside is archived (joined state, no new event)", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      { ...aside, archivedAt: "2026-08-20T10:00:00.000Z" },
+    ] as never)
+    renderTimeline([anchorEvent()], CREATOR)
+
+    expect(screen.queryByText("churn number sanity-check")).toBeNull()
+    expect(document.querySelector("[data-aside-id]")).toBeNull()
+  })
+
+  it("still draws the row with the type's fallback label before the aside stream is cached", () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+    renderTimeline([anchorEvent()], CREATOR)
+
+    expect(document.querySelector("[data-aside-id]")).toHaveTextContent("Aside")
+  })
+})

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { StreamTypes, type StreamEvent } from "@threa/types"
 import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as eventItemModule from "./event-item"
+import { spyOnExport } from "@/test"
 import { createMockStream } from "@/test/fixtures"
 import { groupTimelineItems, TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
 
@@ -43,16 +45,37 @@ const ctx: TimelineItemRenderContext = {
   callEndedPatches: new Map(),
 }
 
-/** The timeline as one viewer sees it: the author gate runs in grouping, the row renders through the real item path. */
+/**
+ * The timeline as one viewer sees it: the author gate runs in grouping, the
+ * row renders through the real item path. Each item gets its own wrapper, the
+ * way the virtualizer gives each item its own cell.
+ */
 function renderTimeline(events: StreamEvent[], viewerId: string) {
   const items = groupTimelineItems(events, viewerId)
   return render(
     <>
       {items.map((item, index) => (
-        <TimelineItemContent key={index} item={item} ctx={ctx} deferSecondaryHydration={false} />
+        <div key={index} data-testid={`item-${index}`}>
+          <TimelineItemContent item={item} ctx={ctx} deferSecondaryHydration={false} />
+        </div>
       ))}
     </>
   )
+}
+
+/** A card the row can anchor to that renders without the message stack's providers. */
+function cardEvent(id: string, sequence: string): StreamEvent {
+  return {
+    id,
+    streamId: "stream_host",
+    sequence,
+    broadcastSequence: sequence,
+    eventType: "call_started",
+    payload: { callId: `call_${id}`, mode: "audio_only", startedBy: CREATOR, startedAt: "2026-08-20T10:00:00.000Z" },
+    actorId: CREATOR,
+    actorType: "user",
+    createdAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+  }
 }
 
 beforeEach(() => {
@@ -88,6 +111,28 @@ describe("AsideAnchorEvent", () => {
 
     expect(screen.queryByText("churn number sanity-check")).toBeNull()
     expect(document.querySelector("[data-aside-id]")).toBeNull()
+  })
+
+  it("renders inside its anchor's cell when the anchor is in the window — no cell of its own", () => {
+    // The anchor card's own body needs the call providers; a marker stands in
+    // for it, the folded row still renders through the real item path.
+    spyOnExport(eventItemModule, "EventItem").mockReturnValue(((props: { event: StreamEvent }) => (
+      <div data-event-id={props.event.id} />
+    )) as never)
+    renderTimeline(
+      [
+        cardEvent("evt_call", "1"),
+        cardEvent("evt_other", "2"),
+        anchorEvent({ payload: { asideId: ASIDE, anchorId: "evt_call" } }),
+      ],
+      CREATOR
+    )
+
+    expect(screen.queryByTestId("item-2")).toBeNull()
+    const first = screen.getByTestId("item-0")
+    expect(first.querySelector("[data-aside-id]")).toHaveTextContent("churn number sanity-check")
+    expect(first.querySelector("[data-event-id='evt_call']")).not.toBeNull()
+    expect(screen.getByTestId("item-1").querySelector("[data-aside-id]")).toBeNull()
   })
 
   it("still draws the row with the type's fallback label before the aside stream is cached", () => {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -62,15 +62,15 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks())
 
 describe("AsideAnchorEvent", () => {
-  it("renders the creator's row: title joined from the aside stream, age, and a Resume affordance", () => {
+  it("renders the creator's row: title joined from the aside stream and age, no controls", () => {
     renderTimeline([anchorEvent()], CREATOR)
 
     const row = document.querySelector('[data-event-id="evt_aside"]')
     expect(row).not.toBeNull()
     expect(row).toHaveTextContent("churn number sanity-check")
     expect(row).toHaveTextContent("9m ago")
-    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument()
     expect(row?.querySelector("[data-aside-id]")).toHaveAttribute("data-aside-id", ASIDE)
+    expect(screen.queryByRole("button")).toBeNull()
   })
 
   it("renders nothing for another viewer of the same host stream", () => {
@@ -78,7 +78,6 @@ describe("AsideAnchorEvent", () => {
 
     expect(document.querySelector('[data-event-id="evt_aside"]')).toBeNull()
     expect(screen.queryByText("churn number sanity-check")).toBeNull()
-    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull()
   })
 
   it("leaves no row once the aside is archived (joined state, no new event)", () => {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -3,7 +3,6 @@ import { StreamTypes, type AsideAnchoredEventPayload, type StreamEvent } from "@
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { formatRelativeTime } from "@/lib/dates"
-import { Button } from "@/components/ui/button"
 
 interface AsideAnchorEventProps {
   event: StreamEvent
@@ -11,13 +10,9 @@ interface AsideAnchorEventProps {
 }
 
 /**
- * The creator-only trace of an aside in its host stream (`aside:anchored`): a
- * hairline in the primary tone with the aside's title and age riding on it.
- * Title and state are a live join against the cached aside stream row — the
- * event is immutable, so a rename shows without a new event and an archived
- * aside leaves no row at all. Resume is revealed on hover/focus but keeps its
- * footprint, so the row never shifts (INV-21); the aside surface it opens lands
- * in a later layer.
+ * The creator-only trace of an aside in its host stream (`aside:anchored`).
+ * Title and archived state are a live join against the cached aside stream row
+ * (the event is immutable); an archived aside leaves no row.
  */
 export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) {
   const payload = event.payload as AsideAnchoredEventPayload | undefined
@@ -30,18 +25,10 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
   const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
 
   return (
-    <div className="group flex items-center gap-2 px-3 py-1 text-xs sm:px-6" data-aside-id={asideId}>
+    <div className="flex items-center gap-2 px-3 py-1 text-xs sm:px-6" data-aside-id={asideId}>
       <span className="min-w-0 shrink truncate text-primary">{title}</span>
       <span aria-hidden className="h-px min-w-4 flex-1 bg-gradient-to-r from-primary/60 to-primary/10" />
       <span className="shrink-0 text-muted-foreground">{age}</span>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-6 shrink-0 px-2 text-xs opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-      >
-        Resume
-      </Button>
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from "react"
+import { StreamTypes, type AsideAnchoredEventPayload, type StreamEvent } from "@threa/types"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { formatRelativeTime } from "@/lib/dates"
+import { Button } from "@/components/ui/button"
+
+interface AsideAnchorEventProps {
+  event: StreamEvent
+  workspaceId: string
+}
+
+/**
+ * The creator-only trace of an aside in its host stream (`aside:anchored`): a
+ * hairline in the primary tone with the aside's title and age riding on it.
+ * Title and state are a live join against the cached aside stream row — the
+ * event is immutable, so a rename shows without a new event and an archived
+ * aside leaves no row at all. Resume is revealed on hover/focus but keeps its
+ * footprint, so the row never shifts (INV-21); the aside surface it opens lands
+ * in a later layer.
+ */
+export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) {
+  const payload = event.payload as AsideAnchoredEventPayload | undefined
+  const asideId = payload?.asideId
+  const streams = useWorkspaceStreams(workspaceId)
+  const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
+  if (!asideId || aside?.archivedAt) return null
+
+  const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
+  const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
+
+  return (
+    <div className="group flex items-center gap-2 px-3 py-1 text-xs sm:px-6" data-aside-id={asideId}>
+      <span className="min-w-0 shrink truncate text-primary">{title}</span>
+      <span aria-hidden className="h-px min-w-4 flex-1 bg-gradient-to-r from-primary/60 to-primary/10" />
+      <span className="shrink-0 text-muted-foreground">{age}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 shrink-0 px-2 text-xs opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+      >
+        Resume
+      </Button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -17,6 +17,7 @@ import { BotAccessEvent } from "./bot-access-event"
 import { BriefUpdatedEvent } from "./brief-updated-event"
 import { DescriptionSetEvent } from "./description-set-event"
 import { CallCard } from "./call-card"
+import { AsideAnchorEvent } from "./aside-anchor-event"
 import { SystemEvent } from "./system-event"
 import { DeletedMessageEvent } from "./deleted-message-event"
 
@@ -255,6 +256,13 @@ export function EventItem({
       // Patch, not a row: it carries the end summary onto the matching call card
       // via callEndedPatches (collected in event-list) — renders nothing itself.
       return null
+
+    case "aside:anchored":
+      return (
+        <div data-event-id={event.id}>
+          <AsideAnchorEvent event={event} workspaceId={workspaceId} />
+        </div>
+      )
 
     case "agent:follow_up_cancelled":
       // Patch, not a row: it flips the matching scheduled card to "Cancelled"

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -23,6 +23,7 @@ import {
   OLDER_SKELETON_ITEMS,
   type TimelineItem,
   type TimelineItemRenderContext,
+  placeAsideAnchors,
 } from "./event-list"
 import { localStartOfDayMs } from "@/lib/dates"
 
@@ -1268,6 +1269,17 @@ describe("aside anchor rows", () => {
     })
     const events = [card, message("evt_m2", "2", "msg_2"), asideRow("evt_aside", "3", "evt_call")]
     expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_call", "evt_aside", "evt_m2"])
+  })
+
+  it("places a row anchored to an event folded into a command group after that group", () => {
+    const cmd = createEvent({ id: "evt_cmd", sequence: "2", eventType: "command_dispatched", payload: {} })
+    const items: TimelineItem[] = [
+      { type: "event", event: message("evt_m1", "1", "msg_1") },
+      { type: "command_group", commandId: "cmd_1", events: [cmd] },
+      { type: "event", event: message("evt_m2", "3", "msg_2") },
+      { type: "event", event: asideRow("evt_aside", "4", "evt_cmd") },
+    ]
+    expect(ids(placeAsideAnchors(items))).toEqual(["evt_m1", "command_group", "evt_aside", "evt_m2"])
   })
 
   it("keeps creation position when the anchor is outside the window, or when there is no anchor", () => {

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -1226,3 +1226,87 @@ describe("injectDayDividers", () => {
     expect(timelineItemEqual(dividerA, dividerB)).toBe(true)
   })
 })
+
+describe("aside anchor rows", () => {
+  function message(id: string, sequence: string, messageId: string): StreamEvent {
+    return {
+      ...createEvent({ id, sequence, eventType: "message_created", payload: { messageId, contentMarkdown: "x" } }),
+      actorId: "user_me",
+      actorType: "user",
+    }
+  }
+  function asideRow(id: string, sequence: string, anchorId: string | null, actorId = "user_me"): StreamEvent {
+    return {
+      ...createEvent({ id, sequence, eventType: "aside:anchored", payload: { asideId: `stream_${id}`, anchorId } }),
+      actorId,
+      actorType: "user",
+    }
+  }
+  const ids = (items: TimelineItem[]) => items.map((item) => (item.type === "event" ? item.event.id : item.type))
+
+  it("keeps the creator's anchor row and drops another actor's (author-scoped like commands)", () => {
+    const events = [message("evt_m1", "1", "msg_1"), asideRow("evt_aside", "2", "msg_1")]
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_aside"])
+    expect(ids(groupTimelineItems(events, "user_other"))).toEqual(["evt_m1"])
+  })
+
+  it("places the row directly after its anchor message when the anchor is in the window", () => {
+    const events = [
+      message("evt_m1", "1", "msg_1"),
+      message("evt_m2", "2", "msg_2"),
+      asideRow("evt_aside", "3", "msg_1"),
+    ]
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_aside", "evt_m2"])
+  })
+
+  it("places a card-anchored row after the card (anchor by event id)", () => {
+    const card = createEvent({
+      id: "evt_call",
+      sequence: "1",
+      eventType: "call_started",
+      payload: { callId: "call_1", mode: "audio_only", startedBy: "user_me", startedAt: "2026-02-19T00:00:00.000Z" },
+    })
+    const events = [card, message("evt_m2", "2", "msg_2"), asideRow("evt_aside", "3", "evt_call")]
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_call", "evt_aside", "evt_m2"])
+  })
+
+  it("keeps creation position when the anchor is outside the window, or when there is no anchor", () => {
+    const base = [message("evt_m1", "1", "msg_1"), message("evt_m2", "2", "msg_2")]
+    expect(ids(groupTimelineItems([...base, asideRow("evt_aside", "3", "msg_older")], "user_me"))).toEqual([
+      "evt_m1",
+      "evt_m2",
+      "evt_aside",
+    ])
+    expect(ids(groupTimelineItems([...base, asideRow("evt_aside", "3", null)], "user_me"))).toEqual([
+      "evt_m1",
+      "evt_m2",
+      "evt_aside",
+    ])
+  })
+
+  it("keeps creation order for several asides on one anchor", () => {
+    const events = [
+      message("evt_m1", "1", "msg_1"),
+      message("evt_m2", "2", "msg_2"),
+      asideRow("evt_a1", "3", "msg_1"),
+      asideRow("evt_a2", "4", "msg_1"),
+    ]
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_a1", "evt_a2", "evt_m2"])
+  })
+
+  it("does not break a same-author run (the creator's layout matches everyone else's)", () => {
+    const events = [
+      message("evt_m1", "1", "msg_1"),
+      message("evt_m2", "2", "msg_2"),
+      asideRow("evt_aside", "3", "msg_1"),
+    ]
+    const items = annotateAuthorGroups(groupTimelineItems(events, "user_me"))
+    expect(
+      items.map((item) => (item.type === "event" ? [item.event.id, item.groupContinuation ?? false] : []))
+    ).toEqual([
+      ["evt_m1", false],
+      ["evt_aside", false],
+      ["evt_m2", true],
+    ])
+  })
+})

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -1294,6 +1294,27 @@ describe("aside anchor rows", () => {
     expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_a1", "evt_a2", "evt_m2"])
   })
 
+  it("opens no day divider of its own — the row rides its anchor's day", () => {
+    const day = (date: string, id: string, sequence: string, messageId: string): StreamEvent => ({
+      ...message(id, sequence, messageId),
+      createdAt: date,
+    })
+    const events = [
+      day("2026-08-10T10:00:00.000Z", "evt_m1", "1", "msg_1"),
+      day("2026-08-10T10:01:00.000Z", "evt_m2", "2", "msg_2"),
+      day("2026-08-11T10:00:00.000Z", "evt_m3", "3", "msg_3"),
+      { ...asideRow("evt_aside", "4", "msg_1"), createdAt: "2026-08-21T10:00:00.000Z" },
+    ]
+    const items = injectDayDividers(groupTimelineItems(events, "user_me"))
+    expect(items.map((item) => (item.type === "event" ? item.event.id : item.type))).toEqual([
+      "evt_m1",
+      "evt_aside",
+      "evt_m2",
+      "day_divider",
+      "evt_m3",
+    ])
+  })
+
   it("does not break a same-author run (the creator's layout matches everyone else's)", () => {
     const events = [
       message("evt_m1", "1", "msg_1"),

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -23,7 +23,7 @@ import {
   OLDER_SKELETON_ITEMS,
   type TimelineItem,
   type TimelineItemRenderContext,
-  placeAsideAnchors,
+  attachAsideAnchors,
 } from "./event-list"
 import { localStartOfDayMs } from "@/lib/dates"
 
@@ -1243,21 +1243,30 @@ describe("aside anchor rows", () => {
       actorType: "user",
     }
   }
-  const ids = (items: TimelineItem[]) => items.map((item) => (item.type === "event" ? item.event.id : item.type))
+  /** Item ids, with an item's folded anchor rows in brackets after it. */
+  const ids = (items: TimelineItem[]) =>
+    items.map((item) => {
+      const own = item.type === "event" ? item.event.id : item.type
+      const anchors = "asideAnchors" in item ? item.asideAnchors : undefined
+      return anchors && anchors.length > 0 ? `${own}[${anchors.map((e) => e.id).join(",")}]` : own
+    })
 
   it("keeps the creator's anchor row and drops another actor's (author-scoped like commands)", () => {
     const events = [message("evt_m1", "1", "msg_1"), asideRow("evt_aside", "2", "msg_1")]
-    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_aside"])
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1[evt_aside]"])
     expect(ids(groupTimelineItems(events, "user_other"))).toEqual(["evt_m1"])
   })
 
-  it("places the row directly after its anchor message when the anchor is in the window", () => {
+  it("folds the row into its anchor message's item when the anchor is in the window — never a new item", () => {
     const events = [
       message("evt_m1", "1", "msg_1"),
       message("evt_m2", "2", "msg_2"),
       asideRow("evt_aside", "3", "msg_1"),
     ]
-    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_aside", "evt_m2"])
+    const items = groupTimelineItems(events, "user_me")
+    expect(ids(items)).toEqual(["evt_m1[evt_aside]", "evt_m2"])
+    // The item count is what the virtualizer sees: the aside added nothing.
+    expect(items).toHaveLength(2)
   })
 
   it("places a card-anchored row after the card (anchor by event id)", () => {
@@ -1268,7 +1277,7 @@ describe("aside anchor rows", () => {
       payload: { callId: "call_1", mode: "audio_only", startedBy: "user_me", startedAt: "2026-02-19T00:00:00.000Z" },
     })
     const events = [card, message("evt_m2", "2", "msg_2"), asideRow("evt_aside", "3", "evt_call")]
-    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_call", "evt_aside", "evt_m2"])
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_call[evt_aside]", "evt_m2"])
   })
 
   it("places a row anchored to an event folded into a command group after that group", () => {
@@ -1279,7 +1288,7 @@ describe("aside anchor rows", () => {
       { type: "event", event: message("evt_m2", "3", "msg_2") },
       { type: "event", event: asideRow("evt_aside", "4", "evt_cmd") },
     ]
-    expect(ids(placeAsideAnchors(items))).toEqual(["evt_m1", "command_group", "evt_aside", "evt_m2"])
+    expect(ids(attachAsideAnchors(items))).toEqual(["evt_m1", "command_group[evt_aside]", "evt_m2"])
   })
 
   it("keeps creation position when the anchor is outside the window, or when there is no anchor", () => {
@@ -1303,7 +1312,7 @@ describe("aside anchor rows", () => {
       asideRow("evt_a1", "3", "msg_1"),
       asideRow("evt_a2", "4", "msg_1"),
     ]
-    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1", "evt_a1", "evt_a2", "evt_m2"])
+    expect(ids(groupTimelineItems(events, "user_me"))).toEqual(["evt_m1[evt_a1,evt_a2]", "evt_m2"])
   })
 
   it("opens no day divider of its own — the row rides its anchor's day", () => {
@@ -1318,13 +1327,7 @@ describe("aside anchor rows", () => {
       { ...asideRow("evt_aside", "4", "msg_1"), createdAt: "2026-08-21T10:00:00.000Z" },
     ]
     const items = injectDayDividers(groupTimelineItems(events, "user_me"))
-    expect(items.map((item) => (item.type === "event" ? item.event.id : item.type))).toEqual([
-      "evt_m1",
-      "evt_aside",
-      "evt_m2",
-      "day_divider",
-      "evt_m3",
-    ])
+    expect(ids(items)).toEqual(["evt_m1[evt_aside]", "evt_m2", "day_divider", "evt_m3"])
   })
 
   it("does not break a same-author run (the creator's layout matches everyone else's)", () => {
@@ -1336,6 +1339,20 @@ describe("aside anchor rows", () => {
     const items = annotateAuthorGroups(groupTimelineItems(events, "user_me"))
     expect(
       items.map((item) => (item.type === "event" ? [item.event.id, item.groupContinuation ?? false] : []))
+    ).toEqual([
+      ["evt_m1", false],
+      ["evt_m2", true],
+    ])
+    // And a row left at its creation position (anchor out of the window)
+    // still breaks no run.
+    const loose = annotateAuthorGroups(
+      groupTimelineItems(
+        [message("evt_m1", "1", "msg_1"), asideRow("evt_aside", "2", "msg_older"), message("evt_m2", "3", "msg_2")],
+        "user_me"
+      )
+    )
+    expect(
+      loose.map((item) => (item.type === "event" ? [item.event.id, item.groupContinuation ?? false] : []))
     ).toEqual([
       ["evt_m1", false],
       ["evt_aside", false],

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from "react"
 import {
   ConversationStatuses,
   type StreamEvent,
+  type AsideAnchoredEventPayload,
   type DelegationStatusChangedEventPayload,
   type BotAccessStatusChangedEventPayload,
   type CallEndedEventPayload,
@@ -162,6 +163,10 @@ function isGroupableMessage(event: StreamEvent): boolean {
 export function annotateAuthorGroups(items: TimelineItem[]): TimelineItem[] {
   let previousMessage: { event: StreamEvent; timeMs: number } | null = null
   return items.map((item) => {
+    // The creator-only anchor row rides between messages without breaking a
+    // same-author run: it is a hairline, not a turn, and the creator's layout
+    // should match what every other member sees.
+    if (item.type === "event" && item.event.eventType === "aside:anchored") return item
     if (item.type !== "event" || !isGroupableMessage(item.event)) {
       previousMessage = null
       return item
@@ -716,6 +721,10 @@ export function groupTimelineItems(events: StreamEvent[], currentUserId: string 
       }
 
       slot.events.push(event)
+    } else if (event.eventType === "aside:anchored") {
+      // Author-scoped like command events: the REST filter hides other actors'
+      // rows, the socket path re-applies the rule here.
+      if (isOwnCommandEvent(event, currentUserId)) result.push({ type: "event", event })
     } else {
       result.push({ type: "event", event })
     }
@@ -738,7 +747,48 @@ export function groupTimelineItems(events: StreamEvent[], currentUserId: string 
     }
   }
 
-  return result
+  return placeAsideAnchors(result)
+}
+
+/**
+ * Move each aside anchor row (`aside:anchored`) to directly after the item it
+ * was opened from — the anchor message or card — when that item is in the
+ * window. The row's sequence is allocated at aside creation, so by sequence
+ * alone it would sit at the tail of a stream whose anchor is far above. A row
+ * whose anchor is not in the window, or that has none (composer/palette aside),
+ * keeps its creation position so it is never silently missing. Rows on one
+ * anchor keep their relative (creation) order.
+ */
+export function placeAsideAnchors(items: TimelineItem[]): TimelineItem[] {
+  const anchorIds = new Set<string>()
+  for (const item of items) {
+    if (item.type !== "event") continue
+    anchorIds.add(item.event.id)
+    const messageId = (item.event.payload as { messageId?: string })?.messageId
+    if (messageId) anchorIds.add(messageId)
+  }
+  const byAnchor = new Map<string, TimelineItem[]>()
+  const moved = new Set<TimelineItem>()
+  for (const item of items) {
+    if (item.type !== "event" || item.event.eventType !== "aside:anchored") continue
+    const anchorId = (item.event.payload as AsideAnchoredEventPayload | undefined)?.anchorId
+    if (!anchorId || !anchorIds.has(anchorId)) continue
+    const rows = byAnchor.get(anchorId) ?? []
+    rows.push(item)
+    byAnchor.set(anchorId, rows)
+    moved.add(item)
+  }
+  if (moved.size === 0) return items
+  const placed: TimelineItem[] = []
+  for (const item of items) {
+    if (moved.has(item)) continue
+    placed.push(item)
+    if (item.type !== "event") continue
+    const messageId = (item.event.payload as { messageId?: string })?.messageId
+    const rows = (messageId ? byAnchor.get(messageId) : undefined) ?? byAnchor.get(item.event.id)
+    if (rows) placed.push(...rows)
+  }
+  return placed
 }
 
 /** Shared context for rendering a timeline item (used by both Virtuoso and non-virtualized paths) */

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -14,6 +14,7 @@ import { useSocket, useCoordinatedLoading } from "@/contexts"
 import { useSteerAgentSession, useStopAgentSession } from "@/hooks"
 import { Loader2 } from "lucide-react"
 import { EventItem } from "./event-item"
+import { AsideAnchorEvent } from "./aside-anchor-event"
 import { AgentSessionEvent } from "./agent-session-event"
 import { CommandEvent } from "./command-event"
 import { UnreadDivider } from "./unread-divider"
@@ -110,9 +111,16 @@ export type TimelineItem =
        * provenance chip. Absent on non-message events and non-revival rows.
        */
       revival?: ConversationRevival
+      asideAnchors?: StreamEvent[]
     }
-  | { type: "command_group"; commandId: string; events: StreamEvent[] }
-  | { type: "session_group"; sessionId: string; sessionVersion: number; events: StreamEvent[] }
+  | { type: "command_group"; commandId: string; events: StreamEvent[]; asideAnchors?: StreamEvent[] }
+  | {
+      type: "session_group"
+      sessionId: string
+      sessionVersion: number
+      events: StreamEvent[]
+      asideAnchors?: StreamEvent[]
+    }
   /**
    * An in-place loading placeholder for a detected hole in the broadcast
    * chain (INV-61): events are known to be missing right after
@@ -747,41 +755,46 @@ export function groupTimelineItems(events: StreamEvent[], currentUserId: string 
     }
   }
 
-  return placeAsideAnchors(result)
+  return attachAsideAnchors(result)
 }
 
 /**
- * Move each aside anchor row (`aside:anchored`) to directly after the item it
- * was opened from — the anchor message or card — when that item is in the
- * window. The row's sequence is allocated at aside creation, so by sequence
- * alone it would sit at the tail of a stream whose anchor is far above. A row
- * whose anchor is not in the window, or that has none (composer/palette aside),
- * keeps its creation position so it is never silently missing. Rows on one
- * anchor keep their relative (creation) order.
+ * Fold each aside anchor row (`aside:anchored`) into the item it was opened
+ * from — the anchor message or card — when that item is in the window: the row
+ * renders at the foot of that item's cell as `asideAnchors`, never as an item of
+ * its own. The row's sequence is allocated at aside creation, so by sequence
+ * alone it would sit at the tail of a stream whose anchor is far above; and
+ * splicing it in as a new item changed the virtualized list's item count
+ * under the reader, which the virtualizer can answer with a scroll correction
+ * the size of the row (INV-70). A row whose anchor is not in the window, or
+ * that has none (composer/palette aside), stays an item at its creation
+ * position so it is never silently missing. Rows on one anchor keep their
+ * relative (creation) order.
  */
-export function placeAsideAnchors(items: TimelineItem[]): TimelineItem[] {
+export function attachAsideAnchors(items: TimelineItem[]): TimelineItem[] {
   const anchorIds = new Set<string>()
   for (const item of items) for (const id of itemAnchorIds(item)) anchorIds.add(id)
-  const byAnchor = new Map<string, TimelineItem[]>()
-  const moved = new Set<TimelineItem>()
+  const byAnchor = new Map<string, StreamEvent[]>()
+  const folded = new Set<TimelineItem>()
   for (const item of items) {
     if (item.type !== "event" || item.event.eventType !== "aside:anchored") continue
     const anchorId = (item.event.payload as AsideAnchoredEventPayload | undefined)?.anchorId
     if (!anchorId || !anchorIds.has(anchorId)) continue
     const rows = byAnchor.get(anchorId) ?? []
-    rows.push(item)
+    rows.push(item.event)
     byAnchor.set(anchorId, rows)
-    moved.add(item)
+    folded.add(item)
   }
-  if (moved.size === 0) return items
+  if (folded.size === 0) return items
   const placed: TimelineItem[] = []
   for (const item of items) {
-    if (moved.has(item)) continue
-    placed.push(item)
-    for (const id of itemAnchorIds(item)) {
-      const rows = byAnchor.get(id)
-      if (rows) placed.push(...rows)
-    }
+    if (folded.has(item)) continue
+    const rows = itemAnchorIds(item).flatMap((id) => byAnchor.get(id) ?? [])
+    placed.push(
+      rows.length > 0 && item.type !== "gap" && item.type !== "skeleton" && item.type !== "day_divider"
+        ? { ...item, asideAnchors: rows }
+        : item
+    )
   }
   return placed
 }
@@ -962,6 +975,12 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
         </div>
       )}
       {eventNode}
+      {"asideAnchors" in item &&
+        item.asideAnchors?.map((anchor) => (
+          <div key={anchor.id} data-event-id={anchor.id}>
+            <AsideAnchorEvent event={anchor} workspaceId={ctx.workspaceId} />
+          </div>
+        ))}
     </>
   )
 
@@ -981,6 +1000,8 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
 function getEventMessageId(event: StreamEvent): string | undefined {
   return (event.payload as { messageId?: string })?.messageId
 }
+
+const NO_EVENTS: StreamEvent[] = []
 
 function eventsArrayEqual(a: StreamEvent[], b: StreamEvent[]): boolean {
   if (a.length !== b.length) return false
@@ -1005,6 +1026,7 @@ export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
       if (a.event !== other.event || (a.groupContinuation ?? false) !== (other.groupContinuation ?? false)) {
         return false
       }
+      if (!eventsArrayEqual(a.asideAnchors ?? NO_EVENTS, other.asideAnchors ?? NO_EVENTS)) return false
       // Overlay + revival annotation objects are rebuilt by every annotation
       // pass, so compare by value — identity would defeat the memo on each
       // data tick.
@@ -1018,14 +1040,19 @@ export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
     }
     case "command_group": {
       const other = b as Extract<TimelineItem, { type: "command_group" }>
-      return a.commandId === other.commandId && eventsArrayEqual(a.events, other.events)
+      return (
+        a.commandId === other.commandId &&
+        eventsArrayEqual(a.events, other.events) &&
+        eventsArrayEqual(a.asideAnchors ?? NO_EVENTS, other.asideAnchors ?? NO_EVENTS)
+      )
     }
     case "session_group": {
       const other = b as Extract<TimelineItem, { type: "session_group" }>
       return (
         a.sessionId === other.sessionId &&
         a.sessionVersion === other.sessionVersion &&
-        eventsArrayEqual(a.events, other.events)
+        eventsArrayEqual(a.events, other.events) &&
+        eventsArrayEqual(a.asideAnchors ?? NO_EVENTS, other.asideAnchors ?? NO_EVENTS)
       )
     }
     case "gap": {

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -761,12 +761,7 @@ export function groupTimelineItems(events: StreamEvent[], currentUserId: string 
  */
 export function placeAsideAnchors(items: TimelineItem[]): TimelineItem[] {
   const anchorIds = new Set<string>()
-  for (const item of items) {
-    if (item.type !== "event") continue
-    anchorIds.add(item.event.id)
-    const messageId = (item.event.payload as { messageId?: string })?.messageId
-    if (messageId) anchorIds.add(messageId)
-  }
+  for (const item of items) for (const id of itemAnchorIds(item)) anchorIds.add(id)
   const byAnchor = new Map<string, TimelineItem[]>()
   const moved = new Set<TimelineItem>()
   for (const item of items) {
@@ -783,12 +778,24 @@ export function placeAsideAnchors(items: TimelineItem[]): TimelineItem[] {
   for (const item of items) {
     if (moved.has(item)) continue
     placed.push(item)
-    if (item.type !== "event") continue
-    const messageId = (item.event.payload as { messageId?: string })?.messageId
-    const rows = (messageId ? byAnchor.get(messageId) : undefined) ?? byAnchor.get(item.event.id)
-    if (rows) placed.push(...rows)
+    for (const id of itemAnchorIds(item)) {
+      const rows = byAnchor.get(id)
+      if (rows) placed.push(...rows)
+    }
   }
   return placed
+}
+
+/** Ids an aside may be anchored to within one timeline item: the event ids it
+ *  renders (a card, or every event folded into a command/session group) plus
+ *  the message id of a message event. */
+function itemAnchorIds(item: TimelineItem): string[] {
+  if (item.type === "event") {
+    const messageId = (item.event.payload as { messageId?: string })?.messageId
+    return messageId ? [item.event.id, messageId] : [item.event.id]
+  }
+  if (item.type === "command_group" || item.type === "session_group") return item.events.map((event) => event.id)
+  return []
 }
 
 /** Shared context for rendering a timeline item (used by both Virtuoso and non-virtualized paths) */

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -163,9 +163,7 @@ function isGroupableMessage(event: StreamEvent): boolean {
 export function annotateAuthorGroups(items: TimelineItem[]): TimelineItem[] {
   let previousMessage: { event: StreamEvent; timeMs: number } | null = null
   return items.map((item) => {
-    // The creator-only anchor row rides between messages without breaking a
-    // same-author run: it is a hairline, not a turn, and the creator's layout
-    // should match what every other member sees.
+    // An aside anchor row never breaks a same-author run.
     if (item.type === "event" && item.event.eventType === "aside:anchored") return item
     if (item.type !== "event" || !isGroupableMessage(item.event)) {
       previousMessage = null
@@ -607,6 +605,8 @@ export function injectGapItems(
 export function itemDayStartMs(item: TimelineItem): number | null {
   switch (item.type) {
     case "event":
+      // A relocated aside row rides its anchor's day, never opening one of its own.
+      if (item.event.eventType === "aside:anchored") return null
       return localStartOfDayMs(new Date(item.event.createdAt))
     case "command_group":
     case "session_group": {

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -557,6 +557,24 @@ describe("useAllDrafts E2E drafts", () => {
 })
 
 describe("useAllDrafts archived streams", () => {
+  it("hides a draft typed in an aside from the list and the badge alike", async () => {
+    await seedStream({ id: "stream_active" })
+    await seedStream({ id: "stream_aside", type: "aside", parentStreamId: "stream_active" })
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_active", scope: "stream:stream_active", contentJson: makeDoc("keep me") }),
+      syncedDraft({ id: "draft_aside", scope: "stream:stream_aside", contentJson: makeDoc("private thinking") }),
+    ])
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.all.drafts.map((d) => d.id)).toEqual(["draft_active"]))
+    await waitFor(() => expect(result.current.summary.isLoading).toBe(false))
+    expect(result.current.summary.draftCount).toBe(1)
+  })
+
   it("hides a draft whose stream is archived and keeps one whose stream is active", async () => {
     await seedStream({ id: "stream_active" })
     await seedStream({ id: "stream_archived", archivedAt: "2026-01-01T00:00:00Z" })

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -15,7 +15,7 @@ import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { isDraftId } from "./use-draft-scratchpads"
 import { purgeScopeDrafts } from "./use-draft-message"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
-import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { getStreamName, isHiddenStreamType, streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { draftInlineText, draftMarkdown, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { conversationOriginLabel, subtopicOriginLabel, threadOriginLabel } from "@/lib/drafts/origin-label"
@@ -209,6 +209,21 @@ export function isStreamArchived(
   if (!stream) return false
   if (stream.archivedAt) return true
   return stream.rootStreamId != null && archivedStreamIds.has(stream.rootStreamId)
+}
+
+/**
+ * Whether a draft's host keeps it off the explorer and the badge alike: an
+ * archived host (directly or through its root), or a host type that never
+ * lists (an aside — its drafts belong to its own surface, not /drafts).
+ */
+export function isDraftHostHidden(
+  streamId: string | null,
+  streamMap: Map<string, CachedStream>,
+  archivedStreamIds: ReadonlySet<string>
+): boolean {
+  if (isStreamArchived(streamId, streamMap, archivedStreamIds)) return true
+  const stream = streamId ? streamMap.get(streamId) : undefined
+  return stream !== undefined && isHiddenStreamType(stream)
 }
 
 /**
@@ -592,7 +607,7 @@ export function useAllDrafts(workspaceId: string) {
       // Hide drafts whose host stream is archived — a channel/DM directly, a
       // thread or board reply via its resolved parent/anchor stream, and any
       // nested thread through the root check inside `isStreamArchived`.
-      if (isStreamArchived(resolved.streamId, streamMap, archivedStreamIds)) continue
+      if (isDraftHostHidden(resolved.streamId, streamMap, archivedStreamIds)) continue
 
       const isStashed = !loadedDraftIds.has(draft.id)
 
@@ -801,7 +816,7 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
         // stream's own.
         const board = parseBoardDraftKey(draft.scope)
         if (!board || !draftHasPayload(draft)) continue
-        if (isStreamArchived(boardDraftHostStreamId(board, boardPostMap), streamMap, archivedStreamIds)) continue
+        if (isDraftHostHidden(boardDraftHostStreamId(board, boardPostMap), streamMap, archivedStreamIds)) continue
         draftCount++
         continue
       }
@@ -812,7 +827,7 @@ export function useDraftSummary(workspaceId: string): DraftSummary {
       // a thread reply via its parent message's host stream (nested threads
       // caught by the root check inside `isStreamArchived`).
       const hostStreamId = parsed.type === "thread" ? (messageToStreamMap.get(parsed.id)?.streamId ?? null) : parsed.id
-      if (isStreamArchived(hostStreamId, streamMap, archivedStreamIds)) continue
+      if (isDraftHostHidden(hostStreamId, streamMap, archivedStreamIds)) continue
       draftCount++
       // A non-thread stream draft that is the loaded (not stashed) one for its
       // scope surfaces as the per-row "unsent draft" hint — mirrors

--- a/apps/frontend/src/hooks/use-archived-aside-ids.ts
+++ b/apps/frontend/src/hooks/use-archived-aside-ids.ts
@@ -1,0 +1,12 @@
+import { useMemo } from "react"
+import { StreamTypes } from "@threa/types"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+
+/** The creator's archived asides, for surfaces that must draw no row for them. */
+export function useArchivedAsideIds(workspaceId: string): ReadonlySet<string> {
+  const streams = useWorkspaceStreams(workspaceId)
+  return useMemo(
+    () => new Set(streams.filter((stream) => stream.type === StreamTypes.ASIDE && stream.archivedAt).map((s) => s.id)),
+    [streams]
+  )
+}

--- a/apps/frontend/src/hooks/use-labels.test.ts
+++ b/apps/frontend/src/hooks/use-labels.test.ts
@@ -219,6 +219,13 @@ describe("selectLabelStreams", () => {
     expect(selectLabelStreams(assignments, streams, "label_a").map((s) => s.id)).toEqual(["stream_keep"])
   })
 
+  it("never lists an aside under a label (asides are reachable by anchor row only)", () => {
+    const assignments = [cachedAssignment("label_a", "stream_keep"), cachedAssignment("label_a", "stream_aside")]
+    const streams = [cachedStream("stream_keep"), cachedStream("stream_aside", { type: "aside" })]
+
+    expect(selectLabelStreams(assignments, streams, "label_a").map((s) => s.id)).toEqual(["stream_keep"])
+  })
+
   it("returns an empty list when nothing carries the label", () => {
     expect(
       selectLabelStreams([cachedAssignment("label_a", "stream_1")], [cachedStream("stream_1")], "label_z")

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -6,7 +6,7 @@ import { db, type CachedLabel, type CachedLabelAssignment, type CachedStream } f
 import { useWorkspaceLabels, useWorkspaceLabelAssignments, useWorkspaceStreams } from "@/stores/workspace-store"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { LabelableResourceTypes } from "@threa/types"
-import { isHiddenStreamType } from "@/lib/streams"
+import { hiddenStreamIds } from "@/lib/streams"
 import type {
   CreateLabelInput,
   Label,
@@ -337,8 +337,9 @@ export function selectLabelStreams(
     if (assignment.labelId === labelId) streamIds.add(assignment.resourceId)
   }
   if (streamIds.size === 0) return []
+  const hidden = hiddenStreamIds(streams)
   return streams
-    .filter((stream) => streamIds.has(stream.id) && !stream.archivedAt && !isHiddenStreamType(stream))
+    .filter((stream) => streamIds.has(stream.id) && !stream.archivedAt && !hidden.has(stream.id))
     .sort((a, b) => streamActivityTime(b) - streamActivityTime(a))
 }
 

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -6,6 +6,7 @@ import { db, type CachedLabel, type CachedLabelAssignment, type CachedStream } f
 import { useWorkspaceLabels, useWorkspaceLabelAssignments, useWorkspaceStreams } from "@/stores/workspace-store"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { LabelableResourceTypes } from "@threa/types"
+import { isHiddenStreamType } from "@/lib/streams"
 import type {
   CreateLabelInput,
   Label,
@@ -337,7 +338,7 @@ export function selectLabelStreams(
   }
   if (streamIds.size === 0) return []
   return streams
-    .filter((stream) => streamIds.has(stream.id) && !stream.archivedAt)
+    .filter((stream) => streamIds.has(stream.id) && !stream.archivedAt && !isHiddenStreamType(stream))
     .sort((a, b) => streamActivityTime(b) - streamActivityTime(a))
 }
 

--- a/apps/frontend/src/hooks/use-last-location.test.tsx
+++ b/apps/frontend/src/hooks/use-last-location.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { renderHook } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
+import { StreamTypes } from "@threa/types"
 import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import { useLastLocation, usePersistLastLocation, resetColdLaunchForTests } from "./use-last-location"
@@ -71,6 +72,14 @@ describe("useLastLocation — stream arm", () => {
     setup({ streams: [archived] })
     const { result } = renderHook(() => useLastLocation(WS))
     expect(result.current).toMatchObject({ redirectStreamId: null, shouldOpenSidebar: true })
+  })
+
+  it("never lands in an aside, even when it is the most recent stream or the stored pointer", () => {
+    const aside = { ...stream("stream_aside", "2026-04-01T00:00:00.000Z"), type: StreamTypes.ASIDE } as CachedStream
+    setup({ streams: [aside, stream("stream_active", "2026-01-01T00:00:00.000Z")] })
+    expect(renderHook(() => useLastLocation(WS)).result.current.redirectStreamId).toBe("stream_active")
+    setLastLocation(USER, WS, { surface: "stream", streamId: "stream_aside", board: null })
+    expect(renderHook(() => useLastLocation(WS)).result.current.redirectStreamId).toBe("stream_active")
   })
 
   it("still honors a stored pointer to a stream archived since the last visit", () => {

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react"
 import { useLocation, useMatch } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
-import { isHiddenStreamType } from "@/lib/streams"
+import { hiddenStreamIds } from "@/lib/streams"
 import {
   buildBoardHref,
   freshExactPath,
@@ -58,8 +58,10 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
 
   return useMemo(() => {
     // An aside opens beside its host stream, never as a page of its own, so it
-    // is neither a restore target nor a most-recent fallback.
-    const visibleStreams = cachedStreams.filter((stream) => !isHiddenStreamType(stream))
+    // (and a thread inside it) is neither a restore target nor a most-recent
+    // fallback.
+    const hidden = hiddenStreamIds(cachedStreams)
+    const visibleStreams = cachedStreams.filter((stream) => !hidden.has(stream.id))
     // The stream cache durably holds archived rows (archived-stream index).
     // They must not count as landing targets: archiving bumps updated_at, so an
     // unfiltered most-recent fallback would redirect a fresh device INTO the
@@ -139,9 +141,13 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
   const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
   const boardMatch = useMatch("/w/:workspaceId/board")
   const { pathname, search } = useLocation()
+  const cachedStreams = useWorkspaceStreams(workspaceId ?? "")
 
   const streamId = streamMatch?.params.streamId
   const onBoard = boardMatch !== null
+  // A hidden stream's page (an aside reached by URL) is never a place to
+  // restore to: it is not recorded, as exact path or as the stream arm.
+  const onHiddenStream = streamId !== undefined && hiddenStreamIds(cachedStreams).has(streamId)
 
   useEffect(() => {
     if (!user || !workspaceId) return
@@ -156,6 +162,7 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
     // that visit warmed, the exact arm would never serve.
     coldLaunch = false
     if (pathname.startsWith(`/w/${workspaceId}/delegations/`) || pathname.startsWith(`/w/${workspaceId}/memos/`)) return
+    if (onHiddenStream) return
     const persist = () => {
       const exact = { path: `${pathname}${search}`, at: Date.now() }
       const existing = getLastLocation(user.id, workspaceId)
@@ -199,7 +206,7 @@ export function usePersistLastLocation(workspaceId: string | undefined) {
     }
     document.addEventListener("visibilitychange", onVisibilityChange)
     return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [user, workspaceId, streamId, search, onBoard, pathname])
+  }, [user, workspaceId, streamId, search, onBoard, pathname, onHiddenStream])
 }
 
 function getMostRecentStreamId(streams: CachedStream[]): string {

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -59,13 +59,13 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
   return useMemo(() => {
     // An aside opens beside its host stream, never as a page of its own, so it
     // is neither a restore target nor a most-recent fallback.
-    const allStreams = cachedStreams.filter((s) => !isHiddenStreamType(s))
+    const visibleStreams = cachedStreams.filter((stream) => !isHiddenStreamType(stream))
     // The stream cache durably holds archived rows (archived-stream index).
     // They must not count as landing targets: archiving bumps updated_at, so an
     // unfiltered most-recent fallback would redirect a fresh device INTO the
     // most-recently-archived stream, and a workspace whose only streams are
     // archived must still land on the fresh-start state.
-    const streams = allStreams.filter((s) => !s.archivedAt)
+    const streams = visibleStreams.filter((stream) => !stream.archivedAt)
     const record = user ? getLastLocation(user.id, workspaceId) : null
 
     const exactPath = coldLaunch ? freshExactPath(record, workspaceId, Date.now()) : null
@@ -91,7 +91,7 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
       // Deliberately checked against ALL rows: a stored pointer to a stream
       // archived since the last visit is still viewable, so honor it rather
       // than falling back. Only the fallbacks below exclude archived.
-      const stillExists = allStreams.some((s) => s.id === storedId)
+      const stillExists = visibleStreams.some((stream) => stream.id === storedId)
       if (stillExists) {
         return {
           exactPath: null,

--- a/apps/frontend/src/hooks/use-last-location.ts
+++ b/apps/frontend/src/hooks/use-last-location.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react"
 import { useLocation, useMatch } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { isHiddenStreamType } from "@/lib/streams"
 import {
   buildBoardHref,
   freshExactPath,
@@ -53,9 +54,12 @@ interface UseLastLocationResult {
  */
 export function useLastLocation(workspaceId: string): UseLastLocationResult {
   const { user } = useAuth()
-  const allStreams = useWorkspaceStreams(workspaceId)
+  const cachedStreams = useWorkspaceStreams(workspaceId)
 
   return useMemo(() => {
+    // An aside opens beside its host stream, never as a page of its own, so it
+    // is neither a restore target nor a most-recent fallback.
+    const allStreams = cachedStreams.filter((s) => !isHiddenStreamType(s))
     // The stream cache durably holds archived rows (archived-stream index).
     // They must not count as landing targets: archiving bumps updated_at, so an
     // unfiltered most-recent fallback would redirect a fresh device INTO the
@@ -119,7 +123,7 @@ export function useLastLocation(workspaceId: string): UseLastLocationResult {
       boardHref: null,
       shouldOpenSidebar: true,
     }
-  }, [user, workspaceId, allStreams])
+  }, [user, workspaceId, cachedStreams])
 }
 
 /**

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -781,7 +781,7 @@ describe("useLastSeenEvent re-scan triggers", () => {
 
   it("never lets a relocated aside anchor row drive the frontier — at the viewport bottom or top", () => {
     // Sequence order: e1..e5 then the aside row (created last, anchored on e2).
-    // `placeAsideAnchors` renders it right after e2, so by index it is the
+    // `attachAsideAnchors` renders it right after e2, so by index it is the
     // newest row while on screen it sits among the oldest.
     const events = [
       { id: "e1", sequence: "1", eventType: "message_created" },

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -779,6 +779,71 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.lastSeenEventId).toBe("evt_real")
   })
 
+  it("never lets a relocated aside anchor row drive the frontier — at the viewport bottom or top", () => {
+    // Sequence order: e1..e5 then the aside row (created last, anchored on e2).
+    // `placeAsideAnchors` renders it right after e2, so by index it is the
+    // newest row while on screen it sits among the oldest.
+    const events = [
+      { id: "e1", sequence: "1", eventType: "message_created" },
+      { id: "e2", sequence: "2", eventType: "message_created" },
+      { id: "e3", sequence: "3", eventType: "message_created" },
+      { id: "e4", sequence: "4", eventType: "message_created" },
+      { id: "e5", sequence: "5", eventType: "message_created" },
+      { id: "aside", sequence: "6", eventType: "aside:anchored" },
+    ] as unknown as StreamEvent[]
+    const mount = (positions: Record<string, { top: number; bottom: number }>, lastReadEventId: string) => {
+      const container = document.createElement("div")
+      container.getBoundingClientRect = () => rect(0, 100)
+      for (const id of ["e1", "e2", "aside", "e3", "e4", "e5"]) {
+        const row = document.createElement("div")
+        row.setAttribute("data-event-id", id)
+        row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+        container.appendChild(row)
+      }
+      return renderHook(() =>
+        useLastSeenEvent({
+          scrollContainerRef: { current: container },
+          events,
+          streamId: "s",
+          lastReadEventId,
+          enabled: true,
+        })
+      )
+    }
+
+    // Bottom: e2 and the aside row fill the viewport; e3..e5 are below the fold.
+    // The aside's index (5) must not become the frontier — e3/e4 were never seen.
+    const bottom = mount(
+      {
+        e1: { top: -50, bottom: -10 },
+        e2: { top: 0, bottom: 50 },
+        aside: { top: 50, bottom: 70 },
+        e3: { top: 110, bottom: 150 },
+        e4: { top: 160, bottom: 200 },
+        e5: { top: 210, bottom: 250 },
+      },
+      "e1"
+    )
+    expect(bottom.result.current.lastSeenEventId).toBe("e2")
+    expect(bottom.result.current.atLastRow).toBe(false)
+
+    // Top: the aside row is the topmost visible row above e3/e4, pointer at e2.
+    // Its index would read as a gap; skipping it keeps the run contiguous.
+    const top = mount(
+      {
+        e1: { top: -100, bottom: -60 },
+        e2: { top: -50, bottom: -10 },
+        aside: { top: 0, bottom: 20 },
+        e3: { top: 20, bottom: 60 },
+        e4: { top: 60, bottom: 100 },
+        e5: { top: 110, bottom: 150 },
+      },
+      "e2"
+    )
+    expect(top.result.current.lastSeenEventId).toBe("e4")
+    expect(top.result.current.unreadAboveViewport).toBe(false)
+  })
+
   it("ignores foreign rows (the thread parent banner) instead of vetoing the scan", () => {
     // A thread renders its parent message as a timeline row carrying the PARENT
     // stream's event id — never present in the thread's own window. In a short

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -180,7 +180,7 @@ export function useLastSeenEvent({
   const indexById = useMemo(() => {
     const m = new Map<string, number>()
     // An aside anchor row renders beside its anchor, not at its sequence
-    // position (`placeAsideAnchors`), so its index would misreport what is on
+    // position (`attachAsideAnchors`), so its index would misreport what is on
     // screen; left unmapped, the scan skips its row like a foreign one.
     for (let i = 0; i < events.length; i++) {
       if (events[i].eventType === "aside:anchored") continue

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -179,7 +179,13 @@ export function useLastSeenEvent({
 
   const indexById = useMemo(() => {
     const m = new Map<string, number>()
-    for (let i = 0; i < events.length; i++) m.set(events[i].id, i)
+    // An aside anchor row renders beside its anchor, not at its sequence
+    // position (`placeAsideAnchors`), so its index would misreport what is on
+    // screen; left unmapped, the scan skips its row like a foreign one.
+    for (let i = 0; i < events.length; i++) {
+      if (events[i].eventType === "aside:anchored") continue
+      m.set(events[i].id, i)
+    }
     return m
   }, [events])
   // Refs keep the scroll-listener closure stable across data ticks — re-attaching

--- a/apps/frontend/src/hooks/use-stream-picker-groups.test.ts
+++ b/apps/frontend/src/hooks/use-stream-picker-groups.test.ts
@@ -23,7 +23,8 @@ const archived = createMockStream({
   archivedAt: "2025-01-01T00:00:00Z",
 })
 const thread = createMockStream({ id: "stream_t1", type: StreamTypes.THREAD, rootStreamId: "stream_c1" })
-const allStreams = [general, random, dm, scratch, archived, thread]
+const aside = createMockStream({ id: "stream_a1", type: StreamTypes.ASIDE, displayName: "churn number sanity-check" })
+const allStreams = [general, random, dm, scratch, archived, thread, aside]
 
 beforeEach(() => {
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue(allStreams as never)
@@ -39,12 +40,13 @@ function groupIds(groups: Map<StreamType, { stream: { id: string } }[]>, type: S
 }
 
 describe("useStreamPickerGroups", () => {
-  it("groups accessible streams by type and drops archived + thread/system", () => {
+  it("groups accessible streams by type and drops archived + thread/system/aside", () => {
     const { result } = renderHook(() => useStreamPickerGroups("workspace_1", { search: "", sortMode: "alphabetical" }))
     expect(groupIds(result.current, StreamTypes.CHANNEL)).toEqual([general.id, random.id])
     expect(groupIds(result.current, StreamTypes.DM)).toEqual([dm.id])
     expect(groupIds(result.current, StreamTypes.SCRATCHPAD)).toEqual([scratch.id])
     expect(result.current.get(StreamTypes.THREAD)).toBeUndefined()
+    expect(result.current.get(StreamTypes.ASIDE)).toBeUndefined()
     expect(groupIds(result.current, StreamTypes.CHANNEL)).not.toContain(archived.id)
   })
 

--- a/apps/frontend/src/hooks/use-stream-picker-groups.ts
+++ b/apps/frontend/src/hooks/use-stream-picker-groups.ts
@@ -7,6 +7,7 @@ import {
   type CachedStream,
 } from "@/stores/workspace-store"
 import { calculateUrgency } from "@/components/layout/sidebar/utils"
+import { isHiddenStreamType } from "@/lib/streams"
 import { scoreStreamMatch, compareStreamEntries, type SortableEntry, type StreamSortMode } from "@/lib/stream-sort"
 
 /** Stable identity for the no-unread-state case so the memo doesn't re-sort every render. */
@@ -18,7 +19,7 @@ export interface StreamPickerGroupsOptions {
   sortMode: StreamSortMode
   /**
    * Extra predicate applied ON TOP of the baseline access filter
-   * (public-or-member, not archived, not a thread/system stream). Lets a caller
+   * (public-or-member, not archived, not a thread/system/aside stream). Lets a caller
    * narrow to postable channels+DMs while another caller keeps scratchpads.
    */
   filter?: (stream: CachedStream) => boolean
@@ -59,7 +60,7 @@ export function useStreamPickerGroups(
     const matchable = streams.filter((s) => {
       if (s.archivedAt) return false
       if (s.rootStreamId) return false
-      if (s.type === StreamTypes.THREAD || s.type === StreamTypes.SYSTEM) return false
+      if (s.type === StreamTypes.THREAD || s.type === StreamTypes.SYSTEM || isHiddenStreamType(s)) return false
       const accessible = s.visibility === Visibilities.PUBLIC || memberStreamIds.has(s.id)
       if (!accessible) return false
       return filter ? filter(s) : true

--- a/apps/frontend/src/hooks/use-unread-tab-indicator.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-tab-indicator.test.tsx
@@ -14,6 +14,7 @@ function setup(unreadCounts: Record<string, number>, mutedStreamIds: string[] = 
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
     { id: "stream_channel", type: StreamTypes.CHANNEL },
     { id: "stream_aside", type: StreamTypes.ASIDE },
+    { id: "stream_aside_thread", type: StreamTypes.THREAD, rootStreamId: "stream_aside" },
   ] as never)
 }
 
@@ -30,8 +31,8 @@ describe("useUnreadTabIndicator", () => {
     expect(document.title).toBe("(2) | Threa")
   })
 
-  it("never counts an aside's unread — a pull surface lights no badge", () => {
-    setup({ stream_channel: 2, stream_aside: 5 })
+  it("never counts an aside's unread, nor a thread's inside it — a pull surface lights no badge", () => {
+    setup({ stream_channel: 2, stream_aside: 5, stream_aside_thread: 4 })
     renderHook(() => useUnreadTabIndicator(WS))
     expect(document.title).toBe("(2) | Threa")
   })

--- a/apps/frontend/src/hooks/use-unread-tab-indicator.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-tab-indicator.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { StreamTypes } from "@threa/types"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import { useUnreadTabIndicator } from "./use-unread-tab-indicator"
+
+const WS = "ws_1"
+
+function setup(unreadCounts: Record<string, number>, mutedStreamIds: string[] = []) {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue({
+    unreadCounts,
+    mutedStreamIds,
+  } as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+    { id: "stream_channel", type: StreamTypes.CHANNEL },
+    { id: "stream_aside", type: StreamTypes.ASIDE },
+  ] as never)
+}
+
+beforeEach(() => {
+  document.title = "Threa"
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useUnreadTabIndicator", () => {
+  it("counts unmuted stream unread into the tab title", () => {
+    setup({ stream_channel: 2 })
+    renderHook(() => useUnreadTabIndicator(WS))
+    expect(document.title).toBe("(2) | Threa")
+  })
+
+  it("never counts an aside's unread — a pull surface lights no badge", () => {
+    setup({ stream_channel: 2, stream_aside: 5 })
+    renderHook(() => useUnreadTabIndicator(WS))
+    expect(document.title).toBe("(2) | Threa")
+  })
+
+  it("shows no count when only asides (or muted streams) are unread", () => {
+    setup({ stream_aside: 5, stream_muted: 3 }, ["stream_muted"])
+    renderHook(() => useUnreadTabIndicator(WS))
+    expect(document.title).toBe("Threa")
+  })
+})

--- a/apps/frontend/src/hooks/use-unread-tab-indicator.ts
+++ b/apps/frontend/src/hooks/use-unread-tab-indicator.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useWorkspaceStreams, useWorkspaceUnreadState } from "@/stores/workspace-store"
-import { isHiddenStreamType } from "@/lib/streams"
+import { hiddenStreamIds } from "@/lib/streams"
 import { buildPageTitle, usePageStreamName } from "@/lib/page-title"
 
 const DARK_FAVICON_SVG = `<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,9 +50,10 @@ export function useUnreadTabIndicator(workspaceId: string) {
   const mutedStreamIds = unreadState?.mutedStreamIds ?? []
 
   const muted = new Set(mutedStreamIds)
-  // A hidden stream type (an aside) is a pull surface: its unread never lights
-  // the badge — the anchor row's state text is its whole signal.
-  const hidden = new Set(streams.filter(isHiddenStreamType).map((stream) => stream.id))
+  // A hidden stream (an aside, or a thread inside one) is a pull surface: its
+  // unread never lights the badge — the anchor row's state text is its whole
+  // signal.
+  const hidden = hiddenStreamIds(streams)
   let totalUnread = 0
   for (const [streamId, count] of Object.entries(unreadCounts)) {
     if (!muted.has(streamId) && !hidden.has(streamId)) totalUnread += count

--- a/apps/frontend/src/hooks/use-unread-tab-indicator.ts
+++ b/apps/frontend/src/hooks/use-unread-tab-indicator.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
-import { useWorkspaceUnreadState } from "@/stores/workspace-store"
+import { useWorkspaceStreams, useWorkspaceUnreadState } from "@/stores/workspace-store"
+import { isHiddenStreamType } from "@/lib/streams"
 import { buildPageTitle, usePageStreamName } from "@/lib/page-title"
 
 const DARK_FAVICON_SVG = `<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -42,15 +43,19 @@ function setFavicon(href: string) {
  */
 export function useUnreadTabIndicator(workspaceId: string) {
   const unreadState = useWorkspaceUnreadState(workspaceId)
+  const streams = useWorkspaceStreams(workspaceId)
   const streamName = usePageStreamName()
 
   const unreadCounts = unreadState?.unreadCounts ?? {}
   const mutedStreamIds = unreadState?.mutedStreamIds ?? []
 
   const muted = new Set(mutedStreamIds)
+  // A hidden stream type (an aside) is a pull surface: its unread never lights
+  // the badge — the anchor row's state text is its whole signal.
+  const hidden = new Set(streams.filter(isHiddenStreamType).map((stream) => stream.id))
   let totalUnread = 0
   for (const [streamId, count] of Object.entries(unreadCounts)) {
-    if (!muted.has(streamId)) totalUnread += count
+    if (!muted.has(streamId) && !hidden.has(streamId)) totalUnread += count
   }
 
   useEffect(() => {

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -549,6 +549,17 @@ describe("resolveBoardEventRows — aside anchor rows", () => {
     expect(rows).toEqual([])
   })
 
+  it("draws nothing for an archived aside, so a folded ledger never keeps a row the full card dropped", () => {
+    const events = [asideRow("live", "usr_me", CONV), asideRow("gone", "usr_me", CONV)]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: "usr_me",
+      archivedAsideIds: new Set(["stream_gone"]),
+    })
+    expect(rows).toEqual([expect.objectContaining({ kind: "aside", key: "live" })])
+  })
+
   it("draws nothing for a message-anchored aside (no conversation named)", () => {
     const events = [asideRow("plain", "usr_me")]
     const rows = resolveBoardEventRows(events, {

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -445,6 +445,14 @@ const ROW_FIXTURES: Partial<Record<EventType, CachedEvent[]>> = {
       payload: { delegationId: "dlg_fixture", title: "Fixture", sourceConversationId: CONV },
     }),
   ],
+  "aside:anchored": [
+    cachedEvent({
+      eventType: "aside:anchored",
+      createdAt: "2026-07-04T10:00:00Z",
+      actorId: USER,
+      payload: { asideId: "stream_aside_fixture", anchorId: "msg_1", conversationId: CONV },
+    }),
+  ],
 }
 
 describe("resolveBoardEventRows covers every spec-declared board row type", () => {
@@ -470,6 +478,7 @@ describe("resolveBoardEventRows covers every spec-declared board row type", () =
       "memos:captured": ["memo"],
       "agent:follow_up_scheduled": ["followUp"],
       "delegation:created": ["delegation"],
+      "aside:anchored": ["aside"],
       command_dispatched: ["command"],
       command_completed: ["command"],
       command_failed: ["command"],
@@ -506,5 +515,47 @@ describe("BOARD_RAIL_EVENT_TYPES covers every patch belonging to a board row typ
     )
     const subscribed = new Set<EventType>(BOARD_RAIL_EVENT_TYPES)
     expect(requiredPatches.filter((type) => !subscribed.has(type))).toEqual([])
+  })
+})
+
+describe("resolveBoardEventRows — aside anchor rows", () => {
+  const asideRow = (id: string, actorId: string, conversationId?: string) =>
+    cachedEvent({
+      id,
+      eventType: "aside:anchored",
+      createdAt: "2026-08-20T10:00:00Z",
+      actorId,
+      actorType: "user",
+      payload: { asideId: `stream_${id}`, anchorId: "msg_1", ...(conversationId && { conversationId }) },
+    })
+
+  it("draws the creator's conversation-anchored row on that conversation only", () => {
+    const events = [asideRow("mine", "usr_me", CONV), asideRow("elsewhere", "usr_me", "conv_other")]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: "usr_me",
+    })
+    expect(rows).toEqual([expect.objectContaining({ kind: "aside", key: "mine" })])
+  })
+
+  it("never draws another member's row, even on the matching conversation", () => {
+    const events = [asideRow("theirs", "usr_other", CONV)]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: "usr_me",
+    })
+    expect(rows).toEqual([])
+  })
+
+  it("draws nothing for a message-anchored aside (no conversation named)", () => {
+    const events = [asideRow("plain", "usr_me")]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(),
+      currentUserId: "usr_me",
+    })
+    expect(rows).toEqual([])
   })
 })

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -47,6 +47,12 @@ export interface ResolveBoardEventRowsCtx {
    * invocations — the same author rule the timeline applies.
    */
   currentUserId?: string | null
+  /**
+   * Asides that are archived draw no row, folded or full — the anchor row's
+   * own rule (`AsideAnchorEvent` renders nothing for an archived aside). The
+   * card resolves this from the stream cache; absent, no aside row is dropped.
+   */
+  archivedAsideIds?: ReadonlySet<string>
 }
 
 function timeMs(event: CachedEvent): number {
@@ -118,6 +124,7 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
       const payload = event.payload as AsideAnchoredEventPayload | undefined
       if (payload?.conversationId !== ctx.conversationId) continue
       if (!isOwnCommandEvent(event, ctx.currentUserId)) continue
+      if (payload?.asideId && ctx.archivedAsideIds?.has(payload.asideId)) continue
       rows.push({ kind: "aside", key: event.id, sortMs: timeMs(event), streamId: event.streamId, event })
       continue
     }

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -1,4 +1,9 @@
-import { STREAM_ROW_SPEC, type DelegationStatusChangedEventPayload, type MemosCapturedEventPayload } from "@threa/types"
+import {
+  STREAM_ROW_SPEC,
+  type AsideAnchoredEventPayload,
+  type DelegationStatusChangedEventPayload,
+  type MemosCapturedEventPayload,
+} from "@threa/types"
 import type { CachedEvent } from "@/db"
 import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "@/components/timeline/session-grouping"
 import { getCommandId, isOwnCommandEvent } from "@/components/timeline/command-grouping"
@@ -16,6 +21,7 @@ export type BoardEventRow =
   | { kind: "memo"; key: string; sortMs: number; streamId: string; event: CachedEvent }
   | { kind: "followUp"; key: string; sortMs: number; streamId: string; event: CachedEvent; cancelled: boolean }
   | { kind: "command"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
+  | { kind: "aside"; key: string; sortMs: number; streamId: string; event: CachedEvent }
   | {
       kind: "delegation"
       key: string
@@ -59,6 +65,8 @@ function timeMs(event: CachedEvent): number {
  * - command events are grouped by `commandId` into one chip row, author-scoped,
  *   placed on the conversation the dispatch names (a stream-level dispatch names
  *   none and draws nowhere).
+ * - `aside:anchored` is a single author-scoped row placed on the conversation
+ *   its payload names (a message-anchored aside names none and draws nowhere).
  * - `agent:follow_up_cancelled` is a patch, not a row: it flips the matching
  *   scheduled card's `cancelled` flag (mirrors the timeline's cancel handling).
  * - `delegation:status_changed` is likewise a patch: the latest one per
@@ -104,6 +112,13 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
         command.dispatched = event
         command.conversation = (event.payload as { conversationId?: string })?.conversationId ?? null
       }
+      continue
+    }
+    if (event.eventType === "aside:anchored") {
+      const payload = event.payload as AsideAnchoredEventPayload | undefined
+      if (payload?.conversationId !== ctx.conversationId) continue
+      if (!isOwnCommandEvent(event, ctx.currentUserId)) continue
+      rows.push({ kind: "aside", key: event.id, sortMs: timeMs(event), streamId: event.streamId, event })
       continue
     }
     const ref = STREAM_ROW_SPEC[event.eventType].conversationRef

--- a/apps/frontend/src/lib/board/ledger.ts
+++ b/apps/frontend/src/lib/board/ledger.ts
@@ -6,6 +6,7 @@ import {
   type AgentSessionCompletedPayload,
   type AgentSessionFailedPayload,
   type AgentSessionStartedPayload,
+  type AsideAnchoredEventPayload,
   type AttachmentSummary,
   type CommandDispatchedPayload,
   type DelegationCreatedEventPayload,
@@ -165,6 +166,8 @@ export interface LedgerEventContent {
 export interface LedgerEventContentCtx {
   /** The session's trace-view URL, from the surface's `useTrace`. */
   traceUrl: (sessionId: string) => string
+  /** An aside's title from the creator's stream cache; null when not cached. */
+  asideTitle?: (asideId: string) => string | null
 }
 
 function stepsLabel(count: number): string {
@@ -266,6 +269,15 @@ export function ledgerEventContent(row: BoardEventRow, ctx: LedgerEventContentCt
         kind: "delegation",
         label: payload?.title ? `Delegation: ${payload.title}` : "Delegation",
         meta: delegationAvailabilityLabel(row.statusPatch?.status ?? DelegationStatuses.OPEN, row.statusPatch?.reason),
+      }
+    }
+    case "aside": {
+      const payload = row.event.payload as AsideAnchoredEventPayload | undefined
+      const title = payload ? ctx.asideTitle?.(payload.asideId) : null
+      return {
+        key: row.key,
+        kind: "aside",
+        label: title ? `Aside: ${title}` : "Aside",
       }
     }
     default: {

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -29,6 +29,18 @@ export function isUtilityStream(stream: { purpose?: string | null }): boolean {
   return stream.purpose != null
 }
 
+/**
+ * A stream type that never lists by itself: an aside is reachable only through
+ * its anchor row in the host stream (and the command palette, own asides only).
+ * The sidebar, the unread badge, the last-location landing and the stream
+ * pickers all apply this one predicate instead of each knowing the type — an
+ * unhandled aside would otherwise inherit scratchpad listing and light the
+ * badge on every agent reply, against its decided silent attention.
+ */
+export function isHiddenStreamType(stream: { type: string }): boolean {
+  return stream.type === StreamTypes.ASIDE
+}
+
 /** Human-readable label for a stream type ("Scratchpad", "Channel", …). */
 export function getStreamTypeLabel(type: StreamType): string {
   switch (type) {

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -41,6 +41,22 @@ export function isHiddenStreamType(stream: { type: string }): boolean {
   return stream.type === StreamTypes.ASIDE
 }
 
+/**
+ * The ids that never list, out of a workspace's cached streams: every hidden
+ * stream and every stream rooted in one (a thread opened inside an aside is a
+ * `thread` row whose root is the aside). For the surfaces that aggregate over
+ * all streams — the tab badge, the last-location landing, label lists — where
+ * a row's own type is not enough to tell.
+ */
+export function hiddenStreamIds(
+  streams: readonly { id: string; type: string; rootStreamId?: string | null }[]
+): Set<string> {
+  const hidden = new Set<string>()
+  for (const stream of streams) if (isHiddenStreamType(stream)) hidden.add(stream.id)
+  for (const stream of streams) if (stream.rootStreamId && hidden.has(stream.rootStreamId)) hidden.add(stream.id)
+  return hidden
+}
+
 /** Human-readable label for a stream type ("Scratchpad", "Channel", …). */
 export function getStreamTypeLabel(type: StreamType): string {
   switch (type) {

--- a/apps/frontend/src/pages/memory.test.tsx
+++ b/apps/frontend/src/pages/memory.test.tsx
@@ -98,6 +98,20 @@ describe("MemoryPage", () => {
     mockUseIsMobile.mockReturnValue(false)
   })
 
+  it("never offers an aside in the stream filter (memory is off there)", async () => {
+    mockUseMemoSearch.mockReturnValue({ data: { results: [] }, isFetching: false, refetch: vi.fn() })
+    mockUseMemoDetail.mockReturnValue({ data: undefined, isLoading: false, isFetching: false, refetch: vi.fn() })
+    mockUseWorkspaceStreams.mockReturnValue([
+      { id: "stream_general", type: "channel", slug: "general", displayName: "General", archivedAt: null },
+      { id: "stream_aside", type: "aside", slug: null, displayName: "churn number sanity-check", archivedAt: null },
+    ])
+    renderPage("/w/ws_1/memory")
+
+    await userEvent.click(screen.getByText("All streams"))
+    expect(await screen.findByRole("option", { name: "#general" })).toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "churn number sanity-check" })).toBeNull()
+  })
+
   it("manually refreshes the memo list and selected memo", async () => {
     const refetchSearch = vi.fn().mockResolvedValue(undefined)
     const refetchDetail = vi.fn().mockResolvedValue(undefined)

--- a/apps/frontend/src/pages/memory.tsx
+++ b/apps/frontend/src/pages/memory.tsx
@@ -32,7 +32,7 @@ import {
   type MemoEditControls,
 } from "@/components/memo/memo-detail"
 import { cn } from "@/lib/utils"
-import { streamLabel } from "@/lib/streams"
+import { isHiddenStreamType, streamLabel } from "@/lib/streams"
 import { getKnowledgeConfig, memoLabel } from "@/lib/memo-display"
 import type { MemoExplorerResult, MemoUpdateRequest } from "@/api"
 
@@ -338,7 +338,7 @@ export function MemoryPage() {
   const isRefreshing = searchResponse.isFetching || selectedMemo.isFetching
 
   const streamOptions = streams
-    .filter((stream) => !stream.archivedAt)
+    .filter((stream) => !stream.archivedAt && !isHiddenStreamType(stream))
     .map((stream) => ({
       id: stream.id,
       label: streamLabel(stream),

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -5067,3 +5067,76 @@ describe("registerStreamSocketHandlers — stream:activity is the single preview
     cleanup()
   })
 })
+
+describe("registerStreamSocketHandlers — stream:created never treats an aside as the anchor's thread", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+  })
+
+  it("writes no threadId for an aside anchored on a message, while a thread still claims it", async () => {
+    const hostId = "stream_host_aside_gate"
+    await db.events.put({
+      ...makeEvent({ id: "evt_anchor", streamId: hostId, sequence: "1", payload: { messageId: "msg_anchor" } }),
+      workspaceId: "ws_1",
+      _sequenceNum: 1,
+      _cachedAt: Date.now(),
+    })
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", hostId, queryClient)
+    const anchored = (id: string, type: "aside" | "thread"): Stream => ({
+      id,
+      workspaceId: "ws_1",
+      type,
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: hostId,
+      parentAnchorId: "msg_anchor",
+      rootStreamId: type === "thread" ? hostId : null,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "user_1",
+      createdAt: "2026-08-20T10:00:00.000Z",
+      updatedAt: "2026-08-20T10:00:00.000Z",
+      archivedAt: null,
+    })
+
+    await emit("stream:created", { workspaceId: "ws_1", streamId: hostId, stream: anchored("stream_aside_1", "aside") })
+    expect((await db.events.get("evt_anchor"))?.payload).not.toHaveProperty("threadId")
+    expect(await db.streams.get("stream_aside_1")).toBeUndefined()
+
+    await emit("stream:created", {
+      workspaceId: "ws_1",
+      streamId: hostId,
+      stream: anchored("stream_thread_1", "thread"),
+    })
+    expect((await db.events.get("evt_anchor"))?.payload).toMatchObject({ threadId: "stream_thread_1" })
+
+    cleanup()
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -873,6 +873,13 @@ interface CommandEventPayload {
   authorId: string
 }
 
+interface AsideAnchoredPayload {
+  workspaceId: string
+  streamId: string
+  event: StreamEvent
+  authorId: string
+}
+
 interface AgentSessionEventPayload {
   workspaceId: string
   streamId: string
@@ -1650,6 +1657,12 @@ function bindStreamSocketHandlers(
   const handleStreamCreated = async (payload: StreamCreatedPayload) => {
     if (payload.streamId !== streamId) return
     const stream = payload.stream
+    // An aside is anchored like a thread but is never the anchor's thread:
+    // writing `threadId` would hijack the thread affordance, and its stream row
+    // reaches the creator's cache through the workspace layer (read-side
+    // listing filters keep it out of the sidebar). Its only timeline trace is
+    // the `aside:anchored` row.
+    if (stream.type === StreamTypes.ASIDE) return
     const anchorId = stream.parentAnchorId
     if (!anchorId) return
 
@@ -1704,6 +1717,7 @@ function bindStreamSocketHandlers(
     payload:
       | AgentSessionEventPayload
       | CommandEventPayload
+      | AsideAnchoredPayload
       | MemberRemovedPayload
       | MemosCapturedPayload
       | StreamLifecycleEventPayload
@@ -1934,6 +1948,7 @@ function bindStreamSocketHandlers(
   socket.on("command:dispatched", handleAppendEvent)
   socket.on("command:completed", handleAppendEvent)
   socket.on("command:failed", handleAppendEvent)
+  socket.on("stream:aside_anchored", handleAppendEvent)
   socket.on("agent_session:started", handleAppendEvent)
   socket.on("agent_session:completed", handleAppendEvent)
   socket.on("agent_session:failed", handleAppendEvent)
@@ -1977,6 +1992,7 @@ function bindStreamSocketHandlers(
     socket.off("command:dispatched", handleAppendEvent)
     socket.off("command:completed", handleAppendEvent)
     socket.off("command:failed", handleAppendEvent)
+    socket.off("stream:aside_anchored", handleAppendEvent)
     socket.off("agent_session:started", handleAppendEvent)
     socket.off("agent_session:completed", handleAppendEvent)
     socket.off("agent_session:failed", handleAppendEvent)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -2030,6 +2030,23 @@ export interface CommandFailedPayload {
   error: string
 }
 
+/**
+ * Payload for `aside:anchored` timeline events: the creator-only row an aside
+ * leaves in its host stream, appended in the aside-creation transaction
+ * (INV-4). Author-scoped like command events — no broadcast slot (INV-61),
+ * never delivered to other members. Immutable by design: it names the aside
+ * and its anchor only; title and state are a client join against the aside
+ * stream row. `anchorId` is the host message/card it was opened from, or null
+ * for a composer/palette aside (the row then sits at creation position).
+ * `conversationId` is set when opened from a conversation surface so the
+ * board/panel projection places the row on that card.
+ */
+export interface AsideAnchoredEventPayload {
+  asideId: string
+  anchorId: string | null
+  conversationId?: string
+}
+
 export interface AIUsageSummary {
   totalCostUsd: number
   promptTokens: number

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -179,12 +179,23 @@ export const EVENT_TYPES = [
   "bot_access:status_changed",
   "call_started",
   "call_ended",
+  "aside:anchored",
 ] as const
 export type EventType = (typeof EVENT_TYPES)[number]
 
 // Command event types (subset of EVENT_TYPES for command lifecycle)
 export const COMMAND_EVENT_TYPES = ["command_dispatched", "command_completed", "command_failed"] as const
 export type CommandEventType = (typeof COMMAND_EVENT_TYPES)[number]
+
+/**
+ * Author-scoped event types (subset of EVENT_TYPES): persisted rows only their
+ * actor may ever read. The repo's viewer filter hides other actors' rows from
+ * fetch and catch-up, and every client surface re-applies the actor rule
+ * (`isOwnCommandEvent`). Command lifecycle plus the aside anchor row — a
+ * private aside's one visible trace in its host stream.
+ */
+export const AUTHOR_SCOPED_EVENT_TYPES = [...COMMAND_EVENT_TYPES, "aside:anchored"] as const
+export type AuthorScopedEventType = (typeof AUTHOR_SCOPED_EVENT_TYPES)[number]
 
 /**
  * Timeline broadcast event types (subset of EVENT_TYPES): events that every

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,8 @@ export {
   type EventType,
   COMMAND_EVENT_TYPES,
   type CommandEventType,
+  AUTHOR_SCOPED_EVENT_TYPES,
+  type AuthorScopedEventType,
   TIMELINE_BROADCAST_EVENT_TYPES,
   type TimelineBroadcastEventType,
   isTimelineBroadcastEventType,
@@ -717,6 +719,7 @@ export type {
   CommandDispatchedPayload,
   CommandCompletedPayload,
   CommandFailedPayload,
+  AsideAnchoredEventPayload,
   // AI Usage
   AIUsageSummary,
   AIUsageOrigin,

--- a/packages/types/src/stream-rows.test.ts
+++ b/packages/types/src/stream-rows.test.ts
@@ -96,6 +96,7 @@ describe("STREAM_ROW_SPEC", () => {
         "command_dispatched",
         "command_completed",
         "command_failed",
+        "aside:anchored",
       ])
     )
     // None of them are message bodies (those are `self-message`, handled directly).

--- a/packages/types/src/stream-rows.ts
+++ b/packages/types/src/stream-rows.ts
@@ -306,6 +306,23 @@ export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
   // A patch carrying the end summary onto the matching `call_started` card — not
   // its own row (the delegation:status_changed analog).
   call_ended: PATCH,
+
+  // The creator-only trace of an aside in its host stream: its own row, no
+  // broadcast slot (author-scoped, so other viewers never have a hole to fill —
+  // INV-61), placed on a board card via the `conversationId` the payload
+  // carries when opened from a conversation surface. Render-only and never
+  // read-blocking: nothing in it was written to be read.
+  "aside:anchored": {
+    rendersAsOwnRow: true,
+    grouping: null,
+    authorGroupable: false,
+    patchesRow: false,
+    broadcastSlot: false,
+    conversationRef: "source-conversation",
+    bumps: false,
+    threadable: false,
+    readBlocking: false,
+  },
 }
 
 /**


### PR DESCRIPTION
_🤖 by Claude Fable 5_

## Problem

An aside ([#1912](https://github.com/threahq/threa/pull/1912), plan: [Seer project](https://seer.build/ws_vbyzjvdg6g/p/aside), [spec](https://seer.build/ws_vbyzjvdg6g/b/aside-build-plan/)) leaves no trace in its host: nothing tells the creator it exists or where it was opened, and an unhandled new stream type lists like a scratchpad — sidebar, unread badge, last-location, pickers, drafts, labels, memory filter — against its decided silent-attention model.

## Solution

Stack layer 2/8. Each aside writes one `aside:anchored` row in its host stream inside the creation transaction (INV-4). The row is author-scoped: a new `AUTHOR_SCOPED_EVENT_TYPES` list drives the repository viewer filter (fetch and catch-up), it takes no broadcast slot (INV-61), and its `stream:aside_anchored` outbox row routes to the creator's user group only. Payload is aside id + anchor ref, plus `conversationId` when opened from a conversation surface, validated inside the create transaction after the host access check (no 400-vs-404 existence oracle). Title and archived state are a client-side join against the aside stream row, so rows stay immutable.

The creator sees a hairline gold row (title · age) beside its anchor in the timeline and on board cards/panel via `STREAM_ROW_SPEC`; `groupTimelineItems` and `resolveBoardEventRows` re-apply the actor rule. The row is excluded from the auto-read scan (`useLastSeenEvent`) because it renders beside its anchor, not at its sequence position, and carries no day divider of its own. One predicate, `isHiddenStreamType`, keeps asides out of the sidebar, tab badge, last-location, pickers, drafts list/badge, label lists and the memory stream filter; the quick switcher lists the creator's own asides only. `stream:created` type-gates asides so the anchor never receives a `threadId`.

Deviation from the blueprint: `aside:anchored` is not in `COMMAND_EVENT_TYPES` (that list pins command grouping); the new author-scoped list carries the SQL filter instead.

## Proof

Real-schema integration (`aside-anchor-event.test.ts`, 5): creator fetch has the row, another member's does not; `broadcastSequence` null; message-less aside at creation position; conversation ref with real rows, wrong-host 400, non-member 404; outbox groups + sync-log catch-up reach the creator alone. PR1 suite still 12/12. Frontend: row renders for creator / absent for others (timeline item path, board card full-tail + ledger), placement beside the anchor, no spurious day divider, run transparency, auto-read scan ignores the relocated row (bottom and top), suppression per surface, quick-switcher own-only. Independent review (privacy, contiguity, suppression sweep) found one blocker (auto-read) and four should-fixes, all closed in the fix commits. Lint, typecheck, prettier clean.

## Caveats

- Placement beside the anchor is client-side and needs the anchor in the loaded window; otherwise the row sits at its creation position.
- The Resume control and the state text (active / draft unsent) land with PR4 and PR6; until then the row is title and age only.

---

_[Claude Fable 5](https://www.anthropic.com/news/claude-fable-5-mythos-5) in [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789925627&installation_model_id=20758&pr_number=1921&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1921&signature=1d5f4ab53a243ec0db157ee818308348d88c4317327647e9b84fdbb480315bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->