### PR TITLE
feat: quoting a selection pins the revision and the span

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -19,6 +19,7 @@ import { resetComposeOverlayStoreCache } from "@/stores/compose-overlay-store"
 import { resetBoardFlashStoreCache } from "@/stores/board-flash-store"
 import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
 import { resetConversationMessageSnapshots } from "@/stores/conversation-messages-store"
+import { resetReferenceSourceStoreCache } from "@/stores/reference-source-store"
 import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
 import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
@@ -92,6 +93,7 @@ function flushModuleStoreCaches(): void {
   resetDraftContextCache()
   resetShareHandoffStoreCache()
   resetSnippetRequestStoreCache()
+  resetReferenceSourceStoreCache()
   resetConversationReplyOpenStoreCache()
   resetE2eSessionStoreCache()
   resetComposeOverlayStoreCache()

--- a/apps/frontend/src/components/editor/quote-reply-extension.test.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.test.ts
@@ -24,6 +24,8 @@ function createQuoteReplyNode(): JSONContent {
       authorId: "user_123",
       actorType: "user",
       snippet: "The vibes are immaculate",
+      version: null,
+      range: null,
     },
   }
 }
@@ -274,5 +276,21 @@ describe("quote reply gap cursor", () => {
     expect(editor.view.dom.classList.contains("has-after-quote-gapcursor")).toBe(true)
 
     editor.destroy()
+  })
+
+  it("round-trips the pin through the HTML clipboard so a copied quote stays pinned", () => {
+    const pinned: JSONContent = {
+      type: "quoteReply",
+      attrs: { ...createQuoteReplyNode().attrs, version: 7, range: { from: 4, to: 19 } },
+    }
+    const source = createQuoteReplyEditor({ type: "doc", content: [pinned] })
+    const html = source.getHTML()
+    source.destroy()
+
+    const pasted = createQuoteReplyEditor(html as unknown as JSONContent)
+    const [node] = pasted.getJSON().content ?? []
+
+    expect(node?.attrs).toMatchObject({ version: 7, range: { from: 4, to: 19 } })
+    pasted.destroy()
   })
 })

--- a/apps/frontend/src/components/editor/quote-reply-extension.test.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { Editor } from "@tiptap/core"
+import { Editor, type Content } from "@tiptap/core"
 import { GapCursor } from "@tiptap/pm/gapcursor"
 import type { ResolvedPos } from "@tiptap/pm/model"
 import type { JSONContent } from "@tiptap/react"
@@ -30,7 +30,7 @@ function createQuoteReplyNode(): JSONContent {
   }
 }
 
-function createQuoteReplyEditor(content: JSONContent = { type: "doc", content: [createQuoteReplyNode()] }) {
+function createQuoteReplyEditor(content: Content = { type: "doc", content: [createQuoteReplyNode()] }) {
   const element = document.createElement("div")
   document.body.append(element)
 
@@ -287,7 +287,7 @@ describe("quote reply gap cursor", () => {
     const html = source.getHTML()
     source.destroy()
 
-    const pasted = createQuoteReplyEditor(html as unknown as JSONContent)
+    const pasted = createQuoteReplyEditor(html)
     const [node] = pasted.getJSON().content ?? []
 
     expect(node?.attrs).toMatchObject({ version: 7, range: { from: 4, to: 19 } })

--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -3,7 +3,16 @@ import { GapCursor } from "@tiptap/pm/gapcursor"
 import type { ResolvedPos } from "@tiptap/pm/model"
 import { NodeSelection, Plugin, PluginKey, Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
+import type { ContentRange } from "@threa/types"
 import { QuoteReplyView } from "./quote-reply-view"
+
+function parseRangeAttribute(raw: string | null): ContentRange | null {
+  const match = raw?.match(/^(\d+)-(\d+)$/)
+  if (!match) return null
+  const from = Number(match[1])
+  const to = Number(match[2])
+  return to > from ? { from, to } : null
+}
 
 function isValidGapCursorPosition($pos: ResolvedPos): boolean {
   const gapCursor = GapCursor as typeof GapCursor & {
@@ -185,6 +194,10 @@ export interface QuoteReplyAttrs {
   actorType: string
   /** The quoted text snippet */
   snippet: string
+  /** Source message revision this quote is pinned to; null = unpinned */
+  version: number | null
+  /** Span inside the pinned version; null = the whole message */
+  range: ContentRange | null
 }
 
 export const QuoteReplyExtension = Node.create({
@@ -225,6 +238,22 @@ export const QuoteReplyExtension = Node.create({
         default: "",
         parseHTML: (element) => element.getAttribute("data-snippet"),
         renderHTML: (attrs) => ({ "data-snippet": attrs.snippet }),
+      },
+      version: {
+        default: null,
+        parseHTML: (element) => {
+          const parsed = Number(element.getAttribute("data-version"))
+          return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+        },
+        renderHTML: (attrs) => (attrs.version == null ? {} : { "data-version": String(attrs.version) }),
+      },
+      range: {
+        default: null,
+        parseHTML: (element) => parseRangeAttribute(element.getAttribute("data-range")),
+        renderHTML: (attrs) => {
+          const range = attrs.range as ContentRange | null
+          return range ? { "data-range": `${range.from}-${range.to}` } : {}
+        },
       },
     }
   },

--- a/apps/frontend/src/components/editor/quote-reply-view.tsx
+++ b/apps/frontend/src/components/editor/quote-reply-view.tsx
@@ -1,6 +1,7 @@
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
 import { X, Quote } from "lucide-react"
 import { useParams } from "react-router-dom"
+import { stripMarkdownToInline, truncateInline } from "@/lib/markdown/strip"
 import { cn } from "@/lib/utils"
 import { useActors } from "@/hooks"
 import { useUserProfile } from "@/components/user-profile"
@@ -11,9 +12,9 @@ import type { AuthorType } from "@threa/types"
 
 export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
   const attrs = node.attrs as QuoteReplyAttrs
-  const snippetLines = attrs.snippet.split("\n")
-  const isLong = snippetLines.length > 3 || attrs.snippet.length > 200
-  const displaySnippet = isLong ? snippetLines.slice(0, 3).join("\n").slice(0, 200) + "..." : attrs.snippet
+  // The snippet is the formatted slice the server will store, so the chip strips
+  // it to inline text rather than showing raw markdown (INV-60).
+  const displaySnippet = truncateInline(stripMarkdownToInline(attrs.snippet), 200)
 
   const { workspaceId } = useParams<{ workspaceId: string }>()
 
@@ -38,7 +39,7 @@ export function QuoteReplyView({ node, deleteNode, selected }: NodeViewProps) {
         ) : (
           <span className="text-xs font-medium text-muted-foreground">{attrs.authorName}</span>
         )}
-        <p className="mt-0.5 whitespace-pre-wrap text-muted-foreground">{displaySnippet}</p>
+        <p className="mt-0.5 text-muted-foreground">{displaySnippet}</p>
       </div>
       <button
         type="button"

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -390,6 +390,8 @@ export function MessageItem({
       authorId: message.authorId,
       actorType: message.authorType,
       snippet,
+      version: null,
+      range: null,
     })
   }, [quoteReplyCtx, message.contentMarkdown, message.id, message.authorId, message.authorType, streamId, authorName])
 

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -9,6 +9,7 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { useActors } from "@/hooks"
 import { getInitials } from "@/lib/initials"
+import type { QuoteSelection } from "@/lib/quote-selection"
 import { cn } from "@/lib/utils"
 import { buildQuickEmojis } from "@/lib/emoji-picker"
 import { ActionDrawerList } from "@/components/actions/action-drawer-list"
@@ -40,7 +41,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
     ? getActorAvatar(context.authorId, (context.actorType ?? "user") as AuthorType).status
     : undefined
   const [expanded, setExpanded] = useState(false)
-  const [selectedText, setSelectedText] = useState("")
+  const [selection, setSelection] = useState<QuoteSelection | null>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
   const handleOpenChange = useCallback(
@@ -53,28 +54,32 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
 
   useEffect(() => {
     if (!expanded) {
-      setSelectedText("")
+      setSelection(null)
       return
     }
 
     const handleSelectionChange = () => {
       const sel = window.getSelection()
       if (!sel || sel.isCollapsed || !sel.rangeCount) {
-        setSelectedText("")
+        setSelection(null)
         return
       }
 
       const text = sel.toString().trim()
-      if (!text) {
-        setSelectedText("")
+      const contentEl = contentRef.current
+      if (!text || !contentEl) {
+        setSelection(null)
         return
       }
 
       const range = sel.getRangeAt(0)
-      if (contentRef.current?.contains(range.startContainer) && contentRef.current?.contains(range.endContainer)) {
-        setSelectedText(text)
+      if (contentEl.contains(range.startContainer) && contentEl.contains(range.endContainer)) {
+        const prefix = contentEl.ownerDocument.createRange()
+        prefix.selectNodeContents(contentEl)
+        prefix.setEnd(range.startContainer, range.startOffset)
+        setSelection({ text, prefixText: prefix.toString() })
       } else {
-        setSelectedText("")
+        setSelection(null)
       }
     }
 
@@ -83,11 +88,11 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
   }, [expanded])
 
   const handleQuoteSelected = useCallback(() => {
-    if (!selectedText || !context.onQuoteReplyWithSnippet) return
-    context.onQuoteReplyWithSnippet(selectedText)
+    if (!selection || !context.onQuoteReplyWithSelection) return
+    context.onQuoteReplyWithSelection(selection)
     window.getSelection()?.removeAllRanges()
     handleOpenChange(false)
-  }, [selectedText, context, handleOpenChange])
+  }, [selection, context, handleOpenChange])
 
   const handleBack = useCallback(() => {
     window.getSelection()?.removeAllRanges()
@@ -152,7 +157,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
             actorType={context.actorType}
             statusEmoji={authorStatus?.emoji ?? null}
             statusText={authorStatus?.text ?? null}
-            selectedText={selectedText}
+            selectedText={selection?.text ?? ""}
             contentRef={contentRef}
             onBack={handleBack}
             onQuote={handleQuoteSelected}
@@ -164,10 +169,10 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
                 type="button"
                 className={cn(
                   "group/preview relative w-full text-left rounded-xl bg-muted/60 px-3.5 py-2.5 disabled:opacity-100 disabled:cursor-default",
-                  context.onQuoteReplyWithSnippet && "active:bg-muted/80 transition-colors cursor-pointer"
+                  context.onQuoteReplyWithSelection && "active:bg-muted/80 transition-colors cursor-pointer"
                 )}
-                onClick={context.onQuoteReplyWithSnippet ? () => setExpanded(true) : undefined}
-                disabled={!context.onQuoteReplyWithSnippet}
+                onClick={context.onQuoteReplyWithSelection ? () => setExpanded(true) : undefined}
+                disabled={!context.onQuoteReplyWithSelection}
               >
                 <div className="mb-0.5 flex items-center gap-1.5 text-[13px] font-medium text-muted-foreground">
                   <span className="truncate">{authorName}</span>
@@ -183,14 +188,14 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
                 <div className="text-sm text-foreground/80 line-clamp-2 leading-snug pr-6 max-h-[2.75rem] overflow-hidden">
                   <MarkdownContent content={context.contentMarkdown} />
                 </div>
-                {context.onQuoteReplyWithSnippet && (
+                {context.onQuoteReplyWithSelection && (
                   <Quote
                     aria-hidden="true"
                     className="absolute top-2.5 right-2.5 h-3.5 w-3.5 text-muted-foreground/40 group-active/preview:text-primary transition-colors"
                   />
                 )}
               </button>
-              {context.onQuoteReplyWithSnippet && (
+              {context.onQuoteReplyWithSelection && (
                 <p className="text-[11px] text-muted-foreground/60 mt-1.5 px-1 flex items-center gap-1">
                   <span className="inline-block h-1 w-1 rounded-full bg-primary/60" />
                   Tap to highlight a passage

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -23,6 +23,7 @@ import {
   Check,
 } from "lucide-react"
 import { toast } from "sonner"
+import type { QuoteSelection } from "@/lib/quote-selection"
 import { buildStreamLink, buildConversationLink } from "@/lib/stream-links"
 import {
   type ActionDefinition,
@@ -98,8 +99,8 @@ export interface MessageActionContext {
   reactions?: Record<string, string[]>
   /** Callback to insert a quote reply into the composer */
   onQuoteReply?: () => void
-  /** Callback to insert a partial quote reply with a user-selected snippet */
-  onQuoteReplyWithSnippet?: (snippet: string) => void
+  /** Callback to insert a partial quote reply from a user's text selection */
+  onQuoteReplyWithSelection?: (selection: QuoteSelection) => void
   /**
    * Arm the stream composer to file its next send into this message's
    * conversation (an `existing` directive — Mechanism C). Set on in-stream

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -80,6 +80,8 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
 import { ReactionEmojiPicker } from "./reaction-emoji-picker"
+import { resolveQuoteSelection, type QuoteSelection } from "@/lib/quote-selection"
+import { registerReferenceSource } from "@/stores/reference-source-store"
 import { useQuoteReply } from "./quote-reply-context"
 import { useConversationReply } from "./conversation-reply-context"
 import { useSwipeAction } from "@/hooks/use-swipe-action"
@@ -951,6 +953,24 @@ function SentMessageEvent({
     deferToNativeLinks: true,
   })
 
+  // Publish this row's body for the floating selection toolbar, which resolves a
+  // quote's range against it (see `reference-source-store`).
+  const referenceSource = useMemo(
+    () =>
+      payload.contentJson
+        ? {
+            contentJson: payload.contentJson,
+            revision: payload.revision ?? null,
+            contentMarkdown: payload.contentMarkdown,
+          }
+        : null,
+    [payload.contentJson, payload.revision, payload.contentMarkdown]
+  )
+  useEffect(() => {
+    if (!referenceSource) return
+    return registerReferenceSource(payload.messageId, referenceSource)
+  }, [payload.messageId, referenceSource])
+
   // Touch: swipe left to quote reply
   const handleSwipeQuote = useCallback(() => {
     const snippet = payload.contentMarkdown.trim()
@@ -962,8 +982,19 @@ function SentMessageEvent({
       authorId: event.actorId ?? "",
       actorType: event.actorType ?? "user",
       snippet,
+      version: payload.revision ?? null,
+      range: null,
     })
-  }, [quoteReplyCtx, payload.messageId, payload.contentMarkdown, streamId, actorName, event.actorId, event.actorType])
+  }, [
+    quoteReplyCtx,
+    payload.messageId,
+    payload.contentMarkdown,
+    payload.revision,
+    streamId,
+    actorName,
+    event.actorId,
+    event.actorType,
+  ])
   const swipe = useSwipeAction({
     onSwipe: handleSwipeQuote,
     enabled: touchCapable && !isEditing && !!quoteReplyCtx && !batch?.enabled,
@@ -1177,17 +1208,26 @@ function SentMessageEvent({
               authorId: event.actorId ?? "",
               actorType: event.actorType ?? "user",
               snippet: payload.contentMarkdown,
+              version: payload.revision ?? null,
+              range: null,
             })
         : undefined,
-      onQuoteReplyWithSnippet: quoteReplyCtx
-        ? (snippet: string) =>
+      onQuoteReplyWithSelection: quoteReplyCtx
+        ? (selection: QuoteSelection) =>
             quoteReplyCtx.triggerQuoteReply({
               messageId: payload.messageId,
               streamId,
               authorName: actorName,
               authorId: event.actorId ?? "",
               actorType: event.actorType ?? "user",
-              snippet,
+              ...resolveQuoteSelection(
+                {
+                  contentJson: payload.contentJson,
+                  revision: payload.revision,
+                  contentMarkdown: payload.contentMarkdown,
+                },
+                selection
+              ),
             })
         : undefined,
       onShareToRoot: rootStream

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1301,6 +1301,8 @@ function SentMessageEvent({
       payload.messageId,
       payload.editedAt,
       payload.reactions,
+      payload.contentJson,
+      payload.revision,
       e2eEnabled,
       event.id,
       event.actorType,

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -12,6 +12,7 @@ import * as hooksModule from "@/hooks"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as authModule from "@/auth"
 import * as quoteReplyModule from "./quote-reply-context"
+import type { QuoteReplyData } from "./quote-reply-context"
 import * as conversationReplyModule from "./conversation-reply-context"
 import * as useConversationsModule from "@/hooks/use-conversations"
 import {
@@ -81,16 +82,7 @@ const mockHandleFileSelect = vi.fn()
 const mockComposerFocus = vi.fn()
 const mockComposerFocusAfterQuoteReply = vi.fn()
 let mockSubmitContentOverride: JSONContent | undefined
-let registeredQuoteReplyHandler:
-  | ((data: {
-      messageId: string
-      streamId: string
-      authorName: string
-      authorId: string
-      actorType: string
-      snippet: string
-    }) => void)
-  | null = null
+let registeredQuoteReplyHandler: ((data: QuoteReplyData) => void) | null = null
 let registeredConversationReplyHandler: ((data: { conversationId: string }) => void) | null = null
 const mockScheduleMutateAsync = vi.fn()
 // Captured from the mocked ScheduledMessagesPicker so a test can drive the
@@ -176,16 +168,7 @@ beforeEach(async () => {
 
   vi.spyOn(quoteReplyModule, "useQuoteReply").mockReturnValue({
     triggerQuoteReply: vi.fn(),
-    registerHandler: (
-      handler: (data: {
-        messageId: string
-        streamId: string
-        authorName: string
-        authorId: string
-        actorType: string
-        snippet: string
-      }) => void
-    ) => {
+    registerHandler: (handler: (data: QuoteReplyData) => void) => {
       registeredQuoteReplyHandler = handler
       return () => {
         if (registeredQuoteReplyHandler === handler) {
@@ -631,7 +614,9 @@ describe("MessageInput", () => {
         authorName: "Ariadne",
         authorId: "user_123",
         actorType: "user",
-        snippet: "The vibes are immaculate",
+        snippet: "**The vibes** are immaculate",
+        version: 3,
+        range: { from: 5, to: 32 },
       })
 
       expect(mockSetContent).toHaveBeenCalledWith({
@@ -646,7 +631,9 @@ describe("MessageInput", () => {
               authorName: "Ariadne",
               authorId: "user_123",
               actorType: "user",
-              snippet: "The vibes are immaculate",
+              snippet: "**The vibes** are immaculate",
+              version: 3,
+              range: { from: 5, to: 32 },
             },
           },
           { type: "paragraph" },

--- a/apps/frontend/src/components/timeline/quote-reply-context.test.ts
+++ b/apps/frontend/src/components/timeline/quote-reply-context.test.ts
@@ -9,6 +9,8 @@ const DATA: QuoteReplyData = {
   authorId: "usr_1",
   actorType: "user",
   snippet: "the quoted body",
+  version: 3,
+  range: { from: 4, to: 19 },
 }
 
 function quoteNode(): JSONContent {
@@ -21,6 +23,8 @@ function quoteNode(): JSONContent {
       authorId: DATA.authorId,
       actorType: DATA.actorType,
       snippet: DATA.snippet,
+      version: DATA.version,
+      range: DATA.range,
     },
   }
 }

--- a/apps/frontend/src/components/timeline/quote-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/quote-reply-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useCallback, useMemo, useRef } from "react"
 import type { ReactNode } from "react"
-import type { JSONContent } from "@threa/types"
+import type { ContentRange, JSONContent } from "@threa/types"
 
 export interface QuoteReplyData {
   messageId: string
@@ -10,6 +10,10 @@ export interface QuoteReplyData {
   actorType: string
   /** Markdown content to quote (preserves formatting) */
   snippet: string
+  /** Source revision the quote pins to; null when the trigger can't know it. */
+  version: number | null
+  /** Span inside the pinned version; null quotes the whole message. */
+  range: ContentRange | null
 }
 
 interface QuoteReplyContextValue {
@@ -66,6 +70,8 @@ export function appendQuoteReplyNode(content: JSONContent, data: QuoteReplyData)
       authorId: data.authorId,
       actorType: data.actorType,
       snippet: data.snippet,
+      version: data.version,
+      range: data.range,
     },
   }
 

--- a/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
@@ -2,10 +2,28 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useEffect, useRef } from "react"
+import type { JSONContent } from "@threa/types"
+import { registerReferenceSource, resetReferenceSourceStoreCache } from "@/stores/reference-source-store"
 import { QuoteReplyProvider, useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
 import { TextSelectionQuote } from "./text-selection-quote"
 
 const BODY_TEXT = "Hello there, this is the body."
+/** The same body the row renders, with "this" bold — a slice across the mark
+ * proves the snippet is the formatted span, not the DOM's plain string. */
+const BODY_JSON: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello there, " },
+        { type: "text", text: "this", marks: [{ type: "bold" }] },
+        { type: "text", text: " is the body." },
+      ],
+    },
+  ],
+}
+const BODY_MARKDOWN = "Hello there, **this** is the body."
 
 /** A message row shaped like `MessageItem` — the data attributes and
  * `.message-content .markdown-content` structure `TextSelectionQuote` reads. */
@@ -32,17 +50,21 @@ function CaptureQuote({ onQuote }: { onQuote: (d: QuoteReplyData) => void }) {
   return null
 }
 
-/** Point `window.getSelection` at a non-collapsed range over `node`. */
-function mockSelection(node: Node, text: string) {
-  const range = {
-    startContainer: node,
-    endContainer: node,
-    getBoundingClientRect: () => ({ top: 120, left: 40, width: 90, height: 20 }) as DOMRect,
-  }
+/**
+ * Point `window.getSelection` at a real DOM range over `node`, spanning the
+ * characters `[start, end)`. Real ranges matter: the component derives the
+ * range resolver's prefix text from the DOM between the body's start and the
+ * selection's start.
+ */
+function mockSelection(node: Node, start: number, end: number) {
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, end)
+  range.getBoundingClientRect = () => ({ top: 120, left: 40, width: 90, height: 20 }) as DOMRect
   vi.spyOn(window, "getSelection").mockReturnValue({
     isCollapsed: false,
     rangeCount: 1,
-    toString: () => text,
+    toString: () => range.toString(),
     getRangeAt: () => range,
     removeAllRanges: () => {},
   } as unknown as Selection)
@@ -54,48 +76,97 @@ function fireSelectionChange() {
   })
 }
 
-afterEach(() => vi.restoreAllMocks())
+function Scene({ onQuote }: { onQuote: (d: QuoteReplyData) => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  return (
+    <QuoteReplyProvider>
+      <CaptureQuote onQuote={onQuote} />
+      {/* Anchor prop differs from the row's data-stream-id: the row wins. */}
+      <TextSelectionQuote streamId="stream_anchor" containerRef={ref} />
+      <div ref={ref}>
+        <MessageRow messageId="msg_1" streamId="stream_thread" />
+      </div>
+    </QuoteReplyProvider>
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetReferenceSourceStoreCache()
+})
 
 describe("TextSelectionQuote", () => {
-  it("quotes the selected snippet against the row's own stream, routed to the scoped composer", async () => {
+  it("pins the quote to the rendered revision and the selected span, quoting the formatted slice", async () => {
+    const user = userEvent.setup()
+    const onQuote = vi.fn()
+    registerReferenceSource("msg_1", { contentJson: BODY_JSON, revision: 4, contentMarkdown: BODY_MARKDOWN })
+
+    render(<Scene onQuote={onQuote} />)
+
+    const bodyEl = screen.getByText(BODY_TEXT)
+    // "this is" — starts inside the bold mark and runs past it.
+    mockSelection(bodyEl.firstChild as Node, 13, 20)
+    fireSelectionChange()
+
+    await user.click(await screen.findByRole("button", { name: /quote/i }))
+
+    expect(onQuote).toHaveBeenCalledWith({
+      messageId: "msg_1",
+      streamId: "stream_thread",
+      authorName: "Alice",
+      authorId: "usr_alice",
+      actorType: "user",
+      snippet: "**this** is",
+      version: 4,
+      range: { from: 14, to: 21 },
+    })
+  })
+
+  it("falls back to a full quote of the pinned revision when the selection can't be mapped", async () => {
+    const user = userEvent.setup()
+    const onQuote = vi.fn()
+    registerReferenceSource("msg_1", { contentJson: BODY_JSON, revision: 4, contentMarkdown: BODY_MARKDOWN })
+
+    render(<Scene onQuote={onQuote} />)
+
+    const bodyEl = screen.getByText(BODY_TEXT)
+    const range = document.createRange()
+    range.selectNodeContents(bodyEl.firstChild as Node)
+    range.getBoundingClientRect = () => ({ top: 120, left: 40, width: 90, height: 20 }) as DOMRect
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      rangeCount: 1,
+      // Text the body does not contain — the resolver returns no range.
+      toString: () => "wholly unrelated wording",
+      getRangeAt: () => range,
+      removeAllRanges: () => {},
+    } as unknown as Selection)
+    fireSelectionChange()
+
+    await user.click(await screen.findByRole("button", { name: /quote/i }))
+
+    expect(onQuote).toHaveBeenCalledWith(expect.objectContaining({ snippet: BODY_MARKDOWN, version: 4, range: null }))
+  })
+
+  it("sends the lenient unpinned form when the row's content isn't registered", async () => {
     const user = userEvent.setup()
     const onQuote = vi.fn()
 
-    function Scene() {
-      const ref = useRef<HTMLDivElement>(null)
-      return (
-        <QuoteReplyProvider>
-          <CaptureQuote onQuote={onQuote} />
-          {/* Anchor prop differs from the row's data-stream-id: the row wins. */}
-          <TextSelectionQuote streamId="stream_anchor" containerRef={ref} />
-          <div ref={ref}>
-            <MessageRow messageId="msg_1" streamId="stream_thread" />
-          </div>
-        </QuoteReplyProvider>
-      )
-    }
-    render(<Scene />)
+    render(<Scene onQuote={onQuote} />)
 
     const bodyEl = screen.getByText(BODY_TEXT)
-    mockSelection(bodyEl.firstChild as Node, "Hello there")
+    mockSelection(bodyEl.firstChild as Node, 0, 11)
     fireSelectionChange()
 
     await user.click(await screen.findByRole("button", { name: /quote/i }))
 
     expect(onQuote).toHaveBeenCalledWith(
-      expect.objectContaining({
-        messageId: "msg_1",
-        streamId: "stream_thread",
-        snippet: "Hello there",
-        authorName: "Alice",
-        authorId: "usr_alice",
-        actorType: "user",
-      })
+      expect.objectContaining({ snippet: "Hello there", version: null, range: null })
     )
   })
 
   it("ignores a selection outside its own container (sibling cards keep their own instance)", () => {
-    function Scene() {
+    function OutsideScene() {
       const ref = useRef<HTMLDivElement>(null)
       return (
         <QuoteReplyProvider>
@@ -108,10 +179,10 @@ describe("TextSelectionQuote", () => {
         </QuoteReplyProvider>
       )
     }
-    render(<Scene />)
+    render(<OutsideScene />)
 
     const bodyEl = screen.getByText(BODY_TEXT)
-    mockSelection(bodyEl.firstChild as Node, "Hello there")
+    mockSelection(bodyEl.firstChild as Node, 0, 11)
     fireSelectionChange()
 
     expect(screen.queryByRole("button", { name: /quote/i })).toBeNull()

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -3,10 +3,13 @@ import { createPortal } from "react-dom"
 import { Quote } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { resolveQuoteSelection } from "@/lib/quote-selection"
+import { getReferenceSource } from "@/stores/reference-source-store"
 import { useQuoteReply } from "./quote-reply-context"
 
 interface SelectionInfo {
   text: string
+  prefixText: string
   messageId: string
   streamId: string
   authorName: string
@@ -26,6 +29,17 @@ function getMessageContext(node: Node): { messageId: string; element: HTMLElemen
   const messageId = messageEl.getAttribute("data-message-id")
   if (!messageId) return null
   return { messageId, element: messageEl }
+}
+
+/**
+ * The rendered text between the body's start and the selection's start. Feeds
+ * the range resolver's tie-break when the selected words repeat in the message.
+ */
+function textBeforeSelection(contentEl: Element, range: Range): string {
+  const prefix = contentEl.ownerDocument.createRange()
+  prefix.selectNodeContents(contentEl)
+  prefix.setEnd(range.startContainer, range.startOffset)
+  return prefix.toString()
 }
 
 /**
@@ -111,6 +125,7 @@ export function TextSelectionQuote({ streamId, containerRef }: TextSelectionQuot
 
     setSelection({
       text,
+      prefixText: textBeforeSelection(contentEl, range),
       messageId: startCtx.messageId,
       streamId: messageStreamId,
       authorName,
@@ -134,13 +149,17 @@ export function TextSelectionQuote({ streamId, containerRef }: TextSelectionQuot
 
   const handleQuote = useCallback(() => {
     if (!selection || !quoteReplyCtx) return
+    const pin = resolveQuoteSelection(getReferenceSource(selection.messageId), {
+      text: selection.text,
+      prefixText: selection.prefixText,
+    })
     quoteReplyCtx.triggerQuoteReply({
       messageId: selection.messageId,
       streamId: selection.streamId,
       authorName: selection.authorName,
       authorId: selection.authorId,
       actorType: selection.actorType,
-      snippet: selection.text,
+      ...pin,
     })
     window.getSelection()?.removeAllRanges()
     setSelection(null)

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -346,7 +346,12 @@ describe("useMessageQueue", () => {
       await new Promise((r) => setTimeout(r, 10))
     })
 
-    expect(errorToast).toHaveBeenCalledTimes(1)
+    expect(errorToast.mock.calls).toEqual([
+      [
+        "Couldn't quote that message — it may have changed or been removed.",
+        { id: "message-reference-temp_quote_gone" },
+      ],
+    ])
     expect(mockUpdate).toHaveBeenCalledWith("temp_quote_gone", {
       terminalFailure: true,
       retryAfter: undefined,

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -11,7 +11,8 @@ import * as draftStoreModule from "@/stores/draft-store"
 import * as boardStoreModule from "@/stores/board-store"
 import * as useDraftMessageModule from "./use-draft-message"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { MessageErrorCodes } from "@threa/types"
+import { MessageErrorCodes, MessageReferenceErrorCodes } from "@threa/types"
+import { toast } from "sonner"
 import { ApiError } from "@/api/client"
 import { createElement, type ReactNode } from "react"
 
@@ -321,6 +322,37 @@ describe("useMessageQueue", () => {
     })
     expect(mockEventsUpdate).toHaveBeenCalledWith("temp_steer_gone", { _status: "failed" })
     expect(mockMarkFailed).toHaveBeenCalledWith("temp_steer_gone")
+  })
+
+  it("parks a quote whose reference the server cannot resolve, and says so once", async () => {
+    const errorToast = vi.spyOn(toast, "error").mockReturnValue("t1")
+    mockCreate.mockRejectedValue(
+      new ApiError(400, MessageReferenceErrorCodes.RANGE_NOT_FOUND, "Quoted text no longer exists in the source")
+    )
+    mockPendingMessages = [
+      {
+        clientId: "temp_quote_gone",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "> stale quote",
+        contentFormat: "markdown",
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(errorToast).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith("temp_quote_gone", {
+      terminalFailure: true,
+      retryAfter: undefined,
+    })
+    expect(mockEventsUpdate).toHaveBeenCalledWith("temp_quote_gone", { _status: "failed" })
+    expect(mockMarkFailed).toHaveBeenCalledWith("temp_quote_gone")
   })
 
   it("does not auto-retry a permanently failed send", async () => {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -10,7 +10,14 @@ import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
 import { reconcileOptimisticBoardPost } from "@/stores/board-store"
 import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
-import { MessageErrorCodes, ShareErrorCodes, StreamTypes, draftStreamScope, draftThreadScope } from "@threa/types"
+import {
+  MessageErrorCodes,
+  MessageReferenceErrorCodes,
+  ShareErrorCodes,
+  StreamTypes,
+  draftStreamScope,
+  draftThreadScope,
+} from "@threa/types"
 import type { PendingMessage } from "@/db"
 import type {
   AttachmentSummary,
@@ -19,8 +26,11 @@ import type {
   Stream,
   StreamWithPreview,
 } from "@threa/types"
+import { toast } from "sonner"
 import { ApiError } from "@/api/client"
 import { surfacePrivacyBlockToast } from "@/lib/share-privacy-toast"
+
+const REFERENCE_FAILURE_CODES: ReadonlySet<string> = new Set(Object.values(MessageReferenceErrorCodes))
 
 /**
  * Exponential backoff delay based on retry count.
@@ -334,7 +344,19 @@ export function useMessageQueue(): void {
           continue
         }
 
-        if (ApiError.isApiError(err) && err.code === MessageErrorCodes.STEER_UNAVAILABLE) {
+        // A reference the server can't pin: the source is gone, the pinned
+        // revision doesn't exist, or the span doesn't resolve. A blind retry
+        // re-sends the same unresolvable reference, so the row stops retrying
+        // and waits for the author to edit or drop it — same shape as an
+        // unavailable steer target.
+        const referenceFailed = ApiError.isApiError(err) && REFERENCE_FAILURE_CODES.has(err.code ?? "")
+
+        if (referenceFailed || (ApiError.isApiError(err) && err.code === MessageErrorCodes.STEER_UNAVAILABLE)) {
+          if (referenceFailed) {
+            toast.error("Couldn't quote that message — it may have changed or been removed.", {
+              id: `message-reference-${next.clientId}`,
+            })
+          }
           type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
           await Promise.all([
             (db.pendingMessages.update as unknown as UpdateFn)(next.clientId, {

--- a/apps/frontend/src/lib/quote-selection.test.ts
+++ b/apps/frontend/src/lib/quote-selection.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import type { JSONContent } from "@threa/types"
+import { buildPartialQuote, resolveQuoteSelection } from "./quote-selection"
+
+const doc: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "the quick brown fox" }] }],
+}
+
+describe("buildPartialQuote", () => {
+  it("should pin the span and render the slice when the revision is known", () => {
+    expect(buildPartialQuote({ contentJson: doc, revision: 3, selectionText: "quick brown" })).toEqual({
+      version: 3,
+      range: { from: 5, to: 16 },
+      snippet: "quick brown",
+    })
+  })
+
+  it("should refuse to pin a span when the revision is unknown", () => {
+    expect(buildPartialQuote({ contentJson: doc, revision: null, selectionText: "quick brown" })).toBeNull()
+  })
+
+  it("should return null when the selection matches nothing", () => {
+    expect(buildPartialQuote({ contentJson: doc, revision: 3, selectionText: "not in here" })).toBeNull()
+  })
+})
+
+describe("resolveQuoteSelection", () => {
+  it("should send the whole message unranged when the row carries no revision", () => {
+    expect(
+      resolveQuoteSelection(
+        { contentJson: doc, revision: null, contentMarkdown: "the quick brown fox" },
+        { text: "quick brown", prefixText: "the " }
+      )
+    ).toEqual({ version: null, range: null, snippet: "the quick brown fox" })
+  })
+
+  it("should fall back to the whole pinned message when the selection cannot be located", () => {
+    expect(
+      resolveQuoteSelection(
+        { contentJson: doc, revision: 2, contentMarkdown: "the quick brown fox" },
+        { text: "elsewhere", prefixText: "" }
+      )
+    ).toEqual({ version: 2, range: null, snippet: "the quick brown fox" })
+  })
+
+  it("should send the lenient unpinned form when the row's content is out of reach", () => {
+    expect(resolveQuoteSelection(null, { text: "quick brown", prefixText: "the " })).toEqual({
+      version: null,
+      range: null,
+      snippet: "quick brown",
+    })
+  })
+})

--- a/apps/frontend/src/lib/quote-selection.ts
+++ b/apps/frontend/src/lib/quote-selection.ts
@@ -1,0 +1,70 @@
+import { normalizeRange, resolveSelectionRange, serializeToMarkdown, sliceContent } from "@threa/prosemirror"
+import type { ContentRange, JSONContent } from "@threa/types"
+
+/** A rendered text selection, as the DOM reports it. */
+export interface QuoteSelection {
+  text: string
+  /** Rendered text between the message body's start and the selection's start. */
+  prefixText: string
+}
+
+/** The reference fields a quote trigger sends alongside the author metadata. */
+export interface QuotePin {
+  version: number | null
+  range: ContentRange | null
+  snippet: string
+}
+
+/** The rendered message a selection was made in, as the timeline holds it. */
+export interface QuoteSource {
+  contentJson?: JSONContent | null
+  revision?: number | null
+  contentMarkdown?: string | null
+}
+
+export interface PartialQuoteInput {
+  contentJson: JSONContent
+  revision: number | null
+  selectionText: string
+  prefixText?: string
+}
+
+/**
+ * Map a selection back to a span of the message it was rendered from, or `null`
+ * when it can't be located. The snippet is derived the same way the server
+ * derives the one it stores, so the composer chip shows what will be sent.
+ */
+export function buildPartialQuote(input: PartialQuoteInput): QuotePin | null {
+  const located = resolveSelectionRange(input.contentJson, {
+    text: input.selectionText,
+    prefixText: input.prefixText,
+  })
+  if (!located) return null
+
+  const range = normalizeRange(input.contentJson, located)
+  const slice = range ? sliceContent(input.contentJson, range.from, range.to) : input.contentJson
+  return { version: input.revision, range, snippet: serializeToMarkdown(slice) }
+}
+
+/**
+ * The pin every selection-driven quote trigger sends. Three outcomes, all valid
+ * to the server: the located span; the whole pinned message when the selection
+ * can't be mapped (the chip shows the fallback, so it isn't silent); and the
+ * lenient unpinned form when the row's content isn't in reach — the server then
+ * locates the snippet itself or rejects the send.
+ */
+export function resolveQuoteSelection(source: QuoteSource | null, selection: QuoteSelection): QuotePin {
+  const contentJson = source?.contentJson
+  if (!contentJson) return { version: null, range: null, snippet: selection.text }
+
+  const revision = source?.revision ?? null
+  const partial = buildPartialQuote({
+    contentJson,
+    revision,
+    selectionText: selection.text,
+    prefixText: selection.prefixText,
+  })
+  if (partial) return partial
+
+  return { version: revision, range: null, snippet: source?.contentMarkdown ?? selection.text }
+}

--- a/apps/frontend/src/lib/quote-selection.ts
+++ b/apps/frontend/src/lib/quote-selection.ts
@@ -35,6 +35,11 @@ export interface PartialQuoteInput {
  * derives the one it stores, so the composer chip shows what will be sent.
  */
 export function buildPartialQuote(input: PartialQuoteInput): QuotePin | null {
+  // Positions only mean something inside a known revision, and the wire form
+  // refuses a range without one — a row cached before revisions shipped has the
+  // body but not the number, so it takes the lenient path instead.
+  if (input.revision === null) return null
+
   const located = resolveSelectionRange(input.contentJson, {
     text: input.selectionText,
     prefixText: input.prefixText,

--- a/apps/frontend/src/stores/reference-source-store.ts
+++ b/apps/frontend/src/stores/reference-source-store.ts
@@ -1,0 +1,40 @@
+import type { JSONContent } from "@threa/types"
+
+/**
+ * The content a mounted message row was rendered from, keyed by message id.
+ *
+ * The floating selection toolbar sees only DOM ids — it walks up from the
+ * browser's selection to `[data-message-id]` — but pinning a quote to a span
+ * needs the row's `contentJson` and revision, which the rendering row already
+ * holds in memory. Rows publish it here on mount so the toolbar can read it
+ * synchronously at click time, instead of re-reading IndexedDB or smuggling a
+ * document through a DOM attribute.
+ */
+export interface ReferenceSource {
+  contentJson: JSONContent
+  revision: number | null
+  contentMarkdown: string
+}
+
+const sources = new Map<string, ReferenceSource>()
+
+/**
+ * Publish a row's content while it is mounted. Returns the unregister. The same
+ * message can be mounted on two surfaces at once (timeline + open thread), so
+ * unregistering only drops the entry it installed.
+ */
+export function registerReferenceSource(messageId: string, source: ReferenceSource): () => void {
+  sources.set(messageId, source)
+  return () => {
+    if (sources.get(messageId) === source) sources.delete(messageId)
+  }
+}
+
+export function getReferenceSource(messageId: string): ReferenceSource | null {
+  return sources.get(messageId) ?? null
+}
+
+/** Module-level map survives an account-switch remount; AccountScope clears it. */
+export function resetReferenceSourceStoreCache(): void {
+  sources.clear()
+}

--- a/apps/frontend/src/stores/reference-source-store.ts
+++ b/apps/frontend/src/stores/reference-source-store.ts
@@ -16,22 +16,32 @@ export interface ReferenceSource {
   contentMarkdown: string
 }
 
-const sources = new Map<string, ReferenceSource>()
+const sources = new Map<string, ReferenceSource[]>()
 
 /**
- * Publish a row's content while it is mounted. Returns the unregister. The same
- * message can be mounted on two surfaces at once (timeline + open thread), so
- * unregistering only drops the entry it installed.
+ * Publish a row's content while it is mounted. Returns the unregister.
+ *
+ * The same message can be mounted on two surfaces at once (timeline and an
+ * open thread), and they unmount in either order, so each registration is kept
+ * rather than overwritten — dropping the newest on its own unmount would take
+ * the still-mounted row's content with it and silently unpin its quotes. The
+ * most recent registration answers reads.
  */
 export function registerReferenceSource(messageId: string, source: ReferenceSource): () => void {
-  sources.set(messageId, source)
+  const registered = sources.get(messageId)
+  if (registered) registered.push(source)
+  else sources.set(messageId, [source])
   return () => {
-    if (sources.get(messageId) === source) sources.delete(messageId)
+    const remaining = sources.get(messageId)
+    if (!remaining) return
+    const at = remaining.lastIndexOf(source)
+    if (at >= 0) remaining.splice(at, 1)
+    if (remaining.length === 0) sources.delete(messageId)
   }
 }
 
 export function getReferenceSource(messageId: string): ReferenceSource | null {
-  return sources.get(messageId) ?? null
+  return sources.get(messageId)?.at(-1) ?? null
 }
 
 /** Module-level map survives an account-switch remount; AccountScope clears it. */

--- a/tests/browser/quote-range.spec.ts
+++ b/tests/browser/quote-range.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect, type Locator, type Page } from "@playwright/test"
+import { createChannel, expectApiOk, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * E2E coverage for quoting part of a message. The contract the plan sets:
+ * a selection-driven quote is pinned to the revision the reader saw and to the
+ * span they highlighted, and the stored snippet is the formatted slice of that
+ * span — not the flat string the DOM handed us. Legacy quotes, which carry no
+ * pin, must keep working: the server locates their snippet and pins them.
+ */
+
+interface QuoteAttrs {
+  messageId: string
+  snippet: string
+  version: number | null
+  range: { from: number; to: number } | null
+}
+
+function workspaceAndStream(page: Page): { workspaceId: string; streamId: string } {
+  const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+  expect(match, "workspace + stream should be resolvable from the URL").toBeTruthy()
+  return { workspaceId: match![1], streamId: match![2] }
+}
+
+/**
+ * Send a message whose body carries a bold run, so a selection that starts
+ * inside the mark and ends outside it exercises a real slice.
+ */
+async function sendBoldMessage(page: Page, prefix: string, bold: string, suffix: string): Promise<string> {
+  const { workspaceId, streamId } = workspaceAndStream(page)
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: {
+      streamId,
+      contentJson: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: prefix },
+              { type: "text", text: bold, marks: [{ type: "bold" }] },
+              { type: "text", text: suffix },
+            ],
+          },
+        ],
+      },
+      contentMarkdown: `${prefix}**${bold}**${suffix}`,
+    },
+  })
+  await expectApiOk(response, "Create bold source message")
+  const body = (await response.json()) as { message?: { id: string } }
+  return body.message?.id ?? ""
+}
+
+function mainMessageRow(page: Page, text: string): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: text }).first()
+}
+
+/**
+ * Put the browser's selection across a message body, from the start of `from`
+ * through `to`'s first characters. Driven in the page because the quote toolbar
+ * reads `window.getSelection()`, which Playwright's own APIs cannot set.
+ */
+async function selectAcross(page: Page, messageId: string, from: string, to: string): Promise<void> {
+  await page.evaluate(
+    ({ messageId, from, to }) => {
+      const row = document.querySelector(`[data-message-id="${messageId}"]`)
+      const body = row?.querySelector(".message-content .markdown-content")
+      if (!body) throw new Error(`No rendered body for ${messageId}`)
+
+      const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT)
+      const textNodes: Text[] = []
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) textNodes.push(node as Text)
+
+      const startNode = textNodes.find((node) => node.data.includes(from))
+      const endNode = textNodes.find((node) => node.data.includes(to))
+      if (!startNode || !endNode) throw new Error(`Could not locate "${from}" / "${to}" in the rendered body`)
+
+      const range = document.createRange()
+      range.setStart(startNode, startNode.data.indexOf(from))
+      range.setEnd(endNode, endNode.data.indexOf(to) + to.length)
+
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      document.dispatchEvent(new Event("selectionchange"))
+    },
+    { messageId, from, to }
+  )
+}
+
+/** The quote node stored on the message whose body contains `marker`. */
+async function storedQuoteAttrs(page: Page, marker: string): Promise<QuoteAttrs> {
+  const { workspaceId, streamId } = workspaceAndStream(page)
+  const response = await page.request.get(`/api/workspaces/${workspaceId}/streams/${streamId}/events?limit=100`)
+  await expectApiOk(response, "List stream events")
+  const body = (await response.json()) as {
+    events: Array<{ eventType: string; payload?: { contentMarkdown?: string; contentJson?: unknown } }>
+  }
+
+  const event = body.events.find(
+    (candidate) => candidate.eventType === "message_created" && candidate.payload?.contentMarkdown?.includes(marker)
+  )
+  if (!event) throw new Error(`No stored message carrying "${marker}"`)
+
+  const found: QuoteAttrs[] = []
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== "object") return
+    const typed = node as { type?: string; attrs?: QuoteAttrs; content?: unknown[] }
+    if (typed.type === "quoteReply" && typed.attrs) found.push(typed.attrs)
+    for (const child of typed.content ?? []) walk(child)
+  }
+  walk(event.payload?.contentJson)
+  if (found.length !== 1) throw new Error(`Expected exactly one quote node, found ${found.length}`)
+  return found[0]
+}
+
+test.describe("Quote by range", () => {
+  test("quotes the highlighted span, pinned to the revision on screen", async ({ page }) => {
+    const { testId } = await loginAndCreateWorkspace(page, "quote-range")
+    await createChannel(page, `qr-${testId}`, { switchToAll: false })
+
+    const sourceText = `deploy-${testId}`
+    const sourceId = await sendBoldMessage(page, `${sourceText} is `, "blocked", " until friday")
+    await expect(mainMessageRow(page, sourceText)).toBeVisible({ timeout: 10000 })
+
+    // Keep the app in mouse mode — the floating quote button is mouse-only.
+    await page.mouse.move(10, 10)
+    await selectAcross(page, sourceId, "blocked", " until")
+
+    const quoteButton = page.getByRole("button", { name: /^quote$/i })
+    await expect(quoteButton).toBeVisible({ timeout: 10000 })
+    await quoteButton.click()
+
+    // The composer chip shows the slice, stripped to inline text (INV-60).
+    const composer = page.locator("[contenteditable='true']").first()
+    const chip = composer.locator("[data-type='quote-reply']")
+    await expect(chip).toHaveCount(1, { timeout: 10000 })
+    await expect(chip).toContainText("blocked until")
+    await expect(chip).not.toContainText("**")
+
+    const marker = `reply-${testId}`
+    await composer.focus()
+    await page.keyboard.type(marker)
+    await page.keyboard.press("Enter")
+
+    await expect(mainMessageRow(page, marker)).toBeVisible({ timeout: 10000 })
+
+    const attrs = await storedQuoteAttrs(page, marker)
+    expect(attrs.messageId).toBe(sourceId)
+    expect(attrs.version).toBe(1)
+    expect(attrs.range).not.toBeNull()
+    expect(attrs.range!.to).toBeGreaterThan(attrs.range!.from)
+    // The span, formatted — a flat DOM string would have lost the bold run.
+    expect(attrs.snippet).toContain("**blocked**")
+    expect(attrs.snippet).not.toContain("friday")
+
+    // Rendered back into the timeline as a quote card carrying the bold word.
+    const quotedRow = mainMessageRow(page, marker)
+    await expect(quotedRow.locator("strong").filter({ hasText: "blocked" })).toBeVisible()
+  })
+
+  test("still renders a legacy quote sent without a version or range", async ({ page }) => {
+    const { testId } = await loginAndCreateWorkspace(page, "quote-legacy")
+    await createChannel(page, `ql-${testId}`, { switchToAll: false })
+
+    const sourceText = `legacy-${testId}`
+    const sourceId = await sendBoldMessage(page, `${sourceText} is `, "blocked", " until friday")
+    await expect(mainMessageRow(page, sourceText)).toBeVisible({ timeout: 10000 })
+
+    const { workspaceId, streamId } = workspaceAndStream(page)
+    const marker = `legacy-reply-${testId}`
+    const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+      data: {
+        streamId,
+        contentJson: {
+          type: "doc",
+          content: [
+            {
+              type: "quoteReply",
+              // Exactly what a client shipped before pins existed: a plain-text
+              // snippet, no version, no range.
+              attrs: {
+                messageId: sourceId,
+                streamId,
+                authorName: "",
+                authorId: "",
+                actorType: "user",
+                snippet: "blocked until",
+              },
+            },
+            { type: "paragraph", content: [{ type: "text", text: marker }] },
+          ],
+        },
+        contentMarkdown: `> blocked until\n\n${marker}`,
+      },
+    })
+    await expectApiOk(response, "Create legacy quote message")
+
+    const row = mainMessageRow(page, marker)
+    await expect(row).toBeVisible({ timeout: 10000 })
+    await expect(row.locator("strong").filter({ hasText: "blocked" })).toBeVisible()
+
+    // The server located the snippet and pinned it, so the legacy node is no
+    // longer unpinned once stored.
+    const attrs = await storedQuoteAttrs(page, marker)
+    expect(attrs.version).toBe(1)
+    expect(attrs.range).not.toBeNull()
+  })
+})

--- a/tests/browser/quote-range.spec.ts
+++ b/tests/browser/quote-range.spec.ts
@@ -89,30 +89,45 @@ async function selectAcross(page: Page, messageId: string, from: string, to: str
   )
 }
 
-/** The quote node stored on the message whose body contains `marker`. */
+/**
+ * The quote node stored on the message whose body contains `marker`.
+ *
+ * Polled: the row is on screen as soon as it renders optimistically, which is
+ * before the server has the event, so a single read races the send.
+ */
 async function storedQuoteAttrs(page: Page, marker: string): Promise<QuoteAttrs> {
   const { workspaceId, streamId } = workspaceAndStream(page)
-  const response = await page.request.get(`/api/workspaces/${workspaceId}/streams/${streamId}/events?limit=100`)
-  await expectApiOk(response, "List stream events")
-  const body = (await response.json()) as {
-    events: Array<{ eventType: string; payload?: { contentMarkdown?: string; contentJson?: unknown } }>
+
+  const readQuotes = async (): Promise<QuoteAttrs[] | null> => {
+    const response = await page.request.get(`/api/workspaces/${workspaceId}/streams/${streamId}/events?limit=100`)
+    if (!response.ok()) return null
+    const body = (await response.json()) as {
+      events: Array<{ eventType: string; payload?: { contentMarkdown?: string; contentJson?: unknown } }>
+    }
+    const event = body.events.find(
+      (candidate) => candidate.eventType === "message_created" && candidate.payload?.contentMarkdown?.includes(marker)
+    )
+    if (!event) return null
+
+    const found: QuoteAttrs[] = []
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== "object") return
+      const typed = node as { type?: string; attrs?: QuoteAttrs; content?: unknown[] }
+      if (typed.type === "quoteReply" && typed.attrs) found.push(typed.attrs)
+      for (const child of typed.content ?? []) walk(child)
+    }
+    walk(event.payload?.contentJson)
+    return found
   }
 
-  const event = body.events.find(
-    (candidate) => candidate.eventType === "message_created" && candidate.payload?.contentMarkdown?.includes(marker)
-  )
-  if (!event) throw new Error(`No stored message carrying "${marker}"`)
+  await expect
+    .poll(async () => (await readQuotes())?.length ?? 0, {
+      timeout: 10000,
+      message: `stored message carrying "${marker}" with exactly one quote node`,
+    })
+    .toBe(1)
 
-  const found: QuoteAttrs[] = []
-  const walk = (node: unknown): void => {
-    if (!node || typeof node !== "object") return
-    const typed = node as { type?: string; attrs?: QuoteAttrs; content?: unknown[] }
-    if (typed.type === "quoteReply" && typed.attrs) found.push(typed.attrs)
-    for (const child of typed.content ?? []) walk(child)
-  }
-  walk(event.payload?.contentJson)
-  if (found.length !== 1) throw new Error(`Expected exactly one quote node, found ${found.length}`)
-  return found[0]
+  return (await readQuotes())![0]
 }
 
 test.describe("Quote by range", () => {


### PR DESCRIPTION
Fifth layer of the quote/share-by-pinned-version stack (plan: https://seer.build/ws_vbyzjvdg6g/b/share-quoted-plan/, on top of #1928). The server already pins and verifies every quote; this is the client half — it names the revision and the span it means, instead of pasting text and hoping.

**Changes**
- `lib/quote-selection.ts` — `buildPartialQuote({ contentJson, revision, selectionText, prefixText })` maps a DOM selection onto positions in the pinned revision (`resolveSelectionRange` → `normalizeRange`) and renders the chip from the same slice the server will store (`serializeToMarkdown(sliceContent(...))`). `resolveQuoteSelection` owns the fallback ladder: located span → whole pinned message → lenient unpinned (server locates or rejects). Formatting inside a partial quote now survives; it used to be flattened to `Selection.toString()`.
- `stores/reference-source-store.ts` — a message row publishes its `{contentJson, revision, contentMarkdown}` while mounted so the floating selection toolbar, which only knows DOM ids, can resolve them synchronously. Cleared on account switch with the other module caches.
- `QuoteReplyData`, `appendQuoteReplyNode` and the tiptap node carry `version`/`range` (`data-version`, `data-range="from-to"`, both omitted when null, and they survive a copy/paste round-trip). Every trigger — row action, hover, swipe, drawer, board — passes the revision it rendered.
- Mobile drawer switched from `onQuoteReplyWithSnippet(snippet)` to `onQuoteReplyWithSelection({ text, prefixText })`, so the range is computed from the row's own payload rather than from a string.
- The composer chip strips markdown to inline (INV-60). The four `REFERENCE_*` codes park the message in the composer with one `toast.error` — the same terminal-failure branch as `STEER_UNAVAILABLE`, not a silent drop.

**Verification**
Focused vitest, rebased and re-run here: `text-selection-quote` + `quote-reply` + `quote-selection` 23/23, `use-message-queue` + `message-event` 48/48, and on the implementer's pass `message-input` 53/53, `message-actions` 80/80. Frontend typecheck and lint clean.

`tests/browser/quote-range.spec.ts` is committed but **not proven green**: its UI path ran end to end (selection → floating Quote → chip carrying the formatted slice → sent row in the timeline), then the run failed inside the spec's own API helper (`eventType`, since fixed). The verifying re-run died at 30s inside shared `helpers.ts` — a second Playwright suite was running on the same 8 GB box — so the post-send assertions are still unverified. It deserves one re-run on a quiet machine; CI is that machine.

**Review fixes since first push**
A row mounted twice (timeline plus an open thread) overwrote its own registered content and the first unmount deleted it, silently unpinning the surviving row's quotes — registrations are now per mount. The action context read `contentJson`/`revision` without listing them as deps, so a row edited in place kept quoting its first body. And a row cached before revisions existed produced a range with no version, which throws in `buildQuoteHref` and would have failed the send; without a revision the selection now takes the lenient path.

**Deviations**
Board and conversation-panel rows send `version: null, range: null` — `RenderableMessage` carries no revision, and adding a field nothing populates would be dead code (INV-36). Those selections take the server's lenient locate path, exactly as they do today.
