### PR TITLE
feat(frontend): the aside shows the conversation and the draft at once

### DIFF
--- a/apps/frontend/src/components/aside/aside-anchor-line.tsx
+++ b/apps/frontend/src/components/aside/aside-anchor-line.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router-dom"
+import { Link, useLocation, useSearchParams } from "react-router-dom"
 import { useAsideAnchor } from "@/hooks/use-aside-anchor"
 import { useStreamName } from "@/hooks/use-stream-name"
 
@@ -24,8 +24,16 @@ interface AsideAnchorLineProps {
  */
 export function AsideAnchorLine({ workspaceId, hostStreamId, anchorId }: AsideAnchorLineProps) {
   const { pathname } = useLocation()
+  const [searchParams] = useSearchParams()
   const hostName = useStreamName(workspaceId, hostStreamId, "breadcrumb")
   const anchored = useAsideAnchor(workspaceId, hostStreamId, anchorId)
+
+  const onHostPage = pathname.endsWith(`/s/${hostStreamId}`)
+  const hostPageSearch = (() => {
+    const next = new URLSearchParams(searchParams)
+    next.set("m", anchorId ?? "")
+    return `?${next.toString()}`
+  })()
 
   const label = anchored
     ? `Anchored to ${anchored.author} ${anchored.at}`
@@ -35,12 +43,14 @@ export function AsideAnchorLine({ workspaceId, hostStreamId, anchorId }: AsideAn
     <div className="flex h-7 shrink-0 items-center gap-2 border-b bg-muted/20 px-3 text-[11px] text-muted-foreground">
       <span className="min-w-0 flex-1 truncate">{label}</span>
       {anchorId && (
-        // The host timeline is on screen beside this pane, and `?m=` is how the
-        // app scrolls one to a message — the aside's own state is keyed by
-        // pathname, so the jump never disturbs it (INV-40).
+        // `?m=` is how the app scrolls a timeline to a message, and the aside's
+        // own state is keyed by pathname, so the jump never disturbs it
+        // (INV-40). Built on top of the page's other params — a thread panel,
+        // a conversation overlay, a board's filters — rather than replacing
+        // them; a board host has no timeline to scroll, so the jump goes to the
+        // host stream's own page instead of doing nothing there.
         <Link
-          to={{ pathname, search: `?m=${anchorId}` }}
-          replace
+          to={onHostPage ? { pathname, search: hostPageSearch } : `/w/${workspaceId}/s/${hostStreamId}?m=${anchorId}`}
           className="shrink-0 rounded text-[11px] font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           Scroll to it

--- a/apps/frontend/src/components/aside/aside-dock-slot.tsx
+++ b/apps/frontend/src/components/aside/aside-dock-slot.tsx
@@ -4,7 +4,6 @@ import { useIsMobile } from "@/hooks/use-mobile"
 import { useResizeDrag } from "@/hooks/use-resize-drag"
 import { PanelResizeHandle } from "@/components/layout"
 import {
-  ASIDE_DOCK_DEFAULT_WIDTH,
   ASIDE_DOCK_MIN_WIDTH,
   setAsideDockWidth,
   useAsideDockWidth,
@@ -14,7 +13,6 @@ import {
 import { AsidePane } from "./aside-pane"
 import { AsideMobileSheet } from "./aside-mobile-sheet"
 
-export const ASIDE_DOCK_WIDTH = ASIDE_DOCK_DEFAULT_WIDTH
 // What the host stream keeps for itself: below this its timeline and composer
 // stop being a place you can read the thing you are writing about. The dock
 // yields to it, which is what caps the drag on a narrow window.
@@ -69,15 +67,14 @@ interface AsideDockSlotProps {
 /**
  * The aside's reading surfaces, mounted as the last flex child of a page's
  * content row — after the thread panel slot, so the aside owns the page's
- * right edge (calls own the app's). Dock pushes the host by ASIDE_DOCK_WIDTH;
+ * right edge (calls own the app's). Dock pushes the host by its dragged width;
  * fullscreen takes half the row with the live host timeline on the left. On a
  * phone the dock is a plain takeover of the content area (PR7 owns the real
  * mobile surface). Renders nothing while no aside is open.
  */
 export function AsideDockSlot({ workspaceId, hostKey }: AsideDockSlotProps) {
   const current = useAsideForHost(hostKey)
-  const reading = current
-  const rendered = useFoldingState(reading)
+  const rendered = useFoldingState(current)
   const isMobile = useIsMobile()
   const slotRef = useRef<HTMLDivElement>(null)
   const rowWidth = useRowWidth(slotRef, rendered !== null)
@@ -123,7 +120,7 @@ export function AsideDockSlot({ workspaceId, hostKey }: AsideDockSlotProps) {
   if (isMobile) {
     // The sheet owns its own drag-to-resize, so a fold animation here would
     // fight it; it simply unmounts with the aside.
-    if (!reading) return null
+    if (!current) return null
     return (
       <AsideMobileSheet
         workspaceId={workspaceId}
@@ -135,7 +132,7 @@ export function AsideDockSlot({ workspaceId, hostKey }: AsideDockSlotProps) {
     )
   }
 
-  const open = reading !== null
+  const open = current !== null
   const docked = surface === "dock"
 
   let width: number | undefined = 0

--- a/apps/frontend/src/components/aside/aside-draft-dock.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-dock.tsx
@@ -13,6 +13,12 @@ interface AsideDraftDockProps {
   onOpenDraft: (scope: string) => void
   /** The draft currently open, so the dock marks it. */
   openScope: string | null
+  /**
+   * An open draft is sitting under this list, so it collapses to the row that
+   * draft is on plus the way to another — the editor below is where the space
+   * belongs.
+   */
+  compact?: boolean
 }
 
 /**
@@ -20,23 +26,24 @@ interface AsideDraftDockProps {
  * saying to Ariadne. Several can live at once, so the dock is a list rather
  * than one slot; each row is its own draft scope.
  */
-export function AsideDraftDock({ workspaceId, asideId, onOpenDraft, openScope }: AsideDraftDockProps) {
+export function AsideDraftDock({ workspaceId, asideId, onOpenDraft, openScope, compact = false }: AsideDraftDockProps) {
   const drafts = useAsideDrafts(workspaceId, asideId)
   const [expanded, setExpanded] = useState(false)
-  const visible = expanded ? drafts : drafts.slice(0, 3)
+  const listed = expanded ? drafts : drafts.slice(0, 3)
+  const visible = compact ? listed.filter((draft) => draft.scope === openScope) : listed
 
   const handleNew = useCallback(() => onOpenDraft(newAsideDraftScope(asideId)), [asideId, onOpenDraft])
 
   const now = new Date()
 
   return (
-    <div className="shrink-0 border-b px-3 py-2" data-testid="aside-draft-dock">
+    <div className={cn("shrink-0 px-3 py-2", !compact && "border-b")} data-testid="aside-draft-dock">
       <div className="flex items-center gap-2">
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
           {drafts.length > 0 ? `Drafts · ${drafts.length}` : "Drafts"}
         </span>
         <span className="flex-1" />
-        {drafts.length > 3 && (
+        {!compact && drafts.length > 3 && (
           <Button
             variant="ghost"
             size="sm"

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -12,7 +12,7 @@ import { closeAside, setAsideSurface, type AsideSurface } from "@/stores/aside-s
 import { AsidePane } from "./aside-pane"
 import {
   ASIDE_PEEK_FRACTION,
-  ASIDE_TAB_HEIGHT,
+  ASIDE_DISMISS_HEIGHT,
   asideMobileHeight,
   nearestAsideSurface,
   steppedAsideSurface,
@@ -41,8 +41,8 @@ function isEditorTarget(target: EventTarget | null): boolean {
 
 /**
  * The aside on a phone: a sheet over the host that peeks at 45% of the
- * viewport, pulls up to the whole of it, and drags down to the strip above the
- * composer. The context strip doubles as the drag handle — the aside's own
+ * viewport, pulls up to the whole of it, and drags down off the bottom to
+ * leave. The context strip doubles as the drag handle — the aside's own
  * chrome is the affordance, so nothing has to tell you to pull it.
  */
 export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originScope, surface }: AsideMobileSheetProps) {
@@ -100,7 +100,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     const now = performance.now()
     // Bottom-anchored: the sheet grows as the pointer moves UP, so the delta is inverted.
     const next = Math.min(
-      Math.max(state.startHeight - (event.clientY - state.startY), ASIDE_TAB_HEIGHT),
+      Math.max(state.startHeight - (event.clientY - state.startY), ASIDE_DISMISS_HEIGHT),
       viewportHeight()
     )
     const dt = now - state.lastT
@@ -144,7 +144,11 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
     const direction = event.key === "ArrowUp" ? 1 : -1
     event.preventDefault()
-    settle(steppedAsideSurface(surface, direction))
+    // The keyboard resizes; it does not dismiss. A drag to the floor is a
+    // deliberate throw-away gesture, an arrow press is not — the header's close
+    // is how a keyboard leaves.
+    const next = steppedAsideSurface(surface, direction)
+    if (next !== "closed") settle(next)
   }
 
   const lifted = keyboardLift || surface === "fullscreen"
@@ -172,7 +176,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
           role="separator"
           aria-orientation="horizontal"
           aria-label="Resize aside"
-          aria-valuemin={0}
+          aria-valuemin={1}
           aria-valuemax={2}
           aria-valuenow={surface === "fullscreen" ? 2 : 1}
           aria-valuetext={surface === "fullscreen" ? "Full screen" : "Peek"}

--- a/apps/frontend/src/components/aside/aside-mobile-snap.test.ts
+++ b/apps/frontend/src/components/aside/aside-mobile-snap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
-  ASIDE_TAB_HEIGHT,
+  ASIDE_DISMISS_HEIGHT,
   asideMobileHeight,
   asideMobileSteps,
   nearestAsideSurface,
@@ -11,8 +11,8 @@ const VIEWPORT = 800
 
 describe("aside mobile snap", () => {
   it("rests at the floor, the peek and the whole viewport", () => {
-    expect(asideMobileSteps(VIEWPORT)).toEqual([ASIDE_TAB_HEIGHT, 360, VIEWPORT])
-    expect(asideMobileHeight("closed", VIEWPORT)).toBe(ASIDE_TAB_HEIGHT)
+    expect(asideMobileSteps(VIEWPORT)).toEqual([ASIDE_DISMISS_HEIGHT, 360, VIEWPORT])
+    expect(asideMobileHeight("closed", VIEWPORT)).toBe(ASIDE_DISMISS_HEIGHT)
     expect(asideMobileHeight("dock", VIEWPORT)).toBe(360)
     expect(asideMobileHeight("fullscreen", VIEWPORT)).toBe(VIEWPORT)
   })
@@ -31,7 +31,7 @@ describe("aside mobile snap", () => {
   })
 
   it("dismisses when the sheet is dragged to the floor — an aside is left, not parked", () => {
-    expect(nearestAsideSurface(ASIDE_TAB_HEIGHT, 0, VIEWPORT)).toBe("closed")
+    expect(nearestAsideSurface(ASIDE_DISMISS_HEIGHT, 0, VIEWPORT)).toBe("closed")
   })
 
   it("steps one detent at a time for the keyboard, clamped at both ends", () => {

--- a/apps/frontend/src/components/aside/aside-mobile-snap.ts
+++ b/apps/frontend/src/components/aside/aside-mobile-snap.ts
@@ -14,7 +14,7 @@ import type { AsideSurface } from "@/stores/aside-store"
 /** Where a drag can settle: the two reading surfaces, or gone. */
 export type AsideDetent = AsideSurface | "closed"
 /** The floor a dismissing drag settles on before the sheet leaves. */
-export const ASIDE_TAB_HEIGHT = 44
+export const ASIDE_DISMISS_HEIGHT = 44
 /** The peek: enough aside to read and type in, with the host still on screen above it. */
 export const ASIDE_PEEK_FRACTION = 0.45
 
@@ -28,12 +28,12 @@ export function steppedAsideSurface(surface: AsideDetent, direction: 1 | -1): As
 }
 
 export function asideMobileSteps(viewportHeight: number): number[] {
-  return [ASIDE_TAB_HEIGHT, Math.round(viewportHeight * ASIDE_PEEK_FRACTION), viewportHeight]
+  return [ASIDE_DISMISS_HEIGHT, Math.round(viewportHeight * ASIDE_PEEK_FRACTION), viewportHeight]
 }
 
 /** The resting height of a detent at this viewport; `closed` is the floor it leaves on. */
 export function asideMobileHeight(surface: AsideDetent, viewportHeight: number): number {
-  return asideMobileSteps(viewportHeight)[MOBILE_DETENTS.indexOf(surface)] ?? ASIDE_TAB_HEIGHT
+  return asideMobileSteps(viewportHeight)[MOBILE_DETENTS.indexOf(surface)] ?? ASIDE_DISMISS_HEIGHT
 }
 
 /**

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -26,7 +26,7 @@ interface AsidePaneProps {
   hostStreamId: string
   /** The draft scope a hand-off files into (`OpenAsideState.originScope`). */
   originScope: string
-  surface: Exclude<AsideSurface, "minimized">
+  surface: AsideSurface
   /** Phone-width takeover: no surface picker, the close control is the way out. */
   takeover?: boolean
 }

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -9,6 +9,7 @@ import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { closeAside, setAsideSurface, type AsideSurface } from "@/stores/aside-store"
 import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { StreamTypes } from "@threa/types"
+import { cn } from "@/lib/utils"
 import { useCallDocked } from "./use-call-docked"
 import { AsideSurfacePicker } from "./aside-surface-picker"
 import { AsideAnchorLine } from "./aside-anchor-line"
@@ -106,45 +107,58 @@ export function AsidePane({
         </header>
       </TooltipProvider>
       <AsideAnchorLine workspaceId={workspaceId} hostStreamId={hostStreamId} anchorId={aside?.parentAnchorId} />
-      {openDraftScope ? (
-        <AsideDraftEditor
+      {/* Conversation above, drafts below — the two halves of an aside are on
+          screen together, because a draft is written FROM what Ariadne just
+          said. Opening one used to replace the pane, which took the reply away
+          at the moment it was most needed. */}
+      <div className="relative min-h-0 flex-1">
+        <StreamErrorBoundary streamId={asideId}>
+          <AgentBlockProvider onInsert={insertAgentBlock}>
+            <StreamContent
+              workspaceId={workspaceId}
+              streamId={asideId}
+              stream={aside}
+              autoFocus={!takeover && !openDraftScope}
+              emptyState={
+                <div className="max-w-[15rem] px-6 text-center">
+                  <p className="text-[13px] text-foreground/80">A private page beside this conversation.</p>
+                  <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
+                    Think out loud with Ariadne, or start a draft — nothing here is sent until you send it.
+                  </p>
+                </div>
+              }
+            />
+          </AgentBlockProvider>
+        </StreamErrorBoundary>
+      </div>
+      <div
+        data-testid="aside-draft-region"
+        data-open={openDraftScope ? "true" : undefined}
+        className={cn(
+          "flex min-h-0 shrink-0 flex-col border-t bg-muted/20",
+          // An open draft takes a little under half the pane and never less
+          // than a paragraph's worth; closed, the dock is just its own height.
+          openDraftScope && "h-[48%] min-h-[220px]"
+        )}
+      >
+        <AsideDraftDock
           workspaceId={workspaceId}
-          scope={openDraftScope}
-          onBack={() => setOpenDraftScope(null)}
-          onSendToComposer={sendToComposer}
-          pendingAgentBlocks={pendingAgentBlocks}
-          onPendingAgentBlocksConsumed={consumePendingAgentBlocks}
+          asideId={asideId}
+          onOpenDraft={setOpenDraftScope}
+          openScope={openDraftScope}
+          compact={openDraftScope !== null}
         />
-      ) : (
-        <>
-          <AsideDraftDock
+        {openDraftScope && (
+          <AsideDraftEditor
             workspaceId={workspaceId}
-            asideId={asideId}
-            onOpenDraft={setOpenDraftScope}
-            openScope={openDraftScope}
+            scope={openDraftScope}
+            onBack={() => setOpenDraftScope(null)}
+            onSendToComposer={sendToComposer}
+            pendingAgentBlocks={pendingAgentBlocks}
+            onPendingAgentBlocksConsumed={consumePendingAgentBlocks}
           />
-          <div className="relative min-h-0 flex-1">
-            <StreamErrorBoundary streamId={asideId}>
-              <AgentBlockProvider onInsert={insertAgentBlock}>
-                <StreamContent
-                  workspaceId={workspaceId}
-                  streamId={asideId}
-                  stream={aside}
-                  autoFocus={!takeover}
-                  emptyState={
-                    <div className="max-w-[15rem] px-6 text-center">
-                      <p className="text-[13px] text-foreground/80">A private page beside this conversation.</p>
-                      <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">
-                        Think out loud with Ariadne, or start a draft — nothing here is sent until you send it.
-                      </p>
-                    </div>
-                  }
-                />
-              </AgentBlockProvider>
-            </StreamErrorBoundary>
-          </div>
-        </>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/components/aside/aside-surface-picker.tsx
+++ b/apps/frontend/src/components/aside/aside-surface-picker.tsx
@@ -4,16 +4,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils"
 import type { AsideSurface } from "@/stores/aside-store"
 
-type ReadingSurface = Exclude<AsideSurface, "minimized">
-
-const SURFACES: { value: ReadingSurface; label: string; icon: typeof PanelRight }[] = [
+const SURFACES: { value: AsideSurface; label: string; icon: typeof PanelRight }[] = [
   { value: "dock", label: "Dock aside", icon: PanelRight },
   { value: "fullscreen", label: "Aside fullscreen", icon: Maximize2 },
 ]
 
 interface AsideSurfacePickerProps {
-  value: ReadingSurface
-  onChange: (surface: ReadingSurface) => void
+  value: AsideSurface
+  onChange: (surface: AsideSurface) => void
   /** Dock is refused while a call owns the right edge. */
   dockDisabled?: boolean
 }

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -330,8 +330,10 @@ describe("aside surfaces", () => {
       expect(getAsideState()?.surface).toBe("fullscreen")
       fireEvent.keyDown(handle, { key: "ArrowDown" })
       expect(getAsideState()?.surface).toBe("dock")
+      // The keyboard resizes but never dismisses: a drag to the floor is a
+      // deliberate throw-away, an arrow press is not. Closing is the header's job.
       fireEvent.keyDown(handle, { key: "ArrowDown" })
-      expect(getAsideState()).toBeNull()
+      expect(getAsideState()?.surface).toBe("dock")
     })
 
     it("rises to the full viewport while an editor in it has focus, and settles back when the keyboard goes", () => {

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -123,9 +123,10 @@ describe("aside surfaces", () => {
     const editor = await screen.findByTestId("aside-draft-editor")
     expect(editor.getAttribute("data-draft-scope")).toMatch(/^aside:stream_aside_1:draft_/)
     expect(editor).toHaveAttribute("data-pending", "persona_01ARIADNE")
-    // The chat timeline is out of the way while the draft is open, and the
-    // block went nowhere else.
-    expect(screen.queryByRole("button", { name: "insert into draft" })).toBeNull()
+    // The conversation stays on screen beside the draft — a draft is written
+    // FROM what was just said — and the block went nowhere but the draft.
+    expect(screen.getByRole("button", { name: "insert into draft" })).toBeInTheDocument()
+    expect(screen.getByTestId("aside-draft-region")).toHaveAttribute("data-open", "true")
   })
 
   it("should render no aside chrome while nothing is open on this page", () => {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -5,7 +5,7 @@ import { StreamTypes, type StreamEvent } from "@threa/types"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as eventItemModule from "./event-item"
 import { spyOnExport } from "@/test"
-import { getAsideState, openAside, resetAsideStoreCache, closeAside } from "@/stores/aside-store"
+import { getAsideState, openAside, resetAsideStoreCache, setAsideSurface, closeAside } from "@/stores/aside-store"
 import { createMockStream } from "@/test/fixtures"
 import { groupTimelineItems, TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
 
@@ -102,7 +102,9 @@ describe("AsideAnchorEvent", () => {
     // hover over space it already occupies (INV-21).
     const control = screen.getByRole("button", { name: /^Resume aside:/ })
     expect(control).toHaveAttribute("data-aside-id", ASIDE)
-    expect(control.querySelector("span.opacity-0")).toHaveTextContent("Resume")
+    // The label is present in the row at rest — reserved space, revealed on
+    // hover — so the row can never change height when it lights up (INV-21).
+    expect(control).toHaveTextContent("Resume")
   })
 
   it("renders nothing for another viewer of the same host stream", () => {
@@ -152,14 +154,17 @@ describe("AsideAnchorEvent", () => {
   })
 
   it("resumes the aside on its host page, into the surface it was last read in, and reads as open", () => {
-    // A previous session on this aside ended in fullscreen; resume returns there.
+    // A previous session on this aside was switched to fullscreen from the
+    // picker — a surface the USER chose, which is what resume returns to (an
+    // open coerced by a docked call is deliberately not remembered).
     openAside({
       hostKey: HOST_PATH,
       hostStreamId: "stream_host",
       asideId: ASIDE,
-      surface: "fullscreen",
+      surface: "dock",
       originScope: "stream:stream_host",
     })
+    setAsideSurface("fullscreen")
     closeAside()
     renderTimeline([anchorEvent()], CREATOR)
 

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -35,11 +35,8 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
   const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
 
   return (
-    // The whole row is the control. It stays a hairline at rest — an aside is
-    // the user's own footnote in someone else's stream, and it must not read as
-    // a message — but the target is the full row rather than five characters of
-    // "Resume", and hover/focus lifts it just enough to say it is one. Reveal is
-    // opacity-only over reserved space (INV-21): no row ever changes height.
+    // The label's space is reserved: it fades in rather than appearing, so a
+    // hovered row never changes height and the timeline never shifts (INV-21).
     <button
       type="button"
       onClick={() =>

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -46,7 +46,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
           ...(payload?.conversationId && { conversationId: payload.conversationId }),
         })
       }
-      aria-label={`Resume aside: ${title}`}
+      aria-label={`${isOpen ? "Open" : "Resume"} aside: ${title}`}
       data-aside-id={asideId}
       data-state={isOpen ? "open" : "closed"}
       className={cn(

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -992,7 +992,9 @@ function MessageInputComponent({
   else if (composer.isDecrypting) composerPlaceholder = "Decrypting your draft…"
   // An aside's composer talks to Ariadne about the stream beside it, not to a
   // room — the default "Type a message" invites the wrong thing.
-  else if (isAsideComposer) composerPlaceholder = "Ask about what you're reading"
+  // Offline still wins: a queued send is the one thing the placeholder must
+  // say, and the aside's wording would swallow it (INV-11).
+  else if (isAsideComposer && !isOffline) composerPlaceholder = "Ask about what you're reading"
 
   // Shared composer props used by both inline and expanded layouts
   const composerProps = {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -626,6 +626,12 @@ interface StreamContentProps {
   /** Auto-focus the message input when mounted */
   autoFocus?: boolean
   /**
+   * Render the timeline without its composer — for a surface that is showing
+   * this stream as reference rather than as a place to write (the aside's
+   * fullscreen host pane). The stream is unchanged; only this view is mute.
+   */
+  hideComposer?: boolean
+  /**
    * What an empty stream shows in place of the default "No messages yet".
    * A surface whose emptiness means something specific says what it means —
    * an aside's blank timeline is a private page, not a conversation nobody
@@ -642,6 +648,7 @@ export function StreamContent({
   stream: streamFromProps,
   autoFocus,
   emptyState,
+  hideComposer = false,
 }: StreamContentProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
@@ -3226,7 +3233,7 @@ export function StreamContent({
                       </div>
                     </AlertDialogContent>
                   </AlertDialog>
-                  {membershipResolved && !isMember && isPublicChannel && (
+                  {!hideComposer && membershipResolved && !isMember && isPublicChannel && (
                     <div className="absolute inset-x-0 bottom-0 z-10">
                       <JoinChannelBar
                         workspaceId={workspaceId}
@@ -3237,7 +3244,7 @@ export function StreamContent({
                       />
                     </div>
                   )}
-                  {(isMember || !isPublicChannel || !membershipResolved) && (
+                  {!hideComposer && (isMember || !isPublicChannel || !membershipResolved) && (
                     <MessageInput
                       workspaceId={workspaceId}
                       streamId={streamId}

--- a/apps/frontend/src/components/timeline/timeline-view.tsx
+++ b/apps/frontend/src/components/timeline/timeline-view.tsx
@@ -4,9 +4,11 @@ import { StreamContent } from "./stream-content"
 interface TimelineViewProps {
   isDraft?: boolean
   autoFocus?: boolean
+  /** Show the stream as reference only — no composer (the aside's fullscreen host pane). */
+  hideComposer?: boolean
 }
 
-export function TimelineView({ isDraft = false, autoFocus }: TimelineViewProps) {
+export function TimelineView({ isDraft = false, autoFocus, hideComposer }: TimelineViewProps) {
   const { workspaceId, streamId } = useParams<{ workspaceId: string; streamId: string }>()
   const [searchParams] = useSearchParams()
   const highlightMessageId = searchParams.get("m")
@@ -22,6 +24,7 @@ export function TimelineView({ isDraft = false, autoFocus }: TimelineViewProps) 
       highlightMessageId={highlightMessageId}
       isDraft={isDraft}
       autoFocus={autoFocus}
+      hideComposer={hideComposer}
     />
   )
 }

--- a/apps/frontend/src/hooks/use-aside-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-aside-anchor.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import { db } from "@/db"
+import { spyOnExport } from "@/test"
+import * as actorsModule from "./use-actors"
+import { useAsideAnchor } from "./use-aside-anchor"
+
+const HOST = "stream_host"
+const ANCHOR = "msg_anchor_1"
+
+async function seedAnchorMessage(overrides: { streamId?: string; messageId?: string; createdAt?: string } = {}) {
+  await db.events.put({
+    id: `evt_${overrides.messageId ?? ANCHOR}_${overrides.streamId ?? HOST}`,
+    workspaceId: "ws_1",
+    streamId: overrides.streamId ?? HOST,
+    sequence: "1",
+    _sequenceNum: 1,
+    eventType: "message_created",
+    payload: { messageId: overrides.messageId ?? ANCHOR, contentMarkdown: "Churn hit 34% in Q2." },
+    actorId: "usr_dana",
+    actorType: "user",
+    createdAt: overrides.createdAt ?? "2026-08-24T09:44:00.000Z",
+    _cachedAt: Date.now(),
+  } as never)
+}
+
+beforeEach(async () => {
+  await db.events.clear()
+  spyOnExport(actorsModule, "useActors").mockReturnValue((() => ({
+    getActorName: (id: string) => (id === "usr_dana" ? "Dana Whitfield" : id),
+  })) as never)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useAsideAnchor", () => {
+  it("names the author and send time of the anchored message from the local cache", async () => {
+    await seedAnchorMessage()
+
+    const { result } = renderHook(() => useAsideAnchor("ws_1", HOST, ANCHOR))
+
+    // The whole point of the hook: without this, the anchor line silently
+    // degrades to "Anchored in {stream}" forever and nothing fails (INV-11).
+    await waitFor(() => expect(result.current).toEqual({ author: "Dana Whitfield", at: expect.any(String) }))
+  })
+
+  it("stays null for an anchor cached under a different stream, so the line never mis-attributes", async () => {
+    await seedAnchorMessage({ streamId: "stream_elsewhere" })
+
+    const { result } = renderHook(() => useAsideAnchor("ws_1", HOST, ANCHOR))
+
+    await waitFor(() => expect(db.events.count()).resolves.toBe(1))
+    expect(result.current).toBeNull()
+  })
+
+  it("stays null with no anchor id and with an uncached anchor", async () => {
+    const withoutAnchor = renderHook(() => useAsideAnchor("ws_1", HOST, null))
+    expect(withoutAnchor.result.current).toBeNull()
+
+    const uncached = renderHook(() => useAsideAnchor("ws_1", HOST, "msg_never_seen"))
+    await waitFor(() => expect(uncached.result.current).toBeNull())
+  })
+})

--- a/apps/frontend/src/hooks/use-aside-anchor.ts
+++ b/apps/frontend/src/hooks/use-aside-anchor.ts
@@ -30,12 +30,11 @@ export function useAsideAnchor(
   const anchorEvent = useLiveQuery(
     async () => {
       if (!anchorId) return null
-      const event = await db.events
-        .where("[streamId+eventType]")
-        .equals([hostStreamId, "message_created"])
-        .filter((e) => (e.payload as { messageId?: string } | null)?.messageId === anchorId)
-        .first()
-      return event ?? null
+      // The `payload.messageId` index (v47) exists so a message anchor is a
+      // direct lookup; the `[streamId+eventType]` range would re-scan every
+      // message in the host stream on each new one while the aside is open.
+      const events = await db.events.where("payload.messageId").equals(anchorId).toArray()
+      return events.find((event) => event.streamId === hostStreamId && event.eventType === "message_created") ?? null
     },
     [anchorId, hostStreamId],
     null

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -58,6 +58,7 @@ import { CallStartMenu, RejoinBar } from "@/components/call"
 import { ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle, StreamTitlePreview, panelTakeoverClasses } from "@/components/layout"
 import { AsideDockSlot, useAsideHost } from "@/components/aside"
+import { useAsideForHost } from "@/stores/aside-store"
 import { PanelHost } from "@/components/layout/panel-host"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { ConversationList } from "@/components/conversations"
@@ -96,6 +97,7 @@ export function StreamPage() {
     handleTransitionEnd,
   } = usePanelLayout(isPanelOpen)
   const asideHostKey = useAsideHost()
+  const asideFullscreen = useAsideForHost(asideHostKey)?.surface === "fullscreen"
 
   useTypeToFocus()
 
@@ -855,7 +857,10 @@ export function StreamPage() {
         {(isChannel || isDm) && !isDraft && <RejoinBar workspaceId={workspaceId!} streamId={streamId!} />}
         <main className="relative flex-1 overflow-hidden" data-editor-zone="main">
           <StreamEncryptionGate workspaceId={workspaceId} encrypted={isEncryptedScratchpad && !isDraft}>
-            <TimelineView isDraft={isDraft} autoFocus={!isMobile} />
+            {/* Fullscreen aside: the host is what you are answering, not a
+                second place to write — its composer stands down so there is one
+                obvious place for the words (the draft on the right). */}
+            <TimelineView isDraft={isDraft} autoFocus={!isMobile && !asideFullscreen} hideComposer={asideFullscreen} />
           </StreamEncryptionGate>
         </main>
         {stream && !isDraft && (

--- a/apps/frontend/src/stores/aside-store.ts
+++ b/apps/frontend/src/stores/aside-store.ts
@@ -56,6 +56,11 @@ function setState(next: OpenAsideState | null): void {
   emit()
 }
 
+/**
+ * Only a surface the user CHOSE is remembered. An open can be coerced — a
+ * docked call pushes an aside that wanted the dock into fullscreen — and
+ * recording that would make one call change where every later aside opens.
+ */
 function remember(asideId: string, surface: AsideSurface): void {
   lastReadingSurfaceByAside.set(asideId, surface)
 }
@@ -70,7 +75,6 @@ export function rememberedAsideSurface(asideId: string): AsideSurface | null {
 }
 
 export function openAside(next: OpenAsideState): void {
-  remember(next.asideId, next.surface)
   setState(next)
 }
 


### PR DESCRIPTION
## Problem

Kris, using the shipped aside: *"I don't think we at all have the fullscreen mode nailed whatsoever? Nor the draft view, still?"* — both, and for the same reason: **the aside never showed the conversation and the draft at the same time.** Opening a draft replaced the pane, so Ariadne's reply — the thing you are drafting *from* — vanished the moment you started writing. And with the draft owning the whole surface, fullscreen was just a wider dock instead of the design's two panes (*"host stream read-only on the left, thinking and drafting on the right"*).

## Solution

- **The pane keeps the conversation and gives the drafts a foot region.** Chat stays above; below it the drafts dock, and when a draft is open its editor sits under the dock at just under half the pane (min 220px). The dock collapses to the open draft's own row while editing — the space belongs to the editor — and closing the draft gives the list back.
- **Fullscreen inherits it**, so it finally reads as the design's split, and the host pane there **stands its composer down**: `hideComposer` on `StreamContent` (threaded through `TimelineView`), because in fullscreen the host is what you're answering, not a second place to type. The host also stops taking autofocus there.

Second commit: **fixes for every finding from the background review of #1949–#1952**, listed in its message — the "Scroll to it" link wiping the page's other query params, a call-docked open poisoning the remembered surface, the aside placeholder swallowing the offline notice, `useAsideAnchor` scanning the whole host stream instead of using the `payload.messageId` index, an accessible name that disagreed with its visible label (WCAG 2.5.3), keyboard-dismiss on the phone sheet, and the dead code left by the parked-state removal.

## Test plan

- [x] frontend `components/aside` + `components/timeline` + `stores` + `lib/aside` + `pages` + the new `use-aside-anchor` suite — 1120 pass
- [x] `use-aside-anchor.test.ts` (new) — the cached branch, a foreign-stream anchor, and both null branches; without it a broken query degraded silently
- [x] `aside-surfaces.test.tsx` — the conversation stays mounted while a draft is open (`aside-draft-region[data-open]`), and the keyboard no longer dismisses the phone sheet
- [ ] Preview on Tailscale — Kris

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790162083&installation_model_id=20758&pr_number=1953&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1953&signature=2f346cfb7964eadc482f53c9ec8268f25d86a8b464d066921100539db3bcde7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->