### PR TITLE
feat(frontend): the aside header says whose it is and what it is anchored to

### DIFF
--- a/apps/frontend/src/components/aside/aside-anchor-line.tsx
+++ b/apps/frontend/src/components/aside/aside-anchor-line.tsx
@@ -1,0 +1,51 @@
+import { Link, useLocation } from "react-router-dom"
+import { useAsideAnchor } from "@/hooks/use-aside-anchor"
+import { useStreamName } from "@/hooks/use-stream-name"
+
+interface AsideAnchorLineProps {
+  workspaceId: string
+  /** The stream this aside sits beside. */
+  hostStreamId: string
+  /** The message the aside was opened from, when it was opened from one. */
+  anchorId?: string | null
+}
+
+/**
+ * Where this aside is anchored, as one line under the header: the message it
+ * was opened from and the way back to it. A line, not a breadcrumb — an aside
+ * has one place it belongs to and it is always this host stream, so the line
+ * states it and offers the jump.
+ *
+ * Local-first, like every other in-app pointer to a message
+ * (`use-in-app-link-chip`): the anchor is a message in the stream the viewer
+ * is reading, so its author and time come from the timeline cache with no
+ * round-trip. Uncached (or anchored to the stream rather than a message), it
+ * names the stream instead of inventing an author.
+ */
+export function AsideAnchorLine({ workspaceId, hostStreamId, anchorId }: AsideAnchorLineProps) {
+  const { pathname } = useLocation()
+  const hostName = useStreamName(workspaceId, hostStreamId, "breadcrumb")
+  const anchored = useAsideAnchor(workspaceId, hostStreamId, anchorId)
+
+  const label = anchored
+    ? `Anchored to ${anchored.author} ${anchored.at}`
+    : `Anchored in ${hostName ?? "this conversation"}`
+
+  return (
+    <div className="flex h-7 shrink-0 items-center gap-2 border-b px-4 text-xs text-muted-foreground">
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      {anchorId && (
+        // The host timeline is on screen beside this pane, and `?m=` is how the
+        // app scrolls one to a message — the aside's own state is keyed by
+        // pathname, so the jump never disturbs it (INV-40).
+        <Link
+          to={{ pathname, search: `?m=${anchorId}` }}
+          replace
+          className="shrink-0 rounded text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          Scroll to it
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react"
-import { Maximize2, Minus, PanelRight, X } from "lucide-react"
+import { Eye, Minus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { StreamContent } from "@/components/timeline"
 import { AgentBlockProvider, type AgentBlockData } from "@/components/timeline/agent-block-context"
 import { StreamErrorBoundary } from "@/components/stream-error-boundary"
@@ -8,8 +9,9 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { closeAside, setAsideSurface, type AsideSurface } from "@/stores/aside-store"
 import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { StreamTypes } from "@threa/types"
-import { cn } from "@/lib/utils"
 import { useCallDocked } from "./use-call-docked"
+import { AsideSurfacePicker } from "./aside-surface-picker"
+import { AsideAnchorLine } from "./aside-anchor-line"
 import { AsideDraftDock } from "./aside-draft-dock"
 import { AsideDraftEditor } from "./aside-draft-editor"
 import { newAsideDraftScope } from "@/lib/drafts/aside-scope"
@@ -80,46 +82,36 @@ export function AsidePane({
       data-editor-zone="aside"
       className="flex h-full min-h-0 flex-col border-t-2 border-primary/70 bg-background"
     >
-      <header className="flex h-12 shrink-0 items-center gap-1 border-b pl-4 pr-2">
-        <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">{title}</h2>
-        {!takeover && (
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn("h-8 w-8", surface === "dock" && "bg-accent text-accent-foreground")}
-              aria-label="Dock aside"
-              aria-pressed={surface === "dock"}
-              disabled={callDocked}
-              onClick={() => setAsideSurface("dock")}
-            >
-              <PanelRight className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn("h-8 w-8", surface === "fullscreen" && "bg-accent text-accent-foreground")}
-              aria-label="Aside fullscreen"
-              aria-pressed={surface === "fullscreen"}
-              onClick={() => setAsideSurface("fullscreen")}
-            >
-              <Maximize2 className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              aria-label="Minimize aside"
-              onClick={() => setAsideSurface("minimized")}
-            >
-              <Minus className="h-4 w-4" />
-            </Button>
-          </>
-        )}
-        <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close aside" onClick={closeAside}>
-          <X className="h-4 w-4" />
-        </Button>
-      </header>
+      <TooltipProvider delayDuration={300}>
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b pl-4 pr-2">
+          <h2 className="min-w-0 truncate text-sm font-semibold">{title}</h2>
+          {/* Nobody else can open this stream — the badge says so where the
+              surface is read, not only where it was created. */}
+          <span className="flex shrink-0 items-center gap-1 rounded-full border border-dashed px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <Eye className="h-2.5 w-2.5 text-primary" aria-hidden />
+            Only you
+          </span>
+          <span className="flex-1" />
+          {!takeover && (
+            <>
+              <AsideSurfacePicker value={surface} onChange={setAsideSurface} dockDisabled={callDocked} />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Minimize aside"
+                onClick={() => setAsideSurface("minimized")}
+              >
+                <Minus className="h-4 w-4" />
+              </Button>
+            </>
+          )}
+          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close aside" onClick={closeAside}>
+            <X className="h-4 w-4" />
+          </Button>
+        </header>
+      </TooltipProvider>
+      <AsideAnchorLine workspaceId={workspaceId} hostStreamId={hostStreamId} anchorId={aside?.parentAnchorId} />
       {openDraftScope ? (
         <AsideDraftEditor
           workspaceId={workspaceId}

--- a/apps/frontend/src/components/aside/aside-surface-picker.tsx
+++ b/apps/frontend/src/components/aside/aside-surface-picker.tsx
@@ -1,0 +1,55 @@
+import { Maximize2, PanelRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+import type { AsideSurface } from "@/stores/aside-store"
+
+type ReadingSurface = Exclude<AsideSurface, "minimized">
+
+const SURFACES: { value: ReadingSurface; label: string; icon: typeof PanelRight }[] = [
+  { value: "dock", label: "Dock aside", icon: PanelRight },
+  { value: "fullscreen", label: "Aside fullscreen", icon: Maximize2 },
+]
+
+interface AsideSurfacePickerProps {
+  value: ReadingSurface
+  onChange: (surface: ReadingSurface) => void
+  /** Dock is refused while a call owns the right edge. */
+  dockDisabled?: boolean
+}
+
+/**
+ * Where the aside is being read, as one segmented control rather than a row of
+ * loose toggles — the shape a call's surface control has, in the place a call
+ * puts it. Minimize and close stay separate: they leave the surface, they are
+ * not another way of showing it.
+ */
+export function AsideSurfacePicker({ value, onChange, dockDisabled = false }: AsideSurfacePickerProps) {
+  return (
+    <div role="group" aria-label="Aside surface" className="flex items-center gap-0.5 rounded-md border p-0.5">
+      {SURFACES.map(({ value: surface, label, icon: Icon }) => {
+        const active = value === surface
+        return (
+          <Tooltip key={surface}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={label}
+                aria-pressed={active}
+                disabled={surface === "dock" && dockDisabled}
+                onClick={() => onChange(surface)}
+                className={cn("h-6 w-6 rounded-[5px]", active && "bg-accent text-primary")}
+              >
+                <Icon className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              {label}
+            </TooltipContent>
+          </Tooltip>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -24,6 +24,7 @@ const aside = createMockStream({
   type: StreamTypes.ASIDE,
   displayName: "churn number sanity-check",
   parentStreamId: "stream_host",
+  parentAnchorId: "msg_anchor_1",
 })
 
 /**
@@ -153,6 +154,18 @@ describe("aside surfaces", () => {
     fireEvent.click(screen.getByRole("button", { name: "Minimize aside" }))
     await waitFor(() => expect(screen.queryByTestId("aside-dock")).toBeNull())
     expect(screen.getByTestId("aside-strip")).toHaveTextContent("churn number sanity-check")
+  })
+
+  it("names the aside as private and points back at the message it was opened from", async () => {
+    renderPage()
+    openOnHost("dock")
+
+    expect(await screen.findByText("Only you")).toBeInTheDocument()
+    // Anchored to a message that isn't in this test's timeline cache: it names
+    // the host stream rather than inventing an author, and still offers the jump.
+    const jump = screen.getByRole("link", { name: "Scroll to it" })
+    expect(jump).toHaveAttribute("href", `${HOST_PATH}?m=msg_anchor_1`)
+    expect(screen.getByText(/^Anchored in/)).toBeInTheDocument()
   })
 
   it("resizes the dock from its handle, keyboard included, and holds the width across a surface round trip", async () => {

--- a/apps/frontend/src/hooks/use-aside-anchor.ts
+++ b/apps/frontend/src/hooks/use-aside-anchor.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "@/db"
+import { useActors } from "@/hooks/use-actors"
+import { formatTime } from "@/lib/dates"
+
+export interface AsideAnchor {
+  /** Display name of whoever wrote the anchored message. */
+  author: string
+  /** Send time, device-local (INV-42). */
+  at: string
+}
+
+/**
+ * Who wrote the message an aside was opened from, and when — for the anchor
+ * line in the aside header.
+ *
+ * Local-first, the same tier the in-app link chip uses: the anchor is a message
+ * in the stream the viewer is reading beside the aside, so it is already in the
+ * timeline cache and resolves with no round-trip. `null` when there is no
+ * anchor message or it isn't cached; the caller names the host stream instead
+ * of inventing an author (INV-11).
+ */
+export function useAsideAnchor(
+  workspaceId: string,
+  hostStreamId: string,
+  anchorId?: string | null
+): AsideAnchor | null {
+  const actors = useActors(workspaceId)
+  const anchorEvent = useLiveQuery(
+    async () => {
+      if (!anchorId) return null
+      const event = await db.events
+        .where("[streamId+eventType]")
+        .equals([hostStreamId, "message_created"])
+        .filter((e) => (e.payload as { messageId?: string } | null)?.messageId === anchorId)
+        .first()
+      return event ?? null
+    },
+    [anchorId, hostStreamId],
+    null
+  )
+
+  return useMemo(() => {
+    if (!anchorEvent?.actorId) return null
+    return {
+      author: actors.getActorName(anchorEvent.actorId, anchorEvent.actorType ?? "user"),
+      at: formatTime(new Date(anchorEvent.createdAt)),
+    }
+  }, [anchorEvent, actors])
+}


### PR DESCRIPTION
## Problem

Two pieces of the [desktop design](https://seer.build/ws_vbyzjvdg6g/b/aside-sidecar-dc5645/) never got built, and their absence is most of why the shipped aside doesn't read like the sketch:

- The header was four loose ghost toggles (dock / fullscreen / minimize / close) where the design has **the calls picker** — "three icons in the aside header, exactly where a call puts them" — and nothing said the stream is private, though privacy is the whole premise of the surface.
- The pane never named what the aside was anchored to. The design is explicit that this is *"an anchor line, not a breadcrumb"*: an aside belongs to exactly one message in exactly one stream, and the line is both the statement and the way back.

## Solution

- `AsideSurfacePicker` — dock and fullscreen as one segmented control (`role="group"`, `aria-pressed` per option), the shape and place a call's surface control has. Minimize and close stay separate buttons: they leave the surface rather than choose one. Dock stays disabled while a call owns the right edge, as before.
- An **Only you** badge beside the title — dashed pill, gold eye — so the privacy is stated where the aside is read, not only where it was created.
- `AsideAnchorLine` under the header: *"Anchored to {author} {time}"* plus **Scroll to it**. Author and time resolve local-first from the timeline cache through the new `useAsideAnchor` hook — the same tier `use-in-app-link-chip` uses, since the anchor is by definition a message in the stream on screen beside the pane. No anchor message, or one not cached: the line names the host stream instead of inventing an author (INV-11). The jump is a `<Link>` to `?m=<anchorId>` (INV-40) — the app's own deep-link scroll, and the aside's state is keyed by pathname, so the jump leaves the surface untouched.

Data access lives in the hook, not the component (INV-15, enforced by the `no-restricted-imports` rule on `@/db`).

Deliberately not here: the drafts foot strip and the read-only host pane in fullscreen (next layers), and the floating surface, which the design itself parked under its open questions.

## Test plan

- [x] `aside-surfaces.test.tsx` — the badge renders, the anchor line falls back to the host stream when the anchor isn't cached, and "Scroll to it" points at `?m=<anchorId>` (19 pass)
- [x] frontend `components/aside` + `components/layout` + the anchor-event spec — 307 pass
- [x] Preview on Tailscale: header reads `Aside · ONLY YOU · [dock|fullscreen] − ×`, anchor line reads "Anchored to Alice Anderson 08:13 — Scroll to it"
- [ ] Kris on the preview

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154183&installation_model_id=20758&pr_number=1950&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1950&signature=0da2ef17e3d02736716d5cf637ea811f55b3447cb0c3adcb8424bcda556192a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->