### PR TITLE
fix: mobile Enter reaches popovers and keeps the autocorrected word

### DIFF
--- a/apps/frontend/src/components/editor/document-editor-modal.tsx
+++ b/apps/frontend/src/components/editor/document-editor-modal.tsx
@@ -188,7 +188,13 @@ export function DocumentEditorModal({
       handleDOMEvents: {
         beforeinput: (_view, event) => {
           const editor = editorRef.current
-          if (!editor || isSuggestionActive(editor)) return false
+          if (!editor) return false
+
+          const suggestionActive = isSuggestionActive(editor)
+          if (handleBeforeInputNewline(editor, event as InputEvent, { allowDuringComposition: suggestionActive })) {
+            return true
+          }
+          if (suggestionActive) return false
 
           // Android atom deletion: keymap doesn't fire for Backspace, so delete
           // adjacent inline atoms here before the browser's two-step selection.
@@ -215,7 +221,7 @@ export function DocumentEditorModal({
             return true
           }
 
-          return handleBeforeInputNewline(editor, event as InputEvent)
+          return false
         },
       },
       handleKeyDown: (_view, event) => {

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -668,26 +668,26 @@ describe("multiline beforeinput enter handling", () => {
     editor.destroy()
   })
 
-  it("flushes the pending autocorrect before splitting, so the corrected word survives Enter", () => {
-    const editor = createTestEditor("- List items steugge")
+  it("reads Gboard's same-batch autocorrect before splitting, even under ProseMirror's deferred flush", () => {
+    const editor = createTestEditor("- Fish and chops")
     editor.commands.setTextSelection(editor.state.doc.content.size - 1)
-    const domObserver = (editor.view as unknown as { domObserver: { flush: () => void } }).domObserver
-    const originalFlush = domObserver.flush.bind(domObserver)
-    // Gboard commits "steugge" → "struggle" into the DOM in the same task as the
-    // newline; ProseMirror only reads it on flush.
-    domObserver.flush = () => {
-      const from = findTextPosition(editor, "steugge")
-      editor.view.dispatch(editor.state.tr.insertText("struggle", from, from + "steugge".length))
-      editor.commands.setTextSelection(editor.state.doc.content.size - 1)
-    }
+    const view = editor.view as unknown as typeof editor.view & { domObserver: { flushSoon: () => void } }
+
+    // Enter-and-pick as traced on Chrome Android: the IME deletes the word and
+    // inserts the correction straight into the DOM, its `deleteContentBackward`
+    // makes ProseMirror schedule a deferred flush (plain `flush()` is then a
+    // no-op), and `insertParagraph` arrives before anything was read back.
+    const textNode = Array.from(view.dom.querySelectorAll("li p"))
+      .flatMap((p) => Array.from(p.childNodes))
+      .find((node): node is Text => node instanceof Text && node.data === "Fish and chops")
+    if (!textNode) throw new Error("text node not found")
+    textNode.data = "Fish and Chips"
+    view.domObserver.flushSoon()
 
     const event = makeBeforeInput("insertParagraph")
-    const handled = handleBeforeInputNewline(editor, event)
-    domObserver.flush = originalFlush
-
-    expect(handled).toBe(true)
+    expect(handleBeforeInputNewline(editor, event)).toBe(true)
     expect(event.prevented).toBe(true)
-    expect(serializeToMarkdown(editor.getJSON())).toBe("- List items struggle\n- ")
+    expect(serializeToMarkdown(editor.getJSON())).toBe("- Fish and Chips\n- ")
     editor.destroy()
   })
 

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -691,6 +691,17 @@ describe("multiline beforeinput enter handling", () => {
     editor.destroy()
   })
 
+  it("clears ProseMirror's iOS Enter fallback marker once it claims the newline", () => {
+    const editor = createTestEditor("plain")
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+    const input = (editor.view as unknown as { input: { lastIOSEnter: number } }).input
+    input.lastIOSEnter = 123
+
+    expect(handleBeforeInputNewline(editor, makeBeforeInput("insertParagraph"))).toBe(true)
+    expect(input.lastIOSEnter).toBe(0)
+    editor.destroy()
+  })
+
   it("leaves the native newline alone while composing", () => {
     const editor = createTestEditor("- List items")
     editor.commands.setTextSelection(editor.state.doc.content.size - 1)

--- a/apps/frontend/src/components/editor/multiline-blocks.test.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { Editor } from "@tiptap/core"
 import type { JSONContent } from "@tiptap/react"
 import { createEditorExtensions } from "./editor-extensions"
+import { EditorBehaviors } from "./editor-behaviors"
 import { serializeToMarkdown, parseMarkdown } from "./editor-markdown"
 import { NodeSelection } from "@tiptap/pm/state"
 import {
@@ -34,9 +35,11 @@ function createTestEditor(content: string | JSONContent) {
     toEmoji: (code) => (code === "rocket" ? "🚀" : null),
   })
 
+  // EditorBehaviors owns the Enter keymap that `handleBeforeInputNewline`
+  // re-dispatches into, mirroring how rich-editor registers it.
   return new Editor({
     element: document.createElement("div"),
-    extensions,
+    extensions: [...extensions, EditorBehaviors],
     content:
       typeof content === "string"
         ? parseMarkdown(
@@ -662,6 +665,80 @@ describe("multiline beforeinput enter handling", () => {
     expect(editor.state.doc.firstChild?.childCount).toBe(2)
     expect(editor.state.doc.lastChild?.type.name).toBe("paragraph")
     expect(editor.isActive("blockquote")).toBe(false)
+    editor.destroy()
+  })
+
+  it("flushes the pending autocorrect before splitting, so the corrected word survives Enter", () => {
+    const editor = createTestEditor("- List items steugge")
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+    const domObserver = (editor.view as unknown as { domObserver: { flush: () => void } }).domObserver
+    const originalFlush = domObserver.flush.bind(domObserver)
+    // Gboard commits "steugge" → "struggle" into the DOM in the same task as the
+    // newline; ProseMirror only reads it on flush.
+    domObserver.flush = () => {
+      const from = findTextPosition(editor, "steugge")
+      editor.view.dispatch(editor.state.tr.insertText("struggle", from, from + "steugge".length))
+      editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+    }
+
+    const event = makeBeforeInput("insertParagraph")
+    const handled = handleBeforeInputNewline(editor, event)
+    domObserver.flush = originalFlush
+
+    expect(handled).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("- List items struggle\n- ")
+    editor.destroy()
+  })
+
+  it("leaves the native newline alone while composing", () => {
+    const editor = createTestEditor("- List items")
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+    ;(editor.view as unknown as { input: { composing: boolean } }).input.composing = true
+
+    const event = makeBeforeInput("insertParagraph")
+    expect(handleBeforeInputNewline(editor, event)).toBe(false)
+    expect(event.prevented).toBe(false)
+    expect(serializeToMarkdown(editor.getJSON())).toBe("- List items")
+    editor.destroy()
+  })
+
+  it("hands Enter to a keydown handler while composing when told to (open popover)", () => {
+    const editor = createTestEditor("plain :ups")
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+    ;(editor.view as unknown as { input: { composing: boolean } }).input.composing = true
+    const seen: KeyboardEvent[] = []
+    editor.setOptions({
+      editorProps: {
+        handleKeyDown: (_view, keydown) => {
+          seen.push(keydown)
+          return true
+        },
+      },
+    })
+
+    const event = makeBeforeInput("insertParagraph")
+    expect(handleBeforeInputNewline(editor, event, { allowDuringComposition: true })).toBe(true)
+    expect(event.prevented).toBe(true)
+    expect(seen.map((keydown) => [keydown.key, keydown.shiftKey])).toEqual([["Enter", false]])
+    expect(serializeToMarkdown(editor.getJSON())).toBe("plain :ups")
+    editor.destroy()
+  })
+
+  it("dispatches insertLineBreak as Shift+Enter", () => {
+    const editor = createTestEditor("plain")
+    const seen: KeyboardEvent[] = []
+    editor.setOptions({
+      editorProps: {
+        handleKeyDown: (_view, keydown) => {
+          seen.push(keydown)
+          return true
+        },
+      },
+    })
+
+    expect(handleBeforeInputNewline(editor, makeBeforeInput("insertLineBreak"))).toBe(true)
+    expect(seen.map((keydown) => [keydown.key, keydown.shiftKey])).toEqual([["Enter", true]])
     editor.destroy()
   })
 })

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -847,12 +847,43 @@ export function handleEnterTextBehavior(editor: Editor): boolean {
   return editor.chain().focus().splitBlock().run()
 }
 
-export function handleBeforeInputNewline(editor: Editor, event: BeforeInputEventLike): boolean {
+interface HandleBeforeInputNewlineOptions {
+  allowDuringComposition?: boolean
+}
+
+/**
+ * Mobile Enter. Chrome Android drops `keydown` Enter inside ProseMirror, so the
+ * keystroke only surfaces here. Re-dispatch it as a keydown so the popovers,
+ * pickers and the Enter keymap see the same single keystroke desktop does.
+ * Flush the DOM observer first: Gboard commits its autocorrect in the same
+ * task as the newline, so editor state can still trail the DOM by a word —
+ * acting on the stale word is what used to eat it. Mid-composition the native
+ * path is left alone (ProseMirror's own Android handling); only an open
+ * popover overrides that, since it must claim Enter or the newline closes it.
+ */
+export function handleBeforeInputNewline(
+  editor: Editor,
+  event: BeforeInputEventLike,
+  options: HandleBeforeInputNewlineOptions = {}
+): boolean {
   if (event.inputType !== "insertParagraph" && event.inputType !== "insertLineBreak") {
     return false
   }
 
-  const handled = handleEnterTextBehavior(editor)
+  const { view } = editor
+  if (view.composing && !options.allowDuringComposition) return false
+
+  flushPendingDomSelection(editor)
+
+  const keydown = new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    shiftKey: event.inputType === "insertLineBreak",
+    bubbles: true,
+    cancelable: true,
+  })
+  const handled = !!view.someProp("handleKeyDown", (handleKeyDown) => handleKeyDown(view, keydown))
   if (handled) {
     event.preventDefault()
   }

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -47,6 +47,13 @@ interface EditorViewWithDomObserver {
     flush?: () => void
     forceFlush?: () => void
   }
+  input?: {
+    lastIOSEnter?: number
+  }
+}
+
+interface FlushPendingDomOptions {
+  cancelDeferred?: boolean
 }
 
 interface IntlSegmenterLike {
@@ -227,13 +234,13 @@ function rangeContainsInlineAtom(state: EditorState, from: number, to: number): 
   return containsAtom
 }
 
-// `forceFlush` first: ProseMirror's own Chrome Android `deleteContentBackward`
+// `cancelDeferred`: ProseMirror's own Chrome Android `deleteContentBackward`
 // handler schedules a 20 ms deferred flush, and while that timer is pending a
 // plain `flush()` is a no-op — exactly the window Gboard's enter-and-pick
 // (delete word → insert correction → Enter, one batch) lands in.
-function flushPendingDomSelection(editor: Editor): void {
+function flushPendingDomSelection(editor: Editor, options: FlushPendingDomOptions = {}): void {
   const domObserver = (editor.view as unknown as EditorViewWithDomObserver).domObserver
-  domObserver?.forceFlush?.()
+  if (options.cancelDeferred) domObserver?.forceFlush?.()
   domObserver?.flush?.()
 }
 
@@ -881,19 +888,18 @@ export function handleBeforeInputNewline(
   const { view } = editor
   if (view.composing && !options.allowDuringComposition) return false
 
-  flushPendingDomSelection(editor)
+  flushPendingDomSelection(editor, { cancelDeferred: true })
 
-  const keydown = new KeyboardEvent("keydown", {
-    key: "Enter",
-    code: "Enter",
-    keyCode: 13,
-    shiftKey: event.inputType === "insertLineBreak",
-    bubbles: true,
-    cancelable: true,
-  })
+  const keydown = new KeyboardEvent("keydown", { key: "Enter", shiftKey: event.inputType === "insertLineBreak" })
   const handled = !!view.someProp("handleKeyDown", (handleKeyDown) => handleKeyDown(view, keydown))
   if (handled) {
     event.preventDefault()
+    // iOS Safari: ProseMirror lets the Return keydown through and arms a 200 ms
+    // fallback that re-dispatches Enter unless a DOM change was read. Claiming
+    // the newline here means no DOM change is read, so clear the marker the
+    // same way ProseMirror does when it handles the Enter itself.
+    const input = (view as unknown as EditorViewWithDomObserver).input
+    if (input?.lastIOSEnter) input.lastIOSEnter = 0
   }
 
   return handled

--- a/apps/frontend/src/components/editor/multiline-blocks.ts
+++ b/apps/frontend/src/components/editor/multiline-blocks.ts
@@ -45,6 +45,7 @@ interface DeleteAdjacentInlineAtomOptions {
 interface EditorViewWithDomObserver {
   domObserver?: {
     flush?: () => void
+    forceFlush?: () => void
   }
 }
 
@@ -226,8 +227,13 @@ function rangeContainsInlineAtom(state: EditorState, from: number, to: number): 
   return containsAtom
 }
 
+// `forceFlush` first: ProseMirror's own Chrome Android `deleteContentBackward`
+// handler schedules a 20 ms deferred flush, and while that timer is pending a
+// plain `flush()` is a no-op — exactly the window Gboard's enter-and-pick
+// (delete word → insert correction → Enter, one batch) lands in.
 function flushPendingDomSelection(editor: Editor): void {
   const domObserver = (editor.view as unknown as EditorViewWithDomObserver).domObserver
+  domObserver?.forceFlush?.()
   domObserver?.flush?.()
 }
 
@@ -855,9 +861,11 @@ interface HandleBeforeInputNewlineOptions {
  * Mobile Enter. Chrome Android drops `keydown` Enter inside ProseMirror, so the
  * keystroke only surfaces here. Re-dispatch it as a keydown so the popovers,
  * pickers and the Enter keymap see the same single keystroke desktop does.
- * Flush the DOM observer first: Gboard commits its autocorrect in the same
- * task as the newline, so editor state can still trail the DOM by a word —
- * acting on the stale word is what used to eat it. Mid-composition the native
+ * Flush the DOM observer first: Gboard's enter-and-pick deletes the word,
+ * inserts the correction and presses Enter in one batch, so editor state can
+ * still trail the DOM by a word — acting on the stale word is what used to eat
+ * it (and left ProseMirror's 50 ms lost-backspace hack to join the new item
+ * back, since it never saw a DOM change). Mid-composition the native
  * path is left alone (ProseMirror's own Android handling); only an open
  * popover overrides that, since it must claim Enter or the newline closes it.
  */

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -857,11 +857,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           if (!editor) return false
 
           const suggestionActive = isSuggestionActive(editor)
-          // Newline handling only matters in cmdEnter mode (Enter sends in default mode).
-          if (
-            messageSendModeRef.current === "cmdEnter" &&
-            handleBeforeInputNewline(editor, event as InputEvent, { allowDuringComposition: suggestionActive })
-          ) {
+          if (handleBeforeInputNewline(editor, event as InputEvent, { allowDuringComposition: suggestionActive })) {
             return true
           }
           if (suggestionActive) return false

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -855,7 +855,16 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
         beforeinput: (_view, event) => {
           const editor = editorRef.current
           if (!editor) return false
-          if (isSuggestionActive(editor)) return false
+
+          const suggestionActive = isSuggestionActive(editor)
+          // Newline handling only matters in cmdEnter mode (Enter sends in default mode).
+          if (
+            messageSendModeRef.current === "cmdEnter" &&
+            handleBeforeInputNewline(editor, event as InputEvent, { allowDuringComposition: suggestionActive })
+          ) {
+            return true
+          }
+          if (suggestionActive) return false
 
           // Android atom deletion: keymap doesn't fire for Backspace, so delete
           // adjacent inline atoms here before the browser's two-step selection.
@@ -897,9 +906,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
             return true
           }
 
-          // Newline handling only matters in cmdEnter mode (Enter sends in default mode).
-          if (messageSendModeRef.current !== "cmdEnter") return false
-          return handleBeforeInputNewline(editor, event as InputEvent)
+          return false
         },
       },
       handleDrop: (_view, event, _slice, moved) => {

--- a/tests/browser/message-send-mode.spec.ts
+++ b/tests/browser/message-send-mode.spec.ts
@@ -79,6 +79,27 @@ test.describe("Message Send Mode", () => {
       await expect(page.locator("p").filter({ hasText: messageContent }).first()).toBeVisible({ timeout: 5000 })
     })
 
+    test("should send on a mobile-keyboard Enter (beforeinput insertParagraph)", async ({ page }) => {
+      await page.getByRole("button", { name: "+ New Scratchpad" }).click()
+      const editor = page.locator("[contenteditable='true']")
+      await expect(editor).toBeVisible({ timeout: 5000 })
+
+      const messageContent = `Beforeinput enter test ${testId}`
+      await editor.click()
+      await page.keyboard.type(messageContent)
+
+      // Chrome Android drops keydown Enter inside ProseMirror; the keystroke
+      // only surfaces as this event.
+      await editor.evaluate((element) => {
+        element.dispatchEvent(
+          new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertParagraph" })
+        )
+      })
+
+      await expect(page.locator("p").filter({ hasText: messageContent }).first()).toBeVisible({ timeout: 5000 })
+      await expect(editor).not.toContainText(messageContent)
+    })
+
     test("should create newline with Shift+Enter (not send)", async ({ page }) => {
       await page.getByRole("button", { name: "+ New Scratchpad" }).click()
       await expect(page.locator("[contenteditable='true']")).toBeVisible({ timeout: 5000 })

--- a/tests/browser/rich-text-editing.spec.ts
+++ b/tests/browser/rich-text-editing.spec.ts
@@ -145,9 +145,11 @@ async function dispatchBeforeInput(
   }, inputType)
 }
 
-// Replays Gboard's enter-and-pick: the autocorrect lands in the DOM and the
-// newline's `beforeinput` fires in the same task, before ProseMirror's
-// DOMObserver has read the corrected word into editor state.
+// Replays the shape of Gboard's enter-and-pick: the autocorrect lands in the
+// DOM and the newline's `beforeinput` fires in the same task. Desktop Chromium
+// never arms ProseMirror's Android deferred flush, so this proves the keydown
+// re-dispatch path end to end, not the `forceFlush` timing (that is the
+// multiline-blocks unit test).
 async function autocorrectThenEnter(page: import("@playwright/test").Page, find: string, replace: string) {
   await page.evaluate(
     ([find, replace]) => {
@@ -1045,6 +1047,9 @@ test.describe("Rich Text Editing", () => {
       await expect(editor.locator("li").nth(1)).toHaveText("")
     })
 
+    // The synthetic `beforeinput` inserts nothing in a real browser, so these
+    // two specs prove the handler hands Enter to the popover (red before the
+    // fix: nothing happened), not that a native newline is suppressed.
     test("beforeinput Enter picks the highlighted emoji instead of inserting a newline", async ({ page }) => {
       const editor = page.locator("[contenteditable='true']")
       await focusMobileComposer(page)

--- a/tests/browser/rich-text-editing.spec.ts
+++ b/tests/browser/rich-text-editing.spec.ts
@@ -145,6 +145,37 @@ async function dispatchBeforeInput(
   }, inputType)
 }
 
+// Replays Gboard's enter-and-pick: the autocorrect lands in the DOM and the
+// newline's `beforeinput` fires in the same task, before ProseMirror's
+// DOMObserver has read the corrected word into editor state.
+async function autocorrectThenEnter(page: import("@playwright/test").Page, find: string, replace: string) {
+  await page.evaluate(
+    ([find, replace]) => {
+      const editor = document.querySelector<HTMLElement>("[contenteditable='true']")
+      if (!editor) throw new Error("Editor not found")
+      const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+      let node: Text | null = null
+      while (walker.nextNode()) {
+        const candidate = walker.currentNode as Text
+        if (candidate.data.includes(find)) node = candidate
+      }
+      if (!node) throw new Error(`no text node containing ${JSON.stringify(find)}`)
+      const index = node.data.lastIndexOf(find)
+      node.replaceData(index, find.length, replace)
+      const range = document.createRange()
+      range.setStart(node, index + replace.length)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      editor.dispatchEvent(
+        new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertParagraph" })
+      )
+    },
+    [find, replace] as const
+  )
+}
+
 async function pastePlainText(page: import("@playwright/test").Page, text: string) {
   await page.evaluate((value) => {
     const editor = document.querySelector<HTMLElement>("[contenteditable='true']")
@@ -999,6 +1030,47 @@ test.describe("Rich Text Editing", () => {
       await expect(editor.locator("blockquote")).toContainText("quoted line")
       await expect(editor.locator("blockquote")).not.toContainText("outside")
       await expect(editor.locator("p").filter({ hasText: "outside" })).toHaveCount(1)
+    })
+
+    test("beforeinput Enter keeps the word the keyboard autocorrected in the same task", async ({ page }) => {
+      const editor = page.locator("[contenteditable='true']")
+      await focusMobileComposer(page)
+      await page.keyboard.type("- List items steugge")
+      await expect(editor.locator("li")).toHaveCount(1)
+
+      await autocorrectThenEnter(page, "steugge", "struggle")
+
+      await expect(editor.locator("li")).toHaveCount(2)
+      await expect(editor.locator("li").first()).toHaveText("List items struggle")
+      await expect(editor.locator("li").nth(1)).toHaveText("")
+    })
+
+    test("beforeinput Enter picks the highlighted emoji instead of inserting a newline", async ({ page }) => {
+      const editor = page.locator("[contenteditable='true']")
+      await focusMobileComposer(page)
+      await page.keyboard.type(":fir")
+      await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+      await dispatchBeforeInput(page)
+
+      await expect(editor).toContainText(/\p{Extended_Pictographic}/u)
+      await expect(editor).not.toContainText("fir")
+      await expect(editor.locator("p")).toHaveCount(1)
+      await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
+    })
+
+    test("beforeinput Enter picks the emoji even when the keyboard autocorrects the query first", async ({ page }) => {
+      const editor = page.locator("[contenteditable='true']")
+      await focusMobileComposer(page)
+      await page.keyboard.type(":upsid")
+      await expect(page.locator("[data-emoji-grid]")).toBeVisible({ timeout: 2000 })
+
+      await autocorrectThenEnter(page, "upsid", "upside")
+
+      await expect(editor).toContainText(/\p{Extended_Pictographic}/u)
+      await expect(editor).not.toContainText("upsid")
+      await expect(editor.locator("p")).toHaveCount(1)
+      await expect(page.locator("[data-emoji-grid]")).not.toBeVisible()
     })
   })
 })


### PR DESCRIPTION
## Problem

On Chrome Android, ProseMirror deliberately ignores keydown Enter (it is "part of a confused sequence of composition events"), so the composer only sees the keystroke as `beforeinput insertParagraph`. `handleBeforeInputNewline` (`multiline-blocks.ts`, from #267) ran `handleEnterTextBehavior` straight from that event, and `rich-editor.tsx` returned early from `beforeinput` whenever a suggestion popover was open. Two visible failures from Kris's video (Gboard, mobile scratchpad):

- `- List items steugge` → Enter with the autocorrect candidate showing: the word vanished and the list broke. Device trace (Gboard, Chrome Android) shows enter-and-pick as one batch within 3 ms — `beforeinput deleteContentBackward` over the word → `insertText "struggle"` → `keydown Enter` → `beforeinput insertParagraph` — before ProseMirror has read any of it. PM's own `deleteContentBackward` handler schedules `domObserver.flushSoon()`, which makes a plain `flush()` a no-op for 20 ms; the split therefore ran on the stale word/selection and wiped the correction, and PM's 50 ms lost-backspace hack (no DOM change counted) then joined the new item back into the previous one — the bullet-less line.
- `/Slad` → Enter, `:upsid` → Enter: the popover never received Enter; the native newline landed (`/Salad`, `:upside` + empty paragraph) and closed the popover. Worked only when no autocorrect was pending, because ProseMirror's own DOM-change heuristic synthesized the Enter in that case — hence "inconsistent".

## Solution

Route the mobile newline through the same keydown pipeline desktop uses instead of a side path.

- `handleBeforeInputNewline` now: returns false while `view.composing` unless `allowDuringComposition` (the popover case) — ProseMirror's native Android handling takes over; otherwise `forceFlush()` + `flush()` the DOM observer (clears PM's deferred timer, so the just-committed autocorrect is in state and `domChangeCount` moves, disarming the lost-backspace hack) and dispatches a synthetic `KeyboardEvent("keydown", Enter)` via `view.someProp("handleKeyDown")` — `insertLineBreak` carries `shiftKey`. That reaches `rich-editor`'s pickers, the `@`/`#`/`/`/`:`/memo suggestion plugins, then the `EditorBehaviors` Enter keymap → `handleEnterTextBehavior`. Prevented only when something handled it.
- `rich-editor.tsx` / `document-editor-modal.tsx`: newline handling moves above the `isSuggestionActive` early-return and passes `allowDuringComposition: suggestionActive`, in both send modes — in `enter` mode the synthetic keydown reaches `handleKeyDown` and sends (CodeRabbit's catch; previously the native newline landed on Chrome Android).
- iOS Safari: ProseMirror lets Return's keydown through and arms a 200 ms fallback that re-dispatches Enter unless it read a DOM change; claiming the newline here means it never does, so `lastIOSEnter` is cleared the way PM does when it handles Enter itself (Opus review; the popover pick would otherwise have been followed by a stray split — the plain-newline variant of that was pre-existing since #267).
- `forceFlush` stays scoped to the newline path (`cancelDeferred`); the atom/grapheme delete handlers keep the plain flush.
- Synthetic keydown over calling the suggestion hook directly — the handler order is already the desktop contract (table input rule at 1100, EditorBehaviors at 1000, core keymap), so one dispatch covers popovers, pickers and keymaps without a second Enter authority.
- Test editor in `multiline-blocks.test.ts` now includes `EditorBehaviors`, matching how `rich-editor` registers it.

Residual: the list/autocorrect browser spec is green before and after in desktop Chromium (PM self-heals the stale word there); the faithful reproduction is the unit test that mutates the DOM and arms `flushSoon()` (red with plain `flush()`). While composing without a popover, the native path runs (ProseMirror's own Android handling; code-block/blockquote "third newline exits" yields to a plain newline there). Kris's Gboard did not compose at all in the traces, so composing IMEs (Korean/Japanese Gboard, SwiftKey) are untested on device — both the guard and the popover pick mid-composition. iOS is reasoned from the vendored prosemirror-view source, not device-verified.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/multiline-blocks.ts` | `handleBeforeInputNewline` force-flushes, then re-dispatches Enter as keydown; composition guard with `allowDuringComposition`; `flushPendingDomSelection` = `forceFlush` + `flush` |
| `apps/frontend/src/components/editor/rich-editor.tsx` | newline handling runs before the suggestion early-return, both send modes, popover allowed mid-composition |
| `apps/frontend/src/components/editor/document-editor-modal.tsx` | same reorder |
| `apps/frontend/src/components/editor/multiline-blocks.test.ts` | test editor gets `EditorBehaviors`; 4 unit tests (Gboard enter-and-pick under `flushSoon`, composing → native, popover override, insertLineBreak → Shift) |
| `tests/browser/rich-text-editing.spec.ts` | 3 mobile specs: autocorrect+Enter in a list, Enter picks emoji with popover open, Enter picks emoji when the query is autocorrected in the same task |
| `tests/browser/message-send-mode.spec.ts` | `beforeinput insertParagraph` sends in `enter` mode |

## Test plan

- [x] `vitest run multiline-blocks.test.ts` — 75 pass (enter-and-pick under `flushSoon` is red with plain `flush()`)
- [x] Playwright `rich-text-editing`, `keyboard-correction-suggestion`, `emoji-shortcuts`, `markdown-table-mobile`, `command-arg-picker`, `message-send-mode` — all pass; with the fix reverted the two popover specs fail (`:fir` / `:upside` left as text), the list spec passes either way
- [x] Independent Opus review (correctness / mobile / failure / tests lenses): 1 blocker (iOS fallback) fixed, forceFlush scope + spec wording fixed, composing-IME caveat recorded above
- [x] `bun run typecheck`, eslint on changed files
- [x] Gboard on Kris's Android phone via a Tailscale preview of this branch: `/Slad`→Enter and `:upsid`→Enter select the item; `- Fish and xjips`→Enter (candidate "Chips") keeps "Fish and Chips" and adds a new item in bulleted and numbered lists; `There feiend`→Enter likewise. Event trace from the device is what drove the `forceFlush` commit; the interim build without it still dropped the word.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
