### PR TITLE
fix: the quote pill stops travelling on entrance

### DIFF
--- a/apps/frontend/src/components/timeline/selection-pill.tsx
+++ b/apps/frontend/src/components/timeline/selection-pill.tsx
@@ -255,14 +255,11 @@ export function SelectionPill({
       className={cn(
         "absolute z-[60] flex h-11 touch-none select-none items-stretch overflow-hidden rounded-full",
         "border border-border bg-popover/95 shadow-lg backdrop-blur-sm",
+        // Named, not bare: a lone `duration-*` transitions `all`, which puts
+        // `top`, `left` and the drag transform on the same curve.
+        "transition-opacity duration-100",
         dragging && "cursor-grabbing will-change-transform",
-        // The pill has to render before it can measure itself, and it renders
-        // at the origin. Fading in only once a placement lands is what keeps
-        // that first frame from reading as a flight in from the corner: a
-        // running `fade-in` animation outranks the `opacity-0` that is supposed
-        // to be hiding it. Tied to `placement` rather than to `dragging`, so a
-        // drop does not replay it either.
-        placement ? "animate-in fade-in-0 duration-100 opacity-100" : "pointer-events-none opacity-0"
+        placement ? "opacity-100" : "pointer-events-none opacity-0"
       )}
       style={{ top: (placement?.top ?? 0) - origin.top, left: (placement?.left ?? 0) - origin.left }}
       onPointerDown={() => onInteractingChange(true)}

--- a/tests/browser/quote-pill-mobile.spec.ts
+++ b/tests/browser/quote-pill-mobile.spec.ts
@@ -51,14 +51,37 @@ async function pillRect(page: Page): Promise<{ y: number; height: number }> {
   await page.waitForFunction(() => {
     const el = document.querySelector('[data-testid="selection-pill"]') as HTMLElement | null
     if (!el || el.className.includes("opacity-0")) return false
-    // Its entrance animation scales the box, so the rect it reports mid-flight
-    // is not where it will come to rest.
     return el.getAnimations().every((animation) => animation.playState === "finished")
   })
   return await page.evaluate(() => {
     const { y, height } = document.querySelector('[data-testid="selection-pill"]')!.getBoundingClientRect()
     return { y, height }
   })
+}
+
+/**
+ * Samples the pill every frame while `act` brings it on screen, so a test can
+ * assert on what was painted rather than on where it came to rest.
+ */
+async function sampleEntrance(page: Page, act: () => Promise<void>): Promise<{ top: number; opacity: number }[]> {
+  await page.evaluate(() => {
+    const samples: { top: number; opacity: number }[] = []
+    ;(window as unknown as { __pillSamples: typeof samples }).__pillSamples = samples
+    const started = performance.now()
+    const tick = () => {
+      const el = document.querySelector('[data-testid="selection-pill"]') as HTMLElement | null
+      if (el) {
+        samples.push({ top: el.getBoundingClientRect().top, opacity: Number(getComputedStyle(el).opacity) })
+      }
+      if (performance.now() - started < 1500) requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+  })
+  await act()
+  await page.waitForTimeout(1600)
+  return await page.evaluate(
+    () => (window as unknown as { __pillSamples: { top: number; opacity: number }[] }).__pillSamples
+  )
 }
 
 /** Drags the pill by its grip, in steps, so the threshold and the move both fire. */
@@ -102,7 +125,7 @@ async function selectInExpandedBody(page: Page, start: number, end: number): Pro
   )
 }
 
-test("the quote pill lands below the selection, clear of the reserved band, and can be parked", async ({
+test("the quote pill appears where it lands, clear of the reserved band, and can be parked", async ({
   page: setupPage,
   browser,
 }) => {
@@ -137,11 +160,20 @@ test("the quote pill lands below the selection, clear of the reserved band, and 
 
   await openExpandedView(page)
 
-  await selectInExpandedBody(page, 4, 24)
+  const entrance = await sampleEntrance(page, () => selectInExpandedBody(page, 4, 24))
 
   const pill = page.getByTestId("selection-pill")
   await expect(pill).toBeVisible({ timeout: 10_000 })
   await expect(page.getByTestId("expanded-quote-title")).toHaveText(/20 characters selected/)
+
+  // It appears where it lands. Anything the reader can see has to already be at
+  // rest: the pill has to render before it can measure itself, so it is briefly
+  // at the sheet's origin, and every frame of that has to be fully transparent.
+  const visible = entrance.filter((sample) => sample.opacity > 0.05)
+  expect(visible.length, "the pill should have been sampled while visible").toBeGreaterThan(0)
+  const settled = visible[visible.length - 1].top
+  const travelled = visible.filter((sample) => Math.abs(sample.top - settled) > 1)
+  expect(travelled, `the pill moved while visible: ${JSON.stringify(travelled)}`).toHaveLength(0)
 
   // Below the selection, and never in the band the Touch to Search peek owns.
   const selectionBottom = await page.evaluate(() => window.getSelection()!.getRangeAt(0).getBoundingClientRect().bottom)


### PR DESCRIPTION
[#1940](https://github.com/threahq/threa/pull/1940) did not remove the mobile quote pill's fly-in, it delayed it. Kris filmed the result: the pill still slides up from the sheet's corner, now with a lag in front of it, and the drag lags behind the finger.

## The actual cause

`duration-100` was set without any `transition-*` class. Tailwind's `duration-*` sets only `transition-duration`, so `transition-property` stayed at its CSS default of `all` — `top`, `left` and the drag `transform` were all on a 100ms eased curve. The pill has to render before it can measure its own width, so it renders once at the sheet origin and a `useLayoutEffect` then sets the real placement; with `all` transitioning, that second pass became a visible flight. `opacity-0` only hid the first ~40ms of it.

The fix names the property: `transition-opacity duration-100`, and `animate-in fade-in-0` goes away entirely (it was never the problem, and with a real transition it is redundant).

Removing the curve from `transform` is why the parked pill should now track the finger instead of trailing it.

## Verification

Frame analysis of the recording put the amber "Quote" label at y≈341 → 413 → 424 over ~125ms: a decelerating slide, not a fade. The new Playwright helper samples the pill every animation frame and fails if any frame with opacity > 0.05 is more than 1px off the resting `top`. Reverted against the old code it fails with `top` 87 → 157 → 202 → 226 → 238 while opacity climbs 0.22 → 0.98; with the fix it passes. Frontend unit suites for the pill: 17 pass. Repo `lint` and `typecheck` green.

## Residual risk

Exit is still an unmount, not a fade — `transition-opacity` gives a fade-out only when `placement` clears while the node stays mounted. Kris has not said whether he wants a real fade-out, or whether "floaty" meant the motion or the floating pill itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790086092&installation_model_id=20758&pr_number=1943&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1943&signature=3f63c6fc2749ce3a9b3aed3195501050f7fc2709b191f94bd674d0ed3958dde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->