### PR TITLE
feat(frontend): polish the aside pane

### DIFF
--- a/apps/frontend/src/components/aside/aside-anchor-line.tsx
+++ b/apps/frontend/src/components/aside/aside-anchor-line.tsx
@@ -32,7 +32,7 @@ export function AsideAnchorLine({ workspaceId, hostStreamId, anchorId }: AsideAn
     : `Anchored in ${hostName ?? "this conversation"}`
 
   return (
-    <div className="flex h-7 shrink-0 items-center gap-2 border-b px-4 text-xs text-muted-foreground">
+    <div className="flex h-7 shrink-0 items-center gap-2 border-b bg-muted/20 px-3 text-[11px] text-muted-foreground">
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {anchorId && (
         // The host timeline is on screen beside this pane, and `?m=` is how the
@@ -41,7 +41,7 @@ export function AsideAnchorLine({ workspaceId, hostStreamId, anchorId }: AsideAn
         <Link
           to={{ pathname, search: `?m=${anchorId}` }}
           replace
-          className="shrink-0 rounded text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="shrink-0 rounded text-[11px] font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           Scroll to it
         </Link>

--- a/apps/frontend/src/components/aside/aside-draft-dock.test.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-dock.test.tsx
@@ -43,7 +43,15 @@ describe("AsideDraftDock", () => {
 
     await waitFor(() => expect(screen.getByText("Drafts · 2")).toBeInTheDocument())
     const rows = screen.getAllByRole("button").filter((button) => button.hasAttribute("data-draft-scope"))
-    expect(rows.map((row) => row.textContent)).toEqual(["newer thought", "older thought"])
+    // Each row reads "<preview> <age>"; order is what this asserts.
+    expect(rows.map((row) => row.getAttribute("data-draft-scope"))).toEqual([
+      asideDraftScope(ASIDE, "draft_b"),
+      asideDraftScope(ASIDE, "draft_a"),
+    ])
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("newer thought"),
+      expect.stringContaining("older thought"),
+    ])
     expect(screen.queryByText("another aside")).toBeNull()
     expect(screen.queryByText("the host's own draft")).toBeNull()
   })

--- a/apps/frontend/src/components/aside/aside-draft-dock.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-dock.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react"
 import { FileText, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import { formatRelativeTime } from "@/lib/dates"
 import { newAsideDraftScope } from "@/lib/drafts/aside-scope"
 import { useAsideDrafts } from "./use-aside-drafts"
 
@@ -26,25 +27,37 @@ export function AsideDraftDock({ workspaceId, asideId, onOpenDraft, openScope }:
 
   const handleNew = useCallback(() => onOpenDraft(newAsideDraftScope(asideId)), [asideId, onOpenDraft])
 
+  const now = new Date()
+
   return (
-    <div className="shrink-0 border-b px-2 py-1.5" data-testid="aside-draft-dock">
-      <div className="flex items-center gap-1">
-        <span className="px-1 text-xs font-medium text-muted-foreground">
+    <div className="shrink-0 border-b px-3 py-2" data-testid="aside-draft-dock">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
           {drafts.length > 0 ? `Drafts · ${drafts.length}` : "Drafts"}
         </span>
         <span className="flex-1" />
         {drafts.length > 3 && (
-          <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => setExpanded((prev) => !prev)}>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-[11px] text-muted-foreground"
+            onClick={() => setExpanded((prev) => !prev)}
+          >
             {expanded ? "Show fewer" : `Show all ${drafts.length}`}
           </Button>
         )}
-        <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={handleNew}>
-          <Plus className="h-3.5 w-3.5" />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 rounded-full bg-primary/10 px-2 text-[11px] font-medium text-primary hover:bg-primary/15 hover:text-primary"
+          onClick={handleNew}
+        >
+          <Plus className="h-3 w-3" />
           New draft
         </Button>
       </div>
       {visible.length > 0 && (
-        <ul className="mt-1 flex flex-col gap-0.5">
+        <ul className="mt-1.5 flex flex-col gap-px">
           {visible.map((draft) => (
             <li key={draft.id}>
               <button
@@ -53,13 +66,23 @@ export function AsideDraftDock({ workspaceId, asideId, onOpenDraft, openScope }:
                 data-draft-scope={draft.scope}
                 aria-current={draft.scope === openScope ? "true" : undefined}
                 className={cn(
-                  "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-muted",
+                  "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] leading-snug transition-colors hover:bg-muted/60",
                   draft.scope === openScope && "bg-muted"
                 )}
               >
-                <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className={cn("min-w-0 truncate", draft.isEmpty && "text-muted-foreground")}>
+                <FileText
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0",
+                    draft.scope === openScope ? "text-primary" : "text-muted-foreground/70"
+                  )}
+                />
+                <span className={cn("min-w-0 flex-1 truncate", draft.isEmpty && "text-muted-foreground")}>
                   {draft.isEmpty ? "Empty draft" : draft.preview}
+                </span>
+                {/* When it was last touched, so a stack of drafts is orderable
+                    by eye — the same terse age the anchor row uses. */}
+                <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+                  {formatRelativeTime(new Date(draft.clientUpdatedAt), now, undefined, { terse: true })}
                 </span>
               </button>
             </li>

--- a/apps/frontend/src/components/aside/aside-minimized-strip.tsx
+++ b/apps/frontend/src/components/aside/aside-minimized-strip.tsx
@@ -1,12 +1,20 @@
 import { useMemo } from "react"
 import { X } from "lucide-react"
 import { StreamTypes } from "@threa/types"
+import { Button } from "@/components/ui/button"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { closeAside, rememberedAsideSurface, setAsideSurface, useAsideForHost } from "@/stores/aside-store"
 import { resolveAsideRestoreSurface } from "@/lib/aside/surface"
-import { streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { COLLAPSED_COMPOSER_SHADOW } from "@/components/composer/collapsed-composer-bar"
+import { truncateContent } from "@/components/layout/sidebar/utils"
+import { STREAM_ICONS, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { formatRelativeTime } from "@/lib/dates"
 import { useCallDocked } from "./use-call-docked"
+import { useAsideDrafts } from "./use-aside-drafts"
+
+const AsideGlyph = STREAM_ICONS[StreamTypes.ASIDE]
 
 interface AsideMinimizedStripProps {
   workspaceId: string
@@ -20,15 +28,23 @@ interface AsideMinimizedStripProps {
 }
 
 /**
- * A minimized aside: a slim strip riding just above the host composer, inside
- * the page's main column (never a global pill — it cannot outlive the stream).
- * The strip is the restore control; the title is its content.
+ * A minimized aside, parked above the host composer inside the page's main
+ * column (never a global pill — it cannot outlive the stream).
+ *
+ * It is a card, not a chip: the composer's own width, radius, border and
+ * shadow, with the aside's gold edge down its left. That matters because this
+ * sits where a composer's attachments and reply strips sit, and those read as
+ * "part of what I am about to send" — this is a surface that was put down, so
+ * it carries the aside's title, what is waiting inside it, and an explicit way
+ * back in rather than being a row that happens to be clickable.
  */
 export function AsideMinimizedStrip({ workspaceId, hostKey, overlay = false }: AsideMinimizedStripProps) {
   const current = useAsideForHost(hostKey)
   const asideId = current?.surface === "minimized" ? current.asideId : null
   const streams = useWorkspaceStreams(workspaceId)
   const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
+  const drafts = useAsideDrafts(workspaceId, asideId ?? "")
+  const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const callDocked = useCallDocked()
   const isMobile = useIsMobile()
   if (!asideId || isMobile !== overlay) return null
@@ -37,33 +53,54 @@ export function AsideMinimizedStrip({ workspaceId, hostKey, overlay = false }: A
   const restore = () =>
     setAsideSurface(resolveAsideRestoreSurface({ remembered: rememberedAsideSurface(asideId), callDocked }))
 
+  // What is waiting in there, so the card is recognisably the thing just being
+  // written in rather than an anonymous bar. Preview goes through the shared
+  // strip-then-truncate path (INV-60), never raw markdown.
+  const preview = aside?.lastMessagePreview
+  const draftCount = drafts.filter((draft) => !draft.isEmpty).length
+  const parts: string[] = []
+  if (draftCount > 0) parts.push(`${draftCount} draft${draftCount === 1 ? "" : "s"}`)
+  if (preview?.content) parts.push(truncateContent(preview.content, 60, toEmoji))
+  else if (preview?.createdAt) parts.push(formatRelativeTime(new Date(preview.createdAt), new Date()))
+  const subtitle = parts.join(" · ")
+
   return (
     <div
-      className="pointer-events-none absolute inset-x-0 z-20 px-3 sm:px-6"
+      className="pointer-events-none absolute inset-x-0 z-20"
       style={{ bottom: "calc(var(--composer-height, 5rem) + 0.25rem)" }}
     >
-      <div
-        data-testid="aside-strip"
-        data-aside-id={asideId}
-        className="pointer-events-auto mx-auto flex h-10 max-w-[800px] items-center gap-2 rounded-lg border border-primary/40 bg-background pl-3 pr-1 shadow-md"
-      >
-        <button
-          type="button"
-          onClick={restore}
-          aria-label={`Open aside: ${title}`}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm"
+      {/* The composer shell's own box, so the card's edges land exactly on the
+          composer's below it rather than a gutter's width outside them. */}
+      <div className="mx-auto w-full min-w-0 max-w-[800px] px-3 sm:px-6">
+        <div
+          data-testid="aside-strip"
+          data-aside-id={asideId}
+          className={`pointer-events-auto flex items-center gap-3 overflow-hidden rounded-[16px] border border-l-2 border-input border-l-primary/70 bg-card py-2 pl-3 pr-2 ${COLLAPSED_COMPOSER_SHADOW}`}
         >
-          <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-primary" />
-          <span className="min-w-0 truncate font-medium">{title}</span>
-        </button>
-        <button
-          type="button"
-          onClick={closeAside}
-          aria-label="Close aside"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          <X className="h-4 w-4" />
-        </button>
+          <AsideGlyph className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-[13px] font-medium leading-tight">{title}</p>
+            {subtitle && <p className="truncate text-[11px] leading-tight text-muted-foreground">{subtitle}</p>}
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={restore}
+            aria-label={`Open aside: ${title}`}
+            className="h-7 shrink-0 rounded-full bg-primary/10 px-3 text-[11px] font-medium text-primary hover:bg-primary/15 hover:text-primary"
+          >
+            Open
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={closeAside}
+            aria-label="Close aside"
+            className="h-7 w-7 shrink-0 text-muted-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -80,14 +80,14 @@ export function AsidePane({
       data-aside-id={asideId}
       data-surface={surface}
       data-editor-zone="aside"
-      className="flex h-full min-h-0 flex-col border-t-2 border-primary/70 bg-background"
+      className="flex h-full min-h-0 flex-col border-t-2 border-primary/70 bg-card"
     >
       <TooltipProvider delayDuration={300}>
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b pl-4 pr-2">
-          <h2 className="min-w-0 truncate text-sm font-semibold">{title}</h2>
+        <header className="flex h-11 shrink-0 items-center gap-2 border-b pl-3 pr-1.5">
+          <h2 className="min-w-0 truncate text-[13px] font-semibold tracking-tight">{title}</h2>
           {/* Nobody else can open this stream — the badge says so where the
               surface is read, not only where it was created. */}
-          <span className="flex shrink-0 items-center gap-1 rounded-full border border-dashed px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span className="flex shrink-0 items-center gap-1 rounded-full border border-dashed border-border/80 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
             <Eye className="h-2.5 w-2.5 text-primary" aria-hidden />
             Only you
           </span>
@@ -98,16 +98,22 @@ export function AsidePane({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8"
+                className="h-7 w-7 text-muted-foreground"
                 aria-label="Minimize aside"
                 onClick={() => setAsideSurface("minimized")}
               >
-                <Minus className="h-4 w-4" />
+                <Minus className="h-3.5 w-3.5" />
               </Button>
             </>
           )}
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Close aside" onClick={closeAside}>
-            <X className="h-4 w-4" />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground"
+            aria-label="Close aside"
+            onClick={closeAside}
+          >
+            <X className="h-3.5 w-3.5" />
           </Button>
         </header>
       </TooltipProvider>
@@ -132,7 +138,20 @@ export function AsidePane({
           <div className="relative min-h-0 flex-1">
             <StreamErrorBoundary streamId={asideId}>
               <AgentBlockProvider onInsert={insertAgentBlock}>
-                <StreamContent workspaceId={workspaceId} streamId={asideId} stream={aside} autoFocus={!takeover} />
+                <StreamContent
+                  workspaceId={workspaceId}
+                  streamId={asideId}
+                  stream={aside}
+                  autoFocus={!takeover}
+                  emptyState={
+                    <div className="max-w-[15rem] px-6 text-center">
+                      <p className="text-[13px] text-foreground/80">A private page beside this conversation.</p>
+                      <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                        Think out loud with Ariadne, or start a draft — nothing here is sent until you send it.
+                      </p>
+                    </div>
+                  }
+                />
               </AgentBlockProvider>
             </StreamErrorBoundary>
           </div>

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -210,6 +210,24 @@ describe("aside surfaces", () => {
     await waitFor(() => expect(screen.queryByTestId("aside-strip")).toBeNull())
   })
 
+  it("parks as a card with the aside's name and its way back in, not a clickable bar", async () => {
+    // It sits where a composer's attachment and reply strips sit, and those mean
+    // "part of what I am about to send" — so this one names itself and offers an
+    // explicit Open rather than being a row that happens to be clickable.
+    renderPage()
+    openOnHost("dock")
+    fireEvent.click(await screen.findByRole("button", { name: "Minimize aside" }))
+
+    const strip = await screen.findByTestId("aside-strip")
+    expect(strip).toHaveTextContent("churn number sanity-check")
+    const open = screen.getByRole("button", { name: "Open aside: churn number sanity-check" })
+    expect(open).toHaveTextContent("Open")
+    expect(strip).toContainElement(open)
+
+    fireEvent.click(open)
+    expect(await screen.findByTestId("aside-dock")).toHaveAttribute("data-surface", "dock")
+  })
+
   it("should fold the dock away on close and leave no chrome", async () => {
     renderPage()
     openOnHost("dock")

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -990,6 +990,9 @@ function MessageInputComponent({
   let composerPlaceholder = offlinePlaceholder
   if (composer.decryptFailed) composerPlaceholder = "Couldn't decrypt your saved draft"
   else if (composer.isDecrypting) composerPlaceholder = "Decrypting your draft…"
+  // An aside's composer talks to Ariadne about the stream beside it, not to a
+  // room — the default "Type a message" invites the wrong thing.
+  else if (isAsideComposer) composerPlaceholder = "Ask about what you're reading"
 
   // Shared composer props used by both inline and expanded layouts
   const composerProps = {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -625,6 +625,13 @@ interface StreamContentProps {
   stream?: Stream
   /** Auto-focus the message input when mounted */
   autoFocus?: boolean
+  /**
+   * What an empty stream shows in place of the default "No messages yet".
+   * A surface whose emptiness means something specific says what it means —
+   * an aside's blank timeline is a private page, not a conversation nobody
+   * has started.
+   */
+  emptyState?: React.ReactNode
 }
 
 export function StreamContent({
@@ -634,6 +641,7 @@ export function StreamContent({
   isDraft = false,
   stream: streamFromProps,
   autoFocus,
+  emptyState,
 }: StreamContentProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
@@ -2988,6 +2996,7 @@ export function StreamContent({
                           isLoading={isLoading}
                           holdForDeepLink={holdForDeepLink}
                           isConfirmedEmpty={isConfirmedEmpty}
+                          emptyState={emptyState}
                           listRef={listRef}
                           scrollerRef={virtualScrollerRef}
                           registerScroller={registerVirtualScroller}
@@ -3251,6 +3260,7 @@ export function StreamContent({
 
 /** Virtuoso-powered message list for streams, channels, and scratchpads */
 function TimelineMessageList({
+  emptyState,
   visibleItems,
   cancelledFollowUpIds,
   delegationStatusPatches,
@@ -3307,6 +3317,8 @@ function TimelineMessageList({
    *  actually empty. During mid-switch transitions this is false, so we avoid
    *  flashing the "No messages yet" state before useLiveQuery catches up. */
   isConfirmedEmpty: boolean
+  /** Host-supplied empty state; the default names the absence of messages. */
+  emptyState?: React.ReactNode
   /** virtua imperative handle (scrollToIndex for deep-link rendering). */
   listRef: React.RefObject<VirtualizerHandle | null>
   /** The scroll container we own (read-only handle; attach via registerScroller). */
@@ -3646,10 +3658,12 @@ function TimelineMessageList({
   if (visibleItems.length === 0 && isConfirmedEmpty) {
     return (
       <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <p className="text-muted-foreground">No messages yet</p>
-          <p className="mt-1 text-sm text-muted-foreground">Start the conversation by sending a message below</p>
-        </div>
+        {emptyState ?? (
+          <div className="text-center">
+            <p className="text-muted-foreground">No messages yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">Start the conversation by sending a message below</p>
+          </div>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Problem

The aside worked and read as unfinished — Kris's words after using it on desktop: *"it's not polished which feels really bad."* Concretely: the pane sat on the same flat `bg-background` as the page behind it, so the dock read as a slice of the stream rather than a surface over it; an empty aside showed the generic *"No messages yet / Start the conversation by sending a message below"*, which describes a room nobody has spoken in, not a private page; the drafts were a plain list under a full-width ghost button; and the composer invited you to "type a message" as if to a channel.

## Solution

Craft pass over the pane, no structural change:

- The pane is a **card** under its gold rule (`bg-card`), so it reads as laid over the stream.
- Header down to 44px with 28px controls; the **Only you** badge in micro-caps beside the title; the anchor line on a faint wash with its jump in gold.
- Drafts: micro-caps `Drafts · N` label, rows at touch height carrying the last-touched age on the right (the same terse form the anchor row uses), and **New draft** as a tinted pill instead of a ghost button the width of a menu item. The open draft's icon takes the gold.
- An **aside-specific empty state**: "A private page beside this conversation. Think out loud with Ariadne, or start a draft — nothing here is sent until you send it." `StreamContent` gains an `emptyState` slot for this; every other stream keeps the default.
- The composer asks about what you're reading — the aside's composer talks to Ariadne about the stream beside it, and the flag for that (`isAsideComposer`) already existed.
- **The parked (minimized) aside is a card, not a bar.** It sat a gutter's width wider than the composer it shadows — `px-3 sm:px-6` outside the 800px box where the composer pads inside it — and was drawn as a full-bleed border with a bare dot, in the exact place a composer's attachment tray and "Replying in…" strip live. Those mean "part of what I am about to send", so the shape told the wrong story: Kris couldn't tell it was the surface he had just been writing in, or how to act on it. It now sits on the composer's own box (measured: both x=504 w=752), takes the composer card's radius, border and shadow with the aside's gold edge down its left, names the aside, says what is waiting in it (drafts, plus the last thing said in there — stripped for preview, INV-60), and offers an explicit **Open**.

## Test plan

- [x] frontend `components/aside` + `components/timeline` — 731 pass (draft-dock row assertion updated for the age column), plus a case that the parked card names the aside and restores from its own Open control
- [x] `message-input.test.tsx` — 65 pass
- [x] Preview on Tailscale, screenshotted: card surface, header, anchor line, drafts row with age, empty state
- [ ] Kris's eye on the preview

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
