### PR TITLE
fix(frontend): the aside on a phone is one thing at a time

### DIFF
--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -72,7 +72,7 @@ export function AsideDraftEditor({
     <div className="flex h-full min-h-0 flex-col" data-testid="aside-draft-editor" data-draft-scope={scope}>
       {/* This draft's own bar, directly above this draft's body: every control
           on it acts on the words below it, and nothing on it acts on the tray. */}
-      <div className="flex h-8 shrink-0 items-center gap-2 border-y border-border/70 bg-muted/30 px-3">
+      <div className="flex h-8 shrink-0 items-center gap-2 border-y border-border/70 px-3">
         {takeover && (
           <Button
             variant="ghost"

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react"
-import { Send, X } from "lucide-react"
+import { ArrowLeft, Send, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
 import { appendAgentBlockNode, type AgentBlockData } from "@/components/timeline/agent-block-context"
@@ -14,6 +14,11 @@ interface AsideDraftEditorProps {
   /** One line of the draft's own body, so its bar names the thing it acts on. */
   title?: string
   onClose: () => void
+  /**
+   * The draft has the whole surface to itself (the phone sheet), so its way
+   * out is a way back to what it replaced rather than a close.
+   */
+  takeover?: boolean
   /** Hand the body and files to the host composer: null when refused, else the destination's verdict. */
   onSendToComposer: (handoff: AsideDraftHandoff) => Promise<{ delivered: Promise<boolean> } | null>
   /** Agent replies queued by "Insert into draft"; appended as attributed blocks once the draft has loaded. */
@@ -41,6 +46,7 @@ export function AsideDraftEditor({
   scope,
   title,
   onClose,
+  takeover = false,
   onSendToComposer,
   pendingAgentBlocks,
   onPendingAgentBlocksConsumed,
@@ -67,6 +73,18 @@ export function AsideDraftEditor({
       {/* This draft's own bar, directly above this draft's body: every control
           on it acts on the words below it, and nothing on it acts on the tray. */}
       <div className="flex h-8 shrink-0 items-center gap-2 border-y border-border/70 bg-muted/30 px-3">
+        {takeover && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="-ml-1.5 h-6 w-6 shrink-0 text-muted-foreground"
+            aria-label="Back to drafts"
+            disabled={busy}
+            onClick={() => void leave()}
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+          </Button>
+        )}
         <span className={ASIDE_LABEL}>Draft</span>
         <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{title || "Empty"}</span>
         <Button
@@ -79,16 +97,18 @@ export function AsideDraftEditor({
           <Send className="h-3 w-3" />
           Send to composer
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6 shrink-0 text-muted-foreground"
-          aria-label="Close draft"
-          disabled={busy}
-          onClick={() => void leave()}
-        >
-          <X className="h-3.5 w-3.5" />
-        </Button>
+        {!takeover && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0 text-muted-foreground"
+            aria-label="Close draft"
+            disabled={busy}
+            onClick={() => void leave()}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
       </div>
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2 pt-1.5">
         {/* Expanded: the editor fills the pane like a document, with the
@@ -118,7 +138,6 @@ export function AsideDraftEditor({
           messageSendMode="cmdEnter"
           scopeId={scope}
           autoFocus
-          initialMobileChromeOpen
         />
       </div>
     </div>

--- a/apps/frontend/src/components/aside/aside-drafts.tsx
+++ b/apps/frontend/src/components/aside/aside-drafts.tsx
@@ -23,7 +23,12 @@ export function AsideDraftTray({ workspaceId, asideId, surface, className }: Asi
   const expanded = useAsideTrayExpanded(asideId)
 
   return (
-    <div className={cn(ASIDE_TRAY, "flex-col gap-1.5", className)}>
+    // preventDefault keeps editor focus — and the phone's keyboard — through
+    // taps anywhere in the tray, the same guard the composer's attachment tray
+    // uses. Safe as a blanket here: every child is one of our own buttons,
+    // nothing portaled. Without it, folding the tray closed the keyboard, and
+    // the sheet dropped out of its keyboard lift with it.
+    <div className={cn(ASIDE_TRAY, "flex-col gap-1.5", className)} onMouseDown={(event) => event.preventDefault()}>
       <button
         type="button"
         aria-expanded={expanded}

--- a/apps/frontend/src/components/aside/aside-drafts.tsx
+++ b/apps/frontend/src/components/aside/aside-drafts.tsx
@@ -7,6 +7,49 @@ import { AsideDraftEditor } from "./aside-draft-editor"
 import { useAsideDrafts } from "./use-aside-drafts"
 import type { AsideDraftSurface } from "./use-aside-draft-surface"
 
+interface AsideDraftTrayProps {
+  workspaceId: string
+  asideId: string
+  surface: AsideDraftSurface
+  className?: string
+}
+
+/**
+ * The aside's drafts as a tray: a count with a chevron, folding to one line
+ * the way the composer's attachment tray does, over the pills themselves.
+ */
+export function AsideDraftTray({ workspaceId, asideId, surface, className }: AsideDraftTrayProps) {
+  const drafts = useAsideDrafts(workspaceId, asideId)
+  const expanded = useAsideTrayExpanded(asideId)
+
+  return (
+    <div className={cn(ASIDE_TRAY, "flex-col gap-1.5", className)}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setAsideTrayExpanded(asideId, !expanded)}
+        className="flex w-full items-center gap-1.5 rounded text-left text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <FileText className="h-3 w-3 shrink-0" aria-hidden />
+        <span className={ASIDE_META}>
+          {drafts.length === 0 ? "No drafts" : `${drafts.length} ${drafts.length === 1 ? "draft" : "drafts"}`}
+        </span>
+        <span className="flex-1" />
+        <ChevronDown className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-180")} />
+      </button>
+      {expanded && (
+        <AsideDraftStrip
+          drafts={drafts}
+          openScope={surface.openScope}
+          onOpen={surface.openDraft}
+          onNew={surface.startDraft}
+          onDelete={surface.discardDraft}
+        />
+      )}
+    </div>
+  )
+}
+
 interface AsideDraftsProps {
   workspaceId: string
   asideId: string
@@ -17,16 +60,15 @@ interface AsideDraftsProps {
 }
 
 /**
- * What you are writing here, as opposed to what you are saying to Ariadne.
+ * What you are writing here, as opposed to what you are saying to Ariadne, on
+ * a surface with room for both at once.
  *
- * Two things stacked, each carrying its own controls: the tray of drafts,
- * which folds to its count the way the composer's attachment tray does, and —
- * below it, so its controls sit against the thing they act on — the draft
+ * Two things stacked, each carrying its own controls: the tray of drafts, and
+ * — below it, so its controls sit against the thing they act on — the draft
  * currently open for writing.
  */
 export function AsideDrafts({ workspaceId, asideId, surface, className, style }: AsideDraftsProps) {
   const drafts = useAsideDrafts(workspaceId, asideId)
-  const expanded = useAsideTrayExpanded(asideId)
   const open = surface.openScope
 
   return (
@@ -36,30 +78,7 @@ export function AsideDrafts({ workspaceId, asideId, surface, className, style }:
       className={cn("flex min-h-0 flex-col", className)}
       style={style}
     >
-      <div className={cn(ASIDE_TRAY, "flex-col gap-1.5")}>
-        <button
-          type="button"
-          aria-expanded={expanded}
-          onClick={() => setAsideTrayExpanded(asideId, !expanded)}
-          className="flex w-full items-center gap-1.5 rounded text-left text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          <FileText className="h-3 w-3 shrink-0" aria-hidden />
-          <span className={ASIDE_META}>
-            {drafts.length === 0 ? "No drafts" : `${drafts.length} ${drafts.length === 1 ? "draft" : "drafts"}`}
-          </span>
-          <span className="flex-1" />
-          <ChevronDown className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-180")} />
-        </button>
-        {expanded && (
-          <AsideDraftStrip
-            drafts={drafts}
-            openScope={open}
-            onOpen={surface.openDraft}
-            onNew={surface.startDraft}
-            onDelete={surface.discardDraft}
-          />
-        )}
-      </div>
+      <AsideDraftTray workspaceId={workspaceId} asideId={asideId} surface={surface} />
       {open && (
         <AsideDraftEditor
           key={open}

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -48,19 +48,14 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   const detent = useAsideSheetDetent()
   const sheetRef = useRef<HTMLDivElement>(null)
   const [dragging, setDragging] = useState(false)
-  // The on-screen keyboard takes the bottom of the viewport; a 45% peek of
-  // what is left is all chrome and composer, no conversation. While an editor
-  // in the sheet has focus the sheet rises to the full (keyboard-shrunk)
-  // viewport — presentation only, the chosen detent is kept and returns when
-  // the keyboard goes. A drag while typing is the user's own call and wins
-  // over the lift; the keyboard stays up through it (the composer's own
-  // resize handle sets the precedent: preventDefault keeps focus).
-  const [keyboardLift, setKeyboardLift] = useState(false)
+  // Writing takes the sheet over: the keyboard takes the bottom of the
+  // viewport, and a 45% peek of what is left is chrome and two lines. The
+  // sheet moves to the full detent and stays there — a real state change a
+  // drag can undo, not a presentation the sheet undoes for you. Rising on
+  // focus and falling back on blur put a resize on both edges of every
+  // keyboard, two heights and a viewport moving at once, and it showed.
   const onFocusCapture = (event: ReactFocusEvent<HTMLDivElement>) => {
-    if (isEditorTarget(event.target)) setKeyboardLift(true)
-  }
-  const onBlurCapture = (event: ReactFocusEvent<HTMLDivElement>) => {
-    if (isEditorTarget(event.target)) setKeyboardLift(false)
+    if (isEditorTarget(event.target)) setAsideSheetDetent("full")
   }
   const drag = useRef<{
     startY: number
@@ -70,21 +65,19 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     lastY: number
     lastT: number
   } | null>(null)
-  // A draft takes the sheet over, so the sheet comes up to meet it: at the
-  // peek a writing surface is all chrome and two lines of text. A real detent,
-  // not a forced height — a drag from here is still the user's call.
+  // Opening a draft takes the sheet over in its own right, ahead of the focus
+  // its editor then takes.
   const openDraft = useAsideOpenDraft(asideId)
   useEffect(() => {
     if (openDraft) setAsideSheetDetent("full")
   }, [openDraft])
 
   const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    // The handle carries text; without this a drag starts a text selection and
-    // the browser cancels the pointer stream mid-gesture, so the sheet snaps
-    // back to where it started. It also keeps focus (and the keyboard) in an
-    // editor that has it — a drag never closes the keyboard.
+    // Without this the browser turns the drag into a text selection and
+    // cancels the pointer stream mid-gesture, so the sheet snaps back to where
+    // it started. It also keeps focus — and the keyboard — in an editor that
+    // has it: a drag never closes the keyboard.
     event.preventDefault()
-    setKeyboardLift(false)
     const startHeight = sheetRef.current?.getBoundingClientRect().height ?? asideMobileHeight(detent, viewportHeight())
     drag.current = {
       startY: event.clientY,
@@ -157,20 +150,10 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     if (next !== "closed") settle(next)
   }
 
-  const lifted = keyboardLift || detent === "full"
-  // The lift lands in the same moment the keyboard resizes the viewport under
-  // the sheet. Easing the height across that leaves the sheet squashing for the
-  // length of the animation while the keyboard is already up, so a lift change
-  // is committed uncushioned; a detent the user chose still eases into place.
-  const previouslyLifted = useRef(keyboardLift)
-  const liftJustChanged = previouslyLifted.current !== keyboardLift
-  useEffect(() => {
-    previouslyLifted.current = keyboardLift
-  }, [keyboardLift])
-  const restingHeight = lifted ? "100dvh" : `${ASIDE_PEEK_FRACTION * 100}dvh`
+  const restingHeight = detent === "full" ? "100dvh" : `${ASIDE_PEEK_FRACTION * 100}dvh`
   // Read from the drag rather than state: an unrelated re-render mid-gesture
-  // (a store update, the lift going off) must re-apply the height the node
-  // already has, not the one it started the drag on.
+  // must re-apply the height the node already has, not the one the drag
+  // started on.
   const height = dragging && drag.current ? `${drag.current.height}px` : restingHeight
 
   return (
@@ -180,13 +163,11 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
         ref={sheetRef}
         data-testid="aside-sheet"
         data-detent={detent}
-        data-keyboard-lift={keyboardLift || undefined}
         onFocusCapture={onFocusCapture}
-        onBlurCapture={onBlurCapture}
         data-suppress-pull-refresh="true"
         className={cn(
           "absolute inset-x-0 bottom-0 z-30 flex flex-col overflow-hidden rounded-t-xl border-t-2 border-primary/70 bg-background shadow-lg",
-          !dragging && !liftJustChanged && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
+          !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
         )}
         style={{ height }}
       >

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -31,8 +31,17 @@ const REDUCED_MOTION =
 
 const SETTLE_MS = 200
 
-function viewportHeight(): number {
-  return window.visualViewport?.height ?? window.innerHeight
+/**
+ * The sheet's ceiling is its host's box, never a viewport unit: the app is
+ * sized by `--viewport-height` (use-visual-viewport.ts), written on its own
+ * schedule around the keyboard — shrink at once, growth debounced, an
+ * optimistic restore on focusout — while `dvh` follows the browser's. Sized
+ * in dvh, the bottom-anchored sheet ran taller than the app while the
+ * keyboard rose (header clipped off the top) and shorter while it fell (host
+ * showing above). A percentage of the host is the same clock.
+ */
+function hostHeight(sheet: HTMLElement | null): number {
+  return sheet?.parentElement?.clientHeight || window.innerHeight
 }
 
 function isEditorTarget(target: EventTarget | null): boolean {
@@ -51,9 +60,9 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   const sheetRef = useRef<HTMLDivElement>(null)
   const [dragging, setDragging] = useState(false)
   // The height eases only on the way from a gesture to its detent. Viewport
-  // changes — the keyboard, mostly — must land instantly: dvh re-resolves in
+  // changes — the keyboard, mostly — must land instantly: the host resizes in
   // steps as the keyboard animates, and easing each step left the sheet
-  // taller than the viewport on the way up and shorter on the way down.
+  // trailing it.
   const [settling, setSettling] = useState(false)
   useEffect(() => {
     if (!settling) return
@@ -90,7 +99,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     // it started. It also keeps focus — and the keyboard — in an editor that
     // has it: a drag never closes the keyboard.
     event.preventDefault()
-    const startHeight = sheetRef.current?.getBoundingClientRect().height ?? asideMobileHeight(detent, viewportHeight())
+    const startHeight = sheetRef.current?.getBoundingClientRect().height ?? asideMobileHeight(detent, hostHeight(sheetRef.current))
     drag.current = {
       startY: event.clientY,
       startHeight,
@@ -110,7 +119,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     // Bottom-anchored: the sheet grows as the pointer moves UP, so the delta is inverted.
     const next = Math.min(
       Math.max(state.startHeight - (event.clientY - state.startY), ASIDE_DISMISS_HEIGHT),
-      viewportHeight()
+      hostHeight(sheetRef.current)
     )
     const dt = now - state.lastT
     if (dt > 0) state.velocity = -(event.clientY - state.lastY) / dt
@@ -138,7 +147,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     if (!state) return
     // A pause before release means the drag stopped — don't flick on stale velocity.
     const velocity = performance.now() - state.lastT > 120 ? 0 : state.velocity
-    settle(nearestAsideDetent(state.height, velocity, viewportHeight()))
+    settle(nearestAsideDetent(state.height, velocity, hostHeight(sheetRef.current)))
   }
 
   // Dragging (or arrowing) below the smallest reading surface dismisses: an
@@ -163,7 +172,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     if (next !== "closed") settle(next)
   }
 
-  const restingHeight = detent === "full" ? "100dvh" : `${ASIDE_PEEK_FRACTION * 100}dvh`
+  const restingHeight = detent === "full" ? "100%" : `${ASIDE_PEEK_FRACTION * 100}%`
   // Read from the drag rather than state: an unrelated re-render mid-gesture
   // must re-apply the height the node already has, not the one the drag
   // started on.

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -29,6 +29,8 @@ interface AsideMobileSheetProps {
 const REDUCED_MOTION =
   typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true
 
+const SETTLE_MS = 200
+
 function viewportHeight(): number {
   return window.visualViewport?.height ?? window.innerHeight
 }
@@ -48,6 +50,16 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   const detent = useAsideSheetDetent()
   const sheetRef = useRef<HTMLDivElement>(null)
   const [dragging, setDragging] = useState(false)
+  // The height eases only on the way from a gesture to its detent. Viewport
+  // changes — the keyboard, mostly — must land instantly: dvh re-resolves in
+  // steps as the keyboard animates, and easing each step left the sheet
+  // taller than the viewport on the way up and shorter on the way down.
+  const [settling, setSettling] = useState(false)
+  useEffect(() => {
+    if (!settling) return
+    const timer = window.setTimeout(() => setSettling(false), SETTLE_MS)
+    return () => window.clearTimeout(timer)
+  }, [settling])
   // Writing takes the sheet over: the keyboard takes the bottom of the
   // viewport, and a 45% peek of what is left is chrome and two lines. The
   // sheet moves to the full detent and stays there — a real state change a
@@ -133,8 +145,9 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   // aside is left, not parked, and its anchor row in the timeline is the way
   // back in.
   const settle = (next: AsideDetent) => {
-    if (next === "closed") closeAside()
-    else setAsideSheetDetent(next)
+    if (next === "closed") return closeAside()
+    setSettling(true)
+    setAsideSheetDetent(next)
   }
 
   // The drag is the primary gesture, but it is a pointer gesture: the handle is
@@ -167,7 +180,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
         data-suppress-pull-refresh="true"
         className={cn(
           "absolute inset-x-0 bottom-0 z-30 flex flex-col overflow-hidden rounded-t-xl border-t-2 border-primary/70 bg-background shadow-lg",
-          !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
+          settling && !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
         )}
         style={{ height }}
       >

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -47,7 +47,6 @@ function isEditorTarget(target: EventTarget | null): boolean {
 export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originScope }: AsideMobileSheetProps) {
   const detent = useAsideSheetDetent()
   const sheetRef = useRef<HTMLDivElement>(null)
-  const [dragHeight, setDragHeight] = useState<number | null>(null)
   const [dragging, setDragging] = useState(false)
   // The on-screen keyboard takes the bottom of the viewport; a 45% peek of
   // what is left is all chrome and composer, no conversation. While an editor
@@ -96,7 +95,6 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
       lastT: performance.now(),
     }
     event.currentTarget.setPointerCapture(event.pointerId)
-    setDragHeight(startHeight)
     setDragging(true)
   }
 
@@ -114,7 +112,11 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     state.lastY = event.clientY
     state.lastT = now
     state.height = next
-    setDragHeight(next)
+    // Written straight to the node, not through state: a render per pointermove
+    // re-renders the pane — a whole timeline — on every frame of the gesture,
+    // and that is the drag's jank. React owns the resting height; the gesture
+    // owns the node for as long as it holds the pointer.
+    if (sheetRef.current) sheetRef.current.style.height = `${next}px`
   }
 
   // The browser took the pointer (a scroll, a system gesture): the drag never
@@ -122,14 +124,12 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   const onPointerCancel = () => {
     drag.current = null
     setDragging(false)
-    setDragHeight(null)
   }
 
   const onPointerUp = () => {
     const state = drag.current
     drag.current = null
     setDragging(false)
-    setDragHeight(null)
     if (!state) return
     // A pause before release means the drag stopped — don't flick on stale velocity.
     const velocity = performance.now() - state.lastT > 120 ? 0 : state.velocity
@@ -158,8 +158,20 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   }
 
   const lifted = keyboardLift || detent === "full"
+  // The lift lands in the same moment the keyboard resizes the viewport under
+  // the sheet. Easing the height across that leaves the sheet squashing for the
+  // length of the animation while the keyboard is already up, so a lift change
+  // is committed uncushioned; a detent the user chose still eases into place.
+  const previouslyLifted = useRef(keyboardLift)
+  const liftJustChanged = previouslyLifted.current !== keyboardLift
+  useEffect(() => {
+    previouslyLifted.current = keyboardLift
+  }, [keyboardLift])
   const restingHeight = lifted ? "100dvh" : `${ASIDE_PEEK_FRACTION * 100}dvh`
-  const height = dragging && dragHeight != null ? `${dragHeight}px` : restingHeight
+  // Read from the drag rather than state: an unrelated re-render mid-gesture
+  // (a store update, the lift going off) must re-apply the height the node
+  // already has, not the one it started the drag on.
+  const height = dragging && drag.current ? `${drag.current.height}px` : restingHeight
 
   return (
     <>
@@ -174,7 +186,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
         data-suppress-pull-refresh="true"
         className={cn(
           "absolute inset-x-0 bottom-0 z-30 flex flex-col overflow-hidden rounded-t-xl border-t-2 border-primary/70 bg-background shadow-lg",
-          !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
+          !dragging && !liftJustChanged && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
         )}
         style={{ height }}
       >

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -63,10 +63,12 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   // changes — the keyboard, mostly — must land instantly: the host resizes in
   // steps as the keyboard animates, and easing each step left the sheet
   // trailing it.
-  const [settling, setSettling] = useState(false)
+  // A count, not a flag: a second settle inside the window restarts the
+  // timer instead of leaving the first one to cut the ease short.
+  const [settling, setSettling] = useState(0)
   useEffect(() => {
     if (!settling) return
-    const timer = window.setTimeout(() => setSettling(false), SETTLE_MS)
+    const timer = window.setTimeout(() => setSettling(0), SETTLE_MS)
     return () => window.clearTimeout(timer)
   }, [settling])
   // Writing takes the sheet over: the keyboard takes the bottom of the
@@ -155,7 +157,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
   // back in.
   const settle = (next: AsideDetent) => {
     if (next === "closed") return closeAside()
-    setSettling(true)
+    setSettling((count) => count + 1)
     setAsideSheetDetent(next)
   }
 
@@ -189,7 +191,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
         data-suppress-pull-refresh="true"
         className={cn(
           "absolute inset-x-0 bottom-0 z-30 flex flex-col overflow-hidden rounded-t-xl border-t-2 border-primary/70 bg-background shadow-lg",
-          settling && !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
+          settling > 0 && !dragging && !REDUCED_MOTION && "transition-[height] duration-200 ease-out"
         )}
         style={{ height }}
       >

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useRef,
   useState,
   type FocusEvent as ReactFocusEvent,
@@ -6,9 +7,8 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react"
 import { HistoryBackClose } from "@/components/ui/history-back-close"
-import { useStreamName } from "@/hooks/use-stream-name"
 import { cn } from "@/lib/utils"
-import { closeAside, setAsideSheetDetent, useAsideSheetDetent } from "@/stores/aside-store"
+import { closeAside, setAsideSheetDetent, useAsideOpenDraft, useAsideSheetDetent } from "@/stores/aside-store"
 import { AsidePane } from "./aside-pane"
 import {
   ASIDE_PEEK_FRACTION,
@@ -40,8 +40,9 @@ function isEditorTarget(target: EventTarget | null): boolean {
 /**
  * The aside on a phone: a sheet over the host that peeks at 45% of the
  * viewport, pulls up to the whole of it, and drags down off the bottom to
- * leave. The context strip doubles as the drag handle — the aside's own
- * chrome is the affordance, so nothing has to tell you to pull it.
+ * leave. The handle carries nothing but the grab pill: every row above the
+ * conversation is a row of it the reader doesn't get, and the pane's own
+ * anchor line already says which stream this sits beside.
  */
 export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originScope }: AsideMobileSheetProps) {
   const detent = useAsideSheetDetent()
@@ -70,7 +71,13 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     lastY: number
     lastT: number
   } | null>(null)
-  const hostName = useStreamName(workspaceId, hostStreamId, "breadcrumb")
+  // A draft takes the sheet over, so the sheet comes up to meet it: at the
+  // peek a writing surface is all chrome and two lines of text. A real detent,
+  // not a forced height — a drag from here is still the user's call.
+  const openDraft = useAsideOpenDraft(asideId)
+  useEffect(() => {
+    if (openDraft) setAsideSheetDetent("full")
+  }, [openDraft])
 
   const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     // The handle carries text; without this a drag starts a text selection and
@@ -182,16 +189,13 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
           tabIndex={0}
           data-testid="aside-sheet-handle"
           onKeyDown={onKeyDown}
-          className="flex shrink-0 touch-none select-none items-center gap-2 px-3 py-2"
+          className="flex shrink-0 touch-none select-none items-center justify-center py-2"
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerCancel}
         >
-          <span aria-hidden className="h-1 w-8 shrink-0 rounded-full bg-muted-foreground/40" />
-          {/* Where the aside sits, not what it is — the pane header below carries
-              its title and the way out, so the handle stays one line of context. */}
-          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{hostName ?? ""}</span>
+          <span aria-hidden className="h-1 w-9 rounded-full bg-muted-foreground/40" />
         </div>
         <div className="min-h-0 flex-1">
           <AsidePane

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -80,12 +80,7 @@ export function AsidePane({ workspaceId, asideId, hostStreamId, originScope }: A
       ) : (
         <>
           <AsideAnchorLine workspaceId={workspaceId} hostStreamId={hostStreamId} anchorId={aside?.parentAnchorId} />
-          <AsideDraftTray
-            workspaceId={workspaceId}
-            asideId={asideId}
-            surface={draftSurface}
-            className="border-b bg-muted/20"
-          />
+          <AsideDraftTray workspaceId={workspaceId} asideId={asideId} surface={draftSurface} className="border-b" />
           <div className="relative min-h-0 flex-1">
             <AsideConversation
               workspaceId={workspaceId}

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -8,11 +8,11 @@ import { streamFallbackLabel, streamLabel } from "@/lib/streams"
 import { StreamTypes } from "@threa/types"
 import { AsideAnchorLine } from "./aside-anchor-line"
 import { AsideConversation } from "./aside-conversation"
-import { AsideDrafts } from "./aside-drafts"
+import { AsideDraftEditor } from "./aside-draft-editor"
+import { AsideDraftTray } from "./aside-drafts"
 import { AsideGlyph, AsidePrivateBadge } from "./aside-chrome"
-import { AsideSplitHandle } from "./aside-split-handle"
+import { useAsideDrafts } from "./use-aside-drafts"
 import { useAsideDraftSurface } from "./use-aside-draft-surface"
-import { useAsideSplit } from "./use-aside-split"
 
 interface AsidePaneProps {
   workspaceId: string
@@ -24,26 +24,28 @@ interface AsidePaneProps {
 }
 
 /**
- * The aside in one column, for the phone sheet: what it is, what it is
- * anchored to, what you are writing, and the conversation you are writing it
- * from. Drafts sit above the chat because the chat owns the bottom edge — its
- * composer is where the cursor rests, and a draft opening under it would keep
- * moving the one input that never moves anywhere else in the app.
+ * The aside on a phone: one thing at a time, under its own header. Either the
+ * conversation with Ariadne — the drafts folded into a tray above it — or one
+ * draft, open for writing, with the whole sheet to itself.
+ *
+ * Not both: a phone sheet split between a draft and a timeline gives each half
+ * a few lines and a keyboard takes what is left, so neither is usable. The
+ * stage stacks them side by side because it has the room to; this doesn't.
  */
 export function AsidePane({ workspaceId, asideId, hostStreamId, originScope }: AsidePaneProps) {
   const draftSurface = useAsideDraftSurface({ workspaceId, asideId, hostStreamId, originScope })
-  // No gaps in this column: the drafts region's border and the divider sit
-  // flush, so only the divider's hairline is between the two halves.
-  const split = useAsideSplit(asideId, { reservedHeight: 1 })
   const streams = useWorkspaceStreams(workspaceId)
+  const drafts = useAsideDrafts(workspaceId, asideId)
   const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
   const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
+  const open = draftSurface.openScope
 
   return (
     <div
       data-testid="aside-pane"
       data-aside-id={asideId}
       data-editor-zone="aside"
+      data-view={open ? "draft" : "chat"}
       className="flex h-full min-h-0 flex-col border-t-2 border-primary/70 bg-card"
     >
       <TooltipProvider delayDuration={300}>
@@ -63,26 +65,38 @@ export function AsidePane({ workspaceId, asideId, hostStreamId, originScope }: A
           </Button>
         </header>
       </TooltipProvider>
-      <AsideAnchorLine workspaceId={workspaceId} hostStreamId={hostStreamId} anchorId={aside?.parentAnchorId} />
-      <div ref={split.containerRef} className="flex min-h-0 flex-1 flex-col">
-        <AsideDrafts
+      {open ? (
+        <AsideDraftEditor
+          key={open}
+          takeover
           workspaceId={workspaceId}
-          asideId={asideId}
-          surface={draftSurface}
-          className="shrink-0 border-b bg-muted/20"
-          style={draftSurface.openScope ? { height: split.height } : undefined}
+          scope={open}
+          title={drafts.find((draft) => draft.scope === open)?.preview}
+          onClose={draftSurface.closeDraft}
+          onSendToComposer={draftSurface.sendToComposer}
+          pendingAgentBlocks={draftSurface.pendingAgentBlocks}
+          onPendingAgentBlocksConsumed={draftSurface.consumePendingAgentBlocks}
         />
-        {draftSurface.openScope && <AsideSplitHandle split={split} />}
-        <div className="relative min-h-0 flex-1">
-          <AsideConversation
+      ) : (
+        <>
+          <AsideAnchorLine workspaceId={workspaceId} hostStreamId={hostStreamId} anchorId={aside?.parentAnchorId} />
+          <AsideDraftTray
             workspaceId={workspaceId}
             asideId={asideId}
-            aside={aside}
-            autoFocus={false}
-            onInsertAgentBlock={draftSurface.insertAgentBlock}
+            surface={draftSurface}
+            className="border-b bg-muted/20"
           />
-        </div>
-      </div>
+          <div className="relative min-h-0 flex-1">
+            <AsideConversation
+              workspaceId={workspaceId}
+              asideId={asideId}
+              aside={aside}
+              autoFocus={false}
+              onInsertAgentBlock={draftSurface.insertAgentBlock}
+            />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -407,6 +407,32 @@ describe("aside surfaces", () => {
       expect(sheet).not.toHaveAttribute("data-keyboard-lift")
     })
 
+    it("keeps the keyboard through a fold of the drafts tray", () => {
+      openOnHost()
+      renderPage()
+
+      const sheet = screen.getByTestId("aside-sheet")
+      const editor = document.createElement("div")
+      editor.setAttribute("contenteditable", "true")
+      editor.tabIndex = 0
+      sheet.appendChild(editor)
+      Object.defineProperty(editor, "isContentEditable", { value: true })
+      editor.focus()
+      fireEvent.focus(editor)
+      expect(sheet).toHaveStyle({ height: "100dvh" })
+
+      // The tray is chrome, not a focus target: the tap is prevented before it
+      // reaches focus, so the keyboard stays up and the sheet keeps its lift.
+      const toggle = screen.getByRole("button", { name: /drafts?$/i })
+      expect(fireEvent.mouseDown(toggle)).toBe(false)
+      fireEvent.click(toggle)
+
+      expect(toggle).toHaveAttribute("aria-expanded", "true")
+      expect(document.activeElement).toBe(editor)
+      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveAttribute("data-keyboard-lift", "true")
+    })
+
     it("resizes while the composer keeps focus — a drag never closes the keyboard, and it overrides the lift", () => {
       openOnHost()
       renderPage()

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { StreamTypes } from "@threa/types"
 import { spyOnExport } from "@/test"
@@ -384,7 +384,7 @@ describe("aside surfaces", () => {
       expect(getAsideSheetDetent()).toBe("peek")
     })
 
-    it("rises to the full viewport while an editor in it has focus, and settles back when the keyboard goes", () => {
+    it("takes the whole viewport once you write in it, and stays there when the keyboard goes", () => {
       openOnHost()
       renderPage()
 
@@ -398,13 +398,13 @@ describe("aside surfaces", () => {
       expect(sheet).toHaveStyle({ height: "45dvh" })
       fireEvent.focus(editor)
       expect(sheet).toHaveStyle({ height: "100dvh" })
-      expect(sheet).toHaveAttribute("data-keyboard-lift", "true")
-      // The chosen detent is presentation-independent: still the peek.
-      expect(getAsideSheetDetent()).toBe("peek")
+      expect(getAsideSheetDetent()).toBe("full")
 
+      // Writing moved the sheet and it stays moved: the keyboard leaving is
+      // not a second resize, and a drag is how it comes back down.
       fireEvent.blur(editor)
-      expect(sheet).toHaveStyle({ height: "45dvh" })
-      expect(sheet).not.toHaveAttribute("data-keyboard-lift")
+      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(getAsideSheetDetent()).toBe("full")
     })
 
     it("keeps the keyboard through a fold of the drafts tray", () => {
@@ -417,12 +417,11 @@ describe("aside surfaces", () => {
       editor.tabIndex = 0
       sheet.appendChild(editor)
       Object.defineProperty(editor, "isContentEditable", { value: true })
-      editor.focus()
-      fireEvent.focus(editor)
+      act(() => editor.focus())
       expect(sheet).toHaveStyle({ height: "100dvh" })
 
       // The tray is chrome, not a focus target: the tap is prevented before it
-      // reaches focus, so the keyboard stays up and the sheet keeps its lift.
+      // reaches focus, so the keyboard stays up and the sheet stays put.
       const toggle = screen.getByRole("button", { name: /drafts?$/i })
       expect(fireEvent.mouseDown(toggle)).toBe(false)
       fireEvent.click(toggle)
@@ -430,10 +429,10 @@ describe("aside surfaces", () => {
       expect(toggle).toHaveAttribute("aria-expanded", "true")
       expect(document.activeElement).toBe(editor)
       expect(sheet).toHaveStyle({ height: "100dvh" })
-      expect(sheet).toHaveAttribute("data-keyboard-lift", "true")
+      expect(getAsideSheetDetent()).toBe("full")
     })
 
-    it("resizes while the composer keeps focus — a drag never closes the keyboard, and it overrides the lift", () => {
+    it("resizes while the composer keeps focus — a drag never closes the keyboard", () => {
       openOnHost()
       renderPage()
 
@@ -444,8 +443,7 @@ describe("aside surfaces", () => {
       editor.tabIndex = 0
       sheet.appendChild(editor)
       Object.defineProperty(editor, "isContentEditable", { value: true })
-      editor.focus()
-      fireEvent.focus(editor)
+      act(() => editor.focus())
       expect(sheet).toHaveStyle({ height: "100dvh" })
       sheet.getBoundingClientRect = () => ({
         height: 360,
@@ -470,7 +468,6 @@ describe("aside surfaces", () => {
       expect(document.activeElement).toBe(editor)
       expect(getAsideSheetDetent()).toBe("full")
       expect(handle.setPointerCapture).toHaveBeenCalled()
-      expect(sheet).not.toHaveAttribute("data-keyboard-lift")
     })
   })
 })

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -367,6 +367,19 @@ describe("aside surfaces", () => {
       expect(sheet).toHaveStyle({ height: "45dvh" })
     })
 
+    it("eases only the settle from a gesture, so a keyboard's viewport change lands instantly", () => {
+      openOnHost()
+      renderPage()
+
+      const sheet = screen.getByTestId("aside-sheet")
+      const handle = screen.getByTestId("aside-sheet-handle")
+      expect(sheet.className).not.toContain("transition-[height]")
+
+      fireEvent.keyDown(handle, { key: "ArrowUp" })
+      expect(getAsideSheetDetent()).toBe("full")
+      expect(sheet.className).toContain("transition-[height]")
+    })
+
     it("reaches the same detents from the keyboard, since the sheet hides the surface picker", () => {
       openOnHost()
       renderPage()

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -280,6 +280,36 @@ describe("aside surfaces", () => {
       expect(screen.getByTestId("stream-content")).toHaveAttribute("data-stream-id", ASIDE)
     })
 
+    it("gives an open draft the whole sheet, and comes back to the conversation behind it", () => {
+      spyOnExport(draftEditorModule, "AsideDraftEditor").mockReturnValue(((props: {
+        takeover?: boolean
+        onClose: () => void
+      }) => (
+        <div data-testid="aside-draft-editor" data-takeover={props.takeover ? "true" : undefined}>
+          <button type="button" onClick={props.onClose}>
+            back
+          </button>
+        </div>
+      )) as never)
+      openOnHost()
+      renderPage()
+
+      fireEvent.click(screen.getByRole("button", { name: /drafts?$/i }))
+      fireEvent.click(screen.getByRole("button", { name: "Start a draft" }))
+
+      // One thing at a time: the draft has the sheet, and the sheet came up to
+      // meet it — a writing surface at the peek is chrome and two lines.
+      expect(screen.getByTestId("aside-pane")).toHaveAttribute("data-view", "draft")
+      expect(screen.getByTestId("aside-draft-editor")).toHaveAttribute("data-takeover", "true")
+      expect(screen.queryByTestId("stream-content")).toBeNull()
+      expect(screen.queryByRole("separator", { name: "Resize draft" })).toBeNull()
+      expect(getAsideSheetDetent()).toBe("full")
+
+      fireEvent.click(screen.getByRole("button", { name: "back" }))
+      expect(screen.getByTestId("aside-pane")).toHaveAttribute("data-view", "chat")
+      expect(screen.getByTestId("stream-content")).toHaveAttribute("data-stream-id", ASIDE)
+    })
+
     it("closes when the sheet is dragged to the floor, and nothing is left behind", () => {
       openOnHost()
       renderPage()

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -364,7 +364,7 @@ describe("aside surfaces", () => {
       fireEvent.pointerCancel(handle, { pointerId: 1, clientY: 500 })
 
       expect(getAsideSheetDetent()).toBe("peek")
-      expect(sheet).toHaveStyle({ height: "45dvh" })
+      expect(sheet).toHaveStyle({ height: "45%" })
     })
 
     it("eases only the settle from a gesture, so a keyboard's viewport change lands instantly", () => {
@@ -408,15 +408,15 @@ describe("aside surfaces", () => {
       sheet.appendChild(editor)
       Object.defineProperty(editor, "isContentEditable", { value: true })
 
-      expect(sheet).toHaveStyle({ height: "45dvh" })
+      expect(sheet).toHaveStyle({ height: "45%" })
       fireEvent.focus(editor)
-      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveStyle({ height: "100%" })
       expect(getAsideSheetDetent()).toBe("full")
 
       // Writing moved the sheet and it stays moved: the keyboard leaving is
       // not a second resize, and a drag is how it comes back down.
       fireEvent.blur(editor)
-      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveStyle({ height: "100%" })
       expect(getAsideSheetDetent()).toBe("full")
     })
 
@@ -431,7 +431,7 @@ describe("aside surfaces", () => {
       sheet.appendChild(editor)
       Object.defineProperty(editor, "isContentEditable", { value: true })
       act(() => editor.focus())
-      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveStyle({ height: "100%" })
 
       // The tray is chrome, not a focus target: the tap is prevented before it
       // reaches focus, so the keyboard stays up and the sheet stays put.
@@ -441,7 +441,7 @@ describe("aside surfaces", () => {
 
       expect(toggle).toHaveAttribute("aria-expanded", "true")
       expect(document.activeElement).toBe(editor)
-      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveStyle({ height: "100%" })
       expect(getAsideSheetDetent()).toBe("full")
     })
 
@@ -457,7 +457,7 @@ describe("aside surfaces", () => {
       sheet.appendChild(editor)
       Object.defineProperty(editor, "isContentEditable", { value: true })
       act(() => editor.focus())
-      expect(sheet).toHaveStyle({ height: "100dvh" })
+      expect(sheet).toHaveStyle({ height: "100%" })
       sheet.getBoundingClientRect = () => ({
         height: 360,
         top: 0,

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -375,9 +375,23 @@ describe("aside surfaces", () => {
       const handle = screen.getByTestId("aside-sheet-handle")
       expect(sheet.className).not.toContain("transition-[height]")
 
-      fireEvent.keyDown(handle, { key: "ArrowUp" })
-      expect(getAsideSheetDetent()).toBe("full")
-      expect(sheet.className).toContain("transition-[height]")
+      vi.useFakeTimers()
+      try {
+        fireEvent.keyDown(handle, { key: "ArrowUp" })
+        expect(getAsideSheetDetent()).toBe("full")
+        expect(sheet.className).toContain("transition-[height]")
+
+        // A second settle inside the window restarts it: the ease must outlive
+        // the second transition, not end on the first one's clock.
+        act(() => vi.advanceTimersByTime(150))
+        fireEvent.keyDown(handle, { key: "ArrowDown" })
+        act(() => vi.advanceTimersByTime(100))
+        expect(sheet.className).toContain("transition-[height]")
+        act(() => vi.advanceTimersByTime(150))
+        expect(sheet.className).not.toContain("transition-[height]")
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it("reaches the same detents from the keyboard, since the sheet hides the surface picker", () => {

--- a/apps/frontend/src/components/composer/message-composer.test.tsx
+++ b/apps/frontend/src/components/composer/message-composer.test.tsx
@@ -407,22 +407,23 @@ describe("MessageComposer", () => {
       expect(screen.getByText(/Press Escape again to close the fullscreen editor\./)).toBeInTheDocument()
     })
 
-    it("on touch, the expanded shell puts the action bar and an open format toolbar at the foot", async () => {
+    it("on touch, the expanded shell puts the action bar at the foot and opens the format toolbar on Aa", async () => {
       isMobileMockValue = true
       render(<MessageComposer {...defaultProps} expanded />)
 
       // No top toolbar: the editor scroller would carry it out of view once the
       // keyboard shortens the pane. The foot holds the action bar with Send,
-      // and the format toolbar is open from the start (toggled by Aa).
+      // and the format toolbar starts closed — the same one row of chrome every
+      // other composer in the app opens with on a phone.
       const actionBar = screen.getByTestId("editor-action-bar")
       expect(actionBar).toContainElement(screen.getByRole("button", { name: "Send" }))
       expect(screen.queryByRole("button", { name: /show actions/i })).not.toBeInTheDocument()
+      expect(screen.queryByTestId("composer-format-toolbar")).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole("button", { name: "Formatting" }))
       expect(screen.getByTestId("composer-format-toolbar")).toContainElement(
         screen.getByTestId("mobile-editor-toolbar")
       )
-
-      await userEvent.click(screen.getByRole("button", { name: "Formatting" }))
-      expect(screen.queryByTestId("composer-format-toolbar")).not.toBeInTheDocument()
     })
 
     it("should only consume shell escape when collapse is available", () => {

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -355,10 +355,6 @@ export function MessageComposer({
   const [mobileFormatToolbarHeight, setMobileFormatToolbarHeight] = useState(0)
   const mobileFormatToolbarHeightRef = useRef(mobileFormatToolbarHeight)
   mobileFormatToolbarHeightRef.current = mobileFormatToolbarHeight
-  // The expanded shell on touch keeps its format toolbar open from the start:
-  // it is a writing surface, and the toolbar is the only formatting affordance
-  // there (no selection bubble on touch).
-  const [formatOpen, setFormatOpen] = useState(expanded)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
   // User-chosen composer height from the drag handle (mobile, chrome open).
@@ -474,6 +470,12 @@ export function MessageComposer({
   // isn't torn down mid-take.
   const [voiceActive, setVoiceActive] = useState(false)
   const isMobile = useIsMobileOrCoarse()
+  // The expanded shell opens its format toolbar from the start on a pointer
+  // device: it is a writing surface, and there is no selection bubble to reach
+  // formatting from. On touch it starts closed like every other composer in the
+  // app — `Aa` opens it — so a phone's writing surface doesn't hand two rows of
+  // chrome to a keyboard that is about to take half the screen.
+  const [formatOpen, setFormatOpen] = useState(expanded && !isMobile)
   // Height of everything above the editor card (attachment tray, link previews)
   // — the same "extras" the drag floor reserves, measured live because a
   // persisted cap outlives the state it was chosen in: shrink the composer with
@@ -780,12 +782,12 @@ export function MessageComposer({
       blurTimeoutRef.current = null
     }
     cancelPendingChromeOpen()
-    setFormatOpen(expanded)
+    setFormatOpen(expanded && !isMobile)
     setMobileExpanded(false)
     setMobileFocused(false)
     setMobileLinkPopoverOpen(false)
     setVoiceActive(false)
-  }, [scopeId, expanded, cancelPendingChromeOpen])
+  }, [scopeId, expanded, isMobile, cancelPendingChromeOpen])
 
   // Reset mobile-only state when viewport crosses the mobile/desktop threshold
   useEffect(() => {

--- a/tests/browser/aside-mobile.spec.ts
+++ b/tests/browser/aside-mobile.spec.ts
@@ -139,4 +139,33 @@ test.describe("Aside — mobile surface", () => {
     await anchor.click()
     await expect(sheet(page)).toHaveAttribute("data-detent", "peek", { timeout: 10000 })
   })
+
+  test("gives an open draft the whole sheet, and comes back to the conversation behind it", async ({ page }) => {
+    await createChannel(page, `aside-md-${testId}`)
+    const { workspaceId, streamId } = extractIds(page)
+    // An empty stream renders its empty state rather than a scroller.
+    await seedMessages(page, workspaceId, streamId, `[${testId}-draft]`)
+    await page.setViewportSize(PHONE)
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(hostScroller(page, streamId)).toBeVisible({ timeout: 20000 })
+
+    await openAsideFromPalette(page)
+    await expect(pane(page)).toHaveAttribute("data-view", "chat", { timeout: 15000 })
+
+    await sheet(page)
+      .getByRole("button", { name: /drafts?$/i })
+      .click()
+    await sheet(page).getByRole("button", { name: "Start a draft" }).click()
+
+    // One thing at a time on a phone: the draft has the sheet to itself, and
+    // the sheet has come up to meet it.
+    await expect(pane(page)).toHaveAttribute("data-view", "draft")
+    await expect(sheet(page)).toHaveAttribute("data-detent", "full", { timeout: 10000 })
+    await expect(sheet(page).getByTestId("aside-conversation")).toHaveCount(0)
+    await expect(sheet(page).locator("[data-stream-scroller]")).toHaveCount(0)
+
+    await sheet(page).getByRole("button", { name: "Back to drafts" }).click()
+    await expect(pane(page)).toHaveAttribute("data-view", "chat")
+    await expect(sheet(page).getByTestId("aside-conversation")).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Problem

The aside's phone sheet had inherited the stage's layout: header, anchor line, drafts tray, the open draft's bar, its composer, a split handle, the conversation and the conversation's own composer — all at once, in 45% of a 780px viewport, with the keyboard about to take half of what was left. Two writing surfaces and a timeline sharing a phone screen means none of them is usable; the reporter's words were "now it does too much, which means I see fuck all".

The draft's composer had also drifted from every other composer in the app on touch. `MessageComposer expanded` opens its format toolbar at mount — right on a pointer device, where there is no selection bubble to reach formatting from — and the aside draft is the **only** surface on a phone that mounts that shell (`message-input.tsx:785` and `stream-panel.tsx:333` both collapse the fullscreen editor on mobile). So it was the one place opening with two rows of chrome instead of the app's one action row plus `Aa`.

Testing the result on a phone turned up more, each reported with a video or a screenshot:

- **The tray fold closed the keyboard.** Tapping the drafts count moved focus out of the composer, so the sheet's keyboard lift went with it and the sheet dropped from full back to the 45% peek on every fold.
- **The drag was janky, worse with the tray open.** Each `pointermove` set React state on the sheet, so every frame of the gesture re-rendered the pane — an entire `StreamContent` timeline.
- **The sheet jumped around every keyboard.** Three causes, found one video at a time. It rose to `full` on editor focus and fell back to the peek on blur, so every keyboard put a height change on both of its edges, in the same moment the keyboard resizes the viewport. `transition-[height]` eased every re-resolution of its `dvh` height, and Android animates the keyboard in steps, so the ease restarted per step and the sheet trailed the viewport both ways. And the app shell is sized by `--viewport-height` (`use-visual-viewport.ts`: shrink at once, growth debounced, optimistic restore on focusout) while the sheet was in `dvh` on the browser's clock — whenever the two disagreed the bottom-anchored sheet was taller than its host (header clipped off the top) or shorter (host showing above).
- **The drafts chrome banded in dark mode only.** `bg-muted` is not the same amount of contrast per theme: over the pane's card it composites to rgb(250,250,249) on rgb(253,253,252) in light — invisible — and rgb(33,30,27) on rgb(31,28,25) in dark, where the eye reads small steps near black as a block.

## Solution

The sheet shows one thing at a time, which is what it did before the stage landed:

- `AsidePane` switches instead of splitting — the conversation with the drafts folded to a count (`data-view="chat"`), or one draft with the whole sheet (`data-view="draft"`). No `useAsideSplit`, no `AsideSplitHandle` on a phone; those stay stage furniture.
- Opening a draft settles the sheet at the `full` detent. A writing surface at the 45% peek is chrome and two lines; the detent is a real state change, so a drag from there is still the user's call.
- `AsideDraftEditor` takes a `takeover` prop: the bar leads with a back arrow ("Back to drafts") rather than trailing an ×, because it is now a way back to what it replaced. Prior art is the pre-stage editor, which had the same arrow.
- The tray split out of `AsideDrafts` as `AsideDraftTray` — the stage stacks tray + editor, the sheet mounts the tray alone.
- The sheet's handle drops the host name it carried: the pane's anchor line one row below said the same words, and every row above the conversation is a row the reader doesn't get.
- `formatOpen` now starts `expanded && !isMobile`, so the expanded shell keeps its toolbar on a pointer device and opens with the app's single action row on touch. Blast radius is exactly the aside draft — it is the only expanded-on-mobile mount in the app. `initialMobileChromeOpen` went with it (it seeds inline chrome, which the expanded branch never reads).

Then the three from the phone:

- The tray carries a blanket `onMouseDown` preventDefault, the same guard `PendingAttachments`' rollup row carries and for the same reason: every child is one of our own buttons, nothing portaled, and the tap must never reach focus.
- The drag writes the height straight to the sheet node while it holds the pointer; React sees the start and the settle. The rendered height reads from the drag rather than from state, so an unrelated re-render mid-gesture re-applies the height the node already has.
- Writing in the sheet moves it to the `full` detent once and leaves it — the rule an opened draft already followed. No fall-back on blur: `keyboardLift`, the blur handler and the transition guard it needed are gone. Trade, called out to the reporter: dismissing the keyboard no longer returns the sheet to the peek; a drag does.
- The height eases only for 200ms after a drag or arrow settles to a detent (`settling` state + timer), never on a viewport change.
- The sheet is sized as a percentage of its host box (`100%` / `45%`, container is `panelTakeoverClasses().container` = `relative h-full`), and the drag maths reads that box (`hostHeight`) — the same clock as the shell, so there is nothing left to disagree.
- The drafts tray and the draft's own bar keep their borders and drop the `bg-muted` fill, so the separation is the same line in both themes. `ASIDE_PANE_HEAD` never had a fill; these two were the outliers.

## Test plan

- [x] `vitest src/components/aside` — 33 pass, including new phone cases: opening a draft gives it the sheet, hides the conversation, settles at `full`, and back returns; a tray fold keeps focus on a focused editor; focus promotes to `full` and blur leaves it there; a drag never blurs; the ease class exists only after a gesture's settle.
- [x] `vitest src/components/composer src/components/board src/components/thread src/components/timeline` — 1196 pass; the touch expectation in `message-composer.test.tsx` now asserts the toolbar opens on `Aa`.
- [x] `playwright tests/browser/aside-mobile.spec.ts` — 2 pass (new spec covers the takeover end to end); `aside-desktop.spec.ts` — 2 pass. All four browser shards green in CI.
- [x] Verified on a real phone viewport against the preview build, before and after each change; the dark/light composited colours above were measured off it. Playwright probes against the preview: driving `--viewport-height` 780→400→780 moves the sheet 780→400→780 in the same frame at both detents, with no transition class present; an arrow settle still eases (591px mid-flight) and rests clean.
- [ ] Drag smoothness and the keyboard's own timing are device properties — verified in code, tests and probes here; the feel is confirmed on the reporter's phone, not here. Still by design and visible on a phone: the timeline inside re-pins to its tail on keyboard open, as the main composer's does.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
