### PR TITLE
fix: the quote pill fades in where it lands

### DIFF
--- a/apps/frontend/src/components/timeline/selection-pill.tsx
+++ b/apps/frontend/src/components/timeline/selection-pill.tsx
@@ -255,8 +255,14 @@ export function SelectionPill({
       className={cn(
         "absolute z-[60] flex h-11 touch-none select-none items-stretch overflow-hidden rounded-full",
         "border border-border bg-popover/95 shadow-lg backdrop-blur-sm",
-        dragging ? "cursor-grabbing will-change-transform" : "animate-in fade-in-0 zoom-in-95 duration-150",
-        placement ? "opacity-100" : "pointer-events-none opacity-0"
+        dragging && "cursor-grabbing will-change-transform",
+        // The pill has to render before it can measure itself, and it renders
+        // at the origin. Fading in only once a placement lands is what keeps
+        // that first frame from reading as a flight in from the corner: a
+        // running `fade-in` animation outranks the `opacity-0` that is supposed
+        // to be hiding it. Tied to `placement` rather than to `dragging`, so a
+        // drop does not replay it either.
+        placement ? "animate-in fade-in-0 duration-100 opacity-100" : "pointer-events-none opacity-0"
       )}
       style={{ top: (placement?.top ?? 0) - origin.top, left: (placement?.left ?? 0) - origin.left }}
       onPointerDown={() => onInteractingChange(true)}


### PR DESCRIPTION
_🤖 by Claude Opus 5_

## Problem

The selection pill looked like it flew in from the top-left corner instead of appearing where it belongs.

It has to render before it can measure its own width, and until a placement lands it renders at the origin. `opacity-0` was meant to hide that first frame, but the `fade-in-0` animation sitting beside it was already animating opacity from 0 to 1, and a running CSS animation outranks the utility class. So the corner frame was painted, then the pill jumped to its real position.

## Solution

The entrance waits for the placement before it starts, drops `zoom-in-95`, and runs for 100ms. Binding it to `placement` rather than to `dragging` also stops it replaying every time a drag is released.

The exit is still an unmount rather than a fade; adding one means keeping the node mounted past the selection it points at, which is a bigger change than this warrants. Say the word if it's wanted.

## Proof

Browser spec and the 17 unit tests pass unchanged; typecheck clean. Reported and confirmed on a real phone against production.

---

_[Claude Opus 5](https://claude.com/product/claude-code) in [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790073897&installation_model_id=20758&pr_number=1940&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1940&signature=d48bcce87f7909ea2173968c3631311f7f91070efc29674418ebee159f748c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->