### PR TITLE
ci: pin bun 1.3.14 for the extension tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,11 +200,16 @@ jobs:
               - 'extensions/**'
               - '.github/workflows/ci.yml'
 
+      # Pinned, not latest: bun 1.4.0 refuses the extensions' transitive
+      # relative file: deps ("unsafe folder path" — claude-code-remote →
+      # remote-session → ../bot-runtime-client), and resolves a file: package's
+      # devDependencies too, so the peer/devDep restructure doesn't work either.
+      # Unpin once the extension packages no longer chain relative file: deps.
       - name: Setup Bun
         if: github.event_name == 'push' || steps.filter.outputs.extensions == 'true'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       # Extensions live outside the root Bun workspaces (apps/*, packages/*):
       # each is a standalone package with its own bun.lock, linked by file:


### PR DESCRIPTION
## Problem

Main CI failed on the #1913 merge (`1ff063b5`): the `Extension Tests` job's `bun install --cwd extensions/claude-code-remote` died with `refusing to install dependency @threa/bot-runtime-client with unsafe folder path "../bot-runtime-client"`. `setup-bun` is `latest`, which resolved to **bun 1.4.0** today (yesterday's passing main run used 1.3.14). 1.4.0 refuses a *transitive* relative `file:` dep — `claude-code-remote → file:../remote-session → file:../bot-runtime-client` — while top-level `file:../` deps still install. The job runs on every push to main (and on PRs only when `extensions/**` or `ci.yml` change), so every merge now fails main CI, and `Deploy Cloudflare` (gated on CI success) skips — #1913's frontend half is not live.

## Solution

Pin the Extension Tests job's `setup-bun` to `1.3.14`, with a comment stating why and the unpin condition. Targeted on purpose: the other jobs/workflows stay on `latest` as before.

Not taken, reproduced locally against bun 1.4.0 in a scratch copy of `extensions/`: `link:` on either edge still refused; moving `remote-session`'s dep to optional peer + devDependency fails because 1.4.0 also resolves a `file:` package's devDependencies relative to its copied location. The real fix is restructuring the extension packages so they don't chain relative `file:` deps — a separate change.

## Test plan

- [x] bun 1.4.0 (scratch install): `claude-code-remote` install fails as on CI; bun 1.3.14: 111 packages installed
- [ ] this PR's own CI runs the Extension Tests job (the path filter includes `ci.yml`) — green = proof

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789926609&installation_model_id=20758&pr_number=1923&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1923&signature=da1eddaa68650bb6d6b160da5acae4c6b06a4152b48145b711b740e171ddbc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->