### PR TITLE
feat(frontend): aside draft is a real composer, chat composer drops schedule/stash/fullscreen

### DIFF
--- a/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
@@ -1,10 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
-import { forwardRef } from "react"
 import type { JSONContent } from "@threa/types"
 import { spyOnExport } from "@/test"
 import * as draftComposerModule from "@/hooks/use-draft-composer"
-import * as editorModule from "@/components/editor"
+import * as composerModule from "@/components/composer"
 import type { DraftComposerState } from "@/hooks/use-draft-composer"
 import { AsideDraftEditor } from "./aside-draft-editor"
 
@@ -14,6 +13,9 @@ function composerStub(overrides: Partial<DraftComposerState> = {}): DraftCompose
   return {
     content: EMPTY,
     isLoaded: true,
+    pendingAttachments: [],
+    getPendingAttachmentsSnapshot: () => [],
+    isUploading: false,
     handleContentChange: vi.fn(),
     flushDraft: vi.fn(async () => undefined),
     clearDraft: vi.fn(async () => undefined),
@@ -30,9 +32,23 @@ describe("AsideDraftEditor — Insert into draft", () => {
     })
     // `spyOnExport` swaps the module getter, so the mocked value IS the hook.
     spyOnExport(draftComposerModule, "useDraftComposer").mockReturnValue((() => composer) as never)
-    spyOnExport(editorModule, "RichEditor").mockReturnValue(
-      forwardRef(() => <div data-testid="rich-editor" />) as never
-    )
+    // The card's own wiring is the composer's; here it reports what the editor handed it.
+    spyOnExport(composerModule, "MessageComposer").mockReturnValue(((props: {
+      submitLabel?: string
+      onExpandClick?: () => void
+      scheduledMessagesTrigger?: unknown
+      stashedDrafts?: unknown
+      commandStreamId?: string | null
+    }) => (
+      <div
+        data-testid="message-composer"
+        data-submit-label={props.submitLabel}
+        data-expand={props.onExpandClick ? "yes" : "no"}
+        data-schedule={props.scheduledMessagesTrigger ? "yes" : "no"}
+        data-stash={props.stashedDrafts ? "yes" : "no"}
+        data-commands={props.commandStreamId ?? "none"}
+      />
+    )) as never)
     const onConsumed = vi.fn()
 
     render(
@@ -66,14 +82,23 @@ describe("AsideDraftEditor — Insert into draft", () => {
       ],
     })
     expect(onConsumed).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId("rich-editor")).toBeInTheDocument()
+    // A real composer card — files, emoji, dictation — with the hand-off as its
+    // primary action and none of the stream composer's send-time extras.
+    const card = screen.getByTestId("message-composer")
+    expect({
+      submit: card.getAttribute("data-submit-label"),
+      expand: card.getAttribute("data-expand"),
+      schedule: card.getAttribute("data-schedule"),
+      stash: card.getAttribute("data-stash"),
+      commands: card.getAttribute("data-commands"),
+    }).toEqual({ submit: "Send to composer", expand: "no", schedule: "no", stash: "no", commands: "none" })
   })
 
   it("waits for the draft to load before appending, so a block never lands on a stale empty body", () => {
     const composer = composerStub({ isLoaded: false })
     // `spyOnExport` swaps the module getter, so the mocked value IS the hook.
     spyOnExport(draftComposerModule, "useDraftComposer").mockReturnValue((() => composer) as never)
-    spyOnExport(editorModule, "RichEditor").mockReturnValue(forwardRef(() => <div />) as never)
+    spyOnExport(composerModule, "MessageComposer").mockReturnValue((() => <div />) as never)
 
     render(
       <AsideDraftEditor

--- a/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
@@ -56,7 +56,7 @@ describe("AsideDraftEditor — Insert into draft", () => {
         workspaceId="ws_1"
         scope="aside:stream_aside:draft_1"
         onBack={vi.fn()}
-        onSendToComposer={vi.fn(async () => true)}
+        onSendToComposer={vi.fn(async () => null)}
         pendingAgentBlocks={[
           {
             authorId: "persona_01ARIADNE",
@@ -105,7 +105,7 @@ describe("AsideDraftEditor — Insert into draft", () => {
         workspaceId="ws_1"
         scope="aside:stream_aside:draft_1"
         onBack={vi.fn()}
-        onSendToComposer={vi.fn(async () => true)}
+        onSendToComposer={vi.fn(async () => null)}
         pendingAgentBlocks={[{ authorId: "bot_1", authorName: "Deploybot", content: [] }]}
         onPendingAgentBlocksConsumed={vi.fn()}
       />

--- a/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
@@ -39,6 +39,8 @@ describe("AsideDraftEditor — Insert into draft", () => {
       scheduledMessagesTrigger?: unknown
       stashedDrafts?: unknown
       commandStreamId?: string | null
+      includeStreamCommands?: boolean
+      expanded?: boolean
     }) => (
       <div
         data-testid="message-composer"
@@ -46,7 +48,8 @@ describe("AsideDraftEditor — Insert into draft", () => {
         data-expand={props.onExpandClick ? "yes" : "no"}
         data-schedule={props.scheduledMessagesTrigger ? "yes" : "no"}
         data-stash={props.stashedDrafts ? "yes" : "no"}
-        data-commands={props.commandStreamId ?? "none"}
+        data-commands={props.includeStreamCommands === false ? "editor-only" : "stream"}
+        data-expanded={props.expanded ? "yes" : "no"}
       />
     )) as never)
     const onConsumed = vi.fn()
@@ -91,7 +94,15 @@ describe("AsideDraftEditor — Insert into draft", () => {
       schedule: card.getAttribute("data-schedule"),
       stash: card.getAttribute("data-stash"),
       commands: card.getAttribute("data-commands"),
-    }).toEqual({ submit: "Send to composer", expand: "no", schedule: "no", stash: "no", commands: "none" })
+      expanded: card.getAttribute("data-expanded"),
+    }).toEqual({
+      submit: "Send to composer",
+      expand: "no",
+      schedule: "no",
+      stash: "no",
+      commands: "editor-only",
+      expanded: "yes",
+    })
   })
 
   it("waits for the draft to load before appending, so a block never lands on a stale empty body", () => {

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -21,10 +21,13 @@ interface AsideDraftEditorProps {
 /**
  * One aside draft, open for writing: the same composer card the stream
  * composer is — formatting, emoji, mentions, files, dictation — with "Send to
- * composer" as its only way out. No fullscreen document editor, nothing to
- * schedule, no stash pile (the aside's drafts live in its own dock), and no
- * slash commands: an aside draft is written here and leaves only through the
- * hand-off, the single path content takes out of a private stream.
+ * composer" as its only way out, in the composer's expanded (document) shape
+ * on every device: full-height editor, formatting toolbar, action bar at the
+ * foot. Nothing to schedule, no stash pile (the aside's drafts live in its own
+ * dock), and no stream/runtime commands in the `/` menu — a command written
+ * here would dispatch from wherever the text is sent, not here. An aside draft
+ * leaves only through the hand-off, the single path content takes out of a
+ * private stream.
  */
 export function AsideDraftEditor({
   workspaceId,
@@ -91,6 +94,7 @@ export function AsideDraftEditor({
           onCancelAttachmentUpload={composer.handleCancelAttachmentUpload}
           workspaceId={workspaceId}
           commandStreamId={null}
+          includeStreamCommands={false}
           fileInputRef={composer.fileInputRef}
           onFileSelect={composer.handleFileSelect}
           onFileUpload={composer.uploadFile}

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -11,8 +11,8 @@ interface AsideDraftEditorProps {
   /** `aside:{asideId}:{draftId}` — the one draft this editor writes. */
   scope: string
   onBack: () => void
-  /** Hand the body and files to the host composer. Resolves false when it couldn't be delivered. */
-  onSendToComposer: (handoff: AsideDraftHandoff) => Promise<boolean>
+  /** Hand the body and files to the host composer: null when refused, else the destination's verdict. */
+  onSendToComposer: (handoff: AsideDraftHandoff) => Promise<{ delivered: Promise<boolean> } | null>
   /** Agent replies queued by "Insert into draft"; appended as attributed blocks once the draft has loaded. */
   pendingAgentBlocks?: AgentBlockData[]
   onPendingAgentBlocksConsumed?: () => void

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -76,8 +76,13 @@ export function AsideDraftEditor({
           Send to composer
         </Button>
       </header>
-      <div className="flex min-h-0 flex-1 flex-col justify-end px-3 py-2">
+      <div className="flex min-h-0 flex-1 flex-col px-3 py-2">
+        {/* Expanded: the editor fills the pane like a document, with the
+            formatting toolbar always visible and the action bar at the foot —
+            a writing surface, not a one-line chat box. */}
         <MessageComposer
+          expanded
+          hideExpandedClose
           composerRef={controlRef}
           content={composer.content}
           onContentChange={composer.handleContentChange}

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -1,29 +1,30 @@
 import { useEffect, useRef } from "react"
 import { ArrowLeft, Send, Trash2 } from "lucide-react"
-import type { JSONContent } from "@threa/types"
 import { Button } from "@/components/ui/button"
-import { RichEditor, type RichEditorHandle } from "@/components/editor"
+import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
 import { appendAgentBlockNode, type AgentBlockData } from "@/components/timeline/agent-block-context"
 import { useDraftComposer } from "@/hooks/use-draft-composer"
-import { useAsideDraftActions } from "@/hooks/use-aside-draft-actions"
+import { useAsideDraftActions, type AsideDraftHandoff } from "@/hooks/use-aside-draft-actions"
 
 interface AsideDraftEditorProps {
   workspaceId: string
   /** `aside:{asideId}:{draftId}` — the one draft this editor writes. */
   scope: string
   onBack: () => void
-  /** Hand the body to the host composer. Resolves false when it couldn't be delivered. */
-  onSendToComposer: (content: JSONContent[]) => Promise<boolean>
+  /** Hand the body and files to the host composer. Resolves false when it couldn't be delivered. */
+  onSendToComposer: (handoff: AsideDraftHandoff) => Promise<boolean>
   /** Agent replies queued by "Insert into draft"; appended as attributed blocks once the draft has loaded. */
   pendingAgentBlocks?: AgentBlockData[]
   onPendingAgentBlocksConsumed?: () => void
 }
 
 /**
- * One aside draft, open for writing. Deliberately not a composer host: no send
- * pipeline, no attachments, no commands — an aside draft is written here and
- * leaves only through the hand-off, which is the single path content takes out
- * of a private stream.
+ * One aside draft, open for writing: the same composer card the stream
+ * composer is — formatting, emoji, mentions, files, dictation — with "Send to
+ * composer" as its only way out. No fullscreen document editor, nothing to
+ * schedule, no stash pile (the aside's drafts live in its own dock), and no
+ * slash commands: an aside draft is written here and leaves only through the
+ * hand-off, the single path content takes out of a private stream.
  */
 export function AsideDraftEditor({
   workspaceId,
@@ -34,7 +35,7 @@ export function AsideDraftEditor({
   onPendingAgentBlocksConsumed,
 }: AsideDraftEditorProps) {
   const composer = useDraftComposer({ workspaceId, draftKey: scope, scopeId: scope })
-  const editorRef = useRef<RichEditorHandle>(null)
+  const controlRef = useRef<ComposerControlHandle | null>(null)
   const { send, remove, busy, canSend } = useAsideDraftActions(composer, { onSendToComposer, onDone: onBack })
 
   const { isLoaded, content, handleContentChange } = composer
@@ -44,7 +45,7 @@ export function AsideDraftEditor({
     for (const block of pendingAgentBlocks) next = appendAgentBlockNode(next, block)
     handleContentChange(next)
     onPendingAgentBlocksConsumed?.()
-    editorRef.current?.focusAfterQuoteReply()
+    controlRef.current?.focusAfterQuoteReply()
   }, [isLoaded, content, handleContentChange, pendingAgentBlocks, onPendingAgentBlocksConsumed])
 
   return (
@@ -75,17 +76,30 @@ export function AsideDraftEditor({
           Send to composer
         </Button>
       </header>
-      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
-        <RichEditor
-          ref={editorRef}
-          value={composer.content}
-          onChange={composer.handleContentChange}
+      <div className="flex min-h-0 flex-1 flex-col justify-end px-3 py-2">
+        <MessageComposer
+          composerRef={controlRef}
+          content={composer.content}
+          onContentChange={composer.handleContentChange}
+          pendingAttachments={composer.pendingAttachments}
+          onRemoveAttachment={composer.handleRemoveAttachment}
+          onCancelAttachmentUpload={composer.handleCancelAttachmentUpload}
+          workspaceId={workspaceId}
+          commandStreamId={null}
+          fileInputRef={composer.fileInputRef}
+          onFileSelect={composer.handleFileSelect}
+          onFileUpload={composer.uploadFile}
+          imageCount={composer.imageCount}
           onSubmit={() => void send()}
-          messageSendMode="cmdEnter"
+          canSubmit={canSend && !busy}
+          isSubmitting={busy}
+          submitLabel="Send to composer"
+          submittingLabel="Sending to composer…"
           placeholder="Write here, then send it to the composer…"
-          ariaLabel="Aside draft"
-          autoFocus
+          messageSendMode="cmdEnter"
           scopeId={scope}
+          autoFocus
+          initialMobileChromeOpen
         />
       </div>
     </div>

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -7,13 +7,14 @@ import { StreamErrorBoundary } from "@/components/stream-error-boundary"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { closeAside, setAsideSurface, type AsideSurface } from "@/stores/aside-store"
 import { streamFallbackLabel, streamLabel } from "@/lib/streams"
-import { StreamTypes, type JSONContent } from "@threa/types"
+import { StreamTypes } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { useCallDocked } from "./use-call-docked"
 import { AsideDraftDock } from "./aside-draft-dock"
 import { AsideDraftEditor } from "./aside-draft-editor"
 import { newAsideDraftScope } from "@/lib/drafts/aside-scope"
 import { useAsideHandoff } from "@/hooks/use-aside-handoff"
+import type { AsideDraftHandoff } from "@/hooks/use-aside-draft-actions"
 
 interface AsidePaneProps {
   workspaceId: string
@@ -56,8 +57,8 @@ export function AsidePane({
   const consumePendingAgentBlocks = useCallback(() => setPendingAgentBlocks([]), [])
   const handoff = useAsideHandoff(workspaceId)
   const sendToComposer = useCallback(
-    async (content: JSONContent[]) => {
-      const delivered = await handoff({ hostStreamId, originScope, content })
+    async ({ content, attachments }: AsideDraftHandoff) => {
+      const delivered = await handoff({ hostStreamId, originScope, content, attachments })
       // Get out of the composer's way once the blocks are on their way to it;
       // the aside stays one tap away in the strip.
       if (delivered) setAsideSurface("minimized")

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -58,11 +58,11 @@ export function AsidePane({
   const handoff = useAsideHandoff(workspaceId)
   const sendToComposer = useCallback(
     async ({ content, attachments }: AsideDraftHandoff) => {
-      const delivered = await handoff({ hostStreamId, originScope, content, attachments })
+      const queued = await handoff({ hostStreamId, originScope, content, attachments })
       // Get out of the composer's way once the blocks are on their way to it;
       // the aside stays one tap away in the strip.
-      if (delivered) setAsideSurface("minimized")
-      return delivered
+      if (queued) setAsideSurface("minimized")
+      return queued
     },
     [handoff, hostStreamId, originScope]
   )

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -172,6 +172,8 @@ export interface MessageComposerProps {
    * must not stand in for it.
    */
   commandStreamId?: string | null
+  /** False keeps workspace/stream/runtime commands out of the `/` menu; the editor's own items stay. */
+  includeStreamCommands?: boolean
   /** Workspace id; required only when `contextRefs` is non-empty so the strip can fetch source metadata. */
   workspaceId?: string
   fileInputRef: RefObject<HTMLInputElement | null>
@@ -285,6 +287,7 @@ export function MessageComposer({
   streamId,
   memoAnchorStreamId = streamId,
   commandStreamId,
+  includeStreamCommands,
   workspaceId,
   fileInputRef,
   onFileSelect,
@@ -1155,6 +1158,7 @@ export function MessageComposer({
       streamContext={streamContext}
       memoAnchorStreamId={memoAnchorStreamId}
       commandStreamId={commandStreamId}
+      includeStreamCommands={includeStreamCommands}
       trayAttachments={pendingAttachments}
       onRequestFileUpload={handleRequestInlineUpload}
     />
@@ -1354,6 +1358,7 @@ export function MessageComposer({
                 streamContext={streamContext}
                 memoAnchorStreamId={memoAnchorStreamId}
                 commandStreamId={commandStreamId}
+                includeStreamCommands={includeStreamCommands}
                 trayAttachments={pendingAttachments}
                 onRequestFileUpload={handleRequestInlineUpload}
                 belowToolbarContent={

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -192,6 +192,8 @@ interface RichEditorProps {
    * unrelated stream can't inherit that stream's runtime commands.
    */
   commandStreamId?: string | null
+  /** False keeps workspace/stream/runtime commands out of the `/` menu (see `useCommandSuggestion`). */
+  includeStreamCommands?: boolean
   /** Whether @mentions should be parsed and autocompleted. */
   enableMentions?: boolean
   /** Whether #channel references should be parsed and autocompleted. */
@@ -294,6 +296,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     streamContext,
     memoAnchorStreamId,
     commandStreamId,
+    includeStreamCommands,
     enableMentions = true,
     enableChannels = true,
     enableCommands = true,
@@ -404,6 +407,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     onOpenAttachment: openAttachmentPicker,
     onCommandPicked: notifyCommandPicked,
     commandStreamId,
+    includeStreamCommands,
   })
   const { suggestionConfig: memoConfig, renderMemoList } = useMemoSuggestion(memoAnchorStreamId)
 

--- a/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
@@ -108,6 +108,7 @@ export function useCommandSuggestion({
   onOpenAttachment,
   onCommandPicked,
   commandStreamId,
+  includeStreamCommands = true,
 }: {
   includeMemoSearch?: boolean
   includeGiphy?: boolean
@@ -130,6 +131,13 @@ export function useCommandSuggestion({
    * over an unrelated stream must never inherit that stream's runtime commands.
    */
   commandStreamId?: string | null
+  /**
+   * False leaves only the editor's own `/` items (memo search, giphy, snippet,
+   * attachment): no workspace, stream or runtime command — for an editor whose
+   * content is never sent from where it is written, so a dispatch would land
+   * elsewhere.
+   */
+  includeStreamCommands?: boolean
 } = {}) {
   const { workspaceId, streamId: routeStreamId } = useParams<{ workspaceId: string; streamId: string }>()
   const streamId = commandStreamId !== undefined ? (commandStreamId ?? undefined) : routeStreamId
@@ -143,7 +151,8 @@ export function useCommandSuggestion({
   onOpenAttachmentRef.current = onOpenAttachment
   const onCommandPickedRef = useRef(onCommandPicked)
   onCommandPickedRef.current = onCommandPicked
-  const effectiveCommands = useStreamCommands(workspaceId, streamId)
+  const streamCommands = useStreamCommands(workspaceId, streamId)
+  const effectiveCommands = includeStreamCommands ? streamCommands : []
 
   const commands = useMemo<CommandItem[]>(() => {
     const serverCommands = effectiveCommands

--- a/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.composer-target.test.tsx
@@ -24,7 +24,12 @@ import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-stor
 import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 import { resetApplyWindow } from "@/stores/apply-window"
 import { setComposerTarget } from "@/hooks/use-composer-target"
-import { peekShareHandoff, queueShareHandoff, resetShareHandoffStoreCache } from "@/stores/composer-handoff-store"
+import {
+  peekShareHandoff,
+  queueContentHandoff,
+  queueShareHandoff,
+  resetShareHandoffStoreCache,
+} from "@/stores/composer-handoff-store"
 // eslint-disable-next-line no-restricted-imports -- seeds/asserts the real draft + composer-target rows
 import { db } from "@/db"
 import { MessageInput } from "./message-input"
@@ -55,6 +60,7 @@ const LOCKED_SESSION = {
 
 let registeredConversationReplyHandler: ((data: { conversationId: string }) => void) | null = null
 let notFound = false
+let restoreAttachments: ReturnType<typeof vi.fn> = vi.fn()
 let loadFailed = false
 let lastActiveStreamId = streamId
 let e2eEnabled = false
@@ -87,6 +93,7 @@ beforeEach(async () => {
 
   vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
   vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  restoreAttachments = vi.fn()
   vi.spyOn(useAttachmentsModule, "useAttachments").mockReturnValue({
     pendingAttachments: [],
     getPendingAttachmentsSnapshot: () => [],
@@ -100,7 +107,7 @@ beforeEach(async () => {
     isReserving: false,
     hasFailed: false,
     clear: vi.fn(),
-    restore: vi.fn(),
+    restore: restoreAttachments,
     imageCount: 0,
   } as unknown as ReturnType<typeof useAttachmentsModule.useAttachments>)
 
@@ -357,6 +364,31 @@ describe("the timeline composer's durable target", () => {
         ],
       },
     })
+  }, 10_000)
+
+  it("adopts an aside draft's files with its blocks — held by the composer and persisted on the draft", async () => {
+    await upsertLoadedDraft(workspaceId, hostScope, { contentJson: makeDoc(""), attachments: [] })
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+    mount()
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toBeInTheDocument())
+    const file = { id: "attach_brief", filename: "brief.pdf", mimeType: "application/pdf", sizeBytes: 1200 }
+
+    queueContentHandoff(streamId, [{ type: "paragraph", content: [{ type: "text", text: "from the aside" }] }], [file])
+
+    await waitFor(() => expect(screen.getByTestId("editor-json")).toHaveTextContent("from the aside"), {
+      timeout: 7000,
+    })
+    await waitFor(() => expect(restoreAttachments).toHaveBeenCalledWith([file]), { timeout: 7000 })
+    await waitFor(
+      async () => {
+        const loadedId = (await db.composerLoaded.get(hostScope))?.draftId
+        expect(loadedId).toBeDefined()
+        expect(await db.drafts.get(loadedId!)).toMatchObject({ attachments: [file] })
+      },
+      { timeout: 7000 }
+    )
   }, 10_000)
 
   it("keeps the draft and handoff when the destination cannot be stashed", async () => {

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -24,6 +24,7 @@ import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
 import * as streamCommandsModule from "@/hooks/use-stream-commands"
 import * as openAsideModule from "@/hooks/use-open-aside"
 import { spyOnExport } from "@/test"
+import * as streamStoreModule from "@/stores/stream-store"
 import { toast } from "sonner"
 import { MessageInput, materializePendingAttachmentReferences } from "./message-input"
 // eslint-disable-next-line no-restricted-imports -- clears the durable composer-target rows the composer reads
@@ -302,6 +303,8 @@ beforeEach(async () => {
     pendingAttachments,
     composerRef,
     scheduledMessagesTrigger,
+    stashedDrafts,
+    onExpandClick,
   }: {
     content: JSONContent
     onContentChange: (v: JSONContent) => void
@@ -312,6 +315,8 @@ beforeEach(async () => {
     pendingAttachments: Array<{ id: string; filename: string; sizeBytes: number; status: string }>
     composerRef?: { current: { focus: () => void; focusAfterQuoteReply: () => void } | null }
     scheduledMessagesTrigger?: ReactNode
+    stashedDrafts?: unknown
+    onExpandClick?: () => void
   }) => {
     if (composerRef) {
       composerRef.current = {
@@ -321,7 +326,11 @@ beforeEach(async () => {
     }
 
     return (
-      <div data-testid="message-composer">
+      <div
+        data-testid="message-composer"
+        data-stash={stashedDrafts ? "yes" : "no"}
+        data-expand={onExpandClick ? "yes" : "no"}
+      >
         <textarea data-testid="rich-editor" />
         {pendingAttachments.map((a) => (
           <div key={a.id}>
@@ -422,6 +431,28 @@ describe("MessageInput", () => {
       expect(screen.getByTestId("message-composer")).toBeInTheDocument()
       expect(screen.getByTestId("rich-editor")).toBeInTheDocument()
       expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument()
+    })
+
+    it("keeps schedule, the stash pile and fullscreen off an aside's composer, on for a channel's", () => {
+      const store = spyOnExport(streamStoreModule, "useStreamFromStore")
+      store.mockReturnValue((() => ({ id: streamId, type: "aside" })) as never)
+      const { unmount } = render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      const aside = screen.getByTestId("message-composer")
+      expect({
+        schedule: screen.queryByTestId("scheduled-messages-picker") !== null,
+        stash: aside.getAttribute("data-stash"),
+        expand: aside.getAttribute("data-expand"),
+      }).toEqual({ schedule: false, stash: "no", expand: "no" })
+      unmount()
+
+      store.mockReturnValue((() => ({ id: streamId, type: "channel" })) as never)
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      const channel = screen.getByTestId("message-composer")
+      expect({
+        schedule: screen.queryByTestId("scheduled-messages-picker") !== null,
+        stash: channel.getAttribute("data-stash"),
+        expand: channel.getAttribute("data-expand"),
+      }).toEqual({ schedule: true, stash: "yes", expand: "yes" })
     })
 
     it("should disable send button when canSend is false", () => {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -55,7 +55,8 @@ import {
 import { consumeSnippetRequest, subscribeSnippetRequest } from "@/stores/snippet-request-store"
 import { requestConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { useComposerCommandSend } from "@/components/composer/use-composer-command-send"
-import type { JSONContent } from "@threa/types"
+import { StreamTypes, type JSONContent } from "@threa/types"
+import { useStreamFromStore } from "@/stores/stream-store"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { ComposerEncryptionNotice } from "@/components/encryption/stream-encryption-affordance"
 
@@ -402,6 +403,10 @@ function MessageInputComponent({
     e2eStreamId: e2eRootStreamId,
   })
   const quoteReplyCtx = useQuoteReply()
+  // An aside's composer is a private thinking surface: nothing to schedule,
+  // no stash pile (its drafts live in the aside's own dock), no fullscreen
+  // document editor — the pane is the surface. Those three slots stay off.
+  const isAsideComposer = useStreamFromStore(streamId)?.type === StreamTypes.ASIDE
 
   // Stashed drafts — explicit "Save for later" pile scoped to this stream.
   // Active DraftMessage stays one-per-scope; this hook manages the sibling
@@ -710,6 +715,11 @@ function MessageInputComponent({
           }
           const inserted = destinationEditor.chain().setContent(shareContent).focus("end").run()
           if (!inserted) throw new Error("destination editor rejected the share")
+          // An aside draft's files arrive with its blocks and become this
+          // draft's own (the source let go of them on delivery).
+          composerRef.current.adoptAttachments(
+            batch.handoffs.flatMap((handoff) => (handoff.kind === "content" ? handoff.attachments : []))
+          )
           acknowledgeShareHandoffBatch(streamId, batch)
           const persisted = await composerRef.current.flushDraftWithResult({ contentJson: shareContent })
           if (!persisted) toast.error("Couldn't save the shared message as a draft. Keep this composer open.")
@@ -1034,19 +1044,21 @@ function MessageInputComponent({
       : undefined,
     streamContext,
     composerRef: composerFocusRef,
-    onStashDraft: stash.handleStashDraft,
-    stashedDrafts: {
-      drafts: stash.drafts,
-      previewById: stashPreviews,
-      originById: stashOrigins,
-      canStashCurrent: composer.canSend,
-      onStashCurrent: stash.handleStashDraft,
-      onRestore: stash.handleRestoreStashed,
-      onDelete: stash.handleDeleteStashed,
-      onOpenChange: stash.setPileOpen,
-      controlsDisabled: composer.isSending,
-    },
-    scheduledMessagesTrigger: (
+    onStashDraft: isAsideComposer ? undefined : stash.handleStashDraft,
+    stashedDrafts: isAsideComposer
+      ? undefined
+      : {
+          drafts: stash.drafts,
+          previewById: stashPreviews,
+          originById: stashOrigins,
+          canStashCurrent: composer.canSend,
+          onStashCurrent: stash.handleStashDraft,
+          onRestore: stash.handleRestoreStashed,
+          onDelete: stash.handleDeleteStashed,
+          onOpenChange: stash.setPileOpen,
+          controlsDisabled: composer.isSending,
+        },
+    scheduledMessagesTrigger: isAsideComposer ? undefined : (
       <ScheduledMessagesPicker
         workspaceId={workspaceId}
         streamId={streamId}
@@ -1055,7 +1067,7 @@ function MessageInputComponent({
         controlsDisabled={composer.isSending}
       />
     ),
-    scheduledMessagesTriggerFab: (
+    scheduledMessagesTriggerFab: isAsideComposer ? undefined : (
       <ScheduledMessagesPicker
         workspaceId={workspaceId}
         streamId={streamId}
@@ -1110,7 +1122,13 @@ function MessageInputComponent({
       <FloatingComposerShell ref={composerHeightRef} hidden={expanded} data-message-composer-root>
         <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={e2eEnabled} streamId={e2eRootStreamId} />
         {!expanded && conversationReplyStrip}
-        {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
+        {!expanded && (
+          <MessageComposer
+            {...composerProps}
+            autoFocus={autoFocus}
+            onExpandClick={isAsideComposer ? undefined : handleExpandClick}
+          />
+        )}
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       </FloatingComposerShell>
     </>

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -49,6 +49,7 @@ import { usePanel, createConversationPanelId } from "@/contexts"
 import {
   acknowledgeShareHandoffBatch,
   peekShareHandoffBatch,
+  settleShareHandoffBatch,
   subscribeShareHandoff,
   type ShareHandoffBatch,
 } from "@/stores/composer-handoff-store"
@@ -722,6 +723,7 @@ function MessageInputComponent({
           )
           acknowledgeShareHandoffBatch(streamId, batch)
           const persisted = await composerRef.current.flushDraftWithResult({ contentJson: shareContent })
+          settleShareHandoffBatch(batch, persisted)
           if (!persisted) toast.error("Couldn't save the shared message as a draft. Keep this composer open.")
         }
       } catch (err) {

--- a/apps/frontend/src/hooks/aside-handoff.test.tsx
+++ b/apps/frontend/src/hooks/aside-handoff.test.tsx
@@ -62,7 +62,9 @@ describe("useAsideHandoff", () => {
       })
 
       expect(delivered).toBe(true)
-      expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([{ kind: "content", content: CONTENT }])
+      expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
+        { kind: "content", content: CONTENT, attachments: [] },
+      ])
       expect(await db.composerTarget.get("stream:stream_host")).toBeUndefined()
       expect(pathname).toBe("/w/ws_1/board")
     } finally {
@@ -78,7 +80,9 @@ describe("useAsideHandoff", () => {
     })
 
     expect(delivered).toBe(true)
-    expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([{ kind: "content", content: CONTENT }])
+    expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
+      { kind: "content", content: CONTENT, attachments: [] },
+    ])
     await waitFor(() => expect(pathname).toBe("/w/ws_1/s/stream_host"))
   })
 
@@ -91,7 +95,9 @@ describe("useAsideHandoff", () => {
 
     expect(delivered).toBe(true)
     expect((await db.composerTarget.get("stream:stream_host"))?.scope).toBe("board:reply:conv_1")
-    expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([{ kind: "content", content: CONTENT }])
+    expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
+      { kind: "content", content: CONTENT, attachments: [] },
+    ])
   })
 
   it("refuses an origin the host composer cannot send, rather than stranding the draft", async () => {
@@ -120,7 +126,23 @@ describe("useAsideHandoff", () => {
 
     expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
       { kind: "pointer", attrs: pointer },
-      { kind: "content", content: CONTENT },
+      { kind: "content", content: CONTENT, attachments: [] },
     ])
+  })
+
+  it("carries the draft's files with its blocks, and a files-only draft still hands off", async () => {
+    const unmount = mountHostScroller("stream_host")
+    try {
+      const file = { id: "attach_1", filename: "brief.pdf", mimeType: "application/pdf", sizeBytes: 1200 }
+      const send = handoff()
+      expect(
+        await send({ hostStreamId: "stream_host", originScope: "stream:stream_host", content: [], attachments: [file] })
+      ).toBe(true)
+      expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
+        { kind: "content", content: [], attachments: [file] },
+      ])
+    } finally {
+      unmount()
+    }
   })
 })

--- a/apps/frontend/src/hooks/aside-handoff.test.tsx
+++ b/apps/frontend/src/hooks/aside-handoff.test.tsx
@@ -6,8 +6,10 @@ import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
 import {
   __resetShareHandoffStoreForTesting,
+  acknowledgeShareHandoffBatch,
   peekShareHandoffBatch,
   queueShareHandoff,
+  settleShareHandoffBatch,
 } from "@/stores/composer-handoff-store"
 import { useAsideHandoff } from "./use-aside-handoff"
 
@@ -61,7 +63,7 @@ describe("useAsideHandoff", () => {
         content: CONTENT,
       })
 
-      expect(delivered).toBe(true)
+      expect(delivered).not.toBeNull()
       expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
         { kind: "content", content: CONTENT, attachments: [] },
       ])
@@ -79,7 +81,7 @@ describe("useAsideHandoff", () => {
       content: CONTENT,
     })
 
-    expect(delivered).toBe(true)
+    expect(delivered).not.toBeNull()
     expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
       { kind: "content", content: CONTENT, attachments: [] },
     ])
@@ -93,7 +95,7 @@ describe("useAsideHandoff", () => {
       content: CONTENT,
     })
 
-    expect(delivered).toBe(true)
+    expect(delivered).not.toBeNull()
     expect((await db.composerTarget.get("stream:stream_host"))?.scope).toBe("board:reply:conv_1")
     expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
       { kind: "content", content: CONTENT, attachments: [] },
@@ -102,11 +104,11 @@ describe("useAsideHandoff", () => {
 
   it("refuses an origin the host composer cannot send, rather than stranding the draft", async () => {
     const send = handoff()
-    expect(await send({ hostStreamId: "stream_host", originScope: "thread:msg_1", content: CONTENT })).toBe(false)
-    expect(await send({ hostStreamId: "stream_host", originScope: "board:subtopic:msg_1", content: CONTENT })).toBe(
-      false
-    )
-    expect(await send({ hostStreamId: "stream_host", originScope: "stream:stream_host", content: [] })).toBe(false)
+    expect(await send({ hostStreamId: "stream_host", originScope: "thread:msg_1", content: CONTENT })).toBeNull()
+    expect(
+      await send({ hostStreamId: "stream_host", originScope: "board:subtopic:msg_1", content: CONTENT })
+    ).toBeNull()
+    expect(await send({ hostStreamId: "stream_host", originScope: "stream:stream_host", content: [] })).toBeNull()
     expect(peekShareHandoffBatch("stream_host")).toBeNull()
     expect(await db.composerTarget.get("stream:stream_host")).toBeUndefined()
   })
@@ -135,12 +137,21 @@ describe("useAsideHandoff", () => {
     try {
       const file = { id: "attach_1", filename: "brief.pdf", mimeType: "application/pdf", sizeBytes: 1200 }
       const send = handoff()
-      expect(
-        await send({ hostStreamId: "stream_host", originScope: "stream:stream_host", content: [], attachments: [file] })
-      ).toBe(true)
-      expect(peekShareHandoffBatch("stream_host")?.handoffs).toEqual([
-        { kind: "content", content: [], attachments: [file] },
-      ])
+      const queued = await send({
+        hostStreamId: "stream_host",
+        originScope: "stream:stream_host",
+        content: [],
+        attachments: [file],
+      })
+      expect(queued).not.toBeNull()
+      const batch = peekShareHandoffBatch("stream_host")!
+      expect(batch.handoffs).toEqual([{ kind: "content", content: [], attachments: [file] }])
+      // The source hears the destination's verdict once it has persisted.
+      let verdict: boolean | null = null
+      void queued!.delivered.then((delivered) => (verdict = delivered))
+      acknowledgeShareHandoffBatch("stream_host", batch)
+      settleShareHandoffBatch(batch, true)
+      await waitFor(() => expect(verdict).toBe(true))
     } finally {
       unmount()
     }

--- a/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
@@ -11,13 +11,20 @@ const CONTENT: JSONContent = {
 }
 
 function composerStub(overrides: Partial<DraftComposerState> = {}): DraftComposerState {
+  const pendingAttachments = overrides.pendingAttachments ?? []
   return {
     content: CONTENT,
+    pendingAttachments,
+    getPendingAttachmentsSnapshot: () => pendingAttachments,
+    isUploading: false,
     flushDraft: vi.fn(async () => {}),
     clearDraft: vi.fn(async () => {}),
+    releaseAttachments: vi.fn(),
     ...overrides,
   } as unknown as DraftComposerState
 }
+
+const FILE = { id: "attach_1", filename: "brief.pdf", mimeType: "application/pdf", sizeBytes: 1200 }
 
 describe("useAsideDraftActions", () => {
   it("delivers the draft once when send is pressed twice before the hand-off resolves", async () => {
@@ -38,7 +45,7 @@ describe("useAsideDraftActions", () => {
       await first
     })
     expect({ sent: onSendToComposer.mock.calls, done: onDone.mock.calls }).toEqual({
-      sent: [[CONTENT.content]],
+      sent: [[{ content: CONTENT.content, attachments: [] }]],
       done: [[]],
     })
   })
@@ -90,6 +97,52 @@ describe("useAsideDraftActions", () => {
       await result.current.send()
     })
     expect({ done: onDone.mock.calls.length, busy: result.current.busy }).toEqual({ done: 0, busy: false })
+  })
+
+  it("moves uploaded files with the text: hands them over, then lets go of them once delivered", async () => {
+    const onSendToComposer = vi.fn(async () => true)
+    const composer = composerStub({
+      pendingAttachments: [
+        { ...FILE, status: "uploaded" },
+        { id: "attach_2", filename: "x.png", mimeType: "image/png", sizeBytes: 10, status: "error" },
+      ] as never,
+    })
+    const { result } = renderHook(() => useAsideDraftActions(composer, { onSendToComposer, onDone: vi.fn() }))
+
+    await act(async () => {
+      await result.current.send()
+    })
+
+    expect({
+      sent: onSendToComposer.mock.calls,
+      released: (composer.releaseAttachments as ReturnType<typeof vi.fn>).mock.calls,
+    }).toEqual({
+      sent: [[{ content: CONTENT.content, attachments: [FILE] }]],
+      released: [[]],
+    })
+  })
+
+  it("keeps its files when the hand-off is refused, and holds while one is still uploading", async () => {
+    const refused = composerStub({ pendingAttachments: [{ ...FILE, status: "uploaded" }] as never })
+    const { result } = renderHook(() =>
+      useAsideDraftActions(refused, { onSendToComposer: vi.fn(async () => false), onDone: vi.fn() })
+    )
+    await act(async () => {
+      await result.current.send()
+    })
+    expect(refused.releaseAttachments).not.toHaveBeenCalled()
+
+    const uploading = composerStub({
+      isUploading: true,
+      pendingAttachments: [{ ...FILE, status: "uploading" }] as never,
+    })
+    const onSendToComposer = vi.fn(async () => true)
+    const held = renderHook(() => useAsideDraftActions(uploading, { onSendToComposer, onDone: vi.fn() }))
+    expect(held.result.current.canSend).toBe(false)
+    await act(async () => {
+      await held.result.current.send()
+    })
+    expect(onSendToComposer).not.toHaveBeenCalled()
   })
 
   it("does nothing for an empty draft", async () => {

--- a/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { toast } from "sonner"
 import type { JSONContent } from "@threa/types"
@@ -25,11 +25,16 @@ function composerStub(overrides: Partial<DraftComposerState> = {}): DraftCompose
 }
 
 const FILE = { id: "attach_1", filename: "brief.pdf", mimeType: "application/pdf", sizeBytes: 1200 }
+const queued = (delivered: boolean | Promise<boolean>) => ({ delivered: Promise.resolve(delivered) })
+
+afterEach(() => vi.restoreAllMocks())
 
 describe("useAsideDraftActions", () => {
   it("delivers the draft once when send is pressed twice before the hand-off resolves", async () => {
-    let deliver: (ok: boolean) => void = () => {}
-    const onSendToComposer = vi.fn(() => new Promise<boolean>((resolve) => (deliver = resolve)))
+    let deliver: (queued: { delivered: Promise<boolean> } | null) => void = () => {}
+    const onSendToComposer = vi.fn(
+      () => new Promise<{ delivered: Promise<boolean> } | null>((resolve) => (deliver = resolve))
+    )
     const onDone = vi.fn()
     const { result } = renderHook(() => useAsideDraftActions(composerStub(), { onSendToComposer, onDone }))
 
@@ -41,7 +46,7 @@ describe("useAsideDraftActions", () => {
     expect({ calls: onSendToComposer.mock.calls.length, busy: result.current.busy }).toEqual({ calls: 1, busy: true })
 
     await act(async () => {
-      deliver(true)
+      deliver(queued(true))
       await first
     })
     expect({ sent: onSendToComposer.mock.calls, done: onDone.mock.calls }).toEqual({
@@ -57,7 +62,10 @@ describe("useAsideDraftActions", () => {
       throw new Error("offline")
     })
     const { result } = renderHook(() =>
-      useAsideDraftActions(composerStub({ flushDraft }), { onSendToComposer: vi.fn(async () => true), onDone })
+      useAsideDraftActions(composerStub({ flushDraft }), {
+        onSendToComposer: vi.fn(async () => queued(true)),
+        onDone,
+      })
     )
 
     await act(async () => {
@@ -72,35 +80,45 @@ describe("useAsideDraftActions", () => {
   })
 
   it("refuses to delete the draft while its hand-off is in flight", async () => {
+    let deliver: (queued: { delivered: Promise<boolean> } | null) => void = () => {}
+    const onSendToComposer = vi.fn(
+      () => new Promise<{ delivered: Promise<boolean> } | null>((resolve) => (deliver = resolve))
+    )
     const clearDraft = vi.fn(async () => {})
-    const onSendToComposer = vi.fn(() => new Promise<boolean>(() => {}))
     const { result } = renderHook(() =>
       useAsideDraftActions(composerStub({ clearDraft }), { onSendToComposer, onDone: vi.fn() })
     )
 
+    let sending: Promise<void> = Promise.resolve()
     await act(async () => {
-      void result.current.send()
-    })
-    await act(async () => {
+      sending = result.current.send()
       await result.current.remove()
     })
     expect(clearDraft).not.toHaveBeenCalled()
+    await act(async () => {
+      deliver(queued(true))
+      await sending
+    })
   })
 
   it("keeps the draft and says so when the composer refuses it", async () => {
+    const error = vi.spyOn(toast, "error").mockImplementation(() => "")
     const onDone = vi.fn()
     const { result } = renderHook(() =>
-      useAsideDraftActions(composerStub(), { onSendToComposer: vi.fn(async () => false), onDone })
+      useAsideDraftActions(composerStub(), { onSendToComposer: vi.fn(async () => null), onDone })
     )
 
     await act(async () => {
       await result.current.send()
     })
-    expect({ done: onDone.mock.calls.length, busy: result.current.busy }).toEqual({ done: 0, busy: false })
+    expect({ toasts: error.mock.calls, done: onDone.mock.calls }).toEqual({
+      toasts: [["Couldn't hand this draft to the composer."]],
+      done: [],
+    })
   })
 
-  it("moves uploaded files with the text: hands them over, then lets go of them once delivered", async () => {
-    const onSendToComposer = vi.fn(async () => true)
+  it("moves uploaded files with the text: hands them over and lets go of exactly those once the destination has them", async () => {
+    const onSendToComposer = vi.fn(async () => queued(true))
     const composer = composerStub({
       pendingAttachments: [
         { ...FILE, status: "uploaded" },
@@ -118,35 +136,44 @@ describe("useAsideDraftActions", () => {
       released: (composer.releaseAttachments as ReturnType<typeof vi.fn>).mock.calls,
     }).toEqual({
       sent: [[{ content: CONTENT.content, attachments: [FILE] }]],
-      released: [[]],
+      released: [[[FILE.id]]],
     })
   })
 
-  it("keeps its files when the hand-off is refused, and holds while one is still uploading", async () => {
-    const refused = composerStub({ pendingAttachments: [{ ...FILE, status: "uploaded" }] as never })
+  it("keeps its files when the destination could not persist them, and says so", async () => {
+    const error = vi.spyOn(toast, "error").mockImplementation(() => "")
+    const composer = composerStub({ pendingAttachments: [{ ...FILE, status: "uploaded" }] as never })
     const { result } = renderHook(() =>
-      useAsideDraftActions(refused, { onSendToComposer: vi.fn(async () => false), onDone: vi.fn() })
+      useAsideDraftActions(composer, { onSendToComposer: vi.fn(async () => queued(false)), onDone: vi.fn() })
     )
     await act(async () => {
       await result.current.send()
     })
-    expect(refused.releaseAttachments).not.toHaveBeenCalled()
+    expect({
+      released: (composer.releaseAttachments as ReturnType<typeof vi.fn>).mock.calls,
+      toasts: error.mock.calls,
+    }).toEqual({
+      released: [],
+      toasts: [["The composer didn't confirm it has the files; this draft keeps them."]],
+    })
+  })
 
+  it("holds while a file is still uploading", async () => {
     const uploading = composerStub({
       isUploading: true,
       pendingAttachments: [{ ...FILE, status: "uploading" }] as never,
     })
-    const onSendToComposer = vi.fn(async () => true)
-    const held = renderHook(() => useAsideDraftActions(uploading, { onSendToComposer, onDone: vi.fn() }))
-    expect(held.result.current.canSend).toBe(false)
+    const onSendToComposer = vi.fn(async () => queued(true))
+    const { result } = renderHook(() => useAsideDraftActions(uploading, { onSendToComposer, onDone: vi.fn() }))
+    expect(result.current.canSend).toBe(false)
     await act(async () => {
-      await held.result.current.send()
+      await result.current.send()
     })
     expect(onSendToComposer).not.toHaveBeenCalled()
   })
 
   it("does nothing for an empty draft", async () => {
-    const onSendToComposer = vi.fn(async () => true)
+    const onSendToComposer = vi.fn(async () => queued(true))
     const empty = composerStub({ content: { type: "doc", content: [{ type: "paragraph" }] } })
     const { result } = renderHook(() => useAsideDraftActions(empty, { onSendToComposer, onDone: vi.fn() }))
 

--- a/apps/frontend/src/hooks/use-aside-draft-actions.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.ts
@@ -1,11 +1,12 @@
 import { useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 import type { JSONContent } from "@threa/types"
+import type { DraftAttachment } from "@/db"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import type { DraftComposerState } from "./use-draft-composer"
 
 export interface AsideDraftActions {
-  /** Persist the draft, then hand its blocks to the host composer. */
+  /** Persist the draft, then hand its blocks and files to the host composer. */
   send: () => Promise<void>
   /** Discard the draft. */
   remove: () => Promise<void>
@@ -14,34 +15,49 @@ export interface AsideDraftActions {
   canSend: boolean
 }
 
+export interface AsideDraftHandoff {
+  content: JSONContent[]
+  attachments: DraftAttachment[]
+}
+
 /**
  * The two things an aside draft can do, kept out of the editor component
  * (INV-15). A send is serialized: the draft is flushed before it leaves, and a
  * second send (or a delete) while one is in flight is refused rather than
- * queueing the same content twice or clearing a draft mid-handoff.
+ * queueing the same content twice or clearing a draft mid-handoff. The text is
+ * copied (the draft survives); the files MOVE — an upload can belong to one
+ * message, so once the host composer adopts them this draft lets go.
  */
 export function useAsideDraftActions(
   composer: DraftComposerState,
-  params: { onSendToComposer: (content: JSONContent[]) => Promise<boolean>; onDone: () => void }
+  params: { onSendToComposer: (handoff: AsideDraftHandoff) => Promise<boolean>; onDone: () => void }
 ): AsideDraftActions {
   const [busy, setBusy] = useState(false)
   const inFlight = useRef(false)
   const { onSendToComposer, onDone } = params
+  const uploaded = composer.pendingAttachments.filter((attachment) => attachment.status === "uploaded")
+  const canSend = (!isEmptyContent(composer.content) || uploaded.length > 0) && !composer.isUploading
 
   const send = useCallback(async () => {
     if (inFlight.current) return
     const content = composer.content
-    if (isEmptyContent(content)) return
+    const attachments = composer
+      .getPendingAttachmentsSnapshot()
+      .filter((attachment) => attachment.status === "uploaded")
+      .map(({ id, filename, mimeType, sizeBytes }) => ({ id, filename, mimeType, sizeBytes }))
+    if (isEmptyContent(content) && attachments.length === 0) return
+    if (composer.isUploading) return
     inFlight.current = true
     setBusy(true)
     try {
-      // Persist before handing off: the hand-off is a copy into another
+      // Persist before handing off: the hand-off copies the text into another
       // composer, so the draft must survive it even if the destination refuses.
       await composer.flushDraft()
-      if (!(await onSendToComposer(content.content ?? []))) {
+      if (!(await onSendToComposer({ content: content.content ?? [], attachments }))) {
         toast.error("Couldn't hand this draft to the composer.")
         return
       }
+      composer.releaseAttachments()
       onDone()
     } catch {
       // The editor fires send without awaiting it; a rejected flush or
@@ -59,5 +75,5 @@ export function useAsideDraftActions(
     onDone()
   }, [composer, onDone])
 
-  return { send, remove, busy, canSend: !isEmptyContent(composer.content) }
+  return { send, remove, busy, canSend }
 }

--- a/apps/frontend/src/hooks/use-aside-draft-actions.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.ts
@@ -20,17 +20,25 @@ export interface AsideDraftHandoff {
   attachments: DraftAttachment[]
 }
 
+/** How long the source waits for the destination to persist before it keeps its files. */
+const DELIVERY_WAIT_MS = 20_000
+
 /**
  * The two things an aside draft can do, kept out of the editor component
  * (INV-15). A send is serialized: the draft is flushed before it leaves, and a
  * second send (or a delete) while one is in flight is refused rather than
  * queueing the same content twice or clearing a draft mid-handoff. The text is
- * copied (the draft survives); the files MOVE — an upload can belong to one
- * message, so once the host composer adopts them this draft lets go.
+ * copied (the draft survives); the files MOVE — an upload belongs to one
+ * message — but only once the destination reports them persisted: if it
+ * cannot (or never answers), this draft keeps them and says so. A failed or
+ * still-uploading file never travels and is never let go of.
  */
 export function useAsideDraftActions(
   composer: DraftComposerState,
-  params: { onSendToComposer: (handoff: AsideDraftHandoff) => Promise<boolean>; onDone: () => void }
+  params: {
+    onSendToComposer: (handoff: AsideDraftHandoff) => Promise<{ delivered: Promise<boolean> } | null>
+    onDone: () => void
+  }
 ): AsideDraftActions {
   const [busy, setBusy] = useState(false)
   const inFlight = useRef(false)
@@ -53,12 +61,22 @@ export function useAsideDraftActions(
       // Persist before handing off: the hand-off copies the text into another
       // composer, so the draft must survive it even if the destination refuses.
       await composer.flushDraft()
-      if (!(await onSendToComposer({ content: content.content ?? [], attachments }))) {
+      const queued = await onSendToComposer({ content: content.content ?? [], attachments })
+      if (!queued) {
         toast.error("Couldn't hand this draft to the composer.")
         return
       }
-      composer.releaseAttachments()
       onDone()
+      if (attachments.length === 0) return
+      const delivered = await Promise.race([
+        queued.delivered,
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DELIVERY_WAIT_MS)),
+      ])
+      if (delivered) {
+        composer.releaseAttachments(attachments.map((attachment) => attachment.id))
+      } else {
+        toast.error("The composer didn't confirm it has the files; this draft keeps them.")
+      }
     } catch {
       // The editor fires send without awaiting it; a rejected flush or
       // hand-off must still reach the user, and the draft stays where it is.

--- a/apps/frontend/src/hooks/use-aside-handoff.ts
+++ b/apps/frontend/src/hooks/use-aside-handoff.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react"
 import { useNavigate } from "react-router-dom"
 import { draftStreamScope, type JSONContent } from "@threa/types"
+import type { DraftAttachment } from "@/db"
 import { queueContentHandoff } from "@/stores/composer-handoff-store"
 import { setComposerTarget } from "./use-composer-target"
 import { parseBoardDraftKey } from "@/lib/board/draft-keys"
@@ -25,8 +26,13 @@ function hostComposerMounted(hostStreamId: string): boolean {
 export function useAsideHandoff(workspaceId: string) {
   const navigate = useNavigate()
   return useCallback(
-    async (params: { hostStreamId: string; originScope: string; content: JSONContent[] }): Promise<boolean> => {
-      if (params.content.length === 0) return false
+    async (params: {
+      hostStreamId: string
+      originScope: string
+      content: JSONContent[]
+      attachments?: DraftAttachment[]
+    }): Promise<boolean> => {
+      if (params.content.length === 0 && (params.attachments?.length ?? 0) === 0) return false
       const hostScope = draftStreamScope(params.hostStreamId)
       if (params.originScope !== hostScope) {
         // Only scopes the timeline composer can hold: today the conversation
@@ -36,7 +42,7 @@ export function useAsideHandoff(workspaceId: string) {
         if (board?.kind !== "reply") return false
         await setComposerTarget(workspaceId, hostScope, params.originScope)
       }
-      queueContentHandoff(params.hostStreamId, params.content)
+      queueContentHandoff(params.hostStreamId, params.content, params.attachments ?? [])
       if (!hostComposerMounted(params.hostStreamId)) {
         navigate(`/w/${workspaceId}/s/${params.hostStreamId}`)
       }

--- a/apps/frontend/src/hooks/use-aside-handoff.ts
+++ b/apps/frontend/src/hooks/use-aside-handoff.ts
@@ -22,6 +22,10 @@ function hostComposerMounted(hostStreamId: string): boolean {
  * without one (the board, a conversation panel on its own) would leave the
  * hand-off parked invisibly, so the send takes the user to the host stream —
  * where the composer is — and the queued blocks land as the page mounts.
+ *
+ * Returns null when refused, else the destination's eventual verdict: true
+ * once it has persisted the blocks and files, false if it could not (or the
+ * hand-off expired) — the caller decides what to let go of on that.
  */
 export function useAsideHandoff(workspaceId: string) {
   const navigate = useNavigate()
@@ -31,22 +35,22 @@ export function useAsideHandoff(workspaceId: string) {
       originScope: string
       content: JSONContent[]
       attachments?: DraftAttachment[]
-    }): Promise<boolean> => {
-      if (params.content.length === 0 && (params.attachments?.length ?? 0) === 0) return false
+    }): Promise<{ delivered: Promise<boolean> } | null> => {
+      if (params.content.length === 0 && (params.attachments?.length ?? 0) === 0) return null
       const hostScope = draftStreamScope(params.hostStreamId)
       if (params.originScope !== hostScope) {
         // Only scopes the timeline composer can hold: today the conversation
         // reply scopes it already adopts. Anything else would arm a host that
         // cannot send it, stranding the draft (INV-11) — refuse instead.
         const board = parseBoardDraftKey(params.originScope)
-        if (board?.kind !== "reply") return false
+        if (board?.kind !== "reply") return null
         await setComposerTarget(workspaceId, hostScope, params.originScope)
       }
-      queueContentHandoff(params.hostStreamId, params.content, params.attachments ?? [])
+      const queued = queueContentHandoff(params.hostStreamId, params.content, params.attachments ?? [])
       if (!hostComposerMounted(params.hostStreamId)) {
         navigate(`/w/${workspaceId}/s/${params.hostStreamId}`)
       }
-      return true
+      return queued
     },
     [workspaceId, navigate]
   )

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -97,6 +97,8 @@ export interface UseAttachmentsReturn {
   hasFailed: boolean
   /** Clear all attachments (releases them — in-flight uploads keep running) */
   clear: () => void
+  /** Drop the given uploaded attachments from this composer without deleting them — another draft now holds them. */
+  forget: (attachmentIds: readonly string[]) => void
   /** Restore attachments from saved state */
   restore: (attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>) => void
   /** Current image count for numbering */
@@ -288,6 +290,19 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
   // message already bound the reserved ids, so the bytes must keep streaming
   // after the composer clears. The claim/release effect above handles the
   // manager side when `entries` empties.
+  const forget = useCallback(
+    (attachmentIds: readonly string[]) => {
+      const gone = new Set(attachmentIds)
+      updateEntries((prev) =>
+        prev.filter((entry) => {
+          const id = entry.kind === "job" ? findUploadJob(entry.jobId)?.attachmentId : entry.id
+          return !(id && gone.has(id))
+        })
+      )
+    },
+    [updateEntries]
+  )
+
   const clear = useCallback(() => {
     entriesRef.current = []
     setEntries([])
@@ -353,6 +368,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
     isReserving,
     hasFailed,
     clear,
+    forget,
     restore,
     imageCount,
   }

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -189,6 +189,17 @@ export interface DraftComposerState {
    */
   resolveDraft: () => Promise<void>
   clearAttachments: () => void
+  /**
+   * Take over already-uploaded attachments from another draft (a hand-off):
+   * held by this composer and persisted onto this draft's row, bytes untouched.
+   */
+  adoptAttachments: (attachments: DraftAttachment[]) => void
+  /**
+   * Let go of this draft's uploaded attachments without deleting the uploads —
+   * the other half of a hand-off, once another draft has adopted them. The
+   * chips leave and the row forgets them; the files stay.
+   */
+  releaseAttachments: () => void
 
   // Loading
   isLoaded: boolean
@@ -664,6 +675,24 @@ export function useDraftComposer({
     [removeAttachment, removeDraftAttachment]
   )
 
+  const adoptAttachments = useCallback(
+    (attachments: DraftAttachment[]) => {
+      if (attachments.length === 0) return
+      // Marked restored so the persistence effect doesn't add them a second
+      // time; the one explicit add below is what writes them onto the row.
+      for (const attachment of attachments) restoredAttachmentIdsRef.current.add(attachment.id)
+      restoreAttachments(attachments)
+      for (const attachment of attachments) addDraftAttachment(attachment)
+    },
+    [restoreAttachments, addDraftAttachment]
+  )
+
+  const releaseAttachments = useCallback(() => {
+    const held = pendingAttachmentsRef.current.filter((attachment) => attachment.status === "uploaded")
+    clearAttachments()
+    for (const attachment of held) removeDraftAttachment(attachment.id)
+  }, [clearAttachments, removeDraftAttachment])
+
   // Cancel an in-flight upload: abort the transfer, drop the chip, delete the
   // reservation — and remove it from the persisted draft so a rehydrate
   // doesn't resurrect a file the user just abandoned.
@@ -736,6 +765,8 @@ export function useDraftComposer({
     clearDraft,
     resolveDraft,
     clearAttachments,
+    adoptAttachments,
+    releaseAttachments,
 
     // Loading
     isLoaded: isDraftLoaded,

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -195,11 +195,12 @@ export interface DraftComposerState {
    */
   adoptAttachments: (attachments: DraftAttachment[]) => void
   /**
-   * Let go of this draft's uploaded attachments without deleting the uploads —
-   * the other half of a hand-off, once another draft has adopted them. The
-   * chips leave and the row forgets them; the files stay.
+   * Let go of the given uploaded attachments without deleting the uploads —
+   * the other half of a hand-off, once another draft has adopted them. Those
+   * chips leave and the row forgets them; the files stay, and so does anything
+   * else this draft holds (a failed or in-flight upload keeps its retry).
    */
-  releaseAttachments: () => void
+  releaseAttachments: (attachmentIds: readonly string[]) => void
 
   // Loading
   isLoaded: boolean
@@ -264,6 +265,7 @@ export function useDraftComposer({
     isReserving,
     hasFailed,
     clear: clearAttachments,
+    forget: forgetAttachments,
     restore: restoreAttachments,
     imageCount,
   } = useAttachments(workspaceId, { e2eEnabled: !!e2eStreamId })
@@ -687,11 +689,14 @@ export function useDraftComposer({
     [restoreAttachments, addDraftAttachment]
   )
 
-  const releaseAttachments = useCallback(() => {
-    const held = pendingAttachmentsRef.current.filter((attachment) => attachment.status === "uploaded")
-    clearAttachments()
-    for (const attachment of held) removeDraftAttachment(attachment.id)
-  }, [clearAttachments, removeDraftAttachment])
+  const releaseAttachments = useCallback(
+    (attachmentIds: readonly string[]) => {
+      if (attachmentIds.length === 0) return
+      forgetAttachments(attachmentIds)
+      for (const id of attachmentIds) removeDraftAttachment(id)
+    },
+    [forgetAttachments, removeDraftAttachment]
+  )
 
   // Cancel an in-flight upload: abort the transfer, drop the chip, delete the
   // reservation — and remove it from the persisted draft so a rehydrate

--- a/apps/frontend/src/stores/composer-handoff-store.test.ts
+++ b/apps/frontend/src/stores/composer-handoff-store.test.ts
@@ -134,7 +134,7 @@ describe("share handoff store", () => {
     const batch = peekShareHandoffBatch("stream_1")
     expect(batch?.handoffs).toEqual([
       { kind: "pointer", attrs: sampleAttrs },
-      { kind: "content", content },
+      { kind: "content", content, attachments: [] },
       { kind: "plaintext", markdown: "sealed body", attrs: { ...sampleAttrs, messageId: "msg_2" } },
     ])
 
@@ -147,7 +147,7 @@ describe("share handoff store", () => {
     const seen: unknown[] = []
     const unsubscribe = subscribeShareHandoff("stream_1", () => seen.push(peekShareHandoffBatch("stream_1")?.handoffs))
     queueContentHandoff("stream_1", content)
-    expect(seen).toEqual([[{ kind: "content", content }]])
+    expect(seen).toEqual([[{ kind: "content", content, attachments: [] }]])
     unsubscribe()
   })
 })

--- a/apps/frontend/src/stores/composer-handoff-store.ts
+++ b/apps/frontend/src/stores/composer-handoff-store.ts
@@ -59,13 +59,27 @@ const HANDOFF_TTL_MS = 5 * 60 * 1000
 let nextQueueId = 0
 const cache = new Map<string, QueuedShareHandoff[]>()
 const listeners = new Map<string, Set<() => void>>()
+// Content hand-offs move files, so their source waits to hear that the
+// destination persisted them before letting go: one resolver per queued entry,
+// settled true by the destination, false on expiry/reset/rejection.
+const deliveryResolvers = new Map<number, (delivered: boolean) => void>()
+
+function settleDelivery(queueId: number, delivered: boolean): void {
+  const resolve = deliveryResolvers.get(queueId)
+  if (!resolve) return
+  deliveryResolvers.delete(queueId)
+  resolve(delivered)
+}
 
 function liveQueue(streamId: string): QueuedShareHandoff[] {
   const queued = cache.get(streamId)
   if (!queued) return []
   const now = Date.now()
   for (let index = queued.length - 1; index >= 0; index--) {
-    if (queued[index].expiresAt < now) queued.splice(index, 1)
+    if (queued[index].expiresAt < now) {
+      settleDelivery(queued[index].queueId, false)
+      queued.splice(index, 1)
+    }
   }
   if (queued.length === 0) cache.delete(streamId)
   return queued
@@ -130,20 +144,27 @@ export function queueContentHandoff(
   targetStreamId: string,
   content: JSONContent[],
   attachments: DraftAttachment[] = []
-): void {
+): { delivered: Promise<boolean> } {
   const queued = cache.get(targetStreamId) ?? []
-  queued.push({
-    queueId: ++nextQueueId,
-    kind: "content",
-    content,
-    attachments,
-    expiresAt: Date.now() + HANDOFF_TTL_MS,
-  })
+  const queueId = ++nextQueueId
+  const delivered = new Promise<boolean>((resolve) => deliveryResolvers.set(queueId, resolve))
+  queued.push({ queueId, kind: "content", content, attachments, expiresAt: Date.now() + HANDOFF_TTL_MS })
   cache.set(targetStreamId, queued)
   const subs = listeners.get(targetStreamId)
   if (subs) {
     for (const listener of subs) listener()
   }
+  return { delivered }
+}
+
+/**
+ * The destination's verdict on a drained batch: true once its blocks and
+ * files are persisted on the destination draft, false when it could not keep
+ * them (the source then keeps its files). Called after
+ * {@link acknowledgeShareHandoffBatch}, which only takes the batch off the queue.
+ */
+export function settleShareHandoffBatch(batch: ShareHandoffBatch, delivered: boolean): void {
+  for (const queueId of batch.ids) settleDelivery(queueId, delivered)
 }
 
 /** Read + clear the oldest pending plaintext (decrypted E2E) share for the stream. */
@@ -229,6 +250,7 @@ export function peekShareHandoff(targetStreamId: string): SharedMessageAttrs | n
  * so a share queued under one account never surfaces in another.
  */
 export function resetShareHandoffStoreCache(): void {
+  for (const queueId of [...deliveryResolvers.keys()]) settleDelivery(queueId, false)
   cache.clear()
   listeners.clear()
 }

--- a/apps/frontend/src/stores/composer-handoff-store.ts
+++ b/apps/frontend/src/stores/composer-handoff-store.ts
@@ -1,5 +1,6 @@
 import type { JSONContent } from "@threa/types"
 import type { SharedMessageAttrs } from "@/components/editor/shared-message-extension"
+import type { DraftAttachment } from "@/db"
 
 /**
  * Ephemeral per-stream "hand-off" of content into a target stream's composer:
@@ -33,13 +34,15 @@ export interface PlaintextShareHandoffEntry {
  */
 export interface ContentHandoffEntry {
   content: JSONContent[]
+  /** Uploaded attachments that move with the blocks; the destination adopts them as its own. */
+  attachments: DraftAttachment[]
   expiresAt: number
 }
 
 export type PendingShareHandoff =
   | { kind: "pointer"; attrs: SharedMessageAttrs }
   | { kind: "plaintext"; markdown: string; attrs: SharedMessageAttrs }
-  | { kind: "content"; content: JSONContent[] }
+  | { kind: "content"; content: JSONContent[]; attachments: DraftAttachment[] }
 
 export interface ShareHandoffBatch {
   ids: readonly number[]
@@ -123,9 +126,19 @@ export function queuePlaintextShareHandoff(targetStreamId: string, markdown: str
  * notification as a share; the composer inserts it through the same path, so a
  * draft already in the destination is stashed rather than overwritten.
  */
-export function queueContentHandoff(targetStreamId: string, content: JSONContent[]): void {
+export function queueContentHandoff(
+  targetStreamId: string,
+  content: JSONContent[],
+  attachments: DraftAttachment[] = []
+): void {
   const queued = cache.get(targetStreamId) ?? []
-  queued.push({ queueId: ++nextQueueId, kind: "content", content, expiresAt: Date.now() + HANDOFF_TTL_MS })
+  queued.push({
+    queueId: ++nextQueueId,
+    kind: "content",
+    content,
+    attachments,
+    expiresAt: Date.now() + HANDOFF_TTL_MS,
+  })
   cache.set(targetStreamId, queued)
   const subs = listeners.get(targetStreamId)
   if (subs) {
@@ -155,7 +168,7 @@ export function peekShareHandoffBatch(targetStreamId: string): ShareHandoffBatch
     ids: queued.map((entry) => entry.queueId),
     handoffs: queued.map((entry) => {
       if (entry.kind === "pointer") return { kind: "pointer", attrs: entry.attrs }
-      if (entry.kind === "content") return { kind: "content", content: entry.content }
+      if (entry.kind === "content") return { kind: "content", content: entry.content, attachments: entry.attachments }
       return { kind: "plaintext", markdown: entry.markdown, attrs: entry.attrs }
     }),
   }


### PR DESCRIPTION
## Problem

The aside's draft editor ([#1935](https://github.com/threahq/threa/pull/1935)) was a bare `RichEditor`: formatting only as the hover-on-selection bubble, no action bar, no files, no emoji, no dictation — on desktop and on phones alike. And the aside's chat composer carried the stream composer's send-time extras that make no sense in a private thinking surface: a fullscreen document editor, scheduled sending, the stash pile. Kris's review on the phone, Aug 23.

## Solution

- `AsideDraftEditor` mounts `MessageComposer` on the draft's own `useDraftComposer` state — in its expanded (document) shape on every device — full-height editor, formatting toolbar always visible, action bar at the foot (Aa, emoji, @, files, mic) — with "Send to composer" as its primary action (`submitLabel`, `cmdEnter`), `includeStreamCommands={false}` (the `/` menu keeps only the editor's own items — memo search, giphy, snippet, attachment — since a stream/runtime command written here would dispatch from wherever the text is sent), and no `onExpandClick` / `scheduledMessagesTrigger` / `stashedDrafts`. The header keeps back, delete and a visible "Send to composer".
- **Files ride the hand-off, and leave only once they have arrived.** `ContentHandoffEntry` carries `attachments`; the draining `MessageInput` calls `DraftComposerState.adoptAttachments` (held + persisted on the host draft's row, bytes untouched) and then `settleShareHandoffBatch(batch, persisted)` — the source awaits that verdict (20 s cap) before `releaseAttachments(ids)`, which lets go of exactly the transferred ids; a failed or in-flight upload keeps its retry. No verdict (destination never persisted, hand-off expired, page reloaded) → the draft keeps its files and says so (INV-11). Text is copied as before, files *move* — an upload belongs to one message. A refused hand-off keeps everything; a draft with an upload in flight does not send.
- The aside's chat composer (`MessageInput` on an `aside` stream) leaves fullscreen, schedule and the stash pile off — the pane is the surface, and the aside's drafts live in its own dock.

## Test plan

- [x] `apps/frontend` — draft actions (files handed over, released only on the destination's verdict, kept + told when it never comes; refused keeps; uploading holds), hand-off hook/store (attachments on the queue, verdict settles), composer-target drain (adopts files: `restore` called, draft row carries them), draft editor (expanded composer with the hand-off label, editor-only `/`, none of the three extras), message-input (aside composer without schedule/stash/expand, channel with) — 174 pass
- [ ] Not covered by a real-component test: the hand-off end to end through two mounted composers (the drain is exercised from the destination side with a mocked `useAttachments`); the review's note stands
- [x] full-workspace typecheck + lint
- [x] Preview on 8447 rebuilt at this head

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
