### PR TITLE
feat(integrations): reconfigure repository access on a live GitHub installation

### DIFF
--- a/apps/backend/src/features/github-webhooks/config.ts
+++ b/apps/backend/src/features/github-webhooks/config.ts
@@ -1,14 +1,22 @@
 import { z } from "zod"
 
 /**
- * Event types that drive a preview refresh. `installation` is handled as a
- * lifecycle event (deactivate only on `deleted`; suspend/unsuspend are no-ops);
- * the PR/issue types derive canonical URLs and refresh matching previews. CP
- * already filters to the app's subscribed set, so anything else is a clean no-op.
+ * Event types that drive a preview refresh: each derives a canonical URL from
+ * its payload and re-fetches matching previews. The two `installation*` types
+ * below are handled separately. CP already filters to the app's subscribed set,
+ * so anything else is a clean no-op.
  */
 export const GITHUB_REFRESH_EVENT_TYPES = ["pull_request", "pull_request_review", "issues"] as const
 
+/** Installation lifecycle. Deactivates only on `deleted`; suspend/unsuspend are no-ops. */
 export const GITHUB_INSTALLATION_EVENT_TYPE = "installation"
+
+/**
+ * Repository access for the installation changed on GitHub (`added`/`removed`).
+ * The grant lives on GitHub, so this is the only push signal that a workspace's
+ * cached repository list went stale; the worker reconciles it.
+ */
+export const GITHUB_INSTALLATION_REPOSITORIES_EVENT_TYPE = "installation_repositories"
 
 /** Wire shape sent by CP's `RegionalClient.dispatchGithubWebhook`. */
 export const githubWebhookEventSchema = z.object({

--- a/apps/backend/src/features/github-webhooks/worker.test.ts
+++ b/apps/backend/src/features/github-webhooks/worker.test.ts
@@ -65,9 +65,11 @@ function fakeWorkspaceIntegrationService(workspaceIds: string[]) {
   return {
     listActiveWorkspaceIdsForInstallation: mock(async () => workspaceIds),
     deactivateInstallation: mock(async () => ({ deactivatedWorkspaceIds: workspaceIds })),
+    refreshGithubInstallationRepositories: mock(async () => ({ refreshedWorkspaceIds: workspaceIds })),
   } as unknown as WorkspaceIntegrationService & {
     listActiveWorkspaceIdsForInstallation: ReturnType<typeof mock>
     deactivateInstallation: ReturnType<typeof mock>
+    refreshGithubInstallationRepositories: ReturnType<typeof mock>
   }
 }
 
@@ -245,5 +247,54 @@ describe("github webhook worker — installation lifecycle", () => {
     await worker(prJob({ eventType: "installation", action: "unsuspend", repositoryFullName: null, payload: {} }))
 
     expect(wis.deactivateInstallation).not.toHaveBeenCalled()
+  })
+})
+
+describe("github webhook worker — repository grant changes", () => {
+  test("installation_repositories → reconciles the installation snapshot, no preview refresh", async () => {
+    const pool = fakePool()
+    const wis = fakeWorkspaceIntegrationService([WORKSPACE_ID])
+    const prefixSpy = spyOn(LinkPreviewRepository, "findByNormalizedUrlPrefix")
+
+    const worker = createGithubWebhookWorker({
+      pool,
+      linkPreviewService: makeService(pool),
+      workspaceIntegrationService: wis,
+      jobQueue: fakeJobQueue(),
+    })
+
+    await worker(
+      prJob({
+        eventType: "installation_repositories",
+        action: "added",
+        repositoryFullName: null,
+        payload: { installation: { id: 42 }, repositories_added: [{ full_name: "acme/widgets" }] },
+      })
+    )
+
+    expect(wis.refreshGithubInstallationRepositories).toHaveBeenCalledWith("42")
+    expect(wis.deactivateInstallation).not.toHaveBeenCalled()
+    expect(prefixSpy).not.toHaveBeenCalled()
+  })
+
+  test("a refresh failure propagates so the delivery is retried", async () => {
+    const pool = fakePool()
+    const wis = fakeWorkspaceIntegrationService([WORKSPACE_ID])
+    wis.refreshGithubInstallationRepositories = mock(async () => {
+      throw new Error("GitHub unavailable")
+    })
+
+    const worker = createGithubWebhookWorker({
+      pool,
+      linkPreviewService: makeService(pool),
+      workspaceIntegrationService: wis,
+      jobQueue: fakeJobQueue(),
+    })
+
+    await expect(
+      worker(
+        prJob({ eventType: "installation_repositories", action: "removed", repositoryFullName: null, payload: {} })
+      )
+    ).rejects.toThrow("GitHub unavailable")
   })
 })

--- a/apps/backend/src/features/github-webhooks/worker.ts
+++ b/apps/backend/src/features/github-webhooks/worker.ts
@@ -4,7 +4,11 @@ import type { Job, JobHandler, QueueManager } from "../../lib/queue"
 import type { GithubWebhookProcessJobData } from "../../lib/queue/job-queue"
 import { findGithubPreviewMatches, type LinkPreviewService } from "../link-previews"
 import type { WorkspaceIntegrationService } from "../workspace-integrations"
-import { GITHUB_INSTALLATION_EVENT_TYPE, GITHUB_REFRESH_EVENT_TYPES } from "./config"
+import {
+  GITHUB_INSTALLATION_EVENT_TYPE,
+  GITHUB_INSTALLATION_REPOSITORIES_EVENT_TYPE,
+  GITHUB_REFRESH_EVENT_TYPES,
+} from "./config"
 import { deriveGithubTargetUrls } from "./derive"
 import { refreshGithubPreviewWithTrailing } from "./preview-refresh"
 
@@ -24,8 +28,9 @@ interface GithubWebhookWorkerDeps {
  * installation, derive the canonical PR/issue URL from the payload, and
  * force-refresh matching link previews (webhook = invalidation signal, not the
  * data source — the refresh re-fetches through the GitHub API). Lifecycle
- * `installation` events deactivate the integration instead. A delivery that
- * matches no workspace or no preview row is a clean no-op.
+ * `installation` events deactivate the integration instead, and
+ * `installation_repositories` re-syncs the cached repository grant. A delivery
+ * that matches no workspace or no preview row is a clean no-op.
  */
 export function createGithubWebhookWorker(deps: GithubWebhookWorkerDeps): JobHandler<GithubWebhookProcessJobData> {
   return async (job: Job<GithubWebhookProcessJobData>) => {
@@ -38,6 +43,16 @@ export function createGithubWebhookWorker(deps: GithubWebhookWorkerDeps): JobHan
 
     if (eventType === GITHUB_INSTALLATION_EVENT_TYPE) {
       await handleInstallationEvent(deps, installationId, action, deliveryGuid)
+      return
+    }
+
+    if (eventType === GITHUB_INSTALLATION_REPOSITORIES_EVENT_TYPE) {
+      const { refreshedWorkspaceIds } =
+        await deps.workspaceIntegrationService.refreshGithubInstallationRepositories(installationId)
+      log.info(
+        { deliveryGuid, installationId, action, refreshedWorkspaceIds },
+        "Reconciled GitHub repository grant change"
+      )
       return
     }
 

--- a/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
+++ b/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
@@ -730,6 +730,231 @@ describe("syncGithubRepositories version-CAS retry (INV-66)", () => {
   })
 })
 
+describe("GitHub repository reconfiguration", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  /**
+   * Stub both app-JWT routes distinctly: the installation read (identity +
+   * repository grant, what a reconfigure on GitHub changes) and the token mint.
+   * `fetch` serves the installation-token Octokit's repository listing.
+   */
+  function stubReconfiguredInstallation(
+    service: WorkspaceIntegrationService,
+    installation: Record<string, unknown>,
+    repositories: Array<{ full_name: string; private: boolean }>
+  ): void {
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async (route: string) => {
+        if (route.startsWith("GET /app/installations")) return { data: installation }
+        return {
+          data: { token: "fresh-tok", expires_at: FUTURE_ISO, permissions: installation.permissions ?? {} },
+        }
+      },
+    })
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ repositories }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
+  }
+
+  function poolCapturingUpdate(selectRow: Record<string, unknown>): {
+    pool: Pool
+    updates: QueryCall[]
+  } {
+    const updates: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        if (text.includes("UPDATE workspace_integrations")) {
+          updates.push({ text, values })
+          return { rows: [{ ...selectRow, metadata: JSON.parse(String(values[5])) }], rowCount: 1 }
+        }
+        return { rows: [selectRow], rowCount: 1 }
+      },
+      release: () => {},
+    } as unknown as Pool
+    return { pool, updates }
+  }
+
+  function makeService(pool: Pool): WorkspaceIntegrationService {
+    return new WorkspaceIntegrationService({
+      pool,
+      github: githubEnabled,
+      linear: linearDisabled,
+      region: "eu-north-1",
+    })
+  }
+
+  it("re-reads the installation so a grant narrowed on GitHub replaces the cached snapshot", async () => {
+    const row = githubRow({
+      installation_id: "42",
+      credentials: encryptedGithubCredentials(42),
+      metadata: {
+        organizationName: "acme",
+        accountType: "Organization",
+        repositorySelection: "all",
+        permissions: {},
+        repositories: [{ fullName: "acme/old", private: false }],
+        rateLimitRemaining: null,
+        rateLimitResetAt: null,
+      },
+      version: 5,
+    })
+    const { pool } = poolCapturingUpdate(row)
+    const service = makeService(pool)
+    stubReconfiguredInstallation(
+      service,
+      {
+        account: { type: "Organization", login: "acme" },
+        repository_selection: "selected",
+        permissions: { contents: "read" },
+        html_url: "https://github.com/organizations/acme/settings/installations/42",
+      },
+      [{ full_name: "acme/widgets", private: true }]
+    )
+
+    const result = await service.syncGithubRepositories("ws_1", "wsi_1")
+
+    expect({
+      repositorySelection: result.repositorySelection,
+      repositories: result.repositories,
+      configurationUrl: result.configurationUrl,
+      permissions: result.permissions,
+    }).toEqual({
+      repositorySelection: "selected",
+      repositories: [{ fullName: "acme/widgets", private: true }],
+      configurationUrl: "https://github.com/organizations/acme/settings/installations/42",
+      permissions: { contents: "read" },
+    })
+  })
+
+  it("parks the row in error and reports GITHUB_INSTALLATION_GONE when GitHub 404s the installation", async () => {
+    const row = githubRow({ installation_id: "42", credentials: encryptedGithubCredentials(42), version: 3 })
+    const updates: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        if (text.includes("UPDATE workspace_integrations")) {
+          updates.push({ text, values })
+          return { rows: [{ ...row, status: "error" }], rowCount: 1 }
+        }
+        return { rows: [row], rowCount: 1 }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = makeService(pool)
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async () => {
+        throw Object.assign(new Error("Not Found"), { status: 404 })
+      },
+    })
+
+    let caught: unknown
+    try {
+      await service.syncGithubRepositories("ws_1", "wsi_1")
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as { status?: number; code?: string }).code).toBe("GITHUB_INSTALLATION_GONE")
+    expect((caught as { status?: number }).status).toBe(409)
+    // status='error', scoped to installation 42, guarded on the row still being active
+    expect(updates).toHaveLength(1)
+    expect([updates[0].values[2], updates[0].values[3], updates[0].values[8]]).toEqual(["42", "error", "active"])
+  })
+
+  it("refreshes every workspace on the installation when GitHub reports a grant change", async () => {
+    const rows = [
+      githubRow({
+        id: "wsi_a",
+        workspace_id: "ws_a",
+        installation_id: "42",
+        credentials: encryptJson(
+          SECRET,
+          { installationId: 42, accessToken: "tok", tokenExpiresAt: FUTURE_ISO },
+          { workspaceId: "ws_a", provider: "github" }
+        ),
+      }),
+      githubRow({
+        id: "wsi_b",
+        workspace_id: "ws_b",
+        installation_id: "42",
+        credentials: encryptJson(
+          SECRET,
+          { installationId: 42, accessToken: "tok", tokenExpiresAt: FUTURE_ISO },
+          { workspaceId: "ws_b", provider: "github" }
+        ),
+      }),
+    ]
+    const updates: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        if (text.includes("UPDATE workspace_integrations")) {
+          updates.push({ text, values })
+          return { rows: [rows[updates.length - 1]], rowCount: 1 }
+        }
+        return { rows, rowCount: rows.length }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = makeService(pool)
+    stubReconfiguredInstallation(
+      service,
+      { account: { type: "Organization", login: "acme" }, repository_selection: "selected", permissions: {} },
+      [{ full_name: "acme/widgets", private: true }]
+    )
+
+    const result = await service.refreshGithubInstallationRepositories("42")
+
+    expect(result.refreshedWorkspaceIds).toEqual(["ws_a", "ws_b"])
+    expect(updates.map((call) => call.values[0])).toEqual(["ws_a", "ws_b"])
+  })
+
+  it("rethrows so the delivery retries when the refresh fails on a transient GitHub error", async () => {
+    const row = githubRow({ installation_id: "42", credentials: encryptedGithubCredentials(42) })
+    const { pool } = recordingPool([row])
+    const service = makeService(pool)
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async () => {
+        throw Object.assign(new Error("Bad gateway"), { status: 502 })
+      },
+    })
+
+    await expect(service.refreshGithubInstallationRepositories("42")).rejects.toThrow(/retrying delivery/)
+  })
+
+  it("derives a configuration URL for installs that predate capturing GitHub's own", async () => {
+    const { pool } = recordingPool([
+      githubRow({
+        id: "wsi_org",
+        installation_id: "42",
+        metadata: { organizationName: "acme", accountType: "Organization" },
+      }),
+      githubRow({
+        id: "wsi_user",
+        installation_id: "77",
+        metadata: { organizationName: "kris", accountType: "User" },
+      }),
+      githubRow({ id: "wsi_unknown", installation_id: "99", metadata: {} }),
+    ])
+    const service = makeService(pool)
+
+    const installs = await service.listGithubInstallations("ws_1")
+
+    expect(installs.map((install) => install.configurationUrl)).toEqual([
+      "https://github.com/organizations/acme/settings/installations/42",
+      "https://github.com/settings/installations/77",
+      null,
+    ])
+  })
+})
+
 describe("listActiveWorkspaceIdsForInstallation", () => {
   it("returns every active workspace on the installation, scoped by (provider, installation_id, active)", async () => {
     const { pool, calls } = recordingPool([
@@ -833,6 +1058,7 @@ describe("GitHub metadata write guards", () => {
     organizationName: "acme",
     accountType: "Organization" as const,
     repositorySelection: "all" as const,
+    configurationUrl: null,
     permissions: {},
     repositories: [],
     rateLimitRemaining: null,

--- a/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
+++ b/apps/backend/src/features/workspace-integrations/installation-routes.test.ts
@@ -868,6 +868,49 @@ describe("GitHub repository reconfiguration", () => {
     expect([updates[0].values[2], updates[0].values[3], updates[0].values[8]]).toEqual(["42", "error", "active"])
   })
 
+  it("keeps a 404 from the repository listing a retryable network failure, not a parked row", async () => {
+    const row = githubRow({ installation_id: "42", credentials: encryptedGithubCredentials(42), version: 3 })
+    const updates: QueryCall[] = []
+    const pool = {
+      query: async (query: unknown, values: unknown[] = []) => {
+        const text = typeof query === "string" ? query : ((query as { text?: string })?.text ?? "")
+        if (text.includes("UPDATE workspace_integrations")) {
+          updates.push({ text, values })
+          return { rows: [row], rowCount: 1 }
+        }
+        return { rows: [row], rowCount: 1 }
+      },
+      release: () => {},
+    } as unknown as Pool
+    const service = makeService(pool)
+    // Both app-JWT calls succeed — the installation demonstrably exists. Only the
+    // installation-token repository listing 404s, which must not park the row:
+    // parking is terminal until a user reconnects.
+    spyOn(service as unknown as { getAppOctokit: () => unknown }, "getAppOctokit").mockReturnValue({
+      request: async (route: string) => {
+        if (route.startsWith("GET /app/installations")) {
+          return { data: { account: { type: "Organization", login: "acme" }, repository_selection: "all" } }
+        }
+        return { data: { token: "fresh-tok", expires_at: FUTURE_ISO, permissions: {} } }
+      },
+    })
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
+
+    let caught: unknown
+    try {
+      await service.syncGithubRepositories("ws_1", "wsi_1")
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as { status?: number; code?: string }).code).toBe("GITHUB_SYNC_FAILED")
+    expect(updates).toHaveLength(0)
+  })
+
   it("refreshes every workspace on the installation when GitHub reports a grant change", async () => {
     const rows = [
       githubRow({

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -105,6 +105,7 @@ describe("GitHubClient captureRateLimit is best-effort", () => {
     organizationName: "acme",
     accountType: "Organization" as const,
     repositorySelection: "all" as const,
+    configurationUrl: null,
     permissions: {},
     repositories: [],
     rateLimitRemaining: null,

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -67,10 +67,23 @@ interface GitHubIntegrationMetadata extends Record<string, unknown> {
   organizationName: string | null
   accountType: "Organization" | "User" | null
   repositorySelection: "all" | "selected" | null
+  // GitHub's `html_url` for the installation — its settings page, where the
+  // repository grant is edited. Absent on rows installed before it was captured;
+  // `mapGithubIntegration` derives a replacement so those still get a link.
+  configurationUrl: string | null
   permissions: Record<string, string>
   repositories: GitHubInstalledRepository[]
   rateLimitRemaining: number | null
   rateLimitResetAt: string | null
+}
+
+/** Installation identity + repository-grant mode as GitHub reports it. */
+interface GitHubInstallationSnapshot {
+  accountLogin: string | null
+  accountType: "Organization" | "User" | null
+  repositorySelection: "all" | "selected" | null
+  configurationUrl: string | null
+  permissions: Record<string, string>
 }
 
 interface RefreshResult {
@@ -293,6 +306,9 @@ export class WorkspaceIntegrationService {
       installationId: record.installationId,
       accountType: metadata.accountType,
       repositorySelection: metadata.repositorySelection,
+      configurationUrl:
+        metadata.configurationUrl ??
+        deriveInstallationConfigurationUrl(record.installationId, metadata.accountType, metadata.organizationName),
       permissions: metadata.permissions,
       repositories: metadata.repositories,
       rateLimit: {
@@ -467,6 +483,14 @@ export class WorkspaceIntegrationService {
     }
   }
 
+  /**
+   * Reconcile one installation's cached snapshot against GitHub: repository grant,
+   * selection mode, account identity, permissions, and a freshly minted token.
+   * The grant itself is edited on GitHub (Threa holds only an installation token,
+   * which cannot change repository access), so this is the read side of every
+   * reconfiguration — user-triggered from settings, or webhook-triggered when the
+   * user adds/removes repositories on GitHub.
+   */
   async syncGithubRepositories(workspaceId: string, integrationId: string): Promise<GitHubWorkspaceIntegration> {
     this.requireGitHubEnabled()
 
@@ -482,23 +506,98 @@ export class WorkspaceIntegrationService {
       })
     }
 
+    const result = await this.syncGithubInstallationRecord(workspaceId, record)
+    if (result.ok) {
+      return this.mapGithubIntegration(result.record)
+    }
+
+    switch (result.failure) {
+      case "decrypt":
+        throw new HttpError("GitHub integration credentials could not be decrypted", {
+          status: 500,
+          code: "GITHUB_CREDENTIALS_DECRYPT_FAILED",
+        })
+      case "installation_gone":
+        throw new HttpError("This GitHub installation no longer exists. Reconnect to restore access.", {
+          status: 409,
+          code: "GITHUB_INSTALLATION_GONE",
+        })
+      case "conflict":
+        throw new HttpError("GitHub integration was disconnected during sync", {
+          status: 409,
+          code: "GITHUB_INTEGRATION_NOT_ACTIVE",
+        })
+      default:
+        throw new HttpError("Failed to sync GitHub repositories", { status: 502, code: "GITHUB_SYNC_FAILED" })
+    }
+  }
+
+  /**
+   * Re-sync every workspace subscribed to an installation. Driven by the
+   * `installation_repositories` webhook, so a repository added or removed on
+   * GitHub lands in Threa without anyone opening settings. A network failure is
+   * rethrown so the queue retries the delivery; terminal per-row failures
+   * (undecryptable credentials, a lost CAS, an installation GitHub no longer
+   * knows) are logged and skipped — retrying them would never succeed.
+   */
+  async refreshGithubInstallationRepositories(installationId: string): Promise<{ refreshedWorkspaceIds: string[] }> {
+    if (!this.isGitHubEnabled()) return { refreshedWorkspaceIds: [] }
+
+    const records = await WorkspaceIntegrationRepository.listActiveByInstallationId(
+      this.deps.pool,
+      WorkspaceIntegrationProviders.GITHUB,
+      installationId
+    )
+    const refreshedWorkspaceIds: string[] = []
+    let retryable = false
+    for (const record of records) {
+      const result = await this.syncGithubInstallationRecord(record.workspaceId, record)
+      if (result.ok) {
+        refreshedWorkspaceIds.push(record.workspaceId)
+        continue
+      }
+      if (result.failure === "network") retryable = true
+      log.warn(
+        { workspaceId: record.workspaceId, installationId, failure: result.failure },
+        "GitHub installation repository refresh failed for a workspace"
+      )
+    }
+
+    if (retryable) {
+      throw new Error(`GitHub installation ${installationId} repository refresh failed; retrying delivery`)
+    }
+    return { refreshedWorkspaceIds }
+  }
+
+  /**
+   * The one snapshot-refresh path, shared by the settings Sync button and the
+   * webhook. All network work happens before any DB write so no connection is
+   * held across it (INV-41).
+   *
+   * The write is a CACHE WRITE — it replaces the whole metadata object — so it
+   * pins the active status and the installation observed before the round-trip
+   * (INV-20) plus the version read at the same point (INV-66), and re-reads and
+   * retries ONCE against the current version before giving up.
+   */
+  private async syncGithubInstallationRecord(
+    workspaceId: string,
+    record: WorkspaceIntegrationRecord
+  ): Promise<
+    | { ok: true; record: WorkspaceIntegrationRecord }
+    | { ok: false; failure: "decrypt" | "installation_gone" | "network" | "conflict" }
+  > {
     let credentials: GitHubIntegrationCredentials
     try {
       credentials = this.parseCredentials(workspaceId, record.credentials)
     } catch (error) {
       log.warn({ err: error, workspaceId }, "GitHub integration credentials could not be decrypted during sync")
-      throw new HttpError("GitHub integration credentials could not be decrypted", {
-        status: 500,
-        code: "GITHUB_CREDENTIALS_DECRYPT_FAILED",
-      })
+      return { ok: false, failure: "decrypt" }
     }
 
-    // Mint a fresh installation token and re-list repositories against
-    // GitHub. The network round-trip happens before any DB write so we
-    // don't hold a connection open during slow remote calls (INV-41).
     let accessToken: string
     let tokenExpiresAt: string
-    let nextPermissions: Record<string, string>
+    let tokenPermissions: Record<string, string>
+    let snapshot: GitHubInstallationSnapshot
     let repositories: GitHubInstalledRepository[]
     try {
       const tokenResponse = await this.getAppOctokit().request(
@@ -507,14 +606,21 @@ export class WorkspaceIntegrationService {
       )
       accessToken = tokenResponse.data.token
       tokenExpiresAt = tokenResponse.data.expires_at
-      nextPermissions = normalizePermissions(tokenResponse.data.permissions)
+      tokenPermissions = normalizePermissions(tokenResponse.data.permissions)
+      snapshot = await this.fetchGithubInstallationSnapshot(credentials.installationId)
       repositories = await listInstallationRepositories(new Octokit({ auth: accessToken }))
     } catch (error) {
+      const status = getErrorStatus(error)
+      // A 404/410 against a valid app JWT is definitive: the app is not installed
+      // there any more. Park the row in `error` (not inactive) so settings offers
+      // Reconnect and the CP routes survive a reinstall on the same id.
+      if (status === 404 || status === 410) {
+        log.warn({ workspaceId, installationId: record.installationId }, "GitHub installation no longer exists")
+        await this.markGithubInstallationError(workspaceId, record)
+        return { ok: false, failure: "installation_gone" }
+      }
       log.warn({ err: error, workspaceId }, "GitHub sync network call failed")
-      throw new HttpError("Failed to sync GitHub repositories", {
-        status: 502,
-        code: "GITHUB_SYNC_FAILED",
-      })
+      return { ok: false, failure: "network" }
     }
 
     const encryptedCredentials = encryptJson(
@@ -523,17 +629,15 @@ export class WorkspaceIntegrationService {
       { workspaceId, provider: WorkspaceIntegrationProviders.GITHUB }
     )
 
-    // CACHE WRITE — version-CAS. This replaces the whole metadata object (its
-    // `repositories` list especially), so a concurrent write must not be lost.
-    // Pin active status + the installation observed before the network calls
-    // (INV-20) AND the version read at the same point (INV-66). Because this is
-    // a user-facing sync (not a background telemetry write), a CAS miss re-reads
-    // and retries ONCE against the current version before surfacing the conflict.
     const persistSync = async (base: WorkspaceIntegrationRecord): Promise<WorkspaceIntegrationRecord | null> => {
       const baseMetadata = this.parseMetadata(base.metadata)
       const nextMetadata: GitHubIntegrationMetadata = {
         ...baseMetadata,
-        permissions: nextPermissions || baseMetadata.permissions,
+        organizationName: snapshot.accountLogin ?? baseMetadata.organizationName,
+        accountType: snapshot.accountType ?? baseMetadata.accountType,
+        repositorySelection: snapshot.repositorySelection ?? baseMetadata.repositorySelection,
+        configurationUrl: snapshot.configurationUrl ?? baseMetadata.configurationUrl,
+        permissions: Object.keys(tokenPermissions).length > 0 ? tokenPermissions : baseMetadata.permissions,
         repositories,
       }
       return WorkspaceIntegrationRepository.update(
@@ -551,23 +655,56 @@ export class WorkspaceIntegrationService {
 
     let updated = await persistSync(record)
     if (!updated) {
-      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndId(
-        this.deps.pool,
-        workspaceId,
-        integrationId
-      )
+      const reread = await WorkspaceIntegrationRepository.findByWorkspaceAndId(this.deps.pool, workspaceId, record.id)
       if (reread && reread.status === WorkspaceIntegrationStatuses.ACTIVE) {
         updated = await persistSync(reread)
       }
     }
     if (!updated) {
-      throw new HttpError("GitHub integration was disconnected during sync", {
-        status: 409,
-        code: "GITHUB_INTEGRATION_NOT_ACTIVE",
-      })
+      return { ok: false, failure: "conflict" }
     }
 
-    return this.mapGithubIntegration(updated)
+    return { ok: true, record: updated }
+  }
+
+  /**
+   * Park an installation GitHub no longer knows in `error`. Scoped to the
+   * installation observed at read and guarded on ACTIVE, so a row that
+   * disconnected or reconnected elsewhere in the meantime is left alone.
+   */
+  private async markGithubInstallationError(workspaceId: string, record: WorkspaceIntegrationRecord): Promise<void> {
+    await WorkspaceIntegrationRepository.update(
+      this.deps.pool,
+      workspaceId,
+      WorkspaceIntegrationProviders.GITHUB,
+      record.installationId,
+      { status: WorkspaceIntegrationStatuses.ERROR },
+      { expectedStatus: WorkspaceIntegrationStatuses.ACTIVE }
+    )
+  }
+
+  /**
+   * Installation identity and repository-grant mode, straight from GitHub. The
+   * `html_url` it returns is the page where that grant is edited — the target of
+   * the settings "Configure on GitHub" link.
+   */
+  private async fetchGithubInstallationSnapshot(installationId: number): Promise<GitHubInstallationSnapshot> {
+    const installation = await this.getAppOctokit().request("GET /app/installations/{installation_id}", {
+      installation_id: installationId,
+    })
+    const accountType = normalizeGithubAccountType(
+      getInstallationAccountType(installation.data.account) ?? installation.data.target_type ?? null
+    )
+    const accountLogin = getInstallationAccountLogin(installation.data.account)
+    return {
+      accountLogin,
+      accountType,
+      repositorySelection: normalizeRepositorySelection(installation.data.repository_selection),
+      configurationUrl:
+        normalizeGithubConfigurationUrl(installation.data.html_url) ??
+        deriveInstallationConfigurationUrl(String(installationId), accountType, accountLogin),
+      permissions: normalizePermissions(installation.data.permissions),
+    }
   }
 
   async handleGithubCallback(params: {
@@ -759,15 +896,9 @@ export class WorkspaceIntegrationService {
       throw new HttpError("Invalid GitHub installation ID", { status: 400, code: "INVALID_GITHUB_INSTALLATION" })
     }
 
-    const installation = await this.getAppOctokit().request("GET /app/installations/{installation_id}", {
-      installation_id: installationId,
-    })
-
     // Both organizations and personal accounts are accepted; the account type is
     // captured into metadata so the settings UI can badge each install.
-    const accountType = normalizeGithubAccountType(
-      getInstallationAccountType(installation.data.account) ?? installation.data.target_type ?? null
-    )
+    const snapshot = await this.fetchGithubInstallationSnapshot(installationId)
 
     // Base the write on the existing row for THIS installation (multi-install: a
     // workspace can hold several), else a fresh default record for a first install.
@@ -795,10 +926,11 @@ export class WorkspaceIntegrationService {
       baseRecord,
       installationId,
       {
-        organizationName: getInstallationAccountLogin(installation.data.account),
-        accountType,
-        repositorySelection: normalizeRepositorySelection(installation.data.repository_selection),
-        permissions: normalizePermissions(installation.data.permissions),
+        organizationName: snapshot.accountLogin,
+        accountType: snapshot.accountType,
+        repositorySelection: snapshot.repositorySelection,
+        configurationUrl: snapshot.configurationUrl,
+        permissions: snapshot.permissions,
         repositories: [],
         rateLimitRemaining: null,
         rateLimitResetAt: null,
@@ -984,6 +1116,7 @@ export class WorkspaceIntegrationService {
       organizationName: typeof payload.organizationName === "string" ? payload.organizationName : null,
       accountType: normalizeGithubAccountType(payload.accountType),
       repositorySelection: normalizeRepositorySelection(payload.repositorySelection),
+      configurationUrl: normalizeGithubConfigurationUrl(payload.configurationUrl),
       permissions: normalizePermissions(payload.permissions),
       repositories: normalizeRepositories(payload.repositories),
       rateLimitRemaining:
@@ -1544,6 +1677,37 @@ function normalizeRepositories(value: unknown): GitHubInstalledRepository[] {
 
 function normalizeRepositorySelection(value: unknown): "all" | "selected" | null {
   return value === "all" || value === "selected" ? value : null
+}
+
+/** Only github.com URLs are accepted, so a poisoned metadata blob can't become an outbound link. */
+function normalizeGithubConfigurationUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  try {
+    const url = new URL(value)
+    return url.protocol === "https:" && url.hostname === "github.com" ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Where GitHub hosts an installation's repository-access settings. Preferred
+ * source is the installation's own `html_url`; this reproduces it for rows that
+ * predate capturing it, so an existing install gets a working link without first
+ * being synced. Both shapes are fixed by GitHub: personal installs live under the
+ * viewer's own settings, org installs under the org's.
+ */
+function deriveInstallationConfigurationUrl(
+  installationId: string | null,
+  accountType: "Organization" | "User" | null,
+  accountLogin: string | null
+): string | null {
+  if (!installationId) return null
+  if (accountType === "User") return `https://github.com/settings/installations/${installationId}`
+  if (accountType === "Organization" && accountLogin) {
+    return `https://github.com/organizations/${encodeURIComponent(accountLogin)}/settings/installations/${installationId}`
+  }
+  return null
 }
 
 function getInstallationAccountType(account: unknown): string | null {

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -608,18 +608,26 @@ export class WorkspaceIntegrationService {
       tokenExpiresAt = tokenResponse.data.expires_at
       tokenPermissions = normalizePermissions(tokenResponse.data.permissions)
       snapshot = await this.fetchGithubInstallationSnapshot(credentials.installationId)
-      repositories = await listInstallationRepositories(new Octokit({ auth: accessToken }))
     } catch (error) {
       const status = getErrorStatus(error)
       // A 404/410 against a valid app JWT is definitive: the app is not installed
       // there any more. Park the row in `error` (not inactive) so settings offers
-      // Reconnect and the CP routes survive a reinstall on the same id.
+      // Reconnect and the CP routes survive a reinstall on the same id. Only these
+      // two app-JWT calls prove it — parking is terminal until a user reconnects,
+      // so nothing weaker than the app's own view of the installation may trigger it.
       if (status === 404 || status === 410) {
         log.warn({ workspaceId, installationId: record.installationId }, "GitHub installation no longer exists")
         await this.markGithubInstallationError(workspaceId, record)
         return { ok: false, failure: "installation_gone" }
       }
       log.warn({ err: error, workspaceId }, "GitHub sync network call failed")
+      return { ok: false, failure: "network" }
+    }
+
+    try {
+      repositories = await listInstallationRepositories(new Octokit({ auth: accessToken }))
+    } catch (error) {
+      log.warn({ err: error, workspaceId }, "GitHub repository listing failed during sync")
       return { ok: false, failure: "network" }
     }
 

--- a/apps/control-plane/src/features/github-webhooks/constants.ts
+++ b/apps/control-plane/src/features/github-webhooks/constants.ts
@@ -20,11 +20,20 @@ export type GithubWebhookDeliveryStatus =
   (typeof GITHUB_WEBHOOK_DELIVERY_STATUS)[keyof typeof GITHUB_WEBHOOK_DELIVERY_STATUS]
 
 /**
- * Events the app is subscribed to and that drive a live preview refresh. Any
- * other event type is acknowledged (202) but never fanned out. `ping` is
- * handled separately (200) as GitHub's endpoint health check.
+ * Events the app is subscribed to and that regions act on. Any other event type
+ * is acknowledged (202) but never fanned out. `ping` is handled separately (200)
+ * as GitHub's endpoint health check. The PR/issue types drive a live preview
+ * refresh; `installation` is a lifecycle signal; `installation_repositories`
+ * carries a repository-grant change made on GitHub, which the region reconciles
+ * into its cached installation snapshot.
  */
-export const FORWARDED_GITHUB_EVENT_TYPES = ["pull_request", "pull_request_review", "issues", "installation"] as const
+export const FORWARDED_GITHUB_EVENT_TYPES = [
+  "pull_request",
+  "pull_request_review",
+  "issues",
+  "installation",
+  "installation_repositories",
+] as const
 
 export interface GithubWebhookDispatchPayload {
   deliveryId: string

--- a/apps/control-plane/tests/integration/github-webhooks.test.ts
+++ b/apps/control-plane/tests/integration/github-webhooks.test.ts
@@ -130,6 +130,34 @@ describe("GithubWebhookService.receive", () => {
     expect(await dispatchRows(pool)).toEqual([])
   })
 
+  test("forwards installation_repositories so regions can reconcile a repository grant change", async () => {
+    await addRoute(pool, 42, "eu-north-1", "ws_a")
+
+    const body = JSON.stringify({
+      action: "added",
+      installation: { id: 42 },
+      repository_selection: "selected",
+      repositories_added: [{ full_name: "acme/widgets" }],
+    })
+    const result = await service.receive({
+      rawBody: Buffer.from(body, "utf8"),
+      signature: sign(body),
+      eventType: "installation_repositories",
+      deliveryGuid: "guid-repos-added",
+    })
+
+    expect(result).toEqual({ kind: "accepted", matchedRegions: ["eu-north-1"] })
+
+    const delivery = await pool.query<{ id: string; event_type: string; action: string }>(
+      "SELECT id, event_type, action FROM github_webhook_deliveries WHERE delivery_guid = 'guid-repos-added'"
+    )
+    expect({ eventType: delivery.rows[0].event_type, action: delivery.rows[0].action }).toEqual({
+      eventType: "installation_repositories",
+      action: "added",
+    })
+    expect(await dispatchRows(pool)).toEqual([{ deliveryId: delivery.rows[0].id, region: "eu-north-1" }])
+  })
+
   test("ignores a non-forwarded event type and records nothing", async () => {
     const body = prPayload(42, 7)
     const result = await service.receive({

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
@@ -31,6 +31,7 @@ function githubInstall(overrides: Partial<GitHubWorkspaceIntegration>): GitHubWo
     installationId: "111",
     accountType: "Organization",
     repositorySelection: "all",
+    configurationUrl: "https://github.com/organizations/acme/settings/installations/111",
     permissions: {},
     repositories: [],
     rateLimit: { remaining: null, resetAt: null },
@@ -150,6 +151,56 @@ describe("IntegrationsTab GitHub installations", () => {
     expect(within(brokenRow).getByRole("link", { name: /reconnect/i })).toBeInTheDocument()
     const healthyRow = screen.getByText("acme").closest("div.rounded-md") as HTMLElement
     expect(within(healthyRow).queryByRole("link", { name: /reconnect/i })).not.toBeInTheDocument()
+  })
+
+  it("links each installation to its own GitHub repository-access page", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [
+        githubInstall({
+          id: "wsint_org",
+          accountLogin: "acme",
+          configurationUrl: "https://github.com/organizations/acme/settings/installations/111",
+        }),
+        githubInstall({
+          id: "wsint_user",
+          accountLogin: "kris",
+          accountType: "User",
+          configurationUrl: "https://github.com/settings/installations/222",
+        }),
+      ],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    const orgRow = (await screen.findByText("acme")).closest("div.rounded-md") as HTMLElement
+    const userRow = screen.getByText("kris").closest("div.rounded-md") as HTMLElement
+    expect(within(orgRow).getByRole("link", { name: /repository access on github/i })).toHaveAttribute(
+      "href",
+      "https://github.com/organizations/acme/settings/installations/111"
+    )
+    expect(within(userRow).getByRole("link", { name: /repository access on github/i })).toHaveAttribute(
+      "href",
+      "https://github.com/settings/installations/222"
+    )
+  })
+
+  it("omits the repository-access link when the installation has no known configuration page", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    vi.spyOn(integrationsApi, "getGithub").mockResolvedValue({
+      configured: true,
+      integrations: [githubInstall({ id: "wsint_legacy", accountLogin: "acme", configurationUrl: null })],
+    })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+
+    renderTab(queryClient)
+
+    await screen.findByText("acme")
+    expect(screen.queryByRole("link", { name: /repository access on github/i })).not.toBeInTheDocument()
   })
 
   it("keeps a single Connect button in the empty state", async () => {

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.test.tsx
@@ -8,6 +8,7 @@ import {
   type WorkspaceBootstrap,
   type WorkspacePermissionSlug,
 } from "@threa/types"
+import { ApiError } from "@/api/client"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { integrationsApi } from "@/api/integrations"
 import { IntegrationsTab } from "./integrations-tab"
@@ -201,6 +202,42 @@ describe("IntegrationsTab GitHub installations", () => {
 
     await screen.findByText("acme")
     expect(screen.queryByRole("link", { name: /repository access on github/i })).not.toBeInTheDocument()
+  })
+
+  it("refetches after a gone installation, but leaves the row alone on a transient sync failure", async () => {
+    const queryClient = new QueryClient()
+    seedBootstrap(queryClient, [WORKSPACE_PERMISSION_SCOPES.WORKSPACE_ADMIN])
+    const getGithub = vi
+      .spyOn(integrationsApi, "getGithub")
+      .mockResolvedValue({ configured: true, integrations: [githubInstall({ id: "wsint_1", accountLogin: "acme" })] })
+    vi.spyOn(integrationsApi, "getLinear").mockResolvedValue({ configured: false, integration: null })
+    vi.spyOn(integrationsApi, "syncGithub").mockRejectedValue(
+      new ApiError(502, "GITHUB_SYNC_FAILED", "Failed to sync GitHub repositories")
+    )
+
+    renderTab(queryClient)
+    await screen.findByText("acme")
+    const fetchesBefore = getGithub.mock.calls.length
+
+    await userEvent.click(screen.getByRole("button", { name: /sync repos/i }))
+
+    // The message stands on its own; a refetch here would resolve back to
+    // Connected and strand it with nothing to clear it.
+    await waitFor(() => expect(screen.getByText("Failed to sync GitHub repositories")).toBeInTheDocument())
+    expect(getGithub.mock.calls.length).toBe(fetchesBefore)
+
+    vi.mocked(integrationsApi.syncGithub).mockRejectedValue(
+      new ApiError(409, "GITHUB_INSTALLATION_GONE", "This GitHub installation no longer exists.")
+    )
+    getGithub.mockResolvedValue({
+      configured: true,
+      integrations: [githubInstall({ id: "wsint_1", accountLogin: "acme", status: "error" })],
+    })
+
+    await userEvent.click(screen.getByRole("button", { name: /sync repos/i }))
+
+    expect(await screen.findByText("Error")).toBeInTheDocument()
+    expect(getGithub.mock.calls.length).toBeGreaterThan(fetchesBefore)
   })
 
   it("keeps a single Connect button in the empty state", async () => {

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Github, ExternalLink, RefreshCw, Plus } from "lucide-react"
+import { Github, ExternalLink, RefreshCw, Plus, Settings } from "lucide-react"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { integrationsApi } from "@/api/integrations"
 import { Button } from "@/components/ui/button"
@@ -70,6 +70,9 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
         integrationId,
         message: error instanceof Error ? error.message : "Failed to sync GitHub repositories.",
       })
+      // A sync can itself change the row (an installation GitHub no longer knows
+      // is parked in `error`), so refetch rather than leave a stale Connected badge.
+      queryClient.invalidateQueries({ queryKey: ["workspace-integrations", workspaceId, "github"] })
     },
   })
 
@@ -197,7 +200,15 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
                     <p className="text-xs text-muted-foreground">{rateLimit.remaining} API requests remaining</p>
                   )}
 
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {installation.configurationUrl && (
+                      <Button variant="outline" size="sm" asChild>
+                        <a href={installation.configurationUrl} target="_blank" rel="noopener noreferrer">
+                          <Settings className="h-3.5 w-3.5 mr-1.5" />
+                          Repository access on GitHub
+                        </a>
+                      </Button>
+                    )}
                     {isActive && (
                       <Button
                         variant="outline"

--- a/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/integrations-tab.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Github, ExternalLink, RefreshCw, Plus, Settings } from "lucide-react"
 import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { ApiError } from "@/api/client"
 import { integrationsApi } from "@/api/integrations"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -70,9 +71,14 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
         integrationId,
         message: error instanceof Error ? error.message : "Failed to sync GitHub repositories.",
       })
-      // A sync can itself change the row (an installation GitHub no longer knows
-      // is parked in `error`), so refetch rather than leave a stale Connected badge.
-      queryClient.invalidateQueries({ queryKey: ["workspace-integrations", workspaceId, "github"] })
+      // Exactly one sync failure changes the row: an installation GitHub no longer
+      // knows gets parked in `error` server-side, so refetch to replace the stale
+      // Connected badge. Refetching on the transient failures too would resolve
+      // back to Connected and leave this message sitting under it with nothing to
+      // clear it, so they leave the row alone.
+      if (ApiError.isApiError(error) && error.code === "GITHUB_INSTALLATION_GONE") {
+        queryClient.invalidateQueries({ queryKey: ["workspace-integrations", workspaceId, "github"] })
+      }
     },
   })
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1323,6 +1323,13 @@ export interface GitHubWorkspaceIntegration extends WorkspaceIntegration {
   installationId: string | null
   accountType: "Organization" | "User" | null
   repositorySelection: "all" | "selected" | null
+  /**
+   * GitHub's own settings page for this installation — where repository access is
+   * granted. The grant lives on GitHub (changing it needs a user-to-server token
+   * Threa never holds), so reconfiguring is a deep link, not an API call. Null
+   * when the installation id or account type is unknown.
+   */
+  configurationUrl: string | null
   permissions: Record<string, string>
   repositories: GitHubInstalledRepository[]
   rateLimit: WorkspaceIntegrationRateLimit


### PR DESCRIPTION
## Problem

A workspace that has already connected GitHub cannot change which repositories Threa can reach. `IntegrationsTab` offers exactly three affordances per installation — Connect (a *new* install), Sync repos, Disconnect — and none of them reaches the repository grant. Disconnect is the only escape hatch, and it is destructive: it clears credentials and emits `github_route:unregister` while the GitHub installation itself survives, so "Connect GitHub" then lands on `installations/new` for an account that is already installed.

Two bugs compound it. `syncGithubRepositories` re-listed `GET /installation/repositories` but never re-read `GET /app/installations/{id}`, so `metadata.repositorySelection` stayed at whatever it was on install day — a workspace that narrowed its grant on GitHub kept reading "All repositories" forever. And nothing handled `installation_repositories`, so a repository added on GitHub never reached Threa at all until somebody happened to press Sync.

## Solution

Repository access is granted on the GitHub App installation, and Threa holds only an installation token — `PUT /user/installations/{id}/repositories/{repo}` needs a user-to-server OAuth token this deployment never mints (`GITHUB_APP_ID`/`SLUG`/`PRIVATE_KEY` are the only GitHub credentials in `lib/env.ts`). So reconfiguration is a deep link out plus reconciliation on the way back, not an API Threa can call.

- **`configurationUrl` per installation** (`GitHubWorkspaceIntegration`). `fetchGithubInstallationSnapshot` captures GitHub's own `html_url`; `mapGithubIntegration` falls back to `deriveInstallationConfigurationUrl` (org → `/organizations/{login}/settings/installations/{id}`, personal → `/settings/installations/{id}`). Deriving over a migration + backfill — existing rows get a working link on the next read, and the stored `html_url` takes over the first time they sync. `normalizeGithubConfigurationUrl` refuses anything that is not `https://github.com`, so a poisoned metadata blob cannot become an outbound link.
- **Sync re-reads the installation.** `syncGithubInstallationRecord` is now the single snapshot path: mint token → `GET /app/installations/{id}` → list repositories → one version-CAS write carrying `repositorySelection`, `organizationName`, `accountType`, `configurationUrl`, permissions and repositories. Same INV-20/INV-66 guards and the same single re-read-and-retry as before.
- **`installation_repositories` webhook** (`FORWARDED_GITHUB_EVENT_TYPES` in CP, `GITHUB_INSTALLATION_REPOSITORIES_EVENT_TYPE` in the region). `refreshGithubInstallationRepositories` runs the same snapshot path for every active workspace on the installation, so a repository added on GitHub lands without anyone opening settings. A `network` failure rethrows so the queue retries the delivery; terminal per-row failures (undecryptable credentials, a lost CAS) are logged and skipped, because retrying them never succeeds.
- **Installation-gone failure state.** A 404/410 against a valid app JWT is definitive, so the row is parked in `error` — scoped to the installation read and guarded on `status='active'` — and the sync answers 409 `GITHUB_INSTALLATION_GONE`. `error` over `inactive`: settings already renders Reconnect for it, and the CP routes survive a reinstall on the same id. The 502 `GITHUB_SYNC_FAILED` path is unchanged for everything else.

Also folded in, because the line moved anyway: the sync's permissions merge was `nextPermissions || baseMetadata.permissions`, and `{}` is truthy — an empty permissions map from GitHub clobbered the cached one on every sync. Now an explicit non-empty check.

Out of scope, deliberately: Threa-side per-repository enable/disable (no such concept exists today — `metadata.repositories` is a cache of the grant, not a selection), and the disconnect-then-reconnect round trip, which still relies on `installations/new`.

## Files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/workspace-integrations/service.ts` | `fetchGithubInstallationSnapshot`, `syncGithubInstallationRecord` (shared by settings + webhook), `refreshGithubInstallationRepositories`, `markGithubInstallationError`, `deriveInstallationConfigurationUrl`, `normalizeGithubConfigurationUrl` |
| `apps/backend/src/features/github-webhooks/worker.ts` · `config.ts` | Route `installation_repositories` to the reconciler |
| `apps/control-plane/src/features/github-webhooks/constants.ts` | Forward `installation_repositories` to regions |
| `apps/frontend/src/components/workspace-settings/integrations-tab.tsx` | Per-install "Repository access on GitHub" link; refetch on sync failure |
| `packages/types/src/domain.ts` | `configurationUrl` on `GitHubWorkspaceIntegration` |

## Test plan

- [x] `bun run test` — 4128 backend unit + 372 e2e pass
- [x] control-plane `bun test tests/` — 245 pass (includes the new `installation_repositories` fan-out case against a real schema)
- [x] frontend — 6997 pass
- [x] `bun run lint` + `bun run typecheck` — clean
- [ ] Not exercised against real GitHub. The webhook path stays inert until the App is subscribed to `installation_repositories` (see below); the settings link and the corrected sync are covered by unit tests only.

**Rollout:** the GitHub App must be subscribed to the `installation_repositories` event in its GitHub settings — a console change outside this repo. Until it is, CP forwards nothing of that type and the manual Sync button carries the flow, which this PR makes correct. Nothing regresses in the meantime.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
