### PR TITLE
feat: mobile quote and share follow the selection

### DIFF
--- a/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoryRouter } from "react-router-dom"
 import { SyncEngineContext } from "@/sync/sync-engine"
@@ -47,6 +47,7 @@ function selectInBody(start: number, end: number) {
     toString: () => range.toString(),
     getRangeAt: () => range,
     removeAllRanges: () => {},
+    addRange: () => {},
   } as unknown as Selection)
   act(() => {
     document.dispatchEvent(new Event("selectionchange"))
@@ -80,5 +81,101 @@ describe("MessageActionDrawer — sharing a selection", () => {
 
     expect(await screen.findByRole("button", { name: /^quote$/i })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /^share$/i })).not.toBeInTheDocument()
+  })
+})
+
+describe("MessageActionDrawer — offering the selection pill", () => {
+  it("waits for the selection to stop moving before offering the pill", async () => {
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection: vi.fn() })
+
+    fireEvent.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+
+    // Mid-drag: the range exists but hasn't settled, so nothing is offered yet.
+    expect(screen.queryByTestId("selection-pill")).not.toBeInTheDocument()
+    expect(await screen.findByTestId("selection-pill")).toBeInTheDocument()
+  })
+
+  it("stands down while a finger is still on the message", async () => {
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection: vi.fn() })
+
+    fireEvent.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+    await screen.findByTestId("selection-pill")
+
+    // On the message itself: a bare `document` event reads as a press outside
+    // the sheet, which is Radix's dismiss gesture rather than a selection drag.
+    fireEvent.pointerDown(screen.getByText(BODY))
+    expect(screen.queryByTestId("selection-pill")).not.toBeInTheDocument()
+
+    // pointercancel, not pointerup: vaul's release handler reads a computed
+    // transform jsdom never produces, and it only listens for the latter.
+    fireEvent.pointerCancel(screen.getByText(BODY))
+    await waitFor(() => expect(screen.getByTestId("selection-pill")).toBeInTheDocument())
+  })
+
+  it("puts the count in the header and leaves the bottom of the sheet to the message", async () => {
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection: vi.fn() })
+
+    fireEvent.click(screen.getByText(BODY))
+    expect(screen.getByTestId("expanded-quote-title")).toHaveTextContent("Full message")
+
+    selectInBody(13, 20)
+    await waitFor(() => expect(screen.getByTestId("expanded-quote-title")).toHaveTextContent("7 characters selected"))
+    expect(screen.queryByText(/long-press the message/i)).not.toBeInTheDocument()
+  })
+
+  it("listens again when the finger lifts somewhere other than the pill", async () => {
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection: vi.fn() })
+
+    fireEvent.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+    const pill = await screen.findByTestId("selection-pill")
+
+    // Press the pill, slide off it, lift elsewhere: the release never reaches
+    // the pill, so the guard has to come off the document instead. Left stuck,
+    // every later selection is ignored and the actions send the old span.
+    fireEvent.pointerDown(pill)
+    fireEvent.pointerCancel(screen.getByText(BODY))
+
+    selectInBody(0, 5)
+    await waitFor(() => expect(screen.getByTestId("expanded-quote-title")).toHaveTextContent("5 characters selected"))
+  })
+
+  it("opts the pill out of the sheet's own drag gesture", async () => {
+    mountDrawer({ onQuoteReplyWithSelection: vi.fn(), onShareWithSelection: vi.fn() })
+
+    fireEvent.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+
+    // vaul reads a press on the sheet as a drag unless there is highlighted
+    // text, and pressing the pill is what collapses the highlight. Without the
+    // opt-out a downward drag on the pill drags the sheet shut.
+    expect(await screen.findByTestId("selection-pill")).toHaveAttribute("data-vaul-no-drag")
+  })
+
+  it("keeps the selection it read when the pill itself is pressed", async () => {
+    const onQuoteReplyWithSelection = vi.fn()
+    mountDrawer({ onQuoteReplyWithSelection })
+
+    fireEvent.click(screen.getByText(BODY))
+    selectInBody(13, 20)
+    const pill = await screen.findByTestId("selection-pill")
+
+    // Chrome collapses the selection when a fixed overlay is touched. The click
+    // that follows must still carry the span the reader highlighted.
+    fireEvent.pointerDown(pill)
+    act(() => {
+      vi.spyOn(window, "getSelection").mockReturnValue({
+        isCollapsed: true,
+        rangeCount: 0,
+        removeAllRanges: () => {},
+        addRange: () => {},
+      } as unknown as Selection)
+      document.dispatchEvent(new Event("selectionchange"))
+    })
+    fireEvent.click(screen.getByRole("button", { name: /^quote$/i }))
+
+    expect(onQuoteReplyWithSelection).toHaveBeenCalledWith({ text: "this is", prefixText: "Hello there, " })
   })
 })

--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { AuthorType } from "@threa/types"
-import { ChevronLeft, Quote, Share2 } from "lucide-react"
+import { ChevronLeft, Quote } from "lucide-react"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
-import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
@@ -20,6 +19,20 @@ import {
   groupVisibleActions,
 } from "./message-actions"
 import { EmojiQuickBar } from "./emoji-quick-bar"
+import { SelectionPill } from "./selection-pill"
+
+function isSameRange(a: Range | null, b: Range): boolean {
+  return (
+    a !== null &&
+    a.startContainer === b.startContainer &&
+    a.startOffset === b.startOffset &&
+    a.endContainer === b.endContainer &&
+    a.endOffset === b.endOffset
+  )
+}
+
+/** Quiet time after the last `selectionchange` before the pill is offered. */
+const SELECTION_SETTLE_MS = 250
 
 interface MessageActionDrawerProps {
   open: boolean
@@ -42,7 +55,20 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
     : undefined
   const [expanded, setExpanded] = useState(false)
   const [selection, setSelection] = useState<QuoteSelection | null>(null)
+  const [range, setRange] = useState<Range | null>(null)
+  // A selection is only worth acting on once it stops moving: the pill would
+  // otherwise chase every `selectionchange` tick of a handle drag, under the
+  // very finger doing the dragging.
+  const [settled, setSettled] = useState(false)
+  const [touching, setTouching] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  // A callback ref, so a sheet node swapped out mid-transition is replaced
+  // rather than remembered. The pill portals into whatever this holds.
+  const [sheet, setSheet] = useState<HTMLDivElement | null>(null)
+  const pillInteractingRef = useRef(false)
+  const rangeRef = useRef<Range | null>(null)
+  rangeRef.current = range
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -52,40 +78,94 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
     [onOpenChange]
   )
 
+  /**
+   * Touching the pill is a press outside the selection, and dragging it drags a
+   * new one, so by the time the finger lifts the highlight it acts on is gone.
+   * Put it back, or the pill tears itself down between its own pointerup and
+   * click. Releasing is idempotent because the finger can lift anywhere: the
+   * pill reports its own pointerup, and the document listener below catches the
+   * lifts and cancels that never reach it.
+   */
+  const releasePillGuard = useCallback(() => {
+    if (!pillInteractingRef.current) return
+    pillInteractingRef.current = false
+    const stored = rangeRef.current
+    if (!stored) return
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(stored)
+  }, [])
+
   useEffect(() => {
     if (!expanded) {
+      pillInteractingRef.current = false
       setSelection(null)
+      setRange(null)
+      setSettled(false)
+      setTouching(false)
       return
     }
 
+    let settleTimer: ReturnType<typeof setTimeout> | undefined
+    const clear = () => {
+      clearTimeout(settleTimer)
+      setSelection(null)
+      setRange(null)
+      setSettled(false)
+    }
+
     const handleSelectionChange = () => {
+      // Pressing the pill is a tap on an overlay outside the selection, which
+      // Chrome collapses. Holding what was already read keeps the button's own
+      // click from tearing its owner down.
+      if (pillInteractingRef.current) return
+
       const sel = window.getSelection()
-      if (!sel || sel.isCollapsed || !sel.rangeCount) {
-        setSelection(null)
-        return
-      }
+      if (!sel || sel.isCollapsed || !sel.rangeCount) return clear()
 
       const text = sel.toString().trim()
       const contentEl = contentRef.current
-      if (!text || !contentEl) {
-        setSelection(null)
-        return
-      }
+      if (!text || !contentEl) return clear()
 
-      const range = sel.getRangeAt(0)
-      if (contentEl.contains(range.startContainer) && contentEl.contains(range.endContainer)) {
-        const prefix = contentEl.ownerDocument.createRange()
-        prefix.selectNodeContents(contentEl)
-        prefix.setEnd(range.startContainer, range.startOffset)
-        setSelection({ text, prefixText: prefix.toString() })
-      } else {
-        setSelection(null)
-      }
+      const selected = sel.getRangeAt(0)
+      if (!contentEl.contains(selected.startContainer) || !contentEl.contains(selected.endContainer)) return clear()
+
+      // Putting the selection back after a press on the pill raises a
+      // `selectionchange` of our own. Recognising it by identity is what keeps
+      // the repair from reading as the reader starting over, which would hide
+      // the pill for another settle and swallow the tap already in flight.
+      if (isSameRange(rangeRef.current, selected)) return
+
+      const prefix = contentEl.ownerDocument.createRange()
+      prefix.selectNodeContents(contentEl)
+      prefix.setEnd(selected.startContainer, selected.startOffset)
+      setSelection({ text, prefixText: prefix.toString() })
+      setRange(selected.cloneRange())
+      setSettled(false)
+      clearTimeout(settleTimer)
+      settleTimer = setTimeout(() => setSettled(true), SELECTION_SETTLE_MS)
+    }
+
+    const handlePointerDown = () => {
+      if (!pillInteractingRef.current) setTouching(true)
+    }
+    const handlePointerUp = () => {
+      setTouching(false)
+      releasePillGuard()
     }
 
     document.addEventListener("selectionchange", handleSelectionChange)
-    return () => document.removeEventListener("selectionchange", handleSelectionChange)
-  }, [expanded])
+    document.addEventListener("pointerdown", handlePointerDown)
+    document.addEventListener("pointerup", handlePointerUp)
+    document.addEventListener("pointercancel", handlePointerUp)
+    return () => {
+      clearTimeout(settleTimer)
+      document.removeEventListener("selectionchange", handleSelectionChange)
+      document.removeEventListener("pointerdown", handlePointerDown)
+      document.removeEventListener("pointerup", handlePointerUp)
+      document.removeEventListener("pointercancel", handlePointerUp)
+    }
+  }, [expanded, releasePillGuard])
 
   const handleQuoteSelected = useCallback(() => {
     if (!selection || !context.onQuoteReplyWithSelection) return
@@ -105,6 +185,17 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
     window.getSelection()?.removeAllRanges()
     setExpanded(false)
   }, [])
+
+  const handlePillInteracting = useCallback(
+    (interacting: boolean) => {
+      if (interacting) {
+        pillInteractingRef.current = true
+        return
+      }
+      releasePillGuard()
+    },
+    [releasePillGuard]
+  )
 
   const activeShortcodes = useMemo(() => {
     if (!context.currentUserId || !context.reactions) return new Set<string>()
@@ -154,7 +245,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
 
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
-      <DrawerContent className={cn(expanded ? "h-[95dvh]" : "max-h-[85dvh]")}>
+      <DrawerContent ref={setSheet} className={cn(expanded ? "h-[95dvh]" : "max-h-[85dvh]")}>
         <DrawerTitle className="sr-only">{expanded ? "Select text to quote or share" : "Message actions"}</DrawerTitle>
 
         {expanded ? (
@@ -165,8 +256,12 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
             statusEmoji={authorStatus?.emoji ?? null}
             statusText={authorStatus?.text ?? null}
             selectedText={selection?.text ?? ""}
+            pillRange={settled && !touching ? range : null}
             contentRef={contentRef}
+            scrollRef={scrollRef}
+            sheet={sheet}
             onBack={handleBack}
+            onPillInteracting={handlePillInteracting}
             onQuote={handleQuoteSelected}
             onShare={context.onShareWithSelection ? handleShareSelected : undefined}
           />
@@ -175,6 +270,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
             <div className="px-4 pt-1 pb-3">
               <button
                 type="button"
+                data-testid="expanded-quote-open"
                 className={cn(
                   "group/preview relative w-full text-left rounded-xl bg-muted/60 px-3.5 py-2.5 disabled:opacity-100 disabled:cursor-default",
                   context.onQuoteReplyWithSelection && "active:bg-muted/80 transition-colors cursor-pointer"
@@ -252,8 +348,13 @@ interface ExpandedQuoteViewProps {
   statusEmoji: string | null
   statusText: string | null
   selectedText: string
+  /** The settled selection the pill anchors to, or null while it is still moving. */
+  pillRange: Range | null
   contentRef: React.RefObject<HTMLDivElement | null>
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  sheet: HTMLDivElement | null
   onBack: () => void
+  onPillInteracting: (interacting: boolean) => void
   onQuote: () => void
   onShare?: () => void
 }
@@ -265,8 +366,12 @@ function ExpandedQuoteView({
   statusEmoji,
   statusText,
   selectedText,
+  pillRange,
   contentRef,
+  scrollRef,
+  sheet,
   onBack,
+  onPillInteracting,
   onQuote,
   onShare,
 }: ExpandedQuoteViewProps) {
@@ -305,11 +410,23 @@ function ExpandedQuoteView({
         >
           <ChevronLeft className="h-5 w-5" />
         </button>
-        <h2 className="text-[15px] font-semibold tracking-tight text-muted-foreground">Full message</h2>
+        <h2
+          data-testid="expanded-quote-title"
+          className="text-[15px] font-semibold tracking-tight text-muted-foreground"
+        >
+          {charCount > 0 ? (
+            <>
+              <span className="tabular-nums text-foreground/85">{charCount}</span>{" "}
+              {charCount === 1 ? "character" : "characters"} selected
+            </>
+          ) : (
+            "Full message"
+          )}
+        </h2>
         <div className="absolute left-0 right-0 bottom-0 h-px bg-gradient-to-r from-transparent via-border/70 to-transparent" />
       </div>
 
-      <div data-vaul-no-drag className="flex-1 min-h-0 overflow-y-auto">
+      <div ref={scrollRef} data-vaul-no-drag className="flex-1 min-h-0 overflow-y-auto">
         <div className={cn("relative", accentClass)}>
           <div aria-hidden="true" className={watermarkClass}>
             &ldquo;
@@ -353,6 +470,7 @@ function ExpandedQuoteView({
 
           <div
             ref={contentRef}
+            data-testid="expanded-quote-body"
             className="relative px-4 pb-6 select-text [-webkit-touch-callout:none] outline-none"
             tabIndex={-1}
           >
@@ -361,36 +479,14 @@ function ExpandedQuoteView({
         </div>
       </div>
 
-      <div className="relative px-4 pt-2.5 pb-[max(10px,env(safe-area-inset-bottom))]">
-        <div
-          aria-hidden="true"
-          className="absolute left-0 right-0 top-0 h-px bg-gradient-to-r from-transparent via-border/70 to-transparent"
-        />
-        {selectedText ? (
-          <div className="flex items-center justify-between gap-3 animate-in fade-in slide-in-from-bottom-1 duration-150">
-            <p className="text-[12px] text-muted-foreground tabular-nums">
-              <span className="font-semibold text-foreground/85">{charCount}</span>{" "}
-              {charCount === 1 ? "character" : "characters"} selected
-            </p>
-            <div className="flex shrink-0 items-center gap-2">
-              {onShare && (
-                <Button size="sm" variant="secondary" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onShare}>
-                  <Share2 className="h-3.5 w-3.5" />
-                  Share
-                </Button>
-              )}
-              <Button size="sm" className="h-9 gap-1.5 px-3.5 font-medium" onClick={onQuote}>
-                <Quote className="h-3.5 w-3.5" />
-                Quote
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <p className="text-[12px] text-muted-foreground/70 text-center py-1">
-            Long-press the message to highlight a passage
-          </p>
-        )}
-      </div>
+      <SelectionPill
+        range={pillRange}
+        viewportRef={scrollRef}
+        portalHost={sheet}
+        onInteractingChange={onPillInteracting}
+        onQuote={onQuote}
+        onShare={onShare}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/selection-pill-placement.test.ts
+++ b/apps/frontend/src/components/timeline/selection-pill-placement.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest"
+import {
+  placeSelectionPill,
+  clampToBounds,
+  isSelectionVisible,
+  HANDLE_CLEARANCE_PX,
+  type Box,
+  type PlacementInput,
+} from "./selection-pill-placement"
+
+const SIZE = { width: 180, height: 44 }
+
+/** The drawer's scrollable region on a phone, already clear of the reserved band. */
+const BOUNDS: Box = { top: 120, bottom: 700, left: 0, right: 400 }
+
+function line(top: number, left = 100, right = 300, height = 20): Box {
+  return { top, bottom: top + height, left, right }
+}
+
+function input(overrides: Partial<PlacementInput> = {}): PlacementInput {
+  const last = line(300)
+  return { last, union: last, size: SIZE, bounds: BOUNDS, ...overrides }
+}
+
+describe("placeSelectionPill", () => {
+  it("goes below the selection, clear of the drag handles, centred on the range", () => {
+    const last = line(300, 100, 300)
+    expect(placeSelectionPill(input({ last, union: last }))).toEqual({
+      top: 320 + HANDLE_CLEARANCE_PX,
+      left: 200 - SIZE.width / 2,
+    })
+  })
+
+  it("measures below from the last line of a multi-line selection", () => {
+    const union: Box = { top: 300, bottom: 380, left: 40, right: 360 }
+    expect(placeSelectionPill(input({ last: line(360), union })).top).toBe(380 + HANDLE_CLEARANCE_PX)
+  })
+
+  it("parks at the floor when the selection runs out of room below it", () => {
+    const last = line(670)
+    const union: Box = { top: 300, bottom: 690, left: 100, right: 300 }
+    expect(placeSelectionPill(input({ last, union }))).toEqual({
+      top: BOUNDS.bottom - SIZE.height,
+      left: 200 - SIZE.width / 2,
+    })
+  })
+
+  it("clamps to the left edge rather than centring off-screen", () => {
+    const last = line(300, 0, 20)
+    expect(placeSelectionPill(input({ last, union: last })).left).toBe(12)
+  })
+
+  it("clamps to the right edge rather than centring off-screen", () => {
+    const last = line(300, 380, 400)
+    expect(placeSelectionPill(input({ last, union: last })).left).toBe(400 - 12 - SIZE.width)
+  })
+
+  it("never places inside the reserved bottom band", () => {
+    for (const top of [200, 400, 600, BOUNDS.bottom - 30, BOUNDS.bottom + 50]) {
+      const last = line(top)
+      const placed = placeSelectionPill(input({ last, union: last }))
+      expect(placed.top + SIZE.height).toBeLessThanOrEqual(BOUNDS.bottom)
+      expect(placed.top).toBeGreaterThanOrEqual(BOUNDS.top)
+    }
+  })
+})
+
+describe("isSelectionVisible", () => {
+  it("is false once the selection has scrolled clear of the readable area", () => {
+    expect(isSelectionVisible(line(400), BOUNDS)).toBe(true)
+    expect(isSelectionVisible(line(20), BOUNDS)).toBe(false)
+    expect(isSelectionVisible(line(760), BOUNDS)).toBe(false)
+    expect(isSelectionVisible(line(110), BOUNDS)).toBe(true)
+  })
+})
+
+describe("clampToBounds", () => {
+  it("pulls a parked point back inside on every edge", () => {
+    expect(clampToBounds({ top: -400, left: -400 }, SIZE, BOUNDS)).toEqual({ top: 120, left: 12 })
+    expect(clampToBounds({ top: 9999, left: 9999 }, SIZE, BOUNDS)).toEqual({
+      top: BOUNDS.bottom - SIZE.height,
+      left: 400 - 12 - SIZE.width,
+    })
+  })
+
+  it("leaves a point that already fits alone", () => {
+    expect(clampToBounds({ top: 400, left: 100 }, SIZE, BOUNDS)).toEqual({ top: 400, left: 100 })
+  })
+})

--- a/apps/frontend/src/components/timeline/selection-pill-placement.ts
+++ b/apps/frontend/src/components/timeline/selection-pill-placement.ts
@@ -1,0 +1,95 @@
+/**
+ * Where the floating quote/share pill goes for a touch selection.
+ *
+ * Three things we don't own want this strip of screen and none of them can be
+ * measured from script. Android's text-selection toolbar (Copy / Share / Select
+ * all) takes the space above the selection whenever there is room for it
+ * between the selection and the top of the web contents; inside a sheet that
+ * starts well below that top there always is, so it is always above and the
+ * space below the selection is always ours. The selection's drag handles hang
+ * below their own line, so "below" still has to clear them. Chrome's Touch to
+ * Search peek draws over the bottom of the page without resizing the visual
+ * viewport, so the caller subtracts {@link RESERVED_BOTTOM_PX} from the bounds
+ * it passes in and nothing is ever placed there.
+ */
+
+export interface Box {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+export interface Size {
+  width: number
+  height: number
+}
+
+export interface Placement {
+  top: number
+  left: number
+}
+
+export interface PlacementInput {
+  /** Last line box of the selection and the union of all of them, in client coords. */
+  last: Box
+  union: Box
+  size: Size
+  /** The area the pill must stay inside, in client coords. */
+  bounds: Box
+}
+
+/**
+ * Selection drag handles hang below their own line, so a pill sitting flush
+ * under the selection covers the end handle and the first tap moves the handle
+ * instead of pressing a button.
+ */
+export const HANDLE_CLEARANCE_PX = 34
+
+/** Bottom band the Touch to Search peek and the gesture bar own. */
+export const RESERVED_BOTTOM_PX = 96
+
+const EDGE_PX = 12
+
+/** Pointer travel before a press on the grip becomes a drag. */
+export const DRAG_THRESHOLD_PX = 8
+
+/** How close a drop has to land to the automatic spot to re-attach to it. */
+export const REATTACH_SNAP_PX = 48
+
+function clampLeft(left: number, size: Size, bounds: Box): number {
+  const lo = bounds.left + EDGE_PX
+  const hi = bounds.right - EDGE_PX - size.width
+  return Math.max(lo, Math.min(left, hi))
+}
+
+/** Keeps a point inside the bounds, used for a parked pill and for a live drag. */
+export function clampToBounds(point: { top: number; left: number }, size: Size, bounds: Box): Placement {
+  return {
+    top: Math.max(bounds.top, Math.min(point.top, bounds.bottom - size.height)),
+    left: clampLeft(point.left, size, bounds),
+  }
+}
+
+/**
+ * A selection scrolled out of the readable area has nothing to anchor to, and a
+ * pill pointing at text nobody can see is worse than no pill. Measured against
+ * the scroller itself, not the placement bounds: text under the reserved band
+ * is still text the reader can see and quote.
+ */
+export function isSelectionVisible(union: Box, scroller: Box): boolean {
+  return union.bottom > scroller.top && union.top < scroller.bottom
+}
+
+export function placeSelectionPill(input: PlacementInput): Placement {
+  const { last, union, size, bounds } = input
+  const left = clampLeft(union.left + (union.right - union.left) / 2 - size.width / 2, size, bounds)
+
+  const below = last.bottom + HANDLE_CLEARANCE_PX
+  if (below >= bounds.top && below + size.height <= bounds.bottom) return { top: below, left }
+
+  // A selection running to the floor leaves no room under it, and above it is
+  // where the OS toolbar already is. The pill parks at the floor of the safe
+  // area instead, which is still reachable and still clear of the peek.
+  return { top: bounds.bottom - size.height, left }
+}

--- a/apps/frontend/src/components/timeline/selection-pill.tsx
+++ b/apps/frontend/src/components/timeline/selection-pill.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react"
+import { createPortal } from "react-dom"
+import { GripVertical, Quote, Share2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  clampToBounds,
+  isSelectionVisible,
+  placeSelectionPill,
+  DRAG_THRESHOLD_PX,
+  REATTACH_SNAP_PX,
+  RESERVED_BOTTOM_PX,
+  type Box,
+  type Placement,
+  type Size,
+} from "./selection-pill-placement"
+
+interface SelectionPillProps {
+  /** The selection to act on, or null when there is nothing selected. */
+  range: Range | null
+  /** Scrollable region the pill stays inside and follows. */
+  viewportRef: RefObject<HTMLElement | null>
+  /**
+   * The sheet the pill renders into. An element, not a ref: vaul swaps the
+   * content node across its open transition, and a ref read in an effect keeps
+   * whichever node happened to be mounted when that effect last ran.
+   */
+  portalHost: HTMLElement | null
+  /**
+   * Raised while a finger is on the pill. A press on it is a press outside the
+   * selection, which Chrome collapses, and a drag on it drags a new one; either
+   * would tear the pill down between its own pointerup and click. While this is
+   * true the owner keeps the selection it already read, and repairs it after.
+   */
+  onInteractingChange: (interacting: boolean) => void
+  onQuote: () => void
+  onShare?: () => void
+}
+
+/**
+ * Floating Quote / Share controls for a touch selection, anchored below the
+ * selection and draggable to a spot of the reader's choosing.
+ *
+ * Placement lives in `selection-pill-placement.ts`; this owns the measuring,
+ * the drag, and the portal.
+ *
+ * It renders inside the sheet, not into `document.body`. A modal sheet sets
+ * `pointer-events: none` on the body and `aria-hidden` on everything outside
+ * itself, so a pill parked next to it would be both untappable and invisible to
+ * a screen reader. Placement is computed in client coordinates and converted to
+ * the sheet's box at render, because the sheet animates with a transform and so
+ * is the containing block for anything positioned inside it.
+ */
+export function SelectionPill({
+  range,
+  viewportRef,
+  portalHost,
+  onInteractingChange,
+  onQuote,
+  onShare,
+}: SelectionPillProps) {
+  const pillRef = useRef<HTMLDivElement>(null)
+  const [placement, setPlacement] = useState<Placement | null>(null)
+  const [origin, setOrigin] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
+  // Where the reader dragged it, in client coords. Deliberately not persisted:
+  // opening the view is a fresh read, so the pill starts back at the selection.
+  const parkedRef = useRef<{ top: number; left: number } | null>(null)
+  const geomRef = useRef<{ bounds: Box; size: Size; auto: Placement } | null>(null)
+  const dragRef = useRef<{
+    id: number
+    grabX: number
+    grabY: number
+    startX: number
+    startY: number
+    origin: Placement
+    point: { top: number; left: number }
+    frame: number
+  } | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  const measure = useCallback(() => {
+    const scroller = viewportRef.current
+    const sheet = portalHost
+    const el = pillRef.current
+    if (!range || !scroller || !sheet || !el) {
+      setPlacement(null)
+      return
+    }
+    const size = { width: el.offsetWidth, height: el.offsetHeight }
+    if (size.width === 0) return
+
+    const rects = range.getClientRects()
+    const union = range.getBoundingClientRect()
+    if (rects.length === 0) {
+      setPlacement(null)
+      return
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect()
+    const bounds: Box = {
+      top: scrollerRect.top,
+      left: scrollerRect.left,
+      right: scrollerRect.right,
+      bottom: Math.min(scrollerRect.bottom, window.innerHeight) - RESERVED_BOTTOM_PX,
+    }
+    if (!isSelectionVisible(union, scrollerRect)) {
+      setPlacement(null)
+      return
+    }
+
+    const auto = placeSelectionPill({ last: rects[rects.length - 1], union, size, bounds })
+    geomRef.current = { bounds, size, auto }
+
+    const sheetRect = sheet.getBoundingClientRect()
+    setOrigin({ top: sheetRect.top + sheet.clientTop, left: sheetRect.left + sheet.clientLeft })
+
+    const parked = parkedRef.current
+    setPlacement(parked ? clampToBounds(parked, size, bounds) : auto)
+  }, [range, viewportRef, portalHost])
+
+  useLayoutEffect(() => {
+    if (dragging) return
+    measure()
+  }, [measure, dragging])
+
+  // Drop lands the offset back into `top`/`left`, so the transform that carried
+  // the drag is cleared in the same commit and the pill never jumps.
+  useLayoutEffect(() => {
+    if (dragging || !pillRef.current) return
+    pillRef.current.style.transform = ""
+  }, [dragging, placement])
+
+  useEffect(() => {
+    const scroller = viewportRef.current
+    if (!range || !scroller) return
+    let frame = 0
+    const schedule = () => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => {
+        if (!dragRef.current) measure()
+      })
+    }
+    scroller.addEventListener("scroll", schedule, { passive: true })
+    window.addEventListener("resize", schedule)
+    window.visualViewport?.addEventListener("resize", schedule)
+    window.visualViewport?.addEventListener("scroll", schedule)
+    return () => {
+      cancelAnimationFrame(frame)
+      scroller.removeEventListener("scroll", schedule)
+      window.removeEventListener("resize", schedule)
+      window.visualViewport?.removeEventListener("resize", schedule)
+      window.visualViewport?.removeEventListener("scroll", schedule)
+    }
+  }, [range, viewportRef, measure])
+
+  const handleGripDown = useCallback(
+    (event: React.PointerEvent<HTMLSpanElement>) => {
+      if (!placement || dragRef.current) return
+      // Capture alone only redirects pointer events; the press would still start
+      // a native drag-select over the text underneath and swallow the moves.
+      event.preventDefault()
+      event.currentTarget.setPointerCapture(event.pointerId)
+      dragRef.current = {
+        id: event.pointerId,
+        grabX: event.clientX - placement.left,
+        grabY: event.clientY - placement.top,
+        startX: event.clientX,
+        startY: event.clientY,
+        origin: placement,
+        point: { top: placement.top, left: placement.left },
+        frame: 0,
+      }
+      onInteractingChange(true)
+    },
+    [placement, onInteractingChange]
+  )
+
+  const handleGripMove = useCallback(
+    (event: React.PointerEvent<HTMLSpanElement>) => {
+      const drag = dragRef.current
+      const geom = geomRef.current
+      if (!drag || drag.id !== event.pointerId || !geom) return
+      if (!dragging && Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) < DRAG_THRESHOLD_PX) return
+      if (!dragging) setDragging(true)
+
+      const next = clampToBounds(
+        { top: event.clientY - drag.grabY, left: event.clientX - drag.grabX },
+        geom.size,
+        geom.bounds
+      )
+      drag.point = { top: next.top, left: next.left }
+
+      // The whole drag is one compositor property on one node. Re-rendering per
+      // move, or writing `top`/`left`, would put React and a layout pass in the
+      // way of every frame, which is what made this feel like it stuttered.
+      cancelAnimationFrame(drag.frame)
+      drag.frame = requestAnimationFrame(() => {
+        const el = pillRef.current
+        if (!el) return
+        el.style.transform = `translate3d(${next.left - drag.origin.left}px, ${next.top - drag.origin.top}px, 0)`
+      })
+    },
+    [dragging]
+  )
+
+  const handleGripUp = useCallback(
+    (event: React.PointerEvent<HTMLSpanElement>, cancelled = false) => {
+      const drag = dragRef.current
+      if (drag && drag.id !== event.pointerId) return
+      dragRef.current = null
+      const geom = geomRef.current
+      // A cancel is the OS taking the gesture away, not a drop, so it reverts
+      // to where the pill was rather than parking it under the last finger
+      // position. The park is recorded before the guard drops, because dropping
+      // it restores the selection and that re-measures against `parkedRef`.
+      if (drag && !cancelled && dragging && geom) {
+        cancelAnimationFrame(drag.frame)
+        // Dropped back where it would have gone on its own: read that as "stop
+        // parking me" rather than as a park that happens to match this selection.
+        const distance = Math.hypot(drag.point.left - geom.auto.left, drag.point.top - geom.auto.top)
+        if (distance <= REATTACH_SNAP_PX) {
+          parkedRef.current = null
+          setPlacement(geom.auto)
+        } else {
+          parkedRef.current = drag.point
+          setPlacement(drag.point)
+        }
+      }
+      if (drag && cancelled) {
+        cancelAnimationFrame(drag.frame)
+        setPlacement(drag.origin)
+      }
+      setDragging(false)
+      onInteractingChange(false)
+    },
+    [dragging, onInteractingChange]
+  )
+
+  const handleGripCancel = useCallback(
+    (event: React.PointerEvent<HTMLSpanElement>) => handleGripUp(event, true),
+    [handleGripUp]
+  )
+
+  if (!range || !portalHost) return null
+
+  return createPortal(
+    <div
+      ref={pillRef}
+      role="toolbar"
+      aria-label="Selection actions"
+      data-testid="selection-pill"
+      // The sheet only ignores a press when there is highlighted text, and a
+      // press on the pill is exactly what collapses the highlight. Without this
+      // a downward drag on the pill drags the sheet down and dismisses it.
+      data-vaul-no-drag
+      className={cn(
+        "absolute z-[60] flex h-11 touch-none select-none items-stretch overflow-hidden rounded-full",
+        "border border-border bg-popover/95 shadow-lg backdrop-blur-sm",
+        dragging ? "cursor-grabbing will-change-transform" : "animate-in fade-in-0 zoom-in-95 duration-150",
+        placement ? "opacity-100" : "pointer-events-none opacity-0"
+      )}
+      style={{ top: (placement?.top ?? 0) - origin.top, left: (placement?.left ?? 0) - origin.left }}
+      onPointerDown={() => onInteractingChange(true)}
+      onPointerUp={() => onInteractingChange(false)}
+    >
+      <span
+        aria-hidden="true"
+        data-testid="selection-pill-grip"
+        className={cn(
+          "flex touch-none items-center pl-2 pr-1 text-muted-foreground/60",
+          dragging ? "text-foreground/70" : "active:text-foreground/70"
+        )}
+        onPointerDown={handleGripDown}
+        onPointerMove={handleGripMove}
+        onPointerUp={handleGripUp}
+        onPointerCancel={handleGripCancel}
+      >
+        <GripVertical className="h-4 w-4" />
+      </span>
+
+      {onShare && (
+        <>
+          <button
+            type="button"
+            className="flex items-center gap-2 px-3.5 text-[13px] font-medium text-secondary-foreground active:bg-muted/70"
+            onClick={onShare}
+          >
+            <Share2 className="h-3.5 w-3.5" />
+            Share
+          </button>
+          <span aria-hidden="true" className="my-2.5 w-px bg-border" />
+        </>
+      )}
+
+      <button
+        type="button"
+        className="flex items-center gap-2 pl-3.5 pr-4 text-[13px] font-semibold text-primary active:bg-primary/10"
+        onClick={onQuote}
+      >
+        <Quote className="h-3.5 w-3.5" />
+        Quote
+      </button>
+    </div>,
+    portalHost
+  )
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -179,6 +179,10 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: frontendPort,
+    // Bind the port asked for or fail. Vite's default is to slide to the next
+    // free one, which leaves the dev stack's readiness probe, its CORS origins
+    // and its Tailscale proxy all addressing a server that is not this one.
+    strictPort: true,
     allowedHosts,
     hmr: isE2ETest ? false : undefined,
     proxy: buildProxyConfig(),
@@ -193,6 +197,7 @@ export default defineConfig({
   preview: {
     host: "0.0.0.0",
     port: frontendPort,
+    strictPort: true,
     proxy: buildProxyConfig(),
   },
 })

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -8,7 +8,7 @@ import path from "path"
 // Ports can be configured via env vars for browser E2E tests
 const backendPort = process.env.VITE_BACKEND_PORT || "3001"
 const socketPort = process.env.VITE_SOCKET_PORT || "3002"
-const frontendPort = parseInt(process.env.VITE_PORT || "3000", 10)
+const frontendPort = parseInt(process.env.VITE_PORT?.trim() || "3000", 10)
 const backendTarget = `http://localhost:${backendPort}`
 const socketTarget = `http://localhost:${socketPort}`
 const allowedHosts = (process.env.VITE_ALLOWED_HOSTS ?? "")

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -5,6 +5,14 @@ import * as os from "os"
 import * as path from "path"
 
 const POSTGRES_HOST = "localhost"
+// Overridable because 3000 is a popular port and another project on the machine
+// may hold it. Deliberately not `VITE_PORT`: the dev stack runs several Vite
+// apps and spreads its own environment into all of them, so a `VITE_PORT` set
+// here is read by whichever one starts first — the backoffice takes the port,
+// the frontend silently falls back to the next one, and the Tailscale proxy
+// then serves the wrong app.
+const FRONTEND_PORT = process.env.DEV_FRONTEND_PORT?.trim() || "3000"
+
 const POSTGRES_PORT = 5454
 const MINIO_HOST = "localhost"
 // Host-side port; docker-compose maps it to MinIO's own 9000 inside the container,
@@ -408,21 +416,21 @@ async function main() {
     console.log(`Remote mode: ${remoteOrigin}`)
   } else if (lanMode) {
     for (const host of lanHosts) {
-      console.log(`LAN mode: http://${host}:3000${host === primaryLanHost ? "  (auth callbacks)" : ""}`)
+      console.log(`LAN mode: http://${host}:${FRONTEND_PORT}${host === primaryLanHost ? "  (auth callbacks)" : ""}`)
     }
   }
 
   const corsOrigins = [
-    "http://localhost:3000",
+    `http://localhost:${FRONTEND_PORT}`,
     "http://localhost:3004",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
   ]
-  for (const host of lanHosts) corsOrigins.push(`http://${host}:3000`)
+  for (const host of lanHosts) corsOrigins.push(`http://${host}:${FRONTEND_PORT}`)
   if (remoteOrigin) corsOrigins.push(remoteOrigin)
 
   const cpEnvOverrides: Record<string, string> = {}
-  const authOrigin = remoteOrigin ?? (primaryLanHost ? `http://${primaryLanHost}:3000` : undefined)
+  const authOrigin = remoteOrigin ?? (primaryLanHost ? `http://${primaryLanHost}:${FRONTEND_PORT}` : undefined)
   const configuredWorkosRedirectUri = cpEnv.WORKOS_REDIRECT_URI ?? process.env.WORKOS_REDIRECT_URI
   if (authOrigin && configuredWorkosRedirectUri) {
     cpEnvOverrides.WORKOS_REDIRECT_URI = replaceUrlOrigin(configuredWorkosRedirectUri, authOrigin)
@@ -509,6 +517,7 @@ async function main() {
     stderr: "inherit",
     env: {
       ...process.env,
+      VITE_PORT: FRONTEND_PORT,
       // Vite rejects unknown Host headers for non-IP hostnames, so every
       // LAN-mode host (Tailscale name included) must be allowlisted or the
       // phone's request bounces with "Blocked request".
@@ -569,7 +578,7 @@ async function main() {
   // exits, unlike `tailscale serve --bg`, which strands a proxy to dead ports.
   const tailscaleServe =
     remoteOrigin && tailscale
-      ? Bun.spawn([tailscale.bin, "serve", `--https=${tailscaleHttpsPort}`, "http://127.0.0.1:3000"], {
+      ? Bun.spawn([tailscale.bin, "serve", `--https=${tailscaleHttpsPort}`, `http://127.0.0.1:${FRONTEND_PORT}`], {
           stdout: "inherit",
           stderr: "inherit",
         })
@@ -614,7 +623,7 @@ async function announceRemoteReady(origin: string): Promise<void> {
   const deadline = Date.now() + 120_000
   while (Date.now() < deadline) {
     try {
-      await fetch("http://127.0.0.1:3000/", { signal: AbortSignal.timeout(2_000) })
+      await fetch(`http://127.0.0.1:${FRONTEND_PORT}/`, { signal: AbortSignal.timeout(2_000) })
       break
     } catch {
       await new Promise((resolve) => setTimeout(resolve, 1_000))

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -11,7 +11,20 @@ const POSTGRES_HOST = "localhost"
 // here is read by whichever one starts first — the backoffice takes the port,
 // the frontend silently falls back to the next one, and the Tailscale proxy
 // then serves the wrong app.
-const FRONTEND_PORT = process.env.DEV_FRONTEND_PORT?.trim() || "3000"
+const FRONTEND_PORT = resolveFrontendPort()
+
+function resolveFrontendPort(): string {
+  const raw = process.env.DEV_FRONTEND_PORT?.trim()
+  if (!raw) return "3000"
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error(`Invalid DEV_FRONTEND_PORT: ${raw}`)
+    process.exit(1)
+  }
+  // Canonical decimal, so every consumer below and Vite itself agree on one
+  // spelling of the same port.
+  return String(port)
+}
 
 const POSTGRES_PORT = 5454
 const MINIO_HOST = "localhost"

--- a/tests/browser/quote-pill-mobile.spec.ts
+++ b/tests/browser/quote-pill-mobile.spec.ts
@@ -70,6 +70,20 @@ async function dragGripTo(page: Page, to: { x: number; y: number }): Promise<voi
   await page.mouse.up()
 }
 
+/**
+ * Opens the full-message view and waits for the sheet to finish growing into
+ * its expanded height. Measuring against a scroller still in motion samples a
+ * placement that is already stale, and the sheet collapses on Back, so the
+ * reopen path needs the same wait as the first open.
+ */
+async function openExpandedView(page: Page): Promise<void> {
+  await page.getByTestId("expanded-quote-open").click()
+  await expect(page.getByTestId("expanded-quote-title")).toBeVisible()
+  await expect
+    .poll(async () => page.evaluate(() => document.querySelector("[data-vaul-drawer]")!.getBoundingClientRect().top))
+    .toBeLessThan(60)
+}
+
 /** Selects `[start, end)` of the expanded view's body, as a long-press drag does. */
 async function selectInExpandedBody(page: Page, start: number, end: number): Promise<void> {
   await page.evaluate(
@@ -121,13 +135,7 @@ test("the quote pill lands below the selection, clear of the reserved band, and 
   const sheet = page.locator("[data-vaul-drawer]")
   await expect(sheet).toBeVisible({ timeout: 10_000 })
 
-  await page.getByTestId("expanded-quote-open").click()
-  await expect(page.getByTestId("expanded-quote-title")).toBeVisible()
-  // The sheet grows into its expanded height; measuring against a moving
-  // scroller would sample a placement that is already stale.
-  await expect
-    .poll(async () => page.evaluate(() => document.querySelector("[data-vaul-drawer]")!.getBoundingClientRect().top))
-    .toBeLessThan(60)
+  await openExpandedView(page)
 
   await selectInExpandedBody(page, 4, 24)
 
@@ -168,7 +176,7 @@ test("the quote pill lands below the selection, clear of the reserved band, and 
   await dragGripTo(page, { x: 90, y: 200 })
   expect((await pillRect(page)).y).toBeLessThan(home)
   await page.getByRole("button", { name: /back to actions/i }).click()
-  await page.getByTestId("expanded-quote-open").click()
+  await openExpandedView(page)
   await selectInExpandedBody(page, 4, 24)
   const reopened = await pillRect(page)
   expect(Math.abs(reopened.y - placed.y)).toBeLessThan(4)

--- a/tests/browser/quote-pill-mobile.spec.ts
+++ b/tests/browser/quote-pill-mobile.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type Page } from "@playwright/test"
+import { createChannel, expectApiOk, loginAndCreateWorkspace } from "./helpers"
+import {
+  HANDLE_CLEARANCE_PX,
+  RESERVED_BOTTOM_PX,
+} from "../../apps/frontend/src/components/timeline/selection-pill-placement"
+
+/**
+ * The mobile quote/share pill: where it lands, and that the reader can move it.
+ *
+ * Chrome's Touch to Search peek and its own selection toolbar are browser
+ * surfaces Playwright cannot render, so what is provable here is our half of
+ * the contract: the pill sits below the selection, never inside the band
+ * reserved for the peek, and a drag parks it somewhere the next selection
+ * honours. The placement arithmetic itself is unit-tested in
+ * `selection-pill-placement.test.ts`.
+ */
+
+test.describe.configure({ timeout: 120_000 })
+
+const PHONE = { width: 390, height: 844 }
+
+const BODY =
+  "The pin backfill drained cleanly across every chunk, so the rollout is done and the numbers in the database agree with what the API reports for each workspace."
+
+function workspaceAndStream(page: Page): { workspaceId: string; streamId: string } {
+  const match = page.url().match(/\/w\/([^/]+)\/s\/([^/?]+)/)
+  expect(match, "workspace + stream should be resolvable from the URL").toBeTruthy()
+  return { workspaceId: match![1], streamId: match![2] }
+}
+
+async function longPress(page: Page, selector: string): Promise<void> {
+  const box = await page.locator(selector).first().boundingBox()
+  expect(box).toBeTruthy()
+  const point = { x: box!.x + box!.width / 2, y: box!.y + 12 }
+  const touch = { identifier: 1, clientX: point.x, clientY: point.y }
+  await page.dispatchEvent(selector, "touchstart", {
+    touches: [touch],
+    changedTouches: [touch],
+    targetTouches: [touch],
+  })
+  await page.waitForTimeout(700)
+  await page.dispatchEvent(selector, "touchend", { touches: [], changedTouches: [], targetTouches: [] })
+}
+
+/**
+ * The pill renders before it has measured itself, so read its box only once a
+ * placement has landed. Reading earlier catches it at its pre-measure origin.
+ */
+async function pillRect(page: Page): Promise<{ y: number; height: number }> {
+  await page.waitForFunction(() => {
+    const el = document.querySelector('[data-testid="selection-pill"]') as HTMLElement | null
+    if (!el || el.className.includes("opacity-0")) return false
+    // Its entrance animation scales the box, so the rect it reports mid-flight
+    // is not where it will come to rest.
+    return el.getAnimations().every((animation) => animation.playState === "finished")
+  })
+  return await page.evaluate(() => {
+    const { y, height } = document.querySelector('[data-testid="selection-pill"]')!.getBoundingClientRect()
+    return { y, height }
+  })
+}
+
+/** Drags the pill by its grip, in steps, so the threshold and the move both fire. */
+async function dragGripTo(page: Page, to: { x: number; y: number }): Promise<void> {
+  const grip = (await page.getByTestId("selection-pill-grip").boundingBox())!
+  await page.mouse.move(grip.x + grip.width / 2, grip.y + grip.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(to.x, to.y, { steps: 8 })
+  await page.mouse.up()
+}
+
+/** Selects `[start, end)` of the expanded view's body, as a long-press drag does. */
+async function selectInExpandedBody(page: Page, start: number, end: number): Promise<void> {
+  await page.evaluate(
+    ({ start, end }) => {
+      const content = document.querySelector('[data-testid="expanded-quote-body"]')
+      const walker = document.createTreeWalker(content!, NodeFilter.SHOW_TEXT)
+      const node = walker.nextNode()!
+      const selection = window.getSelection()!
+      selection.removeAllRanges()
+      const range = document.createRange()
+      range.setStart(node, start)
+      range.setEnd(node, end)
+      selection.addRange(range)
+    },
+    { start, end }
+  )
+}
+
+test("the quote pill lands below the selection, clear of the reserved band, and can be parked", async ({
+  page: setupPage,
+  browser,
+}) => {
+  await loginAndCreateWorkspace(setupPage, "quote-pill")
+  await createChannel(setupPage, `pill-${Date.now().toString(36)}`)
+  const { workspaceId, streamId } = workspaceAndStream(setupPage)
+  const response = await setupPage.request.post(`/api/workspaces/${workspaceId}/messages`, {
+    data: {
+      streamId,
+      contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: BODY }] }] },
+      contentMarkdown: BODY,
+    },
+  })
+  await expectApiOk(response, "Create the message to quote from")
+
+  const context = await browser.newContext({
+    storageState: await setupPage.context().storageState(),
+    hasTouch: true,
+    viewport: PHONE,
+  })
+  const page = await context.newPage()
+  await page.goto(setupPage.url())
+
+  const row = "[data-message-id]"
+  await expect(page.locator(row).first()).toBeVisible({ timeout: 30_000 })
+
+  // The row's touch handlers live on the layout container inside the wrapper,
+  // and synthetic events only bubble upward.
+  await longPress(page, `${row} .message-content`)
+  const sheet = page.locator("[data-vaul-drawer]")
+  await expect(sheet).toBeVisible({ timeout: 10_000 })
+
+  await page.getByTestId("expanded-quote-open").click()
+  await expect(page.getByTestId("expanded-quote-title")).toBeVisible()
+  // The sheet grows into its expanded height; measuring against a moving
+  // scroller would sample a placement that is already stale.
+  await expect
+    .poll(async () => page.evaluate(() => document.querySelector("[data-vaul-drawer]")!.getBoundingClientRect().top))
+    .toBeLessThan(60)
+
+  await selectInExpandedBody(page, 4, 24)
+
+  const pill = page.getByTestId("selection-pill")
+  await expect(pill).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByTestId("expanded-quote-title")).toHaveText(/20 characters selected/)
+
+  // Below the selection, and never in the band the Touch to Search peek owns.
+  const selectionBottom = await page.evaluate(() => window.getSelection()!.getRangeAt(0).getBoundingClientRect().bottom)
+  const placed = await pillRect(page)
+  expect(placed.y).toBeGreaterThan(selectionBottom)
+  expect(placed.y + placed.height).toBeLessThanOrEqual(PHONE.height - RESERVED_BOTTOM_PX)
+
+  // Drag it somewhere of the reader's choosing. Real pointer events, not
+  // dispatched ones: `setPointerCapture` needs a pointer the browser knows.
+  await dragGripTo(page, { x: 90, y: placed.y - 220 })
+
+  const parked = await pillRect(page)
+  expect(parked.y).toBeLessThan(placed.y - 100)
+
+  // A fresh selection honours the parked spot instead of chasing the text.
+  await page.evaluate(() => window.getSelection()!.removeAllRanges())
+  await expect(pill).toBeHidden()
+  await selectInExpandedBody(page, 30, 44)
+  await expect(pill).toBeVisible()
+  const afterReselect = await pillRect(page)
+  expect(Math.abs(afterReselect.y - parked.y)).toBeLessThan(4)
+
+  // Dropped back where it would have gone on its own, it re-attaches: the pill
+  // returns to the computed spot, not to wherever the finger happened to land.
+  const home = await page.evaluate(() => window.getSelection()!.getRangeAt(0).getBoundingClientRect().bottom)
+  await dragGripTo(page, { x: 195, y: home + HANDLE_CLEARANCE_PX + 20 })
+  const reattached = await pillRect(page)
+  expect(Math.abs(reattached.y - (home + HANDLE_CLEARANCE_PX))).toBeLessThan(2)
+
+  // Closing the view forgets the park: opening it again is a fresh read, and
+  // the pill starts back at the selection rather than wherever it was left.
+  await dragGripTo(page, { x: 90, y: 200 })
+  expect((await pillRect(page)).y).toBeLessThan(home)
+  await page.getByRole("button", { name: /back to actions/i }).click()
+  await page.getByTestId("expanded-quote-open").click()
+  await selectInExpandedBody(page, 4, 24)
+  const reopened = await pillRect(page)
+  expect(Math.abs(reopened.y - placed.y)).toBeLessThan(4)
+
+  await context.close()
+})


### PR DESCRIPTION
_🤖 by Claude Opus 5_

## Problem

On a phone, Quote and Share sat in a bar pinned to the bottom of the Full message sheet. Chrome Android opens its Touch to Search peek in exactly that band the moment you long-press text, and it draws over the page rather than resizing the visual viewport, so nothing can measure it or reserve room for it. Both buttons were covered for the first seconds after every selection, which is when you want them.

## Solution

The bar is gone. Quote and Share ride a capsule anchored under the selection, 34px clear of the line so it never lands on a drag handle, clamped inside the sheet, never inside the bottom band the peek owns. A selection running to the floor puts the capsule at the floor of the safe area instead. The character count moved to the header row, idle during a selection, which let the capsule drop to two buttons and killed the "Long-press the message to highlight a passage" footer.

The capsule drags by its grip, because we cannot see the browser chrome but the reader can. Grip-only is deliberate: a tap on Quote that slid a few pixels would otherwise become a silent drag and the quote would never happen. Moves write a transform straight to the node inside `requestAnimationFrame` and commit to `top`/`left` only on release, so a drag costs one render instead of a layout pass per frame. The spot is not persisted; reopening the view puts the capsule back under the selection.

Three seams are worth a reviewer's attention:

- **The sheet is modal**, so the body carries `pointer-events: none` and `aria-hidden`. A capsule portalled to the body is untappable and invisible to a screen reader, so it renders inside the sheet and converts placement from viewport coordinates at render. vaul swaps the sheet node across its open transition, so the portal target is a callback ref.
- **vaul reads a press on the sheet as a drag** unless `getSelection()` is non-empty, and pressing the capsule is what collapses the selection. Without `data-vaul-no-drag` a downward drag on it closed the sheet.
- **Touching a floating overlay is a press outside the selection**, which Chrome collapses; dragging drags a new one. The sheet holds the range it read while a finger is on the capsule and restores it on release. The release comes off the document, not the capsule, because the finger can lift anywhere — a press that slid off would otherwise leave the guard stuck and every later action would send the previous span.

Second commit is unrelated plumbing that this work needed: `scripts/dev.ts` hardcoded 3000, and simply making it `VITE_PORT` was wrong because the stack spreads its environment into several Vite apps — the backoffice took the port, the frontend fell back silently, and the Tailscale proxy served the backoffice with a 403 that read like a broken tunnel. The knob is `DEV_FRONTEND_PORT`; `VITE_PORT` goes to the frontend child alone.

## Proof

`selection-pill-placement.test.ts` (9) covers the arithmetic: below with handle clearance, the floor fallback, both edge clamps, a sweep proving nothing lands in the reserved band, and visibility. `message-action-drawer.test.tsx` (8) covers the offer state machine: settle gating, finger-down gating, the header count, the guard surviving a press that lifts elsewhere (verified to fail without the fix), and the vaul opt-out. `tests/browser/quote-pill-mobile.spec.ts` drives a real 390x844 phone profile through placement, the reserved band, drag to park, the park honoured by a new selection and forgotten on reopen, and re-attach landing on the computed spot.

Timeline suite 686 passing; typecheck and `bun run lint` clean. Exercised by hand on a phone over Tailscale.

## Caveats

- The capsule's segments are raw `<button>`s rather than shadcn `Button` (INV-14), which suits a segmented capsule and matches the raw buttons already in that file. Flagging it as a deliberate choice.
- Desktop's floating selection toolbar still shows two detached chips. Sharing one component across both surfaces is a follow-up, not this PR.
- A selection scrolled out of the readable area hides the capsule and leaves the header reading a count with nothing to act on. Deliberate: a control pointing at text nobody can see is worse than none.

---

_[Claude Opus 5](https://claude.com/product/claude-code) in [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790067984&installation_model_id=20758&pr_number=1938&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1938&signature=5614e3bae36b0c7216243449fe0ef1d5bc9591d8f3508de235a8f839a7e5b875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->