### PR TITLE
fix(frontend): the aside draft composer takes the pane's ground

### DIFF
--- a/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.test.tsx
@@ -41,6 +41,7 @@ describe("AsideDraftEditor — Insert into draft", () => {
       commandStreamId?: string | null
       includeStreamCommands?: boolean
       expanded?: boolean
+      className?: string
     }) => (
       <div
         data-testid="message-composer"
@@ -50,6 +51,7 @@ describe("AsideDraftEditor — Insert into draft", () => {
         data-stash={props.stashedDrafts ? "yes" : "no"}
         data-commands={props.includeStreamCommands === false ? "editor-only" : "stream"}
         data-expanded={props.expanded ? "yes" : "no"}
+        data-ground={props.className}
       />
     )) as never)
     const onConsumed = vi.fn()
@@ -95,6 +97,9 @@ describe("AsideDraftEditor — Insert into draft", () => {
       stash: card.getAttribute("data-stash"),
       commands: card.getAttribute("data-commands"),
       expanded: card.getAttribute("data-expanded"),
+      // The pane paints the ground; the composer's own `bg-background` reads as
+      // a darker square inside it in dark mode.
+      ground: card.getAttribute("data-ground"),
     }).toEqual({
       submit: "Send to composer",
       expand: "no",
@@ -102,6 +107,7 @@ describe("AsideDraftEditor — Insert into draft", () => {
       stash: "no",
       commands: "editor-only",
       expanded: "yes",
+      ground: "bg-transparent",
     })
   })
 

--- a/apps/frontend/src/components/aside/aside-draft-editor.tsx
+++ b/apps/frontend/src/components/aside/aside-draft-editor.tsx
@@ -116,6 +116,10 @@ export function AsideDraftEditor({
             a writing surface, not a one-line chat box. */}
         <MessageComposer
           expanded
+          // The pane is the ground. The composer's own `bg-background` is a
+          // shade under `--card` in dark (8% vs 11% lightness) and a hair over
+          // it in light, so painting it here read as a dark square in dark only.
+          className="bg-transparent"
           composerRef={controlRef}
           content={composer.content}
           onContentChange={composer.handleContentChange}


### PR DESCRIPTION
## Problem

In dark mode the aside's open draft reads as a dark square inset in the sheet. `MessageComposer`'s expanded shell paints `bg-background` (`apps/frontend/src/components/composer/message-composer.tsx:1278`) while `AsidePane` paints `bg-card`, and in the dark palette those are `30 15% 8%` vs `30 12% 11%` — a visible step. The light palette puts them at 98% vs 99%, which is why the same markup looks right in light and only the dark theme shows the square.

| Before | After |
| --- | --- |
| ![before](https://seer.build/ws_vbyzjvdg6g/i/img_q2e69t38et/aside-composer-ground-dark-before.webp) | ![after](https://seer.build/ws_vbyzjvdg6g/i/img_tp5d0rsz4y/aside-composer-ground-dark.webp) |

## Solution

The pane is the ground; the composer stops painting its own. `AsideDraftEditor` passes `className="bg-transparent"`, which `twMerge` resolves over the shell's `bg-background`.

- Scoped to the aside rather than changed in `MessageComposer` — the other two expanded composers (`board-overlay-composer`, `board-inline-composer`) sit inside `OverlayComposerShell`, where `bg-background` is the matching ground. Their surface is unchanged.
- `bg-transparent` over `bg-card` so the composer follows the pane if the pane's token ever changes, instead of two places naming the same colour.
- Same fix covers the desktop stage: that draft editor is the same component inside the same `bg-card` pane.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/aside/aside-draft-editor.tsx` | Composer inherits the pane's ground |
| `apps/frontend/src/components/aside/aside-draft-editor.test.tsx` | Stub records `className`; the existing composer-shape comparison asserts it |

## Test plan

- [x] `bun run test src/components/aside` — 33 pass
- [x] Preview on 8447 at this commit, Playwright phone context in both schemes: shell computed background `rgba(0, 0, 0, 0)` in dark and light; pane `rgb(31, 28, 25)` / `rgb(253, 253, 252)`. Screenshots above are dark, before/after.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790225777&installation_model_id=20758&pr_number=1960&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1960&signature=253e9e1c543f5ac01a40108ba7b669a66834217b910a0586a960292d93c1693e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->