### PR TITLE
feat: legacy quotes and shares earn their pins

### DIFF
--- a/apps/backend/src/db/migrations/20260821130000_backfill_message_reference_pins.sql
+++ b/apps/backend/src/db/migrations/20260821130000_backfill_message_reference_pins.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Backfill: pin legacy quote / share nodes to a source revision and range
+-- =============================================================================
+--
+-- Pairs with `20260620120000_backfill_tracking.sql` (the generic backfill
+-- framework's run/chunk tables). Enqueues one `backfill.plan` job per workspace;
+-- the plan worker fans out small `backfill.chunk` jobs that pin stored
+-- ProseMirror `quoteReply` / `sharedMessage` nodes written before the server
+-- resolved references: a quote gets the revision its stored snippet was taken
+-- from plus the span it covers, a share gets its source's current revision.
+-- The message-reference-pins definition is idempotent (a pinned node is
+-- skipped), so a re-enqueue or chunk redelivery is safe.
+--
+-- `process_after` is delayed 10 minutes (INV-67) so every replica is running the
+-- code that registers the definition before the first plan job is claimed.
+--
+-- ID shape `queue_<uuid hex>` follows the established migration-backfill
+-- convention (see `20260621120000_backfill_mention_actor_refs.sql`);
+-- production enqueues use ULIDs via `queueId()` in code.
+
+INSERT INTO queue_messages (
+    id,
+    queue_name,
+    workspace_id,
+    payload,
+    process_after,
+    inserted_at
+)
+SELECT
+    'queue_' || replace(gen_random_uuid()::text, '-', ''),
+    'backfill.plan',
+    w.id,
+    jsonb_build_object(
+        'workspaceId', w.id,
+        'backfillName', 'message-reference-pins'
+    ),
+    NOW() + INTERVAL '10 minutes',
+    NOW()
+FROM workspaces w;

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -230,6 +230,7 @@ When citing a specific message or file, prefer a structural reference over a par
   \`>\`
   \`> — [Author Name](quote:stream_xxx/msg_yyy/author_id/actor_type)\`
   The trailing \`actor_type\` segment is \`user\` for humans and \`persona\` for AI agents — match it to the original author's type. Author id is \`usr_…\` for users and \`persona_…\` for personas.
+  Quote the source verbatim: the server pins the quote to the revision it can read and re-derives the blockquote from that span, so wording you invented is rejected rather than sent.
 
 - **Resurface an attachment** by id:
   \`[Image #1](attachment:att_xxx)\` for images,

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -24,6 +24,7 @@ export { MessageVersionRepository, messageVersionKey } from "./version-repositor
 export type { MessageVersion, MessageVersionKey } from "./version-repository"
 
 export { resolveMessageReferences, sliceReferenceContent } from "./references"
+export { registerMessageReferencePinsBackfill, MESSAGE_REFERENCE_PINS_BACKFILL_NAME } from "./references"
 export type { ResolveMessageReferencesResult, ReferenceContent } from "./references"
 
 export { EventService } from "./event-service"

--- a/apps/backend/src/features/messaging/references/backfill.ts
+++ b/apps/backend/src/features/messaging/references/backfill.ts
@@ -1,0 +1,256 @@
+import type { ContentRange, JSONContent } from "@threa/types"
+
+import { sql } from "../../../db"
+import { chunkIds, registerBackfill, type BackfillContext } from "../../../lib/backfill"
+import { deriveContentMarkdown } from "../content"
+import { MessageRepository, type Message } from "../repository"
+import { MessageVersionRepository, type MessageVersion } from "../version-repository"
+
+import { locateSnippetRange } from "./locate"
+import { sliceReferenceContent } from "./slice"
+
+export const MESSAGE_REFERENCE_PINS_BACKFILL_NAME = "message-reference-pins"
+
+/**
+ * Tables holding ProseMirror `contentJson` that may carry quote/share nodes
+ * written before the server pinned references to a revision and range. Same
+ * set and same scoping as the mention backfill: `message_versions` scopes (and
+ * skips E2E) through its parent `messages` row, the others carry their own
+ * `workspace_id` and exclude E2E by `e2e_version IS NULL` (messages) or by
+ * `content_json IS NULL` (drafts null it when sealed).
+ */
+type BackfillTable = "messages" | "message_versions" | "scheduled_messages" | "drafts"
+
+interface ReferencePinsChunk {
+  table: BackfillTable
+  ids: string[]
+}
+
+interface ContentRow {
+  id: string
+  content_json: JSONContent
+  created_at: Date
+}
+
+function listIdsQuery(table: BackfillTable, workspaceId: string) {
+  switch (table) {
+    case "messages":
+      return sql`
+        SELECT id FROM messages
+        WHERE stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
+          AND content_json IS NOT NULL AND e2e_version IS NULL
+        ORDER BY id
+      `
+    case "message_versions":
+      return sql`
+        SELECT v.id FROM message_versions v
+        JOIN messages m ON m.id = v.message_id
+        JOIN streams s ON s.id = m.stream_id
+        WHERE s.workspace_id = ${workspaceId} AND m.e2e_version IS NULL AND v.content_json IS NOT NULL
+        ORDER BY v.id
+      `
+    case "scheduled_messages":
+      return sql`
+        SELECT id FROM scheduled_messages
+        WHERE workspace_id = ${workspaceId} AND content_json IS NOT NULL
+        ORDER BY id
+      `
+    case "drafts":
+      return sql`
+        SELECT id FROM drafts
+        WHERE workspace_id = ${workspaceId} AND content_json IS NOT NULL
+        ORDER BY id
+      `
+  }
+}
+
+function selectRowsQuery(table: BackfillTable, workspaceId: string, ids: string[]) {
+  if (table === "message_versions") {
+    return sql`
+      SELECT v.id, v.content_json, v.created_at FROM message_versions v
+      JOIN messages m ON m.id = v.message_id
+      JOIN streams s ON s.id = m.stream_id
+      WHERE s.workspace_id = ${workspaceId} AND v.id = ANY(${ids}) AND v.content_json IS NOT NULL
+    `
+  }
+  if (table === "messages") {
+    return sql`
+      SELECT id, content_json, created_at FROM messages
+      WHERE id = ANY(${ids})
+        AND content_json IS NOT NULL
+        AND stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
+    `
+  }
+  return sql`
+    SELECT id, content_json, created_at FROM ${sql.raw(table)}
+    WHERE workspace_id = ${workspaceId} AND id = ANY(${ids}) AND content_json IS NOT NULL
+  `
+}
+
+interface UnpinnedNode {
+  node: JSONContent
+  attrs: Record<string, unknown>
+  messageId: string
+  isQuote: boolean
+}
+
+/** Quote and share nodes that predate pinning — `version` still absent or null. */
+function collectUnpinnedNodes(root: JSONContent): UnpinnedNode[] {
+  const found: UnpinnedNode[] = []
+  const walk = (node: JSONContent): void => {
+    if (node.type === "quoteReply" || node.type === "sharedMessage") {
+      const attrs = (node.attrs ?? {}) as Record<string, unknown>
+      const messageId = attrs.messageId
+      if (typeof messageId === "string" && messageId.length > 0 && (attrs.version ?? null) === null) {
+        found.push({ node, attrs, messageId, isQuote: node.type === "quoteReply" })
+      }
+    }
+    for (const child of node.content ?? []) walk(child)
+  }
+  walk(root)
+  return found
+}
+
+/**
+ * Revisions to try a legacy quote's snippet against, best guess first: the one
+ * that was live when the quoting row was written, then the rest newest to
+ * oldest. `message_versions.created_at` is the moment that snapshot was
+ * SUPERSEDED, so the live revision at time `t` is the oldest snapshot that
+ * outlived `t` — and the current revision when none did.
+ */
+function candidateVersions(revision: number, versions: readonly MessageVersion[], at: Date): number[] {
+  let live = revision
+  for (const version of versions) {
+    if (version.versionNumber < revision && version.createdAt.getTime() > at.getTime()) {
+      live = version.versionNumber
+      break
+    }
+  }
+  const ordered = [live]
+  for (let candidate = revision; candidate >= 1; candidate--) {
+    if (candidate !== live) ordered.push(candidate)
+  }
+  return ordered
+}
+
+function contentForVersion(source: Message, versions: readonly MessageVersion[], version: number): JSONContent | null {
+  if (version === source.revision) return source.contentJson
+  return versions.find((row) => row.versionNumber === version)?.contentJson ?? null
+}
+
+interface QuotePin {
+  version: number
+  range: ContentRange | null
+  snippet: string
+}
+
+/**
+ * The revision a legacy quote was taken from, found by locating its stored
+ * snippet in each candidate revision. `null` when no revision contains the
+ * snippet — the node then stays unpinned rather than being pinned to a body it
+ * never quoted.
+ */
+function findQuotePin(
+  source: Message,
+  versions: readonly MessageVersion[],
+  snippet: unknown,
+  rowCreatedAt: Date
+): QuotePin | null {
+  for (const version of candidateVersions(source.revision, versions, rowCreatedAt)) {
+    const doc = contentForVersion(source, versions, version)
+    if (!doc) continue
+    const located = locateSnippetRange(doc, snippet)
+    if (!located) continue
+    return { version, range: located.range, snippet: sliceReferenceContent(doc, located.range).contentMarkdown }
+  }
+  return null
+}
+
+function pinReferenceRows(
+  rows: readonly ContentRow[],
+  sourcesById: ReadonlyMap<string, Message>,
+  versionsByMessageId: ReadonlyMap<string, MessageVersion[]>
+): Array<{ id: string; contentJson: JSONContent; contentMarkdown: string }> {
+  const updates: Array<{ id: string; contentJson: JSONContent; contentMarkdown: string }> = []
+  for (const row of rows) {
+    const contentJson = structuredClone(row.content_json)
+    let changed = false
+    for (const reference of collectUnpinnedNodes(contentJson)) {
+      const source = sourcesById.get(reference.messageId)
+      if (!source) continue
+      const versions = versionsByMessageId.get(reference.messageId) ?? []
+
+      if (!reference.isQuote) {
+        reference.node.attrs = { ...reference.attrs, version: source.revision, range: null }
+        changed = true
+        continue
+      }
+
+      const pin = findQuotePin(source, versions, reference.attrs.snippet, row.created_at)
+      if (!pin) continue
+      reference.node.attrs = { ...reference.attrs, version: pin.version, range: pin.range, snippet: pin.snippet }
+      changed = true
+    }
+    if (changed) updates.push({ id: row.id, contentJson, contentMarkdown: deriveContentMarkdown(contentJson) })
+  }
+  return updates
+}
+
+async function plan(ctx: BackfillContext, workspaceId: string): Promise<ReferencePinsChunk[]> {
+  const tables: BackfillTable[] = ["messages", "message_versions", "scheduled_messages", "drafts"]
+  const chunks: ReferencePinsChunk[] = []
+  for (const table of tables) {
+    const result = await ctx.pool.query<{ id: string }>(listIdsQuery(table, workspaceId))
+    const ids = result.rows.map((r) => r.id)
+    for (const slice of chunkIds(ids)) {
+      chunks.push({ table, ids: slice })
+    }
+  }
+  return chunks
+}
+
+async function processChunk(
+  ctx: BackfillContext,
+  workspaceId: string,
+  chunk: ReferencePinsChunk
+): Promise<{ processed: number }> {
+  const { table, ids } = chunk
+  if (ids.length === 0) return { processed: 0 }
+
+  const result = await ctx.pool.query<ContentRow>(selectRowsQuery(table, workspaceId, ids))
+  const rows = result.rows
+  if (rows.length === 0) return { processed: 0 }
+
+  const sourceIds = new Set<string>()
+  const quotedSourceIds = new Set<string>()
+  for (const row of rows) {
+    for (const reference of collectUnpinnedNodes(row.content_json)) {
+      sourceIds.add(reference.messageId)
+      if (reference.isQuote) quotedSourceIds.add(reference.messageId)
+    }
+  }
+  if (sourceIds.size === 0) return { processed: 0 }
+
+  const sourcesById = await MessageRepository.findByIdsInWorkspace(ctx.pool, workspaceId, [...sourceIds])
+  const versionsByMessageId = await MessageVersionRepository.findByMessageIds(ctx.pool, [...quotedSourceIds])
+
+  const updates = pinReferenceRows(rows, sourcesById, versionsByMessageId)
+  if (updates.length > 0) {
+    const updateIds = updates.map((u) => u.id)
+    const updateJson = updates.map((u) => JSON.stringify(u.contentJson))
+    const updateMarkdown = updates.map((u) => u.contentMarkdown)
+    await ctx.pool.query(sql`
+      UPDATE ${sql.raw(table)} AS t
+      SET content_json = data.content_json::jsonb, content_markdown = data.content_markdown
+      FROM unnest(${updateIds}::text[], ${updateJson}::text[], ${updateMarkdown}::text[])
+        AS data(id, content_json, content_markdown)
+      WHERE t.id = data.id
+    `)
+  }
+
+  return { processed: updates.length }
+}
+
+export function registerMessageReferencePinsBackfill(): void {
+  registerBackfill<ReferencePinsChunk>({ name: MESSAGE_REFERENCE_PINS_BACKFILL_NAME, plan, processChunk })
+}

--- a/apps/backend/src/features/messaging/references/backfill.ts
+++ b/apps/backend/src/features/messaging/references/backfill.ts
@@ -232,23 +232,35 @@ async function processChunk(
   if (sourceIds.size === 0) return { processed: 0 }
 
   const sourcesById = await MessageRepository.findByIdsInWorkspace(ctx.pool, workspaceId, [...sourceIds])
-  const versionsByMessageId = await MessageVersionRepository.findByMessageIds(ctx.pool, [...quotedSourceIds])
+  // Ids come out of stored content, so they are whatever an author once wrote.
+  // `sourcesById` is already workspace-resolved; anything it does not name is
+  // not this workspace's to read (INV-8).
+  const versionsByMessageId = await MessageVersionRepository.findByMessageIds(
+    ctx.pool,
+    [...quotedSourceIds].filter((id) => sourcesById.has(id))
+  )
 
+  const observedById = new Map(rows.map((row) => [row.id, JSON.stringify(row.content_json)]))
   const updates = pinReferenceRows(rows, sourcesById, versionsByMessageId)
-  if (updates.length > 0) {
-    const updateIds = updates.map((u) => u.id)
-    const updateJson = updates.map((u) => JSON.stringify(u.contentJson))
-    const updateMarkdown = updates.map((u) => u.contentMarkdown)
-    await ctx.pool.query(sql`
-      UPDATE ${sql.raw(table)} AS t
-      SET content_json = data.content_json::jsonb, content_markdown = data.content_markdown
-      FROM unnest(${updateIds}::text[], ${updateJson}::text[], ${updateMarkdown}::text[])
-        AS data(id, content_json, content_markdown)
-      WHERE t.id = data.id
-    `)
-  }
+  if (updates.length === 0) return { processed: 0 }
 
-  return { processed: updates.length }
+  const updateIds = updates.map((u) => u.id)
+  const updateJson = updates.map((u) => JSON.stringify(u.contentJson))
+  const updateMarkdown = updates.map((u) => u.contentMarkdown)
+  const observedJson = updates.map((u) => observedById.get(u.id) ?? "")
+  // The body was read in a separate statement, so the write has to prove it is
+  // replacing what it read (INV-20) — an author editing in between would
+  // otherwise have their new text overwritten with the old. A row that moved
+  // stays unpinned and the next run pins it, since pinning is idempotent.
+  const written = await ctx.pool.query(sql`
+    UPDATE ${sql.raw(table)} AS t
+    SET content_json = data.content_json::jsonb, content_markdown = data.content_markdown
+    FROM unnest(${updateIds}::text[], ${updateJson}::text[], ${updateMarkdown}::text[], ${observedJson}::text[])
+      AS data(id, content_json, content_markdown, observed_content_json)
+    WHERE t.id = data.id AND t.content_json = data.observed_content_json::jsonb
+  `)
+
+  return { processed: written.rowCount ?? 0 }
 }
 
 export function registerMessageReferencePinsBackfill(): void {

--- a/apps/backend/src/features/messaging/references/index.ts
+++ b/apps/backend/src/features/messaging/references/index.ts
@@ -1,4 +1,5 @@
 export { sliceReferenceContent, type ReferenceContent } from "./slice"
+export { registerMessageReferencePinsBackfill, MESSAGE_REFERENCE_PINS_BACKFILL_NAME } from "./backfill"
 export {
   resolveMessageReferences,
   type ResolveMessageReferencesParams,

--- a/apps/backend/src/features/messaging/references/locate.ts
+++ b/apps/backend/src/features/messaging/references/locate.ts
@@ -1,0 +1,47 @@
+import { normalizeRange, parseMarkdown, resolveSelectionRange } from "@threa/prosemirror"
+import type { ContentRange, JSONContent } from "@threa/types"
+
+/** Text a reader would see, with atoms reduced to a separator. */
+export function docToPlainText(node: JSONContent): string {
+  const parts: string[] = []
+  const walk = (n: JSONContent): void => {
+    if (n.type === "text") {
+      parts.push(n.text ?? "")
+      return
+    }
+    if (n.content) {
+      for (const child of n.content) walk(child)
+    }
+    parts.push(" ")
+  }
+  walk(node)
+  return parts.join("")
+}
+
+export function normalizeText(text: string): string {
+  return text
+    .normalize("NFC")
+    .replace(/[\u00A0\u200B-\u200D\uFEFF]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/**
+ * The span of `pinnedDoc` a rangeless quote is talking about, located from the
+ * snippet the client stored. `null` means the snippet is not in this document;
+ * `{ range: null }` means the whole document.
+ *
+ * The resolver turns a miss into `REFERENCE_RANGE_NOT_FOUND`; the pin backfill
+ * treats it as "this is not the version that was quoted" and tries the next
+ * candidate, so the decision of what a miss means stays with the caller.
+ */
+export function locateSnippetRange(pinnedDoc: JSONContent, snippet: unknown): { range: ContentRange | null } | null {
+  if (typeof snippet !== "string") return { range: null }
+  const wanted = normalizeText(docToPlainText(parseMarkdown(snippet)))
+  if (wanted.length === 0) return { range: null }
+  if (wanted === normalizeText(docToPlainText(pinnedDoc))) return { range: null }
+
+  const located = resolveSelectionRange(pinnedDoc, { text: wanted })
+  if (!located) return null
+  return { range: normalizeRange(pinnedDoc, located) }
+}

--- a/apps/backend/src/features/messaging/references/resolver.ts
+++ b/apps/backend/src/features/messaging/references/resolver.ts
@@ -1,4 +1,4 @@
-import { isEmptySlice, isRangeValid, normalizeRange, parseMarkdown, resolveSelectionRange } from "@threa/prosemirror"
+import { isEmptySlice, isRangeValid, normalizeRange } from "@threa/prosemirror"
 import { MessageReferenceErrorCodes, type ContentRange, type JSONContent } from "@threa/types"
 
 import type { Querier } from "../../../db"
@@ -7,6 +7,7 @@ import { resolveActorNames } from "../../agents"
 import { MessageRepository, type Message } from "../repository"
 import { MessageVersionRepository, messageVersionKey, type MessageVersionKey } from "../version-repository"
 
+import { locateSnippetRange as findSnippetRange } from "./locate"
 import { sliceReferenceContent } from "./slice"
 
 const REFERENCE_NODE_TYPES = new Set(["quoteReply", "sharedMessage"])
@@ -73,31 +74,6 @@ function collectReferenceNodes(root: JSONContent): ReferenceNode[] {
   return found
 }
 
-/** Text a reader would see, with atoms reduced to a separator. */
-function docToPlainText(node: JSONContent): string {
-  const parts: string[] = []
-  const walk = (n: JSONContent): void => {
-    if (n.type === "text") {
-      parts.push(n.text ?? "")
-      return
-    }
-    if (n.content) {
-      for (const child of n.content) walk(child)
-    }
-    parts.push(" ")
-  }
-  walk(node)
-  return parts.join("")
-}
-
-function normalizeText(text: string): string {
-  return text
-    .normalize("NFC")
-    .replace(/[\u00A0\u200B-\u200D\uFEFF]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-}
-
 function readVersion(raw: unknown): number | null {
   if (raw === null || raw === undefined) return null
   if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1) {
@@ -136,21 +112,12 @@ function sameRange(a: ContentRange | null, b: ContentRange | null): boolean {
   return a.from === b.from && a.to === b.to
 }
 
-/**
- * The span of `pinnedDoc` a legacy (rangeless) quote is talking about, located
- * from the snippet the client stored. `null` means the whole message.
- */
 function locateSnippetRange(pinnedDoc: JSONContent, snippet: unknown): ContentRange | null {
-  if (typeof snippet !== "string") return null
-  const wanted = normalizeText(docToPlainText(parseMarkdown(snippet)))
-  if (wanted.length === 0) return null
-  if (wanted === normalizeText(docToPlainText(pinnedDoc))) return null
-
-  const located = resolveSelectionRange(pinnedDoc, { text: wanted })
+  const located = findSnippetRange(pinnedDoc, snippet)
   if (!located) {
     throw referenceError(MessageReferenceErrorCodes.RANGE_NOT_FOUND, "Quoted text is not in the referenced message")
   }
-  return normalizeRange(pinnedDoc, located)
+  return located.range
 }
 
 function validateRange(pinnedDoc: JSONContent, raw: ContentRange): ContentRange | null {

--- a/apps/backend/src/features/messaging/version-repository.ts
+++ b/apps/backend/src/features/messaging/version-repository.ts
@@ -102,6 +102,30 @@ export const MessageVersionRepository = {
     return map
   },
 
+  /**
+   * Every stored snapshot for a set of messages, oldest first per message —
+   * the read behind the pin backfill, which has to try a legacy quote's
+   * snippet against each candidate revision (INV-56: one query per chunk,
+   * never one per source).
+   */
+  async findByMessageIds(db: Querier, messageIds: readonly string[]): Promise<Map<string, MessageVersion[]>> {
+    if (messageIds.length === 0) return new Map()
+
+    const result = await db.query<MessageVersionRow>(sql`
+      SELECT * FROM message_versions
+      WHERE message_id = ANY(${[...messageIds]})
+      ORDER BY message_id, version_number ASC
+    `)
+
+    const map = new Map<string, MessageVersion[]>()
+    for (const row of result.rows) {
+      const existing = map.get(row.message_id)
+      if (existing) existing.push(mapRow(row))
+      else map.set(row.message_id, [mapRow(row)])
+    }
+    return map
+  },
+
   async listByMessageId(db: Querier, messageId: string): Promise<MessageVersion[]> {
     const result = await db.query<MessageVersionRow>(sql`
       SELECT * FROM message_versions

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -167,7 +167,7 @@ const sharedMessageSlotSchema = z.discriminatedUnion("state", [
     content: z
       .string()
       .describe(
-        "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+        "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
       ),
     version: z.number().int().positive().describe("The source revision this slot renders."),
     currentRevision: z

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -62,7 +62,7 @@ import { WorkosOrgServiceImpl, StubWorkosOrgService } from "@threa/backend-commo
 import { PartitionMaintenanceWorker } from "@threa/backend-common"
 import { AccessLogService, createAiAccessLogSink } from "./features/access-log"
 import { StreamService, StreamBriefService } from "./features/streams"
-import { EventService } from "./features/messaging"
+import { EventService, registerMessageReferencePinsBackfill } from "./features/messaging"
 import {
   DynamicNamingConversationTarget,
   DynamicNamingEvaluator,
@@ -1446,6 +1446,7 @@ export async function startServer(): Promise<ServerInstance> {
   // Generic backfill framework. Register definitions BEFORE the workers can run
   // so a redelivered plan/chunk job can always resolve its definition by name.
   registerMentionBackfill()
+  registerMessageReferencePinsBackfill()
   registerStreamContextBackfill()
   registerGithubInstallationBackfill({ workspaceIntegrationService })
   jobQueue.registerHandler(JobQueues.BACKFILL_PLAN, createBackfillPlanWorker({ pool }), {

--- a/apps/backend/tests/integration/message-reference-pins-backfill.test.ts
+++ b/apps/backend/tests/integration/message-reference-pins-backfill.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The `message-reference-pins` backfill against the real schema (INV-68).
+ *
+ * Legacy rows are inserted through the repository rather than the write path,
+ * because the write path now pins everything — an unpinned node can only exist
+ * as stored history, which is exactly what this backfill has to converge.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import type { JSONContent } from "@threa/types"
+
+import { setupTestDatabase, withTransaction, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, StreamMemberRepository } from "../../src/features/streams"
+import {
+  EventService,
+  MessageRepository,
+  MESSAGE_REFERENCE_PINS_BACKFILL_NAME,
+  registerMessageReferencePinsBackfill,
+  sliceReferenceContent,
+} from "../../src/features/messaging"
+import { getBackfill } from "../../src/lib/backfill"
+import { messageId, userId, workspaceId, streamId } from "../../src/lib/id"
+
+function docOf(text: string): JSONContent {
+  return { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] }
+}
+
+/** A quote node as the pre-pinning client wrote it: a snippet and no version. */
+function legacyQuote(sourceId: string, sourceStreamId: string, snippet: string, author: string): JSONContent {
+  return {
+    type: "quoteReply",
+    attrs: { messageId: sourceId, streamId: sourceStreamId, authorName: "Author", authorId: author, snippet },
+  }
+}
+
+function legacyShare(sourceId: string, sourceStreamId: string): JSONContent {
+  return { type: "sharedMessage", attrs: { messageId: sourceId, streamId: sourceStreamId } }
+}
+
+function referenceAttrs(content: JSONContent | null | undefined, type: string): Record<string, unknown> {
+  const node = (content?.content ?? []).find((n) => n.type === type)
+  return (node?.attrs ?? {}) as Record<string, unknown>
+}
+
+describe("message-reference-pins backfill", () => {
+  let pool: Pool
+  let ctx: { pool: Pool }
+  let eventService: EventService
+  let testWorkspaceId: string
+  let author: string
+  let source: string
+  let target: string
+  let sourceMessageId: string
+  let locatableQuoteId: string
+  let unlocatableQuoteId: string
+  let shareId: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    ctx = { pool }
+    eventService = new EventService(pool)
+    testWorkspaceId = workspaceId()
+    author = userId()
+    source = streamId()
+    target = streamId()
+
+    await withTransaction(pool, async (client) => {
+      await WorkspaceRepository.insert(client, {
+        id: testWorkspaceId,
+        name: "Reference Pins",
+        slug: `reference-pins-${testWorkspaceId}`,
+        createdBy: author,
+      })
+      author = (await addTestMember(client, testWorkspaceId, author)).id
+      for (const [id, label] of [
+        [source, "source"],
+        [target, "target"],
+      ] as const) {
+        await StreamRepository.insert(client, {
+          id,
+          workspaceId: testWorkspaceId,
+          type: "channel",
+          visibility: "public",
+          slug: `${label}-${id.slice(-8)}`,
+          createdBy: author,
+        })
+        await StreamMemberRepository.insert(client, id, author)
+      }
+    })
+
+    const src = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: source,
+      authorId: author,
+      authorType: "user",
+      contentJson: docOf("first body"),
+      contentMarkdown: "first body",
+    })
+    sourceMessageId = src.id
+    await eventService.editMessageInternal({
+      workspaceId: testWorkspaceId,
+      messageId: src.id,
+      streamId: source,
+      actorId: author,
+      contentJson: docOf("second body"),
+      contentMarkdown: "second body",
+    })
+
+    locatableQuoteId = messageId()
+    unlocatableQuoteId = messageId()
+    shareId = messageId()
+    const legacyRows: Array<{ id: string; sequence: bigint; content: JSONContent; markdown: string }> = [
+      {
+        id: locatableQuoteId,
+        sequence: 900001n,
+        content: {
+          type: "doc",
+          content: [legacyQuote(sourceMessageId, source, "first", author), ...docOf("agreed").content!],
+        },
+        markdown: "agreed",
+      },
+      {
+        id: unlocatableQuoteId,
+        sequence: 900002n,
+        content: {
+          type: "doc",
+          content: [legacyQuote(sourceMessageId, source, "words nobody ever wrote", author), ...docOf("hm").content!],
+        },
+        markdown: "hm",
+      },
+      {
+        id: shareId,
+        sequence: 900003n,
+        content: { type: "doc", content: [legacyShare(sourceMessageId, source), ...docOf("look").content!] },
+        markdown: "look",
+      },
+    ]
+    await withTransaction(pool, async (client) => {
+      for (const row of legacyRows) {
+        await MessageRepository.insert(client, {
+          id: row.id,
+          streamId: target,
+          sequence: row.sequence,
+          authorId: author,
+          authorType: "user",
+          contentJson: row.content,
+          contentMarkdown: row.markdown,
+        })
+      }
+    })
+
+    registerMessageReferencePinsBackfill()
+    await runBackfill()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  async function runBackfill(): Promise<void> {
+    const definition = getBackfill(MESSAGE_REFERENCE_PINS_BACKFILL_NAME)
+    if (!definition) throw new Error("message-reference-pins backfill is not registered")
+    for (const chunk of await definition.plan(ctx, testWorkspaceId)) {
+      await definition.processChunk(ctx, testWorkspaceId, chunk)
+    }
+  }
+
+  test("a legacy quote pins to the revision its snippet came from, with a re-derived body", async () => {
+    const stored = await MessageRepository.findById(pool, locatableQuoteId)
+    const range = { from: 1, to: 6 }
+    expect(referenceAttrs(stored?.contentJson, "quoteReply")).toEqual({
+      messageId: sourceMessageId,
+      streamId: source,
+      authorName: "Author",
+      authorId: author,
+      snippet: sliceReferenceContent(docOf("first body"), range).contentMarkdown,
+      version: 1,
+      range,
+    })
+  })
+
+  test("a legacy quote whose snippet is in no revision stays unpinned", async () => {
+    const stored = await MessageRepository.findById(pool, unlocatableQuoteId)
+
+    expect(referenceAttrs(stored?.contentJson, "quoteReply")).toEqual({
+      messageId: sourceMessageId,
+      streamId: source,
+      authorName: "Author",
+      authorId: author,
+      snippet: "words nobody ever wrote",
+    })
+  })
+
+  test("a legacy share pins to the source's current revision, whole", async () => {
+    const stored = await MessageRepository.findById(pool, shareId)
+
+    expect(referenceAttrs(stored?.contentJson, "sharedMessage")).toEqual({
+      messageId: sourceMessageId,
+      streamId: source,
+      version: 2,
+      range: null,
+    })
+  })
+
+  test("re-running the backfill changes nothing", async () => {
+    const ids = [locatableQuoteId, unlocatableQuoteId, shareId]
+    const before = await Promise.all(ids.map((id) => MessageRepository.findById(pool, id)))
+
+    await runBackfill()
+
+    const after = await Promise.all(ids.map((id) => MessageRepository.findById(pool, id)))
+    expect(after.map((m) => ({ contentJson: m?.contentJson, contentMarkdown: m?.contentMarkdown }))).toEqual(
+      before.map((m) => ({ contentJson: m?.contentJson, contentMarkdown: m?.contentMarkdown }))
+    )
+  })
+})

--- a/apps/backend/tests/integration/message-reference-pins-backfill.test.ts
+++ b/apps/backend/tests/integration/message-reference-pins-backfill.test.ts
@@ -21,7 +21,8 @@ import {
   sliceReferenceContent,
 } from "../../src/features/messaging"
 import { getBackfill } from "../../src/lib/backfill"
-import { messageId, userId, workspaceId, streamId } from "../../src/lib/id"
+import { DraftsRepository } from "../../src/features/drafts"
+import { messageId, userId, workspaceId, streamId, draftId as draftIdFor } from "../../src/lib/id"
 
 function docOf(text: string): JSONContent {
   return { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] }
@@ -56,6 +57,7 @@ describe("message-reference-pins backfill", () => {
   let locatableQuoteId: string
   let unlocatableQuoteId: string
   let shareId: string
+  let draftId: string
 
   beforeAll(async () => {
     pool = await setupTestDatabase()
@@ -151,6 +153,31 @@ describe("message-reference-pins backfill", () => {
       }
     })
 
+    draftId = draftIdFor()
+    await withTransaction(pool, async (client) => {
+      await DraftsRepository.insertIfAbsent(client, {
+        id: draftId,
+        workspaceId: testWorkspaceId,
+        userId: author,
+        scope: `stream:${target}`,
+        rootStreamId: target,
+        contentJson: {
+          type: "doc",
+          content: [legacyQuote(sourceMessageId, source, "first", author), ...docOf("later").content!],
+        },
+        contentMarkdown: "later",
+        attachmentIds: [],
+        command: null,
+        contextRefs: null,
+        ciphertext: null,
+        envelope: null,
+        e2eVersion: null,
+        lastClientWriteId: null,
+        clientUpdatedAt: new Date(),
+        stashedAt: null,
+      })
+    })
+
     registerMessageReferencePinsBackfill()
     await runBackfill()
   })
@@ -202,6 +229,15 @@ describe("message-reference-pins backfill", () => {
       version: 2,
       range: null,
     })
+  })
+
+  test("an unsent draft is pinned by the same pass", async () => {
+    const row = await pool.query<{ content_json: JSONContent }>("SELECT content_json FROM drafts WHERE id = $1", [
+      draftId,
+    ])
+    const quote = row.rows[0].content_json.content?.[0]
+    expect(quote?.attrs).toMatchObject({ messageId: sourceMessageId, version: 1 })
+    expect(quote?.attrs?.range).not.toBeNull()
   })
 
   test("re-running the backfill changes nothing", async () => {

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -100,6 +100,7 @@ this tree. See Decisions below.
 | attachment-pipeline                                           | Per-region S3, extraction (PDF/OCR), thumbnails, video transcoding                                                                       | `features/attachments`, `lib/storage/`                                                          |
 | search-architecture                                           | Hybrid full-text and pgvector search, embedding jobs, access control                                                                     | `features/search`                                                                               |
 | memo-pipeline                                                 | The GAM machinery: boundary extraction, classification, memo accumulation                                                                | `features/memos` and its outbox handlers                                                        |
+| [message-references](message-references.md) ✅                | Quote and share pinned to a source revision and span: positions/slicing, wire forms, server resolution, slot hydration, pin backfill     | done                                                                                            |
 
 ## Probably skip, or covered elsewhere
 

--- a/docs/features/message-references.md
+++ b/docs/features/message-references.md
@@ -1,0 +1,167 @@
+---
+title: Message References
+status: shipped
+audience: internal
+kind: subsystem
+invariants: [INV-11, INV-32, INV-56, INV-58, INV-60, INV-64, INV-67]
+entry_points:
+  - packages/prosemirror/src/positions.ts
+  - packages/prosemirror/src/slice.ts
+  - packages/prosemirror/src/selection-range.ts
+  - packages/prosemirror/src/pointer-urls.ts
+  - apps/backend/src/features/messaging/references/
+  - apps/backend/src/features/messaging/sharing/hydration.ts
+  - packages/types/src/slots.ts
+public_site: false
+summary: >
+  A quote or a share points at one revision of a source message and, optionally,
+  one span of it. The server pins both, derives the quote body from the pinned
+  span, and hydrates share cards from it, so an edit to the source never rewrites
+  what someone quoted or shared.
+related: [architecture/sync-log.md, concepts/content-canonical-form.md]
+---
+
+## The gist
+
+Two ProseMirror nodes reference another message: `quoteReply` (a blockquote with
+attribution, body stored inline) and `sharedMessage` (a card, body hydrated at
+read time). Both carry the same reference core:
+
+```ts
+{ messageId, streamId, version: number | null, range: { from, to } | null }
+```
+
+- **`version`** is the source's revision (`messages.revision`): 1 for the
+  original body, +1 per edit. `null` on the wire means unpinned — the server
+  pins it to the source's current revision when it writes the node.
+- **`range`** is a pair of ProseMirror document positions inside that
+  revision's `contentJson`. `null` means the whole message; a range covering
+  the whole document is normalized to `null`. Valid iff `0 <= from < to <=
+docContentSize`.
+
+`message_versions` stores the **pre-edit** body under the revision number it
+was, so version _n_ of an edited message is the row with `version_number = n`
+and the current revision has no row.
+
+## Positions and slicing
+
+`packages/prosemirror` owns the position arithmetic, with no dependency on
+`prosemirror-model`: text node size is its text length, a leaf or atom is 1, any
+other node is `2 + children`. `LEAF_NODE_TYPES` is the list of node types with
+no content; an unknown type without content throws rather than guessing a size
+(INV-11), and
+`apps/frontend/src/components/editor/prosemirror-positions.contract.test.ts`
+holds the set against the real tiptap schema in both directions so the two can't
+drift.
+
+`sliceContent(doc, from, to)` reproduces PM's `Node.cut`: ancestors of the cut
+are kept, text is cut at character boundaries with marks preserved, atoms stay
+whole. `resolveSelectionRange(doc, { text, prefixText })` goes the other way —
+it maps rendered text back to a range by projecting each textblock to a string
+with a per-character position map, so a word split across mark boundaries still
+matches and an atom's rendered label is consumed rather than compared.
+
+## Wire forms
+
+Markdown is the external wire format; `contentJson` stays internal (INV-58). A
+reference serializes to a pointer link whose query carries the pin:
+
+```text
+quote:<streamId>/<messageId>/<authorId>/<actorType>?v=<n>&r=<from>-<to>
+shared-message:<streamId>/<messageId>[/<conversationId>]?v=<n>&r=<from>-<to>
+```
+
+`?v=` appears only when `version` is non-null and `&r=` only when `range` is
+non-null, so `r` never appears without `v`. Both parsers accept the legacy
+query-less forms unchanged and report `version: null, range: null` for them.
+
+## Server resolution
+
+`resolveMessageReferences` (`features/messaging/references/resolver.ts`) runs on
+every create and every edit, right after mention resolution and before the
+version snapshot, the timeline event, the projections and the outbox — so
+everything downstream reads one already-pinned body. It is the **only** writer
+of a quote's stored body: a client-supplied `snippet` is advisory input, never
+trusted output.
+
+Per node it loads the source (one batched `findByIdsInWorkspace`, soft-deleted
+rows included), resolves the pinned document (current revision from the
+`messages` row, older revisions through one batched
+`MessageVersionRepository.findByMessageVersions`), settles the range, and writes
+the attrs back. A quote's `snippet` is re-derived as
+`sliceReferenceContent(pinnedDoc, range)` — the same helper hydration and the
+backfill use, so all three agree byte for byte. Running it over its own output
+reports `changed: false` and produces identical JSON.
+
+A rangeless quote with a non-empty snippet gets a **lenient locate**: the
+snippet's plain text is matched against the pinned document
+(`references/locate.ts`); whole-document equality means `range: null`, a partial
+match yields the range, and no match is an error.
+
+Failures are `HttpError` 400s with stable codes (INV-32), from
+`MessageReferenceErrorCodes`:
+
+| Code                          | Cause                                                              |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `REFERENCE_SOURCE_NOT_FOUND`  | No such message in this workspace                                  |
+| `REFERENCE_VERSION_NOT_FOUND` | `version` outside `[1, source.revision]`, or its snapshot is gone  |
+| `REFERENCE_RANGE_INVALID`     | Range outside the document, or covering no content                 |
+| `REFERENCE_RANGE_NOT_FOUND`   | Rangeless quote whose snippet is in no part of the pinned revision |
+
+Cross-stream **access** is not decided here: `ShareService` still runs after
+resolution and still owns access, privacy and grants. E2E streams are skipped
+entirely — the stored content there is a ciphertext placeholder and carries no
+references.
+
+## Hydration and slot keys
+
+A `sharedMessage` node stores no body, so a reader resolves it through a slot.
+The key carries the pin (`packages/types/src/slots.ts`):
+
+```text
+shared:<messageId>                    unpinned (legacy)
+shared:<messageId>@<v>                pinned revision, whole message
+shared:<messageId>@<v>:<from>-<to>    pinned revision, one span
+```
+
+`parseSharedMessageSlotKey` is its inverse, so a holder of a mixed key space can
+route on the result. Hydration groups by `(messageId, version)` and loads one
+query per level.
+
+The `ok` slot serves the **pinned** content — sliced when the reference is
+ranged — plus `version`, `currentRevision`, and `range`. A card whose
+`currentRevision` is greater than its `version` is showing content the source
+has since moved past; the client surfaces that as an "Edited since" link rather
+than silently updating. A ranged reference carries no attachments (`[]`): the
+span, not the message, is what was shared. The other states are the
+privacy-safe placeholders — `deleted`, `missing`, `private` (source stream kind
+and visibility only, never content or author), and `truncated`.
+
+The public API exposes the same map as a response-level `slots` object with
+markdown-only content (`docs/public-api/openapi.json`).
+
+Source edits do not invalidate a pin. The `pointer:invalidated` event still
+fires so clients refetch, and the refetch returns the same pinned body with a
+higher `currentRevision`.
+
+## Backfilling legacy nodes
+
+Nodes written before pinning carry `version: null`. The
+`message-reference-pins` backfill (`references/backfill.ts`, enqueued by
+`20260821130000_backfill_message_reference_pins.sql`) converges them across
+`messages`, `message_versions`, `scheduled_messages` and `drafts`.
+
+For a legacy quote it tries the stored snippet against candidate revisions —
+the one that was live when the quoting row was written first (a
+`message_versions.created_at` is the moment that snapshot was _superseded_),
+then the rest newest to oldest. The first revision that contains the snippet
+sets `version` and `range`, and the snippet is re-derived from that span. When
+no revision contains it, the node stays unpinned rather than being pinned to a
+body it never quoted. A legacy share pins to its source's current revision,
+whole. Sources that no longer exist leave their node untouched.
+
+Each chunk reads set-based and writes one `UPDATE … FROM unnest(...)` for the
+rows that actually changed (INV-56); already-pinned nodes are skipped, so
+redelivery and re-enqueue are no-ops. The enqueue migration delays
+`process_after` by 10 minutes so every replica is running the code that
+registers the definition before the first plan job is claimed (INV-67).

--- a/docs/features/message-references.md
+++ b/docs/features/message-references.md
@@ -98,6 +98,12 @@ snippet's plain text is matched against the pinned document
 (`references/locate.ts`); whole-document equality means `range: null`, a partial
 match yields the range, and no match is an error.
 
+One node is exempt from that error: an unpinned quote that was already in the
+body being replaced. Its source may have been edited past the quote long ago,
+and refusing the write would leave the author unable to edit their own message
+ever again. Such a node is carried through untouched; a quote the edit itself
+adds is still rejected.
+
 Failures are `HttpError` 400s with stable codes (INV-32), from
 `MessageReferenceErrorCodes`:
 

--- a/docs/features/message-references.md
+++ b/docs/features/message-references.md
@@ -80,9 +80,10 @@ query-less forms unchanged and report `version: null, range: null` for them.
 `resolveMessageReferences` (`features/messaging/references/resolver.ts`) runs on
 every create and every edit, right after mention resolution and before the
 version snapshot, the timeline event, the projections and the outbox — so
-everything downstream reads one already-pinned body. It is the **only** writer
-of a quote's stored body: a client-supplied `snippet` is advisory input, never
-trusted output.
+everything downstream reads one already-pinned body. On that path it is the
+**only** writer of a quote's stored body: a client-supplied `snippet` is
+advisory input, never trusted output. (The pin backfill below writes quote
+bodies too, through the same slicer, for nodes written before any of this.)
 
 Per node it loads the source (one batched `findByIdsInWorkspace`, soft-deleted
 rows included), resolves the pinned document (current revision from the
@@ -114,8 +115,12 @@ Failures are `HttpError` 400s with stable codes (INV-32), from
 | `REFERENCE_RANGE_INVALID`     | Range outside the document, or covering no content                 |
 | `REFERENCE_RANGE_NOT_FOUND`   | Rangeless quote whose snippet is in no part of the pinned revision |
 
-Cross-stream **access** is not decided here: `ShareService` still runs after
-resolution and still owns access, privacy and grants. E2E streams are skipped
+A source in **another stream** is read-gated here before any version or range
+work, using the same access split `ShareService` uses: one the caller cannot
+read is reported as `REFERENCE_SOURCE_NOT_FOUND`, exactly like one that does
+not exist, so an error cannot measure a message the author cannot open.
+Authorizing the share itself — the privacy boundary, the grant rows — still
+belongs to `ShareService`, which runs after resolution. E2E streams are skipped
 entirely — the stored content there is a ciphertext placeholder and carries no
 references.
 

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -120,7 +120,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -3056,7 +3056,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -4837,7 +4837,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -5177,7 +5177,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -5736,7 +5736,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -6064,7 +6064,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -6370,7 +6370,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",

--- a/docs/public-api/versions/2026-08-21.json
+++ b/docs/public-api/versions/2026-08-21.json
@@ -120,7 +120,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -3056,7 +3056,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -4837,7 +4837,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -5177,7 +5177,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -5736,7 +5736,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -6064,7 +6064,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",
@@ -6370,7 +6370,7 @@
                               "authorDisplayName": { "type": "string" },
                               "content": {
                                 "type": "string",
-                                "description": "The referenced revision of the source as markdown (the referenced span of it when the key carries a range). The canonical rich-text JSON stays internal."
+                                "description": "The pinned source content as markdown — the revision and span the pointer names, not the source as it reads now. The canonical rich-text JSON stays internal."
                               },
                               "version": {
                                 "type": "integer",


### PR DESCRIPTION
Fourth layer of the quote/share-by-pinned-version stack (plan: https://seer.build/ws_vbyzjvdg6g/b/share-quoted-plan/, on top of #1927). Every reference written from now on is pinned by the server; this gives the ones already in the database a pin too, and writes the feature down. It sits below the two frontend PRs because it depends only on the resolver.

**Changes**
- `messaging/references/backfill.ts` — `message-reference-pins` over `messages`, `message_versions`, `scheduled_messages` and `drafts`, the same scoping, chunking and E2E exclusions as `mention-actor-refs`. Per chunk: one row read, one source read, one `findByMessageIds` for quoted sources, one `UPDATE … FROM unnest(...)` for changed rows (INV-56). An unpinned `quoteReply` is located against the revision that was live at the row's `created_at`, then newest→oldest; the first hit sets `version`/`range` and re-derives `snippet` through the resolver's own `sliceReferenceContent`, so a backfilled node is byte-identical to one the server would write today. No hit or missing source leaves the node alone (a source edited past its quote can no longer be located — best effort by design). Unpinned `sharedMessage` nodes pin to the source's current revision. Already-pinned nodes are skipped, so redelivery is a no-op.
- `references/locate.ts` — the snippet→range lookup moved out of the resolver so both callers share it; it returns `null` on a miss and the resolver keeps throwing `REFERENCE_RANGE_NOT_FOUND` at its own call site.
- Enqueue migration `20260821130000` with `process_after = NOW() + INTERVAL '10 minutes'` (INV-67), so old replicas are gone before the first chunk runs.
- Docs: `docs/features/message-references.md` (reference core, positions and slicing, the `?v=&r=` wire forms, server resolution, error codes, slot keys, hydration states, E2E skip, backfill), an INVENTORY row, and public-API descriptions for the reference-keyed `slots` map.

**Verification**
`tests/integration/message-reference-pins-backfill.test.ts` (4 cases, real schema): a legacy quote whose text only exists in v1 pins to v1 with a range and a re-derived snippet; a quote matching no revision is untouched; a legacy share pins to the current revision; a second run changes nothing. `check:migrations` (261 clean), backend typecheck, lint, `generate:api-docs:check`.

**Risk**
The backfill rewrites stored content. Every write is value-guarded (only changed rows) and idempotent, the enqueue delay covers the rollout, and progress is visible through the existing backfill run/chunk tables. Re-derived snippets can differ in formatting from the stored plain text (bold and links come back) — the text is the same by construction, since the locate step matched it.
