### PR TITLE
fix(frontend): the aside's anchor row says when Ariadne has answered, and the phone sheet takes the typing with it

### DIFF
--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -496,6 +496,18 @@ interface ThreadStreamStats {
  */
 export type GetComposeTraceMode = (workspaceId: string) => Promise<FeatureFlagValue<"composeTraces">>
 
+/**
+ * Only a thread's messages are replies on its anchor. An aside is anchored the
+ * same way (`parentStreamId` + `parentAnchorId`) but is private to its creator:
+ * bumping the anchor's reply stats or emitting `thread:updated` for it would
+ * hand the host message the aside as its thread.
+ */
+function isThreadReplyStream(
+  stream: { type: string; parentStreamId: string | null; parentAnchorId?: string | null } | null | undefined
+): stream is { type: string; parentStreamId: string; parentAnchorId: string } {
+  return stream?.type === StreamTypes.THREAD && !!stream.parentStreamId && !!stream.parentAnchorId
+}
+
 export class EventService {
   constructor(
     private pool: Pool,
@@ -1090,7 +1102,7 @@ export class EventService {
       },
     })
 
-    if (stream?.parentStreamId && stream.parentAnchorId) {
+    if (isThreadReplyStream(stream)) {
       const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, 1)
       await this.emitThreadUpdate(client, updatedThread ?? stream)
     }
@@ -1454,7 +1466,7 @@ export class EventService {
             })
           )
 
-          if (stream?.parentStreamId && stream.parentAnchorId) {
+          if (isThreadReplyStream(stream)) {
             // No count change on edit — refresh only the thread summary; omit
             // replyCount so a stale unlocked read can't clobber a concurrent
             // create/delete's authoritative count (INV-20).
@@ -1664,7 +1676,7 @@ export class EventService {
           })
 
           const stream = await StreamRepository.findById(client, params.streamId)
-          if (stream?.parentStreamId && stream.parentAnchorId) {
+          if (isThreadReplyStream(stream)) {
             const updatedThread = await StreamRepository.bumpThreadReplyCount(client, stream.id, -1)
             await this.emitThreadUpdate(client, updatedThread ?? stream)
           }
@@ -2034,7 +2046,7 @@ export class EventService {
         params.targetMessageId
       )
 
-      if (sourceStream.parentStreamId && sourceStream.parentAnchorId) {
+      if (isThreadReplyStream(sourceStream)) {
         const updatedSourceThread = await StreamRepository.bumpThreadReplyCount(
           client,
           sourceStream.id,

--- a/apps/backend/tests/integration/aside-reply-stats.test.ts
+++ b/apps/backend/tests/integration/aside-reply-stats.test.ts
@@ -82,8 +82,9 @@ describe("Aside reply stats", () => {
     })
 
     const outboxEvents = await OutboxRepository.fetchAfterId(pool, baselineId)
-    expect(outboxEvents.map((event) => event.eventType)).not.toContain("thread:updated")
-    expect(outboxEvents.some((event) => event.eventType === "message:created")).toBe(true)
+    const eventTypes = outboxEvents.map((event) => event.eventType)
+    expect(eventTypes).not.toContain("thread:updated")
+    expect(eventTypes).toEqual(expect.arrayContaining(["message:created", "message:edited"]))
 
     const asideRow = await StreamRepository.findById(pool, aside.id)
     expect(asideRow?.replyCount ?? 0).toBe(0)

--- a/apps/backend/tests/integration/aside-reply-stats.test.ts
+++ b/apps/backend/tests/integration/aside-reply-stats.test.ts
@@ -1,0 +1,92 @@
+/**
+ * An aside is anchored like a thread (`parentStreamId` + `parentAnchorId`) but
+ * is never the anchor's thread: a message sent in it must not bump reply
+ * stats or emit `thread:updated` into the host room — that patch hands the
+ * host message the aside as its `threadId` (thread card, reply count, and the
+ * aside's own draft advertised under the host message).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, withTransaction, addTestMember, testMessageContent } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamService, StreamRepository } from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { OutboxRepository } from "../../src/lib/outbox"
+import { userId, workspaceId } from "../../src/lib/id"
+
+describe("Aside reply stats", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let eventService: EventService
+  let wsId: string
+  let creator: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    eventService = new EventService(pool)
+    wsId = workspaceId()
+    await withTransaction(pool, async (client) => {
+      creator = (await addTestMember(client, wsId, userId())).id
+      await WorkspaceRepository.insert(client, {
+        id: wsId,
+        name: "Aside Reply Stats Workspace",
+        slug: `aside-reply-stats-${wsId.toLowerCase()}`,
+        createdBy: creator,
+      })
+    })
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("a message sent in an aside emits no thread:updated and bumps no reply count", async () => {
+    const channel = await streamService.createChannel({
+      workspaceId: wsId,
+      slug: `aside-stats-${wsId.toLowerCase()}`,
+      visibility: "public",
+      createdBy: creator,
+    })
+    const anchor = await eventService.createMessage({
+      workspaceId: wsId,
+      streamId: channel.id,
+      authorId: creator,
+      authorType: "user",
+      ...testMessageContent("host message"),
+    })
+    const aside = await streamService.createAside({
+      workspaceId: wsId,
+      parentStreamId: channel.id,
+      parentAnchorId: anchor.id,
+      createdBy: creator,
+    })
+
+    const baseline = await pool.query("SELECT COALESCE(MAX(id), 0) AS max_id FROM outbox")
+    const baselineId = BigInt(baseline.rows[0].max_id)
+
+    const sent = await eventService.createMessage({
+      workspaceId: wsId,
+      streamId: aside.id,
+      authorId: creator,
+      authorType: "user",
+      ...testMessageContent("private question"),
+    })
+    await eventService.editMessageInternal({
+      workspaceId: wsId,
+      streamId: aside.id,
+      messageId: sent.id,
+      actorId: creator,
+      ...testMessageContent("private question, edited"),
+    })
+
+    const outboxEvents = await OutboxRepository.fetchAfterId(pool, baselineId)
+    expect(outboxEvents.map((event) => event.eventType)).not.toContain("thread:updated")
+    expect(outboxEvents.some((event) => event.eventType === "message:created")).toBe(true)
+
+    const asideRow = await StreamRepository.findById(pool, aside.id)
+    expect(asideRow?.replyCount ?? 0).toBe(0)
+    expect(await StreamRepository.findThreadSummaryByParentMessage(pool, channel.id, anchor.id)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
+++ b/apps/frontend/src/components/aside/aside-mobile-sheet.tsx
@@ -58,6 +58,12 @@ function isEditorTarget(target: EventTarget | null): boolean {
 export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originScope }: AsideMobileSheetProps) {
   const detent = useAsideSheetDetent()
   const sheetRef = useRef<HTMLDivElement>(null)
+  // An aside opened from a composer (the `/aside` command, mostly) takes the
+  // typing with it: the keyboard is already up, and the host composer the sheet
+  // now covers would otherwise keep every keystroke out of sight. Opened from
+  // a row or the palette, nothing held focus, and the sheet rests at the peek
+  // with the host still readable above it.
+  const [takeFocus] = useState(() => isEditorTarget(document.activeElement))
   const [dragging, setDragging] = useState(false)
   // The height eases only on the way from a gesture to its detent. Viewport
   // changes — the keyboard, mostly — must land instantly: the host resizes in
@@ -101,7 +107,8 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
     // it started. It also keeps focus — and the keyboard — in an editor that
     // has it: a drag never closes the keyboard.
     event.preventDefault()
-    const startHeight = sheetRef.current?.getBoundingClientRect().height ?? asideMobileHeight(detent, hostHeight(sheetRef.current))
+    const startHeight =
+      sheetRef.current?.getBoundingClientRect().height ?? asideMobileHeight(detent, hostHeight(sheetRef.current))
     drag.current = {
       startY: event.clientY,
       startHeight,
@@ -220,6 +227,7 @@ export function AsideMobileSheet({ workspaceId, asideId, hostStreamId, originSco
             asideId={asideId}
             hostStreamId={hostStreamId}
             originScope={originScope}
+            autoFocus={takeFocus}
           />
         </div>
       </div>

--- a/apps/frontend/src/components/aside/aside-pane.tsx
+++ b/apps/frontend/src/components/aside/aside-pane.tsx
@@ -21,6 +21,8 @@ interface AsidePaneProps {
   hostStreamId: string
   /** The draft scope a hand-off files into (`OpenAsideState.originScope`). */
   originScope: string
+  /** Whether the conversation's composer takes focus on mount. */
+  autoFocus: boolean
 }
 
 /**
@@ -32,7 +34,7 @@ interface AsidePaneProps {
  * a few lines and a keyboard takes what is left, so neither is usable. The
  * stage stacks them side by side because it has the room to; this doesn't.
  */
-export function AsidePane({ workspaceId, asideId, hostStreamId, originScope }: AsidePaneProps) {
+export function AsidePane({ workspaceId, asideId, hostStreamId, originScope, autoFocus }: AsidePaneProps) {
   const draftSurface = useAsideDraftSurface({ workspaceId, asideId, hostStreamId, originScope })
   const streams = useWorkspaceStreams(workspaceId)
   const drafts = useAsideDrafts(workspaceId, asideId)
@@ -86,7 +88,7 @@ export function AsidePane({ workspaceId, asideId, hostStreamId, originScope }: A
               workspaceId={workspaceId}
               asideId={asideId}
               aside={aside}
-              autoFocus={false}
+              autoFocus={autoFocus}
               onInsertAgentBlock={draftSurface.insertAgentBlock}
             />
           </div>

--- a/apps/frontend/src/components/aside/aside-surfaces.test.tsx
+++ b/apps/frontend/src/components/aside/aside-surfaces.test.tsx
@@ -80,8 +80,12 @@ beforeEach(() => {
   // The chat pane is the real companion timeline; its data plumbing is out of
   // scope here, so the barrel export renders a marker carrying the stream it
   // was mounted against.
-  spyOnExport(timelineModule, "StreamContent").mockReturnValue(((props: { streamId: string }) => (
-    <div data-testid="stream-content" data-stream-id={props.streamId} />
+  spyOnExport(timelineModule, "StreamContent").mockReturnValue(((props: { streamId: string; autoFocus?: boolean }) => (
+    <div
+      data-testid="stream-content"
+      data-stream-id={props.streamId}
+      data-auto-focus={props.autoFocus ? "true" : undefined}
+    />
   )) as never)
   spyOnExport(boundaryModule, "StreamErrorBoundary").mockReturnValue(((props: { children: React.ReactNode }) => (
     <>{props.children}</>
@@ -278,6 +282,32 @@ describe("aside surfaces", () => {
       expect(screen.getByTestId("aside-sheet-handle")).toBeInTheDocument()
       expect(screen.queryByTestId("aside-stage")).toBeNull()
       expect(screen.getByTestId("stream-content")).toHaveAttribute("data-stream-id", ASIDE)
+    })
+
+    it("takes the typing with it when opened from a composer, and rests at the peek otherwise", () => {
+      // Opened from a row or the palette: nothing held focus, the host stays
+      // readable above the peek, and no keyboard rises on its own.
+      openOnHost()
+      const { unmount } = renderPage()
+      expect(screen.getByTestId("stream-content")).not.toHaveAttribute("data-auto-focus")
+      unmount()
+      resetAsideStoreCache()
+
+      // Opened from the host composer (`/aside`): that composer is now under
+      // the sheet, so its focus — and the keyboard — move to the aside's own.
+      const hostEditor = document.createElement("div")
+      hostEditor.setAttribute("contenteditable", "true")
+      hostEditor.tabIndex = 0
+      Object.defineProperty(hostEditor, "isContentEditable", { value: true })
+      document.body.appendChild(hostEditor)
+      act(() => hostEditor.focus())
+      try {
+        openOnHost()
+        renderPage()
+        expect(screen.getByTestId("stream-content")).toHaveAttribute("data-auto-focus", "true")
+      } finally {
+        hostEditor.remove()
+      }
     })
 
     it("gives an open draft the whole sheet, and comes back to the conversation behind it", () => {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.test.tsx
@@ -6,6 +6,7 @@ import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as eventItemModule from "./event-item"
 import { spyOnExport } from "@/test"
 import { getAsideState, openAside, resetAsideStoreCache, closeAside } from "@/stores/aside-store"
+import { __resetAgentActivityStore, upsertAgentSession } from "@/stores/agent-activity-store"
 import { createMockStream } from "@/test/fixtures"
 import { groupTimelineItems, TimelineItemContent, type TimelineItemRenderContext } from "./event-list"
 
@@ -81,12 +82,21 @@ function cardEvent(id: string, sequence: string): StreamEvent {
   }
 }
 
+function unreadOnAside(count: number) {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue({
+    unreadCounts: { [ASIDE]: count },
+  } as never)
+}
+
 beforeEach(() => {
   resetAsideStoreCache()
+  __resetAgentActivityStore()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([aside] as never)
 })
 
 afterEach(() => vi.restoreAllMocks())
+
+const row = () => document.querySelector("[data-aside-id]")
 
 describe("AsideAnchorEvent", () => {
   it("renders the creator's row: title joined from the aside stream, age, and the resume control", () => {
@@ -105,6 +115,45 @@ describe("AsideAnchorEvent", () => {
     // The label is present in the row at rest — reserved space, revealed on
     // hover — so the row can never change height when it lights up (INV-21).
     expect(control).toHaveTextContent("Resume")
+  })
+
+  it("rests grey when the aside has nothing new, and lights gold once Ariadne answers in it", () => {
+    unreadOnAside(0)
+    const { unmount } = renderTimeline([anchorEvent()], CREATOR)
+    expect(row()).toHaveAttribute("data-attention", "quiet")
+    expect(screen.getByRole("button", { name: "Resume aside: churn number sanity-check" })).toBe(row())
+    unmount()
+
+    // The aside's unread is the answer: its creator is its only member, and
+    // own sends never raise it, so any count is a companion reply not yet read.
+    unreadOnAside(1)
+    renderTimeline([anchorEvent()], CREATOR)
+    expect(row()).toHaveAttribute("data-attention", "new")
+    expect(screen.getByRole("button", { name: "Resume aside: churn number sanity-check (new reply)" })).toBe(row())
+  })
+
+  it("shows Ariadne working in the aside while a session runs there, ahead of any unread", () => {
+    unreadOnAside(1)
+    upsertAgentSession("ws_1", {
+      sessionId: "asess_1",
+      streamId: ASIDE,
+      rootStreamId: ASIDE,
+      personaName: "Ariadne",
+      startedAt: new Date().toISOString(),
+    })
+    renderTimeline([anchorEvent()], CREATOR)
+
+    expect(row()).toHaveAttribute("data-attention", "working")
+    expect(screen.getByRole("button", { name: /\(Ariadne is working\)$/ })).toBe(row())
+  })
+
+  it("reads as open while the aside is on screen, whatever its unread says", () => {
+    unreadOnAside(3)
+    openAside({ hostKey: HOST_PATH, hostStreamId: "stream_host", asideId: ASIDE, originScope: "stream:stream_host" })
+    renderTimeline([anchorEvent()], CREATOR)
+
+    expect(row()).toHaveAttribute("data-attention", "open")
+    expect(row()).toHaveAttribute("data-state", "open")
   })
 
   it("renders nothing for another viewer of the same host stream", () => {

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -63,7 +63,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
   // Gold only when there is something here for the reader: an answer not yet
   // read, or the aside itself on screen. Waiting on Ariadne is grey too — the
   // spinner says she is working, the colour would say "come and look".
-  const lit = attention === "new" || attention === "open"
+  const highlighted = attention === "new" || attention === "open"
   const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
   const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
 
@@ -95,7 +95,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
         <AsideGlyph
           className={cn(
             "h-3 w-3 shrink-0 transition-colors",
-            lit ? "text-primary" : "text-muted-foreground/70 group-hover:text-primary"
+            highlighted ? "text-primary" : "text-muted-foreground/70 group-hover:text-primary"
           )}
           aria-hidden
         />
@@ -103,7 +103,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
       <span
         className={cn(
           "min-w-0 shrink truncate transition-colors",
-          lit ? "text-primary" : "text-muted-foreground group-hover:text-primary"
+          highlighted ? "text-primary" : "text-muted-foreground group-hover:text-primary"
         )}
       >
         {title}
@@ -112,7 +112,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
         aria-hidden
         className={cn(
           "h-px min-w-4 flex-1 bg-gradient-to-r transition-opacity",
-          lit
+          highlighted
             ? "from-primary/70 to-primary/10"
             : "from-border to-border/20 group-hover:from-primary/50 group-hover:to-primary/10",
           !isOpen && "opacity-70 group-hover:opacity-100"
@@ -122,7 +122,7 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
         aria-hidden
         className={cn(
           "shrink-0 rounded-full px-2 py-px font-medium opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
-          lit
+          highlighted
             ? "bg-primary/10 text-primary"
             : "bg-muted text-muted-foreground group-hover:bg-primary/10 group-hover:text-primary"
         )}

--- a/apps/frontend/src/components/timeline/aside-anchor-event.tsx
+++ b/apps/frontend/src/components/timeline/aside-anchor-event.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react"
+import { Loader2 } from "lucide-react"
 import { StreamTypes, type AsideAnchoredEventPayload, type StreamEvent } from "@threa/types"
-import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useWorkspaceStreams, useWorkspaceUnreadState } from "@/stores/workspace-store"
+import { useAgentActivityForStream } from "@/stores/agent-activity-store"
 import { useAsideState } from "@/stores/aside-store"
 import { useResumeAside } from "@/hooks/use-open-aside"
 import { STREAM_ICONS, streamFallbackLabel, streamLabel } from "@/lib/streams"
@@ -15,11 +17,35 @@ interface AsideAnchorEventProps {
 }
 
 /**
+ * What the row is telling the reader. `open`: the aside is on screen. `working`:
+ * Ariadne is answering in it. `new`: an answer landed since the aside was last
+ * read — the aside's own unread, which only its companion can raise (the
+ * creator is its one member, and own sends never count). `quiet`: nothing new.
+ */
+export type AsideAnchorAttention = "open" | "working" | "new" | "quiet"
+
+function resolveAttention(isOpen: boolean, working: boolean, unread: number): AsideAnchorAttention {
+  if (isOpen) return "open"
+  if (working) return "working"
+  return unread > 0 ? "new" : "quiet"
+}
+
+const ATTENTION_LABEL: Record<AsideAnchorAttention, string> = {
+  open: "",
+  working: " (Ariadne is working)",
+  new: " (new reply)",
+  quiet: "",
+}
+
+/**
  * The creator-only trace of an aside in its host stream (`aside:anchored`).
  * Title and archived state are a live join against the cached aside stream row
  * (the event is immutable); an archived aside leaves no row. The row is the
  * resume handle: Resume reveals on hover/focus (opacity only, INV-21) and
  * re-opens the aside in the surface it was last read in — silently (INV-63).
+ * The aside is a pull surface with no badge anywhere else, so this row is also
+ * where an answer written while it was closed shows: gold when there is one,
+ * grey until then.
  */
 export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) {
   const payload = event.payload as AsideAnchoredEventPayload | undefined
@@ -28,9 +54,16 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
   const aside = useMemo(() => streams.find((stream) => stream.id === asideId), [streams, asideId])
   const open = useAsideState()
   const resume = useResumeAside()
+  const unread = useWorkspaceUnreadState(workspaceId)?.unreadCounts[asideId ?? ""] ?? 0
+  const working = useAgentActivityForStream(workspaceId, asideId).length > 0
   if (!asideId || aside?.archivedAt) return null
 
   const isOpen = open?.asideId === asideId
+  const attention = resolveAttention(isOpen, working, unread)
+  // Gold only when there is something here for the reader: an answer not yet
+  // read, or the aside itself on screen. Waiting on Ariadne is grey too — the
+  // spinner says she is working, the colour would say "come and look".
+  const lit = attention === "new" || attention === "open"
   const title = aside ? streamLabel(aside) : streamFallbackLabel(StreamTypes.ASIDE, "generic")
   const age = formatRelativeTime(new Date(event.createdAt), new Date(), undefined, { terse: true })
 
@@ -46,34 +79,53 @@ export function AsideAnchorEvent({ event, workspaceId }: AsideAnchorEventProps) 
           ...(payload?.conversationId && { conversationId: payload.conversationId }),
         })
       }
-      aria-label={`${isOpen ? "Open" : "Resume"} aside: ${title}`}
+      aria-label={`${isOpen ? "Open" : "Resume"} aside: ${title}${ATTENTION_LABEL[attention]}`}
       data-aside-id={asideId}
       data-state={isOpen ? "open" : "closed"}
+      data-attention={attention}
       className={cn(
         "group flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors sm:px-6",
         "hover:bg-primary/[0.04] focus-visible:bg-primary/[0.04] focus-visible:outline-none",
         isOpen && "bg-primary/[0.03]"
       )}
     >
-      <AsideGlyph
+      {attention === "working" ? (
+        <Loader2 className="h-3 w-3 shrink-0 animate-spin text-muted-foreground/70" aria-hidden />
+      ) : (
+        <AsideGlyph
+          className={cn(
+            "h-3 w-3 shrink-0 transition-colors",
+            lit ? "text-primary" : "text-muted-foreground/70 group-hover:text-primary"
+          )}
+          aria-hidden
+        />
+      )}
+      <span
         className={cn(
-          "h-3 w-3 shrink-0 transition-colors",
-          isOpen ? "text-primary" : "text-primary/60 group-hover:text-primary"
+          "min-w-0 shrink truncate transition-colors",
+          lit ? "text-primary" : "text-muted-foreground group-hover:text-primary"
         )}
-        aria-hidden
-      />
-      <span className="min-w-0 shrink truncate text-primary">{title}</span>
+      >
+        {title}
+      </span>
       <span
         aria-hidden
         className={cn(
           "h-px min-w-4 flex-1 bg-gradient-to-r transition-opacity",
-          isOpen ? "from-primary/70 to-primary/10" : "from-primary/50 to-primary/10 opacity-70",
-          "group-hover:opacity-100"
+          lit
+            ? "from-primary/70 to-primary/10"
+            : "from-border to-border/20 group-hover:from-primary/50 group-hover:to-primary/10",
+          !isOpen && "opacity-70 group-hover:opacity-100"
         )}
       />
       <span
         aria-hidden
-        className="shrink-0 rounded-full bg-primary/10 px-2 py-px font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 [@media(hover:none)]:opacity-100"
+        className={cn(
+          "shrink-0 rounded-full px-2 py-px font-medium opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
+          lit
+            ? "bg-primary/10 text-primary"
+            : "bg-muted text-muted-foreground group-hover:bg-primary/10 group-hover:text-primary"
+        )}
       >
         {isOpen ? "Open" : "Resume"}
       </span>

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -194,8 +194,10 @@ test.describe("Aside — desktop surface", () => {
         .locator(".message-item")
         .filter({ hasText: /stub response from the companion/ })
     ).toBeVisible({ timeout: AGENT_REPLY_TIMEOUT })
-    // The host timeline never receives the aside's turns.
+    // The host timeline never receives the aside's turns, and the anchored
+    // message never adopts the aside as its thread (no card linking into it).
     await expect(hostScroller(page, streamId).getByText("What is this about?")).toHaveCount(0)
+    await expect(hostScroller(page, streamId).locator(`a[href*="${asideId}"]`)).toHaveCount(0)
     await expectSilent(page, asideId!)
 
     // The anchor row is the aside's one attention surface (no badge, no

--- a/tests/browser/aside-desktop.spec.ts
+++ b/tests/browser/aside-desktop.spec.ts
@@ -197,6 +197,24 @@ test.describe("Aside — desktop surface", () => {
     // The host timeline never receives the aside's turns.
     await expect(hostScroller(page, streamId).getByText("What is this about?")).toHaveCount(0)
     await expectSilent(page, asideId!)
+
+    // The anchor row is the aside's one attention surface (no badge, no
+    // sidebar). Read and closed, it rests grey; an answer that lands while it
+    // is closed lights it gold; opening it reads it.
+    await page.getByRole("button", { name: "Close aside" }).click()
+    await expectNoAsideChrome(page)
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-attention", "quiet")
+    await expectApiOk(
+      await page.request.post(`/api/workspaces/${workspaceId}/messages`, {
+        data: { streamId: asideId, content: "And what comes next?" },
+      }),
+      "Ask in the closed aside"
+    )
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-attention", "new", { timeout: AGENT_REPLY_TIMEOUT })
+    await anchorRow(page, streamId).click()
+    await expect(stage(page)).toBeVisible({ timeout: 10000 })
+    await expect(anchorRow(page, streamId)).toHaveAttribute("data-attention", "open")
+    await expectSilent(page, asideId!)
   })
 
   test("folds away on navigation, leaves the next stream clean, and resumes silently from the anchor row", async ({

--- a/tests/browser/aside-mobile.spec.ts
+++ b/tests/browser/aside-mobile.spec.ts
@@ -140,6 +140,53 @@ test.describe("Aside — mobile surface", () => {
     await expect(sheet(page)).toHaveAttribute("data-detent", "peek", { timeout: 10000 })
   })
 
+  test("takes the typing with it when opened from the composer, and rests at the peek from the anchor row", async ({
+    page,
+  }) => {
+    await createChannel(page, `aside-mf-${testId}`)
+    const { workspaceId, streamId } = extractIds(page)
+    await seedMessages(page, workspaceId, streamId, `[${testId}-focus]`)
+    await page.setViewportSize(PHONE)
+    await page.goto(`/w/${workspaceId}/s/${streamId}`)
+    await expect(hostScroller(page, streamId)).toBeVisible({ timeout: 20000 })
+
+    // `/aside` from the host composer, the keyboard already up. The composer
+    // card is the tap target: its editor is a hairline at rest.
+    const card = page.locator("[data-composer-card]").last()
+    const box = await card.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.click(box!.x + box!.width / 2, box!.y + 18)
+    const hostEditor = page.locator("[data-editor-zone='main'] [contenteditable='true']").first()
+    await expect(hostEditor).toBeFocused()
+    await page.keyboard.type("/aside")
+    await expect(page.locator("[aria-label='Slash command suggestions']")).toBeVisible({ timeout: 5000 })
+    await page.keyboard.press("Enter")
+    await page.getByRole("button", { name: /^send$/i }).click()
+
+    // The sheet took the focus with it: the host composer is under the sheet
+    // now, so typing lands in the aside's own composer, in view, and the sheet
+    // rose to meet the keyboard.
+    await expect(sheet(page)).toBeVisible({ timeout: 15000 })
+    const asideEditor = sheet(page).getByTestId("aside-conversation").locator("[contenteditable='true']")
+    await expect(asideEditor).toBeFocused({ timeout: 10000 })
+    await expect(sheet(page)).toHaveAttribute("data-detent", "full")
+    await page.keyboard.type("is this about widgets?")
+    await expect(asideEditor).toHaveText("is this about widgets?")
+    await expect(hostEditor).toHaveText("")
+
+    // Closed and resumed from its row: nothing held focus this time, so the
+    // sheet rests at the peek with the host readable above it and no keyboard
+    // of its own.
+    await sheet(page).getByRole("button", { name: "Close aside" }).click()
+    await expect(sheet(page)).toHaveCount(0)
+    const row = hostScroller(page, streamId).locator("[data-aside-id]").first()
+    await row.scrollIntoViewIfNeeded()
+    await row.click()
+    await expect(sheet(page)).toBeVisible({ timeout: 10000 })
+    await expect(sheet(page)).toHaveAttribute("data-detent", "peek")
+    await expect(asideEditor).not.toBeFocused()
+  })
+
   test("gives an open draft the whole sheet, and comes back to the conversation behind it", async ({ page }) => {
     await createChannel(page, `aside-md-${testId}`)
     const { workspaceId, streamId } = extractIds(page)


### PR DESCRIPTION
## Problem

An aside has no attention surface by design (no sidebar row, no badge — [#1921](https://github.com/threahq/threa/pull/1921)), so once you close it there is no way to tell that Ariadne has answered: the anchor row in the host timeline looked the same gold whether the aside was idle, working, or holding an unread reply. Kris uses asides to ask about the conversation he is in, not only to draft, so "did she answer yet" is the question the row has to settle.

CI then surfaced a third defect the new desktop spec catches: sending in an aside stamped the host message with `threadId = <asideId>`. `EventService` bumped reply stats and emitted `thread:updated` for any stream with `parentStreamId && parentAnchorId`, and an aside has both — so the anchored message grew a thread card linking into the private aside, with the aside's own unsent draft advertised under it. Locally the draft was gone by the time the card rendered; on a slower runner it was still there, hence the red.

On a phone, `/aside` from the host composer opened the sheet but left focus in that composer, now under the sheet: the next keystrokes went into a field you could not see. `AsidePane` hard-coded `autoFocus={false}` for the sheet.

## Solution

The anchor row carries a `data-attention` state, one of `open | working | new | quiet`, resolved in that order:

- `working` — `useAgentActivityForStream(workspaceId, asideId)` has a running session; the glyph becomes the app's one working glyph (spinning `Loader2`).
- `new` — `useWorkspaceUnreadState(workspaceId).unreadCounts[asideId] > 0`. The creator is the aside's only member and own sends never raise unread, so any count is a companion reply not yet read. Verified live: 0 while open, 1 after a reply landed while closed, 0 on resume.
- Colour follows Kris's call: quiet and working are grey end to end (glyph or spinner, title, hairline, Resume pill); gold only for `new` and `open`. Hover still lifts a grey row to gold. The `aria-label` gains "(new reply)" / "(Ariadne is working)".
- No new plumbing: the client already joins every member stream's room, and asides are in the bootstrap's `unreadCounts` (probed `GET /bootstrap` — `data.unreadCounts[asideId]`), so both signals arrive with the aside closed.

`isThreadReplyStream` (`event-service.ts`) gates all four reply-stat sites (create, edit, delete, move) on `type === "thread"`; asides keep `reply_count` 0 and never reach the host room via `thread:updated`. Integration test proves red without the fix; the desktop spec now also asserts the host never links to `asideId`.

The phone sheet takes focus only when a composer held it at open: `AsideMobileSheet` reads `document.activeElement` once on mount and passes `autoFocus` down through `AsidePane` → `AsideConversation`. The `/aside` path therefore lands in the aside composer (the existing focus-capture then lifts the sheet to `full`, keyboard staying up); a row or palette open still rests at the peek with no keyboard. Desktop already focused the aside composer on all three entry paths (probed; no change).

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/aside-anchor-event.tsx` | `AsideAnchorAttention`, `resolveAttention`, grey/gold treatment, spinner, `data-attention`, aria-label suffix |
| `apps/frontend/src/components/aside/aside-mobile-sheet.tsx` | `takeFocus` read once at mount, passed to the pane |
| `apps/frontend/src/components/aside/aside-pane.tsx` | `autoFocus` prop replaces the hard-coded `false` |
| `apps/backend/src/features/messaging/event-service.ts` | `isThreadReplyStream` predicate; reply stats and `thread:updated` only for threads |
| `apps/backend/tests/integration/aside-reply-stats.test.ts` | **new** — aside send/edit: no `thread:updated`, `reply_count` 0, no thread summary on the anchor |
| `apps/frontend/src/components/timeline/aside-anchor-event.test.tsx` | quiet / new / working / open cases |
| `apps/frontend/src/components/aside/aside-surfaces.test.tsx` | sheet takes focus from a focused editor, not otherwise |
| `tests/browser/aside-desktop.spec.ts` | close → `quiet`, reply while closed → `new`, resume → `open`; host never links to the aside |
| `tests/browser/aside-mobile.spec.ts` | `/aside` from the composer: typed text lands in the aside composer, sheet at `full`; resume from the row rests at `peek`, unfocused |

## Test plan

- [x] `bun run --cwd apps/frontend test` — full suite, 0 failing (before the grey-only colour tweak; the anchor-row file re-run after it, 9 pass)
- [x] `bun run --cwd apps/backend test tests/integration/aside-reply-stats.test.ts tests/integration/thread-summary.test.ts` — 4129 unit + 21 integration pass; the new test fails on the unpatched service
- [x] `bun run typecheck`, `bun run --cwd apps/frontend lint`, `bun run --cwd apps/backend lint` — clean
- [x] `bunx playwright test tests/browser/aside-desktop.spec.ts tests/browser/aside-mobile.spec.ts --workers=1` — 5 pass locally (twice; the second after the backend fix)
- [x] Tailscale preview (this worktree, stub auth): probes observed `quiet → working → new → open` on the row and typed text landing in the aside composer after `/aside` at 390px
- [ ] Real phone keyboard behaviour — headless can't raise a keyboard; Kris has the preview

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
