### PR TITLE
feat(frontend): aside desktop surface

### DIFF
--- a/apps/backend/src/features/commands/availability.test.ts
+++ b/apps/backend/src/features/commands/availability.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test"
+import { ASIDE_COMMAND, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo, type StreamType } from "@threa/types"
 import type { BotRuntimeInstance } from "../bot-runtimes"
-import { commandRequiresWritableAuthority, resolveAdvertisedSessionControlCommandNames } from "./availability"
+import type { Stream } from "../streams"
+import {
+  commandRequiresWritableAuthority,
+  isClientActionAvailableInStream,
+  resolveAdvertisedSessionControlCommandNames,
+} from "./availability"
+import { listClientActionCommandInfos } from "./catalog"
 
 function presence(capabilities: Record<string, unknown>): BotRuntimeInstance {
   return { capabilities } as BotRuntimeInstance
@@ -37,5 +44,31 @@ describe("session-control command advertisement", () => {
     expect(resolveAdvertisedSessionControlCommandNames(presence({ sessionControlCommands: ["reconnect"] }))).toEqual(
       new Set()
     )
+  })
+})
+
+describe("client-action command availability", () => {
+  const aside = listClientActionCommandInfos().find((info) => info.clientActionId === ASIDE_COMMAND) as CommandInfo
+  const discuss = listClientActionCommandInfos().find(
+    (info) => info.clientActionId === DISCUSS_WITH_ARIADNE_COMMAND
+  ) as CommandInfo
+  const stream = (type: StreamType, overrides: Partial<Stream> = {}): Stream =>
+    ({ id: `stream_${type}`, type, ...overrides }) as Stream
+
+  it("offers /aside on channel, dm, scratchpad and thread hosts only", () => {
+    const types: StreamType[] = ["channel", "dm", "scratchpad", "thread", "system", "aside"]
+    expect(types.map((type) => isClientActionAvailableInStream(aside, stream(type)))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ])
+  })
+
+  it("never offers /aside on an end-to-end encrypted host", () => {
+    expect(isClientActionAvailableInStream(aside, stream("scratchpad", { e2eEnabled: true }))).toBe(false)
+    expect(isClientActionAvailableInStream(discuss, stream("scratchpad", { e2eEnabled: true }))).toBe(true)
   })
 })

--- a/apps/backend/src/features/commands/availability.test.ts
+++ b/apps/backend/src/features/commands/availability.test.ts
@@ -67,6 +67,11 @@ describe("client-action command availability", () => {
     ])
   })
 
+  it("never offers /aside on a read-only (archived) host", () => {
+    expect(isClientActionAvailableInStream(aside, stream("channel"), { writable: false })).toBe(false)
+    expect(isClientActionAvailableInStream(aside, stream("channel"), { writable: true })).toBe(true)
+  })
+
   it("never offers /aside on an end-to-end encrypted host", () => {
     expect(isClientActionAvailableInStream(aside, stream("scratchpad", { e2eEnabled: true }))).toBe(false)
     expect(isClientActionAvailableInStream(discuss, stream("scratchpad", { e2eEnabled: true }))).toBe(true)

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -145,7 +145,7 @@ export class CommandAvailabilityService {
     }
 
     for (const info of listClientActionCommandInfos()) {
-      if (isClientActionAvailableInStream(info, stream)) {
+      if (isClientActionAvailableInStream(info, stream, { writable })) {
         commands.push({ info, executionKind: CommandKinds.CLIENT_ACTION })
       }
     }
@@ -181,12 +181,20 @@ async function isServerCommandAvailableInStream(name: string, stream: Stream, db
 
 /**
  * Client-action commands are gated per host stream. `/aside` follows the create
- * path's own rules (host type, no E2E host) so the palette never offers an
- * aside the server would refuse — and never inside an aside.
+ * path's own rules (host type, no E2E host, writable host) so the palette never
+ * offers an aside the server would refuse — and never inside an aside.
  */
-export function isClientActionAvailableInStream(info: CommandInfo, stream: Stream): boolean {
+export function isClientActionAvailableInStream(
+  info: CommandInfo,
+  stream: Stream,
+  options?: { writable?: boolean }
+): boolean {
   if (info.clientActionId === DISCUSS_WITH_ARIADNE_COMMAND) return !!stream.id
-  if (info.clientActionId === ASIDE_COMMAND) return isAsideHostType(stream.type) && stream.e2eEnabled !== true
+  if (info.clientActionId === ASIDE_COMMAND) {
+    // An aside inherits its host's archive state, so an archived (read-only)
+    // host cannot open one — the create path refuses it.
+    return isAsideHostType(stream.type) && stream.e2eEnabled !== true && options?.writable !== false
+  }
   return true
 }
 

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -4,10 +4,12 @@ import {
   BotRuntimeKinds,
   BotRuntimeStatuses,
   BotTypes,
+  ASIDE_COMMAND,
   CommandKinds,
   DISCUSS_WITH_ARIADNE_COMMAND,
   StreamTypes,
   botHasCapability,
+  isAsideHostType,
   type BotRuntimeKind,
   type CommandArgumentSuggestion,
   type CommandInfo,
@@ -177,8 +179,14 @@ async function isServerCommandAvailableInStream(name: string, stream: Stream, db
   return root?.type === StreamTypes.CHANNEL
 }
 
-function isClientActionAvailableInStream(info: CommandInfo, stream: Stream): boolean {
+/**
+ * Client-action commands are gated per host stream. `/aside` follows the create
+ * path's own rules (host type, no E2E host) so the palette never offers an
+ * aside the server would refuse — and never inside an aside.
+ */
+export function isClientActionAvailableInStream(info: CommandInfo, stream: Stream): boolean {
   if (info.clientActionId === DISCUSS_WITH_ARIADNE_COMMAND) return !!stream.id
+  if (info.clientActionId === ASIDE_COMMAND) return isAsideHostType(stream.type) && stream.e2eEnabled !== true
   return true
 }
 

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -1,4 +1,10 @@
-import { CommandKinds, CommandScopes, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo } from "@threa/types"
+import {
+  ASIDE_COMMAND,
+  CommandKinds,
+  CommandScopes,
+  DISCUSS_WITH_ARIADNE_COMMAND,
+  type CommandInfo,
+} from "@threa/types"
 import type { CommandRegistry } from "./registry"
 
 // Canonical session-control command names, shared across runtimes that drive a
@@ -45,6 +51,13 @@ export function listClientActionCommandInfos(): CommandInfo[] {
       kind: CommandKinds.CLIENT_ACTION,
       scope: CommandScopes.STREAM,
       clientActionId: DISCUSS_WITH_ARIADNE_COMMAND,
+    },
+    {
+      name: ASIDE_COMMAND,
+      description: "Open a private aside with Ariadne beside what you are reading",
+      kind: CommandKinds.CLIENT_ACTION,
+      scope: CommandScopes.STREAM,
+      clientActionId: ASIDE_COMMAND,
     },
   ]
 }

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -40,6 +40,7 @@ import { UserRepository } from "../workspaces"
 import { BotChannelAccessRepository } from "../api-keys"
 import {
   StreamTypes,
+  isAsideHostType,
   Visibilities,
   CompanionModes,
   MemoryModes,
@@ -90,14 +91,6 @@ import { StreamPoliciesRepository } from "./policy-repository"
 import { normalizeStreamDescription } from "./description"
 
 const DM_UNIQUENESS_KEY_PREFIX = "dm"
-
-/** Streams an aside may anchor to: no aside-on-aside, no system hosts. */
-const ASIDE_HOST_TYPES: readonly StreamType[] = [
-  StreamTypes.CHANNEL,
-  StreamTypes.DM,
-  StreamTypes.SCRATCHPAD,
-  StreamTypes.THREAD,
-]
 
 const createScratchpadParamsSchema = z.object({
   workspaceId: z.string(),
@@ -653,7 +646,7 @@ export class StreamService {
       const parent = await checkStreamAccess(client, params.parentStreamId, params.workspaceId, params.createdBy)
       if (!parent) throw new StreamNotFoundError()
 
-      if (!ASIDE_HOST_TYPES.includes(parent.type)) {
+      if (!isAsideHostType(parent.type)) {
         throw new HttpError("An aside cannot be opened on this stream type", {
           status: 400,
           code: "ASIDE_HOST_TYPE_INVALID",

--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -17,6 +17,7 @@ import { resetDraftContextCache } from "@/hooks/use-board-draft-context"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 import { resetComposeOverlayStoreCache } from "@/stores/compose-overlay-store"
 import { resetBoardFlashStoreCache } from "@/stores/board-flash-store"
+import { resetAsideStoreCache } from "@/stores/aside-store"
 import { resetBoardUnreadLatches } from "@/stores/board-unread-latch-store"
 import { resetConversationMessageSnapshots } from "@/stores/conversation-messages-store"
 import { resetReferenceSourceStoreCache } from "@/stores/reference-source-store"
@@ -98,6 +99,7 @@ function flushModuleStoreCaches(): void {
   resetE2eSessionStoreCache()
   resetComposeOverlayStoreCache()
   resetBoardFlashStoreCache()
+  resetAsideStoreCache()
   resetBoardUnreadLatches()
   resetConversationMessageSnapshots()
   // Ordered hangup before state drop: the call-store reset emits leave, closes

--- a/apps/frontend/src/components/aside/aside-dock-slot.tsx
+++ b/apps/frontend/src/components/aside/aside-dock-slot.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+import { cn } from "@/lib/utils"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { useAsideForHost, type OpenAsideState } from "@/stores/aside-store"
+import { AsidePane } from "./aside-pane"
+
+export const ASIDE_DOCK_WIDTH = 400
+// Matches the thread panel slot (`duration-200`): the dock folds shut on the
+// same clock the panel slides on, so the two right-edge surfaces never drift.
+const FOLD_MS = 200
+
+/**
+ * The dock's width snaps to zero through a CSS transition on close; the pane
+ * stays mounted for that one beat so the fold has content to clip, then
+ * unmounts. A surface switch (dock ⇄ fullscreen) swaps in place.
+ */
+function useFoldingState(current: OpenAsideState | null): OpenAsideState | null {
+  const [rendered, setRendered] = useState(current)
+  useEffect(() => {
+    if (current) {
+      setRendered(current)
+      return
+    }
+    const timer = window.setTimeout(() => setRendered(null), FOLD_MS)
+    return () => window.clearTimeout(timer)
+  }, [current])
+  return current ?? rendered
+}
+
+interface AsideDockSlotProps {
+  workspaceId: string
+  hostKey: string
+}
+
+/**
+ * The aside's reading surfaces, mounted as the last flex child of a page's
+ * content row — after the thread panel slot, so the aside owns the page's
+ * right edge (calls own the app's). Dock pushes the host by ASIDE_DOCK_WIDTH;
+ * fullscreen takes half the row with the live host timeline on the left. On a
+ * phone the dock is a plain takeover of the content area (PR7 owns the real
+ * mobile surface). Renders nothing while the aside is minimized or closed.
+ */
+export function AsideDockSlot({ workspaceId, hostKey }: AsideDockSlotProps) {
+  const current = useAsideForHost(hostKey)
+  const reading = current && current.surface !== "minimized" ? current : null
+  const rendered = useFoldingState(reading)
+  const isMobile = useIsMobile()
+
+  if (!rendered) return null
+  const surface = rendered.surface === "fullscreen" ? "fullscreen" : "dock"
+
+  if (isMobile) {
+    return (
+      <div
+        data-testid="aside-dock"
+        data-surface="takeover"
+        className="absolute inset-0 z-30 flex flex-col bg-background"
+      >
+        <AsidePane workspaceId={workspaceId} asideId={rendered.asideId} surface={surface} takeover />
+      </div>
+    )
+  }
+
+  const open = reading !== null
+  let width: number | undefined = 0
+  if (open) width = surface === "fullscreen" ? undefined : ASIDE_DOCK_WIDTH
+  return (
+    <div
+      data-testid="aside-dock"
+      data-surface={surface}
+      className={cn(
+        "flex-shrink-0 overflow-hidden border-l transition-[width] duration-200 ease-out",
+        surface === "fullscreen" && open && "flex-1 basis-1/2"
+      )}
+      style={{ width }}
+    >
+      <div className="h-full" style={{ minWidth: surface === "fullscreen" ? undefined : ASIDE_DOCK_WIDTH }}>
+        <AsidePane workspaceId={workspaceId} asideId={rendered.asideId} surface={surface} />
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aside/aside-dock-slot.tsx
+++ b/apps/frontend/src/components/aside/aside-dock-slot.tsx
@@ -70,7 +70,8 @@ export function AsideDockSlot({ workspaceId, hostKey }: AsideDockSlotProps) {
       data-surface={surface}
       className={cn(
         "flex-shrink-0 overflow-hidden border-l transition-[width] duration-200 ease-out",
-        surface === "fullscreen" && open && "flex-1 basis-1/2"
+        // Half the row: a fixed basis, so the host's `flex-1` takes the other half.
+        surface === "fullscreen" && open && "basis-1/2"
       )}
       style={{ width }}
     >

--- a/apps/frontend/src/components/aside/aside-minimized-strip.tsx
+++ b/apps/frontend/src/components/aside/aside-minimized-strip.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react"
+import { X } from "lucide-react"
+import { StreamTypes } from "@threa/types"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { closeAside, rememberedAsideSurface, setAsideSurface, useAsideForHost } from "@/stores/aside-store"
+import { resolveAsideRestoreSurface } from "@/lib/aside/surface"
+import { streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { useCallDocked } from "./use-call-docked"
+
+interface AsideMinimizedStripProps {
+  workspaceId: string
+  hostKey: string
+}
+
+/**
+ * A minimized aside: a slim strip riding just above the host composer, inside
+ * the page's main column (never a global pill — it cannot outlive the stream).
+ * The strip is the restore control; the title is its content.
+ */
+export function AsideMinimizedStrip({ workspaceId, hostKey }: AsideMinimizedStripProps) {
+  const current = useAsideForHost(hostKey)
+  const asideId = current?.surface === "minimized" ? current.asideId : null
+  const streams = useWorkspaceStreams(workspaceId)
+  const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
+  const callDocked = useCallDocked()
+  if (!asideId) return null
+
+  const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
+  const restore = () =>
+    setAsideSurface(resolveAsideRestoreSurface({ remembered: rememberedAsideSurface(asideId), callDocked }))
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 z-20 px-3 sm:px-6"
+      style={{ bottom: "calc(var(--composer-height, 5rem) + 0.25rem)" }}
+    >
+      <div
+        data-testid="aside-strip"
+        data-aside-id={asideId}
+        className="pointer-events-auto mx-auto flex h-10 max-w-[800px] items-center gap-2 rounded-lg border border-primary/40 bg-background pl-3 pr-1 shadow-md"
+      >
+        <button
+          type="button"
+          onClick={restore}
+          aria-label={`Open aside: ${title}`}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm"
+        >
+          <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-primary" />
+          <span className="min-w-0 truncate font-medium">{title}</span>
+        </button>
+        <button
+          type="button"
+          onClick={closeAside}
+          aria-label="Close aside"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react"
+import { Maximize2, Minus, PanelRight, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { StreamContent } from "@/components/timeline"
+import { StreamErrorBoundary } from "@/components/stream-error-boundary"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { closeAside, setAsideSurface, type AsideSurface } from "@/stores/aside-store"
+import { streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { StreamTypes } from "@threa/types"
+import { cn } from "@/lib/utils"
+import { useCallDocked } from "./use-call-docked"
+
+interface AsidePaneProps {
+  workspaceId: string
+  asideId: string
+  surface: Exclude<AsideSurface, "minimized">
+  /** Phone-width takeover: no surface picker, the close control is the way out. */
+  takeover?: boolean
+}
+
+/**
+ * The aside's chat: the companion timeline against the aside stream (it IS a
+ * companion stream with Ariadne — the same `StreamContent` a scratchpad or a
+ * thread panel mounts), under a gold hairline that marks the private surface.
+ */
+export function AsidePane({ workspaceId, asideId, surface, takeover = false }: AsidePaneProps) {
+  const streams = useWorkspaceStreams(workspaceId)
+  const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
+  const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
+  const callDocked = useCallDocked()
+
+  return (
+    <div
+      data-testid="aside-pane"
+      data-aside-id={asideId}
+      data-surface={surface}
+      data-editor-zone="aside"
+      className="flex h-full min-h-0 flex-col border-t-2 border-primary/70 bg-background"
+    >
+      <header className="flex h-12 shrink-0 items-center gap-1 border-b pl-4 pr-2">
+        <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">{title}</h2>
+        {!takeover && (
+          <>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn("h-8 w-8", surface === "dock" && "bg-accent text-accent-foreground")}
+              aria-label="Dock aside"
+              aria-pressed={surface === "dock"}
+              disabled={callDocked}
+              onClick={() => setAsideSurface("dock")}
+            >
+              <PanelRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn("h-8 w-8", surface === "fullscreen" && "bg-accent text-accent-foreground")}
+              aria-label="Aside fullscreen"
+              aria-pressed={surface === "fullscreen"}
+              onClick={() => setAsideSurface("fullscreen")}
+            >
+              <Maximize2 className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label="Minimize aside"
+              onClick={() => setAsideSurface("minimized")}
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+        <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close aside" onClick={closeAside}>
+          <X className="h-4 w-4" />
+        </Button>
+      </header>
+      <div className="relative min-h-0 flex-1">
+        <StreamErrorBoundary streamId={asideId}>
+          <StreamContent workspaceId={workspaceId} streamId={asideId} stream={aside} autoFocus={!takeover} />
+        </StreamErrorBoundary>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { StreamTypes } from "@threa/types"
+import { spyOnExport } from "@/test"
+import { createMockStream } from "@/test/fixtures"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as timelineModule from "@/components/timeline"
+import * as boundaryModule from "@/components/stream-error-boundary"
+import { clearCallState, setCallPhase, setCallSession, setDesktopSurfaceOverride } from "@/stores/call-store"
+import { __resetCallPrefsForTests } from "@/stores/call-prefs-store"
+import { getAsideState, openAside, resetAsideStoreCache } from "@/stores/aside-store"
+import { resolveAsideOpenSurface } from "@/lib/aside/surface"
+import { AsideDockSlot, AsideMinimizedStrip, useAsideHost } from "./index"
+import { isCallDocked } from "./use-call-docked"
+
+const HOST_PATH = "/w/ws_1/s/stream_host"
+const ASIDE = "stream_aside_1"
+const aside = createMockStream({
+  id: ASIDE,
+  type: StreamTypes.ASIDE,
+  displayName: "churn number sanity-check",
+  parentStreamId: "stream_host",
+})
+
+/** The page's two mount points, bound to the route like the stream page binds them. */
+function Page() {
+  const hostKey = useAsideHost()
+  return (
+    <div className="flex">
+      <main className="relative">
+        <AsideMinimizedStrip workspaceId="ws_1" hostKey={hostKey} />
+      </main>
+      <AsideDockSlot workspaceId="ws_1" hostKey={hostKey} />
+    </div>
+  )
+}
+
+function renderPage(path = HOST_PATH) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/w/:workspaceId/s/:streamId" element={<Page />} />
+        <Route path="/w/:workspaceId/board" element={<Page />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+function openOnHost(surface: "dock" | "fullscreen" | "minimized" = "dock") {
+  openAside({ hostKey: HOST_PATH, hostStreamId: "stream_host", asideId: ASIDE, surface })
+}
+
+beforeEach(() => {
+  resetAsideStoreCache()
+  clearCallState()
+  __resetCallPrefsForTests()
+  localStorage.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([aside] as never)
+  // The chat pane is the real companion timeline; its data plumbing is out of
+  // scope here, so the barrel export renders a marker carrying the stream it
+  // was mounted against.
+  spyOnExport(timelineModule, "StreamContent").mockReturnValue(((props: { streamId: string }) => (
+    <div data-testid="stream-content" data-stream-id={props.streamId} />
+  )) as never)
+  spyOnExport(boundaryModule, "StreamErrorBoundary").mockReturnValue(((props: { children: React.ReactNode }) => (
+    <>{props.children}</>
+  )) as never)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("aside surfaces", () => {
+  it("should render no aside chrome while nothing is open on this page", () => {
+    renderPage()
+    expect(screen.queryByTestId("aside-dock")).toBeNull()
+    expect(screen.queryByTestId("aside-strip")).toBeNull()
+  })
+
+  it("should dock the companion timeline against the aside and switch surfaces from the header", async () => {
+    renderPage()
+    openOnHost("dock")
+
+    const dock = await screen.findByTestId("aside-dock")
+    expect(dock).toHaveAttribute("data-surface", "dock")
+    expect(dock).toHaveStyle({ width: "400px" })
+    expect(screen.getByTestId("stream-content")).toHaveAttribute("data-stream-id", ASIDE)
+    expect(screen.getByRole("heading", { name: "churn number sanity-check" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Dock aside" })).toHaveAttribute("aria-pressed", "true")
+
+    fireEvent.click(screen.getByRole("button", { name: "Aside fullscreen" }))
+    expect(screen.getByTestId("aside-dock")).toHaveAttribute("data-surface", "fullscreen")
+    expect(getAsideState()?.surface).toBe("fullscreen")
+
+    fireEvent.click(screen.getByRole("button", { name: "Minimize aside" }))
+    await waitFor(() => expect(screen.queryByTestId("aside-dock")).toBeNull())
+    expect(screen.getByTestId("aside-strip")).toHaveTextContent("churn number sanity-check")
+  })
+
+  it("should restore a minimized aside into the surface it was last read in, and close from the strip", async () => {
+    renderPage()
+    openOnHost("fullscreen")
+    fireEvent.click(await screen.findByRole("button", { name: "Minimize aside" }))
+    await waitFor(() => expect(screen.queryByTestId("aside-dock")).toBeNull())
+
+    fireEvent.click(screen.getByRole("button", { name: "Open aside: churn number sanity-check" }))
+    expect(await screen.findByTestId("aside-dock")).toHaveAttribute("data-surface", "fullscreen")
+    expect(screen.queryByTestId("aside-strip")).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "Minimize aside" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Close aside" }))
+    expect(getAsideState()).toBeNull()
+    await waitFor(() => expect(screen.queryByTestId("aside-strip")).toBeNull())
+  })
+
+  it("should fold the dock away on close and leave no chrome", async () => {
+    renderPage()
+    openOnHost("dock")
+    fireEvent.click(await screen.findByRole("button", { name: "Close aside" }))
+
+    expect(getAsideState()).toBeNull()
+    // The slot snaps to zero width first (the fold), then unmounts.
+    expect(screen.getByTestId("aside-dock")).toHaveStyle({ width: "0px" })
+    await waitFor(() => expect(screen.queryByTestId("aside-dock")).toBeNull())
+    expect(screen.queryByTestId("aside-strip")).toBeNull()
+  })
+
+  it("should drop the aside when its host page goes away", async () => {
+    const view = renderPage()
+    openOnHost("dock")
+    await screen.findByTestId("aside-dock")
+
+    view.unmount()
+    expect(getAsideState()).toBeNull()
+  })
+
+  it("should not show another page's aside", () => {
+    openOnHost("dock")
+    renderPage("/w/ws_1/board")
+    expect(screen.queryByTestId("aside-dock")).toBeNull()
+    expect(screen.queryByTestId("aside-strip")).toBeNull()
+  })
+
+  describe("right-edge contention with a docked call", () => {
+    beforeEach(() => {
+      setCallSession({ callId: "call_1", workspaceId: "ws_1", streamId: "stream_call", mode: "audio_only" })
+      setCallPhase("connected")
+      setDesktopSurfaceOverride("sidebar")
+    })
+
+    it("should open minimized instead of docking while a call owns the right edge", async () => {
+      expect(isCallDocked()).toBe(true)
+      renderPage()
+      openOnHost(resolveAsideOpenSurface({ remembered: null, callDocked: isCallDocked() }))
+
+      expect(await screen.findByTestId("aside-strip")).toBeInTheDocument()
+      expect(screen.queryByTestId("aside-dock")).toBeNull()
+    })
+
+    it("should restore from the strip into fullscreen and keep the dock control disabled", async () => {
+      renderPage()
+      openOnHost("minimized")
+      fireEvent.click(await screen.findByRole("button", { name: "Open aside: churn number sanity-check" }))
+
+      expect(await screen.findByTestId("aside-dock")).toHaveAttribute("data-surface", "fullscreen")
+      expect(screen.getByRole("button", { name: "Dock aside" })).toBeDisabled()
+    })
+
+    it("should dock again once the call floats", async () => {
+      setDesktopSurfaceOverride("floating")
+      expect(isCallDocked()).toBe(false)
+      renderPage()
+      openOnHost(resolveAsideOpenSurface({ remembered: null, callDocked: isCallDocked() }))
+
+      expect(await screen.findByTestId("aside-dock")).toHaveAttribute("data-surface", "dock")
+      expect(screen.getByRole("button", { name: "Dock aside" })).toBeEnabled()
+    })
+  })
+})

--- a/apps/frontend/src/components/aside/index.ts
+++ b/apps/frontend/src/components/aside/index.ts
@@ -1,0 +1,3 @@
+export { AsideDockSlot } from "./aside-dock-slot"
+export { AsideMinimizedStrip } from "./aside-minimized-strip"
+export { useAsideHost } from "./use-aside-host"

--- a/apps/frontend/src/components/aside/use-aside-host.ts
+++ b/apps/frontend/src/components/aside/use-aside-host.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react"
+import { useLocation } from "react-router-dom"
+import { dropAsideForHost } from "@/stores/aside-store"
+
+/**
+ * Binds the aside surface to the page: the host key is the route pathname, and
+ * leaving the page (the key changing, or the page unmounting) drops whatever
+ * aside was open on it — so the next stream is clean by construction and the
+ * anchor row is the only way back in.
+ */
+export function useAsideHost(): string {
+  const { pathname: hostKey } = useLocation()
+  useEffect(() => () => dropAsideForHost(hostKey), [hostKey])
+  return hostKey
+}

--- a/apps/frontend/src/components/aside/use-call-docked.ts
+++ b/apps/frontend/src/components/aside/use-call-docked.ts
@@ -1,0 +1,23 @@
+import { getCallState } from "@/stores/call-store"
+import { getCallPrefs, resolveDesktopSurface, useCallPrefs } from "@/stores/call-prefs-store"
+import { useCallPhase, useDesktopSurfaceOverride } from "@/components/call/call-store-hooks"
+import { isMobileViewport, useIsMobile } from "@/hooks/use-mobile"
+
+/** Whether the desktop call dock currently owns the right edge (`CallDock` → `DesktopCallDock`). */
+export function isCallDocked(): boolean {
+  const call = getCallState()
+  if (call.phase === "idle" || isMobileViewport()) return false
+  const prefs = getCallPrefs()
+  return (
+    resolveDesktopSurface(prefs.desktopCallSurface, prefs.lastDesktopSurface, call.desktopSurfaceOverride) === "sidebar"
+  )
+}
+
+export function useCallDocked(): boolean {
+  const phase = useCallPhase()
+  const override = useDesktopSurfaceOverride()
+  const { desktopCallSurface, lastDesktopSurface } = useCallPrefs()
+  const isMobile = useIsMobile()
+  if (phase === "idle" || isMobile) return false
+  return resolveDesktopSurface(desktopCallSurface, lastDesktopSurface, override) === "sidebar"
+}

--- a/apps/frontend/src/components/composer/use-composer-command-send.test.tsx
+++ b/apps/frontend/src/components/composer/use-composer-command-send.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { renderHook } from "@testing-library/react"
-import type { CommandInfo, JSONContent } from "@threa/types"
+import { ASIDE_COMMAND, type CommandInfo, type JSONContent } from "@threa/types"
 import { spyOnExport } from "@/test"
 import * as streamCommandsModule from "@/hooks/use-stream-commands"
 import * as dispatchQueueModule from "@/hooks/use-command-dispatch-queue"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
+import * as openAsideModule from "@/hooks/use-open-aside"
 import { useComposerCommandSend } from "./use-composer-command-send"
 
 const COMMANDS: CommandInfo[] = [
@@ -14,6 +15,7 @@ const COMMANDS: CommandInfo[] = [
 
 let queueCommand: ReturnType<typeof vi.fn>
 let queuedFor: Array<string | undefined>
+let openAside: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   queueCommand = vi.fn().mockResolvedValue(undefined)
@@ -27,6 +29,8 @@ beforeEach(() => {
     return { queueCommand }
   }) as never)
   spyOnExport(discussModule, "useDiscussWithAriadne").mockReturnValue((() => vi.fn()) as never)
+  openAside = vi.fn().mockResolvedValue(undefined)
+  spyOnExport(openAsideModule, "useOpenAside").mockReturnValue((() => openAside) as never)
 })
 
 function doc(...content: JSONContent[]): JSONContent {
@@ -98,6 +102,33 @@ describe("useComposerCommandSend dispatchCommand", () => {
     expect(queueCommand.mock.calls[0][0]).toEqual({
       commandMarkdown: "/compact",
       commandName: "compact",
+      conversationId: "conv_1",
+    })
+  })
+
+  it("should open an aside beside the host stream for /aside from a timeline composer, never queueing a dispatch", async () => {
+    await hook("stream_host").current.dispatchCommand({
+      kind: "command",
+      commandName: ASIDE_COMMAND,
+      clientActionId: ASIDE_COMMAND,
+      commandMarkdown: "/aside",
+    })
+    expect({ origin: openAside.mock.calls[0][0], queued: queueCommand.mock.calls.length }).toEqual({
+      origin: { kind: "stream", hostStreamId: "stream_host" },
+      queued: 0,
+    })
+  })
+
+  it("should anchor /aside to the conversation from a board or panel composer", async () => {
+    await hook("stream_root", "conv_1").current.dispatchCommand({
+      kind: "command",
+      commandName: ASIDE_COMMAND,
+      clientActionId: ASIDE_COMMAND,
+      commandMarkdown: "/aside",
+    })
+    expect(openAside.mock.calls[0][0]).toEqual({
+      kind: "conversation",
+      hostStreamId: "stream_root",
       conversationId: "conv_1",
     })
   })

--- a/apps/frontend/src/components/composer/use-composer-command-send.ts
+++ b/apps/frontend/src/components/composer/use-composer-command-send.ts
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from "react"
-import { DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo, type JSONContent } from "@threa/types"
+import { ASIDE_COMMAND, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo, type JSONContent } from "@threa/types"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { extractCommandNode, extractCommandFromRawText, extractSteerDirective } from "@/lib/commands"
 import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
+import { useOpenAside } from "@/hooks/use-open-aside"
 import { useStreamCommands } from "@/hooks/use-stream-commands"
 
 /** A send that resolved to a slash command rather than a message. */
@@ -41,6 +42,7 @@ export function useComposerCommandSend(
 ) {
   const availableCommands = useStreamCommands(workspaceId, streamId)
   const startDiscussWithAriadne = useDiscussWithAriadne(workspaceId)
+  const openAside = useOpenAside(workspaceId)
   const { queueCommand } = useCommandDispatchQueue(workspaceId, streamId ?? "")
 
   const availableCommandByName = useMemo(() => {
@@ -84,9 +86,10 @@ export function useComposerCommandSend(
 
   /**
    * Run a planned command. Client-action commands route locally
-   * (`/discuss-with-ariadne` creates a scratchpad + navigates) and swallow their
-   * failure — the hook already toasts, so a second inline error would render the
-   * same failure twice. A runtime dispatch throws, leaving the surface to report.
+   * (`/discuss-with-ariadne` creates a scratchpad + navigates; `/aside` opens an
+   * aside beside this surface) and swallow their failure — the hook already
+   * toasts, so a second inline error would render the same failure twice. A
+   * runtime dispatch throws, leaving the surface to report.
    */
   const dispatchCommand = useCallback(
     async (plan: ComposerCommandPlan) => {
@@ -99,13 +102,26 @@ export function useComposerCommandSend(
         }
         return
       }
+      if (plan.clientActionId === ASIDE_COMMAND) {
+        if (!streamId) return
+        try {
+          await openAside(
+            conversationId
+              ? { kind: "conversation", hostStreamId: streamId, conversationId }
+              : { kind: "stream", hostStreamId: streamId }
+          )
+        } catch {
+          /* hook already toasted; composer stays clean */
+        }
+        return
+      }
       await queueCommand({
         commandMarkdown: plan.commandMarkdown,
         commandName: plan.commandName,
         ...(conversationId && { conversationId }),
       })
     },
-    [conversationId, queueCommand, startDiscussWithAriadne, streamId]
+    [conversationId, queueCommand, startDiscussWithAriadne, openAside, streamId]
   )
 
   return { availableCommands, planSend, dispatchCommand }

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useRef, useState } from "react"
-import { CircleCheck, Eye, EyeOff, EllipsisVertical, Pencil, RotateCcw, Sparkles } from "lucide-react"
+import {
+  CircleCheck,
+  Eye,
+  EyeOff,
+  EllipsisVertical,
+  MessageSquareDashed,
+  Pencil,
+  RotateCcw,
+  Sparkles,
+} from "lucide-react"
 import {
   ConversationStatuses,
   MAX_CONVERSATION_TOPIC_LENGTH,
   StreamTypes,
+  isAsideHostType,
   type Stream,
   type TitleSource,
 } from "@threa/types"
@@ -31,6 +41,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { effectiveConversationTitle } from "@/lib/conversations/title"
 import { useRenameStream } from "@/hooks/use-rename-stream"
 import { isProtectedRegenerableTitle, useRegenerateTitle } from "@/hooks/use-regenerate-title"
+import { useOpenAside } from "@/hooks/use-open-aside"
 
 interface ConversationActionsMenuProps {
   workspaceId: string
@@ -74,6 +85,8 @@ export function ConversationActionsMenu({
   const streams = useWorkspaceStreams(workspaceId)
   const stream = streams.find((item) => item.id === streamId)
   const isScratchpad = stream?.type === StreamTypes.SCRATCHPAD
+  const openAside = useOpenAside(workspaceId)
+  const canOpenAside = !!streamId && isAsideHostType(stream?.type ?? "") && stream?.e2eEnabled !== true
   const effectiveTitle = effectiveConversationTitle({ streamId: streamId ?? "", topicSummary }, stream)
   const hide = useHideConversation(workspaceId)
   const unhide = useUnhideConversation(workspaceId)
@@ -153,6 +166,18 @@ export function ConversationActionsMenu({
             >
               <Sparkles className="h-4 w-4" />
               Split with AI…
+            </DropdownMenuItem>
+          )}
+          {canOpenAside && (
+            <DropdownMenuItem
+              onSelect={() => {
+                void openAside({ kind: "conversation", hostStreamId: streamId!, conversationId }).catch(() => {
+                  /* toast already surfaced inside the hook */
+                })
+              }}
+            >
+              <MessageSquareDashed className="h-4 w-4" />
+              Open an aside
             </DropdownMenuItem>
           )}
           <DropdownMenuSeparator />

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -86,7 +86,8 @@ export function ConversationActionsMenu({
   const stream = streams.find((item) => item.id === streamId)
   const isScratchpad = stream?.type === StreamTypes.SCRATCHPAD
   const openAside = useOpenAside(workspaceId)
-  const canOpenAside = !!streamId && isAsideHostType(stream?.type ?? "") && stream?.e2eEnabled !== true
+  const canOpenAside =
+    !!streamId && isAsideHostType(stream?.type ?? "") && stream?.e2eEnabled !== true && !stream?.archivedAt
   const effectiveTitle = effectiveConversationTitle({ streamId: streamId ?? "", topicSummary }, stream)
   const hide = useHideConversation(workspaceId)
   const unhide = useUnhideConversation(workspaceId)

--- a/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef } from "react"
 import { useParams } from "react-router-dom"
 import type { Editor } from "@tiptap/react"
-import { DISCUSS_WITH_ARIADNE_COMMAND } from "@threa/types"
+import { ASIDE_COMMAND, DISCUSS_WITH_ARIADNE_COMMAND } from "@threa/types"
 import type { CommandItem } from "./types"
 import { CommandList } from "./command-list"
 import {
@@ -148,8 +148,10 @@ export function useCommandSuggestion({
   const commands = useMemo<CommandItem[]>(() => {
     const serverCommands = effectiveCommands
       .filter((cmd) => {
-        // Gate discuss-with-ariadne on there being a source stream to reference.
-        if (cmd.clientActionId === DISCUSS_WITH_ARIADNE_COMMAND) return !!streamId
+        // Gate the client actions that reference this stream on there being one.
+        if (cmd.clientActionId === DISCUSS_WITH_ARIADNE_COMMAND || cmd.clientActionId === ASIDE_COMMAND) {
+          return !!streamId
+        }
         return true
       })
       .map((cmd) => ({

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -46,6 +46,7 @@ import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useDeleteMessage } from "@/hooks/use-delete-message"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
+import { useOpenAside } from "@/hooks/use-open-aside"
 import { useSettleConversationMessage } from "@/hooks/use-conversations"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { parseMarkdown } from "@threa/prosemirror"
@@ -308,6 +309,23 @@ export function MessageItem({
     })
   }, [startDiscussWithAriadne, conversationId, conversationRootStreamId, message.id])
 
+  // Conversation-anchored aside: the conversation's root stream is the host and
+  // the conversation id the authoritative anchor unit (a card's rows span
+  // streams). The message is a finer anchor only when it lives in the root.
+  const openAside = useOpenAside(workspaceId)
+  const canOpenAside = canDiscussConversation && rowStream?.e2eEnabled !== true
+  const handleOpenAside = useCallback(() => {
+    if (!conversationId || !conversationRootStreamId) return
+    void openAside({
+      kind: "conversation",
+      hostStreamId: conversationRootStreamId,
+      conversationId,
+      anchorId: streamId === conversationRootStreamId ? message.id : undefined,
+    }).catch(() => {
+      /* toast already surfaced inside the hook */
+    })
+  }, [openAside, conversationId, conversationRootStreamId, streamId, message.id])
+
   // The settling pair. Both are wired only while the row is still settling and
   // the surface knows the conversation, so a settled row's menus and toolbar are
   // exactly what they were before this existed. "Not this topic" reuses the
@@ -464,6 +482,7 @@ export function MessageItem({
     onToggleSave: handleToggleSave,
     onRequestReminder: handleRequestReminder,
     onDiscussWithAriadne: canDiscussConversation ? handleDiscussWithAriadne : undefined,
+    onOpenAside: canOpenAside ? handleOpenAside : undefined,
     viewInStream: {
       href: `/w/${workspaceId}/s/${streamId}?m=${message.id}`,
       label: viewInStreamLabel(rowStream?.type),

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom"
 import { toast } from "sonner"
 import { Quote, Check, FolderInput } from "lucide-react"
 import {
+  isAsideHostType,
   LabelableResourceTypes,
   type AttachmentSummary,
   type AuthorType,
@@ -311,9 +312,17 @@ export function MessageItem({
 
   // Conversation-anchored aside: the conversation's root stream is the host and
   // the conversation id the authoritative anchor unit (a card's rows span
-  // streams). The message is a finer anchor only when it lives in the root.
+  // streams). The message is a finer anchor only when it lives in the root —
+  // the server requires an anchor message to belong to the host stream.
   const openAside = useOpenAside(workspaceId)
-  const canOpenAside = canDiscussConversation && rowStream?.e2eEnabled !== true
+  // Gated on the HOST (the conversation's root), not the row's own stream: a
+  // thread row's stream is never the host, so its type and E2E state say
+  // nothing about whether the server would accept the aside.
+  const conversationRootStream = useStreamFromStore(conversationRootStreamId)
+  const canOpenAside =
+    canDiscussConversation &&
+    isAsideHostType(conversationRootStream?.type ?? "") &&
+    conversationRootStream?.e2eEnabled !== true
   const handleOpenAside = useCallback(() => {
     if (!conversationId || !conversationRootStreamId) return
     void openAside({

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -322,7 +322,8 @@ export function MessageItem({
   const canOpenAside =
     canDiscussConversation &&
     isAsideHostType(conversationRootStream?.type ?? "") &&
-    conversationRootStream?.e2eEnabled !== true
+    conversationRootStream?.e2eEnabled !== true &&
+    !conversationRootStream?.archivedAt
   const handleOpenAside = useCallback(() => {
     if (!conversationId || !conversationRootStreamId) return
     void openAside({

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -84,6 +84,8 @@ export interface CommandContext {
    * Saved tab and the offline cache immediately.
    */
   createSavedTodo: (title: string) => Promise<void>
+  /** Open a private aside on the stream in view. Absent when that stream can't host one. */
+  openAside?: (streamId: string) => Promise<void>
 }
 
 export interface Command {

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -10,6 +10,7 @@ import { SidebarProvider } from "@/contexts/sidebar-context"
 import { SearchPanelProvider, useSearchPanel } from "@/components/search/search-panel-context"
 import { StreamTypes } from "@threa/types"
 import { createMockStream, mockStreamsList } from "@/test/fixtures"
+import { getAsideState, resetAsideStoreCache } from "@/stores/aside-store"
 import { mockUsersList } from "@/test/fixtures/users"
 import { mockSearchResultsList } from "@/test/fixtures/messages"
 import * as hooksModule from "@/hooks"
@@ -343,6 +344,32 @@ describe("QuickSwitcher Integration Tests", () => {
 
       expect(screen.getByText("churn number sanity-check")).toBeInTheDocument()
       expect(screen.queryByText("Member's private aside")).not.toBeInTheDocument()
+    })
+
+    it("opens a selected aside on its host page as a surface, never as a page of its own", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      resetAsideStoreCache()
+      mockWorkspaceBootstrap.data.streams = [
+        ...mockStreamsList,
+        createMockStream({
+          id: "stream_aside_mine",
+          type: StreamTypes.ASIDE,
+          displayName: "churn number sanity-check",
+          createdBy: "member_1",
+          parentStreamId: "stream_host",
+        }),
+      ]
+      renderWithProviders(<QuickSwitcher {...defaultProps} open={true} />)
+
+      await user.click(screen.getByText("churn number sanity-check"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("/w/workspace_1/s/stream_host")
+      expect(getAsideState()).toMatchObject({
+        hostKey: "/w/workspace_1/s/stream_host",
+        hostStreamId: "stream_host",
+        asideId: "stream_aside_mine",
+        surface: "dock",
+      })
     })
 
     it("should not render dialog content when open=false", () => {

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -1004,6 +1004,48 @@ describe("QuickSwitcher Integration Tests", () => {
       expect(mockOpenStreamSettings).toHaveBeenCalledWith("stream_channel1")
     })
 
+    it("should offer 'Open an aside here' on a host stream and hand the stream to the layout's opener", async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      const openAside = vi.fn(async () => {})
+      renderWithProviders(
+        <QuickSwitcher
+          {...defaultProps}
+          initialMode="command"
+          currentStreamId="stream_channel1"
+          openAside={openAside}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Open an aside here")).toBeInTheDocument()
+      })
+      await user.click(screen.getByText("Open an aside here"))
+
+      expect(openAside).toHaveBeenCalledWith("stream_channel1")
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it("should hide 'Open an aside here' on an E2E host and without an opener", async () => {
+      mockWorkspaceBootstrap.data.streams = [
+        ...mockStreamsList,
+        createMockStream({ id: "stream_sealed", type: "scratchpad", displayName: "Sealed", e2eEnabled: true }),
+      ]
+      const { unmount } = renderWithProviders(
+        <QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_sealed" openAside={vi.fn()} />
+      )
+      await waitFor(() => {
+        expect(screen.getByText("Open stream settings")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Open an aside here")).toBeNull()
+      unmount()
+
+      renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)
+      await waitFor(() => {
+        expect(screen.getByText("Open stream settings")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Open an aside here")).toBeNull()
+    })
+
     it("should confirm before archiving, and only archive after confirmation", async () => {
       const user = userEvent.setup({ pointerEventsCheck: 0 })
       renderWithProviders(<QuickSwitcher {...defaultProps} initialMode="command" currentStreamId="stream_channel1" />)

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -121,7 +121,15 @@ export function QuickSwitcher({
   // The palette's "Open an aside here" follows the host rules the server
   // enforces (host type, no E2E), so it never offers an aside that would fail.
   const currentStream = currentStreamId ? allStreams.find((s) => s.id === currentStreamId) : undefined
-  const canOpenAside = !!openAside && isAsideHostType(currentStream?.type ?? "") && currentStream?.e2eEnabled !== true
+  const currentRoot = currentStream?.rootStreamId
+    ? allStreams.find((s) => s.id === currentStream.rootStreamId)
+    : undefined
+  const canOpenAside =
+    !!openAside &&
+    isAsideHostType(currentStream?.type ?? "") &&
+    currentStream?.e2eEnabled !== true &&
+    !currentStream?.archivedAt &&
+    !currentRoot?.archivedAt
   // System-purpose streams (persona test scratchpads) are not navigable targets.
   const streams = useMemo(() => allStreams.filter((s) => !isUtilityStream(s)), [allStreams])
   const streamMemberships = useWorkspaceStreamMemberships(workspaceId)

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import { isUtilityStream } from "@/lib/streams"
+import { isAsideHostType } from "@threa/types"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { Terminal, FileText } from "lucide-react"
 import { toast } from "sonner"
@@ -54,6 +55,8 @@ interface QuickSwitcherProps {
   initialMode?: QuickSwitcherMode
   /** Stream currently in view (route param) — drives contextual stream commands. */
   currentStreamId?: string | null
+  /** Open a private aside on a stream (the layout owns the creating hook); gated here per host rules. */
+  openAside?: (streamId: string) => Promise<void>
 }
 
 const MODE_PREFIXES: Record<QuickSwitcherMode, string> = {
@@ -83,7 +86,14 @@ export function getDisplayQuery(query: string, mode: QuickSwitcherMode): string 
   return query
 }
 
-export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, currentStreamId }: QuickSwitcherProps) {
+export function QuickSwitcher({
+  workspaceId,
+  open,
+  onOpenChange,
+  initialMode,
+  currentStreamId,
+  openAside,
+}: QuickSwitcherProps) {
   const navigate = useNavigate()
   const [, setSearchParams] = useSearchParams()
   const user = useUser()
@@ -108,6 +118,10 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
   const [labelPickerStreamId, setLabelPickerStreamId] = useState<string | null>(null)
 
   const allStreams = useWorkspaceStreams(workspaceId)
+  // The palette's "Open an aside here" follows the host rules the server
+  // enforces (host type, no E2E), so it never offers an aside that would fail.
+  const currentStream = currentStreamId ? allStreams.find((s) => s.id === currentStreamId) : undefined
+  const canOpenAside = !!openAside && isAsideHostType(currentStream?.type ?? "") && currentStream?.e2eEnabled !== true
   // System-purpose streams (persona test scratchpads) are not navigable targets.
   const streams = useMemo(() => allStreams.filter((s) => !isUtilityStream(s)), [allStreams])
   const streamMemberships = useWorkspaceStreamMemberships(workspaceId)
@@ -289,8 +303,11 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       requestArchiveStream,
       openLabelPicker,
       createSavedTodo,
+      openAside: canOpenAside ? openAside : undefined,
     }),
     [
+      canOpenAside,
+      openAside,
       workspaceId,
       navigate,
       handleClose,

--- a/apps/frontend/src/components/quick-switcher/stream-commands.ts
+++ b/apps/frontend/src/components/quick-switcher/stream-commands.ts
@@ -1,4 +1,4 @@
-import { Archive, FileCode2, ListChecks, Paperclip, Settings, Tag, Trash2 } from "lucide-react"
+import { Archive, FileCode2, ListChecks, MessageSquareDashed, Paperclip, Settings, Tag, Trash2 } from "lucide-react"
 import { queueSnippetRequest } from "@/stores/snippet-request-store"
 import type { Command } from "./commands"
 
@@ -30,6 +30,21 @@ const createSnippetCommand: Command = {
  */
 export const streamCommands: Command[] = [
   createSnippetCommand,
+  {
+    // Surfaced only while `CommandContext.openAside` is set (the stream in view
+    // can host one) — see `use-command-items`.
+    id: "stream-open-aside",
+    label: "Open an aside here",
+    icon: MessageSquareDashed,
+    keywords: ["ariadne", "think", "draft", "private", "side", "current stream"],
+    action: ({ currentStreamId, openAside, closeDialog }) => {
+      if (!currentStreamId || !openAside) return
+      closeDialog()
+      void openAside(currentStreamId).catch(() => {
+        /* toast already surfaced inside the hook */
+      })
+    },
+  },
   {
     id: "stream-settings",
     label: "Open stream settings",

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -70,6 +70,7 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
     let contextualCommands: Command[] = []
     if (currentStreamId) {
       contextualCommands = isDraftId(currentStreamId) ? draftStreamCommands : streamCommands
+      contextualCommands = contextualCommands.filter((c) => c.id !== "stream-open-aside" || !!commandContext.openAside)
     }
     const contextualGroup = currentStreamName ? `This stream — ${currentStreamName}` : "This stream"
     // Groups render in section order, not by score, so they are ranked

--- a/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
+++ b/apps/frontend/src/components/quick-switcher/use-stream-items.tsx
@@ -7,6 +7,9 @@ import { streamLabel, STREAM_ICONS } from "@/lib/streams"
 import { streamsApi } from "@/api"
 import { createDmDraftId, useUnreadCounts, useActivityCounts } from "@/hooks"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
+import { openAside, rememberedAsideSurface } from "@/stores/aside-store"
+import { resolveAsideOpenSurface } from "@/lib/aside/surface"
+import { isCallDocked } from "@/components/aside/use-call-docked"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
@@ -190,7 +193,10 @@ export function useStreamItems(context: ModeContext): ModeResult {
       mentionCount,
       urgency,
     }: (typeof enriched)[number]): QuickSwitcherItem => {
-      const href = `/w/${workspaceId}/s/${stream.id}`
+      // An aside is never a page: selecting one lands on its host and opens the
+      // surface there, the way its anchor row does.
+      const asideHost = stream.type === StreamTypes.ASIDE ? stream.parentStreamId : null
+      const href = `/w/${workspaceId}/s/${asideHost ?? stream.id}`
       const isArchived = stream.archivedAt != null
       const typeLabel = getStreamTypeLabel(stream.type)
       const notJoined = !memberStreamIds.has(stream.id) && stream.visibility === "public"
@@ -214,6 +220,17 @@ export function useStreamItems(context: ModeContext): ModeResult {
         href,
         onSelect: () => {
           closeDialog()
+          if (asideHost) {
+            openAside({
+              hostKey: href,
+              hostStreamId: asideHost,
+              asideId: stream.id,
+              surface: resolveAsideOpenSurface({
+                remembered: rememberedAsideSurface(stream.id),
+                callDocked: isCallDocked(),
+              }),
+            })
+          }
           navigate(href)
         },
         urgency,

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
 import { StreamTypes, type StreamEvent } from "@threa/types"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as eventItemModule from "./event-item"
 import { spyOnExport } from "@/test"
+import { getAsideState, openAside, resetAsideStoreCache, setAsideSurface, closeAside } from "@/stores/aside-store"
 import { createMockStream } from "@/test/fixtures"
 import { groupTimelineItems, TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
 
 const CREATOR = "usr_creator"
 const OTHER = "usr_other"
 const ASIDE = "stream_aside_1"
+const HOST_PATH = "/w/ws_1/s/stream_host"
 
 const aside = createMockStream({
   id: ASIDE,
@@ -53,13 +56,13 @@ const ctx: TimelineItemRenderContext = {
 function renderTimeline(events: StreamEvent[], viewerId: string) {
   const items = groupTimelineItems(events, viewerId)
   return render(
-    <>
+    <MemoryRouter initialEntries={[HOST_PATH]}>
       {items.map((item, index) => (
         <div key={index} data-testid={`item-${index}`}>
           <TimelineItemContent item={item} ctx={ctx} deferSecondaryHydration={false} />
         </div>
       ))}
-    </>
+    </MemoryRouter>
   )
 }
 
@@ -79,13 +82,14 @@ function cardEvent(id: string, sequence: string): StreamEvent {
 }
 
 beforeEach(() => {
+  resetAsideStoreCache()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([aside] as never)
 })
 
 afterEach(() => vi.restoreAllMocks())
 
 describe("AsideAnchorEvent", () => {
-  it("renders the creator's row: title joined from the aside stream and age, no controls", () => {
+  it("renders the creator's row: title joined from the aside stream, age, and the resume control", () => {
     renderTimeline([anchorEvent()], CREATOR)
 
     const row = document.querySelector('[data-event-id="evt_aside"]')
@@ -93,7 +97,8 @@ describe("AsideAnchorEvent", () => {
     expect(row).toHaveTextContent("churn number sanity-check")
     expect(row).toHaveTextContent("9m ago")
     expect(row?.querySelector("[data-aside-id]")).toHaveAttribute("data-aside-id", ASIDE)
-    expect(screen.queryByRole("button")).toBeNull()
+    expect(row?.querySelector("[data-aside-id]")).toHaveAttribute("data-state", "closed")
+    expect(screen.getByRole("button", { name: "Resume" })).toHaveClass("opacity-0")
   })
 
   it("renders nothing for another viewer of the same host stream", () => {
@@ -140,5 +145,24 @@ describe("AsideAnchorEvent", () => {
     renderTimeline([anchorEvent()], CREATOR)
 
     expect(document.querySelector("[data-aside-id]")).toHaveTextContent("Aside")
+  })
+
+  it("resumes the aside on its host page, into the surface it was last read in, and reads as open", () => {
+    // A previous session on this aside ended in fullscreen; minimized never counts.
+    openAside({ hostKey: HOST_PATH, hostStreamId: "stream_host", asideId: ASIDE, surface: "fullscreen" })
+    setAsideSurface("minimized")
+    closeAside()
+    renderTimeline([anchorEvent()], CREATOR)
+
+    fireEvent.click(screen.getByRole("button", { name: "Resume" }))
+
+    expect(getAsideState()).toEqual({
+      hostKey: HOST_PATH,
+      hostStreamId: "stream_host",
+      asideId: ASIDE,
+      surface: "fullscreen",
+    })
+    expect(document.querySelector("[data-aside-id]")).toHaveAttribute("data-state", "open")
+    expect(document.querySelector("[data-sonner-toast]")).toBeNull()
   })
 })

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from "react"
 import { StreamTypes, type AsideAnchoredEventPayload, type StreamEvent } from "@threa/types"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useAsideState } from "@/stores/aside-store"
+import { useResumeAside } from "@/hooks/use-open-aside"
 import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { formatRelativeTime } from "@/lib/dates"
+import { cn } from "@/lib/utils"
 
 interface AsideAnchorEventProps {
   event: StreamEvent
@@ -12,22 +15,44 @@ interface AsideAnchorEventProps {
 /**
  * The creator-only trace of an aside in its host stream (`aside:anchored`).
  * Title and archived state are a live join against the cached aside stream row
- * (the event is immutable); an archived aside leaves no row.
+ * (the event is immutable); an archived aside leaves no row. The row is the
+ * resume handle: Resume reveals on hover/focus (opacity only, INV-21) and
+ * re-opens the aside in the surface it was last read in — silently (INV-63).
  */
 export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) {
   const payload = event.payload as AsideAnchoredEventPayload | undefined
   const asideId = payload?.asideId
   const streams = useWorkspaceStreams(workspaceId)
   const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
+  const open = useAsideState()
+  const resume = useResumeAside()
   if (!asideId || aside?.archivedAt) return null
 
+  const isOpen = open?.asideId === asideId
   const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
   const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
 
   return (
-    <div className="flex items-center gap-2 px-3 py-1 text-xs sm:px-6" data-aside-id={asideId}>
+    <div
+      className="group flex items-center gap-2 px-3 py-1 text-xs sm:px-6"
+      data-aside-id={asideId}
+      data-state={isOpen ? "open" : "closed"}
+    >
       <span className="min-w-0 shrink truncate text-primary">{title}</span>
-      <span aria-hidden className="h-px min-w-4 flex-1 bg-gradient-to-r from-primary/60 to-primary/10" />
+      <span
+        aria-hidden
+        className={cn(
+          "h-px min-w-4 flex-1 bg-gradient-to-r from-primary/60 to-primary/10 transition-opacity",
+          !isOpen && "opacity-70 group-hover:opacity-100"
+        )}
+      />
+      <button
+        type="button"
+        onClick={() => resume({ asideId, hostStreamId: event.streamId })}
+        className="shrink-0 rounded px-1 text-primary opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        Resume
+      </button>
       <span className="shrink-0 text-muted-foreground">{age}</span>
     </div>
   )

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -49,7 +49,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
       <button
         type="button"
         onClick={() => resume({ asideId, hostStreamId: event.streamId })}
-        className="shrink-0 rounded px-1 text-primary opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="shrink-0 rounded px-1 text-primary opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [@media(hover:none)]:opacity-100"
       >
         Resume
       </button>

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -21,6 +21,7 @@ import {
   GitBranch,
   FolderInput,
   Check,
+  MessageSquareDashed,
 } from "lucide-react"
 import { toast } from "sonner"
 import type { QuoteSelection } from "@/lib/quote-selection"
@@ -183,6 +184,8 @@ export interface MessageActionContext {
   onLabelMessage?: () => void
   /** Callback to start a private "Discuss with Ariadne" scratchpad seeded with this thread */
   onDiscussWithAriadne?: () => void | Promise<void>
+  /** Open a private aside anchored to this message. Set only on surfaces whose host can carry one. */
+  onOpenAside?: () => void
   /**
    * Callback to enter batch-select mode with this message preselected, so
    * the user can extend the selection or drop straight onto a target. The
@@ -435,6 +438,13 @@ export const messageActions: MessageAction[] = [
     icon: Sparkles,
     when: (ctx) => !!ctx.onDiscussWithAriadne && !!ctx.streamId,
     action: (ctx) => ctx.onDiscussWithAriadne?.(),
+  },
+  {
+    id: "open-aside",
+    label: "Open an aside here",
+    icon: MessageSquareDashed,
+    when: (ctx) => !!ctx.onOpenAside,
+    action: (ctx) => ctx.onOpenAside?.(),
   },
   {
     // Per-message entry into the move-to-thread flow. Mirrors the stream

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useRef, useEffect, useState, useMemo, useCallback } from "react"
 import {
+  isAsideHostType,
   isSentViaApi,
   LabelableResourceTypes,
   type StreamEvent,
@@ -64,6 +65,7 @@ import { SaveMessageButton } from "./save-message-button"
 import { ReminderPickerSheet } from "./reminder-picker-sheet"
 import { useSavedForMessage, useSaveMessage, useDeleteSaved } from "@/hooks/use-saved"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
+import { useOpenAside } from "@/hooks/use-open-aside"
 import { MessageActionDrawer } from "./message-action-drawer"
 import { isAgentTraceActor } from "./message-actions"
 import { ThreadSlot } from "./thread-slot"
@@ -1174,6 +1176,18 @@ function SentMessageEvent({
     [startDiscussWithAriadne, streamId, payload.messageId]
   )
 
+  // An aside anchors to this message in its host stream; the host must be a
+  // type an aside can sit in (the server enforces the same list), and never
+  // an E2E stream — there is no plaintext to snapshot. Fire-and-forget like
+  // discuss: the hook toasts on failure.
+  const openAside = useOpenAside(workspaceId)
+  const canOpenAside = isAsideHostType(currentStream?.type ?? "") && !e2eEnabled
+  const handleOpenAside = useCallback(() => {
+    void openAside({ kind: "stream", hostStreamId: streamId, anchorId: payload.messageId }).catch(() => {
+      /* toast already surfaced inside the hook */
+    })
+  }, [openAside, streamId, payload.messageId])
+
   // Shared action context for both desktop dropdown and mobile drawer
   const actionContext = useMemo(
     () => ({
@@ -1207,6 +1221,7 @@ function SentMessageEvent({
       onLabelMessage: () => setLabelPickerOpen(true),
       onRequestReminder: handleRequestReminder,
       onDiscussWithAriadne: handleDiscussWithAriadne,
+      onOpenAside: canOpenAside ? handleOpenAside : undefined,
       onQuoteReply: quoteReplyCtx
         ? () =>
             quoteReplyCtx.triggerQuoteReply({
@@ -1369,6 +1384,8 @@ function SentMessageEvent({
       location,
       isMobile,
       handleDiscussWithAriadne,
+      canOpenAside,
+      handleOpenAside,
       batch?.enabled,
       currentStream?.archivedAt,
       movedTombstoneEvent,

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1181,7 +1181,10 @@ function SentMessageEvent({
   // an E2E stream — there is no plaintext to snapshot. Fire-and-forget like
   // discuss: the hook toasts on failure.
   const openAside = useOpenAside(workspaceId)
-  const canOpenAside = isAsideHostType(currentStream?.type ?? "") && !e2eEnabled
+  // Archived hosts (directly or through the root) cannot open one — the aside
+  // would inherit the archive and the create path refuses it.
+  const hostArchived = !!currentStream?.archivedAt || !!rootStream?.archivedAt
+  const canOpenAside = isAsideHostType(currentStream?.type ?? "") && !e2eEnabled && !hostArchived
   const handleOpenAside = useCallback(() => {
     void openAside({ kind: "stream", hostStreamId: streamId, anchorId: payload.messageId }).catch(() => {
       /* toast already surfaced inside the hook */

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -10,6 +10,7 @@ import * as hooksModule from "@/hooks"
 import * as useAttachmentsModule from "@/hooks/use-attachments"
 import * as currentUserHook from "@/hooks/use-current-workspace-user-id"
 import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as openAsideModule from "@/hooks/use-open-aside"
 import * as authModule from "@/auth"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
 import * as conversationReplyModule from "./conversation-reply-context"
@@ -124,6 +125,9 @@ beforeEach(async () => {
     data: undefined,
   } as unknown as ReturnType<typeof hooksModule.useStreamBootstrap>)
   spyOnExport(streamCommandsModule, "useStreamCommands").mockReturnValue((() => []) as never)
+  // `/aside` in the composer creates a stream through the stream service, which
+  // these tests deliberately mount without a ServicesProvider.
+  spyOnExport(openAsideModule, "useOpenAside").mockReturnValue((async () => {}) as never)
   vi.spyOn(hooksModule, "useMentionStreamContext").mockReturnValue(
     undefined as unknown as ReturnType<typeof hooksModule.useMentionStreamContext>
   )

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -23,6 +23,7 @@ import * as composerModule from "@/components/composer"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
 import * as streamCommandsModule from "@/hooks/use-stream-commands"
+import * as openAsideModule from "@/hooks/use-open-aside"
 import { spyOnExport } from "@/test"
 import { toast } from "sonner"
 import { MessageInput, materializePendingAttachmentReferences } from "./message-input"
@@ -267,6 +268,10 @@ beforeEach(async () => {
   vi.spyOn(hooksModule, "useComposerHeightPublish").mockImplementation(
     () => undefined as unknown as ReturnType<typeof hooksModule.useComposerHeightPublish>
   )
+  // Same wrapper gap: `/aside` in the composer creates a stream through the
+  // stream service. Stub the opener; the aside entry points are covered by
+  // `use-composer-command-send` and the desktop browser spec.
+  spyOnExport(openAsideModule, "useOpenAside").mockReturnValue((async () => {}) as never)
   // The composer's schedule-send entry needs the scheduled service via
   // ServicesProvider; tests run without that wrapper, so stub the hook to a
   // no-op mutation. The schedule path itself is exercised by the page tests.

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -3698,6 +3698,7 @@ function TimelineMessageList({
         className={cn("h-full overflow-y-auto overflow-x-hidden overscroll-y-contain", batch?.enabled && "select-none")}
         style={{ overflowAnchor: "none" }}
         data-suppress-pull-refresh="true"
+        data-stream-scroller={streamId}
         onScroll={handleScroll}
         {...batchPointerHandlers}
       >

--- a/apps/frontend/src/hooks/use-effective-archived.test.ts
+++ b/apps/frontend/src/hooks/use-effective-archived.test.ts
@@ -122,4 +122,55 @@ describe("useEffectiveArchived", () => {
     )
     expect(result.current.rootArchived).toBe(true)
   })
+
+  describe("aside host inheritance (twin of write-authority)", () => {
+    function seedRows(rows: Record<string, Partial<CachedStream>>) {
+      vi.spyOn(streamStore, "useStreamFromStore").mockImplementation(
+        (id) => (id ? (rows[id] as CachedStream | undefined) : undefined) as CachedStream | undefined
+      )
+    }
+    const aside = { archivedAt: null, type: "aside", parentStreamId: "stream_host" }
+
+    it("should seal an aside when its host is archived", () => {
+      seedRows({ stream_host: { id: "stream_host", rootStreamId: null, archivedAt: "2026-01-01T00:00:00.000Z" } })
+      const { result } = renderHook(() =>
+        useEffectiveArchived({ stream: aside, rootStreamId: null, fallbackRootArchived: false })
+      )
+      expect(result.current).toEqual({ ownArchived: false, rootArchived: true, isArchived: true })
+    })
+
+    it("should seal an aside on a thread whose root is archived", () => {
+      seedRows({
+        stream_host: { id: "stream_host", rootStreamId: "stream_root", archivedAt: null },
+        stream_root: { id: "stream_root", rootStreamId: null, archivedAt: "2026-01-01T00:00:00.000Z" },
+      })
+      const { result } = renderHook(() =>
+        useEffectiveArchived({ stream: aside, rootStreamId: null, fallbackRootArchived: false })
+      )
+      expect(result.current).toEqual({ ownArchived: false, rootArchived: true, isArchived: true })
+    })
+
+    it("should leave an aside writable while its host chain is live", () => {
+      seedRows({
+        stream_host: { id: "stream_host", rootStreamId: "stream_root", archivedAt: null },
+        stream_root: { id: "stream_root", rootStreamId: null, archivedAt: null },
+      })
+      const { result } = renderHook(() =>
+        useEffectiveArchived({ stream: aside, rootStreamId: null, fallbackRootArchived: false })
+      )
+      expect(result.current).toEqual({ ownArchived: false, rootArchived: false, isArchived: false })
+    })
+
+    it("should not read a non-aside's parent as a host", () => {
+      seedRows({ stream_host: { id: "stream_host", rootStreamId: null, archivedAt: "2026-01-01T00:00:00.000Z" } })
+      const { result } = renderHook(() =>
+        useEffectiveArchived({
+          stream: { archivedAt: null, type: "thread", parentStreamId: "stream_host" },
+          rootStreamId: null,
+          fallbackRootArchived: false,
+        })
+      )
+      expect(result.current).toEqual({ ownArchived: false, rootArchived: false, isArchived: false })
+    })
+  })
 })

--- a/apps/frontend/src/hooks/use-effective-archived.ts
+++ b/apps/frontend/src/hooks/use-effective-archived.ts
@@ -1,8 +1,13 @@
+import { StreamTypes } from "@threa/types"
 import { useStreamFromStore } from "@/stores/stream-store"
 
 export interface EffectiveArchivedInput {
-  /** The anchor stream row (its own `archivedAt` seals the surface directly). */
-  stream: { archivedAt?: string | null } | null | undefined
+  /**
+   * The anchor stream row (its own `archivedAt` seals the surface directly).
+   * An aside also carries its host pointer: it is a root of its own, so the
+   * host chain is read off `type` + `parentStreamId` rather than the root.
+   */
+  stream: { archivedAt?: string | null; type?: string; parentStreamId?: string | null } | null | undefined
   /** The root to inherit from (INV-62), or null when the anchor IS the root. */
   rootStreamId: string | null | undefined
   /**
@@ -23,7 +28,7 @@ export interface EffectiveArchivedInput {
 export interface EffectiveArchived {
   /** The anchor stream itself is archived. */
   ownArchived: boolean
-  /** The root this surface inherits from is archived. */
+  /** The lineage this surface inherits from is archived: its root, or for an aside its host chain. */
   rootArchived: boolean
   isArchived: boolean
 }
@@ -51,6 +56,10 @@ export interface EffectiveArchived {
  * The two absences ("root active" vs "root unknown") must NOT be merged — that
  * collapses them and lets a stale fallback win after unarchive, which was the
  * flicker/rapid-toggle bug.
+ *
+ * An aside is the twin of the backend's write-authority rule: it is a root of
+ * its own, so root archival never covers its host — the host (parent) and the
+ * host's root are read from the store and an archived one seals the aside.
  */
 export function useEffectiveArchived({
   stream,
@@ -59,6 +68,9 @@ export function useEffectiveArchived({
   fallbackRootArchived,
 }: EffectiveArchivedInput): EffectiveArchived {
   const selfResolvedRoot = useStreamFromStore(rootStream === undefined ? (rootStreamId ?? undefined) : undefined)
+  const asideHostId = stream?.type === StreamTypes.ASIDE ? (stream.parentStreamId ?? undefined) : undefined
+  const asideHost = useStreamFromStore(asideHostId)
+  const asideHostRoot = useStreamFromStore(asideHost?.rootStreamId ?? undefined)
   const rootRow = rootStream === undefined ? selfResolvedRoot : rootStream
   const fallbackArchived = fallbackRootArchived != null && fallbackRootArchived !== false
   let rootArchived = false
@@ -66,6 +78,9 @@ export function useEffectiveArchived({
     rootArchived = rootRow ? rootRow.archivedAt != null : fallbackArchived
   } else if (!stream) {
     rootArchived = fallbackArchived
+  }
+  if (asideHostId) {
+    rootArchived = rootArchived || asideHost?.archivedAt != null || asideHostRoot?.archivedAt != null
   }
   const ownArchived = stream?.archivedAt != null
   return { ownArchived, rootArchived, isArchived: ownArchived || rootArchived }

--- a/apps/frontend/src/hooks/use-open-aside.test.tsx
+++ b/apps/frontend/src/hooks/use-open-aside.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import type { ReactNode } from "react"
+import { spyOnExport } from "@/test"
+import * as streamsModule from "./use-streams"
+import { getAsideState, resetAsideStoreCache } from "@/stores/aside-store"
+import { useOpenAside } from "./use-open-aside"
+
+const HOST_PATH = "/w/ws_1/s/stream_host"
+
+function wrapper(children: ReactNode) {
+  return (
+    <MemoryRouter initialEntries={[HOST_PATH]}>
+      <Routes>
+        <Route path="/w/:workspaceId/s/:streamId" element={<>{children}</>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+let resolveCreate: (stream: { id: string }) => void
+let mutateAsync: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  resetAsideStoreCache()
+  mutateAsync = vi.fn(
+    () =>
+      new Promise<{ id: string }>((resolve) => {
+        resolveCreate = resolve
+      })
+  )
+  // `spyOnExport` replaces the module getter, so the value IS the hook.
+  spyOnExport(streamsModule, "useCreateStream").mockReturnValue((() => ({ mutateAsync })) as never)
+})
+
+describe("useOpenAside", () => {
+  it("shows the surface when the create lands while its host is still mounted", async () => {
+    const { result } = renderHook(() => useOpenAside("ws_1"), { wrapper: ({ children }) => wrapper(children) })
+
+    const opening = result.current({ kind: "stream", hostStreamId: "stream_host" })
+    resolveCreate({ id: "stream_aside" })
+    await opening
+
+    expect(getAsideState()).toMatchObject({ hostKey: HOST_PATH, asideId: "stream_aside", surface: "dock" })
+  })
+
+  it("drops a create that lands after its host is gone, so it cannot resurface on return", async () => {
+    const { result, unmount } = renderHook(() => useOpenAside("ws_1"), { wrapper: ({ children }) => wrapper(children) })
+
+    const opening = result.current({ kind: "stream", hostStreamId: "stream_host" })
+    unmount()
+    resolveCreate({ id: "stream_aside" })
+    await opening
+
+    expect(getAsideState()).toBeNull()
+  })
+})

--- a/apps/frontend/src/hooks/use-open-aside.ts
+++ b/apps/frontend/src/hooks/use-open-aside.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { useLocation } from "react-router-dom"
 import { toast } from "sonner"
 import { ContextRefKinds, StreamTypes, type ContextRef } from "@threa/types"
@@ -48,6 +48,18 @@ function buildOriginRefs(origin: AsideOrigin): ContextRef[] {
 export function useOpenAside(workspaceId: string) {
   const createStream = useCreateStream(workspaceId)
   const { pathname: hostKey } = useLocation()
+  // The create is a round trip; the page can be left (or the account switched)
+  // before it lands. Writing the surface then would strand an aside on a host
+  // that is gone — `dropAsideForHost` already ran against an empty store — and
+  // it would reappear on returning to that path. The ref is the page's own
+  // liveness: null once this host is no longer mounted.
+  const mountedHostKey = useRef<string | null>(hostKey)
+  useEffect(() => {
+    mountedHostKey.current = hostKey
+    return () => {
+      mountedHostKey.current = null
+    }
+  }, [hostKey])
 
   return useCallback(
     async (origin: AsideOrigin) => {
@@ -65,6 +77,7 @@ export function useOpenAside(workspaceId: string) {
         toast.error("Couldn't open an aside. Please try again.")
         throw err
       }
+      if (mountedHostKey.current !== hostKey) return
       openAside({
         hostKey,
         hostStreamId: origin.hostStreamId,

--- a/apps/frontend/src/hooks/use-open-aside.ts
+++ b/apps/frontend/src/hooks/use-open-aside.ts
@@ -1,0 +1,96 @@
+import { useCallback } from "react"
+import { useLocation } from "react-router-dom"
+import { toast } from "sonner"
+import { ContextRefKinds, StreamTypes, type ContextRef } from "@threa/types"
+import { useCreateStream } from "./use-streams"
+import { buildAsideBag, buildViewportRef } from "@/lib/aside/snapshot"
+import { resolveAsideOpenSurface } from "@/lib/aside/surface"
+import { openAside, rememberedAsideSurface } from "@/stores/aside-store"
+import { isCallDocked } from "@/components/aside/use-call-docked"
+
+/**
+ * Where an aside is opened from. A timeline surface (channel, DM, scratchpad,
+ * thread panel) snapshots what the host scroller shows; a conversation surface
+ * (board card, conversation panel) passes the conversation itself, which the
+ * resolver already expands end to end.
+ */
+export type AsideOrigin =
+  | { kind: "stream"; hostStreamId: string; anchorId?: string }
+  | { kind: "conversation"; hostStreamId: string; conversationId: string; anchorId?: string }
+
+/** The scroller of the host stream's mounted timeline (`StreamContent` stamps it), if any. */
+function findStreamScroller(streamId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-stream-scroller="${streamId}"]`)
+}
+
+function buildOriginRefs(origin: AsideOrigin): ContextRef[] {
+  if (origin.kind === "conversation") {
+    return [
+      {
+        kind: ContextRefKinds.CONVERSATION,
+        conversationId: origin.conversationId,
+        streamId: origin.hostStreamId,
+        originMessageId: origin.anchorId,
+      },
+    ]
+  }
+  const scroller = findStreamScroller(origin.hostStreamId)
+  const ref = scroller ? buildViewportRef(scroller, origin.hostStreamId) : null
+  return ref ? [ref] : []
+}
+
+/**
+ * Open a new aside on the current page: create the aside stream (viewport
+ * captured once, here, before the create call) and show it in the surface it
+ * belongs in. Auto-titled by the backend naming path, so no `displayName`.
+ * Creation failure toasts (the one loud signal); success is the surface itself.
+ */
+export function useOpenAside(workspaceId: string) {
+  const createStream = useCreateStream(workspaceId)
+  const { pathname: hostKey } = useLocation()
+
+  return useCallback(
+    async (origin: AsideOrigin) => {
+      const refs = buildOriginRefs(origin)
+      let aside
+      try {
+        aside = await createStream.mutateAsync({
+          type: StreamTypes.ASIDE,
+          parentStreamId: origin.hostStreamId,
+          parentAnchorId: origin.anchorId,
+          ...(origin.kind === "conversation" && { conversationId: origin.conversationId }),
+          ...(refs.length > 0 && { contextBag: buildAsideBag(refs) }),
+        })
+      } catch (err) {
+        toast.error("Couldn't open an aside. Please try again.")
+        throw err
+      }
+      openAside({
+        hostKey,
+        hostStreamId: origin.hostStreamId,
+        asideId: aside.id,
+        surface: resolveAsideOpenSurface({ remembered: null, callDocked: isCallDocked() }),
+      })
+    },
+    [createStream, hostKey]
+  )
+}
+
+/** Re-open an existing aside from its anchor row, into the surface it was last read in. */
+export function useResumeAside() {
+  const { pathname: hostKey } = useLocation()
+  return useCallback(
+    (params: { asideId: string; hostStreamId: string }) => {
+      openAside({
+        hostKey,
+        hostStreamId: params.hostStreamId,
+        asideId: params.asideId,
+        surface: resolveAsideOpenSurface({
+          remembered: rememberedAsideSurface(params.asideId),
+          callDocked: isCallDocked(),
+        }),
+      })
+    },
+    [hostKey]
+  )
+}

--- a/apps/frontend/src/lib/aside/surface.test.ts
+++ b/apps/frontend/src/lib/aside/surface.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { resolveAsideOpenSurface, resolveAsideRestoreSurface } from "./surface"
+
+describe("aside surface resolution", () => {
+  it("should open into the remembered reading surface, docking by default", () => {
+    expect([
+      resolveAsideOpenSurface({ remembered: null, callDocked: false }),
+      resolveAsideOpenSurface({ remembered: "fullscreen", callDocked: false }),
+      resolveAsideOpenSurface({ remembered: "dock", callDocked: false }),
+    ]).toEqual(["dock", "fullscreen", "dock"])
+  })
+
+  it("should yield the right edge to a docked call: dock opens minimized, restores fullscreen", () => {
+    expect([
+      resolveAsideOpenSurface({ remembered: null, callDocked: true }),
+      resolveAsideOpenSurface({ remembered: "fullscreen", callDocked: true }),
+      resolveAsideRestoreSurface({ remembered: null, callDocked: true }),
+      resolveAsideRestoreSurface({ remembered: "dock", callDocked: false }),
+    ]).toEqual(["minimized", "fullscreen", "fullscreen", "dock"])
+  })
+})

--- a/apps/frontend/src/lib/aside/surface.ts
+++ b/apps/frontend/src/lib/aside/surface.ts
@@ -1,0 +1,25 @@
+import type { AsideSurface } from "@/stores/aside-store"
+
+/**
+ * The surface an aside opens into. Calls own the right edge: while a call is
+ * docked there, an aside that would dock opens minimized (the strip above the
+ * composer) instead, and an explicit open from the strip goes fullscreen.
+ */
+export function resolveAsideOpenSurface(params: {
+  remembered: Exclude<AsideSurface, "minimized"> | null
+  callDocked: boolean
+}): AsideSurface {
+  const wanted = params.remembered ?? "dock"
+  if (wanted === "dock" && params.callDocked) return "minimized"
+  return wanted
+}
+
+/** The surface a minimized aside restores into. */
+export function resolveAsideRestoreSurface(params: {
+  remembered: Exclude<AsideSurface, "minimized"> | null
+  callDocked: boolean
+}): Exclude<AsideSurface, "minimized"> {
+  const wanted = params.remembered ?? "dock"
+  if (wanted === "dock" && params.callDocked) return "fullscreen"
+  return wanted
+}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, ArrowLeft, LayoutGrid, PenLine } from "lucide-react"
 import { Link, Navigate, useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { ThreadPanelSlot, panelTakeoverClasses } from "@/components/layout"
+import { AsideDockSlot, AsideMinimizedStrip, useAsideHost } from "@/components/aside"
 import { PanelHost } from "@/components/layout/panel-host"
 import { SidebarToggle } from "@/components/layout/sidebar-toggle"
 import { usePanel, usePreferencesOptional, useSidebar } from "@/contexts"
@@ -200,6 +201,7 @@ export function BoardPage() {
 
 function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: BoardLens }) {
   useTypeToFocus()
+  const asideHostKey = useAsideHost()
   const { isMobile } = useSidebar()
   const { isPanelOpen, closePanel } = usePanel()
   // The board's filters live in the URL (INV-59) — six params, three dimensions
@@ -968,6 +970,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
             </main>
           </div>
         </FloatingComposerAnchorProvider>
+        <AsideMinimizedStrip workspaceId={workspaceId} hostKey={asideHostKey} />
         {/* Floating compose button — always reachable (doesn't scroll with the
             feed), bottom-right. Flat solid accent + a restrained warm shadow, per
             Threa's Button language (no gradient/gloss). On a pointer it expands to
@@ -1032,6 +1035,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
           <PanelHost workspaceId={workspaceId} onClose={closePanel} />
         </ThreadPanelSlot>
       )}
+      <AsideDockSlot workspaceId={workspaceId} hostKey={asideHostKey} />
     </div>
   )
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -57,6 +57,7 @@ import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { CallStartMenu, RejoinBar } from "@/components/call"
 import { ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle, StreamTitlePreview, panelTakeoverClasses } from "@/components/layout"
+import { AsideDockSlot, AsideMinimizedStrip, useAsideHost } from "@/components/aside"
 import { PanelHost } from "@/components/layout/panel-host"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { ConversationList } from "@/components/conversations"
@@ -94,6 +95,7 @@ export function StreamPage() {
     handleResizeKeyDown,
     handleTransitionEnd,
   } = usePanelLayout(isPanelOpen)
+  const asideHostKey = useAsideHost()
 
   useTypeToFocus()
 
@@ -855,6 +857,7 @@ export function StreamPage() {
           <StreamEncryptionGate workspaceId={workspaceId} encrypted={isEncryptedScratchpad && !isDraft}>
             <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
           </StreamEncryptionGate>
+          <AsideMinimizedStrip workspaceId={workspaceId} hostKey={asideHostKey} />
         </main>
         {stream && !isDraft && (
           <LabelPicker
@@ -966,6 +969,7 @@ export function StreamPage() {
             <PanelHost key={panelId} workspaceId={workspaceId} onClose={closePanel} />
           </ThreadPanelSlot>
         )}
+        <AsideDockSlot workspaceId={workspaceId} hostKey={asideHostKey} />
       </div>
       {/* Both are `fixed` overlays that would paint over a fullscreen panel, so a
           takeover keeps them out of the tree entirely rather than merely closed —

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -66,6 +66,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { SyncEngine, SyncEngineContext, isSyncEngineCurrent } from "@/sync/sync-engine"
 import { ReadCommitQueue, ReadCommitQueueContext } from "@/sync/read-commit-queue"
 import { useUnreadCounts } from "@/hooks/use-unread-counts"
+import { useOpenAside } from "@/hooks/use-open-aside"
 import { draftsApi, messagesApi, syncApi } from "@/api"
 import { QuickSwitcher, type QuickSwitcherMode } from "@/components/quick-switcher"
 import { ComposeOverlayMount } from "@/components/board/compose-overlay-mount"
@@ -450,6 +451,11 @@ export function WorkspaceLayout() {
   const [switcherOpen, setSwitcherOpen] = useState(false)
   const [switcherMode, setSwitcherMode] = useState<QuickSwitcherMode>("stream")
   const { user, loading: authLoading } = useAuth()
+  const openAside = useOpenAside(workspaceId ?? "")
+  const openAsideOnStream = useCallback(
+    (streamId: string) => openAside({ kind: "stream", hostStreamId: streamId }),
+    [openAside]
+  )
 
   // Extract streamId from nested route (if on /s/:streamId)
   const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
@@ -549,6 +555,7 @@ export function WorkspaceLayout() {
                                                   onOpenChange={setSwitcherOpen}
                                                   initialMode={switcherMode}
                                                   currentStreamId={streamId}
+                                                  openAside={openAsideOnStream}
                                                 />
                                                 <ComposeOverlayMount workspaceId={workspaceId} />
                                               </SearchPanelProvider>

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useSyncExternalStore,
+  type ComponentProps,
   type ReactNode,
 } from "react"
 import { Outlet, useParams, useSearchParams, useMatch, Navigate } from "react-router-dom"
@@ -445,17 +446,26 @@ function MentionableWrapper({ children, mentionables }: Omit<MentionableMarkdown
   )
 }
 
+/**
+ * The palette with the aside opener bound. The opener creates a stream, so it
+ * needs the services and sync providers the layout mounts below — hence a
+ * sibling of the palette inside them, not a hook on the layout itself.
+ */
+function WorkspaceQuickSwitcher(props: Omit<ComponentProps<typeof QuickSwitcher>, "openAside">) {
+  const openAside = useOpenAside(props.workspaceId)
+  const openAsideOnStream = useCallback(
+    (streamId: string) => openAside({ kind: "stream", hostStreamId: streamId }),
+    [openAside]
+  )
+  return <QuickSwitcher {...props} openAside={openAsideOnStream} />
+}
+
 export function WorkspaceLayout() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const [searchParams] = useSearchParams()
   const [switcherOpen, setSwitcherOpen] = useState(false)
   const [switcherMode, setSwitcherMode] = useState<QuickSwitcherMode>("stream")
   const { user, loading: authLoading } = useAuth()
-  const openAside = useOpenAside(workspaceId ?? "")
-  const openAsideOnStream = useCallback(
-    (streamId: string) => openAside({ kind: "stream", hostStreamId: streamId }),
-    [openAside]
-  )
 
   // Extract streamId from nested route (if on /s/:streamId)
   const streamMatch = useMatch("/w/:workspaceId/s/:streamId")
@@ -549,13 +559,12 @@ export function WorkspaceLayout() {
                                                     </MainContentGate>
                                                   </AppShell>
                                                 </CoordinatedLoadingGate>
-                                                <QuickSwitcher
+                                                <WorkspaceQuickSwitcher
                                                   workspaceId={workspaceId}
                                                   open={switcherOpen}
                                                   onOpenChange={setSwitcherOpen}
                                                   initialMode={switcherMode}
                                                   currentStreamId={streamId}
-                                                  openAside={openAsideOnStream}
                                                 />
                                                 <ComposeOverlayMount workspaceId={workspaceId} />
                                               </SearchPanelProvider>

--- a/apps/frontend/src/stores/aside-store.test.ts
+++ b/apps/frontend/src/stores/aside-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { renderHook, act } from "@testing-library/react"
+import {
+  closeAside,
+  dropAsideForHost,
+  getAsideState,
+  openAside,
+  rememberedAsideSurface,
+  resetAsideStoreCache,
+  setAsideSurface,
+  useAsideForHost,
+} from "./aside-store"
+
+const ACCOUNT_SCOPE = resolve(dirname(fileURLToPath(import.meta.url)), "../auth/account-scope.tsx")
+
+const open = {
+  hostKey: "/w/ws_1/s/stream_host",
+  hostStreamId: "stream_host",
+  asideId: "stream_aside",
+  surface: "dock",
+} as const
+
+beforeEach(() => resetAsideStoreCache())
+
+describe("aside-store", () => {
+  it("should expose the open aside to its host page only", () => {
+    const host = renderHook(() => useAsideForHost(open.hostKey))
+    const other = renderHook(() => useAsideForHost("/w/ws_1/s/stream_other"))
+
+    act(() => openAside(open))
+
+    expect(host.result.current).toEqual(open)
+    expect(other.result.current).toBeNull()
+  })
+
+  it("should drop the surface when its host page unmounts and ignore other hosts", () => {
+    openAside(open)
+    dropAsideForHost("/w/ws_1/s/stream_other")
+    expect(getAsideState()).toEqual(open)
+
+    dropAsideForHost(open.hostKey)
+    expect(getAsideState()).toBeNull()
+  })
+
+  it("should remember the last reading surface, never minimized, for resume", () => {
+    openAside(open)
+    setAsideSurface("fullscreen")
+    setAsideSurface("minimized")
+    expect(getAsideState()).toEqual({ ...open, surface: "minimized" })
+    expect(rememberedAsideSurface(open.asideId)).toBe("fullscreen")
+
+    closeAside()
+    expect(getAsideState()).toBeNull()
+    expect(rememberedAsideSurface(open.asideId)).toBe("fullscreen")
+    expect(rememberedAsideSurface("stream_never")).toBeNull()
+  })
+
+  it("should forget everything on an account switch", () => {
+    openAside(open)
+    resetAsideStoreCache()
+    expect(getAsideState()).toBeNull()
+    expect(rememberedAsideSurface(open.asideId)).toBeNull()
+  })
+
+  it("registration guard: account-scope flushes the aside store cache", () => {
+    const source = readFileSync(ACCOUNT_SCOPE, "utf8")
+    const flushBody = source.slice(source.indexOf("function flushModuleStoreCaches"))
+    expect(flushBody).toContain("resetAsideStoreCache()")
+  })
+})

--- a/apps/frontend/src/stores/aside-store.ts
+++ b/apps/frontend/src/stores/aside-store.ts
@@ -1,0 +1,100 @@
+import { useSyncExternalStore } from "react"
+
+/**
+ * Module store for the one aside surface open on the current page. An aside is
+ * stream-bound: the state is keyed by the host page (`hostKey`, the route
+ * pathname) and the page's surface mount drops it on unmount, so navigating
+ * away leaves no aside chrome anywhere else by construction and coming back
+ * restores nothing — the anchor row is the way back in.
+ *
+ * INV-59 exemption, the call dock's shape (`call-dock.tsx`): which aside is
+ * open and in what surface is transient view state that must NOT survive a
+ * refresh or a shared link (a private aside re-opening from a URL would leak
+ * its existence into the address bar), so it lives here, never in `?panel=`.
+ * Registered in `flushModuleStoreCaches` (account-scope.tsx) like every
+ * sibling store.
+ */
+
+export type AsideSurface = "dock" | "fullscreen" | "minimized"
+
+export interface OpenAsideState {
+  /** The page hosting the surface — `useLocation().pathname`. */
+  hostKey: string
+  hostStreamId: string
+  asideId: string
+  surface: AsideSurface
+}
+
+let state: OpenAsideState | null = null
+const listeners = new Set<() => void>()
+// Resume re-enters the surface the aside was last read in. Minimized is a
+// parked state, not a reading surface, so it never becomes the remembered one.
+const lastReadingSurfaceByAside = new Map<string, Exclude<AsideSurface, "minimized">>()
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+function setState(next: OpenAsideState | null): void {
+  state = next
+  emit()
+}
+
+function remember(asideId: string, surface: AsideSurface): void {
+  if (surface !== "minimized") lastReadingSurfaceByAside.set(asideId, surface)
+}
+
+export function getAsideState(): OpenAsideState | null {
+  return state
+}
+
+/** The surface an aside was last read in, for resume; null for a never-opened aside. */
+export function rememberedAsideSurface(asideId: string): Exclude<AsideSurface, "minimized"> | null {
+  return lastReadingSurfaceByAside.get(asideId) ?? null
+}
+
+export function openAside(next: OpenAsideState): void {
+  remember(next.asideId, next.surface)
+  setState(next)
+}
+
+export function setAsideSurface(surface: AsideSurface): void {
+  if (!state || state.surface === surface) return
+  remember(state.asideId, surface)
+  setState({ ...state, surface })
+}
+
+export function closeAside(): void {
+  if (!state) return
+  setState(null)
+}
+
+/** Drop the surface when its host page goes away; a no-op for any other host. */
+export function dropAsideForHost(hostKey: string): void {
+  if (state?.hostKey !== hostKey) return
+  setState(null)
+}
+
+export function resetAsideStoreCache(): void {
+  lastReadingSurfaceByAside.clear()
+  setState(null)
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function useAsideState(): OpenAsideState | null {
+  return useSyncExternalStore(
+    subscribe,
+    () => state,
+    () => state
+  )
+}
+
+/** The aside open on `hostKey`'s page, or null. */
+export function useAsideForHost(hostKey: string): OpenAsideState | null {
+  const current = useAsideState()
+  return current?.hostKey === hostKey ? current : null
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -67,6 +67,11 @@ interface CreateStreamInputBase {
    * or `event_…` (card). The one anchor track. Required for `type: "thread"`.
    */
   parentAnchorId?: string
+  /**
+   * Aside only: the conversation it was opened from (board card / conversation
+   * panel). Must belong to `parentStreamId`.
+   */
+  conversationId?: string
   memberIds?: string[]
   /** Context bag attached to a new scratchpad (triggers summary pre-compute). */
   contextBag?: ContextBag

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -35,6 +35,23 @@ export type SharedSourceStreamKind = (typeof SHARED_SOURCE_STREAM_KINDS)[number]
 
 export const DM_PARTICIPANT_COUNT = 2
 
+/**
+ * Stream types an aside may anchor to: no aside-on-aside, no system hosts.
+ * The create path, slash-command availability and the client entry points
+ * all read this one list.
+ */
+export const ASIDE_HOST_STREAM_TYPES = [
+  "channel",
+  "dm",
+  "scratchpad",
+  "thread",
+] as const satisfies readonly StreamType[]
+export type AsideHostStreamType = (typeof ASIDE_HOST_STREAM_TYPES)[number]
+
+export function isAsideHostType(type: string): type is AsideHostStreamType {
+  return (ASIDE_HOST_STREAM_TYPES as readonly string[]).includes(type)
+}
+
 export const STREAM_READ_ONLY_REASONS = ["archived", "system_stream", "not_a_member"] as const
 export type StreamReadOnlyReason = (typeof STREAM_READ_ONLY_REASONS)[number]
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,6 +40,9 @@ export {
   SHARED_SOURCE_STREAM_KINDS,
   type SharedSourceStreamKind,
   DM_PARTICIPANT_COUNT,
+  ASIDE_HOST_STREAM_TYPES,
+  type AsideHostStreamType,
+  isAsideHostType,
   STREAM_READ_ONLY_REASONS,
   type StreamReadOnlyReason,
   StreamReadOnlyReasons,
@@ -764,6 +767,9 @@ export { draftStreamScope, draftThreadScope, MAX_DRAFTS_PER_USER, MAX_SEARCH_PHR
 
 // Discuss-with-Ariadne client-action id (single source of truth)
 export const DISCUSS_WITH_ARIADNE_COMMAND = "discuss-with-ariadne" as const
+
+// Open-an-aside client-action id (single source of truth)
+export const ASIDE_COMMAND = "aside" as const
 
 /**
  * Persona slug for Ariadne — the workspace-companion persona that backs

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -90,11 +90,11 @@ async function settledScrollMetrics(
   return previous
 }
 
-async function openAsideFromMessage(page: Page, streamId: string, prefix: string, num: number): Promise<void> {
+async function openMessageActions(page: Page, streamId: string, prefix: string, num: number): Promise<void> {
   const row = hostRow(page, streamId, prefix, num)
   await row.hover()
   await row.getByRole("button", { name: /message actions/i }).click()
-  await page.getByRole("menuitem", { name: "Open an aside here" }).click()
+  await expect(page.getByRole("menuitem", { name: "Open an aside here" })).toBeVisible()
 }
 
 const dock = (page: Page) => page.getByTestId("aside-dock")
@@ -149,13 +149,17 @@ test.describe("Aside — desktop surface", () => {
         { timeout: 15000 }
       )
       .toBeLessThan(MESSAGE_COUNT - 8)
-    // Settle before the baseline: virtua re-measures after a wheel, and under CI
-    // load that can still be moving 300ms later — a baseline caught mid-settle
-    // reads as an aside-caused shift below, which is the opposite of the claim.
+    const anchorNum = (await settledScrollMetrics(page, streamId)).topNum
+    expect(anchorNum).not.toBeNull()
+
+    // Baseline with the row's menu already open: Playwright's hover/click
+    // scrolls a partially clipped actions toolbar into view (Chromium centres
+    // it, ~260px), which is the driver's doing, not the surface's. Everything
+    // from the menu item click on is the aside's.
+    await openMessageActions(page, streamId, prefix, anchorNum! + 1)
     const before = await settledScrollMetrics(page, streamId)
     expect(before.topNum).not.toBeNull()
-
-    await openAsideFromMessage(page, streamId, prefix, before.topNum! + 1)
+    await page.getByRole("menuitem", { name: "Open an aside here" }).click()
 
     await expect(dock(page)).toHaveAttribute("data-surface", "dock", { timeout: 15000 })
     await expect(pane(page)).toBeVisible()

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -54,10 +54,13 @@ function hostRow(page: Page, streamId: string, prefix: string, num: number): Loc
     .first()
 }
 
-async function scrollMetrics(page: Page, streamId: string): Promise<{ scrollTop: number; topNum: number | null }> {
+async function scrollMetrics(
+  page: Page,
+  streamId: string
+): Promise<{ scrollTop: number; topNum: number | null; fromBottom: number }> {
   return page.evaluate((id) => {
     const scroller = document.querySelector(`[data-stream-scroller="${id}"]`)
-    if (!(scroller instanceof HTMLElement)) return { scrollTop: -1, topNum: null }
+    if (!(scroller instanceof HTMLElement)) return { scrollTop: -1, topNum: null, fromBottom: -1 }
     const sr = scroller.getBoundingClientRect()
     let best: { num: number; top: number } | null = null
     for (const row of scroller.querySelectorAll<HTMLElement>(".message-item")) {
@@ -67,7 +70,11 @@ async function scrollMetrics(page: Page, streamId: string): Promise<{ scrollTop:
       if (!match) continue
       if (!best || rr.top < best.top) best = { num: Number(match[1]), top: rr.top }
     }
-    return { scrollTop: Math.round(scroller.scrollTop), topNum: best?.num ?? null }
+    return {
+      scrollTop: Math.round(scroller.scrollTop),
+      topNum: best?.num ?? null,
+      fromBottom: Math.round(scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop),
+    }
   }, streamId)
 }
 
@@ -79,7 +86,7 @@ async function scrollMetrics(page: Page, streamId: string): Promise<{ scrollTop:
 async function settledScrollMetrics(
   page: Page,
   streamId: string
-): Promise<{ scrollTop: number; topNum: number | null }> {
+): Promise<{ scrollTop: number; topNum: number | null; fromBottom: number }> {
   let previous = await scrollMetrics(page, streamId)
   for (let attempt = 0; attempt < 20; attempt++) {
     await page.waitForTimeout(250)
@@ -134,7 +141,12 @@ test.describe("Aside — desktop surface", () => {
     await page.goto(`/w/${workspaceId}/s/${streamId}`)
     await expect(hostRow(page, streamId, prefix, MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
 
-    // Detach from the tail so a tail-follow can't mask a scroll on open.
+    // Detach from the tail: at the tail the timeline follows the bottom, so a
+    // row growing in view (the anchor row) legitimately moves the viewport —
+    // that is the ordinary stick-to-bottom, not the aside's doing. The poll
+    // holds until the scroller is really away from the bottom (a wheel tick
+    // can be dropped under load; "top row below the tail" was already true
+    // at the tail with twenty rows on screen).
     const scroller = hostScroller(page, streamId)
     const box = await scroller.boundingBox()
     expect(box).not.toBeNull()
@@ -142,13 +154,13 @@ test.describe("Aside — desktop surface", () => {
     await expect
       .poll(
         async () => {
-          await page.mouse.wheel(0, -400)
+          await page.mouse.wheel(0, -200)
           await page.waitForTimeout(80)
-          return (await scrollMetrics(page, streamId)).topNum
+          return (await scrollMetrics(page, streamId)).fromBottom
         },
         { timeout: 15000 }
       )
-      .toBeLessThan(MESSAGE_COUNT - 8)
+      .toBeGreaterThan(200)
     const anchorNum = (await settledScrollMetrics(page, streamId)).topNum
     expect(anchorNum).not.toBeNull()
 

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -229,6 +229,16 @@ test.describe("Aside — desktop surface", () => {
     // Surface switching: fullscreen, minimized strip, back to the last reading surface.
     await pane(page).getByRole("button", { name: "Aside fullscreen" }).click()
     await expect(dock(page)).toHaveAttribute("data-surface", "fullscreen")
+    // Half the row: the live host keeps the other half beside the aside.
+    await expect
+      .poll(async () => {
+        const [dockBox, hostBox] = await Promise.all([
+          dock(page).boundingBox(),
+          hostScroller(page, streamId).boundingBox(),
+        ])
+        return dockBox && hostBox ? Math.abs(dockBox.width - hostBox.width) <= 8 : false
+      })
+      .toBe(true)
     await pane(page).getByRole("button", { name: "Minimize aside" }).click()
     await expect(strip(page)).toBeVisible()
     await expect(dock(page)).toHaveCount(0)

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -1,0 +1,235 @@
+import { test, expect, type Locator, type Page } from "@playwright/test"
+import { loginAndCreateWorkspace, createChannel, expectApiOk } from "./helpers"
+
+/**
+ * The desktop aside surface end to end: open from a message beside the host
+ * (never scrolling it — INV-70 has one lander and the aside is not a second),
+ * talk to the companion in the aside grounded in the viewport snapshot, fold
+ * away on navigation (no chrome anywhere else), and resume from the anchor row
+ * silently (no toast, no badge — INV-63).
+ *
+ * Position assertions go through scroller geometry, never Playwright
+ * visibility (virtua keeps rows mounted off-screen). The host scroller is
+ * addressed by `data-stream-scroller` because the aside pane mounts a second
+ * timeline scroller of its own.
+ */
+
+test.describe.configure({ timeout: 150_000 })
+
+const MESSAGE_COUNT = 40
+const AGENT_REPLY_TIMEOUT = 45_000
+
+async function seedMessages(page: Page, workspaceId: string, streamId: string, prefix: string): Promise<void> {
+  const BATCH_SIZE = 5
+  for (let start = 1; start <= MESSAGE_COUNT; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE - 1, MESSAGE_COUNT)
+    await Promise.all(
+      Array.from({ length: end - start + 1 }, (_, i) => start + i).map((n) =>
+        page.request
+          .post(`/api/workspaces/${workspaceId}/messages`, {
+            data: { streamId, content: `${prefix} msg-${String(n).padStart(3, "0")}` },
+          })
+          .then((r) => expectApiOk(r, `Send message ${n}`))
+      )
+    )
+  }
+}
+
+function extractIds(page: Page): { workspaceId: string; streamId: string } {
+  const url = page.url()
+  const workspaceMatch = url.match(/\/w\/([^/]+)/)
+  const streamMatch = url.match(/\/s\/([^/?]+)/)
+  if (!workspaceMatch || !streamMatch) throw new Error(`Could not extract IDs from URL: ${url}`)
+  return { workspaceId: workspaceMatch[1], streamId: streamMatch[1] }
+}
+
+function hostScroller(page: Page, streamId: string): Locator {
+  return page.locator(`[data-stream-scroller="${streamId}"]`)
+}
+
+function hostRow(page: Page, streamId: string, prefix: string, num: number): Locator {
+  return hostScroller(page, streamId)
+    .locator("[data-message-id]")
+    .filter({ hasText: `${prefix} msg-${String(num).padStart(3, "0")}` })
+    .first()
+}
+
+async function scrollMetrics(page: Page, streamId: string): Promise<{ scrollTop: number; topNum: number | null }> {
+  return page.evaluate((id) => {
+    const scroller = document.querySelector(`[data-stream-scroller="${id}"]`)
+    if (!(scroller instanceof HTMLElement)) return { scrollTop: -1, topNum: null }
+    const sr = scroller.getBoundingClientRect()
+    let best: { num: number; top: number } | null = null
+    for (const row of scroller.querySelectorAll<HTMLElement>(".message-item")) {
+      const rr = row.getBoundingClientRect()
+      if (rr.bottom <= sr.top + 1 || rr.top >= sr.bottom) continue
+      const match = row.innerText.match(/msg-(\d+)/)
+      if (!match) continue
+      if (!best || rr.top < best.top) best = { num: Number(match[1]), top: rr.top }
+    }
+    return { scrollTop: Math.round(scroller.scrollTop), topNum: best?.num ?? null }
+  }, streamId)
+}
+
+async function openAsideFromMessage(page: Page, streamId: string, prefix: string, num: number): Promise<void> {
+  const row = hostRow(page, streamId, prefix, num)
+  await row.hover()
+  await row.getByRole("button", { name: /message actions/i }).click()
+  await page.getByRole("menuitem", { name: "Open an aside here" }).click()
+}
+
+const dock = (page: Page) => page.getByTestId("aside-dock")
+const pane = (page: Page) => page.getByTestId("aside-pane")
+const strip = (page: Page) => page.getByTestId("aside-strip")
+const anchorRow = (page: Page, streamId: string) => hostScroller(page, streamId).locator("[data-aside-id]").first()
+
+async function expectNoAsideChrome(page: Page): Promise<void> {
+  await expect(dock(page)).toHaveCount(0)
+  await expect(pane(page)).toHaveCount(0)
+  await expect(strip(page)).toHaveCount(0)
+}
+
+async function expectSilent(page: Page, asideId: string): Promise<void> {
+  await expect(page.locator("[data-sonner-toast]")).toHaveCount(0)
+  await expect(page.locator(`nav a[href*="${asideId}"]`)).toHaveCount(0)
+}
+
+test.describe("Aside — desktop surface", () => {
+  let testId: string
+
+  test.beforeEach(async ({ page }) => {
+    const result = await loginAndCreateWorkspace(page, "aside")
+    testId = result.testId
+    // Wide enough that a 400px dock never reflows the 800px-max timeline column,
+    // so any host scroll movement on open is the surface's doing, not a reflow.
+    await page.setViewportSize({ width: 1600, height: 600 })
+  })
+
+  test("opens from a message beside the host without scrolling it, and the companion answers in the aside", async ({
+    page,
+  }) => {
+    await createChannel(page, `aside-${testId}`)
+    const { workspaceId, streamId } = extractIds(page)
+    const prefix = `[${testId}]`
+    await seedMessages(page, workspaceId, streamId, prefix)
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(hostRow(page, streamId, prefix, MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
+
+    // Detach from the tail so a tail-follow can't mask a scroll on open.
+    const scroller = hostScroller(page, streamId)
+    const box = await scroller.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 24)
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.wheel(0, -400)
+          await page.waitForTimeout(80)
+          return (await scrollMetrics(page, streamId)).topNum
+        },
+        { timeout: 15000 }
+      )
+      .toBeLessThan(MESSAGE_COUNT - 8)
+    await page.waitForTimeout(300)
+    const before = await scrollMetrics(page, streamId)
+    expect(before.topNum).not.toBeNull()
+
+    await openAsideFromMessage(page, streamId, prefix, before.topNum! + 1)
+
+    await expect(dock(page)).toHaveAttribute("data-surface", "dock", { timeout: 15000 })
+    await expect(pane(page)).toBeVisible()
+    const asideId = await pane(page).getAttribute("data-aside-id")
+    expect(asideId).toBeTruthy()
+
+    // INV-70: the host's landing is untouched — same top row, same scrollTop.
+    await page.waitForTimeout(500)
+    const after = await scrollMetrics(page, streamId)
+    expect(after.topNum).toBe(before.topNum)
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(2)
+
+    // The creator-only anchor row lands in the host timeline at the message.
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-aside-id", asideId!, { timeout: 15000 })
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-state", "open")
+
+    // Talk to Ariadne in the aside: the first turn carries the viewport
+    // snapshot ("what you saw") and the companion answers in the aside pane.
+    const asideEditor = pane(page).locator("[contenteditable='true']")
+    await asideEditor.click()
+    await page.keyboard.type("What is this about?")
+    await page.keyboard.press("Meta+Enter")
+    await expect(pane(page).locator(".message-item").filter({ hasText: "What is this about?" })).toBeVisible({
+      timeout: 10000,
+    })
+    await expect(pane(page).getByText(/What you saw in/)).toBeVisible({ timeout: 15000 })
+    await expect(
+      pane(page)
+        .locator(".message-item")
+        .filter({ hasText: /stub response from the companion/ })
+    ).toBeVisible({ timeout: AGENT_REPLY_TIMEOUT })
+    // The host timeline never receives the aside's turns.
+    await expect(hostScroller(page, streamId).getByText("What is this about?")).toHaveCount(0)
+    await expectSilent(page, asideId!)
+  })
+
+  test("folds away on navigation, leaves the next stream clean, and resumes silently from the anchor row", async ({
+    page,
+  }) => {
+    await createChannel(page, `elsewhere-${testId}`)
+    const { workspaceId, streamId: otherStreamId } = extractIds(page)
+    await createChannel(page, `aside-${testId}`)
+    const { streamId } = extractIds(page)
+    const prefix = `[${testId}]`
+    await seedMessages(page, workspaceId, streamId, prefix)
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(hostRow(page, streamId, prefix, MESSAGE_COUNT)).toBeVisible({ timeout: 20000 })
+
+    // Entry point: the /aside slash command in the host composer.
+    const hostEditor = page.getByRole("main").locator("[data-editor-zone='main'] [contenteditable='true']").first()
+    await hostEditor.click()
+    await page.keyboard.type("/aside")
+    const commandPopup = page.locator("[aria-label='Slash command suggestions']")
+    await expect(commandPopup).toBeVisible({ timeout: 5000 })
+    await commandPopup
+      .getByRole("option", { name: /^\/?aside\b/ })
+      .first()
+      .click()
+    await page.keyboard.press("Meta+Enter")
+
+    await expect(dock(page)).toHaveAttribute("data-surface", "dock", { timeout: 15000 })
+    const asideId = await pane(page).getAttribute("data-aside-id")
+    expect(asideId).toBeTruthy()
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-aside-id", asideId!, { timeout: 15000 })
+
+    // Surface switching: fullscreen, minimized strip, back to the last reading surface.
+    await pane(page).getByRole("button", { name: "Aside fullscreen" }).click()
+    await expect(dock(page)).toHaveAttribute("data-surface", "fullscreen")
+    await pane(page).getByRole("button", { name: "Minimize aside" }).click()
+    await expect(strip(page)).toBeVisible()
+    await expect(dock(page)).toHaveCount(0)
+    await strip(page)
+      .getByRole("button", { name: /^Open aside:/ })
+      .click()
+    await expect(dock(page)).toHaveAttribute("data-surface", "fullscreen")
+    await pane(page).getByRole("button", { name: "Dock aside" }).click()
+    await expect(dock(page)).toHaveAttribute("data-surface", "dock")
+
+    // Leave: the next stream carries no aside chrome at all.
+    await page.getByRole("link", { name: `#elsewhere-${testId}` }).click()
+    await expect(page.getByRole("heading", { name: `#elsewhere-${testId}`, level: 1 })).toBeVisible({ timeout: 10000 })
+    await expectNoAsideChrome(page)
+    expect(page.url()).toContain(otherStreamId)
+
+    // Return: nothing re-opens by itself; the anchor row is the way back in.
+    await page.getByRole("link", { name: `#aside-${testId}` }).click()
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-aside-id", asideId!, { timeout: 15000 })
+    await expectNoAsideChrome(page)
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-state", "closed")
+
+    await anchorRow(page, streamId).hover()
+    await anchorRow(page, streamId).getByRole("button", { name: "Resume" }).click()
+    await expect(dock(page)).toHaveAttribute("data-surface", "dock", { timeout: 10000 })
+    await expect(pane(page)).toHaveAttribute("data-aside-id", asideId!)
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-state", "open")
+    await expectSilent(page, asideId!)
+  })
+})

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -71,6 +71,25 @@ async function scrollMetrics(page: Page, streamId: string): Promise<{ scrollTop:
   }, streamId)
 }
 
+/**
+ * A scroll reading the timeline has stopped changing: two identical samples
+ * 250ms apart. The strict equality below is only meaningful against a host that
+ * had already settled when the baseline was taken.
+ */
+async function settledScrollMetrics(
+  page: Page,
+  streamId: string
+): Promise<{ scrollTop: number; topNum: number | null }> {
+  let previous = await scrollMetrics(page, streamId)
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await page.waitForTimeout(250)
+    const current = await scrollMetrics(page, streamId)
+    if (current.topNum === previous.topNum && Math.abs(current.scrollTop - previous.scrollTop) <= 1) return current
+    previous = current
+  }
+  return previous
+}
+
 async function openAsideFromMessage(page: Page, streamId: string, prefix: string, num: number): Promise<void> {
   const row = hostRow(page, streamId, prefix, num)
   await row.hover()
@@ -130,8 +149,10 @@ test.describe("Aside — desktop surface", () => {
         { timeout: 15000 }
       )
       .toBeLessThan(MESSAGE_COUNT - 8)
-    await page.waitForTimeout(300)
-    const before = await scrollMetrics(page, streamId)
+    // Settle before the baseline: virtua re-measures after a wheel, and under CI
+    // load that can still be moving 300ms later — a baseline caught mid-settle
+    // reads as an aside-caused shift below, which is the opposite of the claim.
+    const before = await settledScrollMetrics(page, streamId)
     expect(before.topNum).not.toBeNull()
 
     await openAsideFromMessage(page, streamId, prefix, before.topNum! + 1)
@@ -142,10 +163,11 @@ test.describe("Aside — desktop surface", () => {
     expect(asideId).toBeTruthy()
 
     // INV-70: the host's landing is untouched — same top row, same scrollTop.
-    await page.waitForTimeout(500)
-    const after = await scrollMetrics(page, streamId)
-    expect(after.topNum).toBe(before.topNum)
-    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(2)
+    const after = await settledScrollMetrics(page, streamId)
+    expect({ topRow: after.topNum, scrollTop: after.scrollTop }).toEqual({
+      topRow: before.topNum,
+      scrollTop: before.scrollTop,
+    })
 
     // The creator-only anchor row lands in the host timeline at the message.
     await expect(anchorRow(page, streamId)).toHaveAttribute("data-aside-id", asideId!, { timeout: 15000 })


### PR DESCRIPTION
## Problem

An aside exists in the data layer ([#1912](https://github.com/threahq/threa/pull/1912)), leaves a creator-only anchor row ([#1921](https://github.com/threahq/threa/pull/1921)) and can be grounded in what you were looking at ([#1925](https://github.com/threahq/threa/pull/1925)) — but there is no way to open one, read it, or get back to it. Nothing on the desktop opens an aside, and `createAside`'s host rules (`channel|dm|scratchpad|thread`, never E2E, never aside-on-aside) exist only server-side, so any entry point added naively would offer asides the server refuses.

## Solution

A page-bound surface with three states and four entry points.

- `stores/aside-store.ts` — module store (call-store shape) holding the one aside open on the current page, keyed by `hostKey` (the route pathname). Leaving the page drops it (`useAsideHost`), so no aside chrome can follow you to the next stream and nothing re-opens by itself. The stale-create guard compares the host path only: leaving and returning before the create lands opens the aside on return, which is what was asked for. Deliberately **not** in the URL despite INV-59: `?aside=` would leak a private stream's existence into a shared link and survive a refresh; the call dock's transient-view-state precedent applies.
- Surfaces: `AsideDockSlot` (400px dock on the page's right edge, after the thread panel; fullscreen takes half the row with the live host beside it) and `AsideMinimizedStrip` (a slim strip above the host composer). The dock folds on a 200ms width transition — the same clock the thread panel slides on — and unmounts after.
- Calls own the right edge: `resolveAsideOpenSurface`/`resolveAsideRestoreSurface` open minimized instead of docked while the call dock is there, and restore to fullscreen. Resume re-enters the surface the aside was last *read* in; minimized is a parked state and never becomes the remembered one.
- `ASIDE_HOST_STREAM_TYPES` + `isAsideHostType` move to `packages/types/constants.ts` (INV-33) — the create path, `/aside` availability, the palette, the message action and the conversation menu all read the one list, so an entry point can't drift from what the server enforces.
- Entry points: `/aside` slash command (client action, gated per host in `commands/availability.ts` — host type, no E2E, writable), palette "Open an aside here", message action "Open an aside here", and the conversation actions menu; all of them read the host's archived state (own row and root), since `createAside` refuses an archived host. A palette-selected aside lands on its host and opens the surface there — an aside is never a page of its own. Message/timeline entries anchor to the message; board/panel entries anchor to the conversation.
- `useEffectiveArchived` learns the aside's lineage: an aside is a root of its own (INV-62), so its host and the host's root are read from the store and an archived one seals it — the frontend twin of the backend write-authority rule.
- The anchor row grows a Resume control (hover/focus opacity only, INV-21; visible on coarse pointers where hover never fires) and a `data-state` reflecting whether the aside is open. Re-entry is silent (INV-63).

Not in scope: the real mobile surface (PR7 — a phone currently gets a plain takeover), the agent-attributed block (PR5), drafts and send-to-composer (PR6).

## Test plan

- [x] `apps/frontend` vitest, aside surfaces + store + entry points — 101 pass
- [x] `apps/backend` `src/features/commands` — 28 pass (`/aside` offered on host types only, never on an E2E host)
- [x] `bun run typecheck` (all 15 workspaces) + pre-commit lint/`check:migrations`/api-docs — green
- [x] `tests/browser/aside-desktop.spec.ts` — 8/8 locally (`--repeat-each=4`) and in CI. Also asserts fullscreen gives the host and the aside the same width. Covers: open from a message without moving the host scroller (INV-70), companion answers inside the pane grounded in the viewport snapshot, `/aside` from the composer, dock ⇄ fullscreen ⇄ minimized, fold on navigate leaving the next stream clean, silent resume from the anchor row.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025948&installation_model_id=20758&pr_number=1932&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1932&signature=cb8b0390ff4c14e4bbf525f92c5559acbd55b23101b8e343953fc4f93c0c7e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
