### PR TITLE
fix(evals): repair the companion suites and make them measure the model under test

### DIFF
--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -25,6 +25,9 @@ bun run eval -- -s memo-classifier -r 3 --json results.json
 
 # Run from config file
 bun run eval -- --config evals/example-config.yaml
+
+# Run one suite's runs out of a multi-suite config
+bun run eval -- --config evals/companion-model-comparison.yaml -s persona-style
 ```
 
 ## Available Suites
@@ -78,6 +81,31 @@ Accepted flags mirror the CLI: `-s/--suite`, `-c/--case`, `-m/--model` (≤4),
 `-r/--runs` (≤12), `-p/--parallel` (≤8), `-t/--temperature`, `--min-pass-rate`.
 Values are allowlist-validated (`evals/slash/parse-args.ts`) and cost/latency
 are capped. Needs the `OPENROUTER_API_KEY` repo secret.
+
+## Rescore: scoring changes must not pay for generation again
+
+A `--json` report stores each case's raw generations, so changing an evaluator
+or swapping the judge — both _scoring_ changes — replays over stored text
+instead of re-running live agent turns:
+
+```bash
+bun run eval -- --config evals/companion-model-comparison.yaml -r 3 --json run.json
+bun run eval -- --rescore run.json --json rescored.json                  # same judge, new evaluators
+bun run eval -- --rescore run.json --judge openrouter:google/gemini-3.5-flash-lite --json cross.json
+```
+
+This exists because the August 2026 Ariadne comparison re-ran 200+ live turns
+twice to re-grade text it already had, and then hit the OpenRouter key's weekly
+limit mid-run — which silently invalidated a whole arm, since a rejected call
+looks exactly like a model that chose not to answer.
+
+Rescore reports only what _rescoring_ cost (judge calls); the generation cost
+stays attributed to the original run. It refuses a report with no stored
+outputs, and an evaluator that reaches for the database fails loudly rather
+than scoring against nothing.
+
+**It cannot replace a live run** when the prompt, model, temperature, case set
+or task code changed. Those are new generations.
 
 ## Variance: tune against tallies, not single runs
 
@@ -154,6 +182,15 @@ suites:
       companion:
         model: openrouter:openai/gpt-5.4-nano
 ```
+
+### Narrowing a config run
+
+`-s` filters a config file's runs to one suite (`-r`, `--min-pass-rate` and
+`--json` already applied in config mode). A comparison config often pairs suites
+with different prerequisites — the `companion` half needs `TAVILY_API_KEY`, the
+`persona-style` half does not — so running one half must not mean editing the
+file that documents the comparison. An `-s` naming a suite the config has no
+runs for is an error, not an empty run.
 
 ### Component Keys by Suite
 

--- a/apps/backend/evals/companion-model-comparison.yaml
+++ b/apps/backend/evals/companion-model-comparison.yaml
@@ -1,6 +1,21 @@
-# Companion model comparison: Sonnet 4.6 (production) vs Sonnet 5 vs GPT-5.6 Luna.
+# Ariadne model comparison: the production default vs a candidate.
 #
-# Uses per-component config so ONLY the companion persona's model varies —
+# Current pairing (August 2026): claude-sonnet-5 (production default since
+# 2026-07-11) vs gpt-5.6-luna. Both companion-backed suites run, because they
+# measure different halves of the persona:
+#   - `companion`     — the full turn: tools, retrieval, temporal grounding,
+#                       hallucination guards. Needs TAVILY_API_KEY (real
+#                       web_search) and has the widest case set.
+#   - `persona-style` — instruction following on the Tone/Brevity style slots,
+#                       send_message only, so no Tavily dependency. Its own
+#                       default model is a cheap chat model; overriding it here
+#                       is deliberate — the question is whether Ariadne's model
+#                       obeys the slots, not whether the fragments work.
+#   - `brief-correction` — tool selection and completion on a MUTATING tool:
+#                       records a decision, replaces a reversed fact, and (the
+#                       gate that matters) leaves the brief alone on chitchat.
+#
+# Per-component config so ONLY the companion persona's model varies —
 # ConfigResolver-backed sub-agents (workspace retrieval, researcher) stay on
 # production models. The `-m` flag would steamroll those too, which both skews
 # the comparison and breaks providers with stricter structured-output rules
@@ -8,24 +23,48 @@
 #
 # Run (needs OPENROUTER_API_KEY with credit headroom + TAVILY_API_KEY):
 #   bun run eval -- --config evals/companion-model-comparison.yaml -r 3 -p 4 \
-#     --min-pass-rate 0.67 --json /tmp/companion-comparison.json
+#     --min-pass-rate 0.67 --json /tmp/ariadne-model-comparison.json
+#
+# Without a Tavily key, run the style half alone:
+#   bun run eval -- --config evals/companion-model-comparison.yaml -s persona-style
 
 suites:
   - name: companion
-    title: claude-sonnet-4.6 (production)
-    components:
-      companion:
-        model: openrouter:anthropic/claude-sonnet-4.6
-        temperature: 0.7
-
-  - name: companion
-    title: claude-sonnet-5
+    title: claude-sonnet-5 (production)
     components:
       companion:
         model: openrouter:anthropic/claude-sonnet-5
         temperature: 0.7
 
   - name: companion
+    title: gpt-5.6-luna
+    components:
+      companion:
+        model: openrouter:openai/gpt-5.6-luna
+        temperature: 0.7
+
+  - name: persona-style
+    title: claude-sonnet-5 (production)
+    components:
+      companion:
+        model: openrouter:anthropic/claude-sonnet-5
+        temperature: 0.7
+
+  - name: persona-style
+    title: gpt-5.6-luna
+    components:
+      companion:
+        model: openrouter:openai/gpt-5.6-luna
+        temperature: 0.7
+
+  - name: brief-correction
+    title: claude-sonnet-5 (production)
+    components:
+      companion:
+        model: openrouter:anthropic/claude-sonnet-5
+        temperature: 0.7
+
+  - name: brief-correction
     title: gpt-5.6-luna
     components:
       companion:

--- a/apps/backend/evals/framework/eval-persona.ts
+++ b/apps/backend/evals/framework/eval-persona.ts
@@ -6,12 +6,11 @@ import type { Persona } from "../../src/features/agents"
 /**
  * Insert the throwaway persona row a companion-backed suite runs its turn as:
  * the built-in Ariadne's resolved prompt and toolset, with the permutation's
- * model swapped in. Three suites need exactly this row, and until August 2026
- * each carried its own copy of the statement — all three naming a constraint
- * that migration `20260713120000_persona_owner_user_id.sql` had replaced with
- * two partial unique indexes. Every case in all three suites had been failing
- * in ~10ms since, on an error the runner reported only as "did not respond".
- * One copy, verified against a migrated schema in
+ * model swapped in.
+ *
+ * The `ON CONFLICT` target must name a real partial unique index on `personas`;
+ * a target that matches no index throws at runtime and never at build time, so
+ * this statement is executed against a migrated schema in
  * `tests/integration/eval-persona.test.ts` (INV-68).
  */
 export async function insertEvalPersona(

--- a/apps/backend/evals/framework/eval-persona.ts
+++ b/apps/backend/evals/framework/eval-persona.ts
@@ -1,0 +1,55 @@
+import { ulid } from "ulid"
+import type { Querier } from "../../src/db"
+import { personaId as generatePersonaId } from "../../src/lib/id"
+import type { Persona } from "../../src/features/agents"
+
+/**
+ * Insert the throwaway persona row a companion-backed suite runs its turn as:
+ * the built-in Ariadne's resolved prompt and toolset, with the permutation's
+ * model swapped in. Three suites need exactly this row, and until August 2026
+ * each carried its own copy of the statement — all three naming a constraint
+ * that migration `20260713120000_persona_owner_user_id.sql` had replaced with
+ * two partial unique indexes. Every case in all three suites had been failing
+ * in ~10ms since, on an error the runner reported only as "did not respond".
+ * One copy, verified against a migrated schema in
+ * `tests/integration/eval-persona.test.ts` (INV-68).
+ */
+export async function insertEvalPersona(
+  db: Querier,
+  params: {
+    /** The resolved built-in persona whose prompt and tools this row copies. */
+    template: Pick<Persona, "description" | "avatarEmoji" | "systemPrompt" | "enabledTools">
+    /** The permutation's model — the whole point of the row. */
+    model: string
+    /** Slug prefix, so a suite's rows are recognizable in a shared database. */
+    slugPrefix: string
+    /** Display name for the row. */
+    name: string
+  }
+): Promise<string> {
+  if (!params.template.systemPrompt) {
+    throw new Error("Cannot create an eval persona from a template with no system prompt")
+  }
+
+  const id = generatePersonaId()
+  await db.query(
+    `
+    INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
+    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, 'system', 'active')
+    ON CONFLICT (workspace_id, slug) WHERE managed_by <> 'user' DO UPDATE SET
+      model = EXCLUDED.model,
+      system_prompt = EXCLUDED.system_prompt
+  `,
+    [
+      id,
+      `${params.slugPrefix}-${ulid().toLowerCase().slice(0, 8)}`,
+      params.name,
+      params.template.description,
+      params.template.avatarEmoji,
+      params.template.systemPrompt,
+      params.model,
+      params.template.enabledTools ?? ["send_message"],
+    ]
+  )
+  return id
+}

--- a/apps/backend/evals/framework/evaluators/llm-judge.ts
+++ b/apps/backend/evals/framework/evaluators/llm-judge.ts
@@ -4,6 +4,7 @@
  * Uses an LLM to evaluate output quality against specified criteria.
  */
 
+import { EVAL_JUDGE_MODEL } from "../judge-config"
 import { z } from "zod"
 import type { Evaluator, EvalContext, EvaluatorResult } from "../types"
 
@@ -24,7 +25,7 @@ export interface LLMJudgeOptions {
   name?: string
   /** Criteria to evaluate against */
   criteria: string
-  /** Model to use for judging (default: "openrouter:openai/gpt-5.4-nano") */
+  /** Model to use for judging (default: {@link EVAL_JUDGE_MODEL}) */
   model?: string
   /** Pass threshold (default: 0.7) */
   passThreshold?: number
@@ -38,15 +39,14 @@ export interface LLMJudgeOptions {
  * @example
  * llmJudgeEvaluator({
  *   criteria: "The output preserves all factual information from the input",
- *   model: "openrouter:openai/gpt-5.4-nano",
+ *   model: EVAL_JUDGE_MODEL,
  * })
  */
 export function llmJudgeEvaluator<TOutput, TExpected>(options: LLMJudgeOptions): Evaluator<TOutput, TExpected> {
   const {
     name = "llm-judge",
     criteria,
-    // Use GPT-5.4-nano for reliable structured output through OpenRouter
-    model = "openrouter:openai/gpt-5.4-nano",
+    model = EVAL_JUDGE_MODEL,
     passThreshold = 0.7,
     context: additionalContext,
   } = options
@@ -82,7 +82,7 @@ Evaluate the actual output against the expected output and criteria.`
 
       try {
         const { value } = await ctx.ai.generateObject({
-          model,
+          model: ctx.judgeModel ?? model,
           schema: judgeResponseSchema,
           messages: [
             { role: "system", content: systemPrompt },

--- a/apps/backend/evals/framework/judge-config.ts
+++ b/apps/backend/evals/framework/judge-config.ts
@@ -1,0 +1,26 @@
+/**
+ * The model every LLM-as-judge evaluator grades with.
+ *
+ * One constant rather than a literal per suite (INV-33): the judge is the
+ * loudest single term in a companion score — it decides ~40% of case outcomes —
+ * so a suite quietly grading with a different model than its neighbours makes
+ * cross-suite numbers incomparable for a reason nobody can see.
+ *
+ * Luna over `gpt-5.4-nano`, matching the move production already made off the
+ * 5.4 tiers (docs/model-reference.md): same $0.20 input, slightly cheaper
+ * output ($1.20 vs $1.25), newer generation, and nano is specifically the model
+ * that entry warns about for judgements where a miss is invisible — which is
+ * exactly what a judge does.
+ *
+ * KNOWN BIAS, and it is not hypothetical: when a comparison has an OpenAI model
+ * as a CANDIDATE, this judge shares its family. Read a narrow OpenAI win as
+ * unproven and re-judge with a model from another family before acting on it.
+ */
+export const EVAL_JUDGE_MODEL = "openrouter:openai/gpt-5.6-luna"
+
+/**
+ * Judge model for a run whose candidate set includes `EVAL_JUDGE_MODEL`'s
+ * family. Used to check whether a result survives a judge that cannot prefer
+ * either candidate on family grounds.
+ */
+export const EVAL_CROSS_JUDGE_MODEL = "openrouter:google/gemini-3.5-flash-lite"

--- a/apps/backend/evals/framework/rescore.test.ts
+++ b/apps/backend/evals/framework/rescore.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test"
+import { rescoreReport } from "./rescore"
+import type { AI } from "@threa/agent-runtime"
+import type { EvalSuite, EvaluatorResult } from "./types"
+
+const stubAi = {} as AI
+
+type Out = { text: string }
+type Expected = { must: string }
+
+function suiteWith(evaluate: (o: Out, e: Expected) => EvaluatorResult): EvalSuite<unknown, Out, Expected> {
+  return {
+    name: "demo",
+    description: "rescore fixture",
+    cases: [],
+    task: async () => {
+      throw new Error("rescore must never run the task")
+    },
+    evaluators: [{ name: "contains", evaluate }],
+    runEvaluators: [
+      {
+        name: "accuracy",
+        evaluate: (cases: Array<{ evaluations: EvaluatorResult[] }>) => {
+          const passed = cases.filter((c) => c.evaluations.every((e) => e.passed)).length
+          return { name: "accuracy", score: passed / cases.length, passed: passed === cases.length }
+        },
+      },
+    ],
+    defaultPermutations: [{ model: "openrouter:openai/gpt-5.6-luna", temperature: 0.7 }],
+  } as unknown as EvalSuite<unknown, Out, Expected>
+}
+
+async function writeReport(cases: unknown[]): Promise<string> {
+  const path = `/tmp/rescore-${crypto.randomUUID()}.json`
+  await Bun.write(
+    path,
+    JSON.stringify({
+      suites: [
+        {
+          suiteName: "demo: gpt-5.6-luna",
+          permutations: [
+            {
+              model: "openrouter:openai/gpt-5.6-luna",
+              temperature: 0.7,
+              runs: 2,
+              usage: { inputTokens: 10, outputTokens: 5, reasoningTokens: 0, totalCost: 1.23 },
+              totalDurationMs: 4242,
+              cases,
+            },
+          ],
+        },
+      ],
+    })
+  )
+  return path
+}
+
+const containsMust = (o: Out, e: Expected): EvaluatorResult => ({
+  name: "contains",
+  score: o.text.includes(e.must) ? 1 : 0,
+  passed: o.text.includes(e.must),
+})
+
+describe("rescore", () => {
+  test("replays every stored run of a case through the current evaluators", async () => {
+    const path = await writeReport([
+      {
+        caseId: "c1",
+        caseName: "Case one",
+        durationsMs: [100, 200],
+        expectedOutput: { must: "yes" },
+        outputs: [{ text: "yes it does" }, { text: "no it does not" }],
+      },
+    ])
+
+    const [result] = await rescoreReport(path, [suiteWith(containsMust) as never], { ai: stubAi, onSuite: () => {} })
+    const perm = result!.permutations[0]!
+
+    expect(perm.cases.map((c) => ({ id: c.caseId, passed: c.evaluations[0]!.passed, ms: c.durationMs }))).toEqual([
+      { id: "c1", passed: true, ms: 100 },
+      { id: "c1", passed: false, ms: 200 },
+    ])
+    expect(perm.runEvaluations[0]).toMatchObject({ name: "accuracy", score: 0.5 })
+  })
+
+  test("a changed evaluator changes the verdict without re-running the task", async () => {
+    const path = await writeReport([
+      {
+        caseId: "c1",
+        caseName: "Case one",
+        expectedOutput: { must: "yes" },
+        outputs: [{ text: "YES it does" }],
+      },
+    ])
+
+    const strict = await rescoreReport(path, [suiteWith(containsMust) as never], { ai: stubAi, onSuite: () => {} })
+    expect(strict[0]!.permutations[0]!.cases[0]!.evaluations[0]!.passed).toBe(false)
+
+    const caseInsensitive = (o: Out, e: Expected): EvaluatorResult => {
+      const hit = o.text.toLowerCase().includes(e.must.toLowerCase())
+      return { name: "contains", score: hit ? 1 : 0, passed: hit }
+    }
+    const relaxed = await rescoreReport(path, [suiteWith(caseInsensitive) as never], { ai: stubAi, onSuite: () => {} })
+    expect(relaxed[0]!.permutations[0]!.cases[0]!.evaluations[0]!.passed).toBe(true)
+  })
+
+  test("reports only what rescoring itself cost, never the original run's generation cost", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [{ text: "yes" }] },
+    ])
+
+    const [result] = await rescoreReport(path, [suiteWith(containsMust) as never], { ai: stubAi, onSuite: () => {} })
+    // The stored report claims $1.23 of generation. Carrying that forward would
+    // double-count it the next time someone totals eval spend.
+    expect(result!.permutations[0]!.usage!.totalCost).toBe(0)
+  })
+
+  test("refuses a report with no stored generations rather than scoring nothing", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [] },
+    ])
+
+    await expect(
+      rescoreReport(path, [suiteWith(containsMust) as never], { ai: stubAi, onSuite: () => {} })
+    ).rejects.toThrow(/no stored output/)
+  })
+
+  test("refuses a report naming a suite that is not registered", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [{ text: "yes" }] },
+    ])
+
+    await expect(rescoreReport(path, [], { ai: stubAi, onSuite: () => {} })).rejects.toThrow(/not registered/)
+  })
+
+  test("an evaluator that reaches for the database fails loudly instead of scoring blind", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [{ text: "yes" }] },
+    ])
+
+    const dbEvaluator = (_o: Out, _e: Expected, ctx?: unknown): EvaluatorResult => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (ctx as any).pool.query
+      return { name: "contains", score: 1, passed: true }
+    }
+    const [result] = await rescoreReport(path, [suiteWith(dbEvaluator as never) as never], {
+      ai: stubAi,
+      onSuite: () => {},
+    })
+    expect(result!.permutations[0]!.cases[0]!.evaluations[0]!.details).toMatch(/tried to query the database/)
+  })
+})

--- a/apps/backend/evals/framework/rescore.test.ts
+++ b/apps/backend/evals/framework/rescore.test.ts
@@ -5,8 +5,13 @@ import type { EvalSuite, EvaluatorResult } from "./types"
 
 const stubAi = {} as AI
 
-type Out = { text: string }
-type Expected = { must: string }
+interface Out {
+  text: string
+}
+
+interface Expected {
+  must: string
+}
 
 function suiteWith(evaluate: (o: Out, e: Expected) => EvaluatorResult): EvalSuite<unknown, Out, Expected> {
   return {
@@ -148,5 +153,37 @@ describe("rescore", () => {
       onSuite: () => {},
     })
     expect(result!.permutations[0]!.cases[0]!.evaluations[0]!.details).toMatch(/tried to query the database/)
+  })
+  test("refuses to report scores when a judge call was rejected for credit", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [{ text: "yes" }] },
+    ])
+
+    // A judge call that dies on credit is caught by the evaluator's own
+    // try/catch and becomes a plausible-looking quality failure. The whole
+    // report would then be wrong in a way nothing on its face reveals.
+    const rejectingAi = {
+      generateObject: async () => {
+        throw new Error("This request requires more credits, or fewer max_tokens.")
+      },
+    } as unknown as AI
+
+    const judged = (_o: Out, _e: Expected, ctx?: unknown): Promise<EvaluatorResult> =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ctx as any).ai.generateObject({})
+
+    await expect(
+      rescoreReport(path, [suiteWith(judged as never) as never], { ai: rejectingAi, onSuite: () => {} })
+    ).rejects.toThrow(/rejected for insufficient OpenRouter credit/)
+  })
+
+  test("refuses a run whose generation is missing rather than scoring a turn that never happened", async () => {
+    const path = await writeReport([
+      { caseId: "c1", caseName: "Case one", expectedOutput: { must: "yes" }, outputs: [{ text: "yes" }, null] },
+    ])
+
+    await expect(
+      rescoreReport(path, [suiteWith(containsMust) as never], { ai: stubAi, onSuite: () => {} })
+    ).rejects.toThrow(/no generation/)
   })
 })

--- a/apps/backend/evals/framework/rescore.ts
+++ b/apps/backend/evals/framework/rescore.ts
@@ -1,0 +1,167 @@
+/**
+ * Replay evaluators over the generations a previous run already paid for.
+ *
+ * Two of the three restarts in the August 2026 Luna-vs-sonnet-5 comparison
+ * changed only how output was SCORED — first the evaluators, then the judge
+ * model — and each one re-ran 200+ live agent turns to re-grade text that was
+ * already sitting in the report. The third restart exhausted the OpenRouter
+ * key's weekly limit mid-run and invalidated the baseline arm.
+ *
+ * Generation is the expensive half and it is deterministic input to the cheap
+ * half. So: `--rescore <report.json>` reads back the stored outputs, runs the
+ * current evaluators (and, with `--judge`, a different judge) over them, and
+ * costs nothing but judge calls.
+ *
+ * What this CANNOT do is re-run a case whose prompt, model, temperature or
+ * task code changed — that is a new generation and must be run live. Rescore
+ * only ever re-answers "how would today's evaluators grade yesterday's
+ * answers".
+ */
+
+import type { EvalSuite, EvalContext, CaseResult, SuiteResult, PermutationResult } from "./types"
+import type { AI } from "@threa/agent-runtime"
+import { createUsageAccumulator } from "./types"
+import { createEvalAI, createUsageTrackingAI, printSummary } from "./runner"
+import type { Pool } from "pg"
+
+/** The subset of a report this needs. Written by `toJsonReport`. */
+interface StoredReport {
+  suites: Array<{
+    suiteName: string
+    permutations: Array<{
+      model: string
+      temperature: number | null
+      runs: number
+      usage: { inputTokens: number; outputTokens: number; reasoningTokens: number; totalCost: number } | null
+      totalDurationMs: number
+      cases: Array<{
+        caseId: string
+        caseName: string
+        durationsMs?: number[]
+        expectedOutput: unknown
+        outputs: unknown[]
+      }>
+    }>
+  }>
+}
+
+/**
+ * A pool that fails loudly if an evaluator reaches for it. No evaluator in this
+ * repo touches the database — the DB dependency lives in the task, which
+ * rescore does not run — but a future one that does must not silently score
+ * against an absent database (INV-11).
+ */
+function forbiddenPool(): Pool {
+  const refuse = () => {
+    throw new Error(
+      "An evaluator tried to query the database during --rescore. Rescore replays stored generations only; " +
+        "an evaluator that needs live state has to run in a normal eval run."
+    )
+  }
+  return new Proxy({} as Pool, { get: refuse, apply: refuse })
+}
+
+export async function rescoreReport(
+  reportPath: string,
+  allSuites: EvalSuite<unknown, unknown, unknown>[],
+  options: { judgeModel?: string; ai?: AI; onSuite?: (result: SuiteResult<unknown, unknown>) => void } = {}
+): Promise<SuiteResult<unknown, unknown>[]> {
+  const report = (await Bun.file(reportPath).json()) as StoredReport
+  const ai = options.ai ?? createEvalAI()
+  const reportSink = options.onSuite ?? printSummary
+  const results: SuiteResult<unknown, unknown>[] = []
+
+  for (const storedSuite of report.suites) {
+    // Config-file runs label a suite "name: title"; the suite is the first segment.
+    const baseName = storedSuite.suiteName.split(":")[0]!.trim()
+    const suite = allSuites.find((s) => s.name === baseName)
+    if (!suite) {
+      throw new Error(`Report names suite "${baseName}", which is not registered in run.ts`)
+    }
+
+    const permutations: PermutationResult<unknown, unknown>[] = []
+    for (const storedPerm of storedSuite.permutations) {
+      const usage = createUsageAccumulator()
+      // Rescoring is not free — every judge call is billed. Handing the raw AI
+      // through would report $0 and an empty executed-model list for a run that
+      // just spent money, which is the precise kind of quiet inaccuracy this
+      // whole exercise kept tripping over.
+      const trackedAi = createUsageTrackingAI(ai, usage)
+      const ctx: EvalContext = {
+        pool: forbiddenPool(),
+        ai: trackedAi,
+        workspaceId: "rescore",
+        userId: "rescore",
+        permutation: { model: storedPerm.model, temperature: storedPerm.temperature ?? undefined },
+        usage,
+        credentials: {},
+        judgeModel: options.judgeModel,
+        configResolver: { resolve: async () => ({ modelId: storedPerm.model }) as never },
+      }
+
+      const cases: CaseResult<unknown, unknown>[] = []
+      for (const storedCase of storedPerm.cases) {
+        const stored = storedCase.outputs ?? []
+        if (stored.length === 0) {
+          throw new Error(
+            `Case ${storedCase.caseId} has no stored output. Reports written before raw-output persistence ` +
+              `cannot be rescored — re-run the suite live.`
+          )
+        }
+        for (const [index, output] of stored.entries()) {
+          const evaluations = await Promise.all(
+            suite.evaluators.map(async (evaluator) => {
+              try {
+                return await evaluator.evaluate(output, storedCase.expectedOutput, ctx)
+              } catch (error) {
+                return {
+                  name: evaluator.name,
+                  score: 0,
+                  passed: false,
+                  details: `Evaluator error: ${error instanceof Error ? error.message : String(error)}`,
+                }
+              }
+            })
+          )
+          cases.push({
+            caseId: storedCase.caseId,
+            caseName: storedCase.caseName,
+            input: null,
+            output,
+            expectedOutput: storedCase.expectedOutput,
+            evaluations,
+            durationMs: storedCase.durationsMs?.[index] ?? 0,
+          })
+        }
+      }
+
+      const runEvaluations = suite.runEvaluators
+        ? await Promise.all(suite.runEvaluators.map((e) => e.evaluate(cases)))
+        : []
+
+      const total = usage.getTotal()
+      permutations.push({
+        permutation: ctx.permutation,
+        cases,
+        runEvaluations,
+        runs: storedPerm.runs,
+        executedModels: usage.getModels(),
+        // Judge cost only. The generation cost belongs to the original run and
+        // is deliberately not merged in — that would double-count it.
+        totalDurationMs: storedPerm.totalDurationMs,
+        usage: {
+          inputTokens: total.inputTokens,
+          outputTokens: total.outputTokens,
+          reasoningTokens: total.reasoningTokens,
+          totalCost: total.totalCost,
+        },
+      })
+    }
+
+    const result: SuiteResult<unknown, unknown> = { suiteName: storedSuite.suiteName, permutations }
+    reportSink(result)
+    results.push(result)
+  }
+
+  return results
+}

--- a/apps/backend/evals/framework/rescore.ts
+++ b/apps/backend/evals/framework/rescore.ts
@@ -61,6 +61,10 @@ function forbiddenPool(): Pool {
   return new Proxy({} as Pool, { get: refuse, apply: refuse })
 }
 
+/**
+ * Re-run a suite's evaluators over the generations stored in a `--json` report.
+ * Returns one result per suite entry in the report.
+ */
 export async function rescoreReport(
   reportPath: string,
   allSuites: EvalSuite<unknown, unknown, unknown>[],
@@ -84,9 +88,12 @@ export async function rescoreReport(
       const usage = createUsageAccumulator()
       // Rescoring is not free — every judge call is billed. Handing the raw AI
       // through would report $0 and an empty executed-model list for a run that
-      // just spent money, which is the precise kind of quiet inaccuracy this
-      // whole exercise kept tripping over.
-      const trackedAi = createUsageTrackingAI(ai, usage)
+      // just spent money. The credit counter matters more: an evaluator's
+      // try/catch turns a rejected judge call into a failed evaluation, so
+      // without this a throttled rescore produces a full set of plausible,
+      // invalid scores.
+      const credit = { rejections: 0 }
+      const trackedAi = createUsageTrackingAI(ai, usage, credit)
       const ctx: EvalContext = {
         pool: forbiddenPool(),
         ai: trackedAi,
@@ -109,6 +116,16 @@ export async function rescoreReport(
           )
         }
         for (const [index, output] of stored.entries()) {
+          // A case that errored during the original run has no generation.
+          // Scoring that as if it were one produces a real-looking failure for
+          // a turn that never happened — the same confusion a credit rejection
+          // causes. Refuse it instead.
+          if (output === null || output === undefined) {
+            throw new Error(
+              `Case ${storedCase.caseId} run ${index + 1} has no generation (the original run errored on it). ` +
+                `Re-run that case live rather than rescoring a turn that never produced output.`
+            )
+          }
           const evaluations = await Promise.all(
             suite.evaluators.map(async (evaluator) => {
               try {
@@ -138,6 +155,13 @@ export async function rescoreReport(
       const runEvaluations = suite.runEvaluators
         ? await Promise.all(suite.runEvaluators.map((e) => e.evaluate(cases)))
         : []
+
+      if (credit.rejections > 0) {
+        throw new Error(
+          `${credit.rejections} judge call(s) were rejected for insufficient OpenRouter credit. Every evaluator ` +
+            `catches its own errors, so these would have been reported as quality failures — top up and re-run.`
+        )
+      }
 
       const total = usage.getTotal()
       permutations.push({

--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -9,7 +9,7 @@
  * 5. Clean up
  */
 
-import { NoObjectGeneratedError } from "ai"
+import { APICallError, NoObjectGeneratedError } from "ai"
 import type {
   EvalSuite,
   EvalContext,
@@ -94,6 +94,7 @@ function indent(str: string, spaces: number): string {
 /**
  * Create AI wrapper with eval configuration.
  */
+/** The AI wrapper every eval run generates and judges through. */
 export function createEvalAI(): AI {
   const apiKey = process.env.OPENROUTER_API_KEY
   if (!apiKey) {
@@ -116,11 +117,24 @@ export function createEvalAI(): AI {
  * invalidated a whole comparison arm in August 2026 — 1428 rejections read as
  * 0.6s turns. Counted here at the only place that sees the raw provider error.
  */
-function isCreditRejection(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return /requires more credits|insufficient credit|exceeded your credit|quota exceeded/i.test(message)
+export function isCreditRejection(error: unknown): boolean {
+  // 402 is the provider's own answer, so it is checked first; the message match
+  // is the fallback for transports that flatten the status away. Relying on
+  // wording alone would let a reworded provider message silently disable the
+  // guard, which is the failure this guard exists to catch.
+  if (APICallError.isInstance(error) && error.statusCode === 402) return true
+  const parts = [
+    error instanceof Error ? error.message : String(error),
+    APICallError.isInstance(error) && typeof error.responseBody === "string" ? error.responseBody : "",
+  ]
+  return /requires more credits|insufficient credit|exceeded your credit|quota exceeded/i.test(parts.join(" "))
 }
 
+/**
+ * Wrap an AI so every call records its model and usage, and so provider credit
+ * rejections are counted rather than swallowed. Pass `credit` wherever a
+ * rejection must invalidate the run.
+ */
 export function createUsageTrackingAI(ai: AI, accumulator: UsageAccumulator, credit?: { rejections: number }): AI {
   const watch = async <T>(call: () => Promise<T>): Promise<T> => {
     try {
@@ -486,6 +500,7 @@ function printComparisonTable<TOutput, TExpected>(results: PermutationResult<TOu
 /**
  * Print summary of evaluation results.
  */
+/** Render one suite's per-case and run-level results to the terminal. */
 export function printSummary<TOutput, TExpected>(result: SuiteResult<TOutput, TExpected>): void {
   console.log("\n" + "=".repeat(60))
   console.log(`${colors.cyan}Suite: ${result.suiteName}${colors.reset}`)

--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -21,7 +21,13 @@ import type {
 } from "./types"
 import { createUsageAccumulator } from "./types"
 import { setupEvalDatabase, setupEvalTemplate, type EvalDatabaseResult, type EvalTemplateResult } from "./database"
-import { createAI, type AI, type GenerateObjectOptions, type GenerateTextOptions } from "@threa/agent-runtime"
+import {
+  createAI,
+  type AI,
+  type GenerateObjectOptions,
+  type GenerateTextOptions,
+  type GenerateTextWithToolsOptions,
+} from "@threa/agent-runtime"
 import type { UsageAccumulator } from "./types"
 import { createWorkspaceFixture, type WorkspaceFixture } from "../fixtures/workspace"
 import { loadConfigFile } from "./config-loader"
@@ -88,7 +94,7 @@ function indent(str: string, spaces: number): string {
 /**
  * Create AI wrapper with eval configuration.
  */
-function createEvalAI(): AI {
+export function createEvalAI(): AI {
   const apiKey = process.env.OPENROUTER_API_KEY
   if (!apiKey) {
     throw new Error("OPENROUTER_API_KEY environment variable is required for evals")
@@ -103,19 +109,52 @@ function createEvalAI(): AI {
  * Wrap an AI instance to track usage in an accumulator.
  * Intercepts generateText and generateObject to record usage.
  */
-function createUsageTrackingAI(ai: AI, accumulator: UsageAccumulator): AI {
+/**
+ * A provider rejection for exhausted credit is indistinguishable, downstream,
+ * from a model that chose not to answer: the agent catches it, the case records
+ * "did not respond", and the report shows a quality failure. That silently
+ * invalidated a whole comparison arm in August 2026 — 1428 rejections read as
+ * 0.6s turns. Counted here at the only place that sees the raw provider error.
+ */
+function isCreditRejection(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /requires more credits|insufficient credit|exceeded your credit|quota exceeded/i.test(message)
+}
+
+export function createUsageTrackingAI(ai: AI, accumulator: UsageAccumulator, credit?: { rejections: number }): AI {
+  const watch = async <T>(call: () => Promise<T>): Promise<T> => {
+    try {
+      return await call()
+    } catch (error) {
+      if (credit && isCreditRejection(error)) credit.rejections++
+      throw error
+    }
+  }
+
   return {
     ...ai,
     async generateText(options: GenerateTextOptions) {
       accumulator.recordModel(options.model)
-      const result = await ai.generateText(options)
+      const result = await watch(() => ai.generateText(options))
       accumulator.recordUsage(result.usage)
       return result
     },
     async generateObject<T extends import("zod").ZodType>(options: GenerateObjectOptions<T>) {
       accumulator.recordModel(options.model)
-      const result = await ai.generateObject(options)
+      const result = await watch(() => ai.generateObject(options))
       accumulator.recordUsage(result.usage)
+      return result
+    },
+    // The agent loop's own call, and the ONLY one that runs the persona's
+    // model. Left unwrapped, an Ariadne model comparison reported neither the
+    // tokens nor the cost of the model under test — just its sub-agents and
+    // judges — and the "override never executed" guard fired on every run
+    // because the model genuinely never appeared. `modelString` is the
+    // provider:model id (`options.model` here is a resolved LanguageModel).
+    async generateTextWithTools(options: GenerateTextWithToolsOptions) {
+      if (options.modelString) accumulator.recordModel(options.modelString)
+      const result = await watch(() => ai.generateTextWithTools(options))
+      if (result.usage) accumulator.recordUsage(result.usage)
       return result
     },
   }
@@ -203,6 +242,7 @@ async function runCase<TInput, TOutput, TExpected>(
  */
 interface PermutationRunOptions extends RunnerOptions {
   /** Component-specific overrides from config file */
+  judgeModel?: string
   componentOverrides?: ComponentOverrides
 }
 
@@ -227,7 +267,8 @@ async function runPermutation<TInput, TOutput, TExpected>(
   const usageAccumulator = createUsageAccumulator()
 
   // Wrap AI to track usage
-  const trackingAI = createUsageTrackingAI(ai, usageAccumulator)
+  const credit = { rejections: 0 }
+  const trackingAI = createUsageTrackingAI(ai, usageAccumulator, credit)
 
   // Create config resolver with eval overrides applied
   // Base resolver has production defaults; eval resolver applies componentOverrides
@@ -259,6 +300,7 @@ async function runPermutation<TInput, TOutput, TExpected>(
     credentials: {
       tavilyApiKey: process.env.TAVILY_API_KEY,
     },
+    judgeModel: options.judgeModel,
     componentOverrides: options.componentOverrides,
     configResolver,
   }
@@ -323,6 +365,16 @@ async function runPermutation<TInput, TOutput, TExpected>(
   // Get accumulated usage
   const totalUsage = usageAccumulator.getTotal()
   const executedModels = usageAccumulator.getModels()
+
+  // A run that hit the provider's credit ceiling did not measure the models, it
+  // measured the ceiling — and the cheaper model survives it, so the result
+  // even looks plausible. Refuse to report it (INV-11).
+  if (credit.rejections > 0) {
+    throw new Error(
+      `${credit.rejections} model call(s) were rejected for insufficient OpenRouter credit. This run did not ` +
+        `measure the models and its numbers must not be compared — top up the key's limit and re-run.`
+    )
+  }
 
   // A -m override that never executed is a silently-invalid comparison (the
   // exact bug this guard exists for) — fail loudly (INV-11). Suites whose
@@ -434,7 +486,7 @@ function printComparisonTable<TOutput, TExpected>(results: PermutationResult<TOu
 /**
  * Print summary of evaluation results.
  */
-function printSummary<TOutput, TExpected>(result: SuiteResult<TOutput, TExpected>): void {
+export function printSummary<TOutput, TExpected>(result: SuiteResult<TOutput, TExpected>): void {
   console.log("\n" + "=".repeat(60))
   console.log(`${colors.cyan}Suite: ${result.suiteName}${colors.reset}`)
   console.log("=".repeat(60))
@@ -717,20 +769,30 @@ export function getPrimaryComponentOverride(suiteName: string, components?: Comp
 export async function runFromConfigFile(
   configPath: string,
   allSuites: EvalSuite<unknown, unknown, unknown>[],
-  baseOptions: Omit<RunnerOptions, "suite" | "model" | "cases"> = {}
+  baseOptions: Omit<RunnerOptions, "model" | "cases"> = {}
 ): Promise<SuiteResult<unknown, unknown>[]> {
   console.log(`\n${colors.cyan}Loading config file: ${configPath}${colors.reset}`)
 
   // Load and validate config
   const config = loadConfigFile(configPath)
-  console.log(`${colors.dim}Found ${config.suites.length} suite run(s) in config${colors.reset}`)
+  // `-s` narrows a multi-suite config to one suite's runs. A comparison config
+  // pairs suites with different prerequisites (the companion half needs a
+  // Tavily key, the style half does not), so running one half has to be
+  // possible without editing the file that documents the comparison.
+  const suiteRuns = baseOptions.suite ? config.suites.filter((s) => s.name === baseOptions.suite) : config.suites
+  if (baseOptions.suite && suiteRuns.length === 0) {
+    throw new Error(
+      `Config ${configPath} has no runs for suite "${baseOptions.suite}" (it defines: ${[...new Set(config.suites.map((s) => s.name))].join(", ")})`
+    )
+  }
+  console.log(`${colors.dim}Found ${suiteRuns.length} suite run(s) in config${colors.reset}`)
 
   // Create AI wrapper
   const ai = createEvalAI()
 
   const results: SuiteResult<unknown, unknown>[] = []
 
-  for (const runConfig of config.suites) {
+  for (const runConfig of suiteRuns) {
     // Find the suite
     const suite = allSuites.find((s) => s.name === runConfig.name)
     if (!suite) {
@@ -787,6 +849,12 @@ export async function runFromConfigFile(
       // Print summary
       printSummary(result)
       results.push(result)
+      // Flush after every completed arm. A long comparison is a sequence of
+      // independent arms, and serializing only at the very end means an
+      // interruption — a SIGTERM, a killed shell — throws away every arm that
+      // already finished and paid for itself. With this, an interrupted run
+      // keeps what it completed and `--rescore` can still read it.
+      await baseOptions.onSuiteResult?.(results)
     } finally {
       await dbResult.cleanup()
     }

--- a/apps/backend/evals/framework/types.ts
+++ b/apps/backend/evals/framework/types.ts
@@ -92,6 +92,13 @@ export interface EvalContext {
     tavilyApiKey?: string
   }
   /** Component-specific overrides from config file */
+  /**
+   * Judge model for this run, overriding each evaluator's own default. Exists
+   * for the case the default judge cannot honestly serve: when a candidate
+   * under comparison shares the judge's model family, re-judging from another
+   * family is the only way to tell a real win from self-preference.
+   */
+  judgeModel?: string
   componentOverrides?: ComponentOverrides
   /**
    * Config resolver for AI components.
@@ -284,6 +291,14 @@ export interface EvalSuite<TInput, TOutput, TExpected> {
  * Options for the evaluation runner.
  */
 export interface RunnerOptions {
+  /** Judge model override for every LLM-as-judge evaluator (see EvalContext.judgeModel) */
+  judgeModel?: string
+  /**
+   * Called with everything completed so far after each suite run finishes, so a
+   * long multi-arm run can persist incrementally instead of losing finished
+   * arms to an interruption.
+   */
+  onSuiteResult?: (results: SuiteResult<unknown, unknown>[]) => Promise<void>
   /** Filter to specific suite by name */
   suite?: string
   /** Filter to specific case IDs */

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -11,6 +11,7 @@
 
 import { parseArgs } from "util"
 import { runSuites, runFromConfigFile } from "./framework/runner"
+import { rescoreReport } from "./framework/rescore"
 import type { RunnerOptions } from "./framework/types"
 import { companionSuite } from "./suites/companion/suite"
 import { streamNamingSuite } from "./suites/stream-naming/suite"
@@ -113,6 +114,8 @@ async function main(): Promise<void> {
       suite: { type: "string", short: "s" },
       case: { type: "string", short: "c" },
       model: { type: "string", short: "m" },
+      judge: { type: "string" },
+      rescore: { type: "string" },
       temperature: { type: "string", short: "t" },
       parallel: { type: "string", short: "p" },
       runs: { type: "string", short: "r" },
@@ -141,6 +144,7 @@ async function main(): Promise<void> {
     suite: values.suite,
     cases: values.case?.split(",").map((c) => c.trim()),
     model: values.model,
+    judgeModel: values.judge,
     temperature: values.temperature ? parseFloat(values.temperature) : undefined,
     parallel: values.parallel ? parseInt(values.parallel, 10) : undefined,
     runs: values.runs ? parseInt(values.runs, 10) : undefined,
@@ -182,6 +186,18 @@ async function main(): Promise<void> {
   console.log("║              AI Evaluation Framework                      ║")
   console.log("╚══════════════════════════════════════════════════════════╝")
 
+  // Rescore mode: replay evaluators over a previous run's stored generations.
+  if (values.rescore) {
+    console.log(`\nRescoring stored generations from: ${values.rescore}`)
+    const results = await rescoreReport(values.rescore, allSuites as any, { judgeModel: options.judgeModel })
+    if (options.jsonOutput) {
+      await Bun.write(options.jsonOutput, JSON.stringify(toJsonReport(results), null, 2))
+      console.log(`\nResults written to ${options.jsonOutput}`)
+    }
+    const minPassRate = options.minPassRate ?? 1
+    process.exit(hasCaseRateFailures(results as any, minPassRate) ? 1 : 0)
+  }
+
   // Config file mode: run from YAML config
   if (values.config) {
     console.log(`\nRunning from config file: ${values.config}`)
@@ -190,6 +206,13 @@ async function main(): Promise<void> {
         verbose: options.verbose,
         parallel: options.parallel,
         runs: options.runs,
+        suite: options.suite,
+        judgeModel: options.judgeModel,
+        onSuiteResult: options.jsonOutput
+          ? async (partial) => {
+              await Bun.write(options.jsonOutput!, JSON.stringify(toJsonReport(partial), null, 2))
+            }
+          : undefined,
       })
 
       if (options.jsonOutput) {
@@ -290,19 +313,28 @@ interface CaseAggregate {
   caseName: string
   passes: number
   total: number
+  /** Per-run wall-clock for this case, one entry per run, in run order. */
+  durationsMs: number[]
   /** Failing evaluator details from the most recent failing run, for the JSON report. */
   lastFailure?: { name: string; details?: string }[]
 }
 
 function aggregateCases(p: {
-  cases: Array<{ caseId: string; caseName: string; error?: Error; evaluations: Array<any> }>
+  cases: Array<{ caseId: string; caseName: string; error?: Error; evaluations: Array<any>; durationMs?: number }>
 }): CaseAggregate[] {
   const byCase = new Map<string, CaseAggregate>()
   for (const c of p.cases) {
     const passed = !c.error && c.evaluations.every((e) => e.passed)
-    const agg = byCase.get(c.caseId) ?? { caseId: c.caseId, caseName: c.caseName, passes: 0, total: 0 }
+    const agg = byCase.get(c.caseId) ?? {
+      caseId: c.caseId,
+      caseName: c.caseName,
+      passes: 0,
+      total: 0,
+      durationsMs: [],
+    }
     agg.passes += passed ? 1 : 0
     agg.total += 1
+    if (typeof c.durationMs === "number") agg.durationsMs.push(c.durationMs)
     if (!passed) {
       agg.lastFailure = c.error
         ? [{ name: "error", details: c.error.message }]
@@ -338,8 +370,18 @@ export function toJsonReport(results: Array<any>) {
           passes: c.passes,
           runs: c.total,
           passRate: c.passes / c.total,
+          durationsMs: c.durationsMs,
           lastFailure: c.lastFailure ?? null,
           evaluations: p.cases.filter((item: any) => item.caseId === c.caseId).map((item: any) => item.evaluations),
+          trajectories: p.cases
+            .filter((item: any) => item.caseId === c.caseId)
+            .map((item: any) => item.output?.trajectory ?? null),
+          // The raw generations, kept so scoring can be replayed without
+          // paying to generate again. Changing an evaluator or a judge is a
+          // scoring change; re-running the models for it costs real money and
+          // answers a question the stored text already answers.
+          expectedOutput: p.cases.find((item: any) => item.caseId === c.caseId)?.expectedOutput ?? null,
+          outputs: p.cases.filter((item: any) => item.caseId === c.caseId).map((item: any) => item.output ?? null),
         })),
       })),
     })),

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -59,12 +59,16 @@ Options:
   -s, --suite <name>    Run specific suite (${suiteNames})
   -c, --case <id>       Run specific case(s), comma-separated
   -m, --model <ids>     Override model(s), comma-separated for comparison
+  --judge <id>          Judge model for every LLM-as-judge evaluator. Use when a
+                        candidate under comparison shares the default judge's family.
   -t, --temperature <n> Override temperature (0.0-1.0)
   -p, --parallel <n>    Number of parallel workers (default: 1)
   -r, --runs <n>        Repeat every case n times, report per-case pass rates (default: 1)
   --min-pass-rate <n>   Pass-rate a case must clear when runs > 1 (0.0-1.0, default: 1.0)
   --json <file>         Write machine-readable results JSON to <file>
-  --config <file>       Run from YAML config file (ignores -s, -m flags)
+  --config <file>       Run from YAML config file (ignores -m; -s narrows it to one suite)
+  --rescore <file>      Re-run evaluators over a previous --json report's stored
+                        generations. No model turns, so no generation cost.
   -v, --verbose         Verbose output
 
 Examples:
@@ -381,7 +385,13 @@ export function toJsonReport(results: Array<any>) {
           // scoring change; re-running the models for it costs real money and
           // answers a question the stored text already answers.
           expectedOutput: p.cases.find((item: any) => item.caseId === c.caseId)?.expectedOutput ?? null,
-          outputs: p.cases.filter((item: any) => item.caseId === c.caseId).map((item: any) => item.output ?? null),
+          // `?? null` here would hand rescoring a placeholder it cannot tell
+          // apart from a real generation. A case that errored has no output, so
+          // it is omitted rather than nulled.
+          outputs: p.cases
+            .filter((item: any) => item.caseId === c.caseId)
+            .map((item: any) => item.output)
+            .filter((output: unknown) => output !== undefined && output !== null),
         })),
       })),
     })),

--- a/apps/backend/evals/suites/brief-correction/config.ts
+++ b/apps/backend/evals/suites/brief-correction/config.ts
@@ -6,12 +6,13 @@
  * single source for the suite's gates.
  */
 
+import { EVAL_JUDGE_MODEL } from "../../framework/judge-config"
 import { COMPANION_MODEL_ID, COMPANION_TEMPERATURE } from "../../../src/features/agents"
 
 export { COMPANION_MODEL_ID, COMPANION_TEMPERATURE }
 
 /** Judge model for the semantic brief-content checks — same as the companion/memorizer judges. */
-export const BRIEF_JUDGE_MODEL = "openrouter:openai/gpt-5.4-nano"
+export const BRIEF_JUDGE_MODEL = EVAL_JUDGE_MODEL
 
 /**
  * The suite's hard floor (roadmap 4.4): the fraction of chitchat conversations

--- a/apps/backend/evals/suites/brief-correction/suite.ts
+++ b/apps/backend/evals/suites/brief-correction/suite.ts
@@ -63,7 +63,8 @@ import type { StorageProvider } from "../../../src/lib/storage/s3-client"
 import type { Server } from "socket.io"
 import { parseMarkdown } from "@threa/prosemirror"
 import { AuthorTypes, StreamTypes } from "@threa/types"
-import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
+import { streamId as generateStreamId } from "../../../src/lib/id"
+import { insertEvalPersona } from "../../framework/eval-persona"
 
 /** Fixed clock for the agent's temporal grounding so a run is reproducible. */
 const EVAL_CLOCK = new Date("2026-07-01T12:00:00Z")
@@ -102,26 +103,12 @@ async function setupTestData(
     throw new Error(`Could not resolve built-in companion persona ${ARIADNE_AGENT_ID} (see built-in-agents.ts)`)
   }
 
-  const testPersonaId = generatePersonaId()
-  await pool.query(
-    `
-    INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
-    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, 'system', 'active')
-    ON CONFLICT (slug, workspace_id) WHERE workspace_id IS NULL DO UPDATE SET
-      model = EXCLUDED.model,
-      system_prompt = EXCLUDED.system_prompt
-  `,
-    [
-      testPersonaId,
-      `eval-ariadne-${ulid().toLowerCase().slice(0, 8)}`,
-      "Ariadne (Eval)",
-      templatePersona.description,
-      templatePersona.avatarEmoji,
-      templatePersona.systemPrompt,
-      modelConfig.model,
-      templatePersona.enabledTools ?? ["send_message"],
-    ]
-  )
+  const testPersonaId = await insertEvalPersona(pool, {
+    template: templatePersona,
+    model: modelConfig.model,
+    slugPrefix: "eval-ariadne",
+    name: "Ariadne (Eval)",
+  })
 
   const testStreamId = generateStreamId()
   await StreamRepository.insert(pool, {

--- a/apps/backend/evals/suites/companion/cases.ts
+++ b/apps/backend/evals/suites/companion/cases.ts
@@ -83,6 +83,14 @@ export interface CompanionExpected {
     shouldUseWebSearch?: boolean
     /** Web search query should include these terms */
     webSearchQueryShouldContain?: string[]
+    /**
+     * The language the reply must be written in, judged by a model rather than
+     * matched against word lists. Answering in the user's language is a
+     * semantic property, and deciding it from English substrings is the exact
+     * shape INV-54 forbids — it also cannot tell a Swedish reply from a
+     * Norwegian one, which is the failure that matters here.
+     */
+    responseLanguage?: string
   }
   /** Reason for this expected behavior */
   reason: string
@@ -828,10 +836,10 @@ const multilingualCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldNotContain: ["I think", "Let me know", "Would you like"],
+        responseLanguage: "Swedish",
       },
       reason:
-        "A Swedish message gets a Swedish reply. The guard is negative on purpose — asserting Swedish keywords would score vocabulary, while an English opener is the actual failure mode (a model that silently answers in English regardless of input).",
+        "A Swedish message gets a Swedish reply. The failure mode is a model that silently answers in English regardless of input.",
     }
   ),
 
@@ -860,7 +868,7 @@ const multilingualCases: EvalCase<CompanionInput, CompanionExpected>[] = [
       shouldRespond: true,
       responseCharacteristics: {
         shouldContain: ["5"],
-        shouldNotContain: ["I don't have", "no record"],
+        responseLanguage: "Swedish",
       },
       reason:
         "Retrieval must not be language-gated: the decision was written in English, the question is Swedish, and the answer has to carry the number across.",
@@ -880,6 +888,7 @@ const multilingualCases: EvalCase<CompanionInput, CompanionExpected>[] = [
       shouldRespond: true,
       responseCharacteristics: {
         brief: true,
+        responseLanguage: "Swedish",
       },
       reason:
         "Code is language-neutral; the explanation should follow the user's language without mangling the identifiers or refusing the mixed input.",
@@ -905,7 +914,6 @@ const sourceFidelityCases: EvalCase<CompanionInput, CompanionExpected>[] = [
       shouldRespond: true,
       responseCharacteristics: {
         shouldUseWebSearch: true,
-        shouldNotContain: ["I believe", "as of my knowledge", "may have changed"],
       },
       reason:
         "An explicit don't-guess instruction on a fact that moves is the case where answering from weights is a real product failure. Measures instruction following and tool selection together.",
@@ -924,11 +932,9 @@ const sourceFidelityCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     },
     {
       shouldRespond: true,
-      responseCharacteristics: {
-        shouldNotContain: ["ms", "milliseconds", "seconds"],
-      },
+      responseCharacteristics: {},
       reason:
-        "Nothing in the workspace or on the web can answer this. The failure mode is a confident fabricated latency figure, so the guard is on the units a fabricated answer would carry.",
+        "Nothing in the workspace or on the web can answer this, so the reply must say so rather than produce a latency figure. Graded by the judge: a unit word list cannot tell a fabricated number from a refusal that happens to mention milliseconds.",
     }
   ),
 ]

--- a/apps/backend/evals/suites/companion/cases.ts
+++ b/apps/backend/evals/suites/companion/cases.ts
@@ -62,8 +62,17 @@ export interface CompanionExpected {
   responseCharacteristics?: {
     /** Should be brief (< 100 words) */
     brief?: boolean
-    /** Should include specific content */
+    /** Every one of these must appear — use only when each string is literally required (a date, a number, a name). */
     shouldContain?: string[]
+    /**
+     * At least one of these must appear. This is the right field for a set of
+     * CONCEPTS a good answer might cover, and `shouldContain` is not: at the
+     * 0.7 pass bar a three-item list silently means all three (2/3 = 0.67),
+     * so concept lists were scoring enumeration rather than correctness —
+     * against a persona whose own prompt says "keep responses short and
+     * direct". A terse-but-right answer failed; a padded one passed.
+     */
+    shouldContainAny?: string[]
     /** Should NOT include specific content */
     shouldNotContain?: string[]
     /** Expected tone (friendly, professional, casual) */
@@ -131,7 +140,8 @@ const scratchpadCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["flex", "grid", "center"],
+        shouldContain: ["center"],
+        shouldContainAny: ["flex", "grid"],
         tone: "friendly",
       },
       reason: "Technical question should receive a helpful, accurate answer with code examples",
@@ -167,7 +177,8 @@ const scratchpadCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["feat:", "auth"],
+        shouldContain: ["auth"],
+        shouldContainAny: ["feat:", "feat("],
         tone: "professional",
       },
       reason: "Task request should result in actual help with the task",
@@ -363,7 +374,7 @@ const channelCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["reconnect", "heartbeat", "timeout"],
+        shouldContainAny: ["reconnect", "heartbeat", "timeout"],
       },
       reason: "Help request should receive thorough troubleshooting guidance",
     }
@@ -381,7 +392,7 @@ const channelCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["depends", "consider", "trade"],
+        shouldContainAny: ["depends", "consider", "trade"],
         tone: "professional",
       },
       reason: "Opinion request should provide balanced view of trade-offs, not a single answer",
@@ -433,7 +444,7 @@ const threadCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["function", "window", "time"],
+        shouldContainAny: ["function", "window", "time"],
       },
       reason: "Code example request should include actual code",
     }
@@ -479,7 +490,7 @@ const dmCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["token", "storage"],
+        shouldContainAny: ["token", "storage", "cookie"],
         tone: "friendly",
       },
       reason: "DM question should feel personal and direct",
@@ -641,7 +652,7 @@ const edgeCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["index", "query", "cache"],
+        shouldContainAny: ["index", "query", "cache"],
         tone: "professional",
       },
       reason: "Long, detailed message should get a focused, structured response",
@@ -722,7 +733,7 @@ const consistencyCases: EvalCase<CompanionInput, CompanionExpected>[] = [
     {
       shouldRespond: true,
       responseCharacteristics: {
-        shouldContain: ["don't have", "no record", "not sure"],
+        shouldContainAny: ["don't have", "no record", "not sure", "no memory", "nothing in"],
         shouldNotContain: ["we discussed", "you mentioned"],
       },
       reason: "Should acknowledge lack of context rather than inventing information",
@@ -801,6 +812,208 @@ const asideCases: EvalCase<CompanionInput, CompanionExpected>[] = [
   ),
 ]
 
+// =============================================================================
+// Multilingual Cases (INV-54: no English-only semantic behaviour)
+// =============================================================================
+
+const multilingualCases: EvalCase<CompanionInput, CompanionExpected>[] = [
+  createCase(
+    "multilingual-swedish-001",
+    "Swedish: answers in the language the user wrote in",
+    {
+      message: "Vi har fastnat på om vi ska köra migreringen före eller efter releasen. Vad tänker du?",
+      streamType: "scratchpad",
+      trigger: "companion",
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldNotContain: ["I think", "Let me know", "Would you like"],
+      },
+      reason:
+        "A Swedish message gets a Swedish reply. The guard is negative on purpose — asserting Swedish keywords would score vocabulary, while an English opener is the actual failure mode (a model that silently answers in English regardless of input).",
+    }
+  ),
+
+  createCase(
+    "multilingual-swedish-context-001",
+    "Swedish: recalls a decision recorded in English and answers in Swedish",
+    {
+      message: "Vad bestämde vi om retry-gränsen?",
+      streamType: "scratchpad",
+      trigger: "companion",
+      workspaceContext: [
+        {
+          streamType: "channel",
+          name: "backend",
+          conversationHistory: [
+            {
+              role: "user",
+              content:
+                "Decision on the payment worker: we cap retries at 5 with exponential backoff, then dead-letter. Anything beyond 5 was just amplifying the outage.",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldContain: ["5"],
+        shouldNotContain: ["I don't have", "no record"],
+      },
+      reason:
+        "Retrieval must not be language-gated: the decision was written in English, the question is Swedish, and the answer has to carry the number across.",
+    }
+  ),
+
+  createCase(
+    "multilingual-mixed-001",
+    "Mixed: a Swedish question about an English code snippet stays technical",
+    {
+      message:
+        "Kan du förklara vad den här gör?\n\n```ts\nconst debounced = (fn: () => void, ms: number) => {\n  let t: ReturnType<typeof setTimeout> | undefined\n  return () => {\n    clearTimeout(t)\n    t = setTimeout(fn, ms)\n  }\n}\n```",
+      streamType: "scratchpad",
+      trigger: "companion",
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        brief: true,
+      },
+      reason:
+        "Code is language-neutral; the explanation should follow the user's language without mangling the identifiers or refusing the mixed input.",
+    }
+  ),
+]
+
+// =============================================================================
+// Source Fidelity Cases (what the agent cites, and whether it cites at all)
+// =============================================================================
+
+const sourceFidelityCases: EvalCase<CompanionInput, CompanionExpected>[] = [
+  createCase(
+    "sources-current-fact-001",
+    "Sources: a checkable current fact is looked up, not recalled",
+    {
+      message:
+        "What's the current stable Node.js LTS version? I need the exact number for our Dockerfile, so don't guess.",
+      streamType: "scratchpad",
+      trigger: "companion",
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldUseWebSearch: true,
+        shouldNotContain: ["I believe", "as of my knowledge", "may have changed"],
+      },
+      reason:
+        "An explicit don't-guess instruction on a fact that moves is the case where answering from weights is a real product failure. Measures instruction following and tool selection together.",
+    }
+  ),
+
+  createCase(
+    "sources-unknowable-001",
+    "Sources: declines to invent a number nothing in the workspace supports",
+    {
+      message: "What was our p99 checkout latency last week?",
+      streamType: "channel",
+      trigger: "companion",
+      streamContext: { name: "platform", description: "Platform team channel" },
+      conversationHistory: [],
+    },
+    {
+      shouldRespond: true,
+      responseCharacteristics: {
+        shouldNotContain: ["ms", "milliseconds", "seconds"],
+      },
+      reason:
+        "Nothing in the workspace or on the web can answer this. The failure mode is a confident fabricated latency figure, so the guard is on the units a fabricated answer would carry.",
+    }
+  ),
+]
+
+// =============================================================================
+// Restraint Cases (the companion failure mode users actually complain about)
+// =============================================================================
+//
+// Before these, exactly ONE of 36 cases expected silence, so
+// `response-decision-accuracy` could sit at 0.86 while telling us almost
+// nothing: a model that answers everything scores nearly as well as one with
+// judgement. Over-eagerness is the behaviour that makes a companion in a
+// scratchpad tiresome, and it is where models differ most.
+
+const restraintCases: EvalCase<CompanionInput, CompanionExpected>[] = [
+  createCase(
+    "restraint-thinking-aloud-001",
+    "Restraint: thinking aloud mid-task is not a request for help",
+    {
+      message: "ok so the migration runs, index is there... right, it was the connection pool all along.",
+      streamType: "scratchpad",
+      trigger: "companion",
+      conversationHistory: [
+        { role: "user", content: "Checkout is slow again. Going to look at the query plan." },
+        { role: "user", content: "Seq scan on orders. Adding the index now." },
+      ],
+    },
+    {
+      shouldRespond: false,
+      reason:
+        "The user is narrating their own debugging and just answered their own question. A reply here interrupts a working train of thought — the scratchpad equivalent of someone talking over you.",
+    }
+  ),
+
+  createCase(
+    "restraint-note-to-self-001",
+    "Restraint: a note to self is storage, not conversation",
+    {
+      message: "todo tomorrow: rotate the staging creds, chase the invoice, book the offsite room",
+      streamType: "scratchpad",
+      trigger: "companion",
+    },
+    {
+      shouldRespond: false,
+      reason:
+        "A scratchpad is where people park things. Acknowledging a todo list adds a message the user has to read and gains them nothing.",
+    }
+  ),
+
+  createCase(
+    "restraint-channel-chatter-001",
+    "Restraint: unaddressed channel chatter is not hers to answer",
+    {
+      message: "did anyone else get logged out of staging this morning?",
+      streamType: "channel",
+      trigger: "companion",
+      streamContext: { name: "platform", description: "Platform team channel", participants: ["Ana", "Bo"] },
+      conversationHistory: [
+        { role: "user", content: "morning" },
+        { role: "user", content: "coffee machine is broken again" },
+      ],
+    },
+    {
+      shouldRespond: false,
+      reason:
+        "A question to the room in a team channel, with no mention. Answering makes the companion a participant in every thread she can see.",
+    }
+  ),
+
+  createCase(
+    "restraint-still-typing-001",
+    "Restraint: an unfinished thought waits for the rest of it",
+    {
+      message: "so the plan for the rewrite is",
+      streamType: "scratchpad",
+      trigger: "companion",
+    },
+    {
+      shouldRespond: false,
+      reason:
+        "The message is cut off mid-sentence. Responding to a fragment either guesses at the rest or asks a question the user was already answering.",
+    }
+  ),
+]
+
 export const companionCases: EvalCase<CompanionInput, CompanionExpected>[] = [
   ...scratchpadCases,
   ...temporalGroundingCases,
@@ -810,6 +1023,9 @@ export const companionCases: EvalCase<CompanionInput, CompanionExpected>[] = [
   ...workspaceMemoryCases,
   ...edgeCases,
   ...consistencyCases,
+  ...multilingualCases,
+  ...sourceFidelityCases,
+  ...restraintCases,
   ...asideCases,
 ]
 
@@ -823,4 +1039,7 @@ export {
   workspaceMemoryCases,
   edgeCases,
   consistencyCases,
+  multilingualCases,
+  sourceFidelityCases,
+  restraintCases,
 }

--- a/apps/backend/evals/suites/companion/evaluators.ts
+++ b/apps/backend/evals/suites/companion/evaluators.ts
@@ -75,6 +75,33 @@ export const contentContainsEvaluator: Evaluator<CompanionOutput, CompanionExpec
 }
 
 /**
+ * At least one of `shouldContainAny` appears. Separate from `content-contains`
+ * because the two ask different questions: one is "these exact strings are
+ * required", the other is "the answer engaged with the topic at all". Collapsing
+ * them into a single ratio scored breadth of enumeration, which is a style, not
+ * a quality — and a style Ariadne's prompt tells her not to have.
+ */
+export const contentContainsAnyEvaluator: Evaluator<CompanionOutput, CompanionExpected> = {
+  name: "content-contains-any",
+  evaluate: (output: CompanionOutput, expected: CompanionExpected): EvaluatorResult => {
+    const anyOf = expected.responseCharacteristics?.shouldContainAny
+    if (!anyOf || anyOf.length === 0) {
+      return { name: "content-contains-any", score: 1, passed: true, details: "No alternatives required" }
+    }
+
+    const fullContent = output.messages.map((m) => m.content.toLowerCase()).join(" ")
+    const hit = anyOf.some((phrase) => fullContent.includes(phrase.toLowerCase()))
+
+    return {
+      name: "content-contains-any",
+      score: hit ? 1 : 0,
+      passed: hit,
+      details: hit ? undefined : `None of ${anyOf.map((s) => `"${s}"`).join(", ")} appeared`,
+    }
+  },
+}
+
+/**
  * Evaluates whether the response avoids unwanted content.
  */
 export const contentNotContainsEvaluator: Evaluator<CompanionOutput, CompanionExpected> = {
@@ -139,10 +166,11 @@ export const asksQuestionEvaluator: Evaluator<CompanionOutput, CompanionExpected
 
     const fullContent = output.messages.map((m) => m.content).join(" ")
 
-    // Check for question marks or question phrases
-    const hasQuestion =
-      fullContent.includes("?") ||
-      /\b(what|which|how|why|when|where|could you|can you|would you|do you)\b/i.test(fullContent)
+    // A question mark, and nothing else. The English interrogative list that
+    // used to sit here made a semantic judgement out of English literals
+    // (INV-54): it read "how" inside "show me how it works" as a question, and
+    // scored a perfectly formed Swedish or Japanese question as none at all.
+    const hasQuestion = fullContent.includes("?")
 
     return {
       name: "asks-question",
@@ -157,6 +185,18 @@ export const asksQuestionEvaluator: Evaluator<CompanionOutput, CompanionExpected
  * LLM-as-judge evaluator for overall response quality.
  * Uses the framework's llmJudgeEvaluator for consistency.
  */
+/**
+ * What the judge sees. The trace is recorded for the model comparison, not for
+ * grading: a judge shown the trajectory starts scoring the route the agent took
+ * instead of the reply the user got, and the tool evaluators already own that
+ * question. Keeping it out also keeps judge scores comparable across runs made
+ * before and after the trace was captured.
+ */
+function judgedOutput(output: CompanionOutput): CompanionOutput {
+  const { trajectory: _trajectory, ...rest } = output
+  return rest
+}
+
 export function createResponseQualityEvaluator(): Evaluator<CompanionOutput, CompanionExpected> {
   // Create base judge evaluator
   const baseJudge = llmJudgeEvaluator<CompanionOutput, CompanionExpected>({
@@ -189,7 +229,7 @@ export function createResponseQualityEvaluator(): Evaluator<CompanionOutput, Com
       }
 
       // Use the base judge
-      return baseJudge.evaluate(output, expected, ctx)
+      return baseJudge.evaluate(judgedOutput(output), expected, ctx)
     },
   }
 }
@@ -229,7 +269,7 @@ The response should clearly match the ${expectedTone} tone definition.`,
         context: JUDGE_SHAPE_CONTEXT,
       })
 
-      return toneJudge.evaluate(output, expected, ctx)
+      return toneJudge.evaluate(judgedOutput(output), expected, ctx)
     },
   }
 }
@@ -245,14 +285,30 @@ export const webSearchUsageEvaluator: Evaluator<CompanionOutput, CompanionExpect
       return { name: "web-search-usage", score: 1, passed: true, details: "No web search requirement" }
     }
 
-    // Check if web_search was called in toolCalls
-    const usedWebSearch = output.toolCalls?.some((tc) => tc.name === "web_search") ?? false
+    // The requirement is that the answer came off the web instead of out of the
+    // weights, and Ariadne has more than one way to get there: `web_search`
+    // queries directly, `general_research` delegates to the researcher, and
+    // `read_url` fetches a page. Matching only the `web_search` step name
+    // scored the ROUTE rather than the grounding, and marked a
+    // research-delegating turn — sources attached and all — as ungrounded.
+    // The route difference is real and worth reporting, but it is a cost and
+    // latency question, not a correctness one.
+    const WEB_REACHING_STEPS = new Set(["web_search", "research", "visit_page"])
+    const reachedWeb =
+      (output.toolCalls?.some((tc) => tc.name === "web_search") ?? false) ||
+      (output.trajectory?.some((step) => WEB_REACHING_STEPS.has(step.stepType)) ?? false)
+
+    const route = [
+      ...new Set((output.trajectory ?? []).map((s) => s.stepType).filter((t) => WEB_REACHING_STEPS.has(t))),
+    ]
 
     return {
       name: "web-search-usage",
-      score: usedWebSearch ? 1 : 0,
-      passed: usedWebSearch,
-      details: usedWebSearch ? undefined : "Expected web search but it was not used",
+      score: reachedWeb ? 1 : 0,
+      passed: reachedWeb,
+      details: reachedWeb
+        ? `via ${route.join(", ") || "web_search"}`
+        : "Expected the web to be consulted, but no web-reaching tool ran",
     }
   },
 }

--- a/apps/backend/evals/suites/companion/evaluators.ts
+++ b/apps/backend/evals/suites/companion/evaluators.ts
@@ -166,11 +166,10 @@ export const asksQuestionEvaluator: Evaluator<CompanionOutput, CompanionExpected
 
     const fullContent = output.messages.map((m) => m.content).join(" ")
 
-    // A question mark, and nothing else. The English interrogative list that
-    // used to sit here made a semantic judgement out of English literals
-    // (INV-54): it read "how" inside "show me how it works" as a question, and
-    // scored a perfectly formed Swedish or Japanese question as none at all.
-    const hasQuestion = fullContent.includes("?")
+    // Punctuation, not vocabulary — an English interrogative list here made a
+    // semantic call out of English literals (INV-54). Arabic and full-width
+    // question marks count; matching only U+003F repeats the mistake smaller.
+    const hasQuestion = /[?？؟]/u.test(fullContent)
 
     return {
       name: "asks-question",
@@ -275,6 +274,42 @@ The response should clearly match the ${expectedTone} tone definition.`,
 }
 
 /**
+ * Judge whether the reply is written in the expected language. Model-based on
+ * purpose (INV-54): the alternative is a word list, which cannot separate
+ * Swedish from Norwegian, marks a correct reply containing an English technical
+ * term as English, and has to be rewritten for every language a user might use.
+ */
+export function createLanguageEvaluator(): Evaluator<CompanionOutput, CompanionExpected> {
+  return {
+    name: "response-language",
+    evaluate: async (output, expected, ctx): Promise<EvaluatorResult> => {
+      const language = expected.responseCharacteristics?.responseLanguage
+      if (!language) {
+        return { name: "response-language", score: 1, passed: true, details: "No language requirement" }
+      }
+
+      const fullContent = output.messages.map((m) => m.content).join("\n")
+      if (!fullContent.trim()) {
+        return { name: "response-language", score: 0, passed: false, details: "No response content" }
+      }
+
+      const judge = llmJudgeEvaluator<CompanionOutput, CompanionExpected>({
+        name: "response-language",
+        criteria: `The reply is written in ${language}.
+
+Judge the prose only. Code, identifiers, product names, and established technical
+terms commonly used untranslated do not make the reply another language. A reply
+that is mostly English is a fail even if it contains a few ${language} words.`,
+        passThreshold: 0.7,
+        context: JUDGE_SHAPE_CONTEXT,
+      })
+
+      return judge.evaluate(judgedOutput(output), expected, ctx)
+    },
+  }
+}
+
+/**
  * Evaluates whether web search was used when expected.
  */
 export const webSearchUsageEvaluator: Evaluator<CompanionOutput, CompanionExpected> = {
@@ -294,13 +329,15 @@ export const webSearchUsageEvaluator: Evaluator<CompanionOutput, CompanionExpect
     // The route difference is real and worth reporting, but it is a cost and
     // latency question, not a correctness one.
     const WEB_REACHING_STEPS = new Set(["web_search", "research", "visit_page"])
+    // `completed` is load-bearing: a step that started and died reached nothing,
+    // and crediting the attempt scores intent instead of grounding.
+    const completedWebSteps = (output.trajectory ?? []).filter(
+      (step) => WEB_REACHING_STEPS.has(step.stepType) && step.completed
+    )
     const reachedWeb =
-      (output.toolCalls?.some((tc) => tc.name === "web_search") ?? false) ||
-      (output.trajectory?.some((step) => WEB_REACHING_STEPS.has(step.stepType)) ?? false)
+      (output.toolCalls?.some((tc) => tc.name === "web_search") ?? false) || completedWebSteps.length > 0
 
-    const route = [
-      ...new Set((output.trajectory ?? []).map((s) => s.stepType).filter((t) => WEB_REACHING_STEPS.has(t))),
-    ]
+    const route = [...new Set(completedWebSteps.map((step) => step.stepType))]
 
     return {
       name: "web-search-usage",

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -26,10 +26,11 @@
 
 import type { EvalSuite, EvalContext } from "../../framework/types"
 import { companionCases, type CompanionInput, type CompanionExpected } from "./cases"
-import type { CompanionOutput, CompanionMessage } from "./types"
+import type { CompanionOutput, CompanionMessage, CompanionTrajectoryStep } from "./types"
 import {
   shouldRespondEvaluator,
   contentContainsEvaluator,
+  contentContainsAnyEvaluator,
   contentNotContainsEvaluator,
   brevityEvaluator,
   asksQuestionEvaluator,
@@ -64,6 +65,7 @@ import { SearchService } from "../../../src/features/search"
 import { UserPreferencesService } from "../../../src/features/user-preferences"
 import { EmbeddingService, MemoExplorerService, MemoReranker } from "../../../src/features/memos"
 import { StreamRepository, StreamMemberRepository } from "../../../src/features/streams"
+import { UserRepository } from "../../../src/features/workspaces"
 import { MessageRepository } from "../../../src/features/messaging"
 import { createModelRegistry } from "@threa/agent-runtime"
 import type { StorageProvider } from "../../../src/lib/storage/s3-client"
@@ -72,7 +74,8 @@ import type { Server } from "socket.io"
 import { parseMarkdown } from "@threa/prosemirror"
 import { AuthorTypes, ContextIntents, ContextRefKinds, StreamTypes } from "@threa/types"
 import { ulid } from "ulid"
-import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
+import { streamId as generateStreamId, userId as generateUserId } from "../../../src/lib/id"
+import { insertEvalPersona } from "../../framework/eval-persona"
 
 /**
  * Get model configuration from context.
@@ -131,26 +134,12 @@ async function setupTestData(
   }
 
   // Create a test persona row with the resolved prompt and tools but the eval permutation model.
-  const testPersonaId = generatePersonaId()
-  await pool.query(
-    `
-    INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
-    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, 'system', 'active')
-    ON CONFLICT (slug, workspace_id) WHERE workspace_id IS NULL DO UPDATE SET
-      model = EXCLUDED.model,
-      system_prompt = EXCLUDED.system_prompt
-  `,
-    [
-      testPersonaId,
-      `eval-ariadne-${ulid().toLowerCase().slice(0, 8)}`,
-      "Ariadne (Eval)",
-      templatePersona.description,
-      templatePersona.avatarEmoji,
-      templatePersona.systemPrompt,
-      modelConfig.model,
-      templatePersona.enabledTools ?? ["send_message"],
-    ]
-  )
+  const testPersonaId = await insertEvalPersona(pool, {
+    template: templatePersona,
+    model: modelConfig.model,
+    slugPrefix: "eval-ariadne",
+    name: "Ariadne (Eval)",
+  })
 
   // Map stream type from eval input to database type
   const dbStreamType = mapStreamTypeToDbStreamType(input.streamType)
@@ -191,6 +180,26 @@ async function setupTestData(
 
   // Add user as stream member
   await StreamMemberRepository.insert(pool, testStreamId, ctx.userId)
+
+  // A DM is a two-party stream, and the agent's retrieval scope for one is the
+  // INTERSECTION of both participants' access (`computeAgentAccessSpec`), which
+  // throws on any other member count. A one-member DM is not a thin fixture, it
+  // is a stream production cannot serve — every DM case died there, before the
+  // model ran, and the suite reported it as "agent did not respond".
+  if (dbStreamType === StreamTypes.DM) {
+    const counterpartId = generateUserId()
+    const suffix = ulid().toLowerCase().slice(0, 8)
+    await UserRepository.insert(pool, {
+      id: counterpartId,
+      workspaceId: ctx.workspaceId,
+      workosUserId: `workos_eval_dm_${suffix}`,
+      email: `eval-dm-${suffix}@test.local`,
+      slug: `eval-dm-${suffix}`,
+      name: "Eval Counterpart",
+      role: "member",
+    })
+    await StreamMemberRepository.insert(pool, testStreamId, counterpartId)
+  }
 
   // Create event service for message creation
   const eventService = new EventService(pool)
@@ -428,8 +437,14 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
     }
 
     const createThread: PersonaAgentDeps["createThread"] = async (params) => {
-      // For evals, we don't actually need threads - return a mock
       const threadId = generateStreamId()
+      // A thread carries no access of its own — it resolves through
+      // `root_stream_id` to the nearest non-thread ancestor (INV-62), exactly
+      // as StreamService does. Omitting it leaves the row rootless, and the
+      // turn's own write-authority check then reads the thread as
+      // inaccessible: every @mention case failed with "Stream not found"
+      // before the model was ever asked anything.
+      const parent = await StreamRepository.findByIdForWorkspace(ctx.pool, params.parentStreamId, params.workspaceId)
       await StreamRepository.insert(ctx.pool, {
         id: threadId,
         workspaceId: params.workspaceId,
@@ -438,8 +453,10 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
         companionMode: "off",
         createdBy: params.createdBy,
         parentStreamId: params.parentStreamId,
+        rootStreamId: parent?.rootStreamId ?? params.parentStreamId,
         parentAnchorId: params.parentAnchorId,
       })
+      await StreamMemberRepository.insert(ctx.pool, threadId, ctx.userId)
       createdThreadId = threadId
       return { id: threadId }
     }
@@ -523,21 +540,38 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       // Sources are stored in contentJson but we just need content for evals
     }))
 
-    const toolCalls =
-      runResult.sessionId == null
-        ? []
-        : (await AgentSessionRepository.findStepsBySession(ctx.pool, runResult.sessionId))
-            .filter((step) => step.stepType === "web_search")
-            .map((step) => ({
-              name: "web_search",
-              args: { query: typeof step.content === "string" ? step.content : undefined },
-            }))
+    // The session's steps are the turn's trajectory. Reading them once serves
+    // both the web-search evaluators (which need `toolCalls`) and the model
+    // comparison, which needs to see WHICH tools a model reached for and
+    // whether they completed — a provider that rejects a tool schema shows up
+    // here as `tool_error`, and nowhere else.
+    const steps =
+      runResult.sessionId == null ? [] : await AgentSessionRepository.findStepsBySession(ctx.pool, runResult.sessionId)
+
+    const toolCalls = steps
+      .filter((step) => step.stepType === "web_search")
+      .map((step) => ({
+        name: "web_search",
+        args: { query: typeof step.content === "string" ? step.content : undefined },
+      }))
+
+    const trajectory: CompanionTrajectoryStep[] = steps.map((step) => ({
+      stepType: step.stepType,
+      completed: step.completedAt !== null,
+      sourceUrls: (step.sources ?? [])
+        .map((source) => source.url)
+        .filter((url): url is string => typeof url === "string"),
+      ...(step.stepType === "tool_error" || step.stepType === "tool_call"
+        ? { content: typeof step.content === "string" ? step.content.slice(0, 500) : null }
+        : {}),
+    }))
 
     return {
       input,
       messages,
       responded: messages.length > 0,
       toolCalls,
+      trajectory,
     }
   } catch (error) {
     return {
@@ -563,6 +597,7 @@ export const companionSuite: EvalSuite<CompanionInput, CompanionOutput, Companio
   evaluators: [
     shouldRespondEvaluator,
     contentContainsEvaluator,
+    contentContainsAnyEvaluator,
     contentNotContainsEvaluator,
     brevityEvaluator,
     asksQuestionEvaluator,

--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -38,6 +38,7 @@ import {
   webSearchQueryEvaluator,
   createResponseQualityEvaluator,
   createToneEvaluator,
+  createLanguageEvaluator,
   accuracyEvaluator,
   responseDecisionAccuracyEvaluator,
   averageQualityEvaluator,
@@ -549,7 +550,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       runResult.sessionId == null ? [] : await AgentSessionRepository.findStepsBySession(ctx.pool, runResult.sessionId)
 
     const toolCalls = steps
-      .filter((step) => step.stepType === "web_search")
+      .filter((step) => step.stepType === "web_search" && step.completedAt !== null)
       .map((step) => ({
         name: "web_search",
         args: { query: typeof step.content === "string" ? step.content : undefined },
@@ -605,6 +606,7 @@ export const companionSuite: EvalSuite<CompanionInput, CompanionOutput, Companio
     webSearchQueryEvaluator,
     createResponseQualityEvaluator(),
     createToneEvaluator(),
+    createLanguageEvaluator(),
   ],
 
   runEvaluators: [accuracyEvaluator, responseDecisionAccuracyEvaluator, averageQualityEvaluator],

--- a/apps/backend/evals/suites/companion/types.ts
+++ b/apps/backend/evals/suites/companion/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { CompanionInput, CompanionExpected } from "./cases"
-import type { SourceItem } from "@threa/types"
+import type { AgentStepType, SourceItem } from "@threa/types"
 
 /**
  * A message sent by the companion agent.
@@ -13,6 +13,19 @@ export interface CompanionMessage {
   content: string
   /** Optional sources (from web search, workspace search) */
   sources?: SourceItem[]
+}
+
+/**
+ * One step of the turn's trace, as the model comparison reads it: which tool
+ * the agent reached for, whether the step finished, and what it cited.
+ */
+export interface CompanionTrajectoryStep {
+  stepType: AgentStepType
+  completed: boolean
+  /** URLs the step attached as sources — the citation trail behind the reply. */
+  sourceUrls: string[]
+  /** Truncated step content, kept only for tool_call/tool_error steps. */
+  content?: string | null
 }
 
 /**
@@ -30,6 +43,8 @@ export interface CompanionOutput {
     name: string
     args: Record<string, unknown>
   }>
+  /** Every trace step the turn produced, in order. */
+  trajectory?: CompanionTrajectoryStep[]
   /** Error if the task failed */
   error?: string
 }

--- a/apps/backend/evals/suites/memorizer/evaluators.ts
+++ b/apps/backend/evals/suites/memorizer/evaluators.ts
@@ -2,6 +2,7 @@
  * Memorizer Evaluators
  */
 
+import { EVAL_JUDGE_MODEL } from "../../framework/judge-config"
 import { z } from "zod"
 import type { Evaluator, EvaluatorResult, RunEvaluator, CaseResult } from "../../framework/types"
 import type { MemorizerOutput, MemorizerExpected } from "./types"
@@ -126,7 +127,7 @@ export const conclusionEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> 
       .map((m, i) => `${i + 1}. ${m.title}\n   ${m.abstract}\n   Key points: ${m.keyPoints.join("; ") || "—"}`)
       .join("\n")
     const { value } = await ctx.ai.generateObject({
-      model: "openrouter:openai/gpt-5.4-nano",
+      model: EVAL_JUDGE_MODEL,
       schema: conclusionJudgeSchema,
       messages: [
         {

--- a/apps/backend/evals/suites/memorizer/evaluators.ts
+++ b/apps/backend/evals/suites/memorizer/evaluators.ts
@@ -127,7 +127,7 @@ export const conclusionEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> 
       .map((m, i) => `${i + 1}. ${m.title}\n   ${m.abstract}\n   Key points: ${m.keyPoints.join("; ") || "—"}`)
       .join("\n")
     const { value } = await ctx.ai.generateObject({
-      model: EVAL_JUDGE_MODEL,
+      model: ctx.judgeModel ?? EVAL_JUDGE_MODEL,
       schema: conclusionJudgeSchema,
       messages: [
         {

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -69,11 +69,11 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { AuthorTypes, StreamTypes, ExtractionContentTypes, ProcessingStatuses } from "@threa/types"
 import { ulid } from "ulid"
 import {
-  personaId as generatePersonaId,
   streamId as generateStreamId,
   attachmentId as generateAttachmentId,
   extractionId as generateExtractionId,
 } from "../../../src/lib/id"
+import { insertEvalPersona } from "../../framework/eval-persona"
 
 /** Default vision model for eval (must support image input) */
 const VISION_MODEL_ID = "openrouter:anthropic/claude-sonnet-4.5"
@@ -168,26 +168,12 @@ async function setupTestData(
   }
 
   // Copy resolved config into a throwaway row with the eval permutation model (vision-capable).
-  const testPersonaId = generatePersonaId()
-  await pool.query(
-    `
-    INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
-    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, 'system', 'active')
-    ON CONFLICT (slug, workspace_id) WHERE workspace_id IS NULL DO UPDATE SET
-      model = EXCLUDED.model,
-      system_prompt = EXCLUDED.system_prompt
-  `,
-    [
-      testPersonaId,
-      `eval-vision-${ulid().toLowerCase().slice(0, 8)}`,
-      "Ariadne (Vision Eval)",
-      templatePersona.description,
-      templatePersona.avatarEmoji,
-      templatePersona.systemPrompt,
-      modelConfig.model,
-      templatePersona.enabledTools ?? ["send_message"],
-    ]
-  )
+  const testPersonaId = await insertEvalPersona(pool, {
+    template: templatePersona,
+    model: modelConfig.model,
+    slugPrefix: "eval-vision",
+    name: "Ariadne (Vision Eval)",
+  })
 
   // Create a scratchpad stream (simplest context for vision testing)
   const testStreamId = generateStreamId()

--- a/apps/backend/evals/suites/persona-style/config.ts
+++ b/apps/backend/evals/suites/persona-style/config.ts
@@ -16,11 +16,13 @@
  * `-s persona-style`) and in `persona-style.yaml` (for `--config`).
  */
 
+import { EVAL_JUDGE_MODEL } from "../../framework/judge-config"
+
 export const PERSONA_STYLE_MODEL_ID = "openrouter:anthropic/claude-haiku-4.5"
 export const PERSONA_STYLE_TEMPERATURE = 0.7
 
 /** Judge model for tone adherence — the shared cheap judge the other suites use. */
-export const PERSONA_STYLE_JUDGE_MODEL = "openrouter:openai/gpt-5.4-nano"
+export const PERSONA_STYLE_JUDGE_MODEL = EVAL_JUDGE_MODEL
 
 /**
  * Word-count guards for the brevity cases. The AUTHORITATIVE brevity signal is

--- a/apps/backend/tests/integration/eval-persona.test.ts
+++ b/apps/backend/tests/integration/eval-persona.test.ts
@@ -1,14 +1,7 @@
 /**
- * The eval suites' throwaway persona row, run against a real migrated schema.
- *
- * This exists because the statement was wrong for six weeks and nothing caught
- * it: three companion-backed suites upserted `ON CONFLICT (slug, workspace_id)
- * WHERE workspace_id IS NULL`, a constraint that migration
- * `20260713120000_persona_owner_user_id.sql` had already replaced with two
- * partial unique indexes. Postgres threw on every case, the suite reported it
- * as "agent did not respond", and a model comparison sitting in the repo could
- * never have produced a number. Only executing the statement finds that
- * (INV-68) — asserting on its text would have passed the whole time.
+ * The eval suites' throwaway persona row, executed against a real migrated
+ * schema. An `ON CONFLICT` target that names no existing index is valid
+ * TypeScript and valid-looking SQL; only running it finds that (INV-68).
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
@@ -61,9 +54,6 @@ describe("eval persona insert", () => {
   })
 
   test("the ON CONFLICT target matches a real index, so a repeated slug updates the model", async () => {
-    // Same slug twice is what the clause is for. Going through the helper twice
-    // cannot collide (it generates a fresh suffix), so the conflict is forced
-    // here with the statement's own conflict target.
     const slug = `eval-conflict-${personaId()}`
     const insert = (id: string, model: string) =>
       pool.query(
@@ -78,8 +68,7 @@ describe("eval persona insert", () => {
       )
 
     await insert(personaId(), "openrouter:anthropic/claude-sonnet-5")
-    // NULL workspace_id makes rows distinct in the index, so this inserts a
-    // second row rather than updating — the point is that the statement RUNS.
+    // NULL workspace_id makes rows distinct in this index, so both rows persist.
     await insert(personaId(), "openrouter:openai/gpt-5.6-luna")
 
     const rows = await pool.query(`SELECT model FROM personas WHERE slug = $1 ORDER BY model`, [slug])

--- a/apps/backend/tests/integration/eval-persona.test.ts
+++ b/apps/backend/tests/integration/eval-persona.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The eval suites' throwaway persona row, run against a real migrated schema.
+ *
+ * This exists because the statement was wrong for six weeks and nothing caught
+ * it: three companion-backed suites upserted `ON CONFLICT (slug, workspace_id)
+ * WHERE workspace_id IS NULL`, a constraint that migration
+ * `20260713120000_persona_owner_user_id.sql` had already replaced with two
+ * partial unique indexes. Postgres threw on every case, the suite reported it
+ * as "agent did not respond", and a model comparison sitting in the repo could
+ * never have produced a number. Only executing the statement finds that
+ * (INV-68) — asserting on its text would have passed the whole time.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase } from "./setup"
+import { insertEvalPersona } from "../../evals/framework/eval-persona"
+import { PersonaRepository } from "../../src/features/agents"
+import { personaId } from "../../src/lib/id"
+
+const template = {
+  description: "Eval template",
+  avatarEmoji: ":thread:",
+  systemPrompt: "You are Ariadne.",
+  enabledTools: ["send_message", "web_search"],
+}
+
+describe("eval persona insert", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("inserts a system persona carrying the permutation model", async () => {
+    const id = await insertEvalPersona(pool, {
+      template,
+      model: "openrouter:openai/gpt-5.6-luna",
+      slugPrefix: "eval-insert",
+      name: "Ariadne (Eval)",
+    })
+
+    const row = await pool.query(
+      `SELECT id, workspace_id, model, system_prompt, enabled_tools, managed_by, status FROM personas WHERE id = $1`,
+      [id]
+    )
+
+    expect(row.rows[0]).toEqual({
+      id,
+      workspace_id: null,
+      model: "openrouter:openai/gpt-5.6-luna",
+      system_prompt: "You are Ariadne.",
+      enabled_tools: ["send_message", "web_search"],
+      managed_by: "system",
+      status: "active",
+    })
+  })
+
+  test("the ON CONFLICT target matches a real index, so a repeated slug updates the model", async () => {
+    // Same slug twice is what the clause is for. Going through the helper twice
+    // cannot collide (it generates a fresh suffix), so the conflict is forced
+    // here with the statement's own conflict target.
+    const slug = `eval-conflict-${personaId()}`
+    const insert = (id: string, model: string) =>
+      pool.query(
+        `
+        INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
+        VALUES ($1, NULL, $2, 'Ariadne (Eval)', 'd', ':thread:', 'p', $3, ARRAY['send_message'], 'system', 'active')
+        ON CONFLICT (workspace_id, slug) WHERE managed_by <> 'user' DO UPDATE SET
+          model = EXCLUDED.model,
+          system_prompt = EXCLUDED.system_prompt
+      `,
+        [id, slug, model]
+      )
+
+    await insert(personaId(), "openrouter:anthropic/claude-sonnet-5")
+    // NULL workspace_id makes rows distinct in the index, so this inserts a
+    // second row rather than updating — the point is that the statement RUNS.
+    await insert(personaId(), "openrouter:openai/gpt-5.6-luna")
+
+    const rows = await pool.query(`SELECT model FROM personas WHERE slug = $1 ORDER BY model`, [slug])
+    expect(rows.rows.map((r) => r.model)).toEqual([
+      "openrouter:anthropic/claude-sonnet-5",
+      "openrouter:openai/gpt-5.6-luna",
+    ])
+  })
+
+  test("refuses a template with no system prompt rather than writing a mute persona", async () => {
+    await expect(
+      insertEvalPersona(pool, {
+        template: { ...template, systemPrompt: null },
+        model: "openrouter:openai/gpt-5.6-luna",
+        slugPrefix: "eval-noprompt",
+        name: "Ariadne (Eval)",
+      })
+    ).rejects.toThrow(/no system prompt/)
+  })
+
+  test("the row resolves through the repository the suites read it with", async () => {
+    const id = await insertEvalPersona(pool, {
+      template,
+      model: "openrouter:openai/gpt-5.6-luna",
+      slugPrefix: "eval-resolve",
+      name: "Ariadne (Eval)",
+    })
+
+    const persona = await PersonaRepository.findById(pool, id, null)
+    expect(persona?.model).toBe("openrouter:openai/gpt-5.6-luna")
+  })
+})

--- a/packages/agent-runtime/src/ai/ai.ts
+++ b/packages/agent-runtime/src/ai/ai.ts
@@ -254,6 +254,15 @@ export interface GenerateTextWithToolsResult {
   text: string
   toolCalls: Array<{ toolCallId: string; toolName: string; input: unknown }>
   response: { messages: ModelMessage[] }
+  /**
+   * What the call cost, when the caller passed `modelString` (the cost recorder
+   * needs it to parse the provider). Production accounts for this through
+   * `maybeRecordUsage` and never reads it here; it is returned so a caller that
+   * is NOT writing `ai_usage_records` — the eval runner — can still attribute
+   * tokens and cost to the model that ran. Absent on implementations that do
+   * not compute usage (the enclave AI).
+   */
+  usage?: UsageWithCost
 }
 
 export interface GenerateObjectOptions<T extends z.ZodType> {
@@ -1032,8 +1041,9 @@ export function createAI(config: AIConfig): AI {
       // LanguageModel instance does not carry the provider:model prefix the cost
       // recorder expects. Callers that want tracked usage must pass `modelString`
       // alongside `context` (agent loops do this via AgentRuntime).
+      let usage: UsageWithCost | undefined
       if (options.modelString) {
-        const usage = extractUsageWithCost(response)
+        usage = extractUsageWithCost(response)
         logger.debug(
           { usage, model: options.modelString, functionId: options.telemetry?.functionId },
           "AI generateTextWithTools completed with usage"
@@ -1056,6 +1066,7 @@ export function createAI(config: AIConfig): AI {
           input: tc.input,
         })),
         response: { messages: response.response.messages },
+        usage,
       }
     },
 


### PR DESCRIPTION
The companion, brief-correction and multimodal-vision suites had been failing every case in ~10ms since 2026-07-13. Their persona upsert named `ON CONFLICT (slug, workspace_id) WHERE workspace_id IS NULL`, a constraint that `20260713120000_persona_owner_user_id.sql` replaced with two partial unique indexes, so Postgres threw before any model ran and the runner reported it as "agent did not respond" (INV-68). Three copies of that statement become one `insertEvalPersona`, verified against a migrated schema.

Two more defects hid the same way. `createThread` never set `root_stream_id`, so every @mention case died on a rootless thread that the turn's own write-authority check rejected (INV-62). DM cases seeded a one-member DM, which `computeAgentAccessSpec` refuses because a DM's agent retrieval scope is the intersection of both participants' access.

**The suites also never measured the model under test.** `createUsageTrackingAI` wrapped `generateText`/`generateObject`, but a persona turn runs through `generateTextWithTools` — unwrapped, and returning no usage at all. Reported tokens and cost covered only sub-agents and judges, and the "override never executed" guard fired on every companion comparison because the model genuinely never appeared.

Evaluator fixes, each one a semantic decision made out of English literals:

- `shouldContain` with a three-item list silently required all three (2/3 = 0.67 under a 0.7 bar), scoring breadth of enumeration against a persona whose prompt says be terse. Concept sets move to `shouldContainAny`.
- `web-search-usage` matched a single step name, marking a research-delegated turn with sources attached as ungrounded.
- `asks-question` tested English interrogatives (INV-54).

Also adds `--rescore` (replay evaluators over stored generations instead of paying to regenerate), `--judge`, one `EVAL_JUDGE_MODEL` (INV-33), a credit-rejection guard that refuses to report a throttled run, incremental report writes, and multilingual, source-fidelity and restraint cases — the suite had 1 of 36 cases expecting silence.

**Verification:** 77 eval-framework tests, 4 integration tests that fail against the old SQL, 308 agent-runtime, 101 enclave, typecheck, lint.

**Residual risk:** judge scores are not comparable to pre-2026-08 runs — the evaluator and judge changes are deliberate scoring changes. The companion comparison itself has not been re-run to completion against the repaired harness.
