### PR TITLE
fix(dev): remote-dev env carries SESSION_COOKIE_NAME

### DIFF
--- a/.env.remote-dev
+++ b/.env.remote-dev
@@ -4,6 +4,8 @@ TEST_DATABASE_URL=postgresql://threa:threa@localhost:5454/threa_test
 NODE_ENV=development
 PORT=3001
 USE_STUB_AUTH=true
+# Required since #1933: backend and control-plane refuse to boot without it.
+SESSION_COOKIE_NAME=wos_session_dev
 LOG_LEVEL=info
 S3_BUCKET=threa-uploads
 S3_REGION=us-east-1


### PR DESCRIPTION
## Problem

`bun run dev:remote` from the shipped `.env.remote-dev` template dies at startup: since [#1933](https://github.com/threahq/threa/pull/1933) the backend and control-plane refuse to boot without `SESSION_COOKIE_NAME`, and the template never gained the line. Found bringing up a Tailscale preview for the Aside stack.

## Solution

One line: `SESSION_COOKIE_NAME=wos_session_dev` in `.env.remote-dev`, next to the stub-auth setting it pairs with. A dev-specific name rather than `wos_session`, so a remote-dev sandbox and a prod session in the same browser don't clobber each other's cookie.

## Test plan

- [x] Stack boots from the template (verified on homelab with the port-shifted runner used for the Aside preview; the same boot failed without the line)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790073644&installation_model_id=20758&pr_number=1939&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1939&signature=274760922b58c7eddfc682e63161e5cf0a11f5e01a2c6a621fc14b7dca681602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->