### PR TITLE
feat(agents): default Ariadne to gpt-5.6-luna

### DIFF
--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -42,7 +42,7 @@ export const BUILT_IN_AGENTS = {
     systemPrompt: `You are Ariadne, an AI thinking companion in Threa. You help users explore ideas, think through problems, and make decisions. You have access to their previous conversations and knowledge base through the GAM (General Agentic Memory) system.
 
 Keep responses short and direct. Default to a few sentences unless the user asks for depth. Be warm but not wordy — say what matters and stop. Ask clarifying questions rather than guessing at length.`,
-    model: "openrouter:anthropic/claude-sonnet-5",
+    model: "openrouter:openai/gpt-5.6-luna",
     escalationModel: "openrouter:anthropic/claude-opus-5",
     temperature: 0.7,
     maxTokens: null,

--- a/apps/backend/src/features/agents/persona-config-service.test.ts
+++ b/apps/backend/src/features/agents/persona-config-service.test.ts
@@ -212,7 +212,7 @@ describe("PersonaConfigService.getConfig", () => {
     expect(config!.overridePatch).toEqual({ model: "openrouter:anthropic/claude-haiku-4.5" })
     expect(config!.overrideUpdatedAt).toBe("2026-07-01T00:00:00.000Z")
     expect(config!.resolved.model).toBe("openrouter:anthropic/claude-haiku-4.5")
-    expect(config!.defaults!.model).toBe("openrouter:anthropic/claude-sonnet-5")
+    expect(config!.defaults!.model).toBe("openrouter:openai/gpt-5.6-luna")
   })
 
   it("returns the caller's own draft (validated, no status) alongside the resolved config", async () => {

--- a/apps/backend/src/features/agents/persona-repository.test.ts
+++ b/apps/backend/src/features/agents/persona-repository.test.ts
@@ -68,7 +68,7 @@ describe("PersonaRepository built-in agent config", () => {
       id: ARIADNE_AGENT_ID,
       slug: "ariadne",
       name: "Ariadne",
-      model: "openrouter:anthropic/claude-sonnet-5",
+      model: "openrouter:openai/gpt-5.6-luna",
       managedBy: "system",
       status: "active",
     })

--- a/apps/backend/src/lib/ai/config-resolver.test.ts
+++ b/apps/backend/src/lib/ai/config-resolver.test.ts
@@ -24,7 +24,7 @@ describe("StaticConfigResolver", () => {
     expect(memoMemorizerConfig.temperature).toBe(0.3)
 
     const companionConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_AGENT)
-    expect(companionConfig.modelId).toBe("openrouter:anthropic/claude-sonnet-5")
+    expect(companionConfig.modelId).toBe("openrouter:openai/gpt-5.6-luna")
     expect(companionConfig.temperature).toBe(0.7)
 
     const researcherConfig = await resolver.resolve(COMPONENT_PATHS.COMPANION_RESEARCHER)

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -98,8 +98,8 @@ model picker. The two lists are meant to stay identical — an entry is an offer
 
 **When to use:**
 
-- Default Ariadne companion persona model (since 2026-07-11; won the July 2026 companion eval vs 4.6 — 51/84 vs 46/84 case-runs, best judge quality — at ~34% higher per-conversation cost and ~30% higher latency)
 - Complex reasoning and multi-turn agent conversations
+- Was the default Ariadne persona model from 2026-07-11 to 2026-08-27, on the July 2026 companion eval against 4.6 (51/84 vs 46/84 case-runs, best judge quality) at ~34% higher per-conversation cost and ~30% higher latency. Replaced by Luna as a product decision, not an eval result — see the Luna entry.
 
 **Use instead of:** `claude-sonnet-4.6`
 
@@ -169,9 +169,35 @@ This entry read `$0.25/$1.25` until 2026-07-27 — 4× under the real price. On 
 
 **When to use:**
 
+- Default Ariadne companion persona model (since 2026-08-27)
+- Default LLM-as-judge model for the eval suites (`EVAL_JUDGE_MODEL`)
 - Classification, extraction, ranking, naming, transcript polish, and summarization
 - Memo memorization and tool-call guarding
 - Over-budget model degradation
+
+**On the Ariadne default — read this before citing it as an eval win.** It is
+Kristoffer's product call, taken on Luna's cost and his own use of it, and the
+August 2026 comparison did NOT establish quality parity with `claude-sonnet-5`.
+What that attempt produced:
+
+- The one credit-clean head-to-head ran on a harness with four defects since
+  fixed, and had sonnet-5 marginally AHEAD: 52/105 vs 48/105 case-runs, judge
+  quality 0.661 vs 0.659 — a dead heat.
+- The run that showed Luna far ahead (84/117 vs 43/117) is void: the OpenRouter
+  key hit its weekly cap and rejected 1428 sonnet-5 calls. Luna survived that
+  run _because_ its requests reserve fewer tokens. That number measures the
+  credit ceiling, not the models, and it is the single most misleading artifact
+  of the exercise.
+- The clean rerun was killed by SIGTERM at 126/324 case-runs and never finished.
+
+So the honest status is _unmeasured_, not _equal_. `evals/companion-model-comparison.yaml`
+runs the comparison; finish it before this entry claims anything about quality.
+
+**Consequence of the switch:** over-budget degradation is now a no-op for the
+default persona. Every `MODEL_DEGRADATION_MAP` target is Luna because it is the
+cheapest current-generation model that still holds up on agentic tool use, so a
+workspace whose default persona is already Luna has no cheaper tier to fall back
+to at the soft limit.
 
 **Eval history (July 2026, 6-run tallies vs `gpt-5.4-mini`):** memorizer 10/10 cases perfect against mini's 8/10 — Luna never leaked the anti-gossip residuals and never inverted a decision direction; boundary-extraction effectively tied (0.996 vs 0.992); memo-classifier tied (11/11 both). Luna was ~40% slower per call, but the price cut makes it cheaper than both 5.4 tiers, so every production task previously on a GPT-5.4 tier now uses Luna.
 


### PR DESCRIPTION
Kristoffer's product call, taken on Luna's cost and his own experience using
it. It is NOT backed by a completed eval, and the docs say so plainly so nobody
later cites it as one.

What the August 2026 comparison actually produced, all of it recorded in
model-reference:

- The one credit-clean head-to-head ran on a harness with four defects since
  fixed and had sonnet-5 marginally AHEAD — 52/105 vs 48/105 case-runs, judge
  quality 0.661 vs 0.659. A dead heat.
- The run showing Luna far ahead (84/117 vs 43/117) is void. The OpenRouter key
  hit its weekly cap and rejected 1428 sonnet-5 calls; a rejection is
  indistinguishable downstream from a model declining to answer. Luna survived
  that run because its requests reserve fewer tokens, so the contaminated
  result reads as a plausible win for it.
- The clean rerun was killed at 126/324 case-runs and never finished.

So the honest status is unmeasured, not equal. `evals/companion-model-comparison.yaml`
runs the comparison against the repaired harness whenever we want the number.

`escalationModel` stays `claude-opus-5`, so a turn whose previous attempt failed
response validation still escalates to Opus.

One consequence worth knowing: over-budget degradation is now a no-op for the
default persona. Every `MODEL_DEGRADATION_MAP` target is already Luna — it is
the cheapest current-generation model that holds up on agentic tool use — so a
workspace on the default persona has no cheaper tier at the 80% soft limit,
where it previously degraded sonnet-5 to Luna. Left alone deliberately; picking
a new floor is a separate decision.

Verified: 4129 backend tests, typecheck, lint. The three tests that pin the
default keep pinning the literal rather than reading the constant, so the next
change to it shows up as a visible diff instead of a test that agrees with
itself.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01937oPhzgo1iLverVDn2RPf

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790415544&installation_model_id=20758&pr_number=1964&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1964&signature=0920e537c0ba05aacc20ffde7e57ec3dee0507373a96b4b6b51f9f7d9a1906d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->