### PR TITLE
fix(frontend): a composer's armed save survives its teardown

### DIFF
--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -39,7 +39,10 @@ export function AsideDraftEditor({
 }: AsideDraftEditorProps) {
   const composer = useDraftComposer({ workspaceId, draftKey: scope, scopeId: scope })
   const controlRef = useRef<ComposerControlHandle | null>(null)
-  const { send, remove, busy, canSend } = useAsideDraftActions(composer, { onSendToComposer, onDone: onBack })
+  const { send, leave, remove, busy, canSend } = useAsideDraftActions(composer, {
+    onSendToComposer,
+    onDone: onBack,
+  })
 
   const { isLoaded, content, handleContentChange } = composer
   useEffect(() => {
@@ -54,7 +57,14 @@ export function AsideDraftEditor({
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="aside-draft-editor" data-draft-scope={scope}>
       <header className="flex h-11 shrink-0 items-center gap-1 border-b pl-2 pr-2">
-        <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to drafts" onClick={onBack}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Back to drafts"
+          disabled={busy}
+          onClick={() => void leave()}
+        >
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <span className="flex-1" />

--- a/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.test.ts
@@ -18,6 +18,7 @@ function composerStub(overrides: Partial<DraftComposerState> = {}): DraftCompose
     getPendingAttachmentsSnapshot: () => pendingAttachments,
     isUploading: false,
     flushDraft: vi.fn(async () => {}),
+    flushDraftWithResult: vi.fn(async () => true),
     clearDraft: vi.fn(async () => {}),
     releaseAttachments: vi.fn(),
     ...overrides,
@@ -76,6 +77,55 @@ describe("useAsideDraftActions", () => {
       toasts: [["Couldn't hand this draft to the composer."]],
       done: [],
       busy: false,
+    })
+  })
+
+  describe("leave", () => {
+    it("persists what is written before closing the editor, so the agent reads it and not the older copy", async () => {
+      const flushDraftWithResult = vi.fn(async () => true)
+      const onDone = vi.fn()
+      const { result } = renderHook(() =>
+        useAsideDraftActions(composerStub({ flushDraftWithResult }), { onSendToComposer: vi.fn(), onDone })
+      )
+
+      await act(async () => await result.current.leave())
+
+      expect({ flushed: flushDraftWithResult.mock.calls.length, closed: onDone.mock.calls.length }).toEqual({
+        flushed: 1,
+        closed: 1,
+      })
+    })
+
+    it("keeps the editor open and says so when the text could not be saved", async () => {
+      const error = vi.spyOn(toast, "error").mockImplementation(() => "")
+      const onDone = vi.fn()
+      const { result } = renderHook(() =>
+        useAsideDraftActions(composerStub({ flushDraftWithResult: vi.fn(async () => false) }), {
+          onSendToComposer: vi.fn(),
+          onDone,
+        })
+      )
+
+      await act(async () => await result.current.leave())
+
+      expect(onDone).not.toHaveBeenCalled()
+      expect(error.mock.calls).toEqual([[expect.stringContaining("Couldn't save this draft")]])
+    })
+
+    it("closes an untouched draft without writing a row for it", async () => {
+      const flushDraftWithResult = vi.fn(async () => true)
+      const onDone = vi.fn()
+      const { result } = renderHook(() =>
+        useAsideDraftActions(
+          composerStub({ flushDraftWithResult, content: { type: "doc", content: [{ type: "paragraph" }] } }),
+          { onSendToComposer: vi.fn(), onDone }
+        )
+      )
+
+      await act(async () => await result.current.leave())
+
+      expect(flushDraftWithResult).not.toHaveBeenCalled()
+      expect(onDone).toHaveBeenCalledOnce()
     })
   })
 

--- a/apps/frontend/src/hooks/use-aside-draft-actions.ts
+++ b/apps/frontend/src/hooks/use-aside-draft-actions.ts
@@ -8,6 +8,8 @@ import type { DraftComposerState } from "./use-draft-composer"
 export interface AsideDraftActions {
   /** Persist the draft, then hand its blocks and files to the host composer. */
   send: () => Promise<void>
+  /** Persist what is written, then close the editor. */
+  leave: () => Promise<void>
   /** Discard the draft. */
   remove: () => Promise<void>
   /** True while a send is in flight — both controls are held so one draft is delivered once. */
@@ -87,11 +89,30 @@ export function useAsideDraftActions(
     }
   }, [composer, onSendToComposer, onDone])
 
+  // Leaving the editor is how the user gets back to the aside's chat to ask
+  // about what they just wrote, so the text must be on the server before the
+  // question can be asked — the agent reads the stored draft, not the screen.
+  // The teardown flush in `use-draft-message` is the net for every other way
+  // out (the pane closing, the sheet dismissed); this makes the ordering
+  // explicit on the one path that leads straight to asking.
+  const leave = useCallback(async () => {
+    if (inFlight.current) return
+    const hasPayload = !isEmptyContent(composer.content) || composer.pendingAttachments.length > 0
+    if (hasPayload) {
+      const persisted = await composer.flushDraftWithResult().catch(() => false)
+      if (!persisted) {
+        toast.error("Couldn't save this draft just now — it stays open so nothing is lost.")
+        return
+      }
+    }
+    onDone()
+  }, [composer, onDone])
+
   const remove = useCallback(async () => {
     if (inFlight.current) return
     await composer.clearDraft()
     onDone()
   }, [composer, onDone])
 
-  return { send, remove, busy, canSend }
+  return { send, leave, remove, busy, canSend }
 }

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -310,6 +310,32 @@ describe("useDraftMessage", () => {
       const persisted = await loadedDraft(draftKey)
       expect(persisted?.contentJson).toEqual(thirdContent)
     })
+
+    it("persists an armed save when the composer unmounts inside the debounce window", async () => {
+      // Dropping it was silent loss: the tail lived only in the staging buffer,
+      // which is recovered at the next workspace load — until then the row, the
+      // previews reading it, and the server all showed the older body.
+      const { result, unmount } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+      const tail = makeDoc("Typed then left")
+
+      act(() => result.current.saveDraftDebounced(tail))
+      unmount()
+
+      await waitFor(async () => expect((await loadedDraft(draftKey))?.contentJson).toEqual(tail))
+    })
+
+    it("does not resurrect a save that was deliberately cancelled before teardown", async () => {
+      const { result, unmount } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+
+      act(() => {
+        result.current.saveDraftDebounced(makeDoc("Moot"))
+        result.current.cancelPendingSave()
+      })
+      unmount()
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(await loadedDraft(draftKey)).toBeUndefined()
+    })
   })
 
   describe("addAttachment", () => {

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -827,6 +827,11 @@ export function useDraftMessage(
 ) {
   const e2eEnabled = !!e2eStreamId
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The payload the armed debounce would persist, kept beside the timer so a
+  // teardown can FIRE it instead of dropping it (see the unmount effect). Every
+  // deliberate cancel clears both — an armed save that was cancelled as moot
+  // must not come back to life at unmount.
+  const pendingSaveRef = useRef<{ contentJson: JSONContent; expectedDraftId: string | null } | null>(null)
   const fallbackContentDraftIdRef = useRef<string | null>(null)
   // Serializes this composer's WRITES (typing saves, attachment edits): under a
   // main-thread stall, two queued debounce timers can fire back-to-back and the
@@ -917,6 +922,7 @@ export function useDraftMessage(
         clearTimeout(debounceRef.current)
         debounceRef.current = null
       }
+      pendingSaveRef.current = null
       return chainWrite(async () => {
         // The row this content belongs to. An explicit NON-NULL argument (the
         // debounced save's arm-time id, a repoint flush, a minted detach id) wins;
@@ -1055,11 +1061,13 @@ export function useDraftMessage(
       // `contentJson` belong to the draft loaded now, and the scope's pointer (and
       // with it the composer's identity) may be repointed before the timer fires.
       const expectedDraftId = contentDraftId.current
+      pendingSaveRef.current = { contentJson, expectedDraftId }
       // `saveDraft` reads the live E2E gate when the timer fires, so a value typed
       // while the stream was plaintext is sealed (or dropped) — never written as
       // plaintext — if the stream became encrypted in the meantime (E2EE-4).
       debounceRef.current = setTimeout(() => {
         debounceRef.current = null
+        pendingSaveRef.current = null
         void saveDraft(contentJson, undefined, expectedDraftId)
       }, DEBOUNCE_MS)
     },
@@ -1268,6 +1276,7 @@ export function useDraftMessage(
       clearTimeout(debounceRef.current)
       debounceRef.current = null
     }
+    pendingSaveRef.current = null
   }, [])
 
   const clearDraft = useCallback(async () => {
@@ -1276,6 +1285,7 @@ export function useDraftMessage(
       clearTimeout(debounceRef.current)
       debounceRef.current = null
     }
+    pendingSaveRef.current = null
 
     await clearLoadedDraft(workspaceId, draftKey)
     contentDraftId.current = null
@@ -1294,18 +1304,37 @@ export function useDraftMessage(
       clearTimeout(debounceRef.current)
       debounceRef.current = null
     }
+    pendingSaveRef.current = null
 
     await resolveLoadedDraft(workspaceId, draftKey, contentDraftId.current)
     contentDraftId.current = null
     syncEngine?.kickOperationQueue()
   }, [draftKey, workspaceId, syncEngine, contentDraftId])
 
-  // Cleanup timeout on unmount
+  // Teardown FIRES the armed save rather than dropping it. Clearing the timer
+  // was silent data loss: a composer that unmounts inside the debounce window
+  // (an aside draft closed with "Back", a panel dismissed mid-sentence) left the
+  // tail only in the localStorage staging buffer, which is recovered at the next
+  // WORKSPACE LOAD — so until a reload the row, the dock preview, and anything
+  // reading the draft server-side (the aside's agent) all showed the older body.
+  // Deliberate cancels (`cancelPendingSave`, `clearDraft`, `resolveDraft`) null
+  // the payload, so only a save that was still meant to happen is fired here.
+  // Fire-and-forget by necessity: cleanup cannot await, and `saveDraft`'s write
+  // chain and sync queue outlive this component.
+  const saveDraftRef = useRef(saveDraft)
+  saveDraftRef.current = saveDraft
   useEffect(() => {
     return () => {
       if (debounceRef.current) {
         clearTimeout(debounceRef.current)
+        debounceRef.current = null
       }
+      const pending = pendingSaveRef.current
+      pendingSaveRef.current = null
+      if (!pending) return
+      void saveDraftRef.current(pending.contentJson, undefined, pending.expectedDraftId).catch((err) => {
+        console.error("Failed to persist the draft tail on teardown", err)
+      })
     }
   }, [])
 


### PR DESCRIPTION
## Problem

Typing in a composer and unmounting it inside the 500 ms save debounce dropped the tail. `use-draft-message.ts` cleared the pending timer on teardown instead of firing it, so those keystrokes reached neither IDB nor the server; they survived only in the localStorage staging buffer, which is recovered at the next **workspace load** (`reconcileStagedDrafts`, `sync/draft-sync.ts`). Until a reload, the row, every preview reading it, and reopening the same draft all showed the older body.

Reproduced on the aside preview: type a tail in an aside draft, press "Back" inside the window — server and dock both read `"FIRST BATCH settled text."`, the reopened editor showed the same, and only after a page reload did the server hold `"… TAIL-TYPED-THEN-LEFT"`. The aside hits it because "Back to drafts" unmounts the editor outright, where a stream switch repoints it (and a repoint already flushed).

It matters more now that [#1946](https://github.com/threahq/threa/pull/1946) has the aside's agent read the stored draft: "check my draft" would quietly review a stale copy.

## Solution

- **Teardown fires the armed save instead of dropping it.** The debounce's payload (content + the row id captured at arm time) is kept beside the timer; the unmount effect fires exactly what the timer would have. Fire-and-forget by necessity — cleanup cannot await, and the write chain and sync queue outlive the component.
- **Deliberate cancels null the payload first** (`cancelPendingSave`, `clearDraft`, `resolveDraft`, and a `saveDraft` that supersedes it), so a save cancelled as moot — the empty-editor-about-to-rehydrate case the repoint path exists for — cannot come back to life at teardown.
- **Leaving an aside draft awaits the flush** before the editor closes (`useAsideDraftActions.leave`). That path leads straight to asking the agent about what was just written, so the ordering is explicit rather than left to timing; a failed save keeps the editor open and says so instead of closing over unsaved text (INV-11). Every other way out — the pane closing, the mobile sheet dismissed — is covered by the teardown flush above.

## Test plan

- [x] `use-draft-message.test.ts` — an armed save survives unmount (verified failing on the old code, passing on the new), and a cancelled save stays cancelled (75 pass)
- [x] `use-aside-draft-actions.test.ts` — leave persists then closes; a refused save keeps the editor open and toasts; an untouched draft closes without writing a row (11 pass)
- [x] frontend `hooks` + `components/aside` + `components/composer` — 1381 pass
- [ ] Re-run the preview probe that reproduced the loss, on the stacked build

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790151080&installation_model_id=20758&pr_number=1947&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1947&signature=90a56782be81afca4782079ee6b3b721de89e2c2b89f9f3300255be5d745f5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->