### PR TITLE
fix: label image references with filenames

### DIFF
--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -64,6 +64,14 @@ describe("buildSystemPrompt", () => {
     expect(prompt.indexOf("## Scratchpad Custom Instructions")).toBeLessThan(prompt.indexOf("## Context"))
   })
 
+  test("tells the agent to label attachment pointers with filenames", () => {
+    const prompt = buildJoinedPrompt({ persona, context: scratchpadContext, scratchpadCustomPrompt: null })
+
+    expect(prompt).toContain("[filename.ext](attachment:att_xxx)")
+    expect(prompt).toContain("label the pointer with the filename")
+    expect(prompt).not.toContain("[Image #1](attachment:att_xxx)")
+  })
+
   test("omits the custom instruction section when no scratchpad prompt exists", () => {
     const prompt = buildJoinedPrompt({ persona, context: scratchpadContext, scratchpadCustomPrompt: null })
 

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -233,8 +233,8 @@ When citing a specific message or file, prefer a structural reference over a par
   Quote the source verbatim: the server pins the quote to the revision it can read and re-derives the blockquote from that span, so wording you invented is rejected rather than sent.
 
 - **Resurface an attachment** by id:
-  \`[Image #1](attachment:att_xxx)\` for images,
-  \`[filename.pdf](attachment:att_xxx)\` for other files.
+  \`[filename.ext](attachment:att_xxx)\`
+  Use the filename shown in the attachment description for images and other files.
 
 - **Embed a memo** (own line in your response):
   \`[Memo Title](memo:memo_xxx)\`
@@ -245,7 +245,7 @@ When citing a specific message or file, prefer a structural reference over a par
 You already have the IDs you need most of the time — no extra tool call required. Look here first, then call \`workspace_research\` only if none of these surface what you want:
 
 - **Conversation history** annotates every user message with \`[msg:msg_… author:usr_…]\` and every persona message with \`[msg:msg_…]\`. The active stream id appears once in \`## Context\` as \`Stream id: \`stream_…\` \`. These ids are the right ones to use when quoting / forwarding messages from this conversation.
-- **Attachment descriptions** in conversation history carry \`(attach:att_… #N)\` — the \`#N\` matches the literal \`Image #N\` text used in the pointer.
+- **Attachment descriptions** in conversation history carry \`(attach:att_… #N)\`. The \`#N\` distinguishes images inside your input only; label the pointer with the filename shown in the description.
 - **\`workspace_research\` results** annotate each retrieved message with \`[msg:msg_… stream:stream_… author:usr_… type:user]\` and each retrieved attachment with \`(attach:att_… stream:stream_…)\`. Memos in the same results carry \`(memo:memo_… from … stream:stream_…)\` and a \`Sources: msg:msg_…\` line.
 - **\`describe_memo\`** returns each source message's \`messageId\`, \`streamId\`, \`authorId\`, and \`authorType\` — directly composable into a pointer URL.
 - **\`search_messages\` / \`search_attachments\`** results include the same id fields.

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -438,7 +438,7 @@ export function createMessageHandlers({
       const { contentJson, contentMarkdown } = normalizeContent(data)
       // Union of explicit fresh-upload ids and inline references parsed from
       // the canonical contentJson. Without this, a markdown POST containing
-      // `[Image #1](attachment:att_x)` would skip the access gate AND the
+      // `[filename.png](attachment:att_x)` would skip the access gate AND the
       // attachment_references projection write.
       const inlineRefIds = collectAttachmentReferenceIds(contentJson)
       const attachmentIds = [...new Set([...explicitAttachmentIds, ...inlineRefIds])]

--- a/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { Editor } from "@tiptap/core"
 import { DOMParser as PMDOMParser, DOMSerializer, type Slice } from "@tiptap/pm/model"
 import { NodeSelection, TextSelection } from "@tiptap/pm/state"
+import { attachmentReferenceLabel } from "@threa/prosemirror"
 import { createEditorExtensions } from "./editor-extensions"
 import type { AttachmentReferenceAttrs } from "./attachment-reference-extension"
 
@@ -76,6 +77,16 @@ function pasteHtml(editor: Editor, html: string): Slice {
   wrapper.innerHTML = html
   return PMDOMParser.fromSchema(editor.schema).parseSlice(wrapper)
 }
+
+describe("attachment reference labels", () => {
+  it("uses the filename even when older content carries an image ordinal", () => {
+    expect(attachmentReferenceLabel({ filename: "pasted-image-4.png", imageIndex: 3 })).toBe("pasted-image-4.png")
+  })
+
+  it("keeps metadata-free legacy image references readable", () => {
+    expect(attachmentReferenceLabel({ filename: "", imageIndex: 3 })).toBe("Image #3")
+  })
+})
 
 describe("attachment reference insertion", () => {
   it.each([

--- a/apps/frontend/src/components/editor/attachment-reference-extension.ts
+++ b/apps/frontend/src/components/editor/attachment-reference-extension.ts
@@ -1,5 +1,6 @@
 import { Node, mergeAttributes } from "@tiptap/core"
 import { ReactNodeViewRenderer } from "@tiptap/react"
+import { attachmentReferenceLabel } from "@threa/prosemirror"
 import { AttachmentReferenceView } from "./attachment-reference-view"
 
 export type AttachmentStatus = "uploading" | "uploaded" | "error"
@@ -15,7 +16,7 @@ export interface AttachmentReferenceAttrs {
   sizeBytes: number | null
   /** Upload status */
   status: AttachmentStatus
-  /** Image index (1, 2, 3...) - only for images */
+  /** Image ordinal retained in content for backward compatibility; labels prefer the filename. */
   imageIndex: number | null
   /** Error message if status is "error" */
   error: string | null
@@ -122,11 +123,7 @@ export const AttachmentReferenceExtension = Node.create({
     if (attrs.status === "error") {
       return "[Upload failed]"
     }
-    const isImage = attrs.mimeType.startsWith("image/")
-    if (isImage && attrs.imageIndex) {
-      return `[Image #${attrs.imageIndex}]`
-    }
-    return `[${attrs.filename}]`
+    return `[${attachmentReferenceLabel(attrs)}]`
   },
 
   addNodeView() {

--- a/apps/frontend/src/components/editor/attachment-reference-view.tsx
+++ b/apps/frontend/src/components/editor/attachment-reference-view.tsx
@@ -1,4 +1,5 @@
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
+import { attachmentReferenceLabel } from "@threa/prosemirror"
 import { Loader2, FileIcon, AlertCircle, ImageIcon } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -20,11 +21,7 @@ function getDisplayText(attrs: AttachmentReferenceAttrs): string {
   if (attrs.status === "error") {
     return "Upload failed"
   }
-  const isImage = attrs.mimeType.startsWith("image/")
-  if (isImage && attrs.imageIndex) {
-    return `Image #${attrs.imageIndex}`
-  }
-  return attrs.filename
+  return attachmentReferenceLabel(attrs)
 }
 
 export function AttachmentReferenceView({ node }: NodeViewProps) {

--- a/apps/frontend/src/components/editor/editor-markdown.test.ts
+++ b/apps/frontend/src/components/editor/editor-markdown.test.ts
@@ -1132,7 +1132,7 @@ const x = 1
         }
 
         expect(serializeToMarkdown(doc)).toBe(
-          'Check this [Image #1](attachment:attach_123 "threa-attachment:filename=screenshot.png&mimeType=image%2Fpng&sizeBytes=1024")'
+          'Check this [screenshot.png](attachment:attach_123 "threa-attachment:filename=screenshot.png&mimeType=image%2Fpng&sizeBytes=1024")'
         )
       })
 
@@ -1325,7 +1325,7 @@ const x = 1
 
         const md = serializeToMarkdown(doc)
         expect(md).toBe(
-          '[Image #2](attachment:attach_789 "threa-attachment:filename=photo.png&mimeType=image%2Fpng&sizeBytes=4096")'
+          '[photo.png](attachment:attach_789 "threa-attachment:filename=photo.png&mimeType=image%2Fpng&sizeBytes=4096")'
         )
 
         const parsed = parseMarkdown(md)
@@ -1334,7 +1334,7 @@ const x = 1
           filename: "photo.png",
           mimeType: "image/png",
           sizeBytes: 4096,
-          imageIndex: 2,
+          imageIndex: null,
         })
       })
 

--- a/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tray-drag.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { Editor } from "@tiptap/core"
+import { serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import { ComposerPillDndHost, ComposerPillDndProvider } from "@/components/editor/composer-pill-dnd"
 import { countAttachmentReferences } from "@/components/editor/attachment-reference-counts"
@@ -370,7 +371,24 @@ describe("referenced chip leading slot", () => {
   })
 })
 
-describe("tray-dragged image ordinal", () => {
+describe("tray-dragged image label", () => {
+  it("uses the filename after an earlier image was removed", () => {
+    const editor = createEditor()
+    vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })
+    const attachments = [
+      attachment({ id: "att_1", filename: "pasted-image-1.png", previewUrl: "blob:preview-1" }),
+      attachment({ id: "att_2", filename: "pasted-image-2.png", previewUrl: "blob:preview-2" }),
+      attachment({ id: "att_4", filename: "pasted-image-4.png", previewUrl: "blob:preview-4" }),
+    ]
+    renderTray(editor, attachments)
+
+    dragChipIntoEditor(screen.getByText("pasted-image-4.png"))
+
+    const markdown = serializeToMarkdown(editor.getJSON() as JSONContent)
+    expect(markdown).toContain("[pasted-image-4.png]")
+    expect(markdown).not.toContain("Image #3")
+  })
+
   it("stamps the ordinal send would give it, so both references read the same", () => {
     const editor = createEditor()
     vi.spyOn(editor.view, "posAtCoords").mockReturnValue({ pos: 1, inside: -1 })

--- a/docs/design-system-kitchen-sink.html
+++ b/docs/design-system-kitchen-sink.html
@@ -3546,7 +3546,7 @@
                     <circle cx="8.5" cy="8.5" r="1.5" />
                     <polyline points="21 15 16 10 5 21" />
                   </svg>
-                  Image #1 </span
+                  chart.png </span
                 >, the trend is positive.
               </p>
             </div>
@@ -3968,7 +3968,7 @@
                       <circle cx="8.5" cy="8.5" r="1.5" />
                       <polyline points="21 15 16 10 5 21" />
                     </svg>
-                    Image #1
+                    dashboard.png
                   </span>
                   for the new dashboard design. Let me know if you have any questions!
                 </p>
@@ -6507,7 +6507,7 @@ const refreshToken = async (token: string) => {
                   <circle cx="8.5" cy="8.5" r="1.5" />
                   <polyline points="21 15 16 10 5 21" />
                 </svg>
-                Image #1
+                photo.jpg
               </span>
             </p>
 
@@ -6604,7 +6604,7 @@ const refreshToken = async (token: string) => {
                     <circle cx="8.5" cy="8.5" r="1.5" />
                     <polyline points="21 15 16 10 5 21" />
                   </svg>
-                  Image #1
+                  photo.jpg
                 </span>
                 <span style="font-size: 12px; color: hsl(var(--muted-foreground)); margin-left: 8px"
                   >Image reference</span

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -323,7 +323,7 @@ Appears above selected text for formatting actions.
 }
 ```
 
-Format: `[Image #1]`, `[filename.ext]`
+Format: `[filename.ext]` for every attachment, including images.
 
 ### Code Blocks
 

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -10,6 +10,7 @@ export {
   serializeToMarkdown,
   parseMarkdown,
   normalizeMarkdownTables,
+  attachmentReferenceLabel,
   INLINE_MARKDOWN_PATTERN,
   type MentionTypeLookup,
   type EmojiLookup,

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { normalizeMarkdownTables, parseMarkdown, serializeToMarkdown } from "./markdown"
+import { attachmentReferenceLabel, normalizeMarkdownTables, parseMarkdown, serializeToMarkdown } from "./markdown"
 import type { JSONContent } from "@threa/types"
 
 describe("@threa/prosemirror markdown links", () => {
@@ -84,6 +84,12 @@ describe("@threa/prosemirror markdown links", () => {
 })
 
 describe("@threa/prosemirror markdown attachment metadata", () => {
+  it("uses a legacy ordinal only when attachment metadata has no filename", () => {
+    expect(attachmentReferenceLabel({ filename: "photo.png", imageIndex: 2 })).toBe("photo.png")
+    expect(attachmentReferenceLabel({ filename: "", imageIndex: 2 })).toBe("Image #2")
+    expect(attachmentReferenceLabel({ filename: "", imageIndex: null })).toBe("Attachment")
+  })
+
   it("serializes attachment metadata into the markdown link title", () => {
     const doc: JSONContent = {
       type: "doc",
@@ -113,6 +119,35 @@ describe("@threa/prosemirror markdown attachment metadata", () => {
     )
   })
 
+  it("serializes image references with the filename instead of an ordinal", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "attachmentReference",
+              attrs: {
+                id: "attach_789",
+                filename: "pasted-image-4.png",
+                mimeType: "image/png",
+                sizeBytes: 4096,
+                status: "uploaded",
+                imageIndex: 3,
+                error: null,
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(serializeToMarkdown(doc)).toBe(
+      '[pasted-image-4.png](attachment:attach_789 "threa-attachment:filename=pasted-image-4.png&mimeType=image%2Fpng&sizeBytes=4096")'
+    )
+  })
+
   it("restores attachment metadata from the markdown link title", () => {
     const parsed = parseMarkdown(
       '[Image #2](attachment:attach_789 "threa-attachment:filename=photo.png&mimeType=image%2Fpng&sizeBytes=4096")'
@@ -127,6 +162,25 @@ describe("@threa/prosemirror markdown attachment metadata", () => {
         sizeBytes: 4096,
         status: "uploaded",
         imageIndex: 2,
+        error: null,
+      },
+    })
+  })
+
+  it("parses filename-labeled image metadata without manufacturing an ordinal", () => {
+    const parsed = parseMarkdown(
+      '[pasted-image-4.png](attachment:attach_789 "threa-attachment:filename=pasted-image-4.png&mimeType=image%2Fpng&sizeBytes=4096")'
+    )
+
+    expect(parsed.content?.[0]?.content?.[0]).toEqual({
+      type: "attachmentReference",
+      attrs: {
+        id: "attach_789",
+        filename: "pasted-image-4.png",
+        mimeType: "image/png",
+        sizeBytes: 4096,
+        status: "uploaded",
+        imageIndex: null,
         error: null,
       },
     })

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -279,6 +279,12 @@ function mentionPointerUrl(id: string): string | null {
   return null
 }
 
+export function attachmentReferenceLabel(attrs: { filename?: unknown; imageIndex?: unknown }): string {
+  if (typeof attrs.filename === "string" && attrs.filename.length > 0) return attrs.filename
+  if (typeof attrs.imageIndex === "number" && attrs.imageIndex > 0) return `Image #${attrs.imageIndex}`
+  return "Attachment"
+}
+
 function getNodeText(node: JSONContent): string {
   if (node.type === "hardBreak") return "\n"
   if (node.type === "mention") {
@@ -306,18 +312,15 @@ function getNodeText(node: JSONContent): string {
   }
   if (node.type === "attachmentReference") {
     const id = node.attrs?.id as string
-    const filename = node.attrs?.filename as string
-    const mimeType = node.attrs?.mimeType as string
-    const imageIndex = node.attrs?.imageIndex as number | null
     const status = node.attrs?.status as string
 
     if (status === "uploading" || status === "error") {
       return ""
     }
 
-    // Format: [Image #1](attachment:id) or [filename](attachment:id)
-    const isImage = mimeType?.startsWith("image/")
-    const displayText = isImage && imageIndex ? `Image #${imageIndex}` : filename
+    // Filenames match the attachment tray and stay stable when files are removed.
+    // The ordinal fallback keeps metadata-free legacy image references readable.
+    const displayText = attachmentReferenceLabel(node.attrs ?? {})
     const escapedDisplayText = escapeMarkdownLinkText(displayText)
     const metadata = serializeAttachmentMetadata(node.attrs)
     return `[${escapedDisplayText}](attachment:${id}${metadata})`

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -7,10 +7,10 @@ import { createChannel, loginAndCreateWorkspace } from "./helpers"
  * Tests for inline file uploads via paste and drag-drop.
  *
  * Tests:
- * 1. Pasting an image inserts [Image #N] reference and attachment chip
- * 2. Pasting a non-image file inserts [filename] reference
+ * 1. Pasting an image inserts a filename reference and attachment chip
+ * 2. Pasting a non-image file inserts the same filename reference
  * 3. Drag-drop works the same as paste
- * 4. Multiple images get sequential numbering
+ * 4. Multiple images keep their filenames
  */
 
 test.describe("Inline File Uploads", () => {
@@ -35,7 +35,7 @@ test.describe("Inline File Uploads", () => {
     await createChannel(page, channelName)
   })
 
-  test("should insert [Image #1] reference when pasting an image with sequential name", async ({ page }) => {
+  test("should insert the generated filename when pasting an image", async ({ page }) => {
     // Focus the editor
     const editor = page.locator("[contenteditable='true']")
     await editor.click()
@@ -67,12 +67,13 @@ test.describe("Inline File Uploads", () => {
       editor.dispatchEvent(pasteEvent)
     }, Array.from(imageBuffer))
 
-    // Wait for upload to complete and verify the reference appears
-    // Should show [Image #1]
-    await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
+    // Wait for upload to complete and verify the reference matches the tray filename.
+    const reference = editor.locator("span[data-type='attachment-reference']")
+    await expect(reference).toBeVisible({ timeout: 10000 })
+    await expect(reference).toContainText("[pasted-image-1.png]")
 
-    // Verify attachment chip shows the renamed filename (pasted-image-1.png)
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    // Verify the tray chip shows the renamed filename.
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
   })
 
   test("should insert [filename] reference when pasting a non-image file", async ({ page }) => {
@@ -106,7 +107,7 @@ test.describe("Inline File Uploads", () => {
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
   })
 
-  test("should number images sequentially when pasting multiple", async ({ page }) => {
+  test("should keep generated filenames when pasting multiple images", async ({ page }) => {
     const editor = page.locator("[contenteditable='true']")
     await editor.click()
 
@@ -133,9 +134,9 @@ test.describe("Inline File Uploads", () => {
       editor.dispatchEvent(pasteEvent)
     }, Array.from(imageBuffer))
 
-    // Wait for first upload and verify filename
+    // Wait for first upload and verify the tray filename.
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Paste second image
     await page.evaluate(async (imageData) => {
@@ -158,12 +159,15 @@ test.describe("Inline File Uploads", () => {
       editor.dispatchEvent(pasteEvent)
     }, Array.from(imageBuffer))
 
-    // Should have two references with sequential naming
-    await expect(editor.locator("span[data-type='attachment-reference']")).toHaveCount(2, { timeout: 10000 })
-    await expect(page.getByText("pasted-image-2.png")).toBeVisible({ timeout: 5000 })
+    // Both inline references use the same generated names shown in the tray.
+    const references = editor.locator("span[data-type='attachment-reference']")
+    await expect(references).toHaveCount(2, { timeout: 10000 })
+    await expect(references.nth(0)).toContainText("[pasted-image-1.png]")
+    await expect(references.nth(1)).toContainText("[pasted-image-2.png]")
+    await expect(page.getByRole("button", { name: "Preview pasted-image-2.png" })).toBeVisible({ timeout: 5000 })
   })
 
-  test("should keep a mobile multi-pick inline with sequential image numbers", async ({ page }) => {
+  test("should keep a mobile multi-pick inline with filenames", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     const editor = page.locator("[contenteditable='true']")
     if (!(await editor.isVisible())) {
@@ -180,9 +184,9 @@ test.describe("Inline File Uploads", () => {
 
     const references = editor.locator("span[data-type='attachment-reference']")
     await expect(references).toHaveCount(3, { timeout: 10000 })
-    await expect(references.nth(0)).toContainText("[Image #1]", { timeout: 10000 })
-    await expect(references.nth(1)).toContainText("[Image #2]", { timeout: 10000 })
-    await expect(references.nth(2)).toContainText("[Image #3]", { timeout: 10000 })
+    await expect(references.nth(0)).toContainText("[one.png]", { timeout: 10000 })
+    await expect(references.nth(1)).toContainText("[two.png]", { timeout: 10000 })
+    await expect(references.nth(2)).toContainText("[three.png]", { timeout: 10000 })
   })
 
   test("should open lightbox when clicking image link in sent message", async ({ page }) => {
@@ -213,19 +217,21 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Check out this image: ")
     await page.getByRole("button", { name: "Send" }).click()
 
     // Wait for message to appear in timeline (not in editor anymore)
-    const imageLink = page.locator(".markdown-content button:has-text('Image #1')")
+    const imageLink = page.locator(".markdown-content p button:has-text('pasted-image-1.png')")
     await expect(imageLink).toBeVisible({ timeout: 10000 })
 
     // Wait until attachment metadata is hydrated in the rendered message.
     // Inline link click depends on attachment context, which can lag briefly in CI.
-    const attachmentPill = page.getByRole("button", { name: "pasted-image-1.png", exact: true })
+    const attachmentPill = page
+      .getByRole("button", { name: "pasted-image-1.png", exact: true })
+      .filter({ has: page.locator("img") })
     await expect(attachmentPill).toBeVisible({ timeout: 10000 })
 
     // Ensure the attachment image has loaded (src attribute is set and not a blob placeholder).
@@ -269,18 +275,20 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Hover test: ")
     await page.getByRole("button", { name: "Send" }).click()
 
     // Wait for message to appear
-    const imageLink = page.locator(".markdown-content button:has-text('Image #1')")
+    const imageLink = page.locator(".markdown-content p button:has-text('pasted-image-1.png')")
     await expect(imageLink).toBeVisible({ timeout: 10000 })
 
     // Find the attachment pill (the image button with the filename)
-    const attachmentPill = page.getByRole("button", { name: "pasted-image-1.png", exact: true })
+    const attachmentPill = page
+      .getByRole("button", { name: "pasted-image-1.png", exact: true })
+      .filter({ has: page.locator("img") })
     await expect(attachmentPill).toBeVisible({ timeout: 5000 })
 
     // Before hover: pill should NOT be highlighted


### PR DESCRIPTION
## Problem

Image references used generated labels such as `Image #3`, while the attachment tray showed filenames such as `pasted-image-4.png`. Removing an earlier image or inserting the same image twice left both labels factually valid but visually contradictory, and users had no visible numbered list to reconcile them against.

## Solution

Image references now use the attachment filename everywhere users encounter the pointer: editor chips, plain-text copy, serialized markdown, sent-message links, and agent-authored attachment links. Images now follow the same naming rule as PDFs and other files, so a tray item and each reference to it share one stable label.

`attachmentReferenceLabel` in `@threa/prosemirror` owns the filename-first rule for both markdown and TipTap. Existing `[Image #N](attachment:...)` content still parses. When old content has metadata, it renders the stored filename; metadata-free legacy image links retain `Image #N` as a fallback. No migration or attachment ID behavior changes.

The companion prompt and design-system examples now document filename labels. Opus independently recommended this choice because filenames remain stable under tray mutation and give screen readers the same identifier visible elsewhere.

## Verification

- [x] 143 focused frontend tests, 109 markdown tests, 35 backend prompt tests, and 7/7 inline-upload browser tests; full monorepo typecheck and lint clean
- [x] Browser coverage includes paste, mobile multi-pick, sent-message lightbox, hover linking, and duplicate copied references

## Residual risk

`imageIndex` remains in `contentJson` and clipboard HTML for backward compatibility, but it no longer overrides an available filename.

---

🤖 _PR by Pi using GPT-5.6 Sol_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790190884&installation_model_id=20758&pr_number=1958&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1958&signature=7577cd7ef905f225d4dfff9c394f7bcb4b9c23de2a2b16ca250145e37270e6c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->