### PR TITLE
fix(dev): unblock dev:remote — MinIO host port and a production frontend build

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -7,7 +7,9 @@ import * as path from "path"
 const POSTGRES_HOST = "localhost"
 const POSTGRES_PORT = 5454
 const MINIO_HOST = "localhost"
-const MINIO_PORT = 9000
+// Host-side port; docker-compose maps it to MinIO's own 9000 inside the container,
+// which is what the `docker exec mc` calls below address.
+const MINIO_PORT = 9099
 const MINIO_BUCKET = "threa-uploads"
 
 function loadEnvFile(filePath: string): Record<string, string> {
@@ -428,7 +430,10 @@ async function main() {
 
   if (remoteMode) {
     console.log("Building frontend for reliable Tailscale delivery...")
-    const build = await $`bun run --cwd apps/frontend build`.nothrow()
+    // Force a production build: Bun auto-loads .env, and a dev NODE_ENV there
+    // leaves the bundle unminified, which pushes the entry chunk past
+    // vite-plugin-pwa's 2 MiB precache cap and fails the build.
+    const build = await $`bun run --cwd apps/frontend build`.env({ ...process.env, NODE_ENV: "production" }).nothrow()
     if (build.exitCode !== 0) {
       console.error("Frontend build failed")
       process.exit(build.exitCode)


### PR DESCRIPTION
**Problem.** `bun run dev:remote` (the Tailscale HTTPS dev mode the README points at for device testing) cannot start on a clean machine. It fails twice, for unrelated reasons.

First, the MinIO readiness probe polls `http://localhost:9000`, but `docker-compose.yml` publishes MinIO on host port **9099** (which `.env.example` and `.env.remote-dev` already use for `S3_ENDPOINT`). The probe therefore always times out and the script exits with "MinIO failed to become ready", even though the container is healthy. The `9000` in the `docker exec … mc` calls is MinIO's port *inside* the container and is left alone.

Second, remote mode builds the frontend before serving it, and that build inherits whatever `NODE_ENV` the developer's `.env` carries. Bun auto-loads `.env`, and the shared sandbox defaults in `.env.remote-dev` set `NODE_ENV=development`, so Vite emits an unminified bundle: the entry chunk comes out at 2.34 MB, over `vite-plugin-pwa`'s 2 MiB `injectManifest` cap, and the build aborts with "Assets exceeding the limit".

**Solution.** `MINIO_PORT` becomes 9099 (host side only), and the remote-mode build runs with `NODE_ENV=production` explicitly rather than inheriting it. Fixing it at the call site rather than editing `.env.remote-dev` keeps `NODE_ENV=development` meaningful for the services that read it, and protects the build from any developer's own `.env`.

**Proof.** With both fixes, `TAILSCALE_MODE=true bun scripts/dev.ts` reaches "Remote mode: https://…" and serves the app; the entry chunk builds at 1,899.66 kB (gzip 569.63 kB), under the cap. Found while standing up a device-test deployment for the code-block stack ([#1917](https://github.com/threahq/threa/pull/1920)).

**Caveats.** Untouched: the stale `tailscale serve` foreground/background choice, and the enclave's hard `OPENROUTER_API_KEY` requirement, which still crash-loops that one service in a sandbox env (harmless for non-E2E testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9QSLmTNfdR8ZihLe5U6LM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789937350&installation_model_id=20758&pr_number=1930&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1930&signature=a4c29164196777a6b9e58fcf72dafac8975aeaf1bdfe129061194efd62b09458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->