### PR TITLE
fix(public-site): single-color headings and copy-tell cleanup

### DIFF
--- a/apps/public-site/scripts/build-llms.ts
+++ b/apps/public-site/scripts/build-llms.ts
@@ -258,7 +258,7 @@ function createConverter(): TurndownService {
     replacement: (_content, node) => {
       const el = node as DomNode
       const scopes = qsa(el, "code.api-scope").map((c) => `\`${c.textContent?.trim()}\``)
-      return `\n\nRequired scope: ${scopes.length ? scopes.join(", ") : "none — any valid key"}\n\n`
+      return `\n\nRequired scope: ${scopes.length ? scopes.join(", ") : "none · any valid key"}\n\n`
     },
   })
 

--- a/apps/public-site/src/components/ApiEndpoint.astro
+++ b/apps/public-site/src/components/ApiEndpoint.astro
@@ -152,7 +152,7 @@ const responseExample = successSchema?.properties
         {scopes.length > 0 ? (
           scopes.map((s) => <code class="api-scope">{s}</code>)
         ) : (
-          <span class="api-scope-none">none — any valid key</span>
+          <span class="api-scope-none">none · any valid key</span>
         )}
       </p>
 

--- a/apps/public-site/src/components/ApiReference.astro
+++ b/apps/public-site/src/components/ApiReference.astro
@@ -25,7 +25,7 @@ const hrefFor = (version: string) =>
 ---
 
 <p class="eyebrow">Reference</p>
-<h1>API <span class="accent">reference</span>.</h1>
+<h1>API reference.</h1>
 <p class="lead">
   Every endpoint, generated from the <a class="link" href="/openapi.json">OpenAPI spec</a>
   we ship. Set your workspace ID and key in the Credentials panel (top right) and

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -50,7 +50,7 @@ const schema = [
         <div class="about-hero">
           <h1 class="h-display">
             Threa came out of<br />
-            <span class="accent">curiosity</span>, and a bit<br />
+            curiosity, and a bit<br />
             of frustration.
           </h1>
           <p class="lede">
@@ -181,7 +181,7 @@ const schema = [
        ============================================================ -->
   <div class="frame">
     <div class="memo-shell is-centerpiece about-close">
-      <h2>Early, and <span class="accent">built in the open</span>.</h2>
+      <h2>Early, and built in the open.</h2>
       <p class="lede">
         Threa is early, and there's plenty left to build. Join the waitlist, or
         follow along in the public repo.

--- a/apps/public-site/src/pages/developers/authentication.astro
+++ b/apps/public-site/src/pages/developers/authentication.astro
@@ -24,7 +24,7 @@ const scopes = [
   current="authentication"
 >
   <p class="eyebrow">Authentication</p>
-  <h1>Keys and <span class="accent">scopes</span>.</h1>
+  <h1>Keys and scopes.</h1>
   <p class="lead">
     Every request carries a bearer token. The prefix decides whether you act as
     a person or as a bot, and the scopes on the key decide what you're allowed to

--- a/apps/public-site/src/pages/developers/cli.astro
+++ b/apps/public-site/src/pages/developers/cli.astro
@@ -18,7 +18,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   ]}
 >
   <p class="eyebrow">CLI &amp; MCP</p>
-  <h1>The <span class="accent">threa</span> command line.</h1>
+  <h1>The threa command line.</h1>
   <p class="lead">
     <code>threa</code> wraps the public API as a command-line tool: search
     messages and memos, read streams, post, and run the delegation lifecycle

--- a/apps/public-site/src/pages/developers/feature-requests.astro
+++ b/apps/public-site/src/pages/developers/feature-requests.astro
@@ -8,7 +8,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro"
   current="feature-requests"
 >
   <p class="eyebrow">Feature requests</p>
-  <h1>Something <span class="accent">missing</span>?</h1>
+  <h1>Something missing?</h1>
   <p class="lead">
     The API is small on purpose and grows in the open. If there's an endpoint,
     scope, or integration you need, file it. Threa is public source, so requests

--- a/apps/public-site/src/pages/developers/index.astro
+++ b/apps/public-site/src/pages/developers/index.astro
@@ -9,7 +9,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   current="overview"
 >
   <p class="eyebrow">Developers</p>
-  <h1>Threa's <span class="accent">public API</span>.</h1>
+  <h1>Threa's public API.</h1>
   <p class="lead">
     A REST API over your workspace: messages, streams, members, attachments, and
     the memos Threa builds from your conversations. The memory Ariadne reads is

--- a/apps/public-site/src/pages/developers/markdown.astro
+++ b/apps/public-site/src/pages/developers/markdown.astro
@@ -18,7 +18,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   ]}
 >
   <p class="eyebrow">Markdown</p>
-  <h1>The message content <span class="accent">format</span>.</h1>
+  <h1>The message content format.</h1>
   <p class="lead">
     Message bodies are markdown. On top of standard formatting, a few custom
     link schemes carry what plain markdown has no syntax for: a mention's

--- a/apps/public-site/src/pages/developers/operations.astro
+++ b/apps/public-site/src/pages/developers/operations.astro
@@ -16,7 +16,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   ]}
 >
   <p class="eyebrow">Operations</p>
-  <h1>Running in <span class="accent">production</span>.</h1>
+  <h1>Running in production.</h1>
   <p class="lead">
     How errors come back, how paging works, how to send a message exactly once,
     and the rate limits in force. Plus the CORS setting that gates in-browser

--- a/apps/public-site/src/pages/developers/recipes.astro
+++ b/apps/public-site/src/pages/developers/recipes.astro
@@ -17,7 +17,7 @@ import CodeBlock from "../../components/CodeBlock.astro"
   ]}
 >
   <p class="eyebrow">Recipes</p>
-  <h1>Worked <span class="accent">examples</span>.</h1>
+  <h1>Worked examples.</h1>
   <p class="lead">
     Each one is a real task. Set your credentials in the panel (top right) and the
     runnable samples work as you read. The last wires a local agent into your

--- a/apps/public-site/src/pages/developers/reference.astro
+++ b/apps/public-site/src/pages/developers/reference.astro
@@ -24,7 +24,7 @@ const { groups, sections } = buildReferenceModel(spec)
 
 <DocsLayout
   title="API reference · Threa Developers"
-  description="Every Threa API endpoint with parameters, request and response shapes, required scopes, and a runnable curl example — generated from the OpenAPI spec."
+  description="Every Threa API endpoint with parameters, request and response shapes, required scopes, and a runnable curl example, generated from the OpenAPI spec."
   current="reference"
   sections={sections}
   wide

--- a/apps/public-site/src/pages/developers/versioning.astro
+++ b/apps/public-site/src/pages/developers/versioning.astro
@@ -41,7 +41,7 @@ const changelog: ChangelogEntry[] = changelogRaw
   ]}
 >
   <p class="eyebrow">Versioning</p>
-  <h1>API <span class="accent">versions</span>.</h1>
+  <h1>API versions.</h1>
   <p class="lead">
     Threa versions the API by date. Each key is pinned to a version when you
     create it, so your integration keeps seeing the same shapes until you decide

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -626,7 +626,7 @@ const schema = [
           <span>Open source</span>
           <span>· read · fork · audit</span>
         </div>
-        <h2>The whole thing is open source.</h2>
+        <h2>It's open source.</h2>
         <p class="lede">
           The frontend, backend, control plane, and infrastructure are all public.
           Read exactly how Threa works, fork it if you want your own version, or

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -43,8 +43,7 @@ const schema = [
       <div class="hero-stage">
         <div>
           <h1 class="h-display">
-            Chat that remembers<br/>
-            <span class="accent">the decisions</span>.
+            Chat that remembers the decisions.
           </h1>
           <p class="lede">
             Channels, threads, and DMs, with a memory underneath. The decisions
@@ -221,7 +220,7 @@ const schema = [
     <div class="section-meta">
       <span>The board</span>
     </div>
-    <h2>Chat you can actually find later.</h2>
+    <h2>Chat you can find later.</h2>
     <p class="lede">
       A timeline is great for real-time chat. It's linear and immediate, and good
       for keeping up with what's latest. Where it falls short is discoverability.
@@ -653,7 +652,7 @@ const schema = [
             <h4>Built in the open</h4>
             <p>
               Design docs, implementation plans, and the feature inventory are
-              public too, not just the finished code.
+              public too.
             </p>
           </div>
         </div>
@@ -799,7 +798,7 @@ const schema = [
         <span class="check"><svg><use href="#check-icon"/></svg></span>
         <div>
           <h4>Stash a message</h4>
-          <p>Save a half-written message without sending it and pick it back up later. Not one draft stuck in the input box, but a stash you can pull from.</p>
+          <p>Save a half-written message without sending it and pick it back up later.</p>
         </div>
       </li>
       <li class="missing-item">
@@ -821,7 +820,7 @@ const schema = [
 <div class="frame night" id="waitlist">
   <div class="cta-shell">
     <div>
-      <h3>Get <span class="accent">early</span> access.</h3>
+      <h3>Get early access.</h3>
     </div>
     <div>
       <form class="wl-form" id="waitlist-form" novalidate>

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -471,10 +471,6 @@ a {
   letter-spacing: -0.02em;
   margin: 0 0 16px;
 }
-.docs-article h1 .accent {
-  color: hsl(var(--gold));
-  font-weight: 500;
-}
 .docs-article h2 {
   font-family: var(--font-display);
   font-weight: 500;

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -289,10 +289,6 @@ body::after {
   letter-spacing: -0.02em;
   margin: 0;
 }
-.h-display .accent {
-  color: hsl(var(--gold));
-  font-weight: 500;
-}
 .lede {
   font-size: 16px;
   line-height: 1.55;
@@ -1415,10 +1411,6 @@ body::after {
   margin: 0 0 14px;
   max-width: 720px;
 }
-.memo-shell h2 .accent {
-  color: hsl(var(--gold));
-  font-weight: 500;
-}
 .memo-shell .lede {
   max-width: 580px;
   margin-bottom: 56px;
@@ -1985,11 +1977,6 @@ body::after {
   color: hsl(var(--ink));
   max-width: 720px;
 }
-.byo-quote .accent {
-  color: hsl(var(--gold));
-  font-weight: 500;
-  font-style: normal;
-}
 /* "Bring your own ___" with the agent name rotating through a vertical
      reel. One clip window shows a single word; the track slides up by one
      line each beat. The trailing word duplicates the first so the loop can
@@ -2059,10 +2046,6 @@ body::after {
   letter-spacing: -0.015em;
   margin: 0;
 }
-.cta-shell h3 .accent {
-  color: hsl(var(--gold));
-  font-weight: 500;
-}
 .cta-shell .form-row {
   display: flex;
   gap: 10px;
@@ -2087,12 +2070,9 @@ body::after {
   display: block;
 }
 /* Night variant — the closing band. Gold becomes the button color (ink-on-ink
-   would vanish), the input sinks into the dark, the accent word stays gold. */
+   would vanish) and the input sinks into the dark. */
 .frame.night .cta-shell h3 {
   color: hsl(38 16% 94%);
-}
-.frame.night .cta-shell h3 .accent {
-  color: hsl(var(--gold-soft));
 }
 .frame.night .cta {
   background: hsl(var(--gold));


### PR DESCRIPTION
## Problem

Every page heading on the public site carried a gold accent word (`<span class="accent">`): the hero ("Chat that remembers **the decisions**."), the night CTA ("Get **early** access."), both About headings, and all nine developer-docs titles. One accent-colored phrase in every heading is the formulaic-highlight tell, and Kris called it out directly: headings should be a single color. A copy pass also surfaced a handful of smaller tells.

## Solution

- Removed all 13 `<span class="accent">` wrappers (landing, About, 8 docs pages, `ApiReference`). Words unchanged; headings now render in the heading's base ink.
- Deleted the six now-dead `.accent` rules (`global.css` ×5, `docs.css` ×1), including the night-variant one. Gold stays where it belongs: eyebrows, links, rules, buttons, code highlighting.
- Copy tells: "Chat you can **actually** find later" → "Chat you can find later"; the stash bullet's "Not one draft stuck in the input box, but a stash…" contrast → one plain sentence; "…are public too, not just the finished code" → "…are public too"; reference meta description em-dash → comma; `ApiEndpoint` "none — any valid key" → "none · any valid key".
- First-person founder copy (About page, "Why I built this", waitlist "I'll be in touch") left untouched.

## Verification

- `bun run test` (public-site): 5 pass, including the built-mirror negotiation test against a fresh `bun run build` (14 pages).
- `bun run typecheck` (astro check): 0 errors.
- `grep 'class="accent"' src/` → 0 hits; remaining em-dashes are code comments only.
- Full-page screenshots desktop + mobile, all three surfaces: [home](https://seer.build/ws_vbyzjvdg6g/i/img_pp74q4pvct/refine-home-desktop.webp) · [home mobile](https://seer.build/ws_vbyzjvdg6g/i/img_9vk8z9r8d7/refine-home-mobile.webp) · [about](https://seer.build/ws_vbyzjvdg6g/i/img_rahs2bj7rn/refine-about-desktop.webp) · [about mobile](https://seer.build/ws_vbyzjvdg6g/i/img_3ewjx6vtnn/refine-about-mobile.webp) · [docs](https://seer.build/ws_vbyzjvdg6g/i/img_babs3gxv50/refine-docs-desktop.webp) · [docs mobile](https://seer.build/ws_vbyzjvdg6g/i/img_1jhddehqc6/refine-docs-mobile.webp)

---

🤖 _PR by [OpenCode](https://opencode.ai)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790512339&installation_model_id=20758&pr_number=1967&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1967&signature=c51e6a861ad919a0f1469749e1f3689e844327049298b7baa287915d89ff47e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->