### PR TITLE
feat: sharing a selection pins the revision and the span

### DIFF
--- a/apps/frontend/src/components/editor/quote-reply-extension.ts
+++ b/apps/frontend/src/components/editor/quote-reply-extension.ts
@@ -5,14 +5,7 @@ import { NodeSelection, Plugin, PluginKey, Selection } from "@tiptap/pm/state"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import type { ContentRange } from "@threa/types"
 import { QuoteReplyView } from "./quote-reply-view"
-
-function parseRangeAttribute(raw: string | null): ContentRange | null {
-  const match = raw?.match(/^(\d+)-(\d+)$/)
-  if (!match) return null
-  const from = Number(match[1])
-  const to = Number(match[2])
-  return to > from ? { from, to } : null
-}
+import { referencePinAttributes } from "./reference-attributes"
 
 function isValidGapCursorPosition($pos: ResolvedPos): boolean {
   const gapCursor = GapCursor as typeof GapCursor & {
@@ -239,22 +232,7 @@ export const QuoteReplyExtension = Node.create({
         parseHTML: (element) => element.getAttribute("data-snippet"),
         renderHTML: (attrs) => ({ "data-snippet": attrs.snippet }),
       },
-      version: {
-        default: null,
-        parseHTML: (element) => {
-          const parsed = Number(element.getAttribute("data-version"))
-          return Number.isInteger(parsed) && parsed > 0 ? parsed : null
-        },
-        renderHTML: (attrs) => (attrs.version == null ? {} : { "data-version": String(attrs.version) }),
-      },
-      range: {
-        default: null,
-        parseHTML: (element) => parseRangeAttribute(element.getAttribute("data-range")),
-        renderHTML: (attrs) => {
-          const range = attrs.range as ContentRange | null
-          return range ? { "data-range": `${range.from}-${range.to}` } : {}
-        },
-      },
+      ...referencePinAttributes,
     }
   },
 

--- a/apps/frontend/src/components/editor/reference-attributes.ts
+++ b/apps/frontend/src/components/editor/reference-attributes.ts
@@ -1,0 +1,35 @@
+import type { ContentRange } from "@threa/types"
+
+export function parseRangeAttribute(raw: string | null): ContentRange | null {
+  const match = raw?.match(/^(\d+)-(\d+)$/)
+  if (!match) return null
+  const from = Number(match[1])
+  const to = Number(match[2])
+  return to > from ? { from, to } : null
+}
+
+/**
+ * The reference pin both pointer nodes carry: which revision of the source the
+ * node points at (`version`), and which span of that revision (`range`). Shared
+ * between `quoteReply` and `sharedMessage` so a copy-paste round-trip through
+ * HTML reads the pin the same way for both.
+ */
+export const referencePinAttributes = {
+  version: {
+    default: null,
+    parseHTML: (element: HTMLElement) => {
+      const parsed = Number(element.getAttribute("data-version"))
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+    },
+    renderHTML: (attrs: Record<string, unknown>) =>
+      attrs.version == null ? {} : { "data-version": String(attrs.version) },
+  },
+  range: {
+    default: null,
+    parseHTML: (element: HTMLElement) => parseRangeAttribute(element.getAttribute("data-range")),
+    renderHTML: (attrs: Record<string, unknown>) => {
+      const range = attrs.range as ContentRange | null
+      return range ? { "data-range": `${range.from}-${range.to}` } : {}
+    },
+  },
+}

--- a/apps/frontend/src/components/editor/shared-message-extension.ts
+++ b/apps/frontend/src/components/editor/shared-message-extension.ts
@@ -1,6 +1,8 @@
 import { Node, mergeAttributes } from "@tiptap/core"
 import { ReactNodeViewRenderer } from "@tiptap/react"
+import type { ContentRange } from "@threa/types"
 import { SharedMessageView } from "./shared-message-view"
+import { referencePinAttributes } from "./reference-attributes"
 
 export interface SharedMessageAttrs {
   /** The ID of the referenced source message */
@@ -21,12 +23,17 @@ export interface SharedMessageAttrs {
    * shares leave it undefined and the card links to the stream permalink.
    */
   conversationId?: string
+  /** Source message revision this share is pinned to; null = unpinned */
+  version: number | null
+  /** Span inside the pinned version; null = the whole message */
+  range: ContentRange | null
 }
 
 /**
  * Atomic block node that references a message in another stream. The body is
  * hydrated at render time from the canonical `slots` map returned alongside the
- * stream's events (this node is slot type #1, keyed `shared:<messageId>`).
+ * stream's events (this node is slot type #1, keyed by its reference pin —
+ * `sharedMessageSlotKey(messageId, version, range)`).
  * Updates to the source message propagate automatically on the next fetch; the
  * `pointer:invalidated` realtime event triggers a refetch so live edits surface
  * without page reload.
@@ -72,6 +79,7 @@ export const SharedMessageExtension = Node.create({
         // in-stream share's HTML/markdown stays the legacy two-segment shape.
         renderHTML: (attrs) => (attrs.conversationId ? { "data-conversation-id": attrs.conversationId } : {}),
       },
+      ...referencePinAttributes,
     }
   },
 

--- a/apps/frontend/src/components/editor/shared-message-view.tsx
+++ b/apps/frontend/src/components/editor/shared-message-view.tsx
@@ -20,14 +20,12 @@ import type { SharedMessageAttrs } from "./shared-message-extension"
  */
 export function SharedMessageView({ node, deleteNode, selected }: NodeViewProps) {
   const attrs = node.attrs as SharedMessageAttrs
-  const { workspaceId: _workspaceId } = useParams<{ workspaceId: string }>()
-  // A composer node is never pinned: the server assigns the revision on send,
-  // so this preview reads the unpinned key and falls back to the local cache.
+  const { workspaceId } = useParams<{ workspaceId: string }>()
   const source = useSharedMessageSource({
     messageId: attrs.messageId,
     streamId: attrs.streamId,
-    version: null,
-    range: null,
+    version: attrs.version ?? null,
+    range: attrs.range ?? null,
   })
 
   return (
@@ -41,7 +39,11 @@ export function SharedMessageView({ node, deleteNode, selected }: NodeViewProps)
     >
       <Share2 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <div className="min-w-0 flex-1">
-        <SharedMessageCardBody source={source} fallbackAuthor={attrs.authorName ?? ""} />
+        <SharedMessageCardBody
+          source={source}
+          fallbackAuthor={attrs.authorName ?? ""}
+          sourceHref={workspaceId ? `/w/${workspaceId}/s/${attrs.streamId}?m=${attrs.messageId}` : undefined}
+        />
       </div>
       <button
         type="button"

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -625,6 +625,7 @@ export function MessageItem({
           open={shareModalOpen}
           onOpenChange={setShareModalOpen}
           workspaceId={workspaceId}
+          previewMarkdown={message.contentMarkdown}
           attrs={{
             messageId: message.id,
             streamId,
@@ -635,6 +636,11 @@ export function MessageItem({
             // so the resulting pointer's back-link is conversation-aware exactly
             // where the message was shared from a conversation.
             conversationId,
+            // A board/conversation row carries no revision (RenderableMessage
+            // has none), so the share goes unpinned and the server pins it to
+            // whatever the source reads at send time.
+            version: null,
+            range: null,
           }}
         />
       )}

--- a/apps/frontend/src/components/share/share-message-modal.test.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.test.tsx
@@ -12,6 +12,8 @@ const SAMPLE_ATTRS = {
   authorName: "Ada",
   authorId: "usr_a",
   actorType: "user",
+  version: 2,
+  range: null,
 }
 
 function mountModal({ initialPath = "/w/ws_1/s/current" }: { initialPath?: string } = {}) {

--- a/apps/frontend/src/components/share/share-message-modal.tsx
+++ b/apps/frontend/src/components/share/share-message-modal.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { MarkdownContent } from "@/components/ui/markdown-content"
 import { StreamSortToggle } from "@/components/composer/stream-sort-toggle"
 import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { useStoredStreamSortMode } from "@/lib/stream-sort"
@@ -40,6 +41,13 @@ interface ShareMessageModalProps {
   workspaceId: string
   attrs: SharedMessageAttrs
   /**
+   * What the share will render, as markdown: the pinned span for a share of a
+   * selection, the whole body otherwise. The picker shows it so a selection the
+   * range resolver couldn't map — which shares whole — is visible before the
+   * user picks a target rather than a surprise in the destination composer.
+   */
+  previewMarkdown?: string | null
+  /**
    * Decrypted source content when the message lives in an E2E scratchpad. A
    * sealed message can't be shared as a pointer (recipients hold no key), so
    * sharing it decrypts it and inserts the plaintext as a public quote — gated
@@ -69,7 +77,14 @@ interface ShareMessageModalProps {
  * `SHARE_PRIVACY_CONFIRMATION_REQUIRED` and the queue surfaces a
  * "Share anyway / Cancel" toast (`surfacePrivacyBlockToast`).
  */
-export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs, sourcePlaintext }: ShareMessageModalProps) {
+export function ShareMessageModal({
+  open,
+  onOpenChange,
+  workspaceId,
+  attrs,
+  previewMarkdown,
+  sourcePlaintext,
+}: ShareMessageModalProps) {
   const [search, setSearch] = useState("")
   // When sharing an E2E message, the picked target waits here for confirmation
   // (sharing decrypts it to plaintext) before the hand-off is queued.
@@ -142,6 +157,13 @@ export function ShareMessageModal({ open, onOpenChange, workspaceId, attrs, sour
             <StreamSortToggle value={sortMode} onChange={setSortMode} />
           </div>
         </ResponsiveDialogHeader>
+        {previewMarkdown && (
+          <div className="border-b px-4 py-3">
+            <div className="max-h-24 overflow-hidden rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+              <MarkdownContent content={previewMarkdown} className="text-sm leading-relaxed" />
+            </div>
+          </div>
+        )}
         <Command shouldFilter={false} className="rounded-none">
           <CommandInput placeholder="Search streams…" value={search} onValueChange={setSearch} className="border-b" />
           <CommandList className="max-h-[60vh]">

--- a/apps/frontend/src/components/shared-messages/card-body.test.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.test.tsx
@@ -2,14 +2,18 @@ import { describe, expect, it } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import type { ReactNode } from "react"
+import { MediaGalleryProvider } from "@/contexts"
 import { SharedMessageCardBody } from "./card-body"
+import type { AttachmentSummary } from "@threa/types"
 import type { SharedMessageSource } from "@/hooks/use-shared-message-source"
 
 function renderUnderRoute(node: ReactNode, initialPath = "/w/ws_1/s/current") {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
-        <Route path="/w/:workspaceId/s/:streamId" element={node} />
+        {/* The attachment row resolves presigned URLs through the gallery
+            context, exactly as both card surfaces mount it in the app. */}
+        <Route path="/w/:workspaceId/s/:streamId" element={<MediaGalleryProvider>{node}</MediaGalleryProvider>} />
       </Routes>
     </MemoryRouter>
   )
@@ -50,5 +54,61 @@ describe("SharedMessageCardBody — Slice 2 placeholders", () => {
 
     const link = screen.getByRole("link", { name: /open in source stream/i })
     expect(link.getAttribute("href")).toBe("/w/ws_1/s/stream_deep?m=msg_deep")
+  })
+})
+
+const RESOLVED: SharedMessageSource = {
+  status: "resolved",
+  contentMarkdown: "the pinned body",
+  authorId: "usr_1",
+  actorType: "user",
+  authorName: "Ada",
+  editedAt: null,
+  attachments: [],
+  version: 2,
+  currentRevision: 2,
+  range: null,
+}
+
+describe("SharedMessageCardBody — pinned references", () => {
+  it("links to the source when it was edited after the share was pinned", () => {
+    renderUnderRoute(
+      <SharedMessageCardBody
+        source={{ ...RESOLVED, currentRevision: 3 }}
+        fallbackAuthor=""
+        sourceHref="/w/ws_1/s/stream_src?m=msg_1"
+      />
+    )
+
+    const link = screen.getByRole("link", { name: /edited since/i })
+    expect(link.getAttribute("href")).toBe("/w/ws_1/s/stream_src?m=msg_1")
+    // The card still shows what was pinned, not what the source reads now.
+    expect(screen.getByText("the pinned body")).toBeInTheDocument()
+  })
+
+  it("says nothing when the source still reads as it was pinned", () => {
+    renderUnderRoute(<SharedMessageCardBody source={RESOLVED} fallbackAuthor="" sourceHref="/w/ws_1/s/s?m=m" />)
+    expect(screen.queryByText(/edited since/i)).not.toBeInTheDocument()
+  })
+
+  it("marks the edit as text where the card itself is already the link", () => {
+    renderUnderRoute(<SharedMessageCardBody source={{ ...RESOLVED, currentRevision: 3 }} fallbackAuthor="" />)
+    expect(screen.getByText(/edited since/i)).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /edited since/i })).not.toBeInTheDocument()
+  })
+
+  it("drops the attachments row on a ranged share", () => {
+    const attachments = [
+      { id: "att_1", filename: "plan.pdf", mimeType: "application/pdf", sizeBytes: 10 },
+    ] as unknown as AttachmentSummary[]
+
+    const whole = renderUnderRoute(<SharedMessageCardBody source={{ ...RESOLVED, attachments }} fallbackAuthor="" />)
+    expect(whole.container.textContent).toContain("plan.pdf")
+    whole.unmount()
+
+    const ranged = renderUnderRoute(
+      <SharedMessageCardBody source={{ ...RESOLVED, attachments, range: { from: 1, to: 4 } }} fallbackAuthor="" />
+    )
+    expect(ranged.container.textContent).not.toContain("plan.pdf")
   })
 })

--- a/apps/frontend/src/components/shared-messages/card-body.test.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.test.tsx
@@ -98,9 +98,9 @@ describe("SharedMessageCardBody — pinned references", () => {
   })
 
   it("drops the attachments row on a ranged share", () => {
-    const attachments = [
+    const attachments: AttachmentSummary[] = [
       { id: "att_1", filename: "plan.pdf", mimeType: "application/pdf", sizeBytes: 10 },
-    ] as unknown as AttachmentSummary[]
+    ]
 
     const whole = renderUnderRoute(<SharedMessageCardBody source={{ ...RESOLVED, attachments }} fallbackAuthor="" />)
     expect(whole.container.textContent).toContain("plan.pdf")

--- a/apps/frontend/src/components/shared-messages/card-body.tsx
+++ b/apps/frontend/src/components/shared-messages/card-body.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from "react"
 import { Link, useParams } from "react-router-dom"
+import { cn } from "@/lib/utils"
 import { Skeleton } from "@/components/ui/skeleton"
 import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
 import { AttachmentList } from "@/components/timeline/attachment-list"
@@ -21,13 +23,21 @@ import type { StreamType, Visibility } from "@threa/types"
  * `fallbackAuthor` is the pre-hydration label: the NodeView passes
  * `attrs.authorName` (stamped on the node at share time), the markdown
  * block passes the link-text the markdown serializer emitted.
+ *
+ * `sourceHref` is the source message's permalink, and it is optional because
+ * one of the two surfaces already IS that link: the markdown block wraps the
+ * whole card in it, so an "Edited since" anchor there would nest one `<a>`
+ * inside another. That surface passes nothing and the marker renders as text
+ * the card's own link already carries.
  */
 export function SharedMessageCardBody({
   source,
   fallbackAuthor,
+  sourceHref,
 }: {
   source: SharedMessageSource
   fallbackAuthor: string
+  sourceHref?: string
 }) {
   // The ok-branch needs `workspaceId` to render `<AttachmentList>` (it
   // resolves presigned URLs via the workspace-scoped attachment API).
@@ -79,7 +89,11 @@ export function SharedMessageCardBody({
     )
   }
 
-  const attachments = source.attachments ?? []
+  // A ranged share is a span of text the sharer picked, not the message's
+  // files — the server sends none, and a cached fallback must not add any.
+  const attachments = source.range ? [] : (source.attachments ?? [])
+  const editedSince =
+    source.version != null && source.currentRevision != null && source.currentRevision > source.version
   // Only mount `<AttachmentProvider>` when there's something to render —
   // it depends on `MediaGalleryContext`, which the shared-message card's
   // call sites (TipTap NodeView, markdown-block) wrap in but isolated
@@ -97,7 +111,10 @@ export function SharedMessageCardBody({
   )
   return (
     <>
-      <AuthorLabel name={source.authorName || fallbackAuthor || "—"} />
+      <AuthorLabel
+        name={source.authorName || fallbackAuthor || "—"}
+        trailing={editedSince ? <EditedSinceMarker href={sourceHref} /> : null}
+      />
       {hasAttachments ? (
         <AttachmentProvider workspaceId={workspaceId} attachments={attachments}>
           {body}
@@ -110,8 +127,29 @@ export function SharedMessageCardBody({
   )
 }
 
-function AuthorLabel({ name }: { name: string }) {
-  return <span className="text-xs font-medium text-foreground/80">{name}</span>
+function AuthorLabel({ name, trailing }: { name: string; trailing?: ReactNode }) {
+  return (
+    <span className="flex items-center gap-2">
+      <span className="min-w-0 truncate text-xs font-medium text-foreground/80">{name}</span>
+      {trailing}
+    </span>
+  )
+}
+
+/**
+ * The source has been edited since this share was pinned, so the card is
+ * showing an older revision on purpose. Negative margins keep the 24px tap
+ * target from growing the byline's line box, so the marker appearing never
+ * moves anything below it (INV-21).
+ */
+function EditedSinceMarker({ href }: { href?: string }) {
+  const className = "-my-1 shrink-0 rounded-sm px-1.5 py-1 text-[11px] text-muted-foreground"
+  if (!href) return <span className={className}>Edited since</span>
+  return (
+    <Link to={href} className={cn(className, "underline underline-offset-2 hover:text-foreground")}>
+      Edited since
+    </Link>
+  )
 }
 
 /**

--- a/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { act, render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom"
 import { SyncEngineContext } from "@/sync/sync-engine"
@@ -60,23 +59,23 @@ afterEach(() => {
 
 describe("MessageActionDrawer — sharing a selection", () => {
   it("hands the highlighted span to the share trigger", async () => {
-    const user = userEvent.setup()
     const onShareWithSelection = vi.fn()
     mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection })
 
-    await user.click(screen.getByText(BODY))
+    fireEvent.click(screen.getByText(BODY))
     selectInBody(13, 20)
 
-    await user.click(await screen.findByRole("button", { name: /^share$/i }))
+    // fireEvent, not userEvent: a real pointer sequence reaches vaul's drag
+    // handling, which reads a computed transform jsdom does not produce.
+    fireEvent.click(await screen.findByRole("button", { name: /^share$/i }))
 
     expect(onShareWithSelection).toHaveBeenCalledWith({ text: "this is", prefixText: "Hello there, " })
   })
 
   it("offers Quote alone when the row can't share a span", async () => {
-    const user = userEvent.setup()
     mountDrawer({ onQuoteReplyWithSelection: vi.fn() })
 
-    await user.click(screen.getByText(BODY))
+    fireEvent.click(screen.getByText(BODY))
     selectInBody(13, 20)
 
     expect(await screen.findByRole("button", { name: /^quote$/i })).toBeInTheDocument()

--- a/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MemoryRouter } from "react-router-dom"
+import { SyncEngineContext } from "@/sync/sync-engine"
+import { MessageActionDrawer } from "./message-action-drawer"
+import type { MessageActionContext } from "./message-actions"
+
+const BODY = "Hello there, this is the body."
+
+function mountDrawer(context: Partial<MessageActionContext>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      {/* Reactions read the engine on mount; this drawer test never reacts. */}
+      <SyncEngineContext.Provider value={{} as never}>
+        <MemoryRouter initialEntries={["/w/ws_1/s/stream_1"]}>
+          <MessageActionDrawer
+            open
+            onOpenChange={() => {}}
+            authorName="Alice"
+            context={{
+              contentMarkdown: BODY,
+              messageId: "msg_1",
+              workspaceId: "ws_1",
+              streamId: "stream_1",
+              actorType: "user",
+              replyUrl: "/w/ws_1/s/stream_1?m=msg_1",
+              ...context,
+            }}
+          />
+        </MemoryRouter>
+      </SyncEngineContext.Provider>
+    </QueryClientProvider>
+  )
+}
+
+/** Select `[start, end)` of the drawer's rendered body, as a long-press does. */
+function selectInBody(start: number, end: number) {
+  const node = screen.getByText(BODY).firstChild as Node
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, end)
+  vi.spyOn(window, "getSelection").mockReturnValue({
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => range.toString(),
+    getRangeAt: () => range,
+    removeAllRanges: () => {},
+  } as unknown as Selection)
+  act(() => {
+    document.dispatchEvent(new Event("selectionchange"))
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("MessageActionDrawer — sharing a selection", () => {
+  it("hands the highlighted span to the share trigger", async () => {
+    const user = userEvent.setup()
+    const onShareWithSelection = vi.fn()
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection })
+
+    await user.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+
+    await user.click(await screen.findByRole("button", { name: /^share$/i }))
+
+    expect(onShareWithSelection).toHaveBeenCalledWith({ text: "this is", prefixText: "Hello there, " })
+  })
+
+  it("offers Quote alone when the row can't share a span", async () => {
+    const user = userEvent.setup()
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn() })
+
+    await user.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+
+    expect(await screen.findByRole("button", { name: /^quote$/i })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^share$/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { AuthorType } from "@threa/types"
-import { ChevronLeft, Quote } from "lucide-react"
+import { ChevronLeft, Quote, Share2 } from "lucide-react"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -94,6 +94,13 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
     handleOpenChange(false)
   }, [selection, context, handleOpenChange])
 
+  const handleShareSelected = useCallback(() => {
+    if (!selection || !context.onShareWithSelection) return
+    context.onShareWithSelection(selection)
+    window.getSelection()?.removeAllRanges()
+    handleOpenChange(false)
+  }, [selection, context, handleOpenChange])
+
   const handleBack = useCallback(() => {
     window.getSelection()?.removeAllRanges()
     setExpanded(false)
@@ -148,7 +155,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
       <DrawerContent className={cn(expanded ? "h-[95dvh]" : "max-h-[85dvh]")}>
-        <DrawerTitle className="sr-only">{expanded ? "Select text to quote" : "Message actions"}</DrawerTitle>
+        <DrawerTitle className="sr-only">{expanded ? "Select text to quote or share" : "Message actions"}</DrawerTitle>
 
         {expanded ? (
           <ExpandedQuoteView
@@ -161,6 +168,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
             contentRef={contentRef}
             onBack={handleBack}
             onQuote={handleQuoteSelected}
+            onShare={context.onShareWithSelection ? handleShareSelected : undefined}
           />
         ) : (
           <>
@@ -247,6 +255,7 @@ interface ExpandedQuoteViewProps {
   contentRef: React.RefObject<HTMLDivElement | null>
   onBack: () => void
   onQuote: () => void
+  onShare?: () => void
 }
 
 function ExpandedQuoteView({
@@ -259,6 +268,7 @@ function ExpandedQuoteView({
   contentRef,
   onBack,
   onQuote,
+  onShare,
 }: ExpandedQuoteViewProps) {
   const initials = getInitials(authorName)
   const charCount = selectedText.length
@@ -362,10 +372,18 @@ function ExpandedQuoteView({
               <span className="font-semibold text-foreground/85">{charCount}</span>{" "}
               {charCount === 1 ? "character" : "characters"} selected
             </p>
-            <Button size="sm" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onQuote}>
-              <Quote className="h-3.5 w-3.5" />
-              Quote
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              {onShare && (
+                <Button size="sm" variant="secondary" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onShare}>
+                  <Share2 className="h-3.5 w-3.5" />
+                  Share
+                </Button>
+              )}
+              <Button size="sm" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onQuote}>
+                <Quote className="h-3.5 w-3.5" />
+                Quote
+              </Button>
+            </div>
           </div>
         ) : (
           <p className="text-[12px] text-muted-foreground/70 text-center py-1">

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -163,6 +163,12 @@ export interface MessageActionContext {
    * entries.
    */
   onShare?: () => void
+  /**
+   * Open the same picker for a span of the message the reader highlighted, so
+   * the share pins that span instead of the whole body. Absent when a span
+   * can't be shared (E2E sources decrypt whole).
+   */
+  onShareWithSelection?: (selection: QuoteSelection) => void
   /** Callback to save or unsave the message */
   onToggleSave?: () => void
   /** Callback to open the reminder picker (mobile: bottom sheet) */

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -4,6 +4,7 @@ import {
   LabelableResourceTypes,
   type StreamEvent,
   type AttachmentSummary,
+  type ContentRange,
   type JSONContent,
   type LinkPreviewSummary,
   type MemoEmbedSummary,
@@ -80,7 +81,7 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
 import { ReactionEmojiPicker } from "./reaction-emoji-picker"
-import { resolveQuoteSelection, type QuoteSelection } from "@/lib/quote-selection"
+import { resolveQuoteSelection, resolveShareSelection, type QuoteSelection } from "@/lib/quote-selection"
 import { registerReferenceSource } from "@/stores/reference-source-store"
 import { useQuoteReply } from "./quote-reply-context"
 import { useConversationReply } from "./conversation-reply-context"
@@ -926,7 +927,14 @@ function SentMessageEvent({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
-  const [shareModalOpen, setShareModalOpen] = useState(false)
+  // What the share picker is about to hand off: the pin, plus the body the
+  // picker previews so a selection that couldn't be mapped shows the whole
+  // message it actually falls back to.
+  const [shareRequest, setShareRequest] = useState<{
+    version: number | null
+    range: ContentRange | null
+    previewMarkdown: string
+  } | null>(null)
   const [moveDetailsOpen, setMoveDetailsOpen] = useState(false)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   // Hydrate the destination tombstone on demand for the per-message
@@ -1238,6 +1246,8 @@ function SentMessageEvent({
               authorName: actorName,
               authorId: event.actorId ?? "",
               actorType: event.actorType ?? "user",
+              version: payload.revision ?? null,
+              range: null,
             })
             navigateAfterShareHandoff({ workspaceId, targetStreamId: rootStream.id, location, navigate, isMobile })
           }
@@ -1252,6 +1262,8 @@ function SentMessageEvent({
                 authorName: actorName,
                 authorId: event.actorId ?? "",
                 actorType: event.actorType ?? "user",
+                version: payload.revision ?? null,
+                range: null,
               })
               navigateAfterShareHandoff({
                 workspaceId,
@@ -1263,7 +1275,32 @@ function SentMessageEvent({
             }
           : undefined,
       shareToParentLabel: showParentEntry && parentStream ? buildShareToStreamLabel(parentStream) : undefined,
-      onShare: () => setShareModalOpen(true),
+      onShare: () =>
+        setShareRequest({
+          version: payload.revision ?? null,
+          range: null,
+          previewMarkdown: payload.contentMarkdown,
+        }),
+      // Sharing a sealed message decrypts the WHOLE body into the target as
+      // plaintext, so a span of it has nothing to pin — the E2E row keeps the
+      // full-message share and its confirmation.
+      onShareWithSelection: e2eEnabled
+        ? undefined
+        : (selection: QuoteSelection) => {
+            const pin = resolveShareSelection(
+              {
+                contentJson: payload.contentJson,
+                revision: payload.revision,
+                contentMarkdown: payload.contentMarkdown,
+              },
+              selection
+            )
+            setShareRequest({
+              version: pin.version,
+              range: pin.range,
+              previewMarkdown: pin.previewMarkdown ?? payload.contentMarkdown,
+            })
+          },
       // Per-message entry into the batch-move flow. Hidden during batch
       // mode itself (the row's own checkbox handles that), on the thread
       // parent (moving the parent into its own thread is nonsensical),
@@ -1297,6 +1334,8 @@ function SentMessageEvent({
     }),
     [
       payload.contentMarkdown,
+      payload.contentJson,
+      payload.revision,
       payload.sessionId,
       payload.messageId,
       payload.editedAt,
@@ -1554,10 +1593,12 @@ function SentMessageEvent({
           }}
         />
       )}
-      {shareModalOpen && (
+      {shareRequest && (
         <ShareMessageModal
-          open={shareModalOpen}
-          onOpenChange={setShareModalOpen}
+          open
+          onOpenChange={(next) => {
+            if (!next) setShareRequest(null)
+          }}
           workspaceId={workspaceId}
           attrs={{
             messageId: payload.messageId,
@@ -1565,7 +1606,10 @@ function SentMessageEvent({
             authorName: actorName,
             authorId: event.actorId ?? "",
             actorType: event.actorType ?? "user",
+            version: shareRequest.version,
+            range: shareRequest.range,
           }}
+          previewMarkdown={shareRequest.previewMarkdown}
           sourcePlaintext={e2eDecryptedMarkdown}
         />
       )}

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -317,6 +317,8 @@ describe("the timeline composer's durable target", () => {
       authorName: "Ada",
       authorId: "usr_ada",
       actorType: "user",
+      version: 1,
+      range: null,
     })
 
     await waitFor(() => expect(screen.getByTestId("editor-json")).toHaveTextContent('"type":"sharedMessage"'), {
@@ -377,6 +379,8 @@ describe("the timeline composer's durable target", () => {
       authorName: "Ada",
       authorId: "usr_ada",
       actorType: "user",
+      version: 1,
+      range: null,
     })
 
     await waitFor(() =>
@@ -403,6 +407,8 @@ describe("the timeline composer's durable target", () => {
       authorName: "Ada",
       authorId: "usr_ada",
       actorType: "user",
+      version: 1,
+      range: null,
     })
 
     await waitFor(() =>
@@ -424,6 +430,8 @@ describe("the timeline composer's durable target", () => {
       authorName: "Ada",
       authorId: "usr_ada",
       actorType: "user",
+      version: 1,
+      range: null,
     })
 
     mount(["/"], streamId, true)
@@ -460,6 +468,8 @@ describe("the timeline composer's durable target", () => {
       authorName: "Ada",
       authorId: "usr_ada",
       actorType: "user",
+      version: 1,
+      range: null,
     })
     rerenderAtStream(view, targetStreamId)
 

--- a/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { render, screen, act } from "@testing-library/react"
+import { render, screen, act, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useEffect, useRef } from "react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
 import type { JSONContent } from "@threa/types"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as shareHandoffStoreModule from "@/stores/share-handoff-store"
+import * as useMobileModule from "@/hooks/use-mobile"
 import { registerReferenceSource, resetReferenceSourceStoreCache } from "@/stores/reference-source-store"
 import { QuoteReplyProvider, useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
 import { TextSelectionQuote } from "./text-selection-quote"
@@ -186,5 +190,113 @@ describe("TextSelectionQuote", () => {
     fireSelectionChange()
 
     expect(screen.queryByRole("button", { name: /quote/i })).toBeNull()
+  })
+})
+
+/** The same scene under a workspace route, so the share picker can mount. */
+function ShareScene() {
+  const ref = useRef<HTMLDivElement>(null)
+  return (
+    <MemoryRouter initialEntries={["/w/ws_1/s/stream_thread"]}>
+      <Routes>
+        <Route
+          path="/w/:workspaceId/s/:streamId"
+          element={
+            <QuoteReplyProvider>
+              <TextSelectionQuote streamId="stream_anchor" containerRef={ref} />
+              <div ref={ref}>
+                <MessageRow messageId="msg_1" streamId="stream_thread" />
+              </div>
+            </QuoteReplyProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function stubPickerWithOneChannel() {
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue(
+    undefined as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceUnreadState>
+  )
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+    {
+      id: "ch_target",
+      type: "channel",
+      visibility: "public",
+      displayName: "#general",
+      slug: "general",
+      archivedAt: null,
+      rootStreamId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    },
+  ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue(
+    [] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreamMemberships>
+  )
+  return vi.spyOn(shareHandoffStoreModule, "queueShareHandoff").mockImplementation(() => {})
+}
+
+describe("TextSelectionQuote — sharing a selection", () => {
+  it("hands the picker the highlighted span, pinned to the rendered revision", async () => {
+    const user = userEvent.setup()
+    const queue = stubPickerWithOneChannel()
+    registerReferenceSource("msg_1", { contentJson: BODY_JSON, revision: 4, contentMarkdown: BODY_MARKDOWN })
+
+    render(<ShareScene />)
+
+    const bodyEl = screen.getByText(BODY_TEXT)
+    mockSelection(bodyEl.firstChild as Node, 13, 20)
+    fireSelectionChange()
+
+    await user.click(await screen.findByRole("button", { name: /share/i }))
+
+    // The picker previews the formatted slice, not the DOM's flat string.
+    const dialog = await screen.findByRole("dialog", { name: /share message/i })
+    expect(dialog.querySelector("strong")?.textContent).toBe("this")
+    expect(dialog.textContent).not.toContain("Hello there")
+
+    fireEvent.click(document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')!)
+
+    expect(queue).toHaveBeenCalledWith("ch_target", {
+      messageId: "msg_1",
+      streamId: "stream_thread",
+      authorName: "Alice",
+      authorId: "usr_alice",
+      actorType: "user",
+      version: 4,
+      range: { from: 14, to: 21 },
+    })
+  })
+
+  it("shares the whole pinned message when the selection can't be mapped, and previews that", async () => {
+    const user = userEvent.setup()
+    const queue = stubPickerWithOneChannel()
+    registerReferenceSource("msg_1", { contentJson: BODY_JSON, revision: 4, contentMarkdown: BODY_MARKDOWN })
+
+    render(<ShareScene />)
+
+    const bodyEl = screen.getByText(BODY_TEXT)
+    const range = document.createRange()
+    range.selectNodeContents(bodyEl.firstChild as Node)
+    range.getBoundingClientRect = () => ({ top: 120, left: 40, width: 90, height: 20 }) as DOMRect
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      isCollapsed: false,
+      rangeCount: 1,
+      toString: () => "wholly unrelated wording",
+      getRangeAt: () => range,
+      removeAllRanges: () => {},
+    } as unknown as Selection)
+    fireSelectionChange()
+
+    await user.click(await screen.findByRole("button", { name: /share/i }))
+
+    const dialog = await screen.findByRole("dialog", { name: /share message/i })
+    expect(dialog.textContent).toContain("Hello there")
+
+    fireEvent.click(document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')!)
+
+    expect(queue).toHaveBeenCalledWith("ch_target", expect.objectContaining({ version: 4, range: null }))
   })
 })

--- a/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.test.tsx
@@ -297,6 +297,14 @@ describe("TextSelectionQuote — sharing a selection", () => {
 
     fireEvent.click(document.querySelector<HTMLElement>('[cmdk-item][data-value="ch_target"]')!)
 
-    expect(queue).toHaveBeenCalledWith("ch_target", expect.objectContaining({ version: 4, range: null }))
+    expect(queue).toHaveBeenCalledWith("ch_target", {
+      messageId: "msg_1",
+      streamId: "stream_thread",
+      authorName: "Alice",
+      authorId: "usr_alice",
+      actorType: "user",
+      version: 4,
+      range: null,
+    })
   })
 })

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState, useCallback, type RefObject } from "react"
 import { createPortal } from "react-dom"
-import { Quote } from "lucide-react"
+import { useParams } from "react-router-dom"
+import { Quote, Share2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { ShareMessageModal } from "@/components/share/share-message-modal"
+import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
 import { useInputMode } from "@/hooks/use-input-mode"
-import { resolveQuoteSelection } from "@/lib/quote-selection"
+import { resolveQuoteSelection, resolveShareSelection } from "@/lib/quote-selection"
 import { getReferenceSource } from "@/stores/reference-source-store"
+import { useStreamFromStore } from "@/stores/stream-store"
 import { useQuoteReply } from "./quote-reply-context"
 
 interface SelectionInfo {
@@ -69,13 +73,27 @@ interface TextSelectionQuoteProps {
 }
 
 /**
- * Shows a floating "Quote" button when the user selects text within a message.
- * Active mouse only — touch input uses select-none on messages.
+ * Floating Quote / Share controls for a text selection inside a message. Both
+ * pin the reference to the revision on screen and the span the reader
+ * highlighted. Active mouse only — touch input uses select-none on messages and
+ * reaches the same two actions through the action drawer.
  */
 export function TextSelectionQuote({ streamId, containerRef }: TextSelectionQuoteProps) {
   const inputMode = useInputMode()
   const quoteReplyCtx = useQuoteReply()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
   const [selection, setSelection] = useState<SelectionInfo | null>(null)
+  // Survives the selection being cleared: the picker stays open after the
+  // highlight is gone, and the preview is what the share will actually render.
+  const [shareRequest, setShareRequest] = useState<{
+    attrs: SharedMessageAttrs
+    previewMarkdown: string | null
+  } | null>(null)
+  // Sharing a sealed message decrypts it whole, which is the row menu's
+  // confirmed path — a span of one has nothing to pin, so the toolbar offers
+  // Quote only there.
+  const selectionStream = useStreamFromStore(selection?.streamId ?? streamId)
+  const canShare = workspaceId !== undefined && selectionStream?.e2eEnabled !== true
 
   const handleSelectionChange = useCallback(() => {
     const sel = window.getSelection()
@@ -165,23 +183,74 @@ export function TextSelectionQuote({ streamId, containerRef }: TextSelectionQuot
     setSelection(null)
   }, [selection, quoteReplyCtx])
 
-  if (inputMode !== "mouse" || !selection || !quoteReplyCtx) return null
+  const handleShare = useCallback(() => {
+    if (!selection) return
+    const pin = resolveShareSelection(getReferenceSource(selection.messageId), {
+      text: selection.text,
+      prefixText: selection.prefixText,
+    })
+    setShareRequest({
+      attrs: {
+        messageId: selection.messageId,
+        streamId: selection.streamId,
+        authorName: selection.authorName,
+        authorId: selection.authorId,
+        actorType: selection.actorType,
+        version: pin.version,
+        range: pin.range,
+      },
+      previewMarkdown: pin.previewMarkdown,
+    })
+    window.getSelection()?.removeAllRanges()
+    setSelection(null)
+  }, [selection])
 
-  return createPortal(
-    <div
-      className="fixed z-50 -translate-x-1/2 animate-in fade-in-0 zoom-in-95"
-      style={{ top: selection.rect.top - 36, left: selection.rect.left + selection.rect.width / 2 }}
-    >
-      <Button
-        variant="secondary"
-        size="sm"
-        className="h-7 gap-1.5 rounded-full shadow-md px-3 text-xs"
-        onClick={handleQuote}
-      >
-        <Quote className="h-3 w-3" />
-        Quote
-      </Button>
-    </div>,
-    document.body
+  const toolbar =
+    inputMode === "mouse" && selection && quoteReplyCtx
+      ? createPortal(
+          <div
+            className="fixed z-50 flex -translate-x-1/2 items-center gap-1 animate-in fade-in-0 zoom-in-95"
+            style={{ top: selection.rect.top - 36, left: selection.rect.left + selection.rect.width / 2 }}
+          >
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-7 gap-1.5 rounded-full shadow-md px-3 text-xs"
+              onClick={handleQuote}
+            >
+              <Quote className="h-3 w-3" />
+              Quote
+            </Button>
+            {canShare && (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-7 gap-1.5 rounded-full shadow-md px-3 text-xs"
+                onClick={handleShare}
+              >
+                <Share2 className="h-3 w-3" />
+                Share
+              </Button>
+            )}
+          </div>,
+          document.body
+        )
+      : null
+
+  return (
+    <>
+      {toolbar}
+      {shareRequest && workspaceId && (
+        <ShareMessageModal
+          open
+          onOpenChange={(next) => {
+            if (!next) setShareRequest(null)
+          }}
+          workspaceId={workspaceId}
+          attrs={shareRequest.attrs}
+          previewMarkdown={shareRequest.previewMarkdown}
+        />
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/timeline/text-selection-quote.tsx
+++ b/apps/frontend/src/components/timeline/text-selection-quote.tsx
@@ -93,6 +93,10 @@ export function TextSelectionQuote({ streamId, containerRef }: TextSelectionQuot
   // confirmed path — a span of one has nothing to pin, so the toolbar offers
   // Quote only there.
   const selectionStream = useStreamFromStore(selection?.streamId ?? streamId)
+  // A row whose stream is not in the store (a thread on a board card) still
+  // offers Share: the sealed case it guards is refused server-side with
+  // SHARE_E2E_NOT_ALLOWED, so guessing wrong here costs a rejected send, while
+  // requiring the stream would drop the control on ordinary plaintext rows.
   const canShare = workspaceId !== undefined && selectionStream?.e2eEnabled !== true
 
   const handleSelectionChange = useCallback(() => {

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -34,7 +34,14 @@ interface MockPendingMessage {
   streamId: string
   content: string
   contentFormat: string
-  contentJson?: { type: string; content: Array<{ type: string; content?: Array<{ type: string; text: string }> }> }
+  contentJson?: {
+    type: string
+    content: Array<{
+      type: string
+      attrs?: Record<string, unknown>
+      content?: Array<{ type: string; text: string }>
+    }>
+  }
   attachmentIds?: string[]
   steer?: true
   status?: "editing" | "blocked-privacy"
@@ -358,6 +365,40 @@ describe("useMessageQueue", () => {
     })
     expect(mockEventsUpdate).toHaveBeenCalledWith("temp_quote_gone", { _status: "failed" })
     expect(mockMarkFailed).toHaveBeenCalledWith("temp_quote_gone")
+  })
+
+  it("names a failed share a share, not a quote", async () => {
+    const errorToast = vi.spyOn(toast, "error").mockReturnValue("t2")
+    mockCreate.mockRejectedValue(
+      new ApiError(400, MessageReferenceErrorCodes.SOURCE_NOT_FOUND, "Referenced message not found")
+    )
+    mockPendingMessages = [
+      {
+        clientId: "temp_share_gone",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Shared a message",
+        contentFormat: "markdown",
+        contentJson: {
+          type: "doc",
+          content: [{ type: "sharedMessage", attrs: { messageId: "msg_src", streamId: "stream_src" } }],
+        },
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(errorToast.mock.calls).toEqual([
+      [
+        "Couldn't share that message — it may have changed or been removed.",
+        { id: "message-reference-temp_share_gone" },
+      ],
+    ])
   })
 
   it("does not auto-retry a permanently failed send", async () => {

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -28,20 +28,20 @@ const mockStreamCreate = vi.fn()
 const mockSubscribeStream = vi.fn()
 const mockKickOperationQueue = vi.fn()
 
+interface MockNode {
+  type: string
+  text?: string
+  attrs?: Record<string, unknown>
+  content?: MockNode[]
+}
+
 interface MockPendingMessage {
   clientId: string
   workspaceId: string
   streamId: string
   content: string
   contentFormat: string
-  contentJson?: {
-    type: string
-    content: Array<{
-      type: string
-      attrs?: Record<string, unknown>
-      content?: Array<{ type: string; text: string }>
-    }>
-  }
+  contentJson?: MockNode
   attachmentIds?: string[]
   steer?: true
   status?: "editing" | "blocked-privacy"
@@ -381,7 +381,13 @@ describe("useMessageQueue", () => {
         contentFormat: "markdown",
         contentJson: {
           type: "doc",
-          content: [{ type: "sharedMessage", attrs: { messageId: "msg_src", streamId: "stream_src" } }],
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "look at this" }] },
+            {
+              type: "blockquote",
+              content: [{ type: "sharedMessage", attrs: { messageId: "msg_src", streamId: "stream_src" } }],
+            },
+          ],
         },
         createdAt: 1000,
         retryCount: 0,

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -362,7 +362,7 @@ export function useMessageQueue(): void {
         if (referenceFailed || (ApiError.isApiError(err) && err.code === MessageErrorCodes.STEER_UNAVAILABLE)) {
           if (referenceFailed) {
             toast.error(
-              hasNodeOfType(next.contentJson, "sharedMessage")
+              hasNodeOfType(next.contentJson ?? parseMarkdown(next.content), "sharedMessage")
                 ? "Couldn't share that message — it may have changed or been removed."
                 : "Couldn't quote that message — it may have changed or been removed.",
               { id: `message-reference-${next.clientId}` }

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -32,6 +32,14 @@ import { surfacePrivacyBlockToast } from "@/lib/share-privacy-toast"
 
 const REFERENCE_FAILURE_CODES: ReadonlySet<string> = new Set(Object.values(MessageReferenceErrorCodes))
 
+/** Whether a body carries a node of the given type, at any depth. */
+function hasNodeOfType(node: unknown, type: string): boolean {
+  if (!node || typeof node !== "object") return false
+  const typed = node as { type?: unknown; content?: unknown }
+  if (typed.type === type) return true
+  return Array.isArray(typed.content) && typed.content.some((child) => hasNodeOfType(child, type))
+}
+
 /**
  * Exponential backoff delay based on retry count.
  * First 3 retries are immediate (within the same drain cycle, skipped to next cycle).
@@ -353,9 +361,12 @@ export function useMessageQueue(): void {
 
         if (referenceFailed || (ApiError.isApiError(err) && err.code === MessageErrorCodes.STEER_UNAVAILABLE)) {
           if (referenceFailed) {
-            toast.error("Couldn't quote that message — it may have changed or been removed.", {
-              id: `message-reference-${next.clientId}`,
-            })
+            toast.error(
+              hasNodeOfType(next.contentJson, "sharedMessage")
+                ? "Couldn't share that message — it may have changed or been removed."
+                : "Couldn't quote that message — it may have changed or been removed.",
+              { id: `message-reference-${next.clientId}` }
+            )
           }
           type UpdateFn = (key: string, changes: Record<string, unknown>) => Promise<number>
           await Promise.all([

--- a/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
@@ -152,3 +152,55 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
     expect(card.textContent).not.toContain("**")
   })
 })
+
+describe("MarkdownContent — pinned sharedMessage pointers", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  afterEach(async () => {
+    await db.events.clear()
+  })
+
+  it("renders the pinned span from the pointer's own slot and marks the source as edited since", () => {
+    const range = { from: 14, to: 21 }
+    renderMarkdown("Shared a message from [Ariadne](shared-message:stream_src/msg_abc?v=2&r=14-21)", {
+      // The whole-message slot exists too; the pointer must not read it.
+      [sharedMessageSlotKey("msg_abc")]: {
+        type: "sharedMessage",
+        state: "ok",
+        messageId: "msg_abc",
+        streamId: "stream_src",
+        authorId: "usr_1",
+        authorName: "Ariadne",
+        authorType: "user",
+        contentJson: {},
+        contentMarkdown: "the whole message as it reads now",
+        editedAt: null,
+        createdAt: "2026-04-23T10:00:00Z",
+        attachments: [],
+      },
+      [sharedMessageSlotKey("msg_abc", 2, range)]: {
+        type: "sharedMessage",
+        state: "ok",
+        messageId: "msg_abc",
+        streamId: "stream_src",
+        authorId: "usr_1",
+        authorName: "Ariadne",
+        authorType: "user",
+        contentJson: {},
+        contentMarkdown: "**this** is",
+        editedAt: null,
+        createdAt: "2026-04-23T10:00:00Z",
+        attachments: [],
+        version: 2,
+        currentRevision: 3,
+        range,
+      },
+    })
+
+    expect(screen.getByText("this")).toBeInTheDocument()
+    expect(screen.queryByText(/the whole message as it reads now/)).not.toBeInTheDocument()
+    expect(screen.getByText(/edited since/i)).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/lib/quote-selection.ts
+++ b/apps/frontend/src/lib/quote-selection.ts
@@ -73,3 +73,35 @@ export function resolveQuoteSelection(source: QuoteSource | null, selection: Quo
 
   return { version: revision, range: null, snippet: source?.contentMarkdown ?? selection.text }
 }
+
+/** What a share trigger needs from a selection: the pin, and what it will show. */
+export interface SharePin {
+  version: number | null
+  range: ContentRange | null
+  /** Markdown of exactly what the share will render, or null when out of reach. */
+  previewMarkdown: string | null
+}
+
+/**
+ * The pin a selection-driven share sends. Same three outcomes as
+ * {@link resolveQuoteSelection}, except a share stores no body: an unlocatable
+ * selection falls back to the whole message rather than to a snippet the server
+ * would have to locate, and the preview markdown is what the picker shows so the
+ * fallback is never silent. A range needs a revision to mean anything, so a row
+ * whose revision is unknown shares whole.
+ */
+export function resolveShareSelection(source: QuoteSource | null, selection: QuoteSelection): SharePin {
+  const contentJson = source?.contentJson
+  const revision = source?.revision ?? null
+  const whole: SharePin = { version: revision, range: null, previewMarkdown: source?.contentMarkdown ?? null }
+  if (!contentJson || revision === null) return whole
+
+  const partial = buildPartialQuote({
+    contentJson,
+    revision,
+    selectionText: selection.text,
+    prefixText: selection.prefixText,
+  })
+  if (!partial || !partial.range) return whole
+  return { version: revision, range: partial.range, previewMarkdown: partial.snippet }
+}

--- a/apps/frontend/src/stores/share-handoff-store.test.ts
+++ b/apps/frontend/src/stores/share-handoff-store.test.ts
@@ -18,6 +18,8 @@ const sampleAttrs = {
   authorName: "Alice",
   authorId: "usr_1",
   actorType: "user",
+  version: 3,
+  range: null,
 }
 
 afterEach(() => {

--- a/apps/frontend/src/stores/slot-store.test.ts
+++ b/apps/frontend/src/stores/slot-store.test.ts
@@ -251,6 +251,48 @@ describe("writeSlotCarrier — merge vs replace", () => {
     // msg_elsewhere belongs to an out-of-window page and survives.
     expect(await readMap("stream_a")).toEqual({ [sharedMessageSlotKey("msg_elsewhere")]: slot("msg_elsewhere") })
   })
+
+  it("scopes a replace to the pinned key a pointer actually reads", async () => {
+    const pinned = sharedMessageSlotKey("msg_pinned", 2, { from: 4, to: 9 })
+    await db.slots.bulkPut([
+      { workspaceId: "ws_1", streamId: "stream_a", slotKey: pinned, value: slot("msg_pinned"), _cachedAt: 1 },
+      {
+        workspaceId: "ws_1",
+        streamId: "stream_a",
+        slotKey: sharedMessageSlotKey("msg_pinned"),
+        value: slot("msg_pinned"),
+        _cachedAt: 1,
+      },
+    ])
+
+    await writeSlotCarrier({
+      database: db,
+      workspaceId: "ws_1",
+      streamId: "stream_a",
+      carrier: { slots: {} },
+      mode: "replace",
+      windowEvents: [
+        {
+          payload: {
+            contentJson: {
+              type: "doc",
+              content: [
+                {
+                  type: "sharedMessage",
+                  attrs: { messageId: "msg_pinned", streamId: "stream_src", version: 2, range: { from: 4, to: 9 } },
+                },
+              ],
+            },
+          },
+        },
+      ],
+      cachedAt: 2,
+    })
+
+    // Only the ranged key the window's pointer reads is in scope; the legacy
+    // whole-message row belongs to some other pointer and survives.
+    expect(await readMap("stream_a")).toEqual({ [sharedMessageSlotKey("msg_pinned")]: slot("msg_pinned") })
+  })
 })
 
 describe("writeSlotCarrier — merge richness guard (B1)", () => {

--- a/tests/browser/message-share-range.spec.ts
+++ b/tests/browser/message-share-range.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect, type Locator, type Page } from "@playwright/test"
+import { createChannel, expectApiOk, loginAndCreateWorkspace } from "./helpers"
+
+/**
+ * E2E coverage for sharing part of a message. A share pins the revision the
+ * sharer had on screen and the span they highlighted, so the card keeps
+ * rendering that span after the source moves on — and says the source moved on
+ * rather than quietly rewriting what was shared.
+ */
+
+function workspaceAndStream(page: Page): { workspaceId: string; streamId: string } {
+  const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+  expect(match, "workspace + stream should be resolvable from the URL").toBeTruthy()
+  return { workspaceId: match![1], streamId: match![2] }
+}
+
+/** A body with a bold run, so a span across the mark exercises a real slice. */
+async function sendBoldMessage(page: Page, prefix: string, bold: string, suffix: string): Promise<string> {
+  const { workspaceId, streamId } = workspaceAndStream(page)
+  const response = await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: {
+      streamId,
+      contentJson: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: prefix },
+              { type: "text", text: bold, marks: [{ type: "bold" }] },
+              { type: "text", text: suffix },
+            ],
+          },
+        ],
+      },
+      contentMarkdown: `${prefix}**${bold}**${suffix}`,
+    },
+  })
+  await expectApiOk(response, "Create bold source message")
+  const body = (await response.json()) as { message?: { id: string } }
+  return body.message?.id ?? ""
+}
+
+function mainMessageRow(page: Page, text: string): Locator {
+  return page.getByRole("main").locator("[data-message-id]").filter({ hasText: text }).first()
+}
+
+/**
+ * Put the browser's selection across a message body, from the start of `from`
+ * through `to`. Driven in the page because the selection toolbar reads
+ * `window.getSelection()`, which Playwright's own APIs cannot set.
+ */
+async function selectAcross(page: Page, messageId: string, from: string, to: string): Promise<void> {
+  await page.evaluate(
+    ({ messageId, from, to }) => {
+      const row = document.querySelector(`[data-message-id="${messageId}"]`)
+      const body = row?.querySelector(".message-content .markdown-content")
+      if (!body) throw new Error(`No rendered body for ${messageId}`)
+
+      const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT)
+      const textNodes: Text[] = []
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) textNodes.push(node as Text)
+
+      const startNode = textNodes.find((node) => node.data.includes(from))
+      const endNode = textNodes.find((node) => node.data.includes(to))
+      if (!startNode || !endNode) throw new Error(`Could not locate "${from}" / "${to}" in the rendered body`)
+
+      const range = document.createRange()
+      range.setStart(startNode, startNode.data.indexOf(from))
+      range.setEnd(endNode, endNode.data.indexOf(to) + to.length)
+
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      document.dispatchEvent(new Event("selectionchange"))
+    },
+    { messageId, from, to }
+  )
+}
+
+test.describe("Share by range", () => {
+  test("shares the highlighted span and holds it when the source is edited", async ({ page }) => {
+    const { testId } = await loginAndCreateWorkspace(page, "share-range")
+    const channelName = `sr-${testId}`
+    await createChannel(page, channelName, { switchToAll: false })
+
+    const sourceText = `deploy-${testId}`
+    const sourceId = await sendBoldMessage(page, `${sourceText} is `, "blocked", " until friday")
+    await expect(mainMessageRow(page, sourceText)).toBeVisible({ timeout: 10000 })
+
+    // Keep the app in mouse mode — the floating toolbar is mouse-only.
+    await page.mouse.move(10, 10)
+    await selectAcross(page, sourceId, "blocked", " until")
+
+    const shareButton = page.getByRole("button", { name: "Share", exact: true })
+    await expect(shareButton).toBeVisible({ timeout: 10000 })
+    await shareButton.click()
+
+    // The picker previews exactly what will be shared: the span, not the body.
+    const dialog = page.getByRole("dialog", { name: /share message/i })
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText("blocked until")
+    await expect(dialog).not.toContainText("friday")
+
+    // Share back into the same channel so both the source and the card are on
+    // one timeline (D5 allows a same-stream share).
+    const sameChannel = dialog
+      .locator("[cmdk-item][data-value]")
+      .filter({ hasText: new RegExp(channelName, "i") })
+      .first()
+    await expect(sameChannel).toBeVisible()
+    await sameChannel.click()
+
+    const composer = page.locator("[contenteditable='true']").first()
+    await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 10000 })
+    await composer.focus()
+    await page.keyboard.press("Enter")
+
+    const card = page.getByRole("main").locator("[data-type='shared-message']").filter({ hasText: "blocked" }).first()
+    await expect(card).toBeVisible({ timeout: 10000 })
+    // Only the slice, formatted — the rest of the source never reaches the card.
+    await expect(card.locator("strong").filter({ hasText: "blocked" })).toBeVisible()
+    await expect(card).not.toContainText("friday")
+    await expect(card.getByText(/edited since/i)).toHaveCount(0)
+
+    // Edit the source. The card is pinned to the revision that was shared, so
+    // it keeps the span and picks up the marker instead of rewriting itself.
+    const { workspaceId } = workspaceAndStream(page)
+    const editedText = `rescheduled-${testId}`
+    const editResponse = await page.request.patch(`/api/workspaces/${workspaceId}/messages/${sourceId}`, {
+      data: {
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: editedText }] }] },
+        contentMarkdown: editedText,
+      },
+    })
+    await expectApiOk(editResponse, `Edit source message ${sourceId}`)
+
+    await expect(card.getByText(/edited since/i)).toBeVisible({ timeout: 10000 })
+    await expect(card).toContainText("blocked until")
+    await expect(card).not.toContainText(editedText)
+  })
+})

--- a/tests/browser/message-share-range.spec.ts
+++ b/tests/browser/message-share-range.spec.ts
@@ -112,7 +112,9 @@ test.describe("Share by range", () => {
     await sameChannel.click()
 
     const composer = page.locator("[contenteditable='true']").first()
-    await expect(composer.locator("[data-type='shared-message']")).toHaveCount(1, { timeout: 10000 })
+    // Strict mode fails this on a second match, so it carries the uniqueness a
+    // count would and proves the chip actually rendered.
+    await expect(composer.locator("[data-type='shared-message']")).toBeVisible({ timeout: 10000 })
     await composer.focus()
     await page.keyboard.press("Enter")
 

--- a/tests/browser/message-share-to-parent.spec.ts
+++ b/tests/browser/message-share-to-parent.spec.ts
@@ -154,15 +154,15 @@ test.describe("Message share-to-parent", () => {
     // visible. Nothing more to check on the happy path.
   })
 
-  test("holds the shared revision when the source is edited", async ({ page }) => {
+  test("holds the shared revision when the source is edited, and says the source moved on", async ({ page }) => {
     const channelName = `share-${testId}`
     const threadText = `thread-reply-${testId}`
     const { workspaceId, threadMessageId } = await setUpSharedPointer(page, { channelName, threadText })
 
     // Edit the source thread message via the messages API. The backend's
     // outbox handler emits `pointer:invalidated` to the channel's room and the
-    // frontend refetches — but the pointer names the revision that was shared,
-    // so what the reader sees must not change underneath them.
+    // frontend refetches — but the pointer is pinned to the revision that was
+    // shared, so what it shows must not change under the reader.
     const editedText = `edited-thread-reply-${testId}`
     const editResponse = await page.request.patch(`/api/workspaces/${workspaceId}/messages/${threadMessageId}`, {
       data: {
@@ -179,7 +179,8 @@ test.describe("Message share-to-parent", () => {
     // refetch usually completes within a couple of seconds, but CI can
     // be slow under load.
     const card = page.locator("[data-type='shared-message']").filter({ hasText: new RegExp(threadText) })
-    await expect(card).toContainText(threadText, { timeout: 10000 })
+    await expect(card.getByText(/edited since/i)).toBeVisible({ timeout: 10000 })
+    await expect(card).toContainText(threadText)
     await expect(page.locator("[data-type='shared-message']").filter({ hasText: new RegExp(editedText) })).toHaveCount(
       0
     )


### PR DESCRIPTION
Top of the quote/share-by-pinned-version stack (plan: https://seer.build/ws_vbyzjvdg6g/b/share-quoted-plan/, on top of #1929). The feature Kris asked for: highlight part of a message and share **that part**, frozen at the revision you were looking at.

**Changes**
- `reference-attributes.ts` holds the `version`/`range` tiptap attribute specs once; `quoteReply` now reuses it and `sharedMessage` gains both (required on `SharedMessageAttrs`, so every construction site had to decide what it means). Every share trigger — the picker, share-to-root/parent fast paths, and the two selection paths — passes the revision it rendered.
- Selection sharing: the desktop toolbar gains Share beside Quote, the mobile drawer's expanded view gains a Share button beside Quote. Both route through `resolveShareSelection`, sharing PR4's mapping and its fallback ladder; a selection that can't be mapped shares the whole message, and the picker's markdown preview shows that before you send. Hidden on E2E streams, where a sealed share decrypts whole and has nothing to pin.
- `useSharedMessageSource` now takes the reference `{messageId, streamId, version, range}` and reads `sharedMessageSlotKey(...)`. The IDB fallback answers only at the pinned revision and slices the cached doc itself for a ranged pointer, so a share still previews in the composer before it is sent. `collectReferencedSlotKeys` and the markdown pointer block carry the pin through (`?v=&r=`).
- The card renders the pinned body, drops attachments when ranged, and shows an **Edited since** marker when `currentRevision > version` — a `<Link>` in the composer NodeView, plain text in the markdown block (that surface already wraps the card in the same permalink, so a nested `<a>` would be invalid). It sits on the byline with `-my-1 py-1`: a 24px touch target that adds no layout shift (INV-21).

**Verification**
Focused vitest: `use-shared-message-source` 10, `card-body` 11, `shared-message-block` 9, `slot-store` 24, `slots` 13, `share` 41, `message-input` 53, `editor` 612, `message-action-drawer` 2, `text-selection-quote` 6 — all green, and 36 of them re-run here after the rebase. Browser: `message-share-range.spec.ts` (new) 1 passed, `message-share-to-parent` 3, `message-share-cross-stream` 4. Frontend typecheck and lint clean.

**Decisions worth a reviewer's eye**
- `message-share-to-parent`'s "propagates source edits to the pointer" case now asserts the opposite — the pinned card keeps its body and grows an "Edited since" marker. This is the commit where that old contract flips, because the client only now reads the pinned key.
- `SharedMessageSlot.version`/`currentRevision`/`range` stay optional on the wire: during the rollout a pre-#1927 replica serves slots without them, so requiring them would be a lie about what arrives.
- Ranged shares hiding attachments is proven at unit level, not in a browser spec — that proof needs a real upload for little added confidence.
- Board and conversation rows share unpinned, like they quote unpinned: `RenderableMessage` carries no revision (INV-36).
